### PR TITLE
feat(skills): render <available-skills> from SkillRegistry (all-lazy V1)

### DIFF
--- a/apps/api/src/chat/routes.test.ts
+++ b/apps/api/src/chat/routes.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { LlmNotConfiguredError, type LlmService, UnknownModelError } from "@tulipfarm/llm";
+import type { SoulLoader } from "@tulipfarm/soul";
 import type { LanguageModelV1 } from "ai";
 import type { FastifyInstance, InjectOptions, LightMyRequestResponse } from "fastify";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -542,6 +543,46 @@ describe("chat routes", () => {
       const prompt = capturedPrompts[0] as Array<{ role: string; content: unknown }>;
       expect(prompt[0]?.role).toBe("system");
       expect(JSON.stringify(prompt[0]?.content)).toContain("<memory>\\n- plan: enterprise");
+    });
+
+    // Skills milestone — soul skills surface as the lazy L1 <available-skills> block (all-lazy V1).
+    it("lists soul skills in the assembled <available-skills> block", async () => {
+      await app.close();
+      const soulLoader = {
+        agents: new Map(),
+        skills: new Map([
+          [
+            "code-review",
+            {
+              name: "code-review",
+              frontmatter: { description: "Review code for bugs." },
+              body: "Review carefully.",
+            },
+          ],
+        ]),
+      } as unknown as SoulLoader;
+      app = await buildApp({
+        sessionStore: store,
+        userRepo,
+        tokenRepo,
+        llmService,
+        conversationRepo: repo,
+        messageRepo,
+        streamResumeRepo: streamRepo,
+        streamHub,
+        workingMemoryService: new WorkingMemoryService(workingMemoryRepo),
+        soulLoader,
+      });
+
+      const res = await post({ message: userMsg("hi") });
+      expect(res.statusCode).toBe(200);
+      await waitFor(() => capturedPrompts.length >= 1);
+
+      const prompt = capturedPrompts[0] as Array<{ role: string; content: unknown }>;
+      expect(prompt[0]?.role).toBe("system");
+      expect(JSON.stringify(prompt[0]?.content)).toContain(
+        "<available-skills>\\n- code-review: Review code for bugs."
+      );
     });
 
     it("404 when conversationId is not found", async () => {

--- a/apps/api/src/chat/routes.ts
+++ b/apps/api/src/chat/routes.ts
@@ -13,6 +13,7 @@ import { MAX_TOOL_STEPS } from "../memory/limits";
 import type { WorkingMemoryService } from "../memory/service";
 import { parsePaginationQuery } from "../pagination";
 import { resolveAgent } from "../soul/agents/registry";
+import { listAvailableSkills } from "../soul/skills/registry";
 import { BatchCoordinator } from "../tools/batch-executor";
 import type { ToolRegistry } from "../tools/registry";
 import type { ToolCallResult } from "../tools/types";
@@ -287,6 +288,7 @@ export function registerChatRoutes(
         personality: agent.body,
         memory: workingMemory ? await workingMemory.list(user._id) : [],
         governanceDocs: knowledge ? await knowledge.governanceDocuments() : [],
+        availableSkills: listAvailableSkills(soulLoader),
       });
       if (system) messages.push({ role: "system", content: system });
       messages.push(...history.items.map(toCoreMessage), {

--- a/apps/api/src/context/README.md
+++ b/apps/api/src/context/README.md
@@ -17,8 +17,8 @@ lazily fetched) makes the rendered prefix deterministic and therefore prompt-cac
 <agent-personality>       AGENT.md body
 <memory>                  per-user working memory, ≤ MAX_TOTAL_CHARS (drop whole on overflow)
 <governance-knowledge>    alwaysLoadForAgents docs (reuses knowledge/governance.ts, 4k/16k caps)
-<skills>                  "" — deferred (Skills v0.10)
-<available-skills>        "" — deferred (Skills v0.10)
+<skills>                  "" — eager bodies deferred (all-lazy V1; no agent eager-skill election yet)
+<available-skills>        lazy skill L1 — one `- name: description` per soul skill, 8k cap, drop-whole
 <soul-context>            "" — deferred (soul L1 snapshot builder)
 <available-tools>         "" — deferred (Tools v0.8)
 ```
@@ -27,6 +27,11 @@ Each block renders to a string or `""`. Empty blocks are **omitted entirely** (f
 the `\n` join), matching `buildGovernanceBlock`'s precedent — so the prefix stays byte-identical
 across turns when soul/memory don't change. No `<harness-typed-state>` block is ever emitted
 (deferred MEM-V1-005).
+
+`<available-skills>` is fed by the **SkillRegistry** (`../soul/skills/registry.ts` → `listAvailableSkills`),
+which projects every soul skill to its sorted L1 `{ name, description }`. All-lazy V1: the body (L2) and
+reference files (L3) load on demand via the `load_skill` / `load_skill_reference` platform tools; eager
+`<skills>` bodies are deferred.
 
 ## Why deterministic order matters
 

--- a/apps/api/src/context/assemble.test.ts
+++ b/apps/api/src/context/assemble.test.ts
@@ -178,12 +178,60 @@ describe("assembleSystemPrompt — governance", () => {
   });
 });
 
+describe("assembleSystemPrompt — available-skills (lazy L1)", () => {
+  it("renders one `- name: description` line per skill, in given order", () => {
+    const out = assembleSystemPrompt(
+      baseCtx({
+        availableSkills: [
+          { name: "code-review", description: "Review code for bugs." },
+          { name: "data-export", description: "Export resources to CSV." },
+        ],
+      })
+    );
+    expect(out).toContain(
+      "<available-skills>\n- code-review: Review code for bugs.\n- data-export: Export resources to CSV.\n</available-skills>"
+    );
+  });
+
+  it("renders just `- name` when a skill has no description", () => {
+    const out = assembleSystemPrompt(
+      baseCtx({ availableSkills: [{ name: "bare", description: "" }] })
+    );
+    expect(out).toContain("<available-skills>\n- bare\n</available-skills>");
+  });
+
+  it("omits the block when there are no skills (unset or empty)", () => {
+    expect(assembleSystemPrompt(baseCtx())).not.toContain("<available-skills>");
+    expect(assembleSystemPrompt(baseCtx({ availableSkills: [] }))).not.toContain(
+      "<available-skills>"
+    );
+  });
+
+  it("drops the whole block when over the char budget (never half-rendered)", () => {
+    const huge = "x".repeat(9000);
+    const out = assembleSystemPrompt(
+      baseCtx({ availableSkills: [{ name: "big", description: huge }] })
+    );
+    expect(out).not.toContain("<available-skills>");
+  });
+
+  it("renders after <governance-knowledge> (CONTEXT-ENGINE §1 order)", () => {
+    const out = assembleSystemPrompt(
+      baseCtx({
+        governanceDocs: [govDoc("Policy", "Be compliant.")],
+        availableSkills: [{ name: "code-review", description: "Review code." }],
+      })
+    );
+    expect(out.indexOf("<governance-knowledge>")).toBeLessThan(out.indexOf("<available-skills>"));
+  });
+});
+
 describe("assembleSystemPrompt — deferred + typed-state (AC-V1-003)", () => {
   it("omits the deferred skills/tools/soul-context blocks entirely", () => {
     const out = assembleSystemPrompt(
       baseCtx({ agentId: "sales", memory: [mem("plan", "enterprise")] })
     );
-    for (const tag of ["<skills>", "<available-skills>", "<soul-context>", "<available-tools>"]) {
+    for (const tag of ["<skills>", "<soul-context>", "<available-tools>"]) {
       expect(out).not.toContain(tag);
     }
   });

--- a/apps/api/src/context/assemble.ts
+++ b/apps/api/src/context/assemble.ts
@@ -2,6 +2,7 @@ import { buildGovernanceBlock } from "../knowledge/governance";
 import type { KnowledgeDocument } from "../knowledge/types";
 import { MAX_TOTAL_CHARS } from "../memory/limits";
 import type { WorkingMemoryDoc } from "../memory/working-memory";
+import type { AvailableSkill } from "../soul/skills/registry";
 
 /**
  * Resolved inputs for one turn's system prompt. `assembleSystemPrompt` is pure — the caller
@@ -25,6 +26,12 @@ export interface AssembleContext {
   memory: WorkingMemoryDoc[];
   /** Active `alwaysLoadForAgents` knowledge docs (KN-V1-005). */
   governanceDocs: KnowledgeDocument[];
+  /**
+   * Lazy skill L1 index for `<available-skills>` — every soul skill's name + description, from the
+   * SkillRegistry (`soul/skills/registry.ts`). All-lazy V1: the agent pulls a skill's body (L2) on
+   * demand via `load_skill`. Eager `<skills>` bodies are deferred. Unset → block omitted.
+   */
+  availableSkills?: AvailableSkill[];
 }
 
 function block(tag: string, body: string): string {
@@ -64,12 +71,36 @@ function renderMemory(ctx: AssembleContext): string {
 }
 
 /**
+ * `<available-skills>` budget — total chars across all `name`+`description` pairs. Over this the whole
+ * block is dropped (never half-rendered) so the cacheable prefix can't drift mid-block, matching
+ * `renderMemory`. Defensive: V1 skill counts sit well under it.
+ */
+const MAX_AVAILABLE_SKILLS_CHARS = 8000;
+
+/**
+ * `<available-skills>` block (SKILLS.md, CONTEXT-ENGINE §1). The lazy skill L1 index: one
+ * `- name: description` line per soul skill (just `- name` when the skill declares no description),
+ * in the registry's sorted order. The agent loads a skill's body (L2) on demand via `load_skill`.
+ * Omitted entirely when no skills are available; dropped whole when over budget.
+ */
+function renderAvailableSkills(ctx: AssembleContext): string {
+  const skills = ctx.availableSkills ?? [];
+  if (skills.length === 0) return "";
+  const total = skills.reduce((n, s) => n + s.name.length + s.description.length, 0);
+  if (total > MAX_AVAILABLE_SKILLS_CHARS) return "";
+  const body = skills
+    .map((s) => (s.description ? `- ${s.name}: ${s.description}` : `- ${s.name}`))
+    .join("\n");
+  return block("available-skills", body);
+}
+
+/**
  * Assemble the agent system prompt from the 9 ordered blocks (specs/CONTEXT-ENGINE.md §1). Pure
  * and synchronous. Each block renders to a string or "" (when empty, over budget, or deferred);
- * empty blocks are omitted entirely so the prefix stays byte-stable across turns. The deferred
- * blocks — `<skills>`, `<available-skills>`, `<soul-context>`, `<available-tools>` — emit empty
- * until Skills (v0.10), the soul L1 snapshot, and Tools (v0.8) land. No `<harness-typed-state>`
- * block is ever emitted (deferred MEM-V1-005, AC-V1-003).
+ * empty blocks are omitted entirely so the prefix stays byte-stable across turns. `<available-skills>`
+ * renders the lazy skill L1 index (all-lazy V1); the still-deferred blocks — `<skills>` (eager bodies),
+ * `<soul-context>`, `<available-tools>` — emit empty until eager skills, the soul L1 snapshot, and Tools
+ * land. No `<harness-typed-state>` block is ever emitted (deferred MEM-V1-005, AC-V1-003).
  */
 export function assembleSystemPrompt(ctx: AssembleContext): string {
   const blocks = [
@@ -80,8 +111,8 @@ export function assembleSystemPrompt(ctx: AssembleContext): string {
     // V1: governance is tenant-wide. `domain` is display-only on the agent (AGT-V1-007), so it
     // feeds <agent-identity> but does NOT scope governance — preserving prior behavior.
     buildGovernanceBlock(ctx.governanceDocs, null),
-    "", // <skills> — deferred (Skills v0.10)
-    "", // <available-skills> — deferred (Skills v0.10)
+    "", // <skills> — eager bodies deferred (all-lazy V1; no agent eager-skill election yet)
+    renderAvailableSkills(ctx),
     "", // <soul-context> — deferred (soul L1 snapshot builder)
     "", // <available-tools> — deferred (Tools v0.8)
   ];

--- a/apps/api/src/soul/skills/registry.test.ts
+++ b/apps/api/src/soul/skills/registry.test.ts
@@ -1,0 +1,47 @@
+import type { SoulLoader, SoulSkill } from "@tulipfarm/soul";
+import { describe, expect, it } from "vitest";
+import { type AvailableSkill, listAvailableSkills } from "./registry";
+
+function skill(name: string, frontmatter: Record<string, unknown> = {}, body = ""): SoulSkill {
+  return { name, frontmatter, body };
+}
+
+function makeSoulLoader(skills: SoulSkill[] = []): SoulLoader {
+  return { skills: new Map(skills.map((s) => [s.name, s])) } as unknown as SoulLoader;
+}
+
+describe("listAvailableSkills", () => {
+  it("projects each soul skill to its L1 name + description", () => {
+    const out = listAvailableSkills(
+      makeSoulLoader([skill("code-review", { description: "Review code for bugs." })])
+    );
+    expect(out).toEqual<AvailableSkill[]>([
+      { name: "code-review", description: "Review code for bugs." },
+    ]);
+  });
+
+  it("falls back to an empty description when frontmatter has none or it is not a string", () => {
+    const out = listAvailableSkills(
+      makeSoulLoader([skill("no-desc"), skill("bad-desc", { description: 42 })])
+    );
+    expect(out).toEqual<AvailableSkill[]>([
+      { name: "bad-desc", description: "" },
+      { name: "no-desc", description: "" },
+    ]);
+  });
+
+  it("sorts by name for a deterministic prompt-cache prefix (AC-V1-001)", () => {
+    const out = listAvailableSkills(
+      makeSoulLoader([skill("zebra"), skill("alpha"), skill("mango")])
+    );
+    expect(out.map((s) => s.name)).toEqual(["alpha", "mango", "zebra"]);
+  });
+
+  it("returns [] when the soul loader is absent", () => {
+    expect(listAvailableSkills(undefined)).toEqual([]);
+  });
+
+  it("returns [] when there are no skills", () => {
+    expect(listAvailableSkills(makeSoulLoader([]))).toEqual([]);
+  });
+});

--- a/apps/api/src/soul/skills/registry.ts
+++ b/apps/api/src/soul/skills/registry.ts
@@ -1,0 +1,32 @@
+import type { SoulLoader } from "@tulipfarm/soul";
+
+/**
+ * One skill projected to its L1 surface — `name` + `description` — for the `<available-skills>`
+ * prompt block (specs/CONTEXT-ENGINE.md §1, SKILLS.md). The body (L2) and reference files (L3) are
+ * NOT included here; the agent pulls them on demand via the `load_skill` / `load_skill_reference`
+ * platform tools.
+ */
+export interface AvailableSkill {
+  name: string;
+  description: string;
+}
+
+/**
+ * The SkillRegistry (Skills milestone). Projects every soul skill into its lazy L1 surface for the
+ * `<available-skills>` block. V1 is shared + lazy only: no per-agent filtering (flat ALLOW_ALL —
+ * there is no skill-level ACL in V1, GAP-SKL-001) and no eager `<skills>` election (deferred).
+ *
+ * Sorted by name so the assembled prompt prefix is byte-stable across restarts — `SoulLoader.skills`
+ * is keyed in OS `readdir` order, which sorting normalizes (AC-V1-001). `description` comes from the
+ * SKILL.md frontmatter; a missing or non-string value renders as an empty description.
+ */
+export function listAvailableSkills(soulLoader: SoulLoader | undefined): AvailableSkill[] {
+  if (!soulLoader) return [];
+  return Array.from(soulLoader.skills.values())
+    .map((skill) => ({
+      name: skill.name,
+      description:
+        typeof skill.frontmatter.description === "string" ? skill.frontmatter.description : "",
+    }))
+    .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+}


### PR DESCRIPTION
Add the SkillRegistry seam that projects soul skills into the agent system prompt as the lazy L1 <available-skills> block (one sorted `- name: description` line per skill). The body (L2) and reference files (L3) load on demand via the existing load_skill / load_skill_reference platform tools.

All-lazy V1: eager <skills> bodies and agent-declared eager lists are deferred (SKILL.md stays pure-Claude-format; no agent eager-skill election yet).

- soul/skills/registry.ts: listAvailableSkills(soulLoader) -> sorted L1 projection
- context/assemble.ts: renderAvailableSkills (omit-empty, 8k cap, drop-whole) fills the stub at the <available-skills> slot
- chat/routes.ts: wire availableSkills into assembleSystemPrompt
- tests: registry (5), assemble (+5), routes wiring (+1); api 748 green (lint/typecheck/test all pass)