### PR TITLE
feat(a2ui): tf-schema-form + form tf-* CSS skins, display-only (A2UI-…

### DIFF
--- a/apps/web/app/lib/a2ui/components.ts
+++ b/apps/web/app/lib/a2ui/components.ts
@@ -356,4 +356,134 @@ tf-data-table a {
 tf-data-table a:hover {
   text-decoration: underline;
 }
+
+/* tf-schema-form + form inputs — DISPLAY-ONLY skins over native controls (no iframe JS until
+   A2UI-V1-001; CSP blocks submit). Contract: <tf-schema-form> holds [data-slot="field"] rows, each a
+   caption (data-slot="label", with data-slot="req" for the * marker) + a native control wrapped in
+   its tf-* skin + optional data-slot="error". Field identity rides data-name, never name/id (DOMPurify
+   SANITIZE_DOM strips colliding name/id). x-immutable on edit = native disabled + a data-slot="meta"
+   "(immutable)" note. */
+tf-schema-form { display: block; }
+tf-schema-form [data-slot="field"] {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 12px;
+}
+tf-schema-form [data-slot="label"] { font-size: 0.75rem; color: var(--muted-foreground); }
+tf-schema-form [data-slot="req"] { color: var(--primary); }
+tf-schema-form [data-slot="meta"] { opacity: 0.6; }
+tf-schema-form [data-slot="error"] { font-size: 0.75rem; color: var(--destructive); }
+
+/* shared control base — tf-input/textarea/select/combobox/calendar each wrap a full-width native control */
+tf-input,
+tf-textarea,
+tf-select,
+tf-combobox,
+tf-calendar { display: block; }
+tf-input input,
+tf-textarea textarea,
+tf-select select,
+tf-combobox input,
+tf-calendar input {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: 2px;
+  font: inherit;
+  font-size: 0.875rem;
+  background: var(--background);
+  color: var(--foreground);
+}
+tf-input input:focus-visible,
+tf-textarea textarea:focus-visible,
+tf-select select:focus-visible,
+tf-combobox input:focus-visible,
+tf-calendar input:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+tf-input input:disabled,
+tf-textarea textarea:disabled,
+tf-select select:disabled,
+tf-combobox input:disabled,
+tf-calendar input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+tf-textarea textarea { min-height: 5rem; resize: vertical; }
+
+/* checkbox + radio-group — native accent, inline label carrying the option text */
+tf-checkbox,
+tf-switch { display: inline-flex; align-items: center; }
+tf-radio-group { display: flex; flex-direction: column; gap: 6px; }
+tf-checkbox label,
+tf-switch label,
+tf-radio-group label {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.875rem;
+  color: var(--foreground);
+}
+tf-checkbox input[type="checkbox"],
+tf-radio-group input[type="radio"] {
+  width: 1rem;
+  height: 1rem;
+  margin: 0;
+  accent-color: var(--primary);
+}
+
+/* switch — CSS-only toggle built from a native checkbox (flat 2px radius; off=secondary, on=primary) */
+tf-switch input[type="checkbox"] {
+  appearance: none;
+  -webkit-appearance: none;
+  position: relative;
+  width: 36px;
+  height: 20px;
+  margin: 0;
+  border: 1px solid var(--border);
+  border-radius: 2px;
+  background: var(--secondary);
+  cursor: pointer;
+  transition: background 120ms ease;
+}
+tf-switch input[type="checkbox"]::after {
+  content: "";
+  position: absolute;
+  top: 1px;
+  left: 1px;
+  width: 16px;
+  height: 16px;
+  background: var(--background);
+  border-radius: 1px;
+  transition: left 120ms ease;
+}
+tf-switch input[type="checkbox"]:checked { background: var(--primary); }
+tf-switch input[type="checkbox"]:checked::after { left: 17px; }
+tf-switch input[type="checkbox"]:focus-visible { outline: 2px solid var(--ring); outline-offset: 2px; }
+
+/* combobox — search input + a static options listbox (skinned like tf-list) + a ▾ affordance */
+tf-combobox { position: relative; }
+tf-combobox input { padding-right: 28px; }
+tf-combobox::after {
+  content: "▾";
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  color: var(--muted-foreground);
+  pointer-events: none;
+}
+tf-combobox ul {
+  list-style: none;
+  margin: 4px 0 0;
+  padding: 0;
+  border: 1px solid var(--border);
+  background: var(--background);
+  font-size: 0.875rem;
+}
+tf-combobox li { padding: 6px 12px; color: var(--foreground); }
+tf-combobox li + li { border-top: 1px solid var(--border); }
+tf-combobox li:hover,
+tf-combobox li[aria-selected="true"] { background: var(--accent); color: var(--accent-foreground); }
 `;

--- a/apps/web/app/lib/a2ui/sanitize.test.ts
+++ b/apps/web/app/lib/a2ui/sanitize.test.ts
@@ -106,3 +106,82 @@ test("preserves the v1 tf-* component set with data-* config and slot/semantic c
   // style= is still stripped even amid tf-* content
   expect(out).not.toContain("style=");
 });
+
+test("preserves tf-schema-form + native form controls with data-* config and slot children", () => {
+  const html = `
+    <tf-schema-form>
+      <div data-slot="field">
+        <span data-slot="label">email <span data-slot="req">*</span></span>
+        <tf-input><input type="email" data-name="email" placeholder="you@ex.com"></tf-input>
+        <span data-slot="error">required</span>
+      </div>
+      <div data-slot="field">
+        <tf-textarea><textarea data-name="bio" rows="4"></textarea></tf-textarea>
+      </div>
+      <div data-slot="field">
+        <tf-select><select data-name="status"><option>open</option><option selected>closed</option></select></tf-select>
+      </div>
+      <div data-slot="field">
+        <tf-radio-group><label><input type="radio" name="priority" checked> low</label><label><input type="radio" name="priority"> high</label></tf-radio-group>
+      </div>
+      <div data-slot="field">
+        <tf-checkbox><label><input type="checkbox" data-name="active" checked> active</label></tf-checkbox>
+      </div>
+      <div data-slot="field">
+        <tf-switch><label><input type="checkbox" data-name="notify" checked> notify</label></tf-switch>
+      </div>
+      <div data-slot="field">
+        <tf-combobox><input data-name="customerId" placeholder="Search customer" value="Acme Corp"><ul><li aria-selected="true">Acme Corp</li><li>Globex</li></ul></tf-combobox>
+      </div>
+      <div data-slot="field">
+        <tf-calendar><input type="date" data-name="due" value="2026-06-12"></tf-calendar>
+      </div>
+      <div data-slot="field" data-immutable>
+        <span data-slot="label">id <span data-slot="meta">(immutable)</span></span>
+        <tf-input><input data-name="id" value="TICK-1042" disabled></tf-input>
+      </div>
+      <tf-button>Save</tf-button>
+    </tf-schema-form>`;
+  const out = sanitizeAgentHtml(html);
+
+  // every new tf-* form wrapper survives
+  for (const tag of [
+    "tf-schema-form",
+    "tf-input",
+    "tf-textarea",
+    "tf-select",
+    "tf-radio-group",
+    "tf-checkbox",
+    "tf-switch",
+    "tf-combobox",
+    "tf-calendar",
+  ]) {
+    expect(out).toContain(`<${tag}`);
+  }
+
+  // native form controls survive (DOMPurify default allowlist)
+  for (const tag of ["<input", "<textarea", "<select", "<option", "<ul>", "<li"]) {
+    expect(out).toContain(tag);
+  }
+
+  // control config attributes the skins / future runtime rely on survive
+  expect(out).toContain('type="email"');
+  expect(out).toContain('type="date"');
+  expect(out).toContain('type="radio"');
+  expect(out).toContain('type="checkbox"');
+  expect(out).toContain('placeholder="you@ex.com"');
+  expect(out).toContain('value="2026-06-12"');
+  expect(out).toContain("checked");
+  expect(out).toContain("disabled");
+  expect(out).toContain("selected");
+
+  // identity + slot markers ride the always-safe data-/aria- channel (never name/id — SANITIZE_DOM)
+  expect(out).toContain('data-name="email"');
+  expect(out).toContain('data-slot="field"');
+  expect(out).toContain('data-slot="error"');
+  expect(out).toContain("data-immutable");
+  expect(out).toContain('aria-selected="true"');
+
+  // style= is still stripped even amid the form markup
+  expect(out).not.toContain("style=");
+});

--- a/apps/web/app/lib/a2ui/srcdoc.test.ts
+++ b/apps/web/app/lib/a2ui/srcdoc.test.ts
@@ -47,6 +47,9 @@ test("embeds the tf-* component stylesheet", () => {
   expect(doc).toContain("tf-card");
   expect(doc).toContain("tf-metric-card");
   expect(doc).toContain("tf-data-table");
+  expect(doc).toContain("tf-schema-form");
+  expect(doc).toContain("tf-combobox");
+  expect(doc).toContain("tf-switch");
 });
 
 test("orders styles before the runtime script (reset, then components, then script)", () => {

--- a/apps/web/app/routes/dev.a2ui.tsx
+++ b/apps/web/app/routes/dev.a2ui.tsx
@@ -91,6 +91,58 @@ const SAMPLE_HTML = `
   </table>
 </tf-data-table>
 
+<tf-heading>Schema form</tf-heading>
+<tf-schema-form>
+  <div data-slot="field">
+    <span data-slot="label">email <span data-slot="req">*</span></span>
+    <tf-input><input type="email" data-name="email" value="ada@example.com" placeholder="you@example.com"></tf-input>
+  </div>
+  <div data-slot="field">
+    <span data-slot="label">bio</span>
+    <tf-textarea><textarea data-name="bio" rows="3">Computing pioneer.</textarea></tf-textarea>
+  </div>
+  <div data-slot="field">
+    <span data-slot="label">status</span>
+    <tf-select><select data-name="status"><option>open</option><option selected>closed</option></select></tf-select>
+  </div>
+  <div data-slot="field">
+    <span data-slot="label">priority</span>
+    <tf-radio-group>
+      <label><input type="radio" name="priority" checked> low</label>
+      <label><input type="radio" name="priority"> high</label>
+    </tf-radio-group>
+  </div>
+  <div data-slot="field">
+    <tf-checkbox><label><input type="checkbox" data-name="subscribed" checked> subscribed</label></tf-checkbox>
+  </div>
+  <div data-slot="field">
+    <tf-switch><label><input type="checkbox" data-name="notify" checked> notify by email</label></tf-switch>
+  </div>
+  <div data-slot="field">
+    <span data-slot="label">customer (x-links)</span>
+    <tf-combobox>
+      <input data-name="customerId" value="Acme Corp" placeholder="Search customer">
+      <ul>
+        <li aria-selected="true">Acme Corp</li>
+        <li>Globex</li>
+        <li>Initech</li>
+      </ul>
+    </tf-combobox>
+  </div>
+  <div data-slot="field">
+    <span data-slot="label">due date</span>
+    <tf-calendar><input type="date" data-name="due" value="2026-06-12"></tf-calendar>
+  </div>
+  <div data-slot="field" data-immutable>
+    <span data-slot="label">id <span data-slot="meta">(immutable)</span></span>
+    <tf-input><input data-name="id" value="USER-1042" disabled></tf-input>
+  </div>
+  <p>
+    <tf-button>Save</tf-button>
+    <tf-button data-variant="outline">Cancel</tf-button>
+  </p>
+</tf-schema-form>
+
 <tf-empty-state>
   <span data-slot="title">No results found</span>
   Run a query to see data here.


### PR DESCRIPTION
…V1-002)

Display-only CSS skins over native controls, mirroring tf-data-table (no iframe JS / CSP change). Field identity on data-name since DOMPurify SANITIZE_DOM strips colliding name/id; x-immutable on edit = native disabled. Adds a sanitize round-trip (DOMPurify contract proof), srcdoc asserts, and a /dev/a2ui showcase. Shell resource-form.tsx untouched.