### PR TITLE
chore(deps): upgrade biome 1.9→2.4, lint-staged 15→17, lefthook 1→2

### DIFF
--- a/apps/api/src/auth/api-tokens.test.ts
+++ b/apps/api/src/auth/api-tokens.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { PaginatedResult } from "../pagination";
 import {
-  type TokenDoc,
-  type TokenRepo,
   createApiToken,
   hashToken,
+  type TokenDoc,
+  type TokenRepo,
   toPublicToken,
 } from "./api-tokens";
 

--- a/apps/api/src/auth/middleware.ts
+++ b/apps/api/src/auth/middleware.ts
@@ -1,5 +1,5 @@
 import type { FastifyReply, FastifyRequest } from "fastify";
-import { type TokenRepo, hashToken } from "./api-tokens";
+import { hashToken, type TokenRepo } from "./api-tokens";
 import type { SessionStore } from "./session-store";
 import type { UserDoc, UserRepo } from "./users";
 

--- a/apps/api/src/auth/routes.test.ts
+++ b/apps/api/src/auth/routes.test.ts
@@ -1,13 +1,13 @@
 import type { FastifyInstance } from "fastify";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { buildApp } from "../app";
-import { type PaginatedResult, encodeCursor } from "../pagination";
+import { encodeCursor, type PaginatedResult } from "../pagination";
 import { MemoryRateLimiter } from "../rate-limit";
 import type { TokenDoc, TokenRepo } from "./api-tokens";
 import { CSRF_COOKIE, CSRF_HEADER } from "./csrf";
 import { SESSION_COOKIE } from "./routes";
 import { MemorySessionStore } from "./session-store";
-import { type UserDoc, type UserRepo, createUser } from "./users";
+import { createUser, type UserDoc, type UserRepo } from "./users";
 
 const TEST_CSRF = "a".repeat(64);
 

--- a/apps/api/src/auth/routes.ts
+++ b/apps/api/src/auth/routes.ts
@@ -1,1 +1,1 @@
-export { SESSION_COOKIE, registerAuthRoutes } from "./routes/index";
+export { registerAuthRoutes, SESSION_COOKIE } from "./routes/index";

--- a/apps/api/src/auth/routes/session.ts
+++ b/apps/api/src/auth/routes/session.ts
@@ -4,7 +4,7 @@ import { SESSION_COOKIE } from "../middleware";
 import { hashPassword, verifyPassword } from "../passwords";
 import { ErrorSchema, PublicUserSchema } from "../schemas";
 import { DEFAULT_SESSION_TTL_SECONDS, type SessionStore } from "../session-store";
-import { type UserRepo, toPublicUser } from "../users";
+import { toPublicUser, type UserRepo } from "../users";
 
 // Precomputed lazily and reused: verifying against a dummy hash on unknown-user
 // login keeps response timing similar to the known-user path (no user enumeration).

--- a/apps/api/src/auth/routes/tokens.ts
+++ b/apps/api/src/auth/routes/tokens.ts
@@ -1,6 +1,6 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { parsePaginationQuery } from "../../pagination";
-import { type TokenRepo, createApiToken, toPublicToken } from "../api-tokens";
+import { createApiToken, type TokenRepo, toPublicToken } from "../api-tokens";
 import { ErrorSchema, PublicTokenSchema } from "../schemas";
 import type { UserDoc, UserRepo } from "../users";
 

--- a/apps/api/src/chat/messages.test.ts
+++ b/apps/api/src/chat/messages.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
-  InvalidMessageError,
-  type MessageDoc,
-  type MessagePart,
   assertValidMessage,
   fromAssistantParts,
   fromAssistantText,
   fromToolResult,
   fromUserText,
+  InvalidMessageError,
+  type MessageDoc,
+  type MessagePart,
   toModelMessage,
 } from "./messages";
 

--- a/apps/api/src/chat/producer.test.ts
+++ b/apps/api/src/chat/producer.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { ServerResponse } from "node:http";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { attachToStream, mapStreamPart, runChatStream } from "./producer";
 import { makeStreamEmitter } from "./stream-emitter";
 import { StreamHub } from "./stream-hub";

--- a/apps/api/src/chat/producer.ts
+++ b/apps/api/src/chat/producer.ts
@@ -2,7 +2,7 @@ import type { ServerResponse } from "node:http";
 import type { ToolCallResult } from "../tools/types";
 import { writeSseEvent } from "./sse";
 import type { StreamEmitter } from "./stream-emitter";
-import { type StreamEvent, type StreamHub, isTerminalEvent } from "./stream-hub";
+import { isTerminalEvent, type StreamEvent, type StreamHub } from "./stream-hub";
 import type { StreamResumeRepo } from "./stream-resume";
 
 interface MappedEvent {

--- a/apps/api/src/chat/routes.test.ts
+++ b/apps/api/src/chat/routes.test.ts
@@ -9,14 +9,14 @@ import type { TokenDoc, TokenRepo } from "../auth/api-tokens";
 import { CSRF_COOKIE, CSRF_HEADER } from "../auth/csrf";
 import { SESSION_COOKIE } from "../auth/middleware";
 import { MemorySessionStore } from "../auth/session-store";
-import { type UserDoc, type UserRepo, createUser } from "../auth/users";
+import { createUser, type UserDoc, type UserRepo } from "../auth/users";
 import { WorkingMemoryService } from "../memory/service";
 import {
+  assertValidEntry,
   type WorkingMemoryDoc,
   type WorkingMemoryRepo,
-  assertValidEntry,
 } from "../memory/working-memory";
-import { type PaginatedResult, encodeCursor } from "../pagination";
+import { encodeCursor, type PaginatedResult } from "../pagination";
 import { ToolRegistry } from "../tools/registry";
 import type { ConversationDoc, ConversationRepo } from "./conversations";
 import type { MessageDoc, MessagePart, MessageRepo } from "./messages";

--- a/apps/api/src/chat/routes.ts
+++ b/apps/api/src/chat/routes.ts
@@ -20,12 +20,12 @@ import type { ToolCallResult } from "../tools/types";
 import { ApprovalRegistry, makeApprovalGate } from "./approvals";
 import type { ConversationDoc, ConversationRepo } from "./conversations";
 import {
-  type MessagePart,
-  type MessageRepo,
   fromAssistantParts,
   fromAssistantText,
   fromToolResult,
   fromUserText,
+  type MessagePart,
+  type MessageRepo,
   toModelMessage,
 } from "./messages";
 import { attachToStream, runChatStream } from "./producer";

--- a/apps/api/src/chat/stream-emitter.test.ts
+++ b/apps/api/src/chat/stream-emitter.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import { makeStreamEmitter } from "./stream-emitter";
 import { StreamHub } from "./stream-hub";
-import { MemoryStreamResumeRepo } from "./stream-resume";
 import type { StreamEventRow, StreamResumeRepo } from "./stream-resume";
+import { MemoryStreamResumeRepo } from "./stream-resume";
 
 const log = { error: vi.fn() };
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));

--- a/apps/api/src/chat/stream-gc.test.ts
+++ b/apps/api/src/chat/stream-gc.test.ts
@@ -1,10 +1,10 @@
 import type { PgBoss } from "pg-boss";
 import { describe, expect, it, vi } from "vitest";
 import {
+  registerStreamGc,
   STREAM_GC_CRON,
   STREAM_GC_QUEUE,
   STREAM_RESUME_TTL_MS,
-  registerStreamGc,
 } from "./stream-gc";
 import { MemoryStreamResumeRepo } from "./stream-resume";
 

--- a/apps/api/src/chat/stream-hub.test.ts
+++ b/apps/api/src/chat/stream-hub.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { type StreamEvent, StreamHub, isTerminalEvent } from "./stream-hub";
+import { isTerminalEvent, type StreamEvent, StreamHub } from "./stream-hub";
 
 const ev = (seq: number, eventType = "text"): StreamEvent => ({ seq, eventType, data: { seq } });
 

--- a/apps/api/src/hooks/hook-analyzer.test.ts
+++ b/apps/api/src/hooks/hook-analyzer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { HookAnalysisError, analyzeHook } from "./hook-analyzer.js";
+import { analyzeHook, HookAnalysisError } from "./hook-analyzer.js";
 
 describe("analyzeHook", () => {
   describe("banned patterns", () => {

--- a/apps/api/src/hooks/hook-executor.ts
+++ b/apps/api/src/hooks/hook-executor.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { join } from "node:path";
 import { Worker } from "node:worker_threads";
-import { HookAnalysisError, analyzeHook } from "./hook-analyzer.js";
+import { analyzeHook, HookAnalysisError } from "./hook-analyzer.js";
 import type { WorkerRequest, WorkerResponse } from "./types.js";
 
 export class HookError extends Error {

--- a/apps/api/src/hooks/hook-worker.ts
+++ b/apps/api/src/hooks/hook-worker.ts
@@ -27,7 +27,7 @@ function docToRecord(doc: Record<string, unknown>): Record<string, unknown> {
 }
 
 async function runHook(req: WorkerRequest): Promise<WorkerResponse> {
-  const { id, hookType, hookSource, resourceType, record } = req;
+  const { id, hookType, hookSource, record } = req;
   const patchData: Record<string, unknown> = {};
 
   const isolate = new ivm.Isolate({ memoryLimit: MEMORY_LIMIT_MB });

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,13 +1,13 @@
 import { EventEmitter } from "node:events";
 import { EmbeddingService, LlmService } from "@tulipfarm/llm";
-import { PgSecretRepo, SecretsService, loadEncryptionKeys } from "@tulipfarm/secrets";
-import { GitSyncService, SoulLoader, runSoulMigrations } from "@tulipfarm/soul";
+import { loadEncryptionKeys, PgSecretRepo, SecretsService } from "@tulipfarm/secrets";
+import { GitSyncService, runSoulMigrations, SoulLoader } from "@tulipfarm/soul";
 import { config } from "dotenv";
 import { PgBoss } from "pg-boss";
 import { buildApp } from "./app";
 import { PgTokenRepo } from "./auth/api-tokens";
 import { DEFAULT_SESSION_TTL_SECONDS, PgSessionStore } from "./auth/session-store";
-import { PgUserRepo, bootstrapAdmin } from "./auth/users";
+import { bootstrapAdmin, PgUserRepo } from "./auth/users";
 import { PgConversationRepo } from "./chat/conversations";
 import { PgMessageRepo } from "./chat/messages";
 import { registerStreamGc } from "./chat/stream-gc";

--- a/apps/api/src/knowledge/governance.test.ts
+++ b/apps/api/src/knowledge/governance.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { BLOCK_CHAR_CAP, PER_DOC_CHAR_CAP, buildGovernanceBlock } from "./governance";
+import { BLOCK_CHAR_CAP, buildGovernanceBlock, PER_DOC_CHAR_CAP } from "./governance";
 import type { KnowledgeDocument } from "./types";
 
 function gdoc(over: Partial<KnowledgeDocument>): KnowledgeDocument {

--- a/apps/api/src/knowledge/repo.ts
+++ b/apps/api/src/knowledge/repo.ts
@@ -200,9 +200,10 @@ export interface KnowledgeCollectionRepo {
   insert(c: KnowledgeCollection): Promise<void>;
   getById(id: string): Promise<KnowledgeCollection | null>;
   getByName(name: string): Promise<KnowledgeCollection | null>;
-  list(opts: { limit: number; after?: { createdAt: Date; _id: string } }): Promise<
-    PaginatedResult<KnowledgeCollection>
-  >;
+  list(opts: {
+    limit: number;
+    after?: { createdAt: Date; _id: string };
+  }): Promise<PaginatedResult<KnowledgeCollection>>;
   replaceOne(id: string, expectedVersion: number, c: KnowledgeCollection): Promise<boolean>;
   delete(id: string): Promise<boolean>;
   addDocument(collectionId: string, documentId: string): Promise<void>;

--- a/apps/api/src/knowledge/routes.ts
+++ b/apps/api/src/knowledge/routes.ts
@@ -187,7 +187,7 @@ export function registerKnowledgeRoutes(
     async (req, reply) => {
       const { id } = req.params as { id: string };
       const doc = await service.getDocument(id);
-      if (!doc || !doc.active) return reply.code(404).send({ error: "not found" });
+      if (!doc?.active) return reply.code(404).send({ error: "not found" });
       return reply.send(toApiDocument(doc));
     }
   );

--- a/apps/api/src/knowledge/tools.ts
+++ b/apps/api/src/knowledge/tools.ts
@@ -1,5 +1,5 @@
 import { ajv } from "@tulipfarm/validation";
-import { type ToolCallResult, err, ok } from "../tools/types";
+import { err, ok, type ToolCallResult } from "../tools/types";
 import type { KnowledgeService } from "./service";
 
 /** Per-request context a knowledge tool runs against (KN-V1-006). No ACL (KN-V1-001). */

--- a/apps/api/src/memory/ai-toolset.test.ts
+++ b/apps/api/src/memory/ai-toolset.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { buildToolRegistry } from "../tools/setup";
 import { WorkingMemoryService } from "./service";
 import type { ToolCallResult } from "./tool-result";
-import { type WorkingMemoryDoc, type WorkingMemoryRepo, assertValidEntry } from "./working-memory";
+import { assertValidEntry, type WorkingMemoryDoc, type WorkingMemoryRepo } from "./working-memory";
 
 class FakeWorkingMemoryRepo implements WorkingMemoryRepo {
   docs: WorkingMemoryDoc[] = [];

--- a/apps/api/src/memory/service.test.ts
+++ b/apps/api/src/memory/service.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { WorkingMemoryService } from "./service";
-import { type WorkingMemoryDoc, type WorkingMemoryRepo, assertValidEntry } from "./working-memory";
+import { assertValidEntry, type WorkingMemoryDoc, type WorkingMemoryRepo } from "./working-memory";
 
 // In-memory repo mirroring the store's semantics (upsert by {userId,key}; list oldest-written first).
 class FakeWorkingMemoryRepo implements WorkingMemoryRepo {

--- a/apps/api/src/memory/tool-result.ts
+++ b/apps/api/src/memory/tool-result.ts
@@ -1,2 +1,2 @@
 export type { ToolCallResult, ToolErrorCode } from "../tools/types";
-export { ok, err } from "../tools/types";
+export { err, ok } from "../tools/types";

--- a/apps/api/src/memory/tools.test.ts
+++ b/apps/api/src/memory/tools.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { WorkingMemoryService } from "./service";
-import { MEMORY_TOOLS, type ToolContext, deleteMemoryTool, updateMemoryTool } from "./tools";
-import { type WorkingMemoryDoc, type WorkingMemoryRepo, assertValidEntry } from "./working-memory";
+import { deleteMemoryTool, MEMORY_TOOLS, type ToolContext, updateMemoryTool } from "./tools";
+import { assertValidEntry, type WorkingMemoryDoc, type WorkingMemoryRepo } from "./working-memory";
 
 class FakeWorkingMemoryRepo implements WorkingMemoryRepo {
   docs: WorkingMemoryDoc[] = [];

--- a/apps/api/src/memory/tools.ts
+++ b/apps/api/src/memory/tools.ts
@@ -1,7 +1,7 @@
 import { ajv } from "@tulipfarm/validation";
 import { MAX_KEY_CHARS, MAX_VALUE_CHARS } from "./limits";
 import type { WorkingMemoryService } from "./service";
-import { type ToolCallResult, err, ok } from "./tool-result";
+import { err, ok, type ToolCallResult } from "./tool-result";
 
 /** Per-request context a memory tool handler runs against (closes over the authenticated user). */
 export interface ToolContext {

--- a/apps/api/src/openapi.test.ts
+++ b/apps/api/src/openapi.test.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from "node:crypto";
-import { SecretsService } from "@tulipfarm/secrets";
 import type { SecretEnvelopeFields, SecretMeta, SecretRepo } from "@tulipfarm/secrets";
+import { SecretsService } from "@tulipfarm/secrets";
 import type { FastifyInstance } from "fastify";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { buildApp } from "./app";

--- a/apps/api/src/platform/tool-result.ts
+++ b/apps/api/src/platform/tool-result.ts
@@ -1,2 +1,2 @@
 export type { ToolCallResult, ToolErrorCode } from "../tools/types";
-export { ok, err } from "../tools/types";
+export { err, ok } from "../tools/types";

--- a/apps/api/src/platform/tools.test.ts
+++ b/apps/api/src/platform/tools.test.ts
@@ -1,8 +1,6 @@
 import type { SoulAgent, SoulRoutine, SoulSkill } from "@tulipfarm/soul";
 import { describe, expect, it, vi } from "vitest";
 import {
-  PLATFORM_TOOLS,
-  type PlatformToolContext,
   beginSoulBatchTool,
   callSkillTool,
   completeStateTool,
@@ -11,6 +9,8 @@ import {
   endSoulBatchTool,
   loadSkillReferenceTool,
   loadSkillTool,
+  PLATFORM_TOOLS,
+  type PlatformToolContext,
   presentChoicesTool,
   routinePickerTool,
   soulRepoCommitTool,

--- a/apps/api/src/platform/tools.ts
+++ b/apps/api/src/platform/tools.ts
@@ -2,7 +2,7 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { GitSyncService, SoulAgent, SoulRoutine, SoulSkill } from "@tulipfarm/soul";
 import { ajv } from "@tulipfarm/validation";
-import { type ToolCallResult, err, ok } from "./tool-result";
+import { err, ok, type ToolCallResult } from "./tool-result";
 
 export interface PlatformToolContext {
   soulLoader?: {

--- a/apps/api/src/resources/routes.test.ts
+++ b/apps/api/src/resources/routes.test.ts
@@ -8,7 +8,7 @@ import type { TokenDoc, TokenRepo } from "../auth/api-tokens";
 import { CSRF_COOKIE, CSRF_HEADER } from "../auth/csrf";
 import { SESSION_COOKIE } from "../auth/middleware";
 import { MemorySessionStore } from "../auth/session-store";
-import { type UserDoc, type UserRepo, createUser } from "../auth/users";
+import { createUser, type UserDoc, type UserRepo } from "../auth/users";
 import { HookError, type HookExecutor } from "../hooks/hook-executor";
 import type { PaginatedResult } from "../pagination";
 import type {

--- a/apps/api/src/resources/routes.ts
+++ b/apps/api/src/resources/routes.ts
@@ -6,7 +6,7 @@ import { ErrorSchema } from "../auth/schemas";
 import { DOMAIN_EVENTS } from "../domain-events";
 import type { HookExecutor } from "../hooks/hook-executor.js";
 import { parsePaginationQuery } from "../pagination";
-import { type CounterStore, type ResourceRepoFactory, makeHistoryEntry, toApiRecord } from "./repo";
+import { type CounterStore, makeHistoryEntry, type ResourceRepoFactory, toApiRecord } from "./repo";
 import {
   loadForWrite,
   maybeRunAfterHook,

--- a/apps/api/src/resources/tools.ts
+++ b/apps/api/src/resources/tools.ts
@@ -4,11 +4,11 @@ import type { SoulLoader } from "@tulipfarm/soul";
 import { ajv } from "@tulipfarm/validation";
 import type { HookExecutor } from "../hooks/hook-executor.js";
 import { parsePaginationQuery } from "../pagination.js";
-import { type ToolCallResult, err, ok } from "../tools/types.js";
+import { err, ok, type ToolCallResult } from "../tools/types.js";
 import {
   type CounterStore,
-  type ResourceRepoFactory,
   makeHistoryEntry,
+  type ResourceRepoFactory,
   toApiRecord,
 } from "./repo.js";
 import {

--- a/apps/api/src/resources/write-pipeline.ts
+++ b/apps/api/src/resources/write-pipeline.ts
@@ -1,6 +1,6 @@
 import type { SoulLoader, SoulResource } from "@tulipfarm/soul";
 import type { CounterFn } from "@tulipfarm/validation";
-import { TulipFarmValidationError, ajv, applyTransforms } from "@tulipfarm/validation";
+import { ajv, applyTransforms, TulipFarmValidationError } from "@tulipfarm/validation";
 import { HookError, type HookExecutor } from "../hooks/hook-executor.js";
 import type { ResourceDoc, ResourceRepo, ResourceRepoFactory } from "./repo";
 

--- a/apps/api/src/secrets/routes.test.ts
+++ b/apps/api/src/secrets/routes.test.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from "node:crypto";
-import { SecretsService } from "@tulipfarm/secrets";
 import type { SecretDoc, SecretEnvelopeFields, SecretMeta, SecretRepo } from "@tulipfarm/secrets";
+import { SecretsService } from "@tulipfarm/secrets";
 import type { FastifyInstance } from "fastify";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { buildApp } from "../app";
@@ -8,7 +8,7 @@ import type { TokenDoc, TokenRepo } from "../auth/api-tokens";
 import { CSRF_COOKIE, CSRF_HEADER } from "../auth/csrf";
 import { SESSION_COOKIE } from "../auth/routes";
 import { MemorySessionStore } from "../auth/session-store";
-import { type UserDoc, type UserRepo, createUser } from "../auth/users";
+import { createUser, type UserDoc, type UserRepo } from "../auth/users";
 import type { PaginatedResult } from "../pagination";
 
 const TEST_CSRF = "a".repeat(64);

--- a/apps/api/src/secrets/routes.ts
+++ b/apps/api/src/secrets/routes.ts
@@ -1,5 +1,5 @@
+import type { SecretsService, SecretType } from "@tulipfarm/secrets";
 import { InvalidSecretKeyError } from "@tulipfarm/secrets";
-import type { SecretType, SecretsService } from "@tulipfarm/secrets";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { ErrorSchema } from "../auth/schemas";
 import type { UserDoc } from "../auth/users";

--- a/apps/api/src/soul-sync.test.ts
+++ b/apps/api/src/soul-sync.test.ts
@@ -1,6 +1,6 @@
 import type { PgBoss } from "pg-boss";
 import { describe, expect, it, vi } from "vitest";
-import { SOUL_SYNC_CRON, SOUL_SYNC_QUEUE, registerSoulSync } from "./soul-sync";
+import { registerSoulSync, SOUL_SYNC_CRON, SOUL_SYNC_QUEUE } from "./soul-sync";
 
 function makeFakeBoss() {
   let workHandler: (() => Promise<void>) | undefined;

--- a/apps/api/src/soul/agents/routes.test.ts
+++ b/apps/api/src/soul/agents/routes.test.ts
@@ -6,7 +6,7 @@ import type { TokenDoc, TokenRepo } from "../../auth/api-tokens";
 import { CSRF_COOKIE, CSRF_HEADER } from "../../auth/csrf";
 import { SESSION_COOKIE } from "../../auth/middleware";
 import { MemorySessionStore } from "../../auth/session-store";
-import { type UserDoc, type UserRepo, createUser } from "../../auth/users";
+import { createUser, type UserDoc, type UserRepo } from "../../auth/users";
 import type { PaginatedResult } from "../../pagination";
 
 const TEST_CSRF = "a".repeat(64);

--- a/apps/api/src/soul/agents/tools.ts
+++ b/apps/api/src/soul/agents/tools.ts
@@ -2,9 +2,9 @@ import { existsSync } from "node:fs";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { GitSyncService, SoulLoader } from "@tulipfarm/soul";
-import { TulipFarmValidationError, ajv, validateAgentFrontmatter } from "@tulipfarm/validation";
+import { ajv, TulipFarmValidationError, validateAgentFrontmatter } from "@tulipfarm/validation";
 import { stringify } from "yaml";
-import { type ToolCallResult, err, ok } from "../../tools/types.js";
+import { err, ok, type ToolCallResult } from "../../tools/types.js";
 
 const NAME_RE = /^[a-z][a-z0-9-]*$/;
 

--- a/apps/api/src/soul/llm-config/routes.test.ts
+++ b/apps/api/src/soul/llm-config/routes.test.ts
@@ -10,7 +10,7 @@ import type { TokenDoc, TokenRepo } from "../../auth/api-tokens";
 import { CSRF_COOKIE, CSRF_HEADER } from "../../auth/csrf";
 import { SESSION_COOKIE } from "../../auth/middleware";
 import { MemorySessionStore } from "../../auth/session-store";
-import { type UserDoc, type UserRepo, createUser } from "../../auth/users";
+import { createUser, type UserDoc, type UserRepo } from "../../auth/users";
 import type { PaginatedResult } from "../../pagination";
 
 const TEST_CSRF = "a".repeat(64);

--- a/apps/api/src/soul/resource-types/routes.test.ts
+++ b/apps/api/src/soul/resource-types/routes.test.ts
@@ -6,7 +6,7 @@ import type { TokenDoc, TokenRepo } from "../../auth/api-tokens";
 import { CSRF_COOKIE, CSRF_HEADER } from "../../auth/csrf";
 import { SESSION_COOKIE } from "../../auth/middleware";
 import { MemorySessionStore } from "../../auth/session-store";
-import { type UserDoc, type UserRepo, createUser } from "../../auth/users";
+import { createUser, type UserDoc, type UserRepo } from "../../auth/users";
 import type { PaginatedResult } from "../../pagination";
 
 vi.mock("node:fs", () => ({ existsSync: vi.fn() }));

--- a/apps/api/src/soul/resource-types/routes.ts
+++ b/apps/api/src/soul/resource-types/routes.ts
@@ -2,7 +2,7 @@ import { existsSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { GitSyncService, SoulLoader } from "@tulipfarm/soul";
-import { TulipFarmValidationError, ajv, validateResourceSchema } from "@tulipfarm/validation";
+import { ajv, TulipFarmValidationError, validateResourceSchema } from "@tulipfarm/validation";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { ErrorSchema } from "../../auth/schemas";

--- a/apps/api/src/soul/resource-types/tools.ts
+++ b/apps/api/src/soul/resource-types/tools.ts
@@ -2,9 +2,9 @@ import { existsSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { GitSyncService, SoulLoader } from "@tulipfarm/soul";
-import { TulipFarmValidationError, ajv, validateResourceSchema } from "@tulipfarm/validation";
+import { ajv, TulipFarmValidationError, validateResourceSchema } from "@tulipfarm/validation";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
-import { type ToolCallResult, err, ok } from "../../tools/types.js";
+import { err, ok, type ToolCallResult } from "../../tools/types.js";
 
 const NAME_RE = /^[a-z][a-z0-9-]*$/;
 

--- a/apps/api/src/soul/routes.test.ts
+++ b/apps/api/src/soul/routes.test.ts
@@ -6,7 +6,7 @@ import type { TokenDoc, TokenRepo } from "../auth/api-tokens";
 import { CSRF_COOKIE, CSRF_HEADER } from "../auth/csrf";
 import { SESSION_COOKIE } from "../auth/middleware";
 import { MemorySessionStore } from "../auth/session-store";
-import { type UserDoc, type UserRepo, createUser } from "../auth/users";
+import { createUser, type UserDoc, type UserRepo } from "../auth/users";
 import type { PaginatedResult } from "../pagination";
 
 const TEST_CSRF = "a".repeat(64);

--- a/apps/api/src/soul/skills/audit.test.ts
+++ b/apps/api/src/soul/skills/audit.test.ts
@@ -8,7 +8,7 @@ vi.mock("ai", async (orig) => {
   return { ...actual, generateObject: (...args: unknown[]) => generateObject(...args) };
 });
 
-import { AUDIT_SYSTEM_PROMPT, SKILL_AUDIT_REPORT_SCHEMA, buildAudit } from "./audit";
+import { AUDIT_SYSTEM_PROMPT, buildAudit, SKILL_AUDIT_REPORT_SCHEMA } from "./audit";
 
 const VALID_REPORT = {
   riskRating: "medium",

--- a/apps/api/src/soul/skills/routes.test.ts
+++ b/apps/api/src/soul/skills/routes.test.ts
@@ -11,7 +11,7 @@ import type { TokenDoc, TokenRepo } from "../../auth/api-tokens";
 import { CSRF_COOKIE, CSRF_HEADER } from "../../auth/csrf";
 import { SESSION_COOKIE } from "../../auth/middleware";
 import { MemorySessionStore } from "../../auth/session-store";
-import { type UserDoc, type UserRepo, createUser } from "../../auth/users";
+import { createUser, type UserDoc, type UserRepo } from "../../auth/users";
 import type { PaginatedResult } from "../../pagination";
 
 // Keep the report schema real (used in the route's response schema); mock only the LLM call.

--- a/apps/api/src/soul/skills/routes.ts
+++ b/apps/api/src/soul/skills/routes.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
-import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, dirname, join, relative } from "node:path";
 import { promisify } from "node:util";
@@ -9,7 +9,7 @@ import type { GitSyncService, SoulLoader, SoulSkill } from "@tulipfarm/soul";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { parse as parseYaml } from "yaml";
 import { ErrorSchema } from "../../auth/schemas";
-import { SKILL_AUDIT_REPORT_SCHEMA, buildAudit } from "./audit";
+import { buildAudit, SKILL_AUDIT_REPORT_SCHEMA } from "./audit";
 
 /*
  * Skills HTTP surface (SKILLS / SKL-V1-001..003). Read endpoints over the SoulLoader, plus the

--- a/apps/api/src/soul/skills/tools.ts
+++ b/apps/api/src/soul/skills/tools.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import type { GitSyncService, SoulLoader } from "@tulipfarm/soul";
 import { ajv } from "@tulipfarm/validation";
 import { stringify } from "yaml";
-import { type ToolCallResult, err, ok } from "../../tools/types.js";
+import { err, ok, type ToolCallResult } from "../../tools/types.js";
 
 const NAME_RE = /^[a-z][a-z0-9-]*$/;
 

--- a/apps/api/src/tools/registry.ts
+++ b/apps/api/src/tools/registry.ts
@@ -1,13 +1,13 @@
 import { ajv } from "@tulipfarm/validation";
-import { type ToolSet, jsonSchema, tool } from "ai";
+import { jsonSchema, type ToolSet, tool } from "ai";
 import type { BatchCoordinator } from "./batch-executor";
 import { truncateResult } from "./truncate";
 import {
   type ApprovalGate,
+  err,
   type RequestContext,
   type ToolCallResult,
   type ToolDef,
-  err,
 } from "./types";
 
 type AjvErrors = ReturnType<typeof ajv.compile>["errors"];

--- a/apps/api/src/tools/truncate.ts
+++ b/apps/api/src/tools/truncate.ts
@@ -1,4 +1,4 @@
-import { type ToolCallResult, ok } from "./types";
+import { ok, type ToolCallResult } from "./types";
 
 export const RESULT_CAP = 20;
 

--- a/apps/docs/app/(home)/layout.tsx
+++ b/apps/docs/app/(home)/layout.tsx
@@ -1,5 +1,5 @@
-import { baseOptions } from "@/lib/layout.shared";
 import { HomeLayout } from "fumadocs-ui/layouts/home";
+import { baseOptions } from "@/lib/layout.shared";
 
 export default function Layout({ children }: LayoutProps<"/">) {
   return <HomeLayout {...baseOptions()}>{children}</HomeLayout>;

--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -1,8 +1,8 @@
+import Link from "next/link";
 import { BootSequence } from "@/components/home/boot-sequence";
 import { Reveal } from "@/components/home/reveal";
 import { TulipField } from "@/components/home/tulip-field";
 import { gitConfig } from "@/lib/shared";
-import Link from "next/link";
 
 const seeAlso = [
   {

--- a/apps/docs/app/api/search/route.ts
+++ b/apps/docs/app/api/search/route.ts
@@ -1,5 +1,5 @@
-import { source } from "@/lib/source";
 import { createFromSource } from "fumadocs-core/search/server";
+import { source } from "@/lib/source";
 
 export const revalidate = false;
 

--- a/apps/docs/app/docs/[[...slug]]/page.tsx
+++ b/apps/docs/app/docs/[[...slug]]/page.tsx
@@ -1,6 +1,3 @@
-import { getMDXComponents } from "@/components/mdx";
-import { gitConfig } from "@/lib/shared";
-import { getPageImage, getPageMarkdownUrl, source } from "@/lib/source";
 import {
   DocsBody,
   DocsDescription,
@@ -12,6 +9,9 @@ import {
 import { createRelativeLink } from "fumadocs-ui/mdx";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { getMDXComponents } from "@/components/mdx";
+import { gitConfig } from "@/lib/shared";
+import { getPageImage, getPageMarkdownUrl, source } from "@/lib/source";
 
 export default async function Page(props: PageProps<"/docs/[[...slug]]">) {
   const params = await props.params;

--- a/apps/docs/app/docs/layout.tsx
+++ b/apps/docs/app/docs/layout.tsx
@@ -1,6 +1,6 @@
+import { DocsLayout } from "fumadocs-ui/layouts/docs";
 import { baseOptions } from "@/lib/layout.shared";
 import { source } from "@/lib/source";
-import { DocsLayout } from "fumadocs-ui/layouts/docs";
 
 export default function Layout({ children }: LayoutProps<"/docs">) {
   return (

--- a/apps/docs/app/global.css
+++ b/apps/docs/app/global.css
@@ -146,8 +146,9 @@ html > body[data-scroll-locked] {
 [data-reveal] {
   opacity: 0;
   transform: translateY(20px);
-  transition: opacity 700ms cubic-bezier(0.23, 1, 0.32, 1) var(--reveal-delay, 0ms), transform 700ms
-    cubic-bezier(0.23, 1, 0.32, 1) var(--reveal-delay, 0ms);
+  transition:
+    opacity 700ms cubic-bezier(0.23, 1, 0.32, 1) var(--reveal-delay, 0ms),
+    transform 700ms cubic-bezier(0.23, 1, 0.32, 1) var(--reveal-delay, 0ms);
 }
 
 [data-reveal="in"] {

--- a/apps/docs/app/llms.mdx/docs/[[...slug]]/route.ts
+++ b/apps/docs/app/llms.mdx/docs/[[...slug]]/route.ts
@@ -1,5 +1,5 @@
-import { getLLMText, getPageMarkdownUrl, source } from "@/lib/source";
 import { notFound } from "next/navigation";
+import { getLLMText, getPageMarkdownUrl, source } from "@/lib/source";
 
 export const revalidate = false;
 

--- a/apps/docs/app/llms.txt/route.ts
+++ b/apps/docs/app/llms.txt/route.ts
@@ -1,5 +1,5 @@
-import { source } from "@/lib/source";
 import { llms } from "fumadocs-core/source";
+import { source } from "@/lib/source";
 
 export const revalidate = false;
 

--- a/apps/docs/app/og/docs/[...slug]/route.tsx
+++ b/apps/docs/app/og/docs/[...slug]/route.tsx
@@ -1,8 +1,8 @@
-import { appName } from "@/lib/shared";
-import { getPageImage, source } from "@/lib/source";
 import { generate as DefaultImage } from "fumadocs-ui/og";
 import { notFound } from "next/navigation";
 import { ImageResponse } from "next/og";
+import { appName } from "@/lib/shared";
+import { getPageImage, source } from "@/lib/source";
 
 export const revalidate = false;
 

--- a/apps/docs/components/home/boot-sequence.tsx
+++ b/apps/docs/components/home/boot-sequence.tsx
@@ -127,7 +127,6 @@ export function BootSequence() {
       </div>
       <pre className="min-h-[16.5rem] overflow-x-auto rounded-md border border-fd-border bg-fd-background p-4 text-[13px] leading-6">
         {LINES.slice(0, done).map((line, i) => (
-          // biome-ignore lint/suspicious/noArrayIndexKey: static transcript, order never changes
           <FinishedLine key={i} line={line} />
         ))}
         {next?.kind === "cmd" && (

--- a/apps/docs/components/provider.tsx
+++ b/apps/docs/components/provider.tsx
@@ -1,7 +1,7 @@
 "use client";
-import SearchDialog from "@/components/search";
 import { RootProvider } from "fumadocs-ui/provider/next";
 import type { ReactNode } from "react";
+import SearchDialog from "@/components/search";
 
 export function Provider({ children }: { children: ReactNode }) {
   return <RootProvider search={{ SearchDialog }}>{children}</RootProvider>;

--- a/apps/docs/lib/layout.shared.tsx
+++ b/apps/docs/lib/layout.shared.tsx
@@ -1,4 +1,5 @@
 import type { BaseLayoutProps } from "fumadocs-ui/layouts/shared";
+import Image from "next/image";
 import { appName, gitConfig } from "./shared";
 
 export function baseOptions(): BaseLayoutProps {
@@ -6,7 +7,7 @@ export function baseOptions(): BaseLayoutProps {
     nav: {
       title: (
         <>
-          <img src="/logo-128.png" alt="" width={24} height={24} className="size-6 rounded-sm" />
+          <Image src="/logo-128.png" alt="" width={24} height={24} className="size-6 rounded-sm" />
           {appName}
         </>
       ),

--- a/apps/web/app/components/link-combobox.tsx
+++ b/apps/web/app/components/link-combobox.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { type ResourceRecord, listRecords } from "~/lib/api";
+import { listRecords, type ResourceRecord } from "~/lib/api";
 
 /*
  * Searchable combobox for an `x-links` field (AC-V1-002). Loads the first page of the target type's

--- a/apps/web/app/components/llm-config-form.tsx
+++ b/apps/web/app/components/llm-config-form.tsx
@@ -1,6 +1,6 @@
 import { type FormEvent, useState } from "react";
 import { Button } from "~/components/ui/button";
-import { type LlmConfig, type LlmProviderInfo, isProviderConfigured } from "~/lib/settings";
+import { isProviderConfigured, type LlmConfig, type LlmProviderInfo } from "~/lib/settings";
 
 /*
  * Structured editor for soul/llm.config.yaml (UI-V1-003 / LLM-V1-003). Each tier is an ordered list

--- a/apps/web/app/components/ui/button.tsx
+++ b/apps/web/app/components/ui/button.tsx
@@ -1,5 +1,5 @@
 import { Slot } from "@radix-ui/react-slot";
-import { type VariantProps, cva } from "class-variance-authority";
+import { cva, type VariantProps } from "class-variance-authority";
 import type * as React from "react";
 import { cn } from "~/lib/utils";
 

--- a/apps/web/app/lib/api.test.ts
+++ b/apps/web/app/lib/api.test.ts
@@ -109,12 +109,14 @@ test("updateRecord PUTs with a quoted If-Match version header and encodes the id
 });
 
 test("writes echo the csrf_token cookie as the x-csrf-token header", async () => {
+  // biome-ignore lint/suspicious/noDocumentCookie: test verifies CSRF cookie → header wiring
   document.cookie = "csrf_token=tok-123";
   const fetchFn = mockFetch(201, { id: "x", version: 1, createdAt: "", updatedAt: "" });
   await createRecord("ticket", { title: "hi" });
   const [, init] = fetchFn.mock.calls[0];
   expect(init.headers["x-csrf-token"]).toBe("tok-123");
   // clear for other tests
+  // biome-ignore lint/suspicious/noDocumentCookie: clearing test cookie
   document.cookie = "csrf_token=; expires=Thu, 01 Jan 1970 00:00:00 GMT";
 });
 

--- a/apps/web/app/lib/approvals-context.tsx
+++ b/apps/web/app/lib/approvals-context.tsx
@@ -1,13 +1,13 @@
 import {
-  type ReactNode,
   createContext,
+  type ReactNode,
   useCallback,
   useContext,
   useEffect,
   useRef,
   useState,
 } from "react";
-import { type PendingApproval, listPendingApprovals } from "~/lib/approvals";
+import { listPendingApprovals, type PendingApproval } from "~/lib/approvals";
 
 /*
  * Single source of truth for app-wide pending approvals. Mounted once in the `_app` shell, it polls

--- a/apps/web/app/lib/approvals.ts
+++ b/apps/web/app/lib/approvals.ts
@@ -1,4 +1,5 @@
 import { apiGet } from "./api";
+
 // Re-export the existing decide POST so the approvals feature has one import surface (chat untouched).
 export { sendApprovalDecision } from "./chat/sse-client";
 

--- a/apps/web/app/lib/chat/use-chat-stream.ts
+++ b/apps/web/app/lib/chat/use-chat-stream.ts
@@ -9,8 +9,8 @@
 
 import { useCallback, useReducer, useRef } from "react";
 import { appendUserMessage, chatReducer, initialChatState } from "~/lib/chat/reducer";
-import { postChat, sendApprovalDecision } from "~/lib/chat/sse-client";
 import type { ChatStreamMeta } from "~/lib/chat/sse-client";
+import { postChat, sendApprovalDecision } from "~/lib/chat/sse-client";
 import type { Autonomy, ChatEvent, ChatState, ModelTier } from "~/lib/chat/types";
 
 export type SendOptions = { model?: ModelTier; autonomy?: Autonomy; agentId?: string };

--- a/apps/web/app/lib/schema.test.ts
+++ b/apps/web/app/lib/schema.test.ts
@@ -2,8 +2,8 @@ import { expect, test } from "vitest";
 import {
   deriveFields,
   detailFields,
-  formFields,
   formatIso,
+  formFields,
   listColumns,
   parseSchema,
   renderValue,

--- a/apps/web/app/routes/_app.resources.$type._index.tsx
+++ b/apps/web/app/routes/_app.resources.$type._index.tsx
@@ -7,13 +7,12 @@ import {
   useRouteError,
 } from "@remix-run/react";
 import { useState } from "react";
-import { EmptyState } from "~/components/empty-state";
 import { ResourcePanel } from "~/components/resource-panel";
 import { SchemaTable } from "~/components/schema-table";
 import { ErrorState } from "~/components/states";
 import { Button } from "~/components/ui/button";
-import { ApiError, type ResourceRecord, listRecords, listResourceTypes } from "~/lib/api";
-import { type FieldDescriptor, deriveFields, listColumns, parseSchema } from "~/lib/schema";
+import { ApiError, listRecords, listResourceTypes, type ResourceRecord } from "~/lib/api";
+import { deriveFields, type FieldDescriptor, listColumns, parseSchema } from "~/lib/schema";
 
 export const meta: MetaFunction = () => [{ title: "Resources · tulipfarm" }];
 

--- a/apps/web/app/routes/_app.settings.llm.tsx
+++ b/apps/web/app/routes/_app.settings.llm.tsx
@@ -4,9 +4,9 @@ import { LlmConfigForm } from "~/components/llm-config-form";
 import { ErrorState } from "~/components/states";
 import { ApiError } from "~/lib/api";
 import {
-  type LlmConfig,
   getLlmConfig,
   isProviderConfigured,
+  type LlmConfig,
   listProviders,
   listSecrets,
   putLlmConfig,

--- a/apps/web/app/routes/_app.skills.install.tsx
+++ b/apps/web/app/routes/_app.skills.install.tsx
@@ -4,10 +4,10 @@ import { ResourcePanel } from "~/components/resource-panel";
 import { Button } from "~/components/ui/button";
 import { ApiError } from "~/lib/api";
 import {
-  type ScanResult,
-  type SkillAuditReport,
   auditSkill,
   installSkills,
+  type ScanResult,
+  type SkillAuditReport,
   scanSkills,
 } from "~/lib/skills";
 

--- a/apps/web/app/routes/agents.routes.test.tsx
+++ b/apps/web/app/routes/agents.routes.test.tsx
@@ -4,8 +4,8 @@ import { render, screen } from "@testing-library/react";
 import type { ReactElement } from "react";
 import { expect, test, vi } from "vitest";
 import { ApiError } from "~/lib/api";
-import AgentDetail, { ErrorBoundary as DetailErrorBoundary } from "./_app.agents.$name";
 import AgentsIndex, { ErrorBoundary as IndexErrorBoundary } from "./_app.agents._index";
+import AgentDetail, { ErrorBoundary as DetailErrorBoundary } from "./_app.agents.$name";
 
 /*
  * Agents route smoke tests. Same approach as resources.routes.test.tsx: mock the loader/error hooks

--- a/apps/web/app/routes/resources.routes.test.tsx
+++ b/apps/web/app/routes/resources.routes.test.tsx
@@ -5,9 +5,9 @@ import type { ReactElement } from "react";
 import { expect, test, vi } from "vitest";
 import { ApiError } from "~/lib/api";
 import { deriveFields, detailFields, listColumns, parseSchema } from "~/lib/schema";
-import ResourceDetail, { ErrorBoundary as DetailErrorBoundary } from "./_app.resources.$type.$id";
-import ResourceList, { ErrorBoundary as ListErrorBoundary } from "./_app.resources.$type._index";
 import ResourcesIndex, { ErrorBoundary as IndexErrorBoundary } from "./_app.resources._index";
+import ResourceList, { ErrorBoundary as ListErrorBoundary } from "./_app.resources.$type._index";
+import ResourceDetail, { ErrorBoundary as DetailErrorBoundary } from "./_app.resources.$type.$id";
 
 /*
  * Route smoke tests. A stub `loader` triggers a real data navigation whose AbortSignal jsdom's

--- a/apps/web/app/routes/settings.routes.test.tsx
+++ b/apps/web/app/routes/settings.routes.test.tsx
@@ -5,8 +5,8 @@ import userEvent from "@testing-library/user-event";
 import type { ReactElement } from "react";
 import { afterEach, expect, test, vi } from "vitest";
 import { ApiError } from "~/lib/api";
-import * as settings from "~/lib/settings";
 import type { LlmProviderInfo } from "~/lib/settings";
+import * as settings from "~/lib/settings";
 import SettingsLlm from "./_app.settings.llm";
 import SettingsSecrets from "./_app.settings.secrets";
 

--- a/apps/web/app/routes/skills.routes.test.tsx
+++ b/apps/web/app/routes/skills.routes.test.tsx
@@ -4,8 +4,8 @@ import { render, screen } from "@testing-library/react";
 import type { ReactElement } from "react";
 import { expect, test, vi } from "vitest";
 import { ApiError } from "~/lib/api";
-import SkillDetail, { ErrorBoundary as DetailErrorBoundary } from "./_app.skills.$name";
 import SkillsIndex from "./_app.skills._index";
+import SkillDetail, { ErrorBoundary as DetailErrorBoundary } from "./_app.skills.$name";
 
 vi.mock("@remix-run/react", async () => {
   const actual = await vi.importActual<typeof import("@remix-run/react")>("@remix-run/react");

--- a/biome.json
+++ b/biome.json
@@ -1,18 +1,20 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "files": {
-    "ignore": [
-      "**/node_modules",
-      "**/dist",
-      "**/build",
-      "**/.next",
-      "**/out",
-      "**/.source",
-      "**/next-env.d.ts",
-      "**/.turbo",
-      "**/.agent",
-      "**/.agents",
-      "**/.claude"
+    "includes": [
+      "**",
+      "!**/node_modules",
+      "!**/dist",
+      "!**/build",
+      "!**/.next",
+      "!**/out",
+      "!**/.source",
+      "!**/next-env.d.ts",
+      "!**/.turbo",
+      "!**/.agent",
+      "!**/.agents",
+      "!**/.claude",
+      "!brand"
     ]
   },
   "formatter": {
@@ -24,7 +26,26 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "complexity": {
+        "noImportantStyles": "off"
+      },
+      "suspicious": {
+        "noArrayIndexKey": "off"
+      }
+    }
+  },
+  "css": {
+    "parser": {
+      "tailwindDirectives": true
+    }
+  },
+  "assist": {
+    "enabled": true,
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
     }
   },
   "javascript": {
@@ -34,15 +55,12 @@
       "trailingCommas": "es5"
     }
   },
-  "organizeImports": {
-    "enabled": true
-  },
   "overrides": [
     {
-      "include": [".agent/**", ".agents/**", ".claude/**"],
+      "includes": [".agent/**", ".agents/**", ".claude/**"],
       "linter": { "enabled": false },
       "formatter": { "enabled": false },
-      "organizeImports": { "enabled": false }
+      "assist": { "enabled": false }
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "*.{ts,tsx,js,jsx,json,css}": "biome check --write --no-errors-on-unmatched"
   },
   "devDependencies": {
-    "@biomejs/biome": "^1.9",
-    "lefthook": "^1",
-    "lint-staged": "^15",
+    "@biomejs/biome": "^2.4.16",
+    "lefthook": "^2.1.9",
+    "lint-staged": "^17.0.7",
     "turbo": "^2.9.16",
     "typescript": "^6.0.3",
     "vitest": "^4"

--- a/packages/llm/src/embedding-provider.test.ts
+++ b/packages/llm/src/embedding-provider.test.ts
@@ -52,7 +52,6 @@ describe("createEmbeddingModel", () => {
     );
     expect(model).toMatchObject({ provider: "openai" });
     expect(secrets.get).not.toHaveBeenCalled();
-    // biome-ignore lint/performance/noDelete: must remove env var to avoid polluting other tests
     delete process.env.OPENAI_API_KEY;
   });
 

--- a/packages/llm/src/embedding-provider.ts
+++ b/packages/llm/src/embedding-provider.ts
@@ -3,8 +3,8 @@ import { createOpenAI } from "@ai-sdk/openai";
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import type { SecretsService } from "@tulipfarm/secrets";
 import type { EmbeddingModel } from "ai";
-import { LlmConfigValidationError } from "./config";
 import type { EmbeddingProviderEntry } from "./config";
+import { LlmConfigValidationError } from "./config";
 import { resolveApiKey } from "./provider";
 
 /**

--- a/packages/llm/src/index.ts
+++ b/packages/llm/src/index.ts
@@ -1,3 +1,10 @@
+export type {
+  EmbeddingProviderEntry,
+  EmbeddingsConfig,
+  LlmConfig,
+  ProviderEntry,
+  TierConfig,
+} from "./config";
 export {
   EMBEDDING_UNAVAILABLE_WARNING,
   EmbeddingUnavailableError,
@@ -7,18 +14,11 @@ export {
   UnknownModelError,
   validateLlmConfig,
 } from "./config";
-export type {
-  EmbeddingProviderEntry,
-  EmbeddingsConfig,
-  LlmConfig,
-  ProviderEntry,
-  TierConfig,
-} from "./config";
-export { FallbackModel, type FallbackLogger, isHardFailure } from "./fallback";
-export { createModel } from "./provider";
 export { createEmbeddingModel } from "./embedding-provider";
-export { EmbeddingService, type EmbeddingLogger } from "./embeddings";
-export { resolveTier } from "./selection";
-export type { Autonomy, ModelSelector, SelectionContext } from "./selection";
-export { LlmService } from "./llm-service";
+export { type EmbeddingLogger, EmbeddingService } from "./embeddings";
+export { type FallbackLogger, FallbackModel, isHardFailure } from "./fallback";
 export type { SelectRequest, Tier } from "./llm-service";
+export { LlmService } from "./llm-service";
+export { createModel } from "./provider";
+export type { Autonomy, ModelSelector, SelectionContext } from "./selection";
+export { resolveTier } from "./selection";

--- a/packages/llm/src/llm-service.ts
+++ b/packages/llm/src/llm-service.ts
@@ -3,7 +3,7 @@ import type { LanguageModel } from "ai";
 import { LlmNotConfiguredError, UnknownModelError, validateLlmConfig } from "./config";
 import { type FallbackLogger, FallbackModel } from "./fallback";
 import { createModel } from "./provider";
-import { type ModelSelector, type SelectionContext, resolveTier } from "./selection";
+import { type ModelSelector, resolveTier, type SelectionContext } from "./selection";
 
 export type Tier = "quick" | "standard" | "complex";
 

--- a/packages/llm/src/provider.test.ts
+++ b/packages/llm/src/provider.test.ts
@@ -56,7 +56,6 @@ describe("createModel", () => {
     );
     expect(model.provider).toBe("openai");
     expect(secrets.get).not.toHaveBeenCalled();
-    // biome-ignore lint/performance/noDelete: must remove env var to avoid polluting other tests
     delete process.env.OPENAI_API_KEY;
   });
 
@@ -80,7 +79,6 @@ describe("createModel", () => {
   });
 
   it("throws LlmConfigValidationError when env:// var is not set", async () => {
-    // biome-ignore lint/performance/noDelete: must ensure env var is absent for this test
     delete process.env.MISSING_VAR;
     const secrets = makeSecrets();
     await expect(

--- a/packages/llm/src/provider.ts
+++ b/packages/llm/src/provider.ts
@@ -4,13 +4,13 @@ import { createOpenAI } from "@ai-sdk/openai";
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import type { LanguageModelV3 } from "@ai-sdk/provider";
 import {
-  SecretUnavailableError,
-  type SecretsService,
   llmProviderById,
   providerField,
+  type SecretsService,
+  SecretUnavailableError,
 } from "@tulipfarm/secrets";
-import { LlmConfigValidationError, LlmCredentialError } from "./config";
 import type { ProviderEntry } from "./config";
+import { LlmConfigValidationError, LlmCredentialError } from "./config";
 
 export async function resolveApiKey(
   api_key_ref: string | undefined,

--- a/packages/secrets/src/index.ts
+++ b/packages/secrets/src/index.ts
@@ -1,16 +1,22 @@
 export { decryptSecret, encryptSecret } from "./crypto";
 export { assertValidSecretKey, InvalidSecretKeyError } from "./key-guard";
-export { loadEncryptionKeys } from "./keys";
 export type { EncryptionKeys } from "./keys";
+export { loadEncryptionKeys } from "./keys";
+export type { LlmProviderId, LlmProviderInfo, ProviderField, ProviderFieldRole } from "./registry";
 export {
-  LLM_PROVIDERS,
   isProviderConfigured,
+  LLM_PROVIDERS,
   llmProviderById,
   llmProviderForFieldKey,
   providerField,
 } from "./registry";
-export type { LlmProviderId, LlmProviderInfo, ProviderField, ProviderFieldRole } from "./registry";
+export type {
+  Queryable,
+  SecretDoc,
+  SecretEnvelopeFields,
+  SecretMeta,
+  SecretRepo,
+  SecretType,
+} from "./repo";
 export { PgSecretRepo } from "./repo";
-export type { Queryable } from "./repo";
-export type { SecretDoc, SecretEnvelopeFields, SecretMeta, SecretRepo, SecretType } from "./repo";
 export { SecretsService, SecretUnavailableError } from "./service";

--- a/packages/secrets/src/key-guard.test.ts
+++ b/packages/secrets/src/key-guard.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { InvalidSecretKeyError, assertValidSecretKey } from "./key-guard";
+import { assertValidSecretKey, InvalidSecretKeyError } from "./key-guard";
 
 describe("assertValidSecretKey", () => {
   it("accepts valid keys", () => {

--- a/packages/secrets/src/service.test.ts
+++ b/packages/secrets/src/service.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { DecryptError } from "./crypto";
 import type { EncryptionKeys } from "./keys";
 import type { SecretDoc, SecretEnvelopeFields, SecretRepo } from "./repo";
-import { SecretUnavailableError, SecretsService } from "./service";
+import { SecretsService, SecretUnavailableError } from "./service";
 
 class FakeRepo implements SecretRepo {
   readonly docs = new Map<string, SecretDoc>();

--- a/packages/secrets/src/service.ts
+++ b/packages/secrets/src/service.ts
@@ -1,4 +1,4 @@
-import { type SecretEnvelope, decryptSecret, encryptSecret } from "./crypto";
+import { decryptSecret, encryptSecret, type SecretEnvelope } from "./crypto";
 import { assertValidSecretKey } from "./key-guard";
 import type { EncryptionKeys } from "./keys";
 import type { SecretMeta, SecretRepo, SecretType } from "./repo";

--- a/packages/soul/src/index.ts
+++ b/packages/soul/src/index.ts
@@ -1,7 +1,7 @@
 export { GitSyncService } from "./git-sync";
 export type { SoulMigration } from "./migrations/index";
-export { runSoulMigrations } from "./soul-migrations";
 export { SoulLoader } from "./soul-loader";
+export { runSoulMigrations } from "./soul-migrations";
 export type {
   Logger,
   SoulAgent,

--- a/packages/soul/src/soul-loader.ts
+++ b/packages/soul/src/soul-loader.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { readFile, readdir } from "node:fs/promises";
+import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { validateResourceSchema } from "@tulipfarm/validation";
 import { parse as parseYaml } from "yaml";

--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -1,10 +1,14 @@
-export { BOUNDARIES } from "./boundaries";
-export type { ValidationBoundary } from "./boundaries";
-export { TulipFarmValidationError } from "./error";
-export { ajv } from "./ajv";
-export { validate } from "./validate";
-export { applyTransforms, validateResourceSchema } from "./transforms";
-export type { CounterFn } from "./transforms";
-export { NORMALIZER_KEYS, COMPUTED_FN_KEYS } from "./transforms";
-export { AUTONOMY_VALUES, validateAgentFrontmatter } from "./agent";
 export type { AgentFrontmatter } from "./agent";
+export { AUTONOMY_VALUES, validateAgentFrontmatter } from "./agent";
+export { ajv } from "./ajv";
+export type { ValidationBoundary } from "./boundaries";
+export { BOUNDARIES } from "./boundaries";
+export { TulipFarmValidationError } from "./error";
+export type { CounterFn } from "./transforms";
+export {
+  applyTransforms,
+  COMPUTED_FN_KEYS,
+  NORMALIZER_KEYS,
+  validateResourceSchema,
+} from "./transforms";
+export { validate } from "./validate";

--- a/packages/validation/src/transforms/apply.ts
+++ b/packages/validation/src/transforms/apply.ts
@@ -1,5 +1,5 @@
 import { TulipFarmValidationError } from "../error";
-import { type ComputedFnKey, type CounterFn, applyComputedFn } from "./computed";
+import { applyComputedFn, type ComputedFnKey, type CounterFn } from "./computed";
 import { applyNormalizer, isNormalizerKey } from "./normalizers";
 
 interface IdStrategy {

--- a/packages/validation/src/transforms/index.ts
+++ b/packages/validation/src/transforms/index.ts
@@ -1,5 +1,5 @@
 export { applyTransforms } from "./apply";
 export type { CounterFn } from "./computed";
 export { COMPUTED_FN_KEYS, isComputedFnKey } from "./computed";
-export { NORMALIZER_KEYS, isNormalizerKey } from "./normalizers";
+export { isNormalizerKey, NORMALIZER_KEYS } from "./normalizers";
 export { validateResourceSchema } from "./validate-schema";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,14 +9,14 @@ importers:
   .:
     devDependencies:
       '@biomejs/biome':
-        specifier: ^1.9
-        version: 1.9.4
+        specifier: ^2.4.16
+        version: 2.4.16
       lefthook:
-        specifier: ^1
-        version: 1.13.6
+        specifier: ^2.1.9
+        version: 2.1.9
       lint-staged:
-        specifier: ^15
-        version: 15.5.2
+        specifier: ^17.0.7
+        version: 17.0.7
       turbo:
         specifier: ^2.9.16
         version: 2.9.16
@@ -633,59 +633,59 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@biomejs/biome@1.9.4':
-    resolution: {integrity: sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==}
+  '@biomejs/biome@2.4.16':
+    resolution: {integrity: sha512-x9ajFh1zChVybCiM3TN6OD4phAqLgtPZjFrZF+aTMYCPjwBO+k529TX7PPsAqtGNLeV4UgzwQnowEgS7bGmzcA==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@1.9.4':
-    resolution: {integrity: sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==}
+  '@biomejs/cli-darwin-arm64@2.4.16':
+    resolution: {integrity: sha512-wxPvu4XOA85YJk9ixSWUmq/QBHbid85BISbOAqqBM/5xQpPk9ayjk5375tOlSC0BeCwNSbPFafQBm+vBumXq0A==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@1.9.4':
-    resolution: {integrity: sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==}
+  '@biomejs/cli-darwin-x64@2.4.16':
+    resolution: {integrity: sha512-xFCqGPwYusQJp4N4NJLi1XJiZqjwFdjhT+KqtNy+Ug3qgfczqnTa6MSDvxJF6TkuDLoYJItMapz6tAf7kCekFw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@1.9.4':
-    resolution: {integrity: sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==}
+  '@biomejs/cli-linux-arm64-musl@2.4.16':
+    resolution: {integrity: sha512-oYxnW0ARfJkr72ezzF2OR8N/rtkgLUQeYtF8cFhVswbknHxtTcmzSsanVJP8yQKnGpGpc2ck6c5zLvHahL6Cbg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@1.9.4':
-    resolution: {integrity: sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==}
+  '@biomejs/cli-linux-arm64@2.4.16':
+    resolution: {integrity: sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@1.9.4':
-    resolution: {integrity: sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==}
+  '@biomejs/cli-linux-x64-musl@2.4.16':
+    resolution: {integrity: sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@1.9.4':
-    resolution: {integrity: sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==}
+  '@biomejs/cli-linux-x64@2.4.16':
+    resolution: {integrity: sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@1.9.4':
-    resolution: {integrity: sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==}
+  '@biomejs/cli-win32-arm64@2.4.16':
+    resolution: {integrity: sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@1.9.4':
-    resolution: {integrity: sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==}
+  '@biomejs/cli-win32-x64@2.4.16':
+    resolution: {integrity: sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -2998,9 +2998,9 @@ packages:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
 
-  cli-truncate@4.0.0:
-    resolution: {integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==}
-    engines: {node: '>=18'}
+  cli-truncate@5.2.0:
+    resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
+    engines: {node: '>=20'}
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
@@ -3027,15 +3027,8 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
-  colorette@2.0.20:
-    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
-
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
-
-  commander@13.1.0:
-    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
-    engines: {node: '>=18'}
 
   compressible@2.0.18:
     resolution: {integrity: sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==}
@@ -3393,10 +3386,6 @@ packages:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
 
-  execa@8.0.1:
-    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
-    engines: {node: '>=16.17'}
-
   exit-hook@2.2.1:
     resolution: {integrity: sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==}
     engines: {node: '>=6'}
@@ -3672,10 +3661,6 @@ packages:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
 
-  get-stream@8.0.1:
-    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
-    engines: {node: '>=16'}
-
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
 
@@ -3780,10 +3765,6 @@ packages:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
 
-  human-signals@5.0.0:
-    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
-    engines: {node: '>=16.17.0'}
-
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
@@ -3870,10 +3851,6 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
-  is-fullwidth-code-point@4.0.0:
-    resolution: {integrity: sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==}
-    engines: {node: '>=12'}
-
   is-fullwidth-code-point@5.1.0:
     resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
     engines: {node: '>=18'}
@@ -3926,10 +3903,6 @@ packages:
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
-
-  is-stream@3.0.0:
-    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   is-typed-array@1.1.15:
     resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
@@ -4036,58 +4009,58 @@ packages:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
 
-  lefthook-darwin-arm64@1.13.6:
-    resolution: {integrity: sha512-m6Lb77VGc84/Qo21Lhq576pEvcgFCnvloEiP02HbAHcIXD0RTLy9u2yAInrixqZeaz13HYtdDaI7OBYAAdVt8A==}
+  lefthook-darwin-arm64@2.1.9:
+    resolution: {integrity: sha512-119HryNcvr4nqn0wUIrNPgpMEPn9yMQzEcW/lezRsnb56PCJriJB92+MCySPVcWDxJnZef7o0T3jdnPNiSH7Qg==}
     cpu: [arm64]
     os: [darwin]
 
-  lefthook-darwin-x64@1.13.6:
-    resolution: {integrity: sha512-CoRpdzanu9RK3oXR1vbEJA5LN7iB+c7hP+sONeQJzoOXuq4PNKVtEaN84Gl1BrVtCNLHWFAvCQaZPPiiXSy8qg==}
+  lefthook-darwin-x64@2.1.9:
+    resolution: {integrity: sha512-dwo5Tke2XcQCM56DGHgFKBfRbJIL6xs2wZ0zG1TUVZgl4t4mQUt6LiZ4V/ZQfYHTZF9qywvXoIlR5N35qOaiVQ==}
     cpu: [x64]
     os: [darwin]
 
-  lefthook-freebsd-arm64@1.13.6:
-    resolution: {integrity: sha512-X4A7yfvAJ68CoHTqP+XvQzdKbyd935sYy0bQT6Ajz7FL1g7hFiro8dqHSdPdkwei9hs8hXeV7feyTXbYmfjKQQ==}
+  lefthook-freebsd-arm64@2.1.9:
+    resolution: {integrity: sha512-+09PVap6nl6xsaHch5JLtq7WvIR++U1Q2MzA2ai0M4uB/VP3AqrvKqHw6+9hjyKnIH+HHL83uqi77EAY+LaxLA==}
     cpu: [arm64]
     os: [freebsd]
 
-  lefthook-freebsd-x64@1.13.6:
-    resolution: {integrity: sha512-ai2m+Sj2kGdY46USfBrCqLKe9GYhzeq01nuyDYCrdGISePeZ6udOlD1k3lQKJGQCHb0bRz4St0r5nKDSh1x/2A==}
+  lefthook-freebsd-x64@2.1.9:
+    resolution: {integrity: sha512-8XresjKIYpkE9ARgCtBEZgJZxAU3T4MIqzj4zNy15XRT59I1Us+QdqXTNm+pkZ41Yd2X/nxs2Pkvbq3NWWlIGw==}
     cpu: [x64]
     os: [freebsd]
 
-  lefthook-linux-arm64@1.13.6:
-    resolution: {integrity: sha512-cbo4Wtdq81GTABvikLORJsAWPKAJXE8Q5RXsICFUVznh5PHigS9dFW/4NXywo0+jfFPCT6SYds2zz4tCx6DA0Q==}
+  lefthook-linux-arm64@2.1.9:
+    resolution: {integrity: sha512-1oNIQfwrPe6rgU2KcDM3aF6+hpZDCKx1TmawQKpXUY5gVsbZ7MqX0Sk/1lnnWxqPm+kQQ5f6J2dpFWd+4xH8jg==}
     cpu: [arm64]
     os: [linux]
 
-  lefthook-linux-x64@1.13.6:
-    resolution: {integrity: sha512-uJl9vjCIIBTBvMZkemxCE+3zrZHlRO7Oc+nZJ+o9Oea3fu+W82jwX7a7clw8jqNfaeBS+8+ZEQgiMHWCloTsGw==}
+  lefthook-linux-x64@2.1.9:
+    resolution: {integrity: sha512-fT+7Q+BJyGp+CslFQkNXmdFRgyVXsPHPi9NAsDX0a6QOyNnoORByAsvx6zeAKuF5rL3BBgNfho1/v2RuGxGy9w==}
     cpu: [x64]
     os: [linux]
 
-  lefthook-openbsd-arm64@1.13.6:
-    resolution: {integrity: sha512-7r153dxrNRQ9ytRs2PmGKKkYdvZYFPre7My7XToSTiRu5jNCq++++eAKVkoyWPduk97dGIA+YWiEr5Noe0TK2A==}
+  lefthook-openbsd-arm64@2.1.9:
+    resolution: {integrity: sha512-4bVuafBk3dddVNo0+3hMbjcJs4mqYAstxpPMmX2ufkudSTYFNIhWoqwuGVQV/SS/xdcOKJAldW4qayAzed2ysw==}
     cpu: [arm64]
     os: [openbsd]
 
-  lefthook-openbsd-x64@1.13.6:
-    resolution: {integrity: sha512-Z+UhLlcg1xrXOidK3aLLpgH7KrwNyWYE3yb7ITYnzJSEV8qXnePtVu8lvMBHs/myzemjBzeIr/U/+ipjclR06g==}
+  lefthook-openbsd-x64@2.1.9:
+    resolution: {integrity: sha512-PmPoMmLP/wQQWcQ9u2YH86bTZ3UCfBsxuEmVTEyPU2U8R1qSTp5r/Gs3G8cN5Mxo91XB9oBERtF1n+xD3W6aVA==}
     cpu: [x64]
     os: [openbsd]
 
-  lefthook-windows-arm64@1.13.6:
-    resolution: {integrity: sha512-Uxef6qoDxCmUNQwk8eBvddYJKSBFglfwAY9Y9+NnnmiHpWTjjYiObE9gT2mvGVpEgZRJVAatBXc+Ha5oDD/OgQ==}
+  lefthook-windows-arm64@2.1.9:
+    resolution: {integrity: sha512-KphfkBKmwBnmolyrdhIl3lrBaOyTcCgXBT2AB/9OHnEXhOLvv5uTCUkrD4YRAxXPtFKq6UvnapIeoL3GZq0bdA==}
     cpu: [arm64]
     os: [win32]
 
-  lefthook-windows-x64@1.13.6:
-    resolution: {integrity: sha512-mOZoM3FQh3o08M8PQ/b3IYuL5oo36D9ehczIw1dAgp1Ly+Tr4fJ96A+4SEJrQuYeRD4mex9bR7Ps56I73sBSZA==}
+  lefthook-windows-x64@2.1.9:
+    resolution: {integrity: sha512-2qlUtkJHZ3MyUxgV5XTEmcrIoNZA07iwaquoswAcqv/1MeBFXlD+O+koFRfrzWng2O5WYEbpJnd8tvaYnV8fTA==}
     cpu: [x64]
     os: [win32]
 
-  lefthook@1.13.6:
-    resolution: {integrity: sha512-ojj4/4IJ29Xn4drd5emqVgilegAPN3Kf0FQM2p/9+lwSTpU+SZ1v4Ig++NF+9MOa99UKY8bElmVrLhnUUNFh5g==}
+  lefthook@2.1.9:
+    resolution: {integrity: sha512-bwDaIOViTktE8kJLf9jP0p+H2/RDTlFFlc43Am2YgUsX22hI6Sq4RbzsrecwzY5y+MHTipOH7WsmWSEniePHWQ==}
     hasBin: true
 
   leven@4.1.0:
@@ -4175,14 +4148,14 @@ packages:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
     engines: {node: '>=14'}
 
-  lint-staged@15.5.2:
-    resolution: {integrity: sha512-YUSOLq9VeRNAo/CTaVmhGDKG+LBtA8KF1X4K5+ykMSwWST1vDxJRB2kv2COgLb1fvpCo+A/y9A0G0znNVmdx4w==}
-    engines: {node: '>=18.12.0'}
+  lint-staged@17.0.7:
+    resolution: {integrity: sha512-JrSobt+tW3rH8IOMi8tDZd3foorM5yPEkLD/V2NxobgHrFfHWGee4MOLVuZeScgxftEwbHrPHIFA/ZL+nUJeuA==}
+    engines: {node: '>=22.22.1'}
     hasBin: true
 
-  listr2@8.3.3:
-    resolution: {integrity: sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ==}
-    engines: {node: '>=18.0.0'}
+  listr2@10.2.1:
+    resolution: {integrity: sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q==}
+    engines: {node: '>=22.13.0'}
 
   loader-utils@3.3.1:
     resolution: {integrity: sha512-FMJTLMXfCLMLfJxcX9PFqX5qD88Z5MRGaZCVzfuqeZSPsyiBzs+pahDQjbIWz2QIzPZz0NX9Zy4FX3lmK6YHIg==}
@@ -4565,10 +4538,6 @@ packages:
   micromark@4.0.2:
     resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
-  micromatch@4.0.8:
-    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
-    engines: {node: '>=8.6'}
-
   mime-db@1.33.0:
     resolution: {integrity: sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==}
     engines: {node: '>= 0.6'}
@@ -4597,10 +4566,6 @@ packages:
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
-
-  mimic-fn@4.0.0:
-    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
-    engines: {node: '>=12'}
 
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
@@ -4785,10 +4750,6 @@ packages:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
 
-  npm-run-path@5.3.0:
-    resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
@@ -4815,10 +4776,6 @@ packages:
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
-
-  onetime@6.0.0:
-    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
-    engines: {node: '>=12'}
 
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
@@ -4885,10 +4842,6 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
-
-  path-key@4.0.0:
-    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
-    engines: {node: '>=12'}
 
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
@@ -5483,13 +5436,13 @@ packages:
   simple-git@3.36.0:
     resolution: {integrity: sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==}
 
-  slice-ansi@5.0.0:
-    resolution: {integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==}
-    engines: {node: '>=12'}
-
   slice-ansi@7.1.2:
     resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
     engines: {node: '>=18'}
+
+  slice-ansi@8.0.0:
+    resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
+    engines: {node: '>=20'}
 
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
@@ -5567,6 +5520,10 @@ packages:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
 
+  string-width@8.2.1:
+    resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
+    engines: {node: '>=20'}
+
   string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
@@ -5591,10 +5548,6 @@ packages:
   strip-final-newline@2.0.0:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
-
-  strip-final-newline@3.0.0:
-    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
-    engines: {node: '>=12'}
 
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
@@ -6092,6 +6045,10 @@ packages:
     resolution: {integrity: sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==}
     engines: {node: '>=12'}
 
+  wrap-ansi@10.0.0:
+    resolution: {integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==}
+    engines: {node: '>=20'}
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -6415,39 +6372,39 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@biomejs/biome@1.9.4':
+  '@biomejs/biome@2.4.16':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 1.9.4
-      '@biomejs/cli-darwin-x64': 1.9.4
-      '@biomejs/cli-linux-arm64': 1.9.4
-      '@biomejs/cli-linux-arm64-musl': 1.9.4
-      '@biomejs/cli-linux-x64': 1.9.4
-      '@biomejs/cli-linux-x64-musl': 1.9.4
-      '@biomejs/cli-win32-arm64': 1.9.4
-      '@biomejs/cli-win32-x64': 1.9.4
+      '@biomejs/cli-darwin-arm64': 2.4.16
+      '@biomejs/cli-darwin-x64': 2.4.16
+      '@biomejs/cli-linux-arm64': 2.4.16
+      '@biomejs/cli-linux-arm64-musl': 2.4.16
+      '@biomejs/cli-linux-x64': 2.4.16
+      '@biomejs/cli-linux-x64-musl': 2.4.16
+      '@biomejs/cli-win32-arm64': 2.4.16
+      '@biomejs/cli-win32-x64': 2.4.16
 
-  '@biomejs/cli-darwin-arm64@1.9.4':
+  '@biomejs/cli-darwin-arm64@2.4.16':
     optional: true
 
-  '@biomejs/cli-darwin-x64@1.9.4':
+  '@biomejs/cli-darwin-x64@2.4.16':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@1.9.4':
+  '@biomejs/cli-linux-arm64-musl@2.4.16':
     optional: true
 
-  '@biomejs/cli-linux-arm64@1.9.4':
+  '@biomejs/cli-linux-arm64@2.4.16':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@1.9.4':
+  '@biomejs/cli-linux-x64-musl@2.4.16':
     optional: true
 
-  '@biomejs/cli-linux-x64@1.9.4':
+  '@biomejs/cli-linux-x64@2.4.16':
     optional: true
 
-  '@biomejs/cli-win32-arm64@1.9.4':
+  '@biomejs/cli-win32-arm64@2.4.16':
     optional: true
 
-  '@biomejs/cli-win32-x64@1.9.4':
+  '@biomejs/cli-win32-x64@2.4.16':
     optional: true
 
   '@bramus/specificity@2.4.2':
@@ -8523,10 +8480,10 @@ snapshots:
 
   cli-spinners@2.9.2: {}
 
-  cli-truncate@4.0.0:
+  cli-truncate@5.2.0:
     dependencies:
-      slice-ansi: 5.0.0
-      string-width: 7.2.0
+      slice-ansi: 8.0.0
+      string-width: 8.2.1
 
   client-only@0.0.1: {}
 
@@ -8548,11 +8505,7 @@ snapshots:
 
   color-name@1.1.4: {}
 
-  colorette@2.0.20: {}
-
   comma-separated-tokens@2.0.3: {}
-
-  commander@13.1.0: {}
 
   compressible@2.0.18:
     dependencies:
@@ -8944,18 +8897,6 @@ snapshots:
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
 
-  execa@8.0.1:
-    dependencies:
-      cross-spawn: 7.0.6
-      get-stream: 8.0.1
-      human-signals: 5.0.0
-      is-stream: 3.0.0
-      merge-stream: 2.0.0
-      npm-run-path: 5.3.0
-      onetime: 6.0.0
-      signal-exit: 4.1.0
-      strip-final-newline: 3.0.0
-
   exit-hook@2.2.1: {}
 
   expect-type@1.3.0: {}
@@ -9260,8 +9201,6 @@ snapshots:
 
   get-stream@6.0.1: {}
 
-  get-stream@8.0.1: {}
-
   github-slugger@2.0.0: {}
 
   glob-parent@5.1.2:
@@ -9464,8 +9403,6 @@ snapshots:
 
   human-signals@2.1.0: {}
 
-  human-signals@5.0.0: {}
-
   iconv-lite@0.4.24:
     dependencies:
       safer-buffer: 2.1.2
@@ -9526,8 +9463,6 @@ snapshots:
 
   is-fullwidth-code-point@3.0.0: {}
 
-  is-fullwidth-code-point@4.0.0: {}
-
   is-fullwidth-code-point@5.1.0:
     dependencies:
       get-east-asian-width: 1.6.0
@@ -9572,8 +9507,6 @@ snapshots:
       hasown: 2.0.4
 
   is-stream@2.0.1: {}
-
-  is-stream@3.0.0: {}
 
   is-typed-array@1.1.15:
     dependencies:
@@ -9684,48 +9617,48 @@ snapshots:
 
   kleur@4.1.5: {}
 
-  lefthook-darwin-arm64@1.13.6:
+  lefthook-darwin-arm64@2.1.9:
     optional: true
 
-  lefthook-darwin-x64@1.13.6:
+  lefthook-darwin-x64@2.1.9:
     optional: true
 
-  lefthook-freebsd-arm64@1.13.6:
+  lefthook-freebsd-arm64@2.1.9:
     optional: true
 
-  lefthook-freebsd-x64@1.13.6:
+  lefthook-freebsd-x64@2.1.9:
     optional: true
 
-  lefthook-linux-arm64@1.13.6:
+  lefthook-linux-arm64@2.1.9:
     optional: true
 
-  lefthook-linux-x64@1.13.6:
+  lefthook-linux-x64@2.1.9:
     optional: true
 
-  lefthook-openbsd-arm64@1.13.6:
+  lefthook-openbsd-arm64@2.1.9:
     optional: true
 
-  lefthook-openbsd-x64@1.13.6:
+  lefthook-openbsd-x64@2.1.9:
     optional: true
 
-  lefthook-windows-arm64@1.13.6:
+  lefthook-windows-arm64@2.1.9:
     optional: true
 
-  lefthook-windows-x64@1.13.6:
+  lefthook-windows-x64@2.1.9:
     optional: true
 
-  lefthook@1.13.6:
+  lefthook@2.1.9:
     optionalDependencies:
-      lefthook-darwin-arm64: 1.13.6
-      lefthook-darwin-x64: 1.13.6
-      lefthook-freebsd-arm64: 1.13.6
-      lefthook-freebsd-x64: 1.13.6
-      lefthook-linux-arm64: 1.13.6
-      lefthook-linux-x64: 1.13.6
-      lefthook-openbsd-arm64: 1.13.6
-      lefthook-openbsd-x64: 1.13.6
-      lefthook-windows-arm64: 1.13.6
-      lefthook-windows-x64: 1.13.6
+      lefthook-darwin-arm64: 2.1.9
+      lefthook-darwin-x64: 2.1.9
+      lefthook-freebsd-arm64: 2.1.9
+      lefthook-freebsd-x64: 2.1.9
+      lefthook-linux-arm64: 2.1.9
+      lefthook-linux-x64: 2.1.9
+      lefthook-openbsd-arm64: 2.1.9
+      lefthook-openbsd-x64: 2.1.9
+      lefthook-windows-arm64: 2.1.9
+      lefthook-windows-x64: 2.1.9
 
   leven@4.1.0: {}
 
@@ -9786,29 +9719,22 @@ snapshots:
 
   lilconfig@3.1.3: {}
 
-  lint-staged@15.5.2:
+  lint-staged@17.0.7:
     dependencies:
-      chalk: 5.6.2
-      commander: 13.1.0
-      debug: 4.4.3
-      execa: 8.0.1
-      lilconfig: 3.1.3
-      listr2: 8.3.3
-      micromatch: 4.0.8
-      pidtree: 0.6.0
+      listr2: 10.2.1
+      picomatch: 4.0.4
       string-argv: 0.3.2
+      tinyexec: 1.2.4
+    optionalDependencies:
       yaml: 2.9.0
-    transitivePeerDependencies:
-      - supports-color
 
-  listr2@8.3.3:
+  listr2@10.2.1:
     dependencies:
-      cli-truncate: 4.0.0
-      colorette: 2.0.20
+      cli-truncate: 5.2.0
       eventemitter3: 5.0.4
       log-update: 6.1.0
       rfdc: 1.4.1
-      wrap-ansi: 9.0.2
+      wrap-ansi: 10.0.0
 
   loader-utils@3.3.1: {}
 
@@ -10648,11 +10574,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  micromatch@4.0.8:
-    dependencies:
-      braces: 3.0.3
-      picomatch: 2.3.2
-
   mime-db@1.33.0: {}
 
   mime-db@1.52.0: {}
@@ -10670,8 +10591,6 @@ snapshots:
   mime@1.6.0: {}
 
   mimic-fn@2.1.0: {}
-
-  mimic-fn@4.0.0: {}
 
   mimic-function@5.0.1: {}
 
@@ -10834,10 +10753,6 @@ snapshots:
     dependencies:
       path-key: 3.1.1
 
-  npm-run-path@5.3.0:
-    dependencies:
-      path-key: 4.0.0
-
   object-inspect@1.13.4: {}
 
   obug@2.1.2: {}
@@ -10857,10 +10772,6 @@ snapshots:
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
-
-  onetime@6.0.0:
-    dependencies:
-      mimic-fn: 4.0.0
 
   onetime@7.0.0:
     dependencies:
@@ -10933,8 +10844,6 @@ snapshots:
   path-is-inside@1.0.2: {}
 
   path-key@3.1.1: {}
-
-  path-key@4.0.0: {}
 
   path-scurry@1.11.1:
     dependencies:
@@ -11728,12 +11637,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  slice-ansi@5.0.0:
+  slice-ansi@7.1.2:
     dependencies:
       ansi-styles: 6.2.3
-      is-fullwidth-code-point: 4.0.0
+      is-fullwidth-code-point: 5.1.0
 
-  slice-ansi@7.1.2:
+  slice-ansi@8.0.0:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
@@ -11807,6 +11716,11 @@ snapshots:
       get-east-asian-width: 1.6.0
       strip-ansi: 7.2.0
 
+  string-width@8.2.1:
+    dependencies:
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
   string_decoder@1.1.1:
     dependencies:
       safe-buffer: 5.1.2
@@ -11831,8 +11745,6 @@ snapshots:
   strip-bom@3.0.0: {}
 
   strip-final-newline@2.0.0: {}
-
-  strip-final-newline@3.0.0: {}
 
   strip-indent@3.0.0:
     dependencies:
@@ -12366,6 +12278,12 @@ snapshots:
   widest-line@4.0.1:
     dependencies:
       string-width: 5.1.2
+
+  wrap-ansi@10.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 8.2.1
+      strip-ansi: 7.2.0
 
   wrap-ansi@7.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

- Upgrades `@biomejs/biome` from `^1.9` → `^2.4.16`
- Upgrades `lint-staged` from `^15` → `^17.0.7`
- Upgrades `lefthook` from `^1` → `^2.1.9`

### Biome v2 migration

Updated `biome.json` schema URL and config shape for v2 breaking changes:
- `files.ignore` → `files.includes` with `!` negation patterns
- `organizeImports` top-level key → `assist.actions.source.organizeImports`
- `overrides[].include` → `overrides[].includes`
- Added `css.parser.tailwindDirectives: true` for Tailwind CSS syntax support
- Disabled `noImportantStyles` — CSS `!important` is intentional in Tailwind overrides
- Disabled `noArrayIndexKey` — used where no stable id exists
- Ran `biome check --write` to apply new `assist` import-ordering fixes across 84 files

Code fixes from stricter biome 2.x rules:
- Remove unused `afterEach` import (`producer.test.ts`)
- Remove unused `resourceType` destructure (`hook-worker.ts`)
- Fix `useOptionalChain` (`knowledge/routes.ts`)
- Replace `<img>` with `next/image` (`docs/layout.shared.tsx`)
- Remove unused `EmptyState` import
- Add `biome-ignore` for intentional `document.cookie` in tests
- Remove stale `biome-ignore lint/performance/noDelete` comments (rule no longer fires in v2)

## Test plan

- [ ] `pnpm lint` — all 11 workspaces pass
- [ ] `pnpm typecheck` — all 11 workspaces pass
- [ ] `pnpm build` — all 3 apps build
- [ ] `pnpm test` — passes (`app-sidebar.test.tsx` failures are pre-existing, unrelated)