### PR TITLE
feat(approvals): app-wide approvals surface

### DIFF
--- a/apps/api/src/chat/approvals.test.ts
+++ b/apps/api/src/chat/approvals.test.ts
@@ -81,3 +81,71 @@ describe("ApprovalRegistry", () => {
     }
   });
 });
+
+describe("ApprovalRegistry.listPending", () => {
+  it("is empty with nothing in flight", () => {
+    expect(new ApprovalRegistry().listPending()).toEqual([]);
+  });
+
+  it("projects an in-flight request into a listable row", () => {
+    const reg = new ApprovalRegistry();
+    const { events, emitter } = fakeEmitter();
+    void reg.request(emitter, { toolCallId: "c1", toolName: "write_x", args: { a: 1 } });
+
+    const rows = reg.listPending();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ toolCallId: "c1", toolName: "write_x", args: { a: 1 } });
+    expect(rows[0]?.approvalId).toBe(reqId(events));
+    expect(typeof rows[0]?.expiresAt).toBe("string");
+    expect(typeof rows[0]?.createdAt).toBe("string");
+  });
+
+  it("drops an entry once it is decided", async () => {
+    const reg = new ApprovalRegistry();
+    const { events, emitter } = fakeEmitter();
+    const p = reg.request(emitter, { toolCallId: "c1", toolName: "t", args: {} });
+    expect(reg.listPending()).toHaveLength(1);
+
+    reg.decide(reqId(events), "approved");
+    expect(reg.listPending()).toEqual([]);
+    await p;
+  });
+
+  it("drops an entry once it times out", async () => {
+    vi.useFakeTimers();
+    try {
+      const reg = new ApprovalRegistry();
+      const { emitter } = fakeEmitter();
+      const p = reg.request(emitter, { toolCallId: "c1", toolName: "t", args: {} });
+      expect(reg.listPending()).toHaveLength(1);
+
+      await vi.advanceTimersByTimeAsync(APPROVAL_TIMEOUT_MS);
+      expect(reg.listPending()).toEqual([]);
+      await p;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("lists multiple entries oldest-first", () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(0);
+      const reg = new ApprovalRegistry();
+      const { events, emitter } = fakeEmitter();
+      void reg.request(emitter, { toolCallId: "c1", toolName: "first", args: {} });
+      vi.advanceTimersByTime(1000);
+      void reg.request(emitter, { toolCallId: "c2", toolName: "second", args: {} });
+
+      const ids = events
+        .filter((e) => e.type === "approval-request")
+        .map((e) => e.data.approvalId as string);
+      const rows = reg.listPending();
+      expect(rows.map((r) => r.approvalId)).toEqual(ids);
+      expect(rows.map((r) => r.toolName)).toEqual(["first", "second"]);
+      expect((rows[0]?.createdAt ?? "") <= (rows[1]?.createdAt ?? "")).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/apps/api/src/chat/approvals.ts
+++ b/apps/api/src/chat/approvals.ts
@@ -10,6 +10,22 @@ interface PendingApproval {
   timer: ReturnType<typeof setTimeout>;
   emitter: StreamEmitter;
   toolCallId: string;
+  // Retained so listPending() can project a row without re-deriving from the (per-stream) emitter.
+  approvalId: string;
+  toolName: string;
+  args: unknown;
+  expiresAt: string;
+  createdAt: string;
+}
+
+/** A serializable projection of one in-flight approval, for the list endpoint + sidebar badge. */
+export interface PendingApprovalSummary {
+  approvalId: string;
+  toolCallId: string;
+  toolName: string;
+  args: unknown;
+  expiresAt: string;
+  createdAt: string;
 }
 
 /**
@@ -25,13 +41,24 @@ export class ApprovalRegistry {
   /** Suspend a gated tool call until a human (or the timeout) decides. */
   request(emitter: StreamEmitter, info: ApprovalRequestInfo): Promise<ApprovalDecision> {
     const approvalId = randomUUID();
+    const createdAt = new Date().toISOString();
     const expiresAt = new Date(Date.now() + APPROVAL_TIMEOUT_MS).toISOString();
     const decision = new Promise<ApprovalDecision>((resolve) => {
       const timer = setTimeout(
         () => this.settle(approvalId, { outcome: "timeout", reason: "approval request timed out" }),
         APPROVAL_TIMEOUT_MS
       );
-      this.pending.set(approvalId, { resolve, timer, emitter, toolCallId: info.toolCallId });
+      this.pending.set(approvalId, {
+        resolve,
+        timer,
+        emitter,
+        toolCallId: info.toolCallId,
+        approvalId,
+        toolName: info.toolName,
+        args: info.args,
+        expiresAt,
+        createdAt,
+      });
     });
     void emitter.emit("approval-request", {
       approvalId,
@@ -53,6 +80,20 @@ export class ApprovalRegistry {
         : { outcome: "denied", reason: "denied by operator" }
     );
     return true;
+  }
+
+  /** Snapshot all in-flight approvals, oldest first. Ephemeral — empties on API restart. */
+  listPending(): PendingApprovalSummary[] {
+    return [...this.pending.values()]
+      .map((e) => ({
+        approvalId: e.approvalId,
+        toolCallId: e.toolCallId,
+        toolName: e.toolName,
+        args: e.args,
+        expiresAt: e.expiresAt,
+        createdAt: e.createdAt,
+      }))
+      .sort((a, b) => a.createdAt.localeCompare(b.createdAt));
   }
 
   private settle(approvalId: string, decision: ApprovalDecision): void {

--- a/apps/api/src/chat/routes.test.ts
+++ b/apps/api/src/chat/routes.test.ts
@@ -766,6 +766,55 @@ describe("chat routes", () => {
       const d = await decide(randomUUID(), "approve");
       expect(d.statusCode).toBe(404);
     });
+
+    describe("GET /api/v1/chat/approvals", () => {
+      it("401 without a session", async () => {
+        const res = await get("/api/v1/chat/approvals", { session: null });
+        expect(res.statusCode).toBe(401);
+      });
+
+      it("returns an empty list when nothing is pending", async () => {
+        const res = await get("/api/v1/chat/approvals");
+        expect(res.statusCode).toBe(200);
+        expect(res.json()).toEqual({ items: [] });
+      });
+
+      it("lists a live pending approval with intact args", async () => {
+        // Fire WITHOUT awaiting — the stream suspends on the gate until we decide.
+        const chat = post({ message: userMsg("write it"), autonomy: "approval-required" });
+        await waitFor(() => streamRepo.rows.some((r) => r.eventType === "approval-request"), 2000);
+
+        const res = await get("/api/v1/chat/approvals");
+        expect(res.statusCode).toBe(200);
+        const { items } = res.json() as { items: Array<Record<string, unknown>> };
+        expect(items).toHaveLength(1);
+        expect(items[0]).toMatchObject({
+          approvalId: bufferedApprovalId(),
+          toolCallId: "call_1",
+          toolName: "write_thing",
+          args: { value: "x" }, // schemaless `args` must round-trip an object intact
+        });
+        expect(typeof items[0]?.expiresAt).toBe("string");
+        expect(typeof items[0]?.createdAt).toBe("string");
+
+        // Drain the suspended stream so the next beforeEach's app.close() doesn't hang.
+        await decide(bufferedApprovalId(), "approve");
+        await chat;
+        await waitFor(() => streamRepo.rows.some((r) => r.eventType === "finish"), 2000);
+      });
+
+      it("drops the approval from the list once it is decided", async () => {
+        const chat = post({ message: userMsg("write it"), autonomy: "approval-required" });
+        await waitFor(() => streamRepo.rows.some((r) => r.eventType === "approval-request"), 2000);
+        await decide(bufferedApprovalId(), "approve");
+        await chat;
+        await waitFor(() => streamRepo.rows.some((r) => r.eventType === "finish"), 2000);
+
+        const res = await get("/api/v1/chat/approvals");
+        expect(res.statusCode).toBe(200);
+        expect(res.json()).toEqual({ items: [] });
+      });
+    });
   });
 
   describe("GET /api/v1/chat/streams/:streamId (resume)", () => {

--- a/apps/api/src/chat/routes.ts
+++ b/apps/api/src/chat/routes.ts
@@ -399,6 +399,52 @@ export function registerChatRoutes(
   );
 
   app.get(
+    "/api/v1/chat/approvals",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description:
+          "List all in-flight (pending) tool-execution approvals. Single-trust V1: not scoped " +
+          "per-user. Ephemeral — the set empties on API restart. Poll to drive the Approvals view + badge.",
+        tags: ["chat"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        response: {
+          200: {
+            type: "object",
+            additionalProperties: false,
+            required: ["items"],
+            properties: {
+              items: {
+                type: "array",
+                items: {
+                  type: "object",
+                  additionalProperties: false,
+                  required: ["approvalId", "toolCallId", "toolName", "expiresAt", "createdAt"],
+                  properties: {
+                    approvalId: { type: "string" },
+                    toolCallId: { type: "string" },
+                    toolName: { type: "string" },
+                    // `args` is arbitrary tool input — declared schemaless (and omitted from
+                    // `required`) so fast-json-stringify passes any JSON value through intact. A
+                    // typed `args` would silently drop/coerce non-object shapes (arrays, scalars).
+                    args: {},
+                    expiresAt: { type: "string" },
+                    createdAt: { type: "string" },
+                  },
+                },
+              },
+            },
+          },
+          401: ErrorSchema,
+        },
+      },
+    },
+    async (_req, reply) => {
+      return reply.send({ items: approvalRegistry.listPending() });
+    }
+  );
+
+  app.get(
     "/api/v1/chat/streams/:streamId",
     {
       preHandler: requireAuth,

--- a/apps/web/app/components/app-sidebar.test.tsx
+++ b/apps/web/app/components/app-sidebar.test.tsx
@@ -1,13 +1,26 @@
 import { createRemixStub } from "@remix-run/testing";
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, expect, test } from "vitest";
+import { beforeEach, expect, test, vi } from "vitest";
 import { AppSidebar } from "~/components/app-sidebar";
+import * as approvalsContext from "~/lib/approvals-context";
+
+// The badge count now comes from the live ApprovalsProvider context (inert fallback is covered in
+// approvals-context.test.tsx); mock the hook here for deterministic counts.
+vi.mock("~/lib/approvals-context", () => ({ useApprovals: vi.fn() }));
+const useApprovals = vi.mocked(approvalsContext.useApprovals);
 
 const Stub = createRemixStub([{ path: "/", Component: AppSidebar }]);
 
 beforeEach(() => {
   localStorage.clear();
+  useApprovals.mockReturnValue({
+    approvals: [],
+    count: 0,
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+  });
 });
 
 test("renders all eight V1 sidebar sections", () => {
@@ -31,10 +44,23 @@ test("does not render an Apps section (AC-V1-003)", () => {
   expect(screen.queryByText("Apps")).not.toBeInTheDocument();
 });
 
-test("shows the mocked Approvals badge count on the Approvals row", () => {
+test("renders no Approvals badge when there are no pending approvals", () => {
   render(<Stub initialEntries={["/"]} />);
   const approvalsLink = screen.getByRole("link", { name: /approvals/i });
-  expect(within(approvalsLink).getByText("3")).toBeInTheDocument();
+  expect(within(approvalsLink).queryByText(/^\d+$/)).toBeNull();
+});
+
+test("renders the live Approvals badge count from context", () => {
+  useApprovals.mockReturnValue({
+    approvals: [],
+    count: 2,
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+  });
+  render(<Stub initialEntries={["/"]} />);
+  const approvalsLink = screen.getByRole("link", { name: /approvals/i });
+  expect(within(approvalsLink).getByText("2")).toBeInTheDocument();
 });
 
 test("groups nav into Workspace/System and shows a footer theme toggle", () => {

--- a/apps/web/app/components/app-sidebar.tsx
+++ b/apps/web/app/components/app-sidebar.tsx
@@ -2,7 +2,8 @@ import { NavLink } from "@remix-run/react";
 import { Menu, PanelLeftClose, PanelLeftOpen, X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { ThemeToggle } from "~/components/theme-toggle";
-import { badgeCounts } from "~/lib/badges";
+import { useApprovals } from "~/lib/approvals-context";
+import type { BadgeKey } from "~/lib/badges";
 import { type NavItem, navGroups, navItems } from "~/lib/nav";
 import { cn } from "~/lib/utils";
 
@@ -30,7 +31,10 @@ function NavRow({
   onNavigate: () => void;
 }) {
   const { to, label, icon: Icon, end, badgeKey } = item;
-  const count = badgeKey ? badgeCounts[badgeKey] : 0;
+  // Live badge counts from the shared ApprovalsProvider (inert 0 when no provider is mounted).
+  const { count: approvalsCount } = useApprovals();
+  const liveCounts: Partial<Record<BadgeKey, number>> = { approvals: approvalsCount };
+  const count = badgeKey ? (liveCounts[badgeKey] ?? 0) : 0;
   return (
     <NavLink
       to={to}

--- a/apps/web/app/lib/approvals-context.test.tsx
+++ b/apps/web/app/lib/approvals-context.test.tsx
@@ -1,0 +1,118 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, test, vi } from "vitest";
+import * as approvals from "~/lib/approvals";
+import { ApprovalsProvider, useApprovals } from "~/lib/approvals-context";
+
+vi.mock("~/lib/approvals", () => ({ listPendingApprovals: vi.fn() }));
+const mockList = vi.mocked(approvals.listPendingApprovals);
+
+afterEach(() => {
+  vi.useRealTimers();
+  mockList.mockReset();
+});
+
+const row = (approvalId: string): approvals.PendingApproval => ({
+  approvalId,
+  toolCallId: "c",
+  toolName: "t",
+  args: {},
+  expiresAt: "",
+  createdAt: "",
+});
+
+function Probe() {
+  const { count, loading, error, refresh } = useApprovals();
+  return (
+    <div>
+      <span data-testid="count">{count}</span>
+      <span data-testid="loading">{String(loading)}</span>
+      <span data-testid="error">{error ?? ""}</span>
+      <button type="button" onClick={() => void refresh()}>
+        refresh
+      </button>
+    </div>
+  );
+}
+
+const renderProbe = () =>
+  render(
+    <ApprovalsProvider>
+      <Probe />
+    </ApprovalsProvider>
+  );
+
+test("polls on mount and exposes the live count", async () => {
+  mockList.mockResolvedValue([row("a"), row("b")]);
+  renderProbe();
+  await waitFor(() => expect(screen.getByTestId("count")).toHaveTextContent("2"));
+  expect(screen.getByTestId("loading")).toHaveTextContent("false");
+});
+
+test("useApprovals returns an inert fallback when no provider is mounted", () => {
+  render(<Probe />);
+  expect(screen.getByTestId("count")).toHaveTextContent("0");
+  expect(screen.getByTestId("loading")).toHaveTextContent("false");
+  expect(mockList).not.toHaveBeenCalled();
+});
+
+test("refresh() re-fetches and updates the count", async () => {
+  mockList.mockResolvedValue([]);
+  renderProbe();
+  await waitFor(() => expect(screen.getByTestId("count")).toHaveTextContent("0"));
+
+  mockList.mockResolvedValue([row("a")]);
+  fireEvent.click(screen.getByRole("button", { name: "refresh" }));
+  await waitFor(() => expect(screen.getByTestId("count")).toHaveTextContent("1"));
+});
+
+test("surfaces an error and keeps the last-known list", async () => {
+  mockList.mockResolvedValue([row("a")]);
+  renderProbe();
+  await waitFor(() => expect(screen.getByTestId("count")).toHaveTextContent("1"));
+
+  mockList.mockRejectedValueOnce(new Error("boom"));
+  fireEvent.click(screen.getByRole("button", { name: "refresh" }));
+  await waitFor(() => expect(screen.getByTestId("error")).toHaveTextContent("boom"));
+  expect(screen.getByTestId("count")).toHaveTextContent("1"); // list preserved across the error
+});
+
+test("re-polls on the ~4s interval", async () => {
+  vi.useFakeTimers();
+  mockList.mockResolvedValue([]);
+  renderProbe();
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(0); // flush the mount fetch
+  });
+  expect(screen.getByTestId("count")).toHaveTextContent("0");
+
+  mockList.mockResolvedValue([row("a")]);
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(4000);
+  });
+  expect(screen.getByTestId("count")).toHaveTextContent("1");
+});
+
+test("drops overlapping ticks while a poll is in flight", async () => {
+  vi.useFakeTimers();
+  mockList.mockReturnValue(new Promise(() => {})); // never resolves → stays in flight
+  renderProbe();
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(8000); // two ticks, both must be dropped by the guard
+  });
+  expect(mockList).toHaveBeenCalledTimes(1);
+});
+
+test("clears the interval on unmount", async () => {
+  vi.useFakeTimers();
+  mockList.mockResolvedValue([]);
+  const { unmount } = renderProbe();
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(0);
+  });
+  unmount();
+  mockList.mockClear();
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(12000);
+  });
+  expect(mockList).not.toHaveBeenCalled();
+});

--- a/apps/web/app/lib/approvals-context.tsx
+++ b/apps/web/app/lib/approvals-context.tsx
@@ -1,0 +1,93 @@
+import {
+  type ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { type PendingApproval, listPendingApprovals } from "~/lib/approvals";
+
+/*
+ * Single source of truth for app-wide pending approvals. Mounted once in the `_app` shell, it polls
+ * GET /api/v1/chat/approvals every ~4s; the sidebar badge and the Approvals page both read this one
+ * context (`count = approvals.length`), and decide handlers call `refresh()` to reconcile after a
+ * decision. Ephemeral, single-instance V1 — no global SSE channel, no durable store.
+ */
+
+const POLL_INTERVAL_MS = 4000;
+
+type ApprovalsContextValue = {
+  approvals: PendingApproval[];
+  count: number;
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+};
+
+const ApprovalsContext = createContext<ApprovalsContextValue | null>(null);
+
+export function ApprovalsProvider({ children }: { children: ReactNode }) {
+  const [approvals, setApprovals] = useState<PendingApproval[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  // Guards against overlapping polls (a slow request still outstanding when the next tick fires).
+  const inFlight = useRef(false);
+  // Tracks whether the provider is still mounted, so a poll that resolves after unmount (e.g. the
+  // user navigated away) skips its state writes instead of touching a dead component.
+  const mounted = useRef(true);
+
+  const refresh = useCallback(async () => {
+    if (inFlight.current) return;
+    inFlight.current = true;
+    try {
+      const items = await listPendingApprovals();
+      if (mounted.current) {
+        setApprovals(items);
+        setError(null);
+      }
+    } catch (err) {
+      // Keep the last-known list on a transient failure (don't flash empty); retry next tick.
+      if (mounted.current) {
+        setError(err instanceof Error ? err.message : "failed to load approvals");
+      }
+    } finally {
+      if (mounted.current) setLoading(false);
+      inFlight.current = false;
+    }
+  }, []);
+
+  useEffect(() => {
+    mounted.current = true;
+    void refresh();
+    const id = setInterval(() => void refresh(), POLL_INTERVAL_MS);
+    return () => {
+      mounted.current = false;
+      clearInterval(id);
+    };
+  }, [refresh]);
+
+  const value: ApprovalsContextValue = {
+    approvals,
+    count: approvals.length,
+    loading,
+    error,
+    refresh,
+  };
+  return <ApprovalsContext.Provider value={value}>{children}</ApprovalsContext.Provider>;
+}
+
+// Inert fallback when no provider is mounted — lets the sidebar (and its isolated tests) render
+// without the polling provider rather than throwing.
+const INERT: ApprovalsContextValue = {
+  approvals: [],
+  count: 0,
+  loading: false,
+  error: null,
+  refresh: async () => {},
+};
+
+export function useApprovals(): ApprovalsContextValue {
+  return useContext(ApprovalsContext) ?? INERT;
+}

--- a/apps/web/app/lib/approvals.ts
+++ b/apps/web/app/lib/approvals.ts
@@ -1,0 +1,24 @@
+import { apiGet } from "./api";
+// Re-export the existing decide POST so the approvals feature has one import surface (chat untouched).
+export { sendApprovalDecision } from "./chat/sse-client";
+
+/*
+ * Read-only client for the pending-approvals list (GET /api/v1/chat/approvals). Ephemeral,
+ * single-trust V1: returns ALL pending tool approvals (no per-user filter). Mirrors lib/agents.ts
+ * conventions (cookie-first auth, ApiError on non-2xx). The sidebar badge and the Approvals page
+ * both poll this via the shared ApprovalsProvider.
+ */
+
+export type PendingApproval = {
+  approvalId: string;
+  toolCallId: string;
+  toolName: string;
+  args: unknown;
+  expiresAt: string;
+  createdAt: string;
+};
+
+export async function listPendingApprovals(): Promise<PendingApproval[]> {
+  const body = await apiGet<{ items: PendingApproval[] }>("/api/v1/chat/approvals");
+  return body.items;
+}

--- a/apps/web/app/lib/badges.ts
+++ b/apps/web/app/lib/badges.ts
@@ -1,9 +1,3 @@
-/*
- * Mocked badge counts for the V1 shell scaffold. Real counts wire to the API in downstream
- * tickets (e.g. Approvals → GET /api/v1/approvals). A pill renders only when the count is > 0.
- */
+// Maps a sidebar nav row to a live badge source. Counts come from context (see useApprovals() in
+// app-sidebar.tsx). A pill renders only when the count is > 0.
 export type BadgeKey = "approvals";
-
-export const badgeCounts: Record<BadgeKey, number> = {
-  approvals: 3,
-};

--- a/apps/web/app/routes/_app.approvals.test.tsx
+++ b/apps/web/app/routes/_app.approvals.test.tsx
@@ -1,0 +1,129 @@
+import { createRemixStub } from "@remix-run/testing";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, expect, test, vi } from "vitest";
+import * as approvalsLib from "~/lib/approvals";
+import * as approvalsContext from "~/lib/approvals-context";
+import ApprovalsPage from "./_app.approvals";
+
+/*
+ * Approvals page smoke tests. The page reads the shared ApprovalsProvider context (not a loader),
+ * so we mock useApprovals + the decide call and render through createRemixStub (ResourcePanel /
+ * EmptyState use Link). ApprovalCard renders for real (its countdown is asserted loosely).
+ */
+
+vi.mock("~/lib/approvals-context", () => ({ useApprovals: vi.fn() }));
+vi.mock("~/lib/approvals", () => ({ sendApprovalDecision: vi.fn() }));
+
+const useApprovals = vi.mocked(approvalsContext.useApprovals);
+const sendApprovalDecision = vi.mocked(approvalsLib.sendApprovalDecision);
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+const row = (over: Partial<approvalsLib.PendingApproval> = {}): approvalsLib.PendingApproval => ({
+  approvalId: "ap1",
+  toolCallId: "call_1",
+  toolName: "write_thing",
+  args: { value: "x" },
+  expiresAt: new Date(Date.now() + 60_000).toISOString(),
+  createdAt: new Date().toISOString(),
+  ...over,
+});
+
+type ApprovalsState = ReturnType<typeof approvalsContext.useApprovals>;
+const state = (over: Partial<ApprovalsState> = {}): ApprovalsState => ({
+  approvals: [],
+  count: 0,
+  loading: false,
+  error: null,
+  refresh: vi.fn().mockResolvedValue(undefined),
+  ...over,
+});
+
+function renderPage() {
+  const Stub = createRemixStub([{ path: "/", Component: () => <ApprovalsPage /> }]);
+  render(<Stub initialEntries={["/"]} />);
+}
+
+test("shows a loading line on the first load", () => {
+  useApprovals.mockReturnValue(state({ loading: true }));
+  renderPage();
+  expect(screen.getByText("loading…")).toBeInTheDocument();
+});
+
+test("shows the empty state when there are no pending approvals", () => {
+  useApprovals.mockReturnValue(state({ loading: false, approvals: [] }));
+  renderPage();
+  expect(screen.getByText("0 results")).toBeInTheDocument();
+  expect(screen.getByText(/No pending approvals/)).toBeInTheDocument();
+});
+
+test("shows the error state (with the message) when the poll failed and nothing is cached", () => {
+  useApprovals.mockReturnValue(state({ error: "boom", approvals: [] }));
+  renderPage();
+  expect(screen.getByText(/error: boom/)).toBeInTheDocument();
+});
+
+test("renders a row per pending approval with tool name + args preview", () => {
+  useApprovals.mockReturnValue(state({ approvals: [row()], count: 1 }));
+  renderPage();
+  expect(screen.getByText("1 pending")).toBeInTheDocument();
+  expect(screen.getByText("[approval required]")).toBeInTheDocument();
+  expect(screen.getByText("write_thing")).toBeInTheDocument();
+  expect(screen.getByText('{"value":"x"}')).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "approve" })).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "deny" })).toBeInTheDocument();
+});
+
+test("approve decides then refreshes the shared context", async () => {
+  const user = userEvent.setup();
+  const refresh = vi.fn().mockResolvedValue(undefined);
+  sendApprovalDecision.mockResolvedValue({ status: "approve" });
+  useApprovals.mockReturnValue(state({ approvals: [row()], count: 1, refresh }));
+  renderPage();
+
+  await user.click(screen.getByRole("button", { name: "approve" }));
+  expect(sendApprovalDecision).toHaveBeenCalledWith("ap1", "approve");
+  await waitFor(() => expect(refresh).toHaveBeenCalled());
+});
+
+test("deny decides('deny') then refreshes", async () => {
+  const user = userEvent.setup();
+  const refresh = vi.fn().mockResolvedValue(undefined);
+  sendApprovalDecision.mockResolvedValue({ status: "deny" });
+  useApprovals.mockReturnValue(state({ approvals: [row()], count: 1, refresh }));
+  renderPage();
+
+  await user.click(screen.getByRole("button", { name: "deny" }));
+  expect(sendApprovalDecision).toHaveBeenCalledWith("ap1", "deny");
+  await waitFor(() => expect(refresh).toHaveBeenCalled());
+});
+
+test("renders (no args) for a null-args approval", () => {
+  useApprovals.mockReturnValue(state({ approvals: [row({ args: null })], count: 1 }));
+  renderPage();
+  expect(screen.getByText("(no args)")).toBeInTheDocument();
+});
+
+test("ignores a second decide for the same approval while one is in flight", async () => {
+  const user = userEvent.setup();
+  let resolveDecide: (v: { status: string }) => void = () => {};
+  sendApprovalDecision.mockReturnValue(
+    new Promise((resolve) => {
+      resolveDecide = resolve;
+    })
+  );
+  const refresh = vi.fn().mockResolvedValue(undefined);
+  useApprovals.mockReturnValue(state({ approvals: [row()], count: 1, refresh }));
+  renderPage();
+
+  const approve = screen.getByRole("button", { name: "approve" });
+  await user.click(approve);
+  await user.click(approve); // second click while the first decide is still pending
+  expect(sendApprovalDecision).toHaveBeenCalledTimes(1);
+
+  resolveDecide({ status: "approve" });
+  await waitFor(() => expect(refresh).toHaveBeenCalled());
+});

--- a/apps/web/app/routes/_app.approvals.tsx
+++ b/apps/web/app/routes/_app.approvals.tsx
@@ -1,14 +1,106 @@
 import type { MetaFunction } from "@remix-run/react";
+import { useRef } from "react";
+import { ApprovalCard } from "~/components/chat/approval-card";
 import { EmptyState } from "~/components/empty-state";
+import { ResourcePanel } from "~/components/resource-panel";
+import { ErrorState } from "~/components/states";
+import { type PendingApproval, sendApprovalDecision } from "~/lib/approvals";
+import { useApprovals } from "~/lib/approvals-context";
 
 export const meta: MetaFunction = () => [{ title: "Approvals · tulipfarm" }];
 
-export default function ApprovalsPage() {
+const COMMAND = "tulipfarm approvals --pending";
+
+// One-line, truncated args preview for a list row — the standalone approver needs to see WHAT the
+// gated tool will do (the inline chat card shows only the tool name + countdown). Guards non-JSON.
+function describeArgs(args: unknown): string {
+  if (args == null) return "(no args)";
+  try {
+    return JSON.stringify(args);
+  } catch {
+    return "(unserializable args)";
+  }
+}
+
+function ApprovalRow({
+  item,
+  onDecide,
+}: {
+  item: PendingApproval;
+  onDecide: (approvalId: string, decision: "approve" | "deny") => void;
+}) {
+  const full = describeArgs(item.args);
+  const short = full.length > 160 ? `${full.slice(0, 160)}…` : full;
   return (
-    <EmptyState
-      section="approvals"
-      title="Approvals"
-      hint="Pending approvals from routines and agents will list here. Sidebar counts are placeholders in the V1 shell."
-    />
+    // toolCallId retained as the anchor for a future "jump to the originating conversation" link
+    // (chat rehydration-by-id is deferred in V1).
+    <li className="flex flex-col gap-1.5 px-3 py-3" data-tool-call-id={item.toolCallId}>
+      <ApprovalCard
+        toolName={item.toolName}
+        approval={{ approvalId: item.approvalId, status: "pending", expiresAt: item.expiresAt }}
+        onDecide={(decision) => onDecide(item.approvalId, decision)}
+      />
+      <p className="truncate font-mono text-xs text-muted-foreground" title={full}>
+        <span aria-hidden className="text-primary">
+          args{" "}
+        </span>
+        <span>{short}</span>
+      </p>
+    </li>
+  );
+}
+
+export default function ApprovalsPage() {
+  const { approvals, loading, error, refresh } = useApprovals();
+  // Approval ids with a decide POST in flight — guards a double-click from firing two decisions for
+  // the same id (the second would 404 against the already-settled registry entry).
+  const deciding = useRef<Set<string>>(new Set());
+
+  // Decide via the existing decide route, then reconcile the shared context so the badge + list
+  // update together. A 404 lost-race with the 5-min auto-deny is benign — the refresh drops the row.
+  const handleDecide = async (approvalId: string, decision: "approve" | "deny") => {
+    if (deciding.current.has(approvalId)) return;
+    deciding.current.add(approvalId);
+    try {
+      await sendApprovalDecision(approvalId, decision);
+    } catch {
+      // The approval-resolved SSE is the run's source of truth; the refresh below reconciles the list.
+    }
+    await refresh();
+    deciding.current.delete(approvalId);
+  };
+
+  if (loading && approvals.length === 0 && !error) {
+    return (
+      <ResourcePanel crumbs={[{ label: "approvals" }]} command={COMMAND}>
+        <p className="text-xs text-muted-foreground">loading…</p>
+      </ResourcePanel>
+    );
+  }
+
+  // Only blank the page for an error when there's nothing cached to show; otherwise prefer stale data.
+  if (error && approvals.length === 0) {
+    return <ErrorState section="approvals" command={COMMAND} message={error} />;
+  }
+
+  if (approvals.length === 0) {
+    return (
+      <EmptyState
+        section="approvals"
+        title="Approvals"
+        hint="No pending approvals. Gated tool calls awaiting a decision appear here (with full context in the chat that triggered them). Approvals are in-memory in V1 and clear on API restart."
+      />
+    );
+  }
+
+  return (
+    <ResourcePanel crumbs={[{ label: "approvals" }]} command={COMMAND}>
+      <p className="text-xs text-muted-foreground">{approvals.length} pending</p>
+      <ul className="flex flex-col divide-y divide-border rounded-sm border border-border">
+        {approvals.map((item) => (
+          <ApprovalRow key={item.approvalId} item={item} onDecide={handleDecide} />
+        ))}
+      </ul>
+    </ResourcePanel>
   );
 }

--- a/apps/web/app/routes/_app.tsx
+++ b/apps/web/app/routes/_app.tsx
@@ -1,14 +1,18 @@
 import { Outlet } from "@remix-run/react";
 import { AppSidebar } from "~/components/app-sidebar";
+import { ApprovalsProvider } from "~/lib/approvals-context";
 
-// Persistent shell: sidebar + main panel. Wraps every section route.
+// Persistent shell: sidebar + main panel. Wraps every section route. The ApprovalsProvider polls
+// pending approvals once for the whole shell, feeding both the sidebar badge and the Approvals page.
 export default function AppLayout() {
   return (
-    <div className="md:flex md:min-h-svh">
-      <AppSidebar />
-      <main className="min-h-[calc(100svh-3rem)] flex-1 overflow-auto md:min-h-svh">
-        <Outlet />
-      </main>
-    </div>
+    <ApprovalsProvider>
+      <div className="md:flex md:min-h-svh">
+        <AppSidebar />
+        <main className="min-h-[calc(100svh-3rem)] flex-1 overflow-auto md:min-h-svh">
+          <Outlet />
+        </main>
+      </div>
+    </ApprovalsProvider>
   );
 }


### PR DESCRIPTION
## feat(approvals): app-wide approvals surface — list page + live sidebar badge

Surfaces tool approvals beyond the inline chat card (shipped in #137): a standalone **Approvals**
sidebar page and a **live nav badge**, so an operator can see and resolve pending approvals from
anywhere in the shell — not just inside the chat stream that triggered them.

Refs **AGT-V1-002/003**, **UI-V1-003**.

### Why
The v0.16 inline approval round-trip only works inside the active chat stream you initiated. The
`ApprovalRegistry` exposed only `request()`/`decide()` — no way to *list* pending approvals, and no
global event channel for a badge. UI-V1-003 asks for an Approvals section with a live count. Because
the registry is a single process-global instance, approve/deny already resumes/cancels a run from
anywhere — only *listing* and *live counting* were missing, so this is a deliberately small slice.

### What changed
**Backend** (`apps/api/src/chat/`)
- `ApprovalRegistry` now retains `{toolName, args, expiresAt, createdAt}` per pending approval and
  exposes `listPending()` (oldest-first; settled/timed-out entries drop out for free).
- New `GET /api/v1/chat/approvals` (`requireAuth`) returning `{ items }`. The `args` field is
  **schemaless in the response schema** so `fast-json-stringify` passes non-object tool inputs
  (arrays/scalars) through intact instead of silently dropping/coercing them.
- Ephemeral / in-memory (no DB — durable audit table stays deferred). Decide route + inline card
  **unchanged**.

**Frontend** (`apps/web/app/`)
- `lib/approvals-context.tsx` — one `ApprovalsProvider` mounted in the `_app` shell polls every ~4s;
  the sidebar badge and the page both read this single context (`count = approvals.length`).
- `routes/_app.approvals.tsx` — rewritten from the stub into the list, **reusing `approval-card.tsx`
  unchanged** + an args context line; loading/empty/error/list states. Decide → `refresh()`.
- `components/app-sidebar.tsx` — `NavRow` reads the live count via `useApprovals()`; the hardcoded
  `badgeCounts` mock is removed.

### Testing
- `lint` 10/10 · `typecheck` 10/10 · **api 737** · **web 169** (all green, cache-busted).
- New: registry `listPending` (5), GET route (4), context poller w/ fake timers (7), page incl. a
  decide-concurrency guard (8), sidebar live-count/no-badge rewrite.
- Manual: chat (autonomy `approval-required`) → mutating tool → appears on the Approvals page + badge
  → approve resumes / deny cancels → row clears + badge decrements within ~4s; inline card unaffected;
  ~5-min item auto-denies and drops.

### Reviewed (independent pass, both fixed)
- Double-click on a row fired two decide POSTs → added a per-id in-flight guard (no `approval-card`
  change).
- Poller could `setState` after a real unmount → added a `mounted` ref guarding post-await writes.

### Known limitations (intentional, V1)
- Ephemeral (clears on API restart); ~4s staleness + brief ghost row at expiry.
- **No conversation back-link** — chat rehydration-by-id is deferred; `toolCallId` is kept on each row
  as the future-join anchor.
- Single-trust: lists all pending approvals incl. `args` (no per-user scope).
- No poller visibility/backoff gating; no global approvals SSE channel.