### PR TITLE
chore(deps): upgrade pg-boss v10 → v12, pg v8.13 → v8.21

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -24,15 +24,15 @@
     "dotenv": "^17.4.2",
     "fastify": "^5.8.5",
     "isolated-vm": "^7.0.0",
-    "pg": "^8.13.0",
-    "pg-boss": "^10.0.0",
+    "pg": "^8.21.0",
+    "pg-boss": "^12.18.3",
     "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@ai-sdk/provider": "^3",
     "@electric-sql/pglite": "^0.2.0",
     "@tulipfarm/tsconfig": "workspace:*",
-    "@types/pg": "^8.11.0",
+    "@types/pg": "^8.20.0",
     "@vitest/coverage-v8": "^4.1.8",
     "tsx": "^4.22.4",
     "typescript": "^6.0.3",

--- a/apps/api/src/chat/stream-gc.test.ts
+++ b/apps/api/src/chat/stream-gc.test.ts
@@ -1,4 +1,4 @@
-import type PgBoss from "pg-boss";
+import type { PgBoss } from "pg-boss";
 import { describe, expect, it, vi } from "vitest";
 import {
   STREAM_GC_CRON,

--- a/apps/api/src/chat/stream-gc.ts
+++ b/apps/api/src/chat/stream-gc.ts
@@ -1,4 +1,4 @@
-import type PgBoss from "pg-boss";
+import type { PgBoss } from "pg-boss";
 import type { StreamResumeRepo } from "./stream-resume";
 
 export const STREAM_GC_QUEUE = "stream-resume-gc";

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -3,7 +3,7 @@ import { EmbeddingService, LlmService } from "@tulipfarm/llm";
 import { PgSecretRepo, SecretsService, loadEncryptionKeys } from "@tulipfarm/secrets";
 import { GitSyncService, SoulLoader, runSoulMigrations } from "@tulipfarm/soul";
 import { config } from "dotenv";
-import PgBoss from "pg-boss";
+import { PgBoss } from "pg-boss";
 import { buildApp } from "./app";
 import { PgTokenRepo } from "./auth/api-tokens";
 import { DEFAULT_SESSION_TTL_SECONDS, PgSessionStore } from "./auth/session-store";

--- a/apps/api/src/knowledge/indexing.ts
+++ b/apps/api/src/knowledge/indexing.ts
@@ -1,4 +1,4 @@
-import type PgBoss from "pg-boss";
+import type { PgBoss } from "pg-boss";
 import type { KnowledgeService } from "./service";
 
 export const KNOWLEDGE_INDEX_QUEUE = "knowledge-index";

--- a/apps/api/src/soul-sync.test.ts
+++ b/apps/api/src/soul-sync.test.ts
@@ -1,4 +1,4 @@
-import type PgBoss from "pg-boss";
+import type { PgBoss } from "pg-boss";
 import { describe, expect, it, vi } from "vitest";
 import { SOUL_SYNC_CRON, SOUL_SYNC_QUEUE, registerSoulSync } from "./soul-sync";
 

--- a/apps/api/src/soul-sync.ts
+++ b/apps/api/src/soul-sync.ts
@@ -1,4 +1,4 @@
-import type PgBoss from "pg-boss";
+import type { PgBoss } from "pg-boss";
 
 interface SoulSyncer {
   syncOnce(): Promise<void>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,11 +72,11 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0
       pg:
-        specifier: ^8.13.0
+        specifier: ^8.21.0
         version: 8.21.0
       pg-boss:
-        specifier: ^10.0.0
-        version: 10.4.2
+        specifier: ^12.18.3
+        version: 12.18.3
       yaml:
         specifier: ^2.9.0
         version: 2.9.0
@@ -91,7 +91,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/tsconfig
       '@types/pg':
-        specifier: ^8.11.0
+        specifier: ^8.20.0
         version: 8.20.0
       '@vitest/coverage-v8':
         specifier: ^4.1.8
@@ -3080,9 +3080,9 @@ packages:
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
-  cron-parser@4.9.0:
-    resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
-    engines: {node: '>=12.0.0'}
+  cron-parser@5.5.0:
+    resolution: {integrity: sha512-oML4lKUXxizYswqmxuOCpgFS8BNUJpIu6k/2HVHyaL8Ynnf3wdf9tkns0yRdJLSIjkJ+b0DXHMZEHGpMwjnPww==}
+    engines: {node: '>=18'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -4743,6 +4743,10 @@ packages:
     resolution: {integrity: sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==}
     engines: {node: '>=18'}
 
+  non-error@0.1.0:
+    resolution: {integrity: sha512-TMB1uHiGsHRGv1uYclfhivcnf0/PdFp2pNqRxXjncaAsjYMoisaQJI+SSZCqRq+VliwRTC8tsMQfmrWjDMhkPQ==}
+    engines: {node: '>=20'}
+
   normalize-package-data@5.0.0:
     resolution: {integrity: sha512-h9iPVIfrVZ9wVYQnxFgtw1ugSvGEMOlyPWWtm8BMJhnwyEL/FLbYbTY3V3PpjI/BUK67n9PEWDu6eHzu1fB15Q==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -4898,9 +4902,10 @@ packages:
   periscopic@3.1.0:
     resolution: {integrity: sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==}
 
-  pg-boss@10.4.2:
-    resolution: {integrity: sha512-AttEWOtSzn53av8OnCMWEanwRBvjkZCE1y5nLrZnwvkkMnlZ5XpWDpZ7sKI/BYjvi2OVieMX37arD2ACgJ750w==}
-    engines: {node: '>=20'}
+  pg-boss@12.18.3:
+    resolution: {integrity: sha512-3pwVjvVwWE38XsD1lW01MA3LFlxemkasWbX3qB/NjZ5r9uQDfiytqA3hV7Jmsq7Up8bT7deZLJ98Kagcsw4VAg==}
+    engines: {node: '>=22.12.0'}
+    hasBin: true
 
   pg-cloudflare@1.4.0:
     resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
@@ -5397,9 +5402,9 @@ packages:
     resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
     engines: {node: '>= 0.8.0'}
 
-  serialize-error@8.1.0:
-    resolution: {integrity: sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==}
-    engines: {node: '>=10'}
+  serialize-error@13.0.1:
+    resolution: {integrity: sha512-bBZaRwLH9PN5HbLCjPId4dP5bNGEtumcErgOX952IsvOhVPrm3/AeK1y0UHA/QaPG701eg0yEnOKsCOC6X/kaA==}
+    engines: {node: '>=20'}
 
   serve-handler@6.1.7:
     resolution: {integrity: sha512-CinAq1xWb0vR3twAv9evEU8cNWkXCb9kd5ePAHUKJBkOsUpR1wt/CvGdeca7vqumL1U5cSaeVQ6zZMxiJ3yWsg==}
@@ -5723,10 +5728,6 @@ packages:
 
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
-
-  type-fest@0.20.2:
-    resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
-    engines: {node: '>=10'}
 
   type-fest@2.19.0:
     resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
@@ -8580,7 +8581,7 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
-  cron-parser@4.9.0:
+  cron-parser@5.5.0:
     dependencies:
       luxon: 3.7.2
 
@@ -10779,6 +10780,8 @@ snapshots:
 
   node-releases@2.0.47: {}
 
+  non-error@0.1.0: {}
+
   normalize-package-data@5.0.0:
     dependencies:
       hosted-git-info: 6.1.3
@@ -10939,11 +10942,11 @@ snapshots:
       estree-walker: 3.0.3
       is-reference: 3.0.3
 
-  pg-boss@10.4.2:
+  pg-boss@12.18.3:
     dependencies:
-      cron-parser: 4.9.0
+      cron-parser: 5.5.0
       pg: 8.21.0
-      serialize-error: 8.1.0
+      serialize-error: 13.0.1
     transitivePeerDependencies:
       - pg-native
 
@@ -11560,9 +11563,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  serialize-error@8.1.0:
+  serialize-error@13.0.1:
     dependencies:
-      type-fest: 0.20.2
+      non-error: 0.1.0
+      type-fest: 5.7.0
 
   serve-handler@6.1.7:
     dependencies:
@@ -11946,8 +11950,6 @@ snapshots:
       '@turbo/windows-arm64': 2.9.16
 
   tw-animate-css@1.4.0: {}
-
-  type-fest@0.20.2: {}
 
   type-fest@2.19.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,3 +8,5 @@ allowBuilds:
   lefthook: true
   msgpackr-extract: true
   sharp: true
+minimumReleaseAgeExclude:
+  - pg-boss@12.18.3


### PR DESCRIPTION
## Summary

- Bumps `pg-boss` from `^10.0.0` to `^12.18.3`
- Bumps `pg` from `^8.13.0` to `^8.21.0` (required peer dep of pg-boss v12)
- Bumps `@types/pg` from `^8.11.0` to `^8.20.0`
- Migrates all `import PgBoss from "pg-boss"` → `import { PgBoss } from "pg-boss"` (pg-boss v12 is ESM-only with named exports, no default export)

## Test plan

- [x] `pnpm --filter @tulipfarm/api typecheck` — clean
- [x] `pnpm --filter @tulipfarm/api lint` — clean
- [x] `pnpm --filter @tulipfarm/api build` — clean
- [x] `pnpm --filter @tulipfarm/api test` — same 4 pre-existing failures (stale `dist/*.test.js` artefacts), 3 additional tests pass vs baseline