### PR TITLE
chore(deps): upgrade ai-sdk v4 → v6

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -20,7 +20,7 @@
     "@tulipfarm/secrets": "workspace:*",
     "@tulipfarm/soul": "workspace:*",
     "@tulipfarm/validation": "workspace:*",
-    "ai": "^4",
+    "ai": "^6",
     "dotenv": "^17.4.2",
     "fastify": "^5.8.5",
     "isolated-vm": "^7.0.0",
@@ -29,6 +29,7 @@
     "yaml": "^2.9.0"
   },
   "devDependencies": {
+    "@ai-sdk/provider": "^3",
     "@electric-sql/pglite": "^0.2.0",
     "@tulipfarm/tsconfig": "workspace:*",
     "@types/pg": "^8.11.0",

--- a/apps/api/src/chat/messages.test.ts
+++ b/apps/api/src/chat/messages.test.ts
@@ -8,7 +8,7 @@ import {
   fromAssistantText,
   fromToolResult,
   fromUserText,
-  toCoreMessage,
+  toModelMessage,
 } from "./messages";
 
 describe("assertValidMessage — legal cases", () => {
@@ -105,22 +105,22 @@ describe("assertValidMessage — illegal cases", () => {
   });
 });
 
-describe("toCoreMessage", () => {
+describe("toModelMessage", () => {
   const base = { _id: "m1", conversationId: "conv1", createdAt: new Date() };
 
   it("maps user string → { role, content: string }", () => {
     const doc: MessageDoc = { ...base, role: "user", content: "hi" };
-    expect(toCoreMessage(doc)).toEqual({ role: "user", content: "hi" });
+    expect(toModelMessage(doc)).toEqual({ role: "user", content: "hi" });
   });
 
   it("maps system string → { role, content: string }", () => {
     const doc: MessageDoc = { ...base, role: "system", content: "be nice" };
-    expect(toCoreMessage(doc)).toEqual({ role: "system", content: "be nice" });
+    expect(toModelMessage(doc)).toEqual({ role: "system", content: "be nice" });
   });
 
   it("maps assistant string → assistant message", () => {
     const doc: MessageDoc = { ...base, role: "assistant", content: "Hello" };
-    expect(toCoreMessage(doc)).toEqual({ role: "assistant", content: "Hello" });
+    expect(toModelMessage(doc)).toEqual({ role: "assistant", content: "Hello" });
   });
 
   it("maps assistant [text, tool-call] → assistant with matching parts", () => {
@@ -132,11 +132,11 @@ describe("toCoreMessage", () => {
         { type: "tool-call", toolCallId: "c1", toolName: "search", args: { q: "x" } },
       ],
     };
-    expect(toCoreMessage(doc)).toEqual({
+    expect(toModelMessage(doc)).toEqual({
       role: "assistant",
       content: [
         { type: "text", text: "let me look" },
-        { type: "tool-call", toolCallId: "c1", toolName: "search", args: { q: "x" } },
+        { type: "tool-call", toolCallId: "c1", toolName: "search", input: { q: "x" } },
       ],
     });
   });
@@ -149,10 +149,15 @@ describe("toCoreMessage", () => {
         { type: "tool-result", toolCallId: "c1", toolName: "search", result: { ok: true } },
       ],
     };
-    expect(toCoreMessage(doc)).toEqual({
+    expect(toModelMessage(doc)).toEqual({
       role: "tool",
       content: [
-        { type: "tool-result", toolCallId: "c1", toolName: "search", result: { ok: true } },
+        {
+          type: "tool-result",
+          toolCallId: "c1",
+          toolName: "search",
+          output: { type: "json", value: { ok: true } },
+        },
       ],
     });
   });
@@ -196,7 +201,13 @@ describe("fromAssistantParts / fromToolResult", () => {
     expect(doc.role).toBe("assistant");
     expect(doc.content).toEqual(parts);
     expect(() => assertValidMessage(doc.role, doc.content)).not.toThrow();
-    expect(toCoreMessage(doc)).toEqual({ role: "assistant", content: parts });
+    expect(toModelMessage(doc)).toEqual({
+      role: "assistant",
+      content: [
+        { type: "text", text: "saving that" },
+        { type: "tool-call", toolCallId: "c1", toolName: "update_memory", input: { key: "plan" } },
+      ],
+    });
   });
 
   it("fromToolResult builds a valid tool turn that round-trips", () => {
@@ -212,6 +223,16 @@ describe("fromAssistantParts / fromToolResult", () => {
     expect(doc.role).toBe("tool");
     expect(doc.content).toEqual(parts);
     expect(() => assertValidMessage(doc.role, doc.content)).not.toThrow();
-    expect(toCoreMessage(doc)).toEqual({ role: "tool", content: parts });
+    expect(toModelMessage(doc)).toEqual({
+      role: "tool",
+      content: [
+        {
+          type: "tool-result",
+          toolCallId: "c1",
+          toolName: "update_memory",
+          output: { type: "json", value: { success: true } },
+        },
+      ],
+    });
   });
 });

--- a/apps/api/src/chat/messages.ts
+++ b/apps/api/src/chat/messages.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import type { CoreMessage, TextPart, ToolCallPart, ToolResultPart } from "ai";
+import type { ModelMessage, TextPart, ToolCallPart, ToolResultPart } from "ai";
 import type { Queryable } from "../db";
 import { type PaginatedResult, toPage } from "../pagination";
 
@@ -28,7 +28,7 @@ export class InvalidMessageError extends Error {
 
 /**
  * Enforces the per-role content constraints from the design spec (§3) so that no
- * document that cannot round-trip to a `CoreMessage` is ever persisted.
+ * document that cannot round-trip to a `ModelMessage` is ever persisted.
  */
 export function assertValidMessage(role: MessageRole, content: string | MessagePart[]): void {
   const isString = typeof content === "string";
@@ -68,11 +68,11 @@ export function assertValidMessage(role: MessageRole, content: string | MessageP
 }
 
 /**
- * Maps a stored `MessageDoc` to the AI SDK's `CoreMessage`, resolving the SDK's
+ * Maps a stored `MessageDoc` to the AI SDK's `ModelMessage`, resolving the SDK's
  * per-role content rules (spec §6.1). Relies on the write-time validation above
  * so it never meets an illegal state.
  */
-export function toCoreMessage(doc: MessageDoc): CoreMessage {
+export function toModelMessage(doc: MessageDoc): ModelMessage {
   const { role, content } = doc;
 
   if (role === "system" || role === "user") {
@@ -93,7 +93,7 @@ export function toCoreMessage(doc: MessageDoc): CoreMessage {
           type: "tool-call",
           toolCallId: part.toolCallId,
           toolName: part.toolName,
-          args: part.args,
+          input: part.args,
         });
       }
     }
@@ -109,7 +109,7 @@ export function toCoreMessage(doc: MessageDoc): CoreMessage {
           type: "tool-result",
           toolCallId: part.toolCallId,
           toolName: part.toolName,
-          result: part.result,
+          output: { type: "json" as const, value: part.result as import("ai").JSONValue },
         });
       }
     }

--- a/apps/api/src/chat/producer.test.ts
+++ b/apps/api/src/chat/producer.test.ts
@@ -58,12 +58,12 @@ const log = { error: vi.fn() };
 
 describe("mapStreamPart", () => {
   it("maps the client-relevant parts", () => {
-    expect(mapStreamPart({ type: "text-delta", textDelta: "Hi" })).toEqual({
+    expect(mapStreamPart({ type: "text-delta", text: "Hi" })).toEqual({
       eventType: "text",
       data: { delta: "Hi" },
     });
     expect(
-      mapStreamPart({ type: "tool-call", toolCallId: "c1", toolName: "t", args: { a: 1 } })
+      mapStreamPart({ type: "tool-call", toolCallId: "c1", toolName: "t", input: { a: 1 } })
     ).toEqual({
       eventType: "tool-call",
       data: { toolCallId: "c1", toolName: "t", args: { a: 1 } },
@@ -96,7 +96,7 @@ describe("mapStreamPart", () => {
       const cache = new Map([["c1", full]]);
       expect(
         mapStreamPart(
-          { type: "tool-result", toolCallId: "c1", toolName: "list_things", result: truncated },
+          { type: "tool-result", toolCallId: "c1", toolName: "list_things", output: truncated },
           cache
         )
       ).toEqual({
@@ -109,7 +109,7 @@ describe("mapStreamPart", () => {
       const cache = new Map<string, import("../tools/types").ToolCallResult>();
       expect(
         mapStreamPart(
-          { type: "tool-result", toolCallId: "c2", toolName: "list_things", result: truncated },
+          { type: "tool-result", toolCallId: "c2", toolName: "list_things", output: truncated },
           cache
         )
       ).toEqual({
@@ -120,7 +120,7 @@ describe("mapStreamPart", () => {
 
     it("without cache: uses SDK result directly", () => {
       expect(
-        mapStreamPart({ type: "tool-result", toolCallId: "c3", toolName: "t", result: truncated })
+        mapStreamPart({ type: "tool-result", toolCallId: "c3", toolName: "t", output: truncated })
       ).toEqual({
         eventType: "tool-result",
         data: { toolCallId: "c3", toolName: "t", result: truncated },
@@ -148,8 +148,8 @@ describe("runChatStream", () => {
     await runChatStream(
       streamId,
       fromArray([
-        { type: "text-delta", textDelta: "He" },
-        { type: "text-delta", textDelta: "llo" },
+        { type: "text-delta", text: "He" },
+        { type: "text-delta", text: "llo" },
         { type: "finish", finishReason: "stop" },
       ]),
       { emitter: makeStreamEmitter(streamId, { repo, hub, log }), hub, log }
@@ -162,7 +162,7 @@ describe("runChatStream", () => {
   });
 
   it("synthesises a finish when the stream ends without a terminal", async () => {
-    await runChatStream(streamId, fromArray([{ type: "text-delta", textDelta: "x" }]), {
+    await runChatStream(streamId, fromArray([{ type: "text-delta", text: "x" }]), {
       emitter: makeStreamEmitter(streamId, { repo, hub, log }),
       hub,
       log,
@@ -173,7 +173,7 @@ describe("runChatStream", () => {
 
   it("emits a terminal error and finishes the hub when iteration throws", async () => {
     async function* boom(): AsyncIterable<unknown> {
-      yield { type: "text-delta", textDelta: "partial" };
+      yield { type: "text-delta", text: "partial" };
       throw new Error("provider exploded");
     }
     await runChatStream(streamId, boom(), {
@@ -237,10 +237,10 @@ describe("attachToStream", () => {
     hub.register(streamId);
     const gate = deferred();
     async function* gated(): AsyncIterable<unknown> {
-      yield { type: "text-delta", textDelta: "one" };
-      yield { type: "text-delta", textDelta: "two" };
+      yield { type: "text-delta", text: "one" };
+      yield { type: "text-delta", text: "two" };
       await gate.promise;
-      yield { type: "text-delta", textDelta: "three" };
+      yield { type: "text-delta", text: "three" };
       yield { type: "finish", finishReason: "stop" };
     }
     void runChatStream(streamId, gated(), {

--- a/apps/api/src/chat/producer.ts
+++ b/apps/api/src/chat/producer.ts
@@ -23,15 +23,15 @@ export function mapStreamPart(
   const p = part as Record<string, unknown>;
   switch (p.type) {
     case "text-delta":
-      return { eventType: "text", data: { delta: p.textDelta } };
+      return { eventType: "text", data: { delta: p.text } };
     case "tool-call":
       return {
         eventType: "tool-call",
-        data: { toolCallId: p.toolCallId, toolName: p.toolName, args: p.args },
+        data: { toolCallId: p.toolCallId, toolName: p.toolName, args: p.input },
       };
     case "tool-result": {
       const toolCallId = p.toolCallId as string;
-      const result = fullResultCache?.get(toolCallId) ?? p.result;
+      const result = fullResultCache?.get(toolCallId) ?? p.output;
       return {
         eventType: "tool-result",
         data: { toolCallId, toolName: p.toolName, result },

--- a/apps/api/src/chat/routes.test.ts
+++ b/apps/api/src/chat/routes.test.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
+import type { LanguageModelV3 } from "@ai-sdk/provider";
 import { LlmNotConfiguredError, type LlmService, UnknownModelError } from "@tulipfarm/llm";
 import type { SoulLoader } from "@tulipfarm/soul";
-import type { LanguageModelV1 } from "ai";
 import type { FastifyInstance, InjectOptions, LightMyRequestResponse } from "fastify";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildApp } from "../app";
@@ -30,14 +30,28 @@ const TEST_CSRF = "a".repeat(64);
 // on each call, so history-rebuild assertions can inspect the outgoing messages.
 const capturedPrompts: unknown[][] = [];
 
-// ── Deterministic fake LanguageModelV1 (no network) ───────────────────────────
-// Yields v4 stream parts: one text-delta then a finish part, so streamText
+const V3_USAGE = {
+  inputTokens: { total: 1, noCache: undefined, cacheRead: undefined, cacheWrite: undefined },
+  outputTokens: { total: 1, reasoning: undefined },
+};
+
+// ── Deterministic fake LanguageModelV3 (no network) ───────────────────────────
+// Yields V3 stream parts: text-start/delta/end then a finish part, so streamText
 // produces text "Hello" and onFinish fires with { text: "Hello" }.
 function makeStreamResult(textDeltas: string[]) {
-  const chunks = [
-    ...textDeltas.map((textDelta) => ({ type: "text-delta", textDelta })),
-    { type: "finish", finishReason: "stop", usage: { promptTokens: 1, completionTokens: 1 } },
-  ];
+  const chunks: unknown[] = [];
+  textDeltas.forEach((delta, idx) => {
+    chunks.push(
+      { type: "text-start", id: `t${idx}` },
+      { type: "text-delta", id: `t${idx}`, delta },
+      { type: "text-end", id: `t${idx}` }
+    );
+  });
+  chunks.push({
+    type: "finish",
+    finishReason: { unified: "stop", raw: undefined },
+    usage: V3_USAGE,
+  });
   let i = 0;
   const stream = new ReadableStream({
     pull(controller) {
@@ -45,14 +59,14 @@ function makeStreamResult(textDeltas: string[]) {
       else controller.close();
     },
   });
-  return { stream, rawCall: { rawPrompt: null, rawSettings: {} } };
+  return { stream };
 }
 
-// Stream that emits one delta then an error part — how a v4 provider signals a
-// mid-stream failure (finishReason "error"); proves the assistant reply is not persisted.
+// Stream that emits one delta then an error part — proves the assistant reply is not persisted.
 function makeErrorStreamResult() {
-  const chunks = [
-    { type: "text-delta", textDelta: "partial" },
+  const chunks: unknown[] = [
+    { type: "text-start", id: "t0" },
+    { type: "text-delta", id: "t0", delta: "partial" },
     { type: "error", error: new Error("provider exploded") },
   ];
   let i = 0;
@@ -62,26 +76,25 @@ function makeErrorStreamResult() {
       else controller.close();
     },
   });
-  return { stream, rawCall: { rawPrompt: null, rawSettings: {} } };
+  return { stream };
 }
 
-// Stream that emits provider-level tool-call parts (args is a JSON string) then a tool-calls finish,
+// Stream that emits provider-level tool-call parts then a tool-calls finish,
 // so streamText invokes the bound tool's execute and (with maxSteps>1) requests a continuation.
 function makeToolCallStreamResult(
   toolCalls: Array<{ toolCallId: string; toolName: string; args: unknown }>
 ) {
-  const chunks = [
+  const chunks: unknown[] = [
     ...toolCalls.map((tc) => ({
       type: "tool-call",
-      toolCallType: "function",
       toolCallId: tc.toolCallId,
       toolName: tc.toolName,
-      args: JSON.stringify(tc.args),
+      input: JSON.stringify(tc.args),
     })),
     {
       type: "finish",
-      finishReason: "tool-calls",
-      usage: { promptTokens: 1, completionTokens: 1 },
+      finishReason: { unified: "tool-calls", raw: undefined },
+      usage: V3_USAGE,
     },
   ];
   let i = 0;
@@ -91,18 +104,18 @@ function makeToolCallStreamResult(
       else controller.close();
     },
   });
-  return { stream, rawCall: { rawPrompt: null, rawSettings: {} } };
+  return { stream };
 }
 
 function makeFakeModel(
   modelId: string,
   stream: () => ReturnType<typeof makeStreamResult> = () => makeStreamResult(["Hello"])
-): LanguageModelV1 {
+): LanguageModelV3 {
   return {
-    specificationVersion: "v1",
+    specificationVersion: "v3",
     provider: "test",
     modelId,
-    defaultObjectGenerationMode: undefined,
+    supportedUrls: {},
     doStream: vi.fn(async (options: { prompt: unknown[] }) => {
       capturedPrompts.push(options.prompt);
       return stream();
@@ -110,14 +123,14 @@ function makeFakeModel(
     doGenerate: vi.fn(async () => {
       throw new Error("doGenerate unused");
     }),
-  } as unknown as LanguageModelV1;
+  } as unknown as LanguageModelV3;
 }
 
 // Model that calls a tool on its first step, then returns text on the continuation step.
 function makeToolThenTextModel(
   toolCalls: Array<{ toolCallId: string; toolName: string; args: unknown }>,
   followupText: string
-): LanguageModelV1 {
+): LanguageModelV3 {
   let call = 0;
   return makeFakeModel("claude-opus-4-8", () => {
     call += 1;

--- a/apps/api/src/chat/routes.ts
+++ b/apps/api/src/chat/routes.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import type { EventEmitter } from "node:events";
 import { LlmNotConfiguredError, type LlmService, UnknownModelError } from "@tulipfarm/llm";
 import type { SoulLoader } from "@tulipfarm/soul";
-import { type CoreMessage, streamText } from "ai";
+import { type ModelMessage, streamText } from "ai";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { ErrorSchema } from "../auth/schemas";
 import type { UserDoc } from "../auth/users";
@@ -26,7 +26,7 @@ import {
   fromAssistantText,
   fromToolResult,
   fromUserText,
-  toCoreMessage,
+  toModelMessage,
 } from "./messages";
 import { attachToStream, runChatStream } from "./producer";
 import { MessageSchema } from "./schemas";
@@ -116,8 +116,8 @@ export function parseLastEventId(
 interface PersistableStep {
   text: string;
   finishReason: string;
-  toolCalls: ReadonlyArray<{ toolCallId: string; toolName: string; args: unknown }>;
-  toolResults: ReadonlyArray<{ toolCallId: string; toolName: string; result: unknown }>;
+  toolCalls: ReadonlyArray<{ toolCallId: string; toolName: string; input: unknown }>;
+  toolResults: ReadonlyArray<{ toolCallId: string; toolName: string; output: unknown }>;
 }
 
 /**
@@ -141,7 +141,7 @@ export async function persistStep(
         type: "tool-call",
         toolCallId: tc.toolCallId,
         toolName: tc.toolName,
-        args: tc.args,
+        args: tc.input,
       });
     }
     await messageRepo.create(fromAssistantParts(conversationId, parts)).catch(onError);
@@ -151,7 +151,7 @@ export async function persistStep(
         type: "tool-result",
         toolCallId: tr.toolCallId,
         toolName: tr.toolName,
-        result: tr.result,
+        result: tr.output,
       }));
       await messageRepo.create(fromToolResult(conversationId, resultParts)).catch(onError);
     }
@@ -267,7 +267,7 @@ export function registerChatRoutes(
           conversationId: convo._id,
           userId: user._id,
           requestedModel: body.model,
-          resolvedModelId: selected.modelId,
+          resolvedModelId: (selected as { modelId?: string }).modelId ?? "",
           isNewConversation: isNew,
         }),
         "chat turn"
@@ -277,7 +277,7 @@ export function registerChatRoutes(
       //    prompt is reconstructed every turn from durable stores in a fixed block order
       //    (CONTEXT-ENGINE §1), so the cacheable prefix is byte-stable across turns (AC-V1-001).
       const history = await messageRepo.listByConversation(convo._id, 1000);
-      const messages: CoreMessage[] = [];
+      const messages: ModelMessage[] = [];
       const agent = resolveAgent(soulLoader, convo.agentId);
       const agentDomain =
         typeof agent.frontmatter.domain === "string" ? agent.frontmatter.domain : null;
@@ -291,7 +291,7 @@ export function registerChatRoutes(
         availableSkills: listAvailableSkills(soulLoader),
       });
       if (system) messages.push({ role: "system", content: system });
-      messages.push(...history.items.map(toCoreMessage), {
+      messages.push(...history.items.map(toModelMessage), {
         role: "user",
         content: body.message.content,
       });
@@ -326,7 +326,7 @@ export function registerChatRoutes(
         model: selected,
         messages,
         tools,
-        maxSteps: MAX_TOOL_STEPS,
+        stopWhen: ({ steps }) => steps.length >= MAX_TOOL_STEPS,
         onError: ({ error }) => {
           req.log.error({ err: error, conversationId: convo._id }, "chat stream error");
         },

--- a/apps/api/src/tools/registry.ts
+++ b/apps/api/src/tools/registry.ts
@@ -59,7 +59,7 @@ export class ToolRegistry {
         t.name,
         tool({
           description: t.description,
-          parameters: jsonSchema(t.inputSchema as Parameters<typeof jsonSchema>[0]),
+          inputSchema: jsonSchema(t.inputSchema as Parameters<typeof jsonSchema>[0]),
           execute: async (args: unknown, opts: { toolCallId: string }) => {
             const v = this.validators.get(t.name) ?? ajv.compile(t.inputSchema);
             if (!v(args)) return err("validation_error", firstArgError(v.errors));

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -9,11 +9,12 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "ai": "^4",
-    "@ai-sdk/anthropic": "^1",
-    "@ai-sdk/azure": "^1",
-    "@ai-sdk/openai": "^1",
-    "@ai-sdk/openai-compatible": "^0",
+    "ai": "^6",
+    "@ai-sdk/anthropic": "^3",
+    "@ai-sdk/azure": "^3",
+    "@ai-sdk/openai": "^3",
+    "@ai-sdk/openai-compatible": "^2",
+    "@ai-sdk/provider": "^3",
     "@sinclair/typebox": "^0.34",
     "@tulipfarm/secrets": "workspace:*",
     "@tulipfarm/validation": "workspace:*"

--- a/packages/llm/src/embedding-provider.ts
+++ b/packages/llm/src/embedding-provider.ts
@@ -14,7 +14,7 @@ import { resolveApiKey } from "./provider";
 export async function createEmbeddingModel(
   entry: EmbeddingProviderEntry,
   secrets: SecretsService
-): Promise<EmbeddingModel<string>> {
+): Promise<EmbeddingModel> {
   const apiKey = await resolveApiKey(entry.api_key_ref, secrets);
 
   switch (entry.provider) {

--- a/packages/llm/src/embeddings.ts
+++ b/packages/llm/src/embeddings.ts
@@ -15,7 +15,7 @@ export interface EmbeddingLogger {
 
 interface ActiveEmbedder {
   entry: EmbeddingProviderEntry;
-  model: EmbeddingModel<string>;
+  model: EmbeddingModel;
   dimension: number | null;
 }
 

--- a/packages/llm/src/fallback.test.ts
+++ b/packages/llm/src/fallback.test.ts
@@ -1,13 +1,9 @@
-import {
-  APICallError,
-  type LanguageModelV1,
-  type LanguageModelV1CallOptions,
-  LoadAPIKeyError,
-} from "ai";
+import type { LanguageModelV3, LanguageModelV3CallOptions } from "@ai-sdk/provider";
+import { APICallError, LoadAPIKeyError } from "ai";
 import { describe, expect, it, vi } from "vitest";
 import { FallbackModel, isHardFailure } from "./fallback";
 
-const opts = {} as LanguageModelV1CallOptions;
+const opts = {} as LanguageModelV3CallOptions;
 
 function apiError(statusCode: number, isRetryable: boolean): APICallError {
   return new APICallError({
@@ -20,16 +16,17 @@ function apiError(statusCode: number, isRetryable: boolean): APICallError {
 }
 
 function makeModel(
-  overrides: Partial<Pick<LanguageModelV1, "doGenerate" | "doStream">> = {}
-): LanguageModelV1 {
+  overrides: Partial<Pick<LanguageModelV3, "doGenerate" | "doStream">> = {}
+): LanguageModelV3 {
   return {
+    specificationVersion: "v3",
     provider: "test",
     modelId: "test-model",
-    defaultObjectGenerationMode: "json",
+    supportedUrls: {},
     doGenerate: vi.fn().mockRejectedValue(new Error("not implemented")),
     doStream: vi.fn().mockRejectedValue(new Error("not implemented")),
     ...overrides,
-  } as unknown as LanguageModelV1;
+  } as unknown as LanguageModelV3;
 }
 
 function makeStreamResult(chunks: unknown[], failAfterChunks?: number) {
@@ -104,7 +101,7 @@ describe("FallbackModel.doStream", () => {
     const result = await fallback.doStream(opts);
     const reader = result.stream.getReader();
     const { value } = await reader.read();
-    expect((value as { textDelta: string }).textDelta).toBe("hi");
+    expect((value as unknown as { textDelta: string }).textDelta).toBe("hi");
   });
 
   it("falls back when first model doStream rejects before any chunk", async () => {
@@ -115,7 +112,7 @@ describe("FallbackModel.doStream", () => {
     const result = await fallback.doStream(opts);
     const reader = result.stream.getReader();
     const { value } = await reader.read();
-    expect((value as { textDelta: string }).textDelta).toBe("fallback");
+    expect((value as unknown as { textDelta: string }).textDelta).toBe("fallback");
   });
 
   it("does not fall back after first chunk received", async () => {
@@ -159,7 +156,7 @@ describe("FallbackModel.doStream", () => {
     const result = await fallback.doStream(opts);
     const reader = result.stream.getReader();
     const { value } = await reader.read();
-    expect((value as { textDelta: string }).textDelta).toBe("ok");
+    expect((value as unknown as { textDelta: string }).textDelta).toBe("ok");
   });
 });
 

--- a/packages/llm/src/fallback.ts
+++ b/packages/llm/src/fallback.ts
@@ -1,12 +1,9 @@
-import {
-  APICallError,
-  type LanguageModelV1,
-  type LanguageModelV1CallOptions,
-  type LanguageModelV1StreamPart,
-  LoadAPIKeyError,
-} from "ai";
-
-type ObjectGenerationMode = "json" | "tool" | undefined;
+import type {
+  LanguageModelV3,
+  LanguageModelV3CallOptions,
+  LanguageModelV3StreamPart,
+} from "@ai-sdk/provider";
+import { APICallError, LoadAPIKeyError } from "ai";
 
 /** Minimal logger surface for fallback events (pino/console compatible). */
 export interface FallbackLogger {
@@ -39,27 +36,22 @@ function errorReason(err: unknown): string {
   return String(err);
 }
 
-export class FallbackModel implements LanguageModelV1 {
-  readonly specificationVersion = "v1" as const;
+export class FallbackModel implements LanguageModelV3 {
+  readonly specificationVersion = "v3" as const;
   readonly provider = "fallback";
   readonly modelId: string;
-  readonly defaultObjectGenerationMode: ObjectGenerationMode;
-  readonly supportsImageUrls?: boolean;
-  readonly supportsStructuredOutputs?: boolean;
+  readonly supportedUrls: Record<string, RegExp[]> = {};
 
   constructor(
-    private readonly models: LanguageModelV1[],
+    private readonly models: LanguageModelV3[],
     private readonly logger: FallbackLogger = noopLogger
   ) {
     const primary = models[0];
     if (!primary) throw new Error("FallbackModel requires at least one model");
     this.modelId = models.map((m) => m.modelId).join("|");
-    this.defaultObjectGenerationMode = primary.defaultObjectGenerationMode;
-    this.supportsImageUrls = primary.supportsImageUrls;
-    this.supportsStructuredOutputs = primary.supportsStructuredOutputs;
   }
 
-  async doGenerate(options: LanguageModelV1CallOptions) {
+  async doGenerate(options: LanguageModelV3CallOptions) {
     let lastError: unknown;
     for (const model of this.models) {
       try {
@@ -74,10 +66,10 @@ export class FallbackModel implements LanguageModelV1 {
     throw lastError;
   }
 
-  async doStream(options: LanguageModelV1CallOptions) {
+  async doStream(options: LanguageModelV3CallOptions) {
     let lastError: unknown;
     for (const model of this.models) {
-      let result: Awaited<ReturnType<LanguageModelV1["doStream"]>>;
+      let result: Awaited<ReturnType<LanguageModelV3["doStream"]>>;
       try {
         result = await model.doStream(options);
       } catch (err) {
@@ -100,7 +92,7 @@ export class FallbackModel implements LanguageModelV1 {
       }
 
       // First chunk received — stream is committed, reconstruct with remaining
-      const stream = new ReadableStream<LanguageModelV1StreamPart>({
+      const stream = new ReadableStream<LanguageModelV3StreamPart>({
         async start(controller) {
           if (!firstChunk.done) controller.enqueue(firstChunk.value);
           try {
@@ -125,7 +117,7 @@ export class FallbackModel implements LanguageModelV1 {
     throw lastError;
   }
 
-  private logFallback(model: LanguageModelV1, err: unknown): void {
+  private logFallback(model: LanguageModelV3, err: unknown): void {
     this.logger.warn(
       `[llm] fallback provider=${model.provider} model=${model.modelId} reason=${errorReason(err)}`
     );

--- a/packages/llm/src/llm-service.test.ts
+++ b/packages/llm/src/llm-service.test.ts
@@ -1,4 +1,5 @@
-import { APICallError, type LanguageModelV1, type LanguageModelV1CallOptions } from "ai";
+import type { LanguageModelV3, LanguageModelV3CallOptions } from "@ai-sdk/provider";
+import { APICallError } from "ai";
 import { describe, expect, it, vi } from "vitest";
 import { LlmConfigValidationError, LlmNotConfiguredError, UnknownModelError } from "./config";
 import { LlmService } from "./llm-service";
@@ -7,12 +8,13 @@ import { createModel } from "./provider";
 vi.mock("./provider", () => ({
   createModel: vi.fn((entry: { provider: string; model: string }) =>
     Promise.resolve({
+      specificationVersion: "v3",
       provider: entry.provider,
       modelId: entry.model,
-      defaultObjectGenerationMode: "json",
+      supportedUrls: {},
       doGenerate: vi.fn(),
       doStream: vi.fn(),
-    } as unknown as LanguageModelV1)
+    } as unknown as LanguageModelV3)
   ),
 }));
 
@@ -79,12 +81,13 @@ describe("LlmService", () => {
     });
     const rejecting = (entry: { provider: string; model: string }) =>
       Promise.resolve({
+        specificationVersion: "v3",
         provider: entry.provider,
         modelId: entry.model,
-        defaultObjectGenerationMode: "json",
+        supportedUrls: {},
         doGenerate: vi.fn().mockRejectedValue(transient),
         doStream: vi.fn(),
-      } as unknown as LanguageModelV1);
+      } as unknown as LanguageModelV3);
     // Only the two quick-tier providers reject; standard/complex use the default mock.
     vi.mocked(createModel).mockImplementationOnce(rejecting).mockImplementationOnce(rejecting);
 
@@ -104,9 +107,9 @@ describe("LlmService", () => {
     const logger = { warn: vi.fn() };
     const svc = new LlmService();
     await svc.init(twoProviderConfig, fakeSecrets, logger);
-    await expect(svc.getModel("quick").doGenerate({} as LanguageModelV1CallOptions)).rejects.toBe(
-      transient
-    );
+    await expect(
+      (svc.getModel("quick") as LanguageModelV3).doGenerate({} as LanguageModelV3CallOptions)
+    ).rejects.toBe(transient);
     expect(logger.warn).toHaveBeenCalled();
   });
 });
@@ -120,24 +123,30 @@ describe("LlmService.select", () => {
 
   it("model auto + supervised resolves to standard (AC-V1-001)", async () => {
     const svc = await init();
-    expect(svc.select({ model: "auto", autonomy: "supervised" }).modelId).toBe("claude-sonnet-4-6");
+    expect((svc.select({ model: "auto", autonomy: "supervised" }) as LanguageModelV3).modelId).toBe(
+      "claude-sonnet-4-6"
+    );
   });
 
   it("explicit tier overrides auto rules (AC3)", async () => {
     const svc = await init();
-    expect(svc.select({ model: "complex", autonomy: "full" }).modelId).toBe("claude-opus-4-8");
+    expect((svc.select({ model: "complex", autonomy: "full" }) as LanguageModelV3).modelId).toBe(
+      "claude-opus-4-8"
+    );
   });
 
   it("session model overrides configured tier for the turn (AC4)", async () => {
     const svc = await init();
-    expect(svc.select({ model: "complex", sessionModel: "quick" }).modelId).toBe(
-      "claude-haiku-4-5"
-    );
+    expect(
+      (svc.select({ model: "complex", sessionModel: "quick" }) as LanguageModelV3).modelId
+    ).toBe("claude-haiku-4-5");
   });
 
   it("raw model id bypasses tiers via getModelById", async () => {
     const svc = await init();
-    expect(svc.select({ model: "claude-opus-4-8" }).modelId).toBe("claude-opus-4-8");
+    expect((svc.select({ model: "claude-opus-4-8" }) as LanguageModelV3).modelId).toBe(
+      "claude-opus-4-8"
+    );
   });
 
   it("unknown raw model id throws UnknownModelError", async () => {
@@ -147,7 +156,7 @@ describe("LlmService.select", () => {
 
   it("defaults to auto → standard when no model given", async () => {
     const svc = await init();
-    expect(svc.select({}).modelId).toBe("claude-sonnet-4-6");
+    expect((svc.select({}) as LanguageModelV3).modelId).toBe("claude-sonnet-4-6");
   });
 
   it("select before init throws LlmNotConfiguredError", () => {

--- a/packages/llm/src/llm-service.ts
+++ b/packages/llm/src/llm-service.ts
@@ -1,5 +1,5 @@
 import type { SecretsService } from "@tulipfarm/secrets";
-import type { LanguageModelV1 } from "ai";
+import type { LanguageModel } from "ai";
 import { LlmNotConfiguredError, UnknownModelError, validateLlmConfig } from "./config";
 import { type FallbackLogger, FallbackModel } from "./fallback";
 import { createModel } from "./provider";
@@ -17,8 +17,8 @@ export type SelectRequest = SelectionContext & {
 };
 
 export class LlmService {
-  private models: Map<Tier, LanguageModelV1> | null = null;
-  private byModelId: Map<string, LanguageModelV1> = new Map();
+  private models: Map<Tier, LanguageModel> | null = null;
+  private byModelId: Map<string, LanguageModel> = new Map();
 
   async init(
     rawConfig: unknown,
@@ -31,8 +31,8 @@ export class LlmService {
     }
 
     const config = validateLlmConfig(rawConfig);
-    const models = new Map<Tier, LanguageModelV1>();
-    const byModelId = new Map<string, LanguageModelV1>();
+    const models = new Map<Tier, LanguageModel>();
+    const byModelId = new Map<string, LanguageModel>();
 
     for (const tier of TIERS) {
       const { providers } = config.tiers[tier];
@@ -49,14 +49,14 @@ export class LlmService {
     this.byModelId = byModelId;
   }
 
-  getModel(tier: Tier): LanguageModelV1 {
+  getModel(tier: Tier): LanguageModel {
     if (!this.models) throw new LlmNotConfiguredError();
     const model = this.models.get(tier);
     if (!model) throw new LlmNotConfiguredError();
     return model;
   }
 
-  getModelById(id: string): LanguageModelV1 {
+  getModelById(id: string): LanguageModel {
     if (!this.models) throw new LlmNotConfiguredError();
     const model = this.byModelId.get(id);
     if (!model) throw new UnknownModelError(id);
@@ -69,7 +69,7 @@ export class LlmService {
    * fallback chain; `auto` runs the rule-based selection; any other string is a
    * raw provider model id that bypasses tiers (single model, no fallback).
    */
-  select(req: SelectRequest): LanguageModelV1 {
+  select(req: SelectRequest): LanguageModel {
     const selector = req.sessionModel ?? req.model ?? "auto";
     if (selector === "auto") return this.getModel(resolveTier(req));
     if (isTier(selector)) return this.getModel(selector);

--- a/packages/llm/src/provider.ts
+++ b/packages/llm/src/provider.ts
@@ -2,13 +2,13 @@ import { createAnthropic } from "@ai-sdk/anthropic";
 import { createAzure } from "@ai-sdk/azure";
 import { createOpenAI } from "@ai-sdk/openai";
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import type { LanguageModelV3 } from "@ai-sdk/provider";
 import {
   SecretUnavailableError,
   type SecretsService,
   llmProviderById,
   providerField,
 } from "@tulipfarm/secrets";
-import type { LanguageModelV1 } from "ai";
 import { LlmConfigValidationError, LlmCredentialError } from "./config";
 import type { ProviderEntry } from "./config";
 
@@ -54,7 +54,7 @@ async function resolveStored(
 export async function createModel(
   entry: ProviderEntry,
   secrets: SecretsService
-): Promise<LanguageModelV1> {
+): Promise<LanguageModelV3> {
   const info = llmProviderById(entry.provider);
 
   // API key: an explicit api_key_ref (incl. env://VAR escape) wins; otherwise the provider's
@@ -84,10 +84,7 @@ export async function createModel(
     }
     case "openai": {
       const p = createOpenAI({ apiKey });
-      // structuredOutputs:false → tools are sent non-strict, so schemas with optional
-      // properties are accepted (strict mode requires every property in `required`).
-      // Tool args are still validated at runtime by the ToolRegistry (ajv).
-      return p(entry.model, { structuredOutputs: false });
+      return p(entry.model);
     }
     case "openai-compatible": {
       if (!baseUrl) {
@@ -101,8 +98,7 @@ export async function createModel(
         throw new LlmConfigValidationError("azure provider requires resource_name or base_url");
       }
       const p = createAzure({ resourceName, baseURL: baseUrl, apiKey });
-      // See openai case: disable strict tool schemas so optional properties are allowed.
-      return p(entry.model, { structuredOutputs: false });
+      return p(entry.model);
     }
     default:
       throw new LlmConfigValidationError(`unknown provider: ${entry.provider}`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/validation
       ai:
-        specifier: ^4
-        version: 4.3.19(react@19.2.7)(zod@4.4.3)
+        specifier: ^6
+        version: 6.0.199(zod@4.4.3)
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
@@ -81,6 +81,9 @@ importers:
         specifier: ^2.9.0
         version: 2.9.0
     devDependencies:
+      '@ai-sdk/provider':
+        specifier: ^3
+        version: 3.0.10
       '@electric-sql/pglite':
         specifier: ^0.2.0
         version: 0.2.17
@@ -282,17 +285,20 @@ importers:
   packages/llm:
     dependencies:
       '@ai-sdk/anthropic':
-        specifier: ^1
-        version: 1.2.12(zod@4.4.3)
+        specifier: ^3
+        version: 3.0.82(zod@4.4.3)
       '@ai-sdk/azure':
-        specifier: ^1
-        version: 1.3.25(zod@4.4.3)
+        specifier: ^3
+        version: 3.0.71(zod@4.4.3)
       '@ai-sdk/openai':
-        specifier: ^1
-        version: 1.3.24(zod@4.4.3)
+        specifier: ^3
+        version: 3.0.69(zod@4.4.3)
       '@ai-sdk/openai-compatible':
-        specifier: ^0
-        version: 0.2.16(zod@4.4.3)
+        specifier: ^2
+        version: 2.0.48(zod@4.4.3)
+      '@ai-sdk/provider':
+        specifier: ^3
+        version: 3.0.10
       '@sinclair/typebox':
         specifier: ^0.34
         version: 0.34.49
@@ -303,8 +309,8 @@ importers:
         specifier: workspace:*
         version: link:../validation
       ai:
-        specifier: ^4
-        version: 4.3.19(react@19.2.7)(zod@4.4.3)
+        specifier: ^6
+        version: 6.0.199(zod@4.4.3)
     devDependencies:
       '@tulipfarm/tsconfig':
         specifier: workspace:*
@@ -425,55 +431,45 @@ packages:
   '@adobe/css-tools@4.5.0':
     resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
 
-  '@ai-sdk/anthropic@1.2.12':
-    resolution: {integrity: sha512-YSzjlko7JvuiyQFmI9RN1tNZdEiZxc+6xld/0tq/VkJaHpEzGAb1yiNxxvmYVcjvfu/PcvCxAAYXmTYQQ63IHQ==}
+  '@ai-sdk/anthropic@3.0.82':
+    resolution: {integrity: sha512-WKKou2wbhGGYV8PSALAPyV2YY4nfCqCPkyBzYtJtDA9yCcIFwsbtkTNgg7bqtLCVzeEsY7wwxRoCWy+EMfrw/A==}
     engines: {node: '>=18'}
     peerDependencies:
-      zod: ^3.0.0
+      zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/azure@1.3.25':
-    resolution: {integrity: sha512-cTME89A9UYrza0t5pbY9b80yYY02Q5ALQdB2WP3R7/Yl1PLwbFChx994Q3Un0G2XV5h3arlm4fZTViY10isjhQ==}
+  '@ai-sdk/azure@3.0.71':
+    resolution: {integrity: sha512-Ymq31j6C02dn2n6ubqCH+JSnYwc3aYoR8Xzj0nE3OaWA3YWT5Qq6iw//cLycu+hR1HJPFT0tF38nsmMZNyB7RA==}
     engines: {node: '>=18'}
     peerDependencies:
-      zod: ^3.0.0
+      zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/openai-compatible@0.2.16':
-    resolution: {integrity: sha512-LkvfcM8slJedRyJa/MiMiaOzcMjV1zNDwzTHEGz7aAsgsQV0maLfmJRi/nuSwf5jmp0EouC+JXXDUj2l94HgQw==}
+  '@ai-sdk/gateway@3.0.127':
+    resolution: {integrity: sha512-Obmw5hmE5x+ccRrMp/Djx5r0rpFVX87YqE6OY06g5fwYlRI30dA84ARfTzX45ivCvkW4eCnBpOVXVWQ/pjH85w==}
     engines: {node: '>=18'}
     peerDependencies:
-      zod: ^3.0.0
+      zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/openai@1.3.24':
-    resolution: {integrity: sha512-GYXnGJTHRTZc4gJMSmFRgEQudjqd4PUN0ZjQhPwOAYH1yOAvQoG/Ikqs+HyISRbLPCrhbZnPKCNHuRU4OfpW0Q==}
+  '@ai-sdk/openai-compatible@2.0.48':
+    resolution: {integrity: sha512-z9MC6M4Oh/yUY/F/eszOtO8wc2nMz99XmZQKd2gWTtyIfe716xTfrKe3aYZKg20NZDtyjqPPKPSR+wqz7q1T7Q==}
     engines: {node: '>=18'}
     peerDependencies:
-      zod: ^3.0.0
+      zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@2.2.8':
-    resolution: {integrity: sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==}
+  '@ai-sdk/openai@3.0.69':
+    resolution: {integrity: sha512-T/J3ED6ERDsine+crkXHfraisSG20k6BkBdgjvXCvySYnnJ19IaLIOsQPYfvXdOsKrl0LVNghooTV/nKCA7SmQ==}
     engines: {node: '>=18'}
     peerDependencies:
-      zod: ^3.23.8
+      zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider@1.1.3':
-    resolution: {integrity: sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==}
-    engines: {node: '>=18'}
-
-  '@ai-sdk/react@1.2.12':
-    resolution: {integrity: sha512-jK1IZZ22evPZoQW3vlkZ7wvjYGYF+tRBKXtrcolduIkQ/m/sOAVcVeVDUDvh1T91xCnWCdUGCPZg2avZ90mv3g==}
+  '@ai-sdk/provider-utils@4.0.27':
+    resolution: {integrity: sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==}
     engines: {node: '>=18'}
     peerDependencies:
-      react: ^18 || ^19 || ^19.0.0-rc
-      zod: ^3.23.8
-    peerDependenciesMeta:
-      zod:
-        optional: true
+      zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/ui-utils@1.2.11':
-    resolution: {integrity: sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==}
+  '@ai-sdk/provider@3.0.10':
+    resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
     engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.23.8
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -2569,9 +2565,6 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
-  '@types/diff-match-patch@1.0.36':
-    resolution: {integrity: sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==}
-
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
@@ -2633,6 +2626,10 @@ packages:
 
   '@vanilla-extract/private@1.0.9':
     resolution: {integrity: sha512-gT2jbfZuaaCLrAxwXbRgIhGhcXbRZCG3v4TTUnjw0EJ7ArdBRxkq4msNJkbuRkCgfIK5ATmprB5t9ljvLeFDEA==}
+
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
 
   '@vitejs/plugin-react@6.0.2':
     resolution: {integrity: sha512-DlSMqo4WhThw4vB8Mpn0Woe9J+Jfq1geJ61AKW0QEgLzGMNwtIMdxbDUzLxcun8W7NbJO0e2Jg/Nxm3cCSVzzg==}
@@ -2719,15 +2716,11 @@ packages:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
 
-  ai@4.3.19:
-    resolution: {integrity: sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q==}
+  ai@6.0.199:
+    resolution: {integrity: sha512-6H9RPEjzBQECM+eU1JxAh6jHcZPU/6q5QZ8D8QV8agubf0Mm/kcBlwqrFcFtup6RQzmEvMkVaQOoLCZ8bQ13lA==}
     engines: {node: '>=18'}
     peerDependencies:
-      react: ^18 || ^19 || ^19.0.0-rc
-      zod: ^3.23.8
-    peerDependenciesMeta:
-      react:
-        optional: true
+      zod: ^3.25.76 || ^4.1.8
 
   ajv-draft-04@1.0.0:
     resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
@@ -3193,9 +3186,6 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
-  diff-match-patch@1.0.5:
-    resolution: {integrity: sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==}
-
   diff@5.2.2:
     resolution: {integrity: sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==}
     engines: {node: '>=0.3.1'}
@@ -3384,6 +3374,10 @@ packages:
 
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
 
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
@@ -4019,11 +4013,6 @@ packages:
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
-    hasBin: true
-
-  jsondiffpatch@0.6.0:
-    resolution: {integrity: sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ==}
-    engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
   jsonfile@6.2.1:
@@ -5392,9 +5381,6 @@ packages:
   scroll-into-view-if-needed@3.1.0:
     resolution: {integrity: sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==}
 
-  secure-json-parse@2.7.0:
-    resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
-
   secure-json-parse@4.1.0:
     resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
@@ -5629,11 +5615,6 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
-  swr@2.4.1:
-    resolution: {integrity: sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==}
-    peerDependencies:
-      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -5666,10 +5647,6 @@ packages:
   thread-stream@4.2.0:
     resolution: {integrity: sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==}
     engines: {node: '>=20'}
-
-  throttleit@2.1.0:
-    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
-    engines: {node: '>=18'}
 
   through2@2.0.5:
     resolution: {integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==}
@@ -5877,11 +5854,6 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
-
-  use-sync-external-store@1.6.0:
-    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -6162,11 +6134,6 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  zod-to-json-schema@3.25.2:
-    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
-    peerDependencies:
-      zod: ^3.25.28 || ^4
-
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
@@ -6177,58 +6144,48 @@ snapshots:
 
   '@adobe/css-tools@4.5.0': {}
 
-  '@ai-sdk/anthropic@1.2.12(zod@4.4.3)':
+  '@ai-sdk/anthropic@3.0.82(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/azure@1.3.25(zod@4.4.3)':
+  '@ai-sdk/azure@3.0.71(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/openai': 1.3.24(zod@4.4.3)
-      '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@4.4.3)
+      '@ai-sdk/openai': 3.0.69(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/openai-compatible@0.2.16(zod@4.4.3)':
+  '@ai-sdk/gateway@3.0.127(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      '@vercel/oidc': 3.2.0
       zod: 4.4.3
 
-  '@ai-sdk/openai@1.3.24(zod@4.4.3)':
+  '@ai-sdk/openai-compatible@2.0.48(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/provider-utils@2.2.8(zod@4.4.3)':
+  '@ai-sdk/openai@3.0.69(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 1.1.3
-      nanoid: 3.3.12
-      secure-json-parse: 2.7.0
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/provider@1.1.3':
+  '@ai-sdk/provider-utils@4.0.27(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.4.3
+
+  '@ai-sdk/provider@3.0.10':
     dependencies:
       json-schema: 0.4.0
-
-  '@ai-sdk/react@1.2.12(react@19.2.7)(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/provider-utils': 2.2.8(zod@4.4.3)
-      '@ai-sdk/ui-utils': 1.2.11(zod@4.4.3)
-      react: 19.2.7
-      swr: 2.4.1(react@19.2.7)
-      throttleit: 2.1.0
-    optionalDependencies:
-      zod: 4.4.3
-
-  '@ai-sdk/ui-utils@1.2.11(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@4.4.3)
-      zod: 4.4.3
-      zod-to-json-schema: 3.25.2(zod@4.4.3)
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -8062,8 +8019,6 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
-  '@types/diff-match-patch@1.0.36': {}
-
   '@types/estree-jsx@1.0.5':
     dependencies:
       '@types/estree': 1.0.9
@@ -8168,6 +8123,8 @@ snapshots:
 
   '@vanilla-extract/private@1.0.9': {}
 
+  '@vercel/oidc@3.2.0': {}
+
   '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@22.19.19)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
@@ -8265,17 +8222,13 @@ snapshots:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  ai@4.3.19(react@19.2.7)(zod@4.4.3):
+  ai@6.0.199(zod@4.4.3):
     dependencies:
-      '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@4.4.3)
-      '@ai-sdk/react': 1.2.12(react@19.2.7)(zod@4.4.3)
-      '@ai-sdk/ui-utils': 1.2.11(zod@4.4.3)
+      '@ai-sdk/gateway': 3.0.127(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
       '@opentelemetry/api': 1.9.0
-      jsondiffpatch: 0.6.0
       zod: 4.4.3
-    optionalDependencies:
-      react: 19.2.7
 
   ajv-draft-04@1.0.0(ajv@8.20.0):
     optionalDependencies:
@@ -8705,8 +8658,6 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  diff-match-patch@1.0.5: {}
-
   diff@5.2.2: {}
 
   dom-accessibility-api@0.5.16: {}
@@ -8960,6 +8911,8 @@ snapshots:
   event-target-shim@5.0.1: {}
 
   eventemitter3@5.0.4: {}
+
+  eventsource-parser@3.1.0: {}
 
   execa@5.1.1:
     dependencies:
@@ -9700,12 +9653,6 @@ snapshots:
   json-schema@0.4.0: {}
 
   json5@2.2.3: {}
-
-  jsondiffpatch@0.6.0:
-    dependencies:
-      '@types/diff-match-patch': 1.0.36
-      chalk: 5.6.2
-      diff-match-patch: 1.0.5
 
   jsonfile@6.2.1:
     dependencies:
@@ -11589,8 +11536,6 @@ snapshots:
     dependencies:
       compute-scroll-into-view: 3.1.1
 
-  secure-json-parse@2.7.0: {}
-
   secure-json-parse@4.1.0: {}
 
   semver@6.3.1: {}
@@ -11893,12 +11838,6 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  swr@2.4.1(react@19.2.7):
-    dependencies:
-      dequal: 2.0.3
-      react: 19.2.7
-      use-sync-external-store: 1.6.0(react@19.2.7)
-
   symbol-tree@3.2.4: {}
 
   tagged-tag@1.0.0: {}
@@ -11936,8 +11875,6 @@ snapshots:
   thread-stream@4.2.0:
     dependencies:
       real-require: 1.0.0
-
-  throttleit@2.1.0: {}
 
   through2@2.0.5:
     dependencies:
@@ -12156,10 +12093,6 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.16
-
-  use-sync-external-store@1.6.0(react@19.2.7):
-    dependencies:
-      react: 19.2.7
 
   util-deprecate@1.0.2: {}
 
@@ -12448,10 +12381,6 @@ snapshots:
   yaml@2.9.0: {}
 
   yocto-queue@0.1.0: {}
-
-  zod-to-json-schema@3.25.2(zod@4.4.3):
-    dependencies:
-      zod: 4.4.3
 
   zod@4.4.3: {}
 


### PR DESCRIPTION
## Summary

- Bumps `ai` to `^6`, `@ai-sdk/openai` / `@ai-sdk/anthropic` / `@ai-sdk/azure` / `@ai-sdk/openai-compatible` to latest major, adds `@ai-sdk/provider@^3` as explicit dep to both `packages/llm` and `apps/api`
- Migrates all v4→v6 breaking changes across `packages/llm` and `apps/api`

## Breaking changes migrated

| v4 | v6 |
|---|---|
| `LanguageModelV1` / `LanguageModelV1CallOptions` | `LanguageModelV3` / `LanguageModelV3CallOptions` from `@ai-sdk/provider` |
| `CoreMessage` | `ModelMessage` |
| `toCoreMessage` | `toModelMessage` |
| `ToolCallPart.args` | `ToolCallPart.input` |
| `ToolResultPart.result` | `ToolResultPart.output: { type: "json", value }` |
| `tool({ parameters })` | `tool({ inputSchema })` |
| `fullStream` text-delta `.textDelta` | `.text` |
| `fullStream` tool-call `.args` | `.input` |
| `fullStream` tool-result `.result` | `.output` |
| `streamText({ maxSteps })` | `streamText({ stopWhen: ({ steps }) => steps.length >= N })` |
| `EmbeddingModel<string>` | `EmbeddingModel` (no longer generic) |
| `FallbackModel implements LanguageModelV1` | implements `LanguageModelV3` (adds `supportedUrls`, removes `defaultObjectGenerationMode`) |
| Provider factory 2-arg `p(model, { structuredOutputs: false })` | 1-arg `p(model)` |

## Test plan

- [x] `pnpm -r typecheck` — clean
- [x] `pnpm -r lint` — clean
- [x] `pnpm -r build` — clean
- [x] `pnpm --filter @tulipfarm/llm test` — 81/81 pass
- [x] `pnpm --filter @tulipfarm/api test` — 730/730 src tests pass (4 pre-existing `isolated-vm`/Node 25 failures unaffected)