### PR TITLE
chore(deps): ignore node and @types/node in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "node"
+      - dependency-name: "@types/node"
     groups:
       # Collapse the noisy minor/patch churn into a single PR per week.
       minor-and-patch:


### PR DESCRIPTION
## Summary
- Adds `ignore` block in dependabot npm config to skip `node` and `@types/node` updates
- Prevents breaking peer resolution from `@types/node` major bumps (pinned to ^22 across all workspaces)