### PR TITLE
feat(a2ui): inline terminal-tool blocks + bridge postback (A2UI-V1-001/002)

### DIFF
--- a/apps/api/src/chat/a2ui-render.test.ts
+++ b/apps/api/src/chat/a2ui-render.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { ok } from "../tools/types";
+import { renderA2uiHtml } from "./a2ui-render";
+
+describe("renderA2uiHtml", () => {
+  it("passes compose_view html through unchanged", () => {
+    const html = "<tf-card><tf-text>hi</tf-text></tf-card>";
+    expect(renderA2uiHtml("compose_view", ok({ html }))).toBe(html);
+  });
+
+  it("returns null for compose_view with empty/non-string html", () => {
+    expect(renderA2uiHtml("compose_view", ok({ html: "" }))).toBeNull();
+    expect(renderA2uiHtml("compose_view", ok({ html: 42 }))).toBeNull();
+  });
+
+  it("renders present_choices as one tf-button per choice with a choice payload", () => {
+    const html = renderA2uiHtml(
+      "present_choices",
+      ok({
+        question: "Pick a stage",
+        choices: [
+          { label: "Staging", value: "staging" },
+          { label: "Prod", value: "prod", description: "live" },
+        ],
+      })
+    );
+    expect(html).not.toBeNull();
+    const buttons = [...(html as string).matchAll(/<tf-button /g)];
+    expect(buttons).toHaveLength(2);
+    expect(html).toContain("Pick a stage");
+    expect(html).toContain(
+      `data-a2ui-send="${'{"kind":"choice","value":"staging","label":"Staging"}'
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")}"`
+    );
+    expect(html).toContain("live"); // description rendered
+  });
+
+  it("renders suggest_agent as a card with an accept button carrying the agent payload", () => {
+    const html = renderA2uiHtml(
+      "suggest_agent",
+      ok({ agentId: "billing", agentName: "Billing Bot", reason: "handles invoices" })
+    );
+    expect(html).not.toBeNull();
+    expect(html).toContain("Billing Bot");
+    expect(html).toContain("handles invoices");
+    expect(html).toContain(`&quot;kind&quot;:&quot;suggest_agent&quot;`);
+    expect(html).toContain(`&quot;agentId&quot;:&quot;billing&quot;`);
+  });
+
+  it("escapes agent-controlled strings so a choice label cannot break out of the attribute/tag", () => {
+    const html = renderA2uiHtml(
+      "present_choices",
+      ok({
+        question: "q",
+        choices: [{ label: '"><tf-button data-a2ui-send="{}">x', value: "v" }],
+      })
+    ) as string;
+    // The injected markup must be neutralised — no second real button, no raw closing quote+bracket.
+    expect(html).not.toContain('"><tf-button data-a2ui-send="{}">');
+    expect([...html.matchAll(/<tf-button /g)]).toHaveLength(1);
+    expect(html).toContain("&lt;tf-button");
+  });
+
+  it("returns null for non-view tools and failed results", () => {
+    expect(renderA2uiHtml("load_skill", ok({ name: "x" }))).toBeNull();
+    expect(
+      renderA2uiHtml("present_choices", {
+        success: false,
+        error: { code: "validation_error", message: "bad" },
+      })
+    ).toBeNull();
+  });
+});

--- a/apps/api/src/chat/a2ui-render.ts
+++ b/apps/api/src/chat/a2ui-render.ts
@@ -1,0 +1,81 @@
+import type { ToolCallResult } from "../tools/types";
+
+/**
+ * Server-side render of a terminal/view tool result into an A2UI `tf-*` HTML block. The string is
+ * emitted as an `a2ui` SSE event and rendered in the sandboxed iframe (DOMPurify + CSP) in the chat
+ * shell. Interactive controls carry a `data-a2ui-send` JSON payload that the in-iframe runtime posts
+ * back through the `agent` bridge channel on click (see lib/a2ui/runtime.ts).
+ *
+ * Only three tools produce a view: `compose_view` (passthrough HTML), `present_choices`, and
+ * `suggest_agent`. Every other tool — and every failed result — returns `null` (no a2ui event).
+ * All agent-controlled strings are HTML-escaped so a `"`/`<` in a label cannot break out of the
+ * attribute or tag and smuggle a different `data-a2ui-send` payload.
+ */
+
+const ESCAPE: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+};
+
+function esc(value: string): string {
+  return value.replace(/[&<>"']/g, (c) => ESCAPE[c] as string);
+}
+
+/** Serialize a postback payload into an HTML-escaped `data-a2ui-send` attribute value. */
+function sendAttr(payload: unknown): string {
+  return `data-a2ui-send="${esc(JSON.stringify(payload))}"`;
+}
+
+interface Choice {
+  label: string;
+  value: string;
+  description?: string;
+}
+
+function renderChoices(data: { question: string; choices: Choice[] }): string {
+  const buttons = data.choices
+    .map((c) => {
+      const attr = sendAttr({ kind: "choice", value: c.value, label: c.label });
+      const desc = c.description
+        ? `<tf-text data-tone="muted" data-size="sm">${esc(c.description)}</tf-text>`
+        : "";
+      return `<tf-button ${attr}>${esc(c.label)}</tf-button>${desc}`;
+    })
+    .join("");
+  return `<tf-card><tf-text>${esc(data.question)}</tf-text>${buttons}</tf-card>`;
+}
+
+function renderSuggestAgent(data: {
+  agentId: string;
+  agentName: string;
+  reason: string | null;
+}): string {
+  const reason = data.reason
+    ? `<tf-text data-tone="muted" data-size="sm">${esc(data.reason)}</tf-text>`
+    : "";
+  const label = `Switch to ${data.agentName}`;
+  const attr = sendAttr({ kind: "suggest_agent", agentId: data.agentId, label });
+  return `<tf-alert data-tone="brand"><tf-text>Suggested agent: ${esc(
+    data.agentName
+  )}</tf-text>${reason}<tf-button ${attr}>${esc(label)}</tf-button></tf-alert>`;
+}
+
+export function renderA2uiHtml(toolName: string, result: ToolCallResult): string | null {
+  if (!result.success) return null;
+  const data = result.data as Record<string, unknown>;
+  switch (toolName) {
+    case "compose_view":
+      return typeof data.html === "string" && data.html.length > 0 ? data.html : null;
+    case "present_choices":
+      return renderChoices(data as unknown as { question: string; choices: Choice[] });
+    case "suggest_agent":
+      return renderSuggestAgent(
+        data as unknown as { agentId: string; agentName: string; reason: string | null }
+      );
+    default:
+      return null;
+  }
+}

--- a/apps/api/src/chat/producer.test.ts
+++ b/apps/api/src/chat/producer.test.ts
@@ -401,3 +401,59 @@ describe("attachToStream", () => {
     expect(res2.ended).toBe(true);
   });
 });
+
+// ── A2UI follow-on emission for view/terminal tools ───────────────────────────
+describe("runChatStream a2ui follow-on", () => {
+  type Emitted = { eventType: string; data: unknown };
+  const captureEmitter = (sink: Emitted[]): import("./stream-emitter").StreamEmitter => ({
+    emit: (eventType, data) => {
+      sink.push({ eventType, data });
+      return Promise.resolve();
+    },
+  });
+
+  it("emits both tool-result and a2ui for a present_choices result", async () => {
+    const hub = new StreamHub();
+    const sid = randomUUID();
+    const emitted: Emitted[] = [];
+    await runChatStream(
+      sid,
+      fromArray([
+        {
+          type: "tool-result",
+          toolCallId: "c1",
+          toolName: "present_choices",
+          output: {
+            success: true,
+            data: { question: "Pick", choices: [{ label: "A", value: "a" }] },
+          },
+        },
+        { type: "finish", finishReason: "stop" },
+      ]),
+      { emitter: captureEmitter(emitted), hub, log }
+    );
+    expect(emitted.map((e) => e.eventType)).toEqual(["tool-result", "a2ui", "finish"]);
+    const a2ui = emitted.find((e) => e.eventType === "a2ui");
+    expect((a2ui?.data as { html: string }).html).toContain("data-a2ui-send");
+  });
+
+  it("emits only tool-result for a non-view tool", async () => {
+    const hub = new StreamHub();
+    const sid = randomUUID();
+    const emitted: Emitted[] = [];
+    await runChatStream(
+      sid,
+      fromArray([
+        {
+          type: "tool-result",
+          toolCallId: "c2",
+          toolName: "list_things",
+          output: { success: true, data: { items: [] } },
+        },
+        { type: "finish", finishReason: "stop" },
+      ]),
+      { emitter: captureEmitter(emitted), hub, log }
+    );
+    expect(emitted.map((e) => e.eventType)).toEqual(["tool-result", "finish"]);
+  });
+});

--- a/apps/api/src/chat/producer.ts
+++ b/apps/api/src/chat/producer.ts
@@ -1,5 +1,6 @@
 import type { ServerResponse } from "node:http";
 import type { ToolCallResult } from "../tools/types";
+import { renderA2uiHtml } from "./a2ui-render";
 import { writeSseEvent } from "./sse";
 import type { StreamEmitter } from "./stream-emitter";
 import { isTerminalEvent, type StreamEvent, type StreamHub } from "./stream-hub";
@@ -123,6 +124,14 @@ export async function runChatStream(
         if (blocked) continue;
       }
       await deps.emitter.emit(mapped.eventType, mapped.data);
+      // A view/terminal tool (compose_view, present_choices, suggest_agent) result also emits a
+      // follow-on `a2ui` event carrying the rendered tf-* block; the tool-result stays intact so the
+      // model still reads the structured data. Non-view tools render `null` → no a2ui event.
+      if (mapped.eventType === "tool-result") {
+        const { toolName, result } = mapped.data as { toolName: string; result: ToolCallResult };
+        const html = renderA2uiHtml(toolName, result);
+        if (html) await deps.emitter.emit("a2ui", { html });
+      }
       if (isTerminalEvent(mapped.eventType)) sawTerminal = true;
     }
     if (scanOutput) await flushText(scanOutput);

--- a/apps/web/app/components/chat/chat-panel.tsx
+++ b/apps/web/app/components/chat/chat-panel.tsx
@@ -49,7 +49,8 @@ export function ChatPanel({
   agentId?: string;
   defaultModel?: ModelTier;
 }) {
-  const { messages, status, error, send, approve, regenerate, reset } = useChatStream();
+  const { messages, status, error, send, approve, regenerate, reset, sendA2uiAgent } =
+    useChatStream();
   const busy = status === "submitted" || status === "streaming";
   const agent = agentId || "GeneralAssistant";
   const hasMessages = messages.length > 0;
@@ -75,6 +76,7 @@ export function ChatPanel({
           status={status}
           onApprove={approve}
           onRegenerate={regenerate}
+          onA2uiAgent={sendA2uiAgent}
         />
       ) : (
         <EmptyState agent={agent} onPick={(text) => send(text, { model: defaultModel, agentId })} />

--- a/apps/web/app/components/chat/parts.test.tsx
+++ b/apps/web/app/components/chat/parts.test.tsx
@@ -1,0 +1,14 @@
+import { render } from "@testing-library/react";
+import { expect, test, vi } from "vitest";
+import type { TimelinePart } from "~/lib/chat/types";
+import { MessagePartView } from "./parts";
+
+test("an a2ui part renders the sandboxed A2uiFrame iframe", () => {
+  const part: TimelinePart = { kind: "a2ui", html: "<tf-card>x</tf-card>" };
+  const { container } = render(
+    <MessagePartView part={part} onApprove={() => {}} onA2uiAgent={vi.fn()} />
+  );
+  const iframe = container.querySelector('iframe[title="A2UI content"]');
+  expect(iframe).not.toBeNull();
+  expect(iframe?.getAttribute("sandbox")).toBe("allow-scripts");
+});

--- a/apps/web/app/components/chat/parts.tsx
+++ b/apps/web/app/components/chat/parts.tsx
@@ -110,10 +110,12 @@ export function MessagePartView({
   part,
   streaming,
   onApprove,
+  onA2uiAgent,
 }: {
   part: TimelinePart;
   streaming?: boolean;
   onApprove: (approvalId: string, decision: "approve" | "deny") => void;
+  onA2uiAgent?: (payload: unknown) => void;
 }) {
   switch (part.kind) {
     case "text":
@@ -177,6 +179,12 @@ export function MessagePartView({
         </div>
       );
     case "a2ui":
-      return <A2uiFrame html={part.html} className="w-full rounded-sm border border-border" />;
+      return (
+        <A2uiFrame
+          html={part.html}
+          onAgent={onA2uiAgent}
+          className="w-full rounded-sm border border-border"
+        />
+      );
   }
 }

--- a/apps/web/app/components/chat/transcript.tsx
+++ b/apps/web/app/components/chat/transcript.tsx
@@ -59,12 +59,14 @@ function Message({
   isLast,
   onApprove,
   onRegenerate,
+  onA2uiAgent,
 }: {
   message: ChatMessage;
   status: ChatStatus;
   isLast: boolean;
   onApprove: (approvalId: string, decision: "approve" | "deny") => void;
   onRegenerate?: () => void;
+  onA2uiAgent?: (payload: unknown) => void;
 }) {
   if (message.role === "user") {
     return (
@@ -90,6 +92,7 @@ function Message({
           part={part}
           streaming={streaming && i === lastIndex && part.kind === "text"}
           onApprove={onApprove}
+          onA2uiAgent={onA2uiAgent}
         />
       ))}
       {message.sealed && text ? <Actions text={text} onRegenerate={canRegenerate} /> : null}
@@ -114,11 +117,13 @@ export function Transcript({
   status,
   onApprove,
   onRegenerate,
+  onA2uiAgent,
 }: {
   messages: ChatMessage[];
   status: ChatStatus;
   onApprove: (approvalId: string, decision: "approve" | "deny") => void;
   onRegenerate?: () => void;
+  onA2uiAgent?: (payload: unknown) => void;
 }) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const endRef = useRef<HTMLDivElement>(null);
@@ -145,6 +150,7 @@ export function Transcript({
             isLast={i === messages.length - 1}
             onApprove={onApprove}
             onRegenerate={onRegenerate}
+            onA2uiAgent={onA2uiAgent}
           />
         ))}
         {status === "submitted" ? <Loader /> : null}

--- a/apps/web/app/lib/a2ui/runtime.test.ts
+++ b/apps/web/app/lib/a2ui/runtime.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, expect, test, vi } from "vitest";
+import { A2UI_RUNTIME } from "~/lib/a2ui/runtime";
+
+// Run the audited runtime STRING the way the iframe does. In jsdom `window.parent === window`, so a
+// spy on `window.postMessage` captures every outbound frame; we filter for the `agent` channel.
+function runRuntime(): { agentPosts: unknown[] } {
+  const agentPosts: unknown[] = [];
+  vi.spyOn(window, "postMessage").mockImplementation((msg: unknown) => {
+    const frame = msg as { channel?: string; payload?: unknown } | null;
+    if (frame && typeof frame === "object" && frame.channel === "agent") {
+      agentPosts.push(frame.payload);
+    }
+  });
+  new Function(A2UI_RUNTIME)();
+  return { agentPosts };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  document.body.innerHTML = "";
+});
+
+test("a click on a [data-a2ui-send] control posts its payload through the agent channel", () => {
+  document.body.innerHTML =
+    '<tf-card><tf-button data-a2ui-send=\'{"kind":"choice","value":"a","label":"A"}\'>A</tf-button></tf-card>';
+  const { agentPosts } = runRuntime();
+  document.querySelector("tf-button")?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  expect(agentPosts).toContainEqual({ kind: "choice", value: "a", label: "A" });
+});
+
+test("a click on a child of the control still resolves the nearest data-a2ui-send", () => {
+  document.body.innerHTML =
+    '<tf-button data-a2ui-send=\'{"kind":"choice","value":"x"}\'><span id="inner">x</span></tf-button>';
+  const { agentPosts } = runRuntime();
+  document.getElementById("inner")?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  expect(agentPosts).toContainEqual({ kind: "choice", value: "x" });
+});
+
+test("malformed data-a2ui-send JSON is a no-op (no throw, no post)", () => {
+  document.body.innerHTML = '<tf-button data-a2ui-send="{not json">bad</tf-button>';
+  const { agentPosts } = runRuntime();
+  expect(() =>
+    document.querySelector("tf-button")?.dispatchEvent(new MouseEvent("click", { bubbles: true }))
+  ).not.toThrow();
+  expect(agentPosts).toHaveLength(0);
+});

--- a/apps/web/app/lib/a2ui/runtime.ts
+++ b/apps/web/app/lib/a2ui/runtime.ts
@@ -32,6 +32,22 @@ export const A2UI_RUNTIME = `(function () {
     document.dispatchEvent(new CustomEvent("a2ui:message", { detail: event.data }));
   });
 
+  // Interactivity bridge: tf-* controls are static (DOMPurify strips inline handlers), so clicks are
+  // delegated here. A click on (or inside) an element carrying data-a2ui-send posts its JSON payload
+  // out through the "agent" channel — the host turns it into a follow-up turn. Malformed JSON no-ops.
+  document.addEventListener("click", function (event) {
+    var node = event.target;
+    while (node && node !== document) {
+      if (node.nodeType === 1 && node.hasAttribute("data-a2ui-send")) {
+        try {
+          window.__a2ui.send("agent", JSON.parse(node.getAttribute("data-a2ui-send")));
+        } catch (_e) {}
+        return;
+      }
+      node = node.parentNode;
+    }
+  });
+
   // Auto-size: report content height, rAF-batched (outer-height only ⇒ no feedback loop).
   var pending = false;
   function reportHeight() {

--- a/apps/web/app/lib/a2ui/sanitize.test.ts
+++ b/apps/web/app/lib/a2ui/sanitize.test.ts
@@ -185,3 +185,13 @@ test("preserves tf-schema-form + native form controls with data-* config and slo
   // style= is still stripped even amid the form markup
   expect(out).not.toContain("style=");
 });
+
+test("data-a2ui-send postback attribute survives on tf-* controls", () => {
+  const out = sanitizeAgentHtml(
+    '<tf-card><tf-button data-a2ui-send=\'{"kind":"choice","value":"a"}\'>A</tf-button></tf-card>'
+  );
+  expect(out).toContain("<tf-button");
+  // The attribute survives; DOMPurify entity-encodes the quotes (the browser decodes on getAttribute).
+  expect(out).toContain("data-a2ui-send=");
+  expect(out).toContain("&quot;kind&quot;:&quot;choice&quot;");
+});

--- a/apps/web/app/lib/chat/use-chat-stream.test.ts
+++ b/apps/web/app/lib/chat/use-chat-stream.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "vitest";
+import { a2uiAgentToSend } from "~/lib/chat/use-chat-stream";
+
+describe("a2uiAgentToSend", () => {
+  test("maps a choice payload to a user turn using the label", () => {
+    expect(a2uiAgentToSend({ kind: "choice", value: "staging", label: "Staging" })).toEqual({
+      text: "Staging",
+    });
+  });
+
+  test("falls back to the choice value when no label is present", () => {
+    expect(a2uiAgentToSend({ kind: "choice", value: "staging" })).toEqual({ text: "staging" });
+  });
+
+  test("maps a suggest_agent payload to a turn that switches the agent", () => {
+    expect(
+      a2uiAgentToSend({ kind: "suggest_agent", agentId: "billing", label: "Switch to Billing" })
+    ).toEqual({ text: "Switch to Billing", opts: { agentId: "billing" } });
+  });
+
+  test("ignores unknown / malformed payloads", () => {
+    expect(a2uiAgentToSend(null)).toBeNull();
+    expect(a2uiAgentToSend({ kind: "choice" })).toBeNull();
+    expect(a2uiAgentToSend({ kind: "other", label: "x" })).toBeNull();
+    expect(a2uiAgentToSend("nope")).toBeNull();
+  });
+});

--- a/apps/web/app/lib/chat/use-chat-stream.ts
+++ b/apps/web/app/lib/chat/use-chat-stream.ts
@@ -24,6 +24,26 @@ type ChatAction =
   | { type: "regenerate" }
   | { type: "reset" };
 
+/**
+ * Map an A2UI bridge `agent` payload (posted by a tf-* control click via the iframe runtime) into a
+ * follow-up user turn. `choice` submits the chosen label (falling back to its value); `suggest_agent`
+ * submits a prompt and switches the active agent. Unknown/malformed payloads are ignored.
+ */
+export function a2uiAgentToSend(payload: unknown): { text: string; opts?: SendOptions } | null {
+  if (typeof payload !== "object" || payload === null) return null;
+  const p = payload as Record<string, unknown>;
+  if (p.kind === "choice") {
+    const text = typeof p.label === "string" ? p.label : typeof p.value === "string" ? p.value : "";
+    return text ? { text } : null;
+  }
+  if (p.kind === "suggest_agent") {
+    const text = typeof p.label === "string" ? p.label : "";
+    const agentId = typeof p.agentId === "string" ? p.agentId : undefined;
+    return text ? { text, opts: agentId ? { agentId } : undefined } : null;
+  }
+  return null;
+}
+
 function reducer(state: ChatState, action: ChatAction): ChatState {
   if (action.type === "user") return appendUserMessage(state, action.text);
   if (action.type === "reset") return initialChatState;
@@ -116,6 +136,15 @@ export function useChatStream() {
     dispatch({ type: "reset" });
   }, []);
 
+  // Bridge postback from an A2UI tf-* control: turn the `agent` payload into a follow-up user turn.
+  const sendA2uiAgent = useCallback(
+    (payload: unknown) => {
+      const mapped = a2uiAgentToSend(payload);
+      if (mapped) void send(mapped.text, mapped.opts);
+    },
+    [send]
+  );
+
   return {
     messages: state.messages,
     pendingApprovals: state.pendingApprovals,
@@ -125,5 +154,6 @@ export function useChatStream() {
     approve,
     regenerate,
     reset,
+    sendA2uiAgent,
   };
 }


### PR DESCRIPTION
## What
Render agent-emitted A2UI `tf-*` HTML blocks inline within chat messages, and wire the interactive terminal tools (`present_choices`, `suggest_agent`) so user interactions post back through the iframe postMessage bridge.

Closes the three wires missing on top of the existing A2UI foundation (sandbox/CSP/DOMPurify/bridge, `tf-*` CSS, `A2uiFrame`, `a2ui` SSE pipeline).

## Spec
specs/A2UI.md — A2UI-V1-001 / A2UI-V1-002.

## Changes
**Backend (apps/api)**
- `chat/a2ui-render.ts` *(new)* — `renderA2uiHtml(toolName, result)`: `compose_view` passthrough; `present_choices` → `tf-card` + one `tf-button[data-a2ui-send]` per choice; `suggest_agent` → `tf-alert` accept card. All agent-controlled strings HTML-escaped to block attribute/markup injection.
- `chat/producer.ts` — emit a follow-on `a2ui` SSE event after a view tool's `tool-result`; `tool-result` kept intact so the model still reads the structured data.

**Frontend (apps/web)**
- `lib/a2ui/runtime.ts` — delegate clicks on `[data-a2ui-send]` → `window.__a2ui.send("agent", payload)`, making static `tf-*` controls interactive without inline scripts.
- `lib/chat/use-chat-stream.ts` — `a2uiAgentToSend` maps a bridge payload to a follow-up user turn (`choice`) or turn + agent switch (`suggest_agent`); `sendA2uiAgent` threaded through `parts` → `transcript` → `chat-panel` to `A2uiFrame.onAgent` (previously unwired).

## Design decisions
- **Part-based inline** — `a2ui` stays a discrete TimelinePart in message order, not embedded mid-markdown.
- **Postback = new user turn** — no server-side tool pause/resume in V1.
- **Server-side render** of terminal-tool HTML, emitted through the existing sanitized `a2ui` pipeline.

## Validation
- [x] An agent message containing a `tf-*` block renders the iframe inline; terminal-tool interactions post back through the bridge.

Verified on Node 24:
- `pnpm lint` → EXIT 0 (biome clean)
- `pnpm typecheck` → 11/11 packages
- `pnpm test` → 10/10 packages (api 847 tests; web touched 18/18)

New tests: renderer (escaping incl. injection attempt), producer dual-emit, runtime click delegation (jsdom), sanitize survival of `data-a2ui-send`, host payload mapping, parts render.

## Deferred
True tool pause/resume · mid-markdown embed · `tf-schema-form` + Chart.js (AC-V1-003) · `api`/`navigate` channel semantics.