### PR TITLE
feat(skills): skill-forge triggers SkillAudit before activation (AC-V1-002)

### DIFF
--- a/apps/api/src/soul/skills/registry.test.ts
+++ b/apps/api/src/soul/skills/registry.test.ts
@@ -45,6 +45,16 @@ describe("listAvailableSkills", () => {
     expect(out).toEqual<AvailableSkill[]>([{ name: "lazy-skill", description: "Lazy." }]);
   });
 
+  it("excludes skills with _pendingAudit: true (not yet activated by operator)", () => {
+    const out = listAvailableSkills(
+      makeSoulLoader([
+        skill("active-skill", { description: "Active." }),
+        skill("pending-skill", { _pendingAudit: true, description: "Pending." }),
+      ])
+    );
+    expect(out).toEqual<AvailableSkill[]>([{ name: "active-skill", description: "Active." }]);
+  });
+
   it("sorts by name for a deterministic prompt-cache prefix (AC-V1-001)", () => {
     const out = listAvailableSkills(
       makeSoulLoader([skill("zebra"), skill("alpha"), skill("mango")])
@@ -85,6 +95,16 @@ describe("listEagerSkills", () => {
 
   it("returns [] when no skills are eager", () => {
     expect(listEagerSkills(makeSoulLoader([skill("lazy", { description: "x" })]))).toEqual([]);
+  });
+
+  it("excludes eager skills with _pendingAudit: true", () => {
+    const out = listEagerSkills(
+      makeSoulLoader([
+        skill("active-eager", { eager: true }, "active body"),
+        skill("pending-eager", { eager: true, _pendingAudit: true }, "pending body"),
+      ])
+    );
+    expect(out).toEqual<EagerSkill[]>([{ name: "active-eager", body: "active body" }]);
   });
 
   it("returns [] when the soul loader is absent", () => {

--- a/apps/api/src/soul/skills/registry.ts
+++ b/apps/api/src/soul/skills/registry.ts
@@ -29,7 +29,7 @@ export interface EagerSkill {
 export function listEagerSkills(soulLoader: SoulLoader | undefined): EagerSkill[] {
   if (!soulLoader) return [];
   return Array.from(soulLoader.skills.values())
-    .filter((skill) => skill.frontmatter.eager === true)
+    .filter((skill) => skill.frontmatter.eager === true && !skill.frontmatter._pendingAudit)
     .map((skill) => ({ name: skill.name, body: skill.body }))
     .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
 }
@@ -42,7 +42,7 @@ export function listEagerSkills(soulLoader: SoulLoader | undefined): EagerSkill[
 export function listAvailableSkills(soulLoader: SoulLoader | undefined): AvailableSkill[] {
   if (!soulLoader) return [];
   return Array.from(soulLoader.skills.values())
-    .filter((skill) => skill.frontmatter.eager !== true)
+    .filter((skill) => skill.frontmatter.eager !== true && !skill.frontmatter._pendingAudit)
     .map((skill) => ({
       name: skill.name,
       description:

--- a/apps/api/src/soul/skills/routes.test.ts
+++ b/apps/api/src/soul/skills/routes.test.ts
@@ -194,12 +194,34 @@ describe("skills routes", () => {
         description: "From the marketplace.",
         provenance: "marketplace",
         source: "owner/repo",
+        pendingAudit: false,
       });
       expect(skills).toContainEqual({
         name: "my-skill",
         description: "Authored by hand.",
         provenance: "user",
+        pendingAudit: false,
       });
+    });
+
+    it("marks forge-created skills with pendingAudit: true", async () => {
+      // Add a pending skill to the soul loader.
+      (soulLoader.skills as Map<string, SoulSkill>).set("pending-skill", {
+        name: "pending-skill",
+        frontmatter: { _pendingAudit: true, description: "Pending." },
+        body: "Pending body.",
+      });
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/skills",
+        cookies: auth(),
+        headers,
+      });
+      expect(res.statusCode).toBe(200);
+      const { skills } = res.json();
+      expect(skills).toContainEqual(
+        expect.objectContaining({ name: "pending-skill", pendingAudit: true })
+      );
     });
 
     it("does not crash when skills-lock.json is an empty object", async () => {

--- a/apps/api/src/soul/skills/routes.ts
+++ b/apps/api/src/soul/skills/routes.ts
@@ -172,6 +172,7 @@ function toSkillSummary(
   description?: string;
   provenance: "builtin" | "marketplace" | "user";
   source?: string;
+  pendingAudit: boolean;
 } {
   const locked = lock.skills[skill.name];
   return {
@@ -179,6 +180,7 @@ function toSkillSummary(
     description: asString(skill.frontmatter.description),
     provenance: locked ? "marketplace" : "user",
     source: locked?.sourceUrl,
+    pendingAudit: skill.frontmatter._pendingAudit === true,
   };
 }
 
@@ -259,6 +261,7 @@ const SummaryProps = {
   description: { type: "string" },
   provenance: { type: "string", enum: ["builtin", "marketplace", "user"] },
   source: { type: "string" },
+  pendingAudit: { type: "boolean" },
 } as const;
 
 export function registerSkillRoutes(
@@ -285,7 +288,7 @@ export function registerSkillRoutes(
                 type: "array",
                 items: {
                   type: "object",
-                  required: ["name", "provenance"],
+                  required: ["name", "provenance", "pendingAudit"],
                   properties: SummaryProps,
                 },
               },
@@ -404,7 +407,7 @@ export function registerSkillRoutes(
         response: {
           200: {
             type: "object",
-            required: ["name", "provenance", "body"],
+            required: ["name", "provenance", "body", "pendingAudit"],
             properties: { ...SummaryProps, body: { type: "string" } },
           },
           401: ErrorSchema,

--- a/apps/api/src/soul/skills/tools.test.ts
+++ b/apps/api/src/soul/skills/tools.test.ts
@@ -1,3 +1,5 @@
+import type { LlmService } from "@tulipfarm/llm";
+import { LlmNotConfiguredError } from "@tulipfarm/llm";
 import type { GitSyncService, SoulLoader, SoulSkill } from "@tulipfarm/soul";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SKILL_TOOLS, type SkillTool, type SkillToolContext } from "./tools";
@@ -9,8 +11,22 @@ vi.mock("node:fs/promises", () => ({
   rm: vi.fn().mockResolvedValue(undefined),
 }));
 
+// Mock buildAudit so tests don't hit a real LLM.
+const mockBuildAudit = vi.fn();
+vi.mock("./audit", async (orig) => {
+  const actual = await orig<typeof import("./audit")>();
+  return { ...actual, buildAudit: (...args: unknown[]) => mockBuildAudit(...args) };
+});
+
 import { existsSync } from "node:fs";
 import { mkdir, rm, writeFile } from "node:fs/promises";
+
+const FAKE_REPORT = {
+  riskRating: "low" as const,
+  summary: "Benign skill.",
+  toolsReach: [],
+  findings: [],
+};
 
 function makeGitSync(soulPath = "/fake/soul"): GitSyncService {
   return {
@@ -26,14 +42,28 @@ function makeSoulLoader(skills: SoulSkill[] = []): SoulLoader {
   } as unknown as SoulLoader;
 }
 
-function makeCtx(skills: SoulSkill[] = []): SkillToolContext & {
+function makeLlmService(configured = true): LlmService {
+  return {
+    select: configured
+      ? vi.fn().mockReturnValue({})
+      : vi.fn().mockImplementation(() => {
+          throw new LlmNotConfiguredError();
+        }),
+  } as unknown as LlmService;
+}
+
+function makeCtx(
+  skills: SoulSkill[] = [],
+  llmService?: LlmService
+): SkillToolContext & {
   gitSync: ReturnType<typeof makeGitSync>;
   soulLoader: ReturnType<typeof makeSoulLoader>;
 } {
-  return { gitSync: makeGitSync(), soulLoader: makeSoulLoader(skills) };
+  return { gitSync: makeGitSync(), soulLoader: makeSoulLoader(skills), llmService };
 }
 
 const createTool = SKILL_TOOLS.find((t) => t.name === "skill_create") as SkillTool;
+const activateTool = SKILL_TOOLS.find((t) => t.name === "skill_activate") as SkillTool;
 const updateTool = SKILL_TOOLS.find((t) => t.name === "skill_update") as SkillTool;
 const getTool = SKILL_TOOLS.find((t) => t.name === "skill_get") as SkillTool;
 const listTool = SKILL_TOOLS.find((t) => t.name === "skill_list") as SkillTool;
@@ -45,10 +75,11 @@ describe("skill_create", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(existsSync).mockReturnValue(false);
+    mockBuildAudit.mockResolvedValue(FAKE_REPORT);
   });
 
-  it("creates SKILL.md, commits via withSync, reloads", async () => {
-    const ctx = makeCtx();
+  it("writes SKILL.md with _pendingAudit marker, commits, reloads, returns auditReport", async () => {
+    const ctx = makeCtx([], makeLlmService());
     const res = await createTool.handler(
       { name: "code-review", body: "Review code carefully." },
       ctx
@@ -56,22 +87,27 @@ describe("skill_create", () => {
 
     expect(res).toEqual({
       success: true,
-      data: { name: "code-review", frontmatter: {}, body: "Review code carefully." },
+      data: {
+        name: "code-review",
+        frontmatter: {},
+        body: "Review code carefully.",
+        auditReport: FAKE_REPORT,
+      },
     });
     expect(mkdir).toHaveBeenCalledWith(expect.stringContaining("skills/code-review"), {
       recursive: true,
     });
-    expect(writeFile).toHaveBeenCalledWith(
-      expect.stringContaining("SKILL.md"),
-      "Review code carefully.",
-      "utf8"
-    );
+    // Written content must include _pendingAudit marker.
+    const content = vi.mocked(writeFile).mock.calls[0][1] as string;
+    expect(content).toContain("_pendingAudit: true");
+    expect(content).toContain("Review code carefully.");
     expect(ctx.gitSync.withSync).toHaveBeenCalledWith("soul: add skill code-review");
     expect(ctx.soulLoader.reload).toHaveBeenCalledOnce();
+    expect(mockBuildAudit).toHaveBeenCalledOnce();
   });
 
-  it("includes frontmatter block when provided", async () => {
-    const ctx = makeCtx();
+  it("includes user frontmatter in SKILL.md alongside _pendingAudit", async () => {
+    const ctx = makeCtx([], makeLlmService());
     const res = await createTool.handler(
       { name: "planner", body: "Plan tasks.", frontmatter: { tags: ["planning"] } },
       ctx
@@ -81,25 +117,43 @@ describe("skill_create", () => {
     const content = vi.mocked(writeFile).mock.calls[0][1] as string;
     expect(content).toMatch(/^---\n/);
     expect(content).toContain("planning");
+    expect(content).toContain("_pendingAudit: true");
     expect(content).toContain("Plan tasks.");
+    // Returned frontmatter excludes _pendingAudit (internal marker not surfaced to caller).
+    const data = (res as { success: true; data: { frontmatter: unknown } }).data;
+    expect(data.frontmatter).toEqual({ tags: ["planning"] });
+  });
+
+  it("returns audit_required if llmService absent from context", async () => {
+    const ctx = makeCtx();
+    const res = await createTool.handler({ name: "code-review", body: "body" }, ctx);
+    expect(res).toMatchObject({ success: false, error: { code: "audit_required" } });
+    expect(mkdir).not.toHaveBeenCalled();
+  });
+
+  it("returns audit_required if LlmNotConfiguredError thrown by llmService.select", async () => {
+    const ctx = makeCtx([], makeLlmService(false));
+    const res = await createTool.handler({ name: "code-review", body: "body" }, ctx);
+    expect(res).toMatchObject({ success: false, error: { code: "audit_required" } });
+    expect(mkdir).not.toHaveBeenCalled();
   });
 
   it("returns validation_error for invalid name (uppercase)", async () => {
-    const ctx = makeCtx();
+    const ctx = makeCtx([], makeLlmService());
     const res = await createTool.handler({ name: "CodeReview", body: "body" }, ctx);
     expect(res).toMatchObject({ success: false, error: { code: "validation_error" } });
     expect(ctx.gitSync.withSync).not.toHaveBeenCalled();
   });
 
   it("returns validation_error for name starting with digit", async () => {
-    const ctx = makeCtx();
+    const ctx = makeCtx([], makeLlmService());
     const res = await createTool.handler({ name: "1skill", body: "body" }, ctx);
     expect(res).toMatchObject({ success: false, error: { code: "validation_error" } });
   });
 
   it("returns validation_error if skill dir already exists", async () => {
     vi.mocked(existsSync).mockReturnValue(true);
-    const ctx = makeCtx();
+    const ctx = makeCtx([], makeLlmService());
     const res = await createTool.handler({ name: "code-review", body: "body" }, ctx);
     expect(res).toMatchObject({
       success: false,
@@ -109,8 +163,56 @@ describe("skill_create", () => {
   });
 
   it("returns validation_error for missing required args", async () => {
-    const ctx = makeCtx();
+    const ctx = makeCtx([], makeLlmService());
     const res = await createTool.handler({ name: "skill-x" }, ctx);
+    expect(res).toMatchObject({ success: false, error: { code: "validation_error" } });
+  });
+});
+
+// ── skill_activate ────────────────────────────────────────────────────────────
+
+describe("skill_activate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const pendingSkill: SoulSkill = {
+    name: "code-review",
+    frontmatter: { _pendingAudit: true, tags: ["review"] },
+    body: "Review code.",
+  };
+
+  it("removes _pendingAudit, rewrites SKILL.md, commits, reloads", async () => {
+    const ctx = makeCtx([pendingSkill]);
+    const res = await activateTool.handler({ name: "code-review" }, ctx);
+
+    expect(res).toEqual({ success: true, data: { name: "code-review", activated: true } });
+    const content = vi.mocked(writeFile).mock.calls[0][1] as string;
+    expect(content).not.toContain("_pendingAudit");
+    expect(content).toContain("review"); // user frontmatter preserved
+    expect(ctx.gitSync.withSync).toHaveBeenCalledWith("soul: activate skill code-review");
+    expect(ctx.soulLoader.reload).toHaveBeenCalledOnce();
+  });
+
+  it("returns validation_error if skill is already active (no _pendingAudit)", async () => {
+    const ctx = makeCtx([{ name: "code-review", frontmatter: {}, body: "body" }]);
+    const res = await activateTool.handler({ name: "code-review" }, ctx);
+    expect(res).toMatchObject({
+      success: false,
+      error: { code: "validation_error", message: expect.stringContaining("already active") },
+    });
+    expect(ctx.gitSync.withSync).not.toHaveBeenCalled();
+  });
+
+  it("returns not_found for unknown skill", async () => {
+    const ctx = makeCtx();
+    const res = await activateTool.handler({ name: "ghost" }, ctx);
+    expect(res).toMatchObject({ success: false, error: { code: "not_found" } });
+  });
+
+  it("returns validation_error for missing name", async () => {
+    const ctx = makeCtx();
+    const res = await activateTool.handler({}, ctx);
     expect(res).toMatchObject({ success: false, error: { code: "validation_error" } });
   });
 });
@@ -274,13 +376,14 @@ describe("skill_delete", () => {
 // ── SKILL_TOOLS export ────────────────────────────────────────────────────────
 
 describe("SKILL_TOOLS", () => {
-  it("exports 5 tools with correct mutating flags", () => {
-    expect(SKILL_TOOLS).toHaveLength(5);
+  it("exports 6 tools with correct mutating flags", () => {
+    expect(SKILL_TOOLS).toHaveLength(6);
     const byName = Object.fromEntries(SKILL_TOOLS.map((t) => [t.name, t]));
     expect(byName.skill_create.mutating).toBe(true);
     expect(byName.skill_update.mutating).toBe(true);
     expect(byName.skill_get.mutating).toBe(false);
     expect(byName.skill_list.mutating).toBe(false);
     expect(byName.skill_delete.mutating).toBe(true);
+    expect(byName.skill_activate.mutating).toBe(true);
   });
 });

--- a/apps/api/src/soul/skills/tools.ts
+++ b/apps/api/src/soul/skills/tools.ts
@@ -1,16 +1,19 @@
 import { existsSync } from "node:fs";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { LlmNotConfiguredError, type LlmService } from "@tulipfarm/llm";
 import type { GitSyncService, SoulLoader } from "@tulipfarm/soul";
 import { ajv } from "@tulipfarm/validation";
 import { stringify } from "yaml";
 import { err, ok, type ToolCallResult } from "../../tools/types.js";
+import { buildAudit } from "./audit.js";
 
 const NAME_RE = /^[a-z][a-z0-9-]*$/;
 
 export interface SkillToolContext {
   gitSync: GitSyncService;
   soulLoader: SoulLoader;
+  llmService?: LlmService;
 }
 
 export interface SkillTool {
@@ -61,7 +64,7 @@ const validateCreate = ajv.compile(CREATE_SCHEMA);
 const skillCreate: SkillTool = {
   name: "skill_create",
   description:
-    "Create a new skill in the soul repo by writing its SKILL.md. Commits and pushes via withSync. No approval gate.",
+    "Create a new skill in the soul repo. Writes SKILL.md (pending audit), commits via withSync, runs SkillAudit synchronously, and returns the audit report. The skill is not active in prompt assembly until confirmed via skill_activate.",
   mutating: true,
   inputSchema: CREATE_SCHEMA,
   handler: async (args, ctx) => {
@@ -81,9 +84,31 @@ const skillCreate: SkillTool = {
     const skillDir = join(ctx.gitSync.path, "skills", name);
     if (existsSync(skillDir)) return err("validation_error", "skill already exists");
 
+    // Fail fast before writing: SkillAudit requires a working LLM (AC-V1-002).
+    if (!ctx.llmService) {
+      return err(
+        "audit_required",
+        "LLM service not available — configure a provider before creating skills"
+      );
+    }
+    let model: ReturnType<typeof ctx.llmService.select>;
+    try {
+      model = ctx.llmService.select({ model: "standard" });
+    } catch (e) {
+      if (e instanceof LlmNotConfiguredError) {
+        return err(
+          "audit_required",
+          "LLM not configured — configure a provider before creating skills"
+        );
+      }
+      return err("internal_error", reason(e));
+    }
+
+    // Write with _pendingAudit marker so the skill is committed but inactive until operator confirms.
+    const pendingFm = { ...frontmatter, _pendingAudit: true };
     try {
       await mkdir(skillDir, { recursive: true });
-      await writeFile(join(skillDir, "SKILL.md"), serializeSkill(frontmatter, body), "utf8");
+      await writeFile(join(skillDir, "SKILL.md"), serializeSkill(pendingFm, body), "utf8");
     } catch (e) {
       return err("internal_error", reason(e));
     }
@@ -100,7 +125,21 @@ const skillCreate: SkillTool = {
       return err("internal_error", reason(e));
     }
 
-    return ok({ name, frontmatter, body });
+    // Run SkillAudit synchronously. Skill is already committed; surface errors but keep it pending.
+    let auditReport: Awaited<ReturnType<typeof buildAudit>>;
+    try {
+      auditReport = await buildAudit(model, {
+        name,
+        description:
+          typeof frontmatter.description === "string" ? frontmatter.description : undefined,
+        body,
+      });
+    } catch (e) {
+      return err("internal_error", `skill committed as pending but audit failed: ${reason(e)}`);
+    }
+
+    // Return user-supplied frontmatter (without the internal _pendingAudit marker).
+    return ok({ name, frontmatter, body, auditReport });
   },
 };
 
@@ -266,10 +305,64 @@ const skillDelete: SkillTool = {
   },
 };
 
+// ── skill_activate ────────────────────────────────────────────────────────────
+
+const ACTIVATE_SCHEMA = {
+  type: "object",
+  required: ["name"],
+  additionalProperties: false,
+  properties: {
+    name: { type: "string", minLength: 1, description: "Skill name to activate." },
+  },
+} as const;
+
+const validateActivate = ajv.compile(ACTIVATE_SCHEMA);
+
+const skillActivate: SkillTool = {
+  name: "skill_activate",
+  description:
+    "Activate a forge-created skill after the operator has reviewed its SkillAudit report. Removes the _pendingAudit marker, commits, and reloads — making the skill available in prompt assembly.",
+  mutating: true,
+  inputSchema: ACTIVATE_SCHEMA,
+  handler: async (args, ctx) => {
+    if (!validateActivate(args)) return err("validation_error", firstError(validateActivate));
+    const { name } = args as { name: string };
+
+    const skill = ctx.soulLoader.skills.get(name);
+    if (!skill) return err("not_found", `skill not found: ${name}`);
+    if (!skill.frontmatter._pendingAudit) {
+      return err("validation_error", `skill '${name}' is already active`);
+    }
+
+    const { _pendingAudit: _removed, ...activeFm } = skill.frontmatter;
+    const skillFile = join(ctx.gitSync.path, "skills", name, "SKILL.md");
+    try {
+      await writeFile(skillFile, serializeSkill(activeFm, skill.body), "utf8");
+    } catch (e) {
+      return err("internal_error", reason(e));
+    }
+
+    try {
+      await ctx.gitSync.withSync(`soul: activate skill ${name}`);
+    } catch (e) {
+      return err("internal_error", reason(e));
+    }
+
+    try {
+      await ctx.soulLoader.reload();
+    } catch (e) {
+      return err("internal_error", reason(e));
+    }
+
+    return ok({ name, activated: true });
+  },
+};
+
 export const SKILL_TOOLS: SkillTool[] = [
   skillCreate,
   skillUpdate,
   skillGet,
   skillList,
   skillDelete,
+  skillActivate,
 ];

--- a/apps/api/src/tools/types.ts
+++ b/apps/api/src/tools/types.ts
@@ -1,6 +1,11 @@
 export type ToolTier = "system" | "platform" | "integration";
 
-export type ToolErrorCode = "validation_error" | "oversize_value" | "not_found" | "internal_error";
+export type ToolErrorCode =
+  | "validation_error"
+  | "oversize_value"
+  | "not_found"
+  | "internal_error"
+  | "audit_required";
 
 export type ToolCallResult =
   | { success: true; data: unknown }


### PR DESCRIPTION
## Summary

- `skill_create` now fails fast with `audit_required` if LLM is absent or unconfigured — no write happens
- On success: writes SKILL.md with `_pendingAudit: true` in frontmatter, commits via `withSync`, reloads, then runs `SkillAudit` synchronously and returns the `auditReport` in the tool response
- New `skill_activate` tool: operator calls this after reviewing the report — removes the `_pendingAudit` marker, commits, reloads, making the skill live in prompt assembly
- `listAvailableSkills` + `listEagerSkills` filter out `_pendingAudit: true` skills so they never appear in prompts until activated
- `GET /api/v1/skills` now surfaces `pendingAudit: boolean` per skill
- `"audit_required"` added to `ToolErrorCode`

## Spec refs

`specs/SKILLS.md` AC-V1-002/003 · `specs/AGENTS.md` AGT-V1-001

## Test plan

- [ ] `skill_create` returns `audit_required` when `llmService` missing from context
- [ ] `skill_create` returns `audit_required` when `LlmNotConfiguredError` thrown
- [ ] `skill_create` writes `_pendingAudit: true` into SKILL.md, returns `auditReport` in response
- [ ] Returned `frontmatter` excludes the internal `_pendingAudit` marker
- [ ] `skill_activate` removes `_pendingAudit`, rewrites + commits + reloads
- [ ] `skill_activate` returns `validation_error` if skill already active
- [ ] `listAvailableSkills` and `listEagerSkills` exclude pending skills
- [ ] `GET /api/v1/skills` includes `pendingAudit: true` for forge-created pending skills
- [ ] `vitest run apps/api/src/` → 79/79 files, 829 tests pass