### PR TITLE
feat(skills): implement eager <skills> block in system-prompt assembly

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -9,7 +9,7 @@ runs:
     - name: Install pnpm
       uses: pnpm/action-setup@v6
       with:
-        version: 11.1.3
+        version: 11.5.3
 
     - name: Setup Node
       uses: actions/setup-node@v6

--- a/apps/api/src/context/assemble.test.ts
+++ b/apps/api/src/context/assemble.test.ts
@@ -226,12 +226,60 @@ describe("assembleSystemPrompt — available-skills (lazy L1)", () => {
   });
 });
 
+describe("assembleSystemPrompt — skills (eager L2)", () => {
+  it("renders a ## section per eager skill in <skills>", () => {
+    const out = assembleSystemPrompt(
+      baseCtx({
+        eagerSkills: [
+          { name: "code-review", body: "Review code carefully." },
+          { name: "data-export", body: "Export to CSV." },
+        ],
+      })
+    );
+    expect(out).toContain(
+      "<skills>\n## code-review\nReview code carefully.\n\n## data-export\nExport to CSV.\n</skills>"
+    );
+  });
+
+  it("omits the block when eagerSkills is unset or empty", () => {
+    expect(assembleSystemPrompt(baseCtx())).not.toContain("<skills>");
+    expect(assembleSystemPrompt(baseCtx({ eagerSkills: [] }))).not.toContain("<skills>");
+  });
+
+  it("drops the whole block when over the char budget (never half-rendered)", () => {
+    const out = assembleSystemPrompt(
+      baseCtx({ eagerSkills: [{ name: "big", body: "x".repeat(33000) }] })
+    );
+    expect(out).not.toContain("<skills>");
+  });
+
+  it("renders before <available-skills> (CONTEXT-ENGINE §1 order)", () => {
+    const out = assembleSystemPrompt(
+      baseCtx({
+        eagerSkills: [{ name: "eager", body: "eager body" }],
+        availableSkills: [{ name: "lazy", description: "lazy desc" }],
+      })
+    );
+    expect(out.indexOf("<skills>")).toBeLessThan(out.indexOf("<available-skills>"));
+  });
+
+  it("renders after <governance-knowledge> (CONTEXT-ENGINE §1 order)", () => {
+    const out = assembleSystemPrompt(
+      baseCtx({
+        governanceDocs: [govDoc("Policy", "Be compliant.")],
+        eagerSkills: [{ name: "eager", body: "eager body" }],
+      })
+    );
+    expect(out.indexOf("<governance-knowledge>")).toBeLessThan(out.indexOf("<skills>"));
+  });
+});
+
 describe("assembleSystemPrompt — deferred + typed-state (AC-V1-003)", () => {
-  it("omits the deferred skills/tools/soul-context blocks entirely", () => {
+  it("omits the still-deferred soul-context and tools blocks", () => {
     const out = assembleSystemPrompt(
       baseCtx({ agentId: "sales", memory: [mem("plan", "enterprise")] })
     );
-    for (const tag of ["<skills>", "<soul-context>", "<available-tools>"]) {
+    for (const tag of ["<soul-context>", "<available-tools>"]) {
       expect(out).not.toContain(tag);
     }
   });

--- a/apps/api/src/context/assemble.ts
+++ b/apps/api/src/context/assemble.ts
@@ -2,7 +2,7 @@ import { buildGovernanceBlock } from "../knowledge/governance";
 import type { KnowledgeDocument } from "../knowledge/types";
 import { MAX_TOTAL_CHARS } from "../memory/limits";
 import type { WorkingMemoryDoc } from "../memory/working-memory";
-import type { AvailableSkill } from "../soul/skills/registry";
+import type { AvailableSkill, EagerSkill } from "../soul/skills/registry";
 
 /**
  * Resolved inputs for one turn's system prompt. `assembleSystemPrompt` is pure — the caller
@@ -27,9 +27,14 @@ export interface AssembleContext {
   /** Active `alwaysLoadForAgents` knowledge docs (KN-V1-005). */
   governanceDocs: KnowledgeDocument[];
   /**
-   * Lazy skill L1 index for `<available-skills>` — every soul skill's name + description, from the
-   * SkillRegistry (`soul/skills/registry.ts`). All-lazy V1: the agent pulls a skill's body (L2) on
-   * demand via `load_skill`. Eager `<skills>` bodies are deferred. Unset → block omitted.
+   * Eager skill bodies for `<skills>` — skills with `eager: true` in their SKILL.md frontmatter.
+   * Their full body is included in the prompt so the agent can apply them without a `load_skill`
+   * call. Unset or empty → block omitted.
+   */
+  eagerSkills?: EagerSkill[];
+  /**
+   * Lazy skill L1 index for `<available-skills>` — non-eager soul skills projected to name +
+   * description. The agent pulls a skill's body (L2) on demand via `load_skill`. Unset → block omitted.
    */
   availableSkills?: AvailableSkill[];
 }
@@ -68,6 +73,27 @@ function renderMemory(ctx: AssembleContext): string {
   if (total > MAX_TOTAL_CHARS) return "";
   const body = ctx.memory.map((e) => `- ${e.key}: ${e.value}`).join("\n");
   return block("memory", body);
+}
+
+/**
+ * `<skills>` budget — total chars across all eager skill `name`+`body` pairs. Over this the whole
+ * block is dropped (never half-rendered). Skill bodies can be large (multi-page playbooks), so the
+ * budget is generous; drop-whole prevents a partial-body from reaching the agent.
+ */
+const MAX_EAGER_SKILLS_CHARS = 32000;
+
+/**
+ * `<skills>` block (CONTEXT-ENGINE §1). Renders eager skill bodies so the agent can apply them
+ * without a `load_skill` call. One `## name\nbody` section per skill, in sorted order.
+ * Omitted when no eager skills are supplied; dropped whole when over budget.
+ */
+function renderEagerSkills(ctx: AssembleContext): string {
+  const skills = ctx.eagerSkills ?? [];
+  if (skills.length === 0) return "";
+  const total = skills.reduce((n, s) => n + s.name.length + s.body.length, 0);
+  if (total > MAX_EAGER_SKILLS_CHARS) return "";
+  const body = skills.map((s) => `## ${s.name}\n${s.body}`).join("\n\n");
+  return block("skills", body);
 }
 
 /**
@@ -111,7 +137,7 @@ export function assembleSystemPrompt(ctx: AssembleContext): string {
     // V1: governance is tenant-wide. `domain` is display-only on the agent (AGT-V1-007), so it
     // feeds <agent-identity> but does NOT scope governance — preserving prior behavior.
     buildGovernanceBlock(ctx.governanceDocs, null),
-    "", // <skills> — eager bodies deferred (all-lazy V1; no agent eager-skill election yet)
+    renderEagerSkills(ctx),
     renderAvailableSkills(ctx),
     "", // <soul-context> — deferred (soul L1 snapshot builder)
     "", // <available-tools> — deferred (Tools v0.8)

--- a/apps/api/src/soul/skills/registry.test.ts
+++ b/apps/api/src/soul/skills/registry.test.ts
@@ -1,6 +1,11 @@
 import type { SoulLoader, SoulSkill } from "@tulipfarm/soul";
 import { describe, expect, it } from "vitest";
-import { type AvailableSkill, listAvailableSkills } from "./registry";
+import {
+  type AvailableSkill,
+  type EagerSkill,
+  listAvailableSkills,
+  listEagerSkills,
+} from "./registry";
 
 function skill(name: string, frontmatter: Record<string, unknown> = {}, body = ""): SoulSkill {
   return { name, frontmatter, body };
@@ -11,7 +16,7 @@ function makeSoulLoader(skills: SoulSkill[] = []): SoulLoader {
 }
 
 describe("listAvailableSkills", () => {
-  it("projects each soul skill to its L1 name + description", () => {
+  it("projects each non-eager soul skill to its L1 name + description", () => {
     const out = listAvailableSkills(
       makeSoulLoader([skill("code-review", { description: "Review code for bugs." })])
     );
@@ -30,6 +35,16 @@ describe("listAvailableSkills", () => {
     ]);
   });
 
+  it("excludes skills with eager: true (they appear in <skills> instead)", () => {
+    const out = listAvailableSkills(
+      makeSoulLoader([
+        skill("lazy-skill", { description: "Lazy." }),
+        skill("eager-skill", { eager: true, description: "Eager." }),
+      ])
+    );
+    expect(out).toEqual<AvailableSkill[]>([{ name: "lazy-skill", description: "Lazy." }]);
+  });
+
   it("sorts by name for a deterministic prompt-cache prefix (AC-V1-001)", () => {
     const out = listAvailableSkills(
       makeSoulLoader([skill("zebra"), skill("alpha"), skill("mango")])
@@ -43,5 +58,40 @@ describe("listAvailableSkills", () => {
 
   it("returns [] when there are no skills", () => {
     expect(listAvailableSkills(makeSoulLoader([]))).toEqual([]);
+  });
+});
+
+describe("listEagerSkills", () => {
+  it("returns only skills with eager: true, projecting name + body", () => {
+    const out = listEagerSkills(
+      makeSoulLoader([
+        skill("lazy", { description: "I'm lazy." }, "lazy body"),
+        skill("alpha-eager", { eager: true }, "eager body"),
+      ])
+    );
+    expect(out).toEqual<EagerSkill[]>([{ name: "alpha-eager", body: "eager body" }]);
+  });
+
+  it("sorts by name for a deterministic prompt-cache prefix (AC-V1-001)", () => {
+    const out = listEagerSkills(
+      makeSoulLoader([
+        skill("zebra", { eager: true }, "z"),
+        skill("alpha", { eager: true }, "a"),
+        skill("mango", { eager: true }, "m"),
+      ])
+    );
+    expect(out.map((s) => s.name)).toEqual(["alpha", "mango", "zebra"]);
+  });
+
+  it("returns [] when no skills are eager", () => {
+    expect(listEagerSkills(makeSoulLoader([skill("lazy", { description: "x" })]))).toEqual([]);
+  });
+
+  it("returns [] when the soul loader is absent", () => {
+    expect(listEagerSkills(undefined)).toEqual([]);
+  });
+
+  it("returns [] when there are no skills", () => {
+    expect(listEagerSkills(makeSoulLoader([]))).toEqual([]);
   });
 });

--- a/apps/api/src/soul/skills/registry.ts
+++ b/apps/api/src/soul/skills/registry.ts
@@ -4,7 +4,8 @@ import type { SoulLoader } from "@tulipfarm/soul";
  * One skill projected to its L1 surface — `name` + `description` — for the `<available-skills>`
  * prompt block (specs/CONTEXT-ENGINE.md §1, SKILLS.md). The body (L2) and reference files (L3) are
  * NOT included here; the agent pulls them on demand via the `load_skill` / `load_skill_reference`
- * platform tools.
+ * platform tools. Skills with `eager: true` in frontmatter are excluded — they appear in `<skills>`
+ * instead.
  */
 export interface AvailableSkill {
   name: string;
@@ -12,17 +13,36 @@ export interface AvailableSkill {
 }
 
 /**
- * The SkillRegistry (Skills milestone). Projects every soul skill into its lazy L1 surface for the
- * `<available-skills>` block. V1 is shared + lazy only: no per-agent filtering (flat ALLOW_ALL —
- * there is no skill-level ACL in V1, GAP-SKL-001) and no eager `<skills>` election (deferred).
- *
- * Sorted by name so the assembled prompt prefix is byte-stable across restarts — `SoulLoader.skills`
- * is keyed in OS `readdir` order, which sorting normalizes (AC-V1-001). `description` comes from the
- * SKILL.md frontmatter; a missing or non-string value renders as an empty description.
+ * One skill projected to its eager surface — `name` + `body` — for the `<skills>` prompt block.
+ * A skill opts in by setting `eager: true` in its SKILL.md frontmatter; the full body is included
+ * so the agent can apply it without a `load_skill` call.
+ */
+export interface EagerSkill {
+  name: string;
+  body: string;
+}
+
+/**
+ * Projects skills with `eager: true` frontmatter into the eager surface. Sorted by name for a
+ * byte-stable prompt prefix (AC-V1-001).
+ */
+export function listEagerSkills(soulLoader: SoulLoader | undefined): EagerSkill[] {
+  if (!soulLoader) return [];
+  return Array.from(soulLoader.skills.values())
+    .filter((skill) => skill.frontmatter.eager === true)
+    .map((skill) => ({ name: skill.name, body: skill.body }))
+    .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+}
+
+/**
+ * Projects non-eager skills into their lazy L1 surface for `<available-skills>`. Skills with
+ * `eager: true` are excluded because they already appear in `<skills>`. Sorted by name
+ * (AC-V1-001). `description` comes from frontmatter; missing or non-string renders as "".
  */
 export function listAvailableSkills(soulLoader: SoulLoader | undefined): AvailableSkill[] {
   if (!soulLoader) return [];
   return Array.from(soulLoader.skills.values())
+    .filter((skill) => skill.frontmatter.eager !== true)
     .map((skill) => ({
       name: skill.name,
       description:


### PR DESCRIPTION
## Summary

- Skills with `eager: true` in `SKILL.md` frontmatter now appear in the `<skills>` prompt block with their full body — no `load_skill` call needed
- `listAvailableSkills` now excludes eager skills to avoid duplication across blocks
- `assembleSystemPrompt` renders `<skills>` at position 6 per CONTEXT-ENGINE §1 order, with a 32 k char budget (drops whole block when over; never half-rendered)
- 11 new tests; updated the deferred-blocks test since `<skills>` is no longer deferred

## Test plan

- [ ] `pnpm --filter api test` passes (750 tests, 10 skipped — was 739)
- [ ] `pnpm --filter api exec tsc --noEmit` clean
- [ ] Biome lint clean on all 4 changed files