### PR TITLE
feat(onboarding): adaptive soul-derived suggestion chips over chat (ONB-V1-001/002/003)

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -26,6 +26,7 @@ import type { HookExecutor } from "./hooks/hook-executor";
 import { registerKnowledgeRoutes } from "./knowledge/routes";
 import type { KnowledgeService } from "./knowledge/service";
 import type { WorkingMemoryService } from "./memory/service";
+import { registerOnboardingRoutes } from "./onboarding/routes";
 import type { RateLimiter } from "./rate-limit";
 import type { CounterStore, ResourceRepoFactory } from "./resources/repo";
 import { registerResourceRoutes } from "./resources/routes";
@@ -156,6 +157,7 @@ export async function buildApp(opts: AppOptions = {}) {
           opts.reconcileResources
         );
         registerAgentRoutes(app, opts.soulLoader, requireAuth);
+        registerOnboardingRoutes(app, opts.soulLoader, requireAuth);
         if (opts.llmService) {
           registerSkillRoutes(app, opts.soulLoader, opts.gitSync, opts.llmService, requireAuth);
           if (opts.secretsService) {

--- a/apps/api/src/onboarding/catalog.ts
+++ b/apps/api/src/onboarding/catalog.ts
@@ -1,0 +1,56 @@
+/*
+ * Static seed catalog for the Information Architect suggestion layer (ONBOARDING ONB-V1-002/003).
+ * Each entry is a candidate onboarding suggestion. `resources` is the match key: the resource
+ * name(s) the suggestion would create — an entry is hidden once any of them already exists in the
+ * soul (AC-V1-002). `label` is the chip text; `prompt` is the message seeded into chat on tap.
+ */
+
+export interface SuggestionEntry {
+  /** Stable id, e.g. "tickets". */
+  id: string;
+  /** Chip text shown to the user. */
+  label: string;
+  /** Message sent to chat when the chip is tapped. */
+  prompt: string;
+  /** Resource name(s) this suggestion would create; hide the entry if any already exist. */
+  resources: string[];
+}
+
+export const CATALOG: SuggestionEntry[] = [
+  {
+    id: "tickets",
+    label: "Set up ticket management?",
+    prompt: "Help me set up ticket management.",
+    resources: ["tickets"],
+  },
+  {
+    id: "leads",
+    label: "Track sales leads?",
+    prompt: "Help me track sales leads.",
+    resources: ["leads"],
+  },
+  {
+    id: "employees",
+    label: "Manage employees?",
+    prompt: "Help me set up employee management.",
+    resources: ["employees"],
+  },
+  {
+    id: "invoices",
+    label: "Track invoices & billing?",
+    prompt: "Help me set up invoices and billing.",
+    resources: ["invoices"],
+  },
+  {
+    id: "inventory",
+    label: "Manage inventory?",
+    prompt: "Help me set up inventory tracking.",
+    resources: ["inventory"],
+  },
+  {
+    id: "projects",
+    label: "Organize projects & tasks?",
+    prompt: "Help me organize projects and tasks.",
+    resources: ["projects"],
+  },
+];

--- a/apps/api/src/onboarding/routes.test.ts
+++ b/apps/api/src/onboarding/routes.test.ts
@@ -1,0 +1,129 @@
+import type { GitSyncService, SoulLoader } from "@tulipfarm/soul";
+import type { FastifyInstance } from "fastify";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { buildApp } from "../app";
+import type { TokenDoc, TokenRepo } from "../auth/api-tokens";
+import { CSRF_COOKIE, CSRF_HEADER } from "../auth/csrf";
+import { SESSION_COOKIE } from "../auth/middleware";
+import { MemorySessionStore } from "../auth/session-store";
+import { createUser, type UserDoc, type UserRepo } from "../auth/users";
+import type { PaginatedResult } from "../pagination";
+import { CATALOG } from "./catalog";
+
+const TEST_CSRF = "a".repeat(64);
+
+class FakeUserRepo implements UserRepo {
+  private users: UserDoc[] = [];
+  async findByEmail(email: string) {
+    return this.users.find((u) => u.email === email.trim().toLowerCase()) ?? null;
+  }
+  async findById(id: string) {
+    return this.users.find((u) => u._id === id) ?? null;
+  }
+  async count() {
+    return this.users.length;
+  }
+  async insert(user: UserDoc) {
+    this.users.push(user);
+  }
+}
+
+class FakeTokenRepo implements TokenRepo {
+  private tokens: TokenDoc[] = [];
+  async create(token: TokenDoc) {
+    this.tokens.push(token);
+  }
+  async findByHash(hash: string) {
+    return this.tokens.find((t) => t.tokenHash === hash) ?? null;
+  }
+  async findByUserId(userId: string) {
+    return this.tokens.filter((t) => t.userId === userId);
+  }
+  async findAll() {
+    return [...this.tokens];
+  }
+  async findById(id: string) {
+    return this.tokens.find((t) => t._id === id) ?? null;
+  }
+  async deleteById(id: string) {
+    this.tokens = this.tokens.filter((t) => t._id !== id);
+  }
+  async findAllPaginated(): Promise<PaginatedResult<TokenDoc>> {
+    return { items: [], nextCursor: null };
+  }
+  async findByUserIdPaginated(): Promise<PaginatedResult<TokenDoc>> {
+    return { items: [], nextCursor: null };
+  }
+}
+
+function makeFakeGitSync() {
+  return {
+    commit: vi.fn().mockResolvedValue({ sha: "abc1234", filesChanged: 0 }),
+    push: vi.fn().mockResolvedValue(true),
+    path: "/tmp/soul",
+  } as unknown as GitSyncService;
+}
+
+function makeSoulLoader(resourceNames: string[]) {
+  return {
+    resources: new Map(resourceNames.map((n) => [n, {}])),
+    agents: new Map(),
+    skills: new Map(),
+  } as unknown as SoulLoader;
+}
+
+async function appWithSoul(resourceNames: string[]) {
+  const store = new MemorySessionStore();
+  const userRepo = new FakeUserRepo();
+  const tokenRepo = new FakeTokenRepo();
+  const user = await createUser(userRepo, "user@example.com", "pass", "member");
+  const sid = await store.create(user._id);
+  const app = await buildApp({
+    sessionStore: store,
+    userRepo,
+    tokenRepo,
+    gitSync: makeFakeGitSync(),
+    soulLoader: makeSoulLoader(resourceNames),
+  });
+  const authed = (url: string) => ({
+    method: "GET" as const,
+    url,
+    cookies: { [SESSION_COOKIE]: sid, [CSRF_COOKIE]: TEST_CSRF },
+    headers: { [CSRF_HEADER]: TEST_CSRF },
+  });
+  return { app, authed };
+}
+
+describe("GET /api/v1/onboarding/suggestions", () => {
+  let app: FastifyInstance;
+
+  afterEach(async () => {
+    await app?.close();
+  });
+
+  it("returns 401 without auth", async () => {
+    ({ app } = await appWithSoul([]));
+    const res = await app.inject({ method: "GET", url: "/api/v1/onboarding/suggestions" });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("returns the full catalog when the soul has no resources", async () => {
+    let authed: Awaited<ReturnType<typeof appWithSoul>>["authed"];
+    ({ app, authed } = await appWithSoul([]));
+    const res = await app.inject(authed("/api/v1/onboarding/suggestions"));
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { suggestions: { id: string; label: string; prompt: string }[] };
+    expect(body.suggestions).toHaveLength(CATALOG.length);
+    expect(Object.keys(body.suggestions[0]).sort()).toEqual(["id", "label", "prompt"]);
+  });
+
+  it("omits a suggestion whose resource already exists (AC-V1-002)", async () => {
+    let authed: Awaited<ReturnType<typeof appWithSoul>>["authed"];
+    ({ app, authed } = await appWithSoul(["tickets"]));
+    const res = await app.inject(authed("/api/v1/onboarding/suggestions"));
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { suggestions: { id: string }[] };
+    expect(body.suggestions.map((s) => s.id)).not.toContain("tickets");
+    expect(body.suggestions).toHaveLength(CATALOG.length - 1);
+  });
+});

--- a/apps/api/src/onboarding/routes.ts
+++ b/apps/api/src/onboarding/routes.ts
@@ -1,0 +1,55 @@
+import type { SoulLoader } from "@tulipfarm/soul";
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { ErrorSchema } from "../auth/schemas";
+import { deriveSuggestions } from "./suggestions";
+
+/*
+ * Read-only HTTP surface for the onboarding / Information Architect suggestion layer
+ * (ONBOARDING ONB-V1-002/003, AC-V1-002). Suggestions are derived from the current soul state
+ * (the SoulLoader's resource set) — a candidate is omitted once the resource it would create
+ * already exists. Non-blocking by design: the chat landing surface renders whatever this returns.
+ */
+
+type PreHandler = (req: FastifyRequest, reply: FastifyReply) => Promise<void>;
+
+export function registerOnboardingRoutes(
+  app: FastifyInstance,
+  soulLoader: SoulLoader,
+  requireAuth: PreHandler
+): void {
+  app.get(
+    "/api/v1/onboarding/suggestions",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description: "Adaptive onboarding suggestions derived from the current soul state.",
+        tags: ["onboarding"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        response: {
+          200: {
+            type: "object",
+            required: ["suggestions"],
+            properties: {
+              suggestions: {
+                type: "array",
+                items: {
+                  type: "object",
+                  required: ["id", "label", "prompt"],
+                  properties: {
+                    id: { type: "string" },
+                    label: { type: "string" },
+                    prompt: { type: "string" },
+                  },
+                },
+              },
+            },
+          },
+          401: ErrorSchema,
+        },
+      },
+    },
+    async () => {
+      return { suggestions: deriveSuggestions(soulLoader) };
+    }
+  );
+}

--- a/apps/api/src/onboarding/suggestions.test.ts
+++ b/apps/api/src/onboarding/suggestions.test.ts
@@ -1,0 +1,45 @@
+import type { SoulLoader } from "@tulipfarm/soul";
+import { describe, expect, it } from "vitest";
+import { CATALOG } from "./catalog";
+import { deriveSuggestions } from "./suggestions";
+
+/** Minimal SoulLoader slice: deriveSuggestions only reads `.resources`. */
+function soul(resourceNames: string[]): Pick<SoulLoader, "resources"> {
+  const resources = new Map(resourceNames.map((n) => [n, {} as never]));
+  return { resources } as Pick<SoulLoader, "resources">;
+}
+
+describe("deriveSuggestions", () => {
+  it("returns the full catalog when the soul has no resources (empty soul)", () => {
+    const out = deriveSuggestions(soul([]));
+    expect(out).toHaveLength(CATALOG.length);
+    expect(out.map((s) => s.id)).toEqual(CATALOG.map((e) => e.id));
+  });
+
+  it("hides an entry whose resource already exists (AC-V1-002)", () => {
+    const out = deriveSuggestions(soul(["tickets"]));
+    expect(out.map((s) => s.id)).not.toContain("tickets");
+    expect(out).toHaveLength(CATALOG.length - 1);
+  });
+
+  it("keeps entries whose resources are absent", () => {
+    const out = deriveSuggestions(soul(["tickets"]));
+    expect(out.map((s) => s.id)).toContain("leads");
+    expect(out.map((s) => s.id)).toContain("projects");
+  });
+
+  it("hides multiple entries when several matching resources exist", () => {
+    const out = deriveSuggestions(soul(["tickets", "leads", "invoices"]));
+    const ids = out.map((s) => s.id);
+    expect(ids).not.toContain("tickets");
+    expect(ids).not.toContain("leads");
+    expect(ids).not.toContain("invoices");
+    expect(out).toHaveLength(CATALOG.length - 3);
+  });
+
+  it("projects to { id, label, prompt } and omits the resources match key", () => {
+    const [first] = deriveSuggestions(soul([]));
+    expect(Object.keys(first).sort()).toEqual(["id", "label", "prompt"]);
+    expect(first).not.toHaveProperty("resources");
+  });
+});

--- a/apps/api/src/onboarding/suggestions.ts
+++ b/apps/api/src/onboarding/suggestions.ts
@@ -1,0 +1,21 @@
+import type { SoulLoader } from "@tulipfarm/soul";
+import { CATALOG } from "./catalog";
+
+/** A suggestion projected for the client — the `resources` match key is stripped. */
+export interface Suggestion {
+  id: string;
+  label: string;
+  prompt: string;
+}
+
+/**
+ * Derive the adaptive onboarding suggestions for the current soul state (ONB-V1-003, AC-V1-002).
+ * Pure: keeps a catalog entry iff none of the resource name(s) it would create already exist in the
+ * soul, then projects to `{ id, label, prompt }` (dropping the `resources` match key). Typed against
+ * the minimal `resources` map slice so it is trivially testable with a stub.
+ */
+export function deriveSuggestions(soulLoader: Pick<SoulLoader, "resources">): Suggestion[] {
+  return CATALOG.filter((e) => !e.resources.some((r) => soulLoader.resources.has(r))).map(
+    ({ id, label, prompt }) => ({ id, label, prompt })
+  );
+}

--- a/apps/web/app/components/chat/chat-panel.test.tsx
+++ b/apps/web/app/components/chat/chat-panel.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, expect, test, vi } from "vitest";
+import { ChatPanel } from "~/components/chat/chat-panel";
+import type { Suggestion } from "~/lib/onboarding";
+
+// ChatPanel drives the conversation through useChatStream; mock it so the empty-state surface
+// renders deterministically and `send` is observable.
+const send = vi.fn();
+vi.mock("~/lib/chat/use-chat-stream", () => ({
+  useChatStream: () => ({
+    messages: [],
+    status: "ready",
+    error: null,
+    send,
+    approve: vi.fn(),
+    regenerate: vi.fn(),
+    reset: vi.fn(),
+    sendA2uiAgent: vi.fn(),
+  }),
+}));
+
+beforeEach(() => send.mockClear());
+
+const SUGGESTIONS: Suggestion[] = [
+  {
+    id: "tickets",
+    label: "Set up ticket management?",
+    prompt: "Help me set up ticket management.",
+  },
+  { id: "leads", label: "Track sales leads?", prompt: "Help me track sales leads." },
+];
+
+test("renders one chip per adaptive suggestion using its label (ONB-V1-002)", () => {
+  render(<ChatPanel suggestions={SUGGESTIONS} />);
+  expect(screen.getByRole("button", { name: "Set up ticket management?" })).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "Track sales leads?" })).toBeInTheDocument();
+});
+
+test("tapping a chip seeds the chat with its prompt (not its label)", async () => {
+  const user = userEvent.setup();
+  render(<ChatPanel suggestions={SUGGESTIONS} />);
+
+  await user.click(screen.getByRole("button", { name: "Set up ticket management?" }));
+
+  expect(send).toHaveBeenCalledWith("Help me set up ticket management.", {
+    model: "standard",
+    agentId: undefined,
+  });
+});
+
+test("with no suggestions, renders no chips but the composer stays interactive (default = [])", () => {
+  render(<ChatPanel />);
+  expect(screen.queryByRole("button", { name: /set up|track|manage/i })).toBeNull();
+  expect(screen.getByLabelText("Message")).toBeInTheDocument();
+});

--- a/apps/web/app/components/chat/chat-panel.tsx
+++ b/apps/web/app/components/chat/chat-panel.tsx
@@ -1,11 +1,18 @@
 import type { ModelTier } from "~/lib/chat/types";
 import { useChatStream } from "~/lib/chat/use-chat-stream";
+import type { Suggestion } from "~/lib/onboarding";
 import { Composer } from "./composer";
 import { Transcript } from "./transcript";
 
-const SUGGESTIONS = ["what can you do?", "show my open approvals", "summarize recent leads"];
-
-function EmptyState({ agent, onPick }: { agent: string; onPick: (text: string) => void }) {
+function EmptyState({
+  agent,
+  suggestions = [],
+  onPick,
+}: {
+  agent: string;
+  suggestions?: Suggestion[];
+  onPick: (text: string) => void;
+}) {
   return (
     <div className="flex flex-1 flex-col items-center justify-center gap-8 overflow-y-auto px-6 py-16">
       <div className="flex w-full max-w-3xl flex-col gap-3 motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-2 motion-safe:duration-500">
@@ -26,14 +33,14 @@ function EmptyState({ agent, onPick }: { agent: string; onPick: (text: string) =
         </p>
       </div>
       <div className="flex w-full max-w-3xl flex-wrap gap-2">
-        {SUGGESTIONS.map((s) => (
+        {suggestions.map((s) => (
           <button
-            key={s}
+            key={s.id}
             type="button"
-            onClick={() => onPick(s)}
+            onClick={() => onPick(s.prompt)}
             className="rounded-sm border border-border bg-secondary px-2.5 py-1 text-xs text-muted-foreground transition-colors hover:border-primary hover:text-foreground"
           >
-            {s}
+            {s.label}
           </button>
         ))}
       </div>
@@ -45,9 +52,11 @@ function EmptyState({ agent, onPick }: { agent: string; onPick: (text: string) =
 export function ChatPanel({
   agentId,
   defaultModel = "standard",
+  suggestions = [],
 }: {
   agentId?: string;
   defaultModel?: ModelTier;
+  suggestions?: Suggestion[];
 }) {
   const { messages, status, error, send, approve, regenerate, reset, sendA2uiAgent } =
     useChatStream();
@@ -79,7 +88,11 @@ export function ChatPanel({
           onA2uiAgent={sendA2uiAgent}
         />
       ) : (
-        <EmptyState agent={agent} onPick={(text) => send(text, { model: defaultModel, agentId })} />
+        <EmptyState
+          agent={agent}
+          suggestions={suggestions}
+          onPick={(text) => send(text, { model: defaultModel, agentId })}
+        />
       )}
       <Composer
         busy={busy}

--- a/apps/web/app/lib/onboarding.ts
+++ b/apps/web/app/lib/onboarding.ts
@@ -1,0 +1,14 @@
+import { apiGet } from "./api";
+
+/*
+ * Read-only client for the onboarding suggestion layer (ONBOARDING ONB-V1-002/003). The API derives
+ * an adaptive chip set from the current soul state; the chat landing surface renders them. Mirrors
+ * lib/agents.ts conventions (cookie-first auth via apiGet, ApiError on non-2xx).
+ */
+
+export type Suggestion = { id: string; label: string; prompt: string };
+
+export async function listOnboardingSuggestions(): Promise<Suggestion[]> {
+  const body = await apiGet<{ suggestions: Suggestion[] }>("/api/v1/onboarding/suggestions");
+  return body.suggestions;
+}

--- a/apps/web/app/routes/_app._index.test.tsx
+++ b/apps/web/app/routes/_app._index.test.tsx
@@ -2,7 +2,7 @@ import * as remix from "@remix-run/react";
 import { createRemixStub } from "@remix-run/testing";
 import { render, screen } from "@testing-library/react";
 import { expect, test, vi } from "vitest";
-import ChatRoute from "~/routes/_app._index";
+import ChatRoute, { clientLoader } from "~/routes/_app._index";
 
 // Mock the loader hook and render the Component directly (the convention used by the other route
 // tests) — avoids the async clientLoader boundary while still supplying router context for the
@@ -12,13 +12,30 @@ vi.mock("@remix-run/react", async () => {
   return { ...actual, useLoaderData: vi.fn() };
 });
 
+// clientLoader-direct test (catch path) mocks the data clients it calls.
+vi.mock("~/lib/agents", () => ({ getAgent: vi.fn() }));
+vi.mock("~/lib/onboarding", () => ({ listOnboardingSuggestions: vi.fn() }));
+
+import { getAgent } from "~/lib/agents";
+import { listOnboardingSuggestions } from "~/lib/onboarding";
+
 // jsdom has no layout engine; the transcript's auto-scroll calls scrollIntoView.
 Element.prototype.scrollIntoView = vi.fn();
 
 const Stub = createRemixStub([{ path: "/", Component: ChatRoute }]);
 
-test("default view is the live chat empty state with a composer (AC-V1-001)", () => {
-  vi.mocked(remix.useLoaderData).mockReturnValue({ agentId: undefined, defaultModel: "standard" });
+test("default view is the live chat empty state with adaptive suggestions (AC-V1-001/002)", () => {
+  vi.mocked(remix.useLoaderData).mockReturnValue({
+    agentId: undefined,
+    defaultModel: "standard",
+    suggestions: [
+      {
+        id: "tickets",
+        label: "Set up ticket management?",
+        prompt: "Help me set up ticket management.",
+      },
+    ],
+  });
   render(<Stub initialEntries={["/"]} />);
 
   // Signature welcome (blinking wordmark + ready status + active agent).
@@ -26,10 +43,23 @@ test("default view is the live chat empty state with a composer (AC-V1-001)", ()
   expect(screen.getByText("ready")).toBeInTheDocument();
   expect(screen.getByText("GeneralAssistant")).toBeInTheDocument();
 
-  // Suggestion chips seed the composer; the composer itself is interactive (no longer a placeholder).
-  expect(screen.getByRole("button", { name: /what can you do/i })).toBeInTheDocument();
+  // Adaptive soul-derived suggestion chip (replaces the former hardcoded set).
+  expect(screen.getByRole("button", { name: "Set up ticket management?" })).toBeInTheDocument();
   expect(screen.getByLabelText("Message")).toBeInTheDocument();
 
   // No file-attachment affordance in V1.
   expect(document.querySelector('input[type="file"]')).toBeNull();
+});
+
+test("clientLoader never blocks chat: a failed suggestions fetch yields [] (AC-V1-001)", async () => {
+  vi.mocked(getAgent).mockRejectedValue(new Error("api down"));
+  vi.mocked(listOnboardingSuggestions).mockRejectedValue(new Error("api down"));
+
+  const data = await clientLoader({
+    request: new Request("http://localhost/"),
+    params: {},
+  } as Parameters<typeof clientLoader>[0]);
+
+  expect(data.suggestions).toEqual([]);
+  expect(data.defaultModel).toBe("standard");
 });

--- a/apps/web/app/routes/_app._index.tsx
+++ b/apps/web/app/routes/_app._index.tsx
@@ -2,6 +2,7 @@ import { type ClientLoaderFunctionArgs, type MetaFunction, useLoaderData } from 
 import { ChatPanel } from "~/components/chat/chat-panel";
 import { getAgent } from "~/lib/agents";
 import type { ModelTier } from "~/lib/chat/types";
+import { listOnboardingSuggestions } from "~/lib/onboarding";
 
 export const meta: MetaFunction = () => [{ title: "Chat · tulipfarm" }];
 
@@ -19,10 +20,13 @@ export async function clientLoader({ request }: ClientLoaderFunctionArgs) {
   } catch {
     // Unknown agent / transient API error — keep the standard default rather than break the page.
   }
-  return { agentId, defaultModel };
+  // Adaptive onboarding suggestions (ONB-V1-002/003). Non-blocking (AC-V1-001): a failed fetch
+  // resolves to [] so chat always renders (mirrors the agent lookup above — no hard dependency).
+  const suggestions = await listOnboardingSuggestions().catch(() => []);
+  return { agentId, defaultModel, suggestions };
 }
 
 export default function ChatRoute() {
-  const { agentId, defaultModel } = useLoaderData<typeof clientLoader>();
-  return <ChatPanel agentId={agentId} defaultModel={defaultModel} />;
+  const { agentId, defaultModel, suggestions } = useLoaderData<typeof clientLoader>();
+  return <ChatPanel agentId={agentId} defaultModel={defaultModel} suggestions={suggestions} />;
 }


### PR DESCRIPTION
## What

Non-blocking Information Architect suggestion layer on the chat landing surface. Adaptive suggestion chips ("Set up ticket management?", "Track sales leads?") derived from current soul state. Tapping a chip seeds a normal chat turn. **Surface-only** scope — no sub-interview, no async generation pipeline.

Spec: `specs/ONBOARDING.md` ONB-V1-001/002/003 · `specs/AGENTS.md` AC-V1-001/002.

## How

- **API** — new `apps/api/src/onboarding/`:
  - `catalog.ts` — 6 seed entries `{ id, label, prompt, resources[] }`.
  - `suggestions.ts` — `deriveSuggestions()`: pure filter, hides an entry when any of its `resources` already exist in `SoulLoader.resources`; strips the match key.
  - `routes.ts` — `GET /api/v1/onboarding/suggestions` (OpenAPI schema + `security`).
  - wired in `app.ts` beside `registerAgentRoutes`.
- **Web**:
  - `lib/onboarding.ts` — `listOnboardingSuggestions()` client.
  - `chat-panel.tsx` — hardcoded `SUGGESTIONS` → adaptive `suggestions` prop (default `[]`); chip text = `label`, tap → `send(prompt)`.
  - `_app._index.tsx` — loader fetches with `.catch(() => [])` so chat always renders.

## Acceptance criteria

- **AC-V1-001** (no onboarding gate; chat never blocked) — loader swallows fetch failures → `[]`; no middleware/gate added. Covered by the clientLoader catch test + chat-panel composer test.
- **AC-V1-002** (adaptive to soul state) — a suggestion for an existing resource type is omitted. Covered by `suggestions.test.ts` (5) + `routes.test.ts` (3, via `buildApp.inject`).

## Notes

- The spec's "Depends on: soul-context (built)" is **inaccurate** — `<soul-context>` L1 is still deferred (`assemble.ts`). This derives soul state from `SoulLoader` directly instead; the deferred block is untouched.

## Verification (Node 24)

- `pnpm exec biome check .` → clean
- `pnpm typecheck` → 11/11 green
- `pnpm test` → 10/10 workspaces (api 82 files / 855 tests, +8 new)
- Independent diff review → 4.6/5

## Out of scope (deferred)

Sub-interview on tap; async generation (BullMQ ARCH-V1-004); no-approval soul commit (ONB-V1-004, AC-V1-003/004); persistent chip strip; cards; LLM-generated suggestions.