### PR TITLE
feat(a2ui): V1 core layout + data tf-* web components (A2UI-V1-002)

### DIFF
--- a/apps/web/app/lib/a2ui/components.ts
+++ b/apps/web/app/lib/a2ui/components.ts
@@ -1,0 +1,311 @@
+/**
+ * A2UI tf-* component styles, injected into the srcdoc iframe as an inline <style> (see srcdoc.ts).
+ * Authored as a TS string constant — mirroring runtime.ts's A2UI_RUNTIME — so it is a real value in
+ * every environment (app + Vitest) without a `?raw`/CSS transform. Tokens come from tokens.css
+ * (already inlined in the <head>); this only references var(--token) + literal units — no external
+ * resources, no web fonts, no SVG. Containers: radius 0; interactive: ~2px; hairline 1px borders;
+ * no box-shadow; font inherited (system monospace). Variants/tones are palette-honest: neutral
+ * (--muted/--secondary), brand (--primary, sparing), danger (--destructive) — no green/amber.
+ */
+export const A2UI_COMPONENT_CSS = `
+/* tf-card — border is the only separator (light: --card ≈ --background). */
+tf-card {
+  display: block;
+  background: var(--card);
+  color: var(--card-foreground);
+  border: 1px solid var(--border);
+  padding: 12px 16px;
+}
+
+/* tf-grid — data-cols="N" explicit; default responsive auto-fit. */
+tf-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+tf-grid[data-cols="1"] { grid-template-columns: repeat(1, 1fr); }
+tf-grid[data-cols="2"] { grid-template-columns: repeat(2, 1fr); }
+tf-grid[data-cols="3"] { grid-template-columns: repeat(3, 1fr); }
+tf-grid[data-cols="4"] { grid-template-columns: repeat(4, 1fr); }
+tf-grid[data-cols="5"] { grid-template-columns: repeat(5, 1fr); }
+tf-grid[data-cols="6"] { grid-template-columns: repeat(6, 1fr); }
+
+/* tf-heading — default bold; data-variant="label" = the [section] label style. */
+tf-heading {
+  display: block;
+  font-weight: 700;
+  color: var(--foreground);
+  margin: 0 0 8px;
+}
+tf-heading[data-variant="label"] {
+  font-size: 0.75rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--muted-foreground);
+}
+tf-heading[data-variant="label"]::before { content: "["; color: var(--primary); }
+tf-heading[data-variant="label"]::after { content: "]"; color: var(--primary); }
+
+/* tf-text */
+tf-text {
+  display: block;
+  color: var(--foreground);
+  margin: 0 0 4px;
+}
+tf-text[data-tone="muted"] { color: var(--muted-foreground); }
+tf-text[data-tone="brand"] { color: var(--primary); }
+tf-text[data-tone="danger"] { color: var(--destructive); }
+tf-text[data-size="xs"] { font-size: 0.75rem; }
+tf-text[data-size="sm"] { font-size: 0.875rem; }
+tf-text[data-size="base"] { font-size: 1rem; }
+
+/* tf-badge — default = neutral. */
+tf-badge {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 2px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1.4;
+  background: var(--secondary);
+  color: var(--secondary-foreground);
+  border: 1px solid transparent;
+}
+tf-badge[data-variant="brand"] {
+  background: var(--primary);
+  color: var(--primary-foreground);
+}
+tf-badge[data-variant="danger"] {
+  background: var(--destructive);
+  color: var(--destructive-foreground);
+}
+tf-badge[data-variant="outline"] {
+  background: transparent;
+  color: var(--foreground);
+  border-color: var(--border);
+}
+
+/* tf-alert — tone via border + text color (shell-consistent, no icon dependency). */
+tf-alert {
+  display: block;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  background: var(--muted);
+  color: var(--foreground);
+  font-size: 0.875rem;
+}
+tf-alert [data-slot="title"] {
+  display: block;
+  font-weight: 700;
+  margin-bottom: 2px;
+}
+tf-alert[data-tone="danger"] {
+  background: color-mix(in oklch, var(--destructive) 10%, var(--background));
+  border-color: var(--destructive);
+}
+tf-alert[data-tone="danger"] [data-slot="title"] {
+  color: var(--destructive);
+}
+tf-alert[data-tone="brand"] {
+  background: color-mix(in oklch, var(--primary) 8%, var(--background));
+  border-color: var(--primary);
+}
+
+/* tf-empty-state — centered; no animation dep. */
+tf-empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: 8px;
+  padding: 32px 24px;
+  color: var(--muted-foreground);
+  font-size: 0.875rem;
+}
+tf-empty-state [data-slot="title"] {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--foreground);
+}
+
+/* tf-list — bordered; canonical <ul><li> rows with hairline dividers. */
+tf-list {
+  display: block;
+  border: 1px solid var(--border);
+  font-size: 0.875rem;
+}
+tf-list ul,
+tf-list ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+tf-list li {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 12px;
+  color: var(--foreground);
+}
+tf-list li + li {
+  border-top: 1px solid var(--border);
+}
+tf-list [data-slot="meta"] {
+  font-size: 0.75rem;
+  color: var(--muted-foreground);
+  margin-left: auto;
+  white-space: nowrap;
+}
+
+/* tf-metric-card — big value + label + trend delta (palette-honest). */
+tf-metric-card {
+  display: block;
+  background: var(--card);
+  color: var(--card-foreground);
+  border: 1px solid var(--border);
+  padding: 14px 16px;
+}
+tf-metric-card [data-slot="value"] {
+  display: block;
+  font-size: 1.75rem;
+  font-weight: 700;
+  line-height: 1.1;
+  color: var(--foreground);
+}
+tf-metric-card [data-slot="label"] {
+  display: block;
+  margin-top: 4px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: var(--muted-foreground);
+}
+tf-metric-card [data-slot="delta"] {
+  display: inline-block;
+  margin-top: 6px;
+  font-size: 0.75rem;
+  color: var(--muted-foreground);
+}
+tf-metric-card[data-trend="up"] [data-slot="delta"]::before { content: "↑ "; color: var(--foreground); }
+tf-metric-card[data-trend="flat"] [data-slot="delta"]::before { content: "→ "; color: var(--muted-foreground); }
+tf-metric-card[data-trend="down"] [data-slot="delta"] { color: var(--destructive); }
+tf-metric-card[data-trend="down"] [data-slot="delta"]::before { content: "↓ "; color: var(--destructive); }
+
+/* tf-detail-view — key/value rows; native dl/dt/dd canonical + data-slot variant. */
+tf-detail-view {
+  display: block;
+  border: 1px solid var(--border);
+  font-size: 0.875rem;
+}
+tf-detail-view dl {
+  margin: 0;
+  padding: 0;
+}
+tf-detail-view dl > div,
+tf-detail-view [data-slot="row"] {
+  display: grid;
+  grid-template-columns: 10rem 1fr;
+  gap: 12px;
+  padding: 8px 12px;
+  border-top: 1px solid var(--border);
+}
+tf-detail-view dl > div:first-child,
+tf-detail-view [data-slot="row"]:first-child {
+  border-top: none;
+}
+tf-detail-view dt,
+tf-detail-view [data-slot="label"] {
+  color: var(--muted-foreground);
+  word-break: break-word;
+}
+tf-detail-view dd,
+tf-detail-view [data-slot="value"] {
+  margin: 0;
+  min-width: 0;
+  color: var(--foreground);
+  word-break: break-word;
+}
+
+/* tf-button — flat, styled like ui/button.tsx; DISPLAY-ONLY (no JS). */
+tf-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  height: 36px;
+  padding: 8px 16px;
+  border: none;
+  border-radius: 2px;
+  font: inherit;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
+  cursor: default;
+  text-decoration: none;
+  background: var(--primary);
+  color: var(--primary-foreground);
+  transition: background 120ms ease, color 120ms ease;
+}
+tf-button:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+tf-button:not([data-variant]):hover,
+tf-button[data-variant="default"]:hover {
+  background: color-mix(in oklch, var(--primary) 90%, transparent);
+}
+tf-button[data-variant="secondary"] {
+  background: var(--secondary);
+  color: var(--secondary-foreground);
+}
+tf-button[data-variant="secondary"]:hover {
+  background: color-mix(in oklch, var(--secondary) 80%, transparent);
+}
+tf-button[data-variant="outline"] {
+  background: var(--background);
+  color: var(--foreground);
+  border: 1px solid var(--input);
+}
+tf-button[data-variant="outline"]:hover {
+  background: var(--accent);
+  color: var(--accent-foreground);
+}
+tf-button[data-variant="ghost"] {
+  background: transparent;
+  color: var(--foreground);
+}
+tf-button[data-variant="ghost"]:hover {
+  background: var(--accent);
+  color: var(--accent-foreground);
+}
+tf-button[data-variant="destructive"] {
+  background: var(--destructive);
+  color: var(--destructive-foreground);
+}
+tf-button[data-variant="destructive"]:hover {
+  background: color-mix(in oklch, var(--destructive) 90%, transparent);
+}
+tf-button[data-variant="link"] {
+  height: auto;
+  padding: 0;
+  background: transparent;
+  color: var(--primary);
+  text-decoration: underline;
+  text-underline-offset: 4px;
+}
+tf-button[data-size="sm"] {
+  height: 32px;
+  padding: 6px 12px;
+  font-size: 0.8125rem;
+}
+tf-button[data-size="lg"] {
+  height: 40px;
+  padding: 8px 24px;
+  font-size: 1rem;
+}
+`;

--- a/apps/web/app/lib/a2ui/sanitize.test.ts
+++ b/apps/web/app/lib/a2ui/sanitize.test.ts
@@ -40,3 +40,56 @@ test("preserves safe formatting markup", () => {
   expect(out).toContain("<strong>bold</strong>");
   expect(out).toContain("<em>italic</em>");
 });
+
+test("preserves the v1 tf-* component set with data-* config and slot/semantic children", () => {
+  const html = `
+    <tf-card data-test="1"><tf-heading data-variant="label">h</tf-heading></tf-card>
+    <tf-grid data-cols="2"><tf-card>cell</tf-card></tf-grid>
+    <tf-text data-tone="muted" data-size="sm">t</tf-text>
+    <tf-badge data-variant="danger">b</tf-badge>
+    <tf-alert data-tone="danger"><span data-slot="title">e</span>msg</tf-alert>
+    <tf-empty-state><span data-slot="title">empty</span></tf-empty-state>
+    <tf-list><ul><li>item<span data-slot="meta">m</span></li></ul></tf-list>
+    <tf-metric-card data-trend="down"><span data-slot="value">42</span><span data-slot="label">n</span><span data-slot="delta">-3</span></tf-metric-card>
+    <tf-detail-view><dl><div><dt>k</dt><dd>v</dd></div></dl></tf-detail-view>
+    <tf-button data-variant="outline" data-size="sm">go</tf-button>`;
+  const out = sanitizeAgentHtml(html);
+
+  // every in-scope tag survives
+  for (const tag of [
+    "tf-card",
+    "tf-grid",
+    "tf-heading",
+    "tf-text",
+    "tf-badge",
+    "tf-alert",
+    "tf-empty-state",
+    "tf-list",
+    "tf-metric-card",
+    "tf-detail-view",
+    "tf-button",
+  ]) {
+    expect(out).toContain(`<${tag}`);
+  }
+
+  // data-* config attributes survive
+  expect(out).toContain('data-variant="label"');
+  expect(out).toContain('data-cols="2"');
+  expect(out).toContain('data-tone="muted"');
+  expect(out).toContain('data-size="sm"');
+  expect(out).toContain('data-trend="down"');
+
+  // data-slot markers survive
+  expect(out).toContain('data-slot="title"');
+  expect(out).toContain('data-slot="value"');
+  expect(out).toContain('data-slot="meta"');
+
+  // native semantic children survive inside tf-* wrappers
+  expect(out).toContain("<dl>");
+  expect(out).toContain("<dt>");
+  expect(out).toContain("<dd>");
+  expect(out).toContain("<li>");
+
+  // style= is still stripped even amid tf-* content
+  expect(out).not.toContain("style=");
+});

--- a/apps/web/app/lib/a2ui/srcdoc.test.ts
+++ b/apps/web/app/lib/a2ui/srcdoc.test.ts
@@ -41,3 +41,28 @@ test("never grants same-origin to the sandbox", () => {
 test("includes the in-iframe runtime", () => {
   expect(buildSrcdoc(base)).toContain("window.__a2ui");
 });
+
+test("embeds the tf-* component stylesheet", () => {
+  const doc = buildSrcdoc(base);
+  expect(doc).toContain("tf-card");
+  expect(doc).toContain("tf-metric-card");
+});
+
+test("orders styles before the runtime script (reset, then components, then script)", () => {
+  const doc = buildSrcdoc(base);
+  const resetIdx = doc.indexOf("box-sizing:border-box");
+  const compIdx = doc.indexOf("tf-card");
+  const scriptIdx = doc.indexOf("<script nonce=");
+  expect(resetIdx).toBeGreaterThan(-1);
+  expect(resetIdx).toBeLessThan(compIdx);
+  expect(compIdx).toBeLessThan(scriptIdx);
+});
+
+test("keeps the component stylesheet inside a <style>, not a script", () => {
+  const doc = buildSrcdoc(base);
+  const compIdx = doc.indexOf("tf-card");
+  const styleOpen = doc.lastIndexOf("<style>", compIdx);
+  const styleClose = doc.indexOf("</style>", compIdx);
+  expect(styleOpen).toBeGreaterThan(-1);
+  expect(styleClose).toBeGreaterThan(styleOpen);
+});

--- a/apps/web/app/lib/a2ui/srcdoc.ts
+++ b/apps/web/app/lib/a2ui/srcdoc.ts
@@ -1,3 +1,4 @@
+import { A2UI_COMPONENT_CSS } from "~/lib/a2ui/components";
 import { A2UI_RUNTIME } from "~/lib/a2ui/runtime";
 
 /**
@@ -41,6 +42,7 @@ export function buildSrcdoc(input: {
 <meta http-equiv="Content-Security-Policy" content="${csp}">
 <style>${tokensCss}</style>
 <style>${RESET}</style>
+<style>${A2UI_COMPONENT_CSS}</style>
 <script nonce="${nonce}">${A2UI_RUNTIME}</script>
 </head>
 <body>${sanitizedHtml}</body>

--- a/apps/web/app/routes/dev.a2ui.tsx
+++ b/apps/web/app/routes/dev.a2ui.tsx
@@ -11,12 +11,90 @@ import { A2uiFrame, type A2uiFrameHandle } from "~/components/a2ui-frame";
  * `/dev/a2ui` is an inert empty page outside development — no renderer is exposed.
  */
 const SAMPLE_HTML = `
-<tf-card data-test="safe">
-  <tf-heading>Hello from A2UI</tf-heading>
-  <tf-text>Rendered inside a sandboxed iframe.</tf-text>
-  <p style="color: var(--primary)" id="token-probe">token-driven color</p>
+<tf-heading>A2UI component showcase</tf-heading>
+<tf-heading data-variant="label">system</tf-heading>
+
+<tf-text>Default body text — inherits the system monospace from the reset.</tf-text>
+<tf-text data-tone="muted">Muted secondary text.</tf-text>
+<tf-text data-tone="brand">Brand-toned text (ruby, used sparingly).</tf-text>
+<tf-text data-tone="danger">Danger-toned text.</tf-text>
+<tf-text data-size="xs">Extra-small annotation.</tf-text>
+
+<p>
+  <tf-badge>neutral</tf-badge>
+  <tf-badge data-variant="brand">brand</tf-badge>
+  <tf-badge data-variant="danger">danger</tf-badge>
+  <tf-badge data-variant="outline">outline</tf-badge>
+</p>
+
+<tf-alert>Default neutral alert — informational message.</tf-alert>
+<tf-alert data-tone="danger"><span data-slot="title">Error</span>Authentication required. Check your API token.</tf-alert>
+<tf-alert data-tone="brand"><span data-slot="title">Info</span>3 tasks queued for processing.</tf-alert>
+
+<tf-card>
+  <tf-heading>Agent report</tf-heading>
+  <tf-text data-tone="muted">Processed 42 records in the last run.</tf-text>
+  <tf-badge data-variant="outline">last run: 2m ago</tf-badge>
 </tf-card>
+
+<tf-grid data-cols="3">
+  <tf-metric-card data-trend="up">
+    <span data-slot="value">1,284</span>
+    <span data-slot="label">Records indexed</span>
+    <span data-slot="delta">+12% vs last week</span>
+  </tf-metric-card>
+  <tf-metric-card data-trend="down">
+    <span data-slot="value">3</span>
+    <span data-slot="label">Failed syncs</span>
+    <span data-slot="delta">+1 since yesterday</span>
+  </tf-metric-card>
+  <tf-metric-card data-trend="flat">
+    <span data-slot="value">99.2%</span>
+    <span data-slot="label">Uptime</span>
+    <span data-slot="delta">no change</span>
+  </tf-metric-card>
+</tf-grid>
+
+<tf-list>
+  <ul>
+    <li>task-001 — generate report<span data-slot="meta">done</span></li>
+    <li>task-002 — sync contacts<span data-slot="meta">running</span></li>
+    <li>task-003 — archive records<span data-slot="meta">queued</span></li>
+  </ul>
+</tf-list>
+
+<tf-detail-view>
+  <dl>
+    <div><dt>id</dt><dd>a1b2c3d4-e5f6-7890-abcd-ef1234567890</dd></div>
+    <div><dt>name</dt><dd>Production sync agent</dd></div>
+    <div><dt>status</dt><dd>active</dd></div>
+    <div><dt>model</dt><dd>claude-sonnet-4-6</dd></div>
+  </dl>
+</tf-detail-view>
+
+<tf-empty-state>
+  <span data-slot="title">No results found</span>
+  Run a query to see data here.
+  <tf-button data-variant="outline" data-size="sm">Run query</tf-button>
+</tf-empty-state>
+
+<p>
+  <tf-button>default</tf-button>
+  <tf-button data-variant="secondary">secondary</tf-button>
+  <tf-button data-variant="outline">outline</tf-button>
+  <tf-button data-variant="ghost">ghost</tf-button>
+  <tf-button data-variant="destructive">destructive</tf-button>
+  <tf-button data-variant="link">link</tf-button>
+</p>
+<p>
+  <tf-button data-size="sm">small</tf-button>
+  <tf-button>default size</tf-button>
+  <tf-button data-size="lg">large</tf-button>
+</p>
+
 <tf-kanban>this unknown element renders empty without crashing</tf-kanban>
+
+<p style="color: var(--primary)" id="token-probe">token-driven color</p>
 <p>plain <strong>safe</strong> markup</p>
 <img src="https://example.com/should-be-blocked.png" alt="external (CSP should block)">
 <script>window.__a2uiPwned = true;</script>


### PR DESCRIPTION
Declarative token-CSS for the 11 core tf-* blocks (card, grid, heading, text, badge, alert, empty-state, list, metric-card, detail-view, button), injected into the sandboxed iframe via srcdoc. Config via data-*, content via children/slots; palette-honest (ruby/coral/neutral, no green/amber); tf-button display-only; deferred tags render inert. Satisfies AC-V1-002.

- new components.ts (A2UI_COMPONENT_CSS) wired through srcdoc.ts
- srcdoc + sanitize tests: stylesheet embed/order/CSP + 11-component sanitize round-trip
- dev.a2ui showcase for all 11 + deferred tf-kanban