### PR TITLE
fix(skills): wire eager <skills> into prompt assembly; harden load_sk…

### DIFF
--- a/apps/api/src/chat/routes.test.ts
+++ b/apps/api/src/chat/routes.test.ts
@@ -598,6 +598,58 @@ describe("chat routes", () => {
       );
     });
 
+    // Progressive disclosure — eager soul skills (eager: true) surface as full bodies in the
+    // <skills> block without a load_skill call, and are excluded from the lazy <available-skills>
+    // index (CONTEXT-ENGINE §1; SKILLS.md L1/L2/L3).
+    it("renders eager soul skills in <skills> and omits them from <available-skills>", async () => {
+      await app.close();
+      const soulLoader = {
+        agents: new Map(),
+        skills: new Map([
+          [
+            "code-review",
+            {
+              name: "code-review",
+              frontmatter: { eager: true, description: "Review code for bugs." },
+              body: "Review carefully.",
+            },
+          ],
+          [
+            "data-export",
+            {
+              name: "data-export",
+              frontmatter: { description: "Export data." },
+              body: "Export rows.",
+            },
+          ],
+        ]),
+      } as unknown as SoulLoader;
+      app = await buildApp({
+        sessionStore: store,
+        userRepo,
+        tokenRepo,
+        llmService,
+        conversationRepo: repo,
+        messageRepo,
+        streamResumeRepo: streamRepo,
+        streamHub,
+        workingMemoryService: new WorkingMemoryService(workingMemoryRepo),
+        soulLoader,
+      });
+
+      const res = await post({ message: userMsg("hi") });
+      expect(res.statusCode).toBe(200);
+      await waitFor(() => capturedPrompts.length >= 1);
+
+      const prompt = capturedPrompts[0] as Array<{ role: string; content: unknown }>;
+      const system = JSON.stringify(prompt[0]?.content);
+      // Eager body renders in <skills> (no load_skill needed).
+      expect(system).toContain("<skills>\\n## code-review\\nReview carefully.");
+      // Lazy skill stays in the L1 index; the eager one does not leak into it.
+      expect(system).toContain("<available-skills>\\n- data-export: Export data.");
+      expect(system).not.toContain("- code-review");
+    });
+
     it("404 when conversationId is not found", async () => {
       const res = await post({ conversationId: randomUUID(), message: userMsg("hi") });
       expect(res.statusCode).toBe(404);

--- a/apps/api/src/chat/routes.ts
+++ b/apps/api/src/chat/routes.ts
@@ -13,7 +13,7 @@ import { MAX_TOOL_STEPS } from "../memory/limits";
 import type { WorkingMemoryService } from "../memory/service";
 import { parsePaginationQuery } from "../pagination";
 import { resolveAgent } from "../soul/agents/registry";
-import { listAvailableSkills } from "../soul/skills/registry";
+import { listAvailableSkills, listEagerSkills } from "../soul/skills/registry";
 import { BatchCoordinator } from "../tools/batch-executor";
 import type { ToolRegistry } from "../tools/registry";
 import type { ToolCallResult } from "../tools/types";
@@ -289,6 +289,7 @@ export function registerChatRoutes(
         memory: workingMemory ? await workingMemory.list(user._id) : [],
         governanceDocs: knowledge ? await knowledge.governanceDocuments() : [],
         availableSkills: listAvailableSkills(soulLoader),
+        eagerSkills: listEagerSkills(soulLoader),
       });
       if (system) messages.push({ role: "system", content: system });
       messages.push(...history.items.map(toModelMessage), {

--- a/apps/api/src/context/README.md
+++ b/apps/api/src/context/README.md
@@ -17,7 +17,7 @@ lazily fetched) makes the rendered prefix deterministic and therefore prompt-cac
 <agent-personality>       AGENT.md body
 <memory>                  per-user working memory, ≤ MAX_TOTAL_CHARS (drop whole on overflow)
 <governance-knowledge>    alwaysLoadForAgents docs (reuses knowledge/governance.ts, 4k/16k caps)
-<skills>                  "" — eager bodies deferred (all-lazy V1; no agent eager-skill election yet)
+<skills>                  eager skill bodies — `## name` + body per `eager: true` skill, 32k cap, drop-whole
 <available-skills>        lazy skill L1 — one `- name: description` per soul skill, 8k cap, drop-whole
 <soul-context>            "" — deferred (soul L1 snapshot builder)
 <available-tools>         "" — deferred (Tools v0.8)
@@ -28,10 +28,11 @@ the `\n` join), matching `buildGovernanceBlock`'s precedent — so the prefix st
 across turns when soul/memory don't change. No `<harness-typed-state>` block is ever emitted
 (deferred MEM-V1-005).
 
-`<available-skills>` is fed by the **SkillRegistry** (`../soul/skills/registry.ts` → `listAvailableSkills`),
-which projects every soul skill to its sorted L1 `{ name, description }`. All-lazy V1: the body (L2) and
-reference files (L3) load on demand via the `load_skill` / `load_skill_reference` platform tools; eager
-`<skills>` bodies are deferred.
+Both skill blocks are fed by the **SkillRegistry** (`../soul/skills/registry.ts`): `listEagerSkills`
+projects skills with `eager: true` to their full `{ name, body }` for `<skills>`, and `listAvailableSkills`
+projects the rest to their sorted L1 `{ name, description }` for `<available-skills>` — the two sets are
+disjoint. A lazy skill's body (L2) and reference files (L3) load on demand via the `load_skill` /
+`load_skill_reference` platform tools; per-agent eager-skill election stays deferred post-V1.
 
 ## Why deterministic order matters
 
@@ -47,5 +48,5 @@ drop **whole** on overflow (never half-rendered) so the prefix can't drift mid-b
 ## Tests
 
 `assemble.test.ts` — pure unit coverage (order, determinism, skip, omit-empty, budgets,
-no-typed-state). The wiring is covered in `chat/routes.test.ts` ("prepends the assembled system
-prompt carrying working memory").
+no-typed-state). The wiring is covered in `chat/routes.test.ts` (working memory, the lazy
+`<available-skills>` list, and the eager `<skills>` block).

--- a/apps/api/src/context/assemble.ts
+++ b/apps/api/src/context/assemble.ts
@@ -123,10 +123,10 @@ function renderAvailableSkills(ctx: AssembleContext): string {
 /**
  * Assemble the agent system prompt from the 9 ordered blocks (specs/CONTEXT-ENGINE.md §1). Pure
  * and synchronous. Each block renders to a string or "" (when empty, over budget, or deferred);
- * empty blocks are omitted entirely so the prefix stays byte-stable across turns. `<available-skills>`
- * renders the lazy skill L1 index (all-lazy V1); the still-deferred blocks — `<skills>` (eager bodies),
- * `<soul-context>`, `<available-tools>` — emit empty until eager skills, the soul L1 snapshot, and Tools
- * land. No `<harness-typed-state>` block is ever emitted (deferred MEM-V1-005, AC-V1-003).
+ * empty blocks are omitted entirely so the prefix stays byte-stable across turns. `<skills>` renders
+ * eager skill bodies and `<available-skills>` the lazy skill L1 index; the still-deferred blocks —
+ * `<soul-context>`, `<available-tools>` — emit empty until the soul L1 snapshot and Tools land. No
+ * `<harness-typed-state>` block is ever emitted (deferred MEM-V1-005, AC-V1-003).
  */
 export function assembleSystemPrompt(ctx: AssembleContext): string {
   const blocks = [

--- a/apps/api/src/platform/tools.test.ts
+++ b/apps/api/src/platform/tools.test.ts
@@ -1,3 +1,6 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { SoulAgent, SoulRoutine, SoulSkill } from "@tulipfarm/soul";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -131,6 +134,50 @@ describe("loadSkillReferenceTool", () => {
   it("returns validation_error for missing args", async () => {
     const res = await loadSkillReferenceTool.handler({ skill: "foo" }, makeCtx());
     expect(res).toMatchObject({ success: false, error: { code: "validation_error" } });
+  });
+
+  it("rejects a reference that escapes the references directory (path traversal)", async () => {
+    const res = await loadSkillReferenceTool.handler(
+      { skill: "foo", reference: "../../../../../../../../etc/passwd" },
+      makeCtx({}, {}, "/some/soul")
+    );
+    expect(res).toMatchObject({ success: false, error: { code: "validation_error" } });
+  });
+
+  it("rejects an unsafe skill name (path traversal)", async () => {
+    const res = await loadSkillReferenceTool.handler(
+      { skill: "../evil", reference: "guide.md" },
+      makeCtx({}, {}, "/some/soul")
+    );
+    expect(res).toMatchObject({ success: false, error: { code: "validation_error" } });
+  });
+
+  it("loads a reference contained in the skill's references/ directory (incl. sub-paths)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "skill-ref-"));
+    await mkdir(join(dir, "skills", "research", "references", "sub"), { recursive: true });
+    await writeFile(join(dir, "skills", "research", "references", "guide.md"), "top guide", "utf8");
+    await writeFile(
+      join(dir, "skills", "research", "references", "sub", "deep.md"),
+      "deep guide",
+      "utf8"
+    );
+    try {
+      const top = await loadSkillReferenceTool.handler(
+        { skill: "research", reference: "guide.md" },
+        makeCtx({}, {}, dir)
+      );
+      expect(top).toEqual({
+        success: true,
+        data: { skill: "research", reference: "guide.md", content: "top guide" },
+      });
+      const deep = await loadSkillReferenceTool.handler(
+        { skill: "research", reference: "sub/deep.md" },
+        makeCtx({}, {}, dir)
+      );
+      expect(deep).toMatchObject({ success: true, data: { content: "deep guide" } });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/apps/api/src/platform/tools.ts
+++ b/apps/api/src/platform/tools.ts
@@ -1,5 +1,5 @@
 import { readFile } from "node:fs/promises";
-import { join } from "node:path";
+import { isAbsolute, relative, resolve, sep } from "node:path";
 import type { GitSyncService, SoulAgent, SoulRoutine, SoulSkill } from "@tulipfarm/soul";
 import { ajv } from "@tulipfarm/validation";
 import { err, ok, type ToolCallResult } from "./tool-result";
@@ -67,7 +67,12 @@ const LOAD_SKILL_REFERENCE_SCHEMA: Record<string, unknown> = {
   additionalProperties: false,
   required: ["skill", "reference"],
   properties: {
-    skill: { type: "string", minLength: 1, description: "Skill name." },
+    skill: {
+      type: "string",
+      minLength: 1,
+      pattern: "^[a-z][a-z0-9-]*$",
+      description: "Skill name (kebab-case, as registered in the soul).",
+    },
     reference: {
       type: "string",
       minLength: 1,
@@ -90,7 +95,16 @@ export const loadSkillReferenceTool: PlatformTool = {
     const { skill, reference } = args as { skill: string; reference: string };
     if (!ctx.soulPath)
       return err("not_found", `Skill "${skill}" references directory not available.`);
-    const refPath = join(ctx.soulPath, "skills", skill, "references", reference);
+    // Contain the read to the skill's references/ dir — `reference` is LLM-controlled, so a
+    // `../`-escape (e.g. driven by a malicious skill) must not read outside the soul (SKL-V1-002).
+    const base = resolve(ctx.soulPath, "skills", skill, "references");
+    const refPath = resolve(base, reference);
+    const rel = relative(base, refPath);
+    if (rel === "" || rel === ".." || rel.startsWith(`..${sep}`) || isAbsolute(rel))
+      return err(
+        "validation_error",
+        `Reference "${reference}" escapes the skill references directory.`
+      );
     try {
       const content = await readFile(refPath, "utf8");
       return ok({ skill, reference, content });


### PR DESCRIPTION
…ill_reference vs path traversal

Eager skill bodies were rendered by assembleSystemPrompt but chat/routes.ts never passed eagerSkills, so the <skills> block was always empty in production — the only progressive-disclosure conformance gap after #32. Wire listEagerSkills into the prompt and correct the now-stale assembly docs.

Also harden load_skill_reference: skill and reference were LLM-controlled and a ../ escape read arbitrary files (a test confirmed reading /etc/passwd). Constrain skill to ^[a-z][a-z0-9-]*$ and contain reference within the skill references/ directory via resolve+relative; escapes return validation_error.

Tests: eager-wiring regression in routes.test.ts; traversal rejection + contained-read in tools.test.ts.