### PR TITLE
feat(knowledge): web management UI + derived indexingStatus (UI-V1-003)

### DIFF
--- a/apps/api/src/knowledge/chunks-repo.ts
+++ b/apps/api/src/knowledge/chunks-repo.ts
@@ -1,6 +1,12 @@
 import { randomUUID } from "node:crypto";
 import type { Queryable } from "../db";
-import type { ChunkInput, KnowledgeSource, SearchFilters, SearchHit } from "./types";
+import type {
+  ChunkInput,
+  IndexingStatus,
+  KnowledgeSource,
+  SearchFilters,
+  SearchHit,
+} from "./types";
 
 /** Push `d.*` filter conditions onto `params` and return the SQL fragments. */
 function docFilterConditions(filters: SearchFilters, params: unknown[]): string[] {
@@ -43,6 +49,10 @@ export interface KnowledgeChunkRepo {
   ): Promise<SearchHit[]>;
   /** Lexical fallback via `websearch_to_tsquery` + `ts_rank`. */
   searchLexical(query: string, limit: number, filters: SearchFilters): Promise<SearchHit[]>;
+  /** Derived per-doc index state: pending (no chunks) | lexical-only (chunks, null embeddings) | indexed. */
+  getIndexingStatus(documentId: string): Promise<IndexingStatus>;
+  /** Batch variant — one grouped query; ids absent from the result default to "pending". */
+  getIndexingStatuses(documentIds: string[]): Promise<Map<string, IndexingStatus>>;
 }
 
 export class PgKnowledgeChunkRepo implements KnowledgeChunkRepo {
@@ -109,5 +119,28 @@ export class PgKnowledgeChunkRepo implements KnowledgeChunkRepo {
       params
     );
     return rows.map((r) => rowToHit(r, Number((r as { rank: number }).rank)));
+  }
+
+  async getIndexingStatuses(documentIds: string[]): Promise<Map<string, IndexingStatus>> {
+    const result = new Map<string, IndexingStatus>();
+    if (documentIds.length === 0) return result;
+    for (const id of documentIds) result.set(id, "pending");
+    const { rows } = await this.q.query(
+      `SELECT document_id,
+              CASE WHEN bool_and(embedding IS NOT NULL) THEN 'indexed' ELSE 'lexical-only' END AS status
+       FROM knowledge_chunks
+       WHERE document_id = ANY($1::uuid[])
+       GROUP BY document_id`,
+      [documentIds]
+    );
+    for (const r of rows as Array<{ document_id: string; status: IndexingStatus }>) {
+      result.set(r.document_id, r.status);
+    }
+    return result;
+  }
+
+  async getIndexingStatus(documentId: string): Promise<IndexingStatus> {
+    const statuses = await this.getIndexingStatuses([documentId]);
+    return statuses.get(documentId) ?? "pending";
   }
 }

--- a/apps/api/src/knowledge/routes.test.ts
+++ b/apps/api/src/knowledge/routes.test.ts
@@ -131,6 +131,43 @@ describe("knowledge routes", () => {
     expect(body.warnings).toEqual([]);
   });
 
+  it("reports indexingStatus=indexed on get + list when embeddings are available", async () => {
+    const id = await createDoc();
+    const got = await app.inject({ method: "GET", url: `${base}/documents/${id}` });
+    expect(got.json<{ indexingStatus: string }>().indexingStatus).toBe("indexed");
+
+    const list = await app.inject({ method: "GET", url: `${base}/documents` });
+    expect(list.json<{ items: { indexingStatus: string }[] }>().items[0].indexingStatus).toBe(
+      "indexed"
+    );
+  });
+
+  it("reports indexingStatus=pending when a document has no chunks", async () => {
+    const id = await createDoc();
+    await new PgKnowledgeChunkRepo(db).deleteByDocument(id);
+    const got = await app.inject({ method: "GET", url: `${base}/documents/${id}` });
+    expect(got.json<{ indexingStatus: string }>().indexingStatus).toBe("pending");
+  });
+
+  it("reports indexingStatus=lexical-only when no embedding provider is available", async () => {
+    const db2 = await makePglite();
+    await runPgMigrations(db2);
+    const app2 = await buildKnowledgeApp(db2, false);
+    try {
+      const res = await app2.inject({
+        method: "POST",
+        url: `${base}/documents`,
+        payload: { title: "x", content: "lexical only body" },
+      });
+      const id = res.json<{ id: string }>().id;
+      const got = await app2.inject({ method: "GET", url: `${base}/documents/${id}` });
+      expect(got.json<{ indexingStatus: string }>().indexingStatus).toBe("lexical-only");
+    } finally {
+      await app2.close();
+      await db2.close();
+    }
+  });
+
   it("manages collections and membership", async () => {
     const docId = await createDoc();
     const colRes = await app.inject({
@@ -159,6 +196,40 @@ describe("knowledge routes", () => {
       url: `${base}/collections/${colId}/documents/${docId}`,
     });
     expect(remove.statusCode).toBe(204);
+  });
+
+  it("gets a collection by id and 404s a missing one", async () => {
+    const colRes = await app.inject({
+      method: "POST",
+      url: `${base}/collections`,
+      payload: { name: "kb2", description: "desc" },
+    });
+    const colId = colRes.json<{ id: string }>().id;
+    const got = await app.inject({ method: "GET", url: `${base}/collections/${colId}` });
+    expect(got.statusCode).toBe(200);
+    expect(got.json<{ name: string }>().name).toBe("kb2");
+    const missing = await app.inject({
+      method: "GET",
+      url: `${base}/collections/00000000-0000-0000-0000-000000000000`,
+    });
+    expect(missing.statusCode).toBe(404);
+  });
+
+  it("refuses to add a soft-deleted document to a collection", async () => {
+    const docId = await createDoc();
+    const colRes = await app.inject({
+      method: "POST",
+      url: `${base}/collections`,
+      payload: { name: "kb3" },
+    });
+    const colId = colRes.json<{ id: string }>().id;
+    await app.inject({ method: "DELETE", url: `${base}/documents/${docId}` });
+    const add = await app.inject({
+      method: "POST",
+      url: `${base}/collections/${colId}/documents`,
+      payload: { documentId: docId },
+    });
+    expect(add.statusCode).toBe(404);
   });
 
   it("404s adding to a missing collection", async () => {

--- a/apps/api/src/knowledge/routes.ts
+++ b/apps/api/src/knowledge/routes.ts
@@ -3,6 +3,7 @@ import { ErrorSchema } from "../auth/schemas";
 import { parsePaginationQuery } from "../pagination";
 import type { KnowledgeService } from "./service";
 import type {
+  IndexingStatus,
   KnowledgeCollection,
   KnowledgeDocument,
   KnowledgeRevision,
@@ -20,7 +21,7 @@ function parseIfMatch(req: FastifyRequest): number | null {
   return Number.isNaN(n) ? null : n;
 }
 
-function toApiDocument(d: KnowledgeDocument): Record<string, unknown> {
+function toApiDocument(d: KnowledgeDocument, status?: IndexingStatus): Record<string, unknown> {
   return {
     id: d._id,
     title: d.title,
@@ -34,6 +35,7 @@ function toApiDocument(d: KnowledgeDocument): Record<string, unknown> {
     version: d.version,
     createdAt: d.createdAt.toISOString(),
     updatedAt: d.updatedAt.toISOString(),
+    ...(status !== undefined ? { indexingStatus: status } : {}),
   };
 }
 
@@ -139,7 +141,8 @@ export function registerKnowledgeRoutes(
         alwaysLoadForAgents?: boolean;
       };
       const doc = await service.createDocument(b);
-      return reply.code(201).send(toApiDocument(doc));
+      const status = await service.getIndexingStatus(doc._id);
+      return reply.code(201).send(toApiDocument(doc, status));
     }
   );
 
@@ -168,7 +171,11 @@ export function registerKnowledgeRoutes(
       const q = req.query as Record<string, unknown>;
       const { limit, after } = parsePaginationQuery(q);
       const page = await service.listDocuments({ limit, after, ...filtersFromQuery(q) });
-      return reply.send({ items: page.items.map(toApiDocument), nextCursor: page.nextCursor });
+      const statuses = await service.getIndexingStatuses(page.items.map((d) => d._id));
+      return reply.send({
+        items: page.items.map((d) => toApiDocument(d, statuses.get(d._id) ?? "pending")),
+        nextCursor: page.nextCursor,
+      });
     }
   );
 
@@ -188,7 +195,8 @@ export function registerKnowledgeRoutes(
       const { id } = req.params as { id: string };
       const doc = await service.getDocument(id);
       if (!doc?.active) return reply.code(404).send({ error: "not found" });
-      return reply.send(toApiDocument(doc));
+      const status = await service.getIndexingStatus(doc._id);
+      return reply.send(toApiDocument(doc, status));
     }
   );
 
@@ -225,7 +233,8 @@ export function registerKnowledgeRoutes(
           ? reply.code(404).send({ error: "not found" })
           : reply.code(409).send({ error: "version conflict" });
       }
-      return reply.send(toApiDocument(outcome.value));
+      const status = await service.getIndexingStatus(id);
+      return reply.send(toApiDocument(outcome.value, status));
     }
   );
 
@@ -389,6 +398,26 @@ export function registerKnowledgeRoutes(
       const { limit, after } = parsePaginationQuery(req.query as Record<string, unknown>);
       const page = await service.listCollections({ limit, after });
       return reply.send({ items: page.items.map(toApiCollection), nextCursor: page.nextCursor });
+    }
+  );
+
+  app.get(
+    "/api/v1/knowledge/collections/:id",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description: "Get one knowledge collection.",
+        tags,
+        security: sec,
+        params: { type: "object", properties: { id: { type: "string" } }, required: ["id"] },
+        response: { 200: DocumentSchema, 404: ErrorSchema, 401: ErrorSchema },
+      },
+    },
+    async (req, reply) => {
+      const { id } = req.params as { id: string };
+      const c = await service.getCollection(id);
+      if (!c) return reply.code(404).send({ error: "not found" });
+      return reply.send(toApiCollection(c));
     }
   );
 

--- a/apps/api/src/knowledge/service.ts
+++ b/apps/api/src/knowledge/service.ts
@@ -11,6 +11,7 @@ import type {
 import { search } from "./search-service";
 import type {
   EmbeddingPort,
+  IndexingStatus,
   KnowledgeCollection,
   KnowledgeDocument,
   KnowledgeRevision,
@@ -112,6 +113,16 @@ export class KnowledgeService {
 
   listDocuments(opts: DocumentListOpts): Promise<PaginatedResult<KnowledgeDocument>> {
     return this.deps.documents.list(opts);
+  }
+
+  /** Derived read-only index state for a document (from its chunks). */
+  getIndexingStatus(documentId: string): Promise<IndexingStatus> {
+    return this.deps.chunks.getIndexingStatus(documentId);
+  }
+
+  /** Batch index states keyed by document id (for list responses). */
+  getIndexingStatuses(documentIds: string[]): Promise<Map<string, IndexingStatus>> {
+    return this.deps.chunks.getIndexingStatuses(documentIds);
   }
 
   async updateDocument(
@@ -233,7 +244,8 @@ export class KnowledgeService {
 
   async addToCollection(collectionId: string, documentId: string): Promise<AddToCollectionResult> {
     if (!(await this.deps.collections.getById(collectionId))) return "collection_not_found";
-    if (!(await this.deps.documents.getById(documentId))) return "document_not_found";
+    const doc = await this.deps.documents.getById(documentId);
+    if (!doc?.active) return "document_not_found";
     await this.deps.collections.addDocument(collectionId, documentId);
     return "ok";
   }

--- a/apps/api/src/knowledge/types.ts
+++ b/apps/api/src/knowledge/types.ts
@@ -4,6 +4,9 @@
 
 export type KnowledgeSource = "authored" | "resource" | "conversation";
 
+/** Per-document index state derived from its chunks (read-only; not persisted). */
+export type IndexingStatus = "indexed" | "lexical-only" | "pending";
+
 export interface KnowledgeDocument {
   _id: string;
   title: string;

--- a/apps/web/app/components/knowledge/README.md
+++ b/apps/web/app/components/knowledge/README.md
@@ -1,0 +1,43 @@
+# Knowledge section (web)
+
+Frontend for managing knowledge **documents** and **collections** in the shell. Markdown-only
+content — **no file upload** (AC-V1-004). The backend (`apps/api/src/knowledge`) is the source of
+truth; this is the UI over it.
+
+## Data layer
+- **`app/lib/knowledge-api.ts`** — typed client over the shared `apiGet/apiWrite/apiSend/apiDelete`
+  primitives in `app/lib/api.ts` (cookie-first auth, CSRF echo, quoted `If-Match`). Covers documents
+  CRUD, collections CRUD + membership, and search. `listCollectionsWithCounts` fans out one
+  `documentIds` request per collection (N+1 — collections are few).
+  - `apiSend` (added to `api.ts`) is for 204-returning mutations (e.g. add-to-collection) where
+    `apiWrite` would throw parsing an empty body.
+
+## Components (this dir — all presentational; routes own data + navigation)
+- `index-status-badge` — per-doc `indexingStatus` pill (`indexed` ruby / `lexical-only` · `pending` muted).
+- `doc-list` — `DocTable` (browse, sortable title/domain/updated) + `SearchResults` (semantic hits).
+- `doc-form` — title / content (textarea + **markdown preview** via `MarkdownView`) / tags
+  (comma ↔ `string[]`) / domain / `alwaysLoadForAgents`. Server-authoritative errors via props.
+- `doc-detail` — `MarkdownView` body + metadata + badge + two-step inline **delete**.
+- `collection-list` — name / description / **doc count**.
+- `collection-form` — name / description / domain.
+- `collection-detail` — meta + member documents with add (by id) / remove.
+
+Shared chrome reused (not duplicated): `ResourcePanel`, `EmptyState`, `states` (Error/NotFound),
+`MarkdownView`, `ui/button`, `resource-form`'s exported `writeErrorState` (422→field, 409→banner).
+
+## Routes (`app/routes/_app.knowledge.*`)
+`_app.knowledge.tsx` = layout with the `[documents] · [collections]` sub-nav + `<Outlet/>`;
+`_app.knowledge._index.tsx` redirects to `/knowledge/documents` (via `<Navigate replace>`). Each entity
+has `_index` / `new` / `$id` / `$id.edit`, mirroring the `_app.resources.*` convention. Routes fetch in
+`clientLoader`, render via `useLoaderData`, and expose an `ErrorBoundary` (401 → auth, 404 → not found).
+
+## indexingStatus (backend contract)
+The API derives `indexingStatus ∈ {indexed, lexical-only, pending}` per document from its chunks
+(read-only; returned on document create/get/list/update). `pending` = not yet indexed (prod indexing
+is async); `lexical-only` = indexed without embeddings (no provider — search returns the
+`embedding-unavailable` warning the list surfaces).
+
+## Tests
+`*.test.tsx` colocated (badge, doc-form) + `app/routes/knowledge.{documents,collections}.routes.test.tsx`
+(Vitest + `createRemixStub` + mocked `useLoaderData`/`useRouteError`). `app/lib/knowledge-api.test.ts`
+mocks `fetch`. Run: `pnpm --filter @tulipfarm/web test knowledge`.

--- a/apps/web/app/components/knowledge/collection-detail.tsx
+++ b/apps/web/app/components/knowledge/collection-detail.tsx
@@ -1,0 +1,102 @@
+import { Link } from "@remix-run/react";
+import { type FormEvent, useState } from "react";
+import { Button } from "~/components/ui/button";
+import type { KnowledgeCollection, KnowledgeDocument } from "~/lib/knowledge-api";
+
+/*
+ * Collection drill-in: meta + member documents with add/remove. Presentational — the route resolves
+ * member ids to documents, owns the mutations, and revalidates. Membership add is a raw document-id
+ * input (no autocomplete in V1).
+ */
+export function CollectionDetail({
+  collection,
+  documents,
+  editTo,
+  onAdd,
+  onRemove,
+  busy,
+}: {
+  collection: KnowledgeCollection;
+  documents: KnowledgeDocument[];
+  editTo: string;
+  onAdd: (documentId: string) => void | Promise<void>;
+  onRemove: (documentId: string) => void | Promise<void>;
+  busy: boolean;
+}) {
+  const [docId, setDocId] = useState("");
+
+  function handleAdd(e: FormEvent) {
+    e.preventDefault();
+    const id = docId.trim();
+    if (!id) return;
+    onAdd(id);
+    setDocId("");
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <h1 className="text-base font-bold text-foreground">{collection.name}</h1>
+        <div className="ml-auto">
+          <Button asChild variant="outline" size="sm">
+            <Link to={editTo}>Edit</Link>
+          </Button>
+        </div>
+      </div>
+
+      {collection.description ? (
+        <p className="text-sm text-muted-foreground">{collection.description}</p>
+      ) : null}
+
+      <div className="flex flex-col gap-2">
+        <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">
+          <span className="text-primary">[</span>documents<span className="text-primary">]</span>{" "}
+          <span className="tabular-nums">{documents.length}</span>
+        </p>
+        {documents.length === 0 ? (
+          <p className="text-muted-foreground">0 results</p>
+        ) : (
+          <ul className="flex flex-col divide-y divide-border rounded-sm border border-border">
+            {documents.map((d) => (
+              <li key={d.id} className="flex items-center gap-2 px-3 py-2">
+                <Link
+                  to={`/knowledge/documents/${encodeURIComponent(d.id)}`}
+                  className="text-primary hover:underline"
+                >
+                  {d.title}
+                </Link>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="ml-auto"
+                  onClick={() => onRemove(d.id)}
+                  disabled={busy}
+                >
+                  remove
+                </Button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <form onSubmit={handleAdd} className="flex items-end gap-2">
+        <div className="flex flex-1 flex-col gap-1">
+          <label htmlFor="addDocId" className="text-xs text-muted-foreground">
+            add document by id
+          </label>
+          <input
+            id="addDocId"
+            className="w-full rounded-sm border border-border bg-background px-3 py-2 text-sm outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+            value={docId}
+            onChange={(e) => setDocId(e.target.value)}
+            placeholder="document uuid"
+          />
+        </div>
+        <Button type="submit" variant="outline" disabled={busy || docId.trim() === ""}>
+          Add
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/apps/web/app/components/knowledge/collection-form.tsx
+++ b/apps/web/app/components/knowledge/collection-form.tsx
@@ -1,0 +1,107 @@
+import { Link } from "@remix-run/react";
+import { type FormEvent, useState } from "react";
+import { Button } from "~/components/ui/button";
+import type { CollectionInput } from "~/lib/knowledge-api";
+
+/*
+ * Bespoke create/edit form for knowledge collections (name, description, domain). Mirrors doc-form's
+ * look and server-authoritative error handling; empty optional fields submit as null.
+ */
+const inputClass =
+  "w-full rounded-sm border border-border bg-background px-3 py-2 text-sm outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:opacity-60";
+
+export type CollectionFormProps = {
+  mode: "create" | "edit";
+  initial?: Partial<{ name: string; description: string | null; domain: string | null }>;
+  onSubmit: (body: CollectionInput) => void | Promise<void>;
+  submitting: boolean;
+  fieldErrors?: Record<string, string>;
+  formError?: string | null;
+  cancelTo: string;
+};
+
+export function CollectionForm({
+  mode,
+  initial,
+  onSubmit,
+  submitting,
+  fieldErrors = {},
+  formError,
+  cancelTo,
+}: CollectionFormProps) {
+  const [name, setName] = useState(initial?.name ?? "");
+  const [description, setDescription] = useState(initial?.description ?? "");
+  const [domain, setDomain] = useState(initial?.domain ?? "");
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    onSubmit({
+      name: name.trim(),
+      description: description.trim() === "" ? null : description.trim(),
+      domain: domain.trim() === "" ? null : domain.trim(),
+    });
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4" noValidate>
+      {formError ? (
+        <p className="rounded-sm border border-destructive/40 bg-destructive/5 px-3 py-2 text-destructive">
+          error: {formError}
+        </p>
+      ) : null}
+
+      <div className="flex flex-col gap-1">
+        <label htmlFor="name" className="text-xs text-muted-foreground">
+          name<span className="text-primary"> *</span>
+        </label>
+        <input
+          id="name"
+          className={inputClass}
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+        />
+        {fieldErrors.name ? <p className="text-xs text-destructive">{fieldErrors.name}</p> : null}
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label htmlFor="description" className="text-xs text-muted-foreground">
+          description<span className="opacity-60"> (optional)</span>
+        </label>
+        <textarea
+          id="description"
+          className={`${inputClass} min-h-20`}
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+        {fieldErrors.description ? (
+          <p className="text-xs text-destructive">{fieldErrors.description}</p>
+        ) : null}
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label htmlFor="domain" className="text-xs text-muted-foreground">
+          domain<span className="opacity-60"> (optional scope)</span>
+        </label>
+        <input
+          id="domain"
+          className={inputClass}
+          value={domain}
+          onChange={(e) => setDomain(e.target.value)}
+        />
+        {fieldErrors.domain ? (
+          <p className="text-xs text-destructive">{fieldErrors.domain}</p>
+        ) : null}
+      </div>
+
+      <div className="flex items-center gap-2 pt-2">
+        <Button type="submit" disabled={submitting}>
+          {submitting ? "saving…" : mode === "create" ? "Create" : "Save"}
+        </Button>
+        <Button asChild variant="outline">
+          <Link to={cancelTo}>Cancel</Link>
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/apps/web/app/components/knowledge/collection-list.tsx
+++ b/apps/web/app/components/knowledge/collection-list.tsx
@@ -1,0 +1,46 @@
+import { Link } from "@remix-run/react";
+import type { CollectionWithCount } from "~/lib/knowledge-api";
+
+/*
+ * Collections list with per-collection document counts. Plain Tailwind table matching SchemaTable's
+ * terminal aesthetic; the name links into the collection drill-in. Counts are `tabular-nums`.
+ */
+export function CollectionList({ items }: { items: CollectionWithCount[] }) {
+  return (
+    <div className="overflow-x-auto rounded-sm border border-border">
+      <table className="w-full border-collapse text-left text-sm">
+        <thead>
+          <tr className="border-b border-border text-xs uppercase tracking-[0.15em] text-muted-foreground">
+            <th scope="col" className="px-3 py-2 font-medium">
+              name
+            </th>
+            <th scope="col" className="px-3 py-2 font-medium">
+              description
+            </th>
+            <th scope="col" className="px-3 py-2 font-medium">
+              documents
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border">
+          {items.map((c) => (
+            <tr key={c.id} className="transition-colors hover:bg-accent">
+              <td className="whitespace-nowrap px-3 py-2 align-top">
+                <Link
+                  to={`/knowledge/collections/${encodeURIComponent(c.id)}`}
+                  className="font-medium text-primary hover:underline"
+                >
+                  {c.name}
+                </Link>
+              </td>
+              <td className="px-3 py-2 align-top">
+                {c.description ? c.description : <span className="text-muted-foreground">—</span>}
+              </td>
+              <td className="whitespace-nowrap px-3 py-2 align-top tabular-nums">{c.docCount}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/app/components/knowledge/doc-detail.tsx
+++ b/apps/web/app/components/knowledge/doc-detail.tsx
@@ -1,0 +1,83 @@
+import { Link } from "@remix-run/react";
+import { useState } from "react";
+import { MarkdownView } from "~/components/markdown-view";
+import { Button } from "~/components/ui/button";
+import type { KnowledgeDocument } from "~/lib/knowledge-api";
+import { IndexStatusBadge } from "./index-status-badge";
+
+/*
+ * Read-only document view: title + indexing badge + metadata, then the markdown content rendered via
+ * MarkdownView. Edit links out; Delete uses a two-step inline confirm (no modal) before calling
+ * `onDelete` (the route owns the soft-delete + navigation).
+ */
+export function DocDetail({
+  doc,
+  editTo,
+  onDelete,
+  deleting,
+}: {
+  doc: KnowledgeDocument;
+  editTo: string;
+  onDelete: () => void | Promise<void>;
+  deleting: boolean;
+}) {
+  const [confirming, setConfirming] = useState(false);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <h1 className="text-base font-bold text-foreground">{doc.title}</h1>
+        <IndexStatusBadge status={doc.indexingStatus ?? "pending"} />
+        <div className="ml-auto flex items-center gap-2">
+          <Button asChild variant="outline" size="sm">
+            <Link to={editTo}>Edit</Link>
+          </Button>
+          {confirming ? (
+            <>
+              <Button variant="destructive" size="sm" onClick={onDelete} disabled={deleting}>
+                {deleting ? "deleting…" : "Confirm delete"}
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setConfirming(false)}
+                disabled={deleting}
+              >
+                Cancel
+              </Button>
+            </>
+          ) : (
+            <Button variant="ghost" size="sm" onClick={() => setConfirming(true)}>
+              Delete
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <dl className="flex flex-col text-xs">
+        <Meta label="domain" value={doc.domain ?? "—"} />
+        <Meta label="tags" value={doc.tags.length ? doc.tags.join(", ") : "—"} />
+        <Meta label="source" value={doc.source} />
+        <Meta label="version" value={String(doc.version)} />
+        <Meta label="updated" value={doc.updatedAt} />
+      </dl>
+
+      <div className="rounded-sm border border-border bg-background px-4 py-3">
+        {doc.content.trim() ? (
+          <MarkdownView>{doc.content}</MarkdownView>
+        ) : (
+          <p className="text-sm text-muted-foreground">(empty document)</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Meta({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="grid grid-cols-[8rem_1fr] gap-3 border-t border-border px-1 py-1.5">
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="min-w-0 break-words text-foreground">{value}</dd>
+    </div>
+  );
+}

--- a/apps/web/app/components/knowledge/doc-form.test.tsx
+++ b/apps/web/app/components/knowledge/doc-form.test.tsx
@@ -1,0 +1,55 @@
+import { createRemixStub } from "@remix-run/testing";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { DocForm, type DocFormProps } from "./doc-form";
+
+function renderForm(overrides: Partial<DocFormProps> = {}): DocFormProps {
+  const props: DocFormProps = {
+    mode: "create",
+    onSubmit: vi.fn(),
+    submitting: false,
+    cancelTo: "/knowledge/documents",
+    ...overrides,
+  };
+  const Stub = createRemixStub([{ path: "/", Component: () => <DocForm {...props} /> }]);
+  render(<Stub initialEntries={["/"]} />);
+  return props;
+}
+
+describe("DocForm", () => {
+  it("renders title, content, tags, domain, and the governance toggle", () => {
+    renderForm();
+    expect(screen.getByLabelText(/title/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/content/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/tags/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/domain/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/alwaysLoadForAgents/)).toBeInTheDocument();
+  });
+
+  it("preview toggle renders markdown instead of the textarea", () => {
+    renderForm({ initial: { content: "# Heading" } });
+    fireEvent.click(screen.getByText("preview"));
+    expect(screen.getByRole("heading", { name: "Heading" })).toBeInTheDocument();
+    expect(screen.queryByLabelText(/content/)).not.toBeInTheDocument();
+  });
+
+  it("splits comma-separated tags and nulls an empty domain on submit", () => {
+    const props = renderForm({ initial: { title: "T", content: "C" } });
+    fireEvent.change(screen.getByLabelText(/tags/), { target: { value: "a, b ,, c " } });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+    expect(props.onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "T",
+        content: "C",
+        tags: ["a", "b", "c"],
+        domain: null,
+        alwaysLoadForAgents: false,
+      })
+    );
+  });
+
+  it("shows a form-level error banner", () => {
+    renderForm({ formError: "this document changed since you loaded it — reload and retry" });
+    expect(screen.getByText(/this document changed/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/components/knowledge/doc-form.tsx
+++ b/apps/web/app/components/knowledge/doc-form.tsx
@@ -1,0 +1,193 @@
+import { Link } from "@remix-run/react";
+import { type FormEvent, type ReactNode, useState } from "react";
+import { MarkdownView } from "~/components/markdown-view";
+import { Button } from "~/components/ui/button";
+import type { DocumentInput } from "~/lib/knowledge-api";
+
+/*
+ * Bespoke create/edit form for knowledge documents. Mirrors resource-form's look (local `inputClass`,
+ * muted labels, server-authoritative errors via `fieldErrors`/`formError`) but adds the markdown-specific
+ * affordances the generic form lacks: a write/preview toggle (reusing MarkdownView) and a comma-separated
+ * tags input that round-trips to `string[]`. No file-upload affordance (AC-V1-004).
+ */
+const inputClass =
+  "w-full rounded-sm border border-border bg-background px-3 py-2 text-sm outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:opacity-60";
+
+export type DocFormInitial = {
+  title: string;
+  content: string;
+  tags: string[];
+  domain: string | null;
+  alwaysLoadForAgents: boolean;
+};
+
+export type DocFormProps = {
+  mode: "create" | "edit";
+  initial?: Partial<DocFormInitial>;
+  onSubmit: (body: DocumentInput) => void | Promise<void>;
+  submitting: boolean;
+  fieldErrors?: Record<string, string>;
+  formError?: string | null;
+  cancelTo: string;
+};
+
+export function DocForm({
+  mode,
+  initial,
+  onSubmit,
+  submitting,
+  fieldErrors = {},
+  formError,
+  cancelTo,
+}: DocFormProps) {
+  const [title, setTitle] = useState(initial?.title ?? "");
+  const [content, setContent] = useState(initial?.content ?? "");
+  const [tags, setTags] = useState((initial?.tags ?? []).join(", "));
+  const [domain, setDomain] = useState(initial?.domain ?? "");
+  const [always, setAlways] = useState(initial?.alwaysLoadForAgents ?? false);
+  const [preview, setPreview] = useState(false);
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    onSubmit({
+      title: title.trim(),
+      content,
+      tags: tags
+        .split(",")
+        .map((t) => t.trim())
+        .filter(Boolean),
+      domain: domain.trim() === "" ? null : domain.trim(),
+      alwaysLoadForAgents: always,
+    });
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4" noValidate>
+      {formError ? (
+        <p className="rounded-sm border border-destructive/40 bg-destructive/5 px-3 py-2 text-destructive">
+          error: {formError}
+        </p>
+      ) : null}
+
+      <Labeled name="title" required error={fieldErrors.title}>
+        <input
+          id="title"
+          className={inputClass}
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          required
+        />
+      </Labeled>
+
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center justify-between">
+          <label htmlFor="content" className="text-xs text-muted-foreground">
+            content<span className="text-primary"> *</span>
+            <span className="opacity-60"> (markdown)</span>
+          </label>
+          <div className="flex gap-2 text-xs">
+            <button type="button" onClick={() => setPreview(false)} className={tabClass(!preview)}>
+              write
+            </button>
+            <button type="button" onClick={() => setPreview(true)} className={tabClass(preview)}>
+              preview
+            </button>
+          </div>
+        </div>
+        {preview ? (
+          <div className="min-h-40 rounded-sm border border-border bg-background px-3 py-2">
+            {content.trim() ? (
+              <MarkdownView>{content}</MarkdownView>
+            ) : (
+              <p className="text-sm text-muted-foreground">nothing to preview</p>
+            )}
+          </div>
+        ) : (
+          <textarea
+            id="content"
+            className={`${inputClass} min-h-40 font-mono`}
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            required
+          />
+        )}
+        {fieldErrors.content ? (
+          <p className="text-xs text-destructive">{fieldErrors.content}</p>
+        ) : null}
+      </div>
+
+      <Labeled name="tags" hint="comma-separated" error={fieldErrors.tags}>
+        <input
+          id="tags"
+          className={inputClass}
+          value={tags}
+          onChange={(e) => setTags(e.target.value)}
+          placeholder="onboarding, sales"
+        />
+      </Labeled>
+
+      <Labeled name="domain" hint="optional scope" error={fieldErrors.domain}>
+        <input
+          id="domain"
+          className={inputClass}
+          value={domain}
+          onChange={(e) => setDomain(e.target.value)}
+        />
+      </Labeled>
+
+      <div className="flex items-center gap-2">
+        <input
+          id="alwaysLoadForAgents"
+          type="checkbox"
+          className="size-4 accent-primary"
+          checked={always}
+          onChange={(e) => setAlways(e.target.checked)}
+        />
+        <label htmlFor="alwaysLoadForAgents" className="text-xs text-muted-foreground">
+          alwaysLoadForAgents<span className="opacity-60"> (inject into agent context)</span>
+        </label>
+      </div>
+
+      <div className="flex items-center gap-2 pt-2">
+        <Button type="submit" disabled={submitting}>
+          {submitting ? "saving…" : mode === "create" ? "Create" : "Save"}
+        </Button>
+        <Button asChild variant="outline">
+          <Link to={cancelTo}>Cancel</Link>
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+function tabClass(active: boolean): string {
+  return active
+    ? "text-primary underline underline-offset-4"
+    : "text-muted-foreground hover:text-foreground";
+}
+
+function Labeled({
+  name,
+  required,
+  hint,
+  error,
+  children,
+}: {
+  name: string;
+  required?: boolean;
+  hint?: string;
+  error?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <label htmlFor={name} className="text-xs text-muted-foreground">
+        {name}
+        {required ? <span className="text-primary"> *</span> : null}
+        {hint ? <span className="opacity-60"> ({hint})</span> : null}
+      </label>
+      {children}
+      {error ? <p className="text-xs text-destructive">{error}</p> : null}
+    </div>
+  );
+}

--- a/apps/web/app/components/knowledge/doc-list.tsx
+++ b/apps/web/app/components/knowledge/doc-list.tsx
@@ -1,0 +1,117 @@
+import { Link } from "@remix-run/react";
+import type { KnowledgeDocument, SearchHit } from "~/lib/knowledge-api";
+import type { SortState } from "~/lib/schema";
+import { IndexStatusBadge } from "./index-status-badge";
+
+/*
+ * Documents browse table + semantic-search results list. Both presentational; the route owns the
+ * loaded set, sort state, "load more" cursor, and search mode. Matches SchemaTable's terminal look.
+ */
+const SORTABLE = new Set(["title", "domain", "updatedAt"]);
+const COLUMNS: { key: string; label: string }[] = [
+  { key: "title", label: "title" },
+  { key: "domain", label: "domain" },
+  { key: "tags", label: "tags" },
+  { key: "updatedAt", label: "updated" },
+  { key: "indexingStatus", label: "status" },
+];
+
+export function DocTable({
+  documents,
+  sort,
+  onToggleSort,
+}: {
+  documents: KnowledgeDocument[];
+  sort?: SortState;
+  onToggleSort?: (column: string) => void;
+}) {
+  return (
+    <div className="overflow-x-auto rounded-sm border border-border">
+      <table className="w-full border-collapse text-left text-sm">
+        <thead>
+          <tr className="border-b border-border text-xs uppercase tracking-[0.15em] text-muted-foreground">
+            {COLUMNS.map((col) => {
+              const active = sort?.field === col.key;
+              const sortable = onToggleSort && SORTABLE.has(col.key);
+              return (
+                <th
+                  key={col.key}
+                  scope="col"
+                  aria-sort={active ? (sort.dir === "asc" ? "ascending" : "descending") : undefined}
+                  className="whitespace-nowrap px-3 py-2 font-medium"
+                >
+                  {sortable ? (
+                    <button
+                      type="button"
+                      onClick={() => onToggleSort(col.key)}
+                      className="inline-flex items-center gap-1 hover:text-foreground"
+                    >
+                      {col.label}
+                      {active ? <span aria-hidden>{sort.dir === "asc" ? "↑" : "↓"}</span> : null}
+                    </button>
+                  ) : (
+                    col.label
+                  )}
+                </th>
+              );
+            })}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border">
+          {documents.map((d) => (
+            <tr key={d.id} className="transition-colors hover:bg-accent">
+              <td className="whitespace-nowrap px-3 py-2 align-top">
+                <Link
+                  to={`/knowledge/documents/${encodeURIComponent(d.id)}`}
+                  className="font-medium text-primary hover:underline"
+                >
+                  {d.title}
+                </Link>
+              </td>
+              <td className="px-3 py-2 align-top">
+                {d.domain ? d.domain : <span className="text-muted-foreground">—</span>}
+              </td>
+              <td className="px-3 py-2 align-top">
+                {d.tags.length ? (
+                  d.tags.join(", ")
+                ) : (
+                  <span className="text-muted-foreground">—</span>
+                )}
+              </td>
+              <td className="whitespace-nowrap px-3 py-2 align-top text-muted-foreground">
+                {d.updatedAt.slice(0, 10)}
+              </td>
+              <td className="whitespace-nowrap px-3 py-2 align-top">
+                <IndexStatusBadge status={d.indexingStatus ?? "pending"} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export function SearchResults({ hits }: { hits: SearchHit[] }) {
+  if (hits.length === 0) return <p className="text-muted-foreground">0 results</p>;
+  return (
+    <ul className="flex flex-col gap-2">
+      {hits.map((h) => (
+        <li key={h.chunkId} className="rounded-sm border border-border px-3 py-2">
+          <div className="flex items-center gap-2">
+            <Link
+              to={`/knowledge/documents/${encodeURIComponent(h.documentId)}`}
+              className="font-medium text-primary hover:underline"
+            >
+              {h.title}
+            </Link>
+            <span className="ml-auto text-xs tabular-nums text-muted-foreground">
+              score {h.score.toFixed(2)}
+            </span>
+          </div>
+          <p className="mt-1 whitespace-pre-wrap break-words text-muted-foreground">{h.content}</p>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/web/app/components/knowledge/index-status-badge.test.tsx
+++ b/apps/web/app/components/knowledge/index-status-badge.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { IndexStatusBadge } from "./index-status-badge";
+
+describe("IndexStatusBadge", () => {
+  it("renders indexed in the ruby (primary) color", () => {
+    const { container } = render(<IndexStatusBadge status="indexed" />);
+    expect(screen.getByText("indexed")).toBeInTheDocument();
+    expect(container.querySelector("[data-status='indexed']")?.className).toContain("text-primary");
+  });
+
+  it("renders lexical-only muted", () => {
+    const { container } = render(<IndexStatusBadge status="lexical-only" />);
+    expect(screen.getByText("lexical-only")).toBeInTheDocument();
+    expect(container.querySelector("[data-status='lexical-only']")?.className).toContain(
+      "text-muted-foreground"
+    );
+  });
+
+  it("renders pending muted", () => {
+    const { container } = render(<IndexStatusBadge status="pending" />);
+    expect(screen.getByText("pending")).toBeInTheDocument();
+    expect(container.querySelector("[data-status='pending']")?.className).toContain(
+      "text-muted-foreground"
+    );
+  });
+});

--- a/apps/web/app/components/knowledge/index-status-badge.tsx
+++ b/apps/web/app/components/knowledge/index-status-badge.tsx
@@ -1,0 +1,44 @@
+import type { IndexingStatus } from "~/lib/knowledge-api";
+
+/*
+ * Per-document indexing-status pill. `indexed` earns the ruby brand color (the one "good/active"
+ * state); `lexical-only` and `pending` stay muted. Glyph + label, terminal aesthetic, no shadow.
+ * The `title` carries a plain-language explanation on hover.
+ */
+const META: Record<
+  IndexingStatus,
+  { glyph: string; label: string; className: string; hint: string }
+> = {
+  indexed: {
+    glyph: "●",
+    label: "indexed",
+    className: "text-primary",
+    hint: "Embedded — searchable by vector similarity.",
+  },
+  "lexical-only": {
+    glyph: "◐",
+    label: "lexical-only",
+    className: "text-muted-foreground",
+    hint: "Keyword-searchable only (no embedding provider was available at index time).",
+  },
+  pending: {
+    glyph: "○",
+    label: "pending",
+    className: "text-muted-foreground",
+    hint: "Not indexed yet — indexing runs in the background.",
+  },
+};
+
+export function IndexStatusBadge({ status }: { status: IndexingStatus }) {
+  const m = META[status];
+  return (
+    <span
+      data-status={status}
+      title={m.hint}
+      className={`inline-flex items-center gap-1 text-xs tracking-[0.1em] ${m.className}`}
+    >
+      <span aria-hidden>{m.glyph}</span>
+      <span>{m.label}</span>
+    </span>
+  );
+}

--- a/apps/web/app/lib/api.ts
+++ b/apps/web/app/lib/api.ts
@@ -71,6 +71,26 @@ export async function apiWrite<T>(
   return (await res.json()) as T;
 }
 
+// Like apiWrite (cookie-first auth, CSRF echo, optional If-Match) but for endpoints that return
+// 204 No Content — sends a JSON body and parses nothing, so it returns void.
+export async function apiSend(
+  method: "POST" | "PUT",
+  path: string,
+  body: unknown,
+  ifMatch?: number
+): Promise<void> {
+  const headers = mutationHeaders();
+  if (ifMatch !== undefined) headers["If-Match"] = `"${ifMatch}"`;
+
+  const res = await fetch(`${API_BASE}${path}`, {
+    method,
+    credentials: "include",
+    headers,
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw await readError(res);
+}
+
 // DELETE client. Mirrors apiWrite's cookie-first auth + CSRF echo, but sends no body and expects an
 // empty (204) response, so it returns void instead of parsing JSON.
 export async function apiDelete(path: string): Promise<void> {

--- a/apps/web/app/lib/knowledge-api.test.ts
+++ b/apps/web/app/lib/knowledge-api.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  addDocToCollection,
+  createDocument,
+  deleteDocument,
+  listCollectionsWithCounts,
+  listDocuments,
+  searchDocuments,
+  updateDocument,
+} from "./knowledge-api";
+
+type Call = { url: string; init: RequestInit };
+
+// Stub global fetch with a responder; `undefined` body simulates a 204 (no JSON parsed).
+function mockFetch(responder: (url: string, init: RequestInit) => unknown): Call[] {
+  const calls: Call[] = [];
+  const fn = vi.fn(async (url: string, init: RequestInit = {}) => {
+    calls.push({ url, init });
+    const body = responder(url, init);
+    return { ok: true, status: body === undefined ? 204 : 200, json: async () => body } as Response;
+  });
+  vi.stubGlobal("fetch", fn);
+  return calls;
+}
+
+const headersOf = (init: RequestInit): Record<string, string> =>
+  (init.headers ?? {}) as Record<string, string>;
+
+describe("knowledge-api", () => {
+  beforeEach(() => {
+    // biome-ignore lint/suspicious/noDocumentCookie: test seeds the csrf cookie that api.ts echoes.
+    document.cookie = "csrf_token=tok123";
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("listDocuments builds a paginated GET", async () => {
+    const calls = mockFetch(() => ({ items: [], nextCursor: null }));
+    await listDocuments("CUR", 10);
+    expect(calls[0].init.method ?? "GET").toBe("GET");
+    expect(calls[0].url).toContain("/api/v1/knowledge/documents?");
+    expect(calls[0].url).toContain("limit=10");
+    expect(calls[0].url).toContain("cursor=CUR");
+  });
+
+  it("createDocument POSTs the body with the CSRF echo header", async () => {
+    const calls = mockFetch(() => ({ id: "d1", version: 1 }));
+    await createDocument({ title: "t", content: "c" });
+    expect(calls[0].init.method).toBe("POST");
+    expect(calls[0].url).toContain("/api/v1/knowledge/documents");
+    expect(headersOf(calls[0].init)["x-csrf-token"]).toBe("tok123");
+    expect(JSON.parse(String(calls[0].init.body))).toEqual({ title: "t", content: "c" });
+  });
+
+  it("updateDocument sends a quoted If-Match header", async () => {
+    const calls = mockFetch(() => ({ id: "d1", version: 3 }));
+    await updateDocument("d1", 2, { title: "x" });
+    expect(calls[0].init.method).toBe("PUT");
+    expect(headersOf(calls[0].init)["If-Match"]).toBe('"2"');
+  });
+
+  it("searchDocuments POSTs to /search", async () => {
+    const calls = mockFetch(() => ({ results: [], warnings: [] }));
+    await searchDocuments("hello", 5);
+    expect(calls[0].init.method).toBe("POST");
+    expect(calls[0].url).toContain("/api/v1/knowledge/search");
+    expect(JSON.parse(String(calls[0].init.body))).toEqual({ query: "hello", limit: 5 });
+  });
+
+  it("addDocToCollection sends a 204 POST without parsing a body", async () => {
+    const calls = mockFetch(() => undefined);
+    await addDocToCollection("c1", "d1");
+    expect(calls[0].init.method).toBe("POST");
+    expect(calls[0].url).toContain("/api/v1/knowledge/collections/c1/documents");
+    expect(JSON.parse(String(calls[0].init.body))).toEqual({ documentId: "d1" });
+  });
+
+  it("deleteDocument issues a DELETE", async () => {
+    const calls = mockFetch(() => undefined);
+    await deleteDocument("d1");
+    expect(calls[0].init.method).toBe("DELETE");
+    expect(calls[0].url).toContain("/api/v1/knowledge/documents/d1");
+  });
+
+  it("listCollectionsWithCounts attaches docCount via per-collection id fetch (N+1)", async () => {
+    const calls = mockFetch((url) => {
+      if (url.includes("/collections/c1/documents")) return { documentIds: ["a", "b"] };
+      if (url.includes("/collections/c2/documents")) return { documentIds: [] };
+      if (url.includes("/collections?")) {
+        return {
+          items: [
+            {
+              id: "c1",
+              name: "one",
+              description: null,
+              domain: null,
+              version: 1,
+              createdAt: "",
+              updatedAt: "",
+            },
+            {
+              id: "c2",
+              name: "two",
+              description: null,
+              domain: null,
+              version: 1,
+              createdAt: "",
+              updatedAt: "",
+            },
+          ],
+          nextCursor: null,
+        };
+      }
+      return { items: [], nextCursor: null };
+    });
+    const res = await listCollectionsWithCounts();
+    expect(res.items.find((c) => c.id === "c1")?.docCount).toBe(2);
+    expect(res.items.find((c) => c.id === "c2")?.docCount).toBe(0);
+    expect(calls.length).toBe(3); // 1 list + 2 count fetches
+  });
+});

--- a/apps/web/app/lib/knowledge-api.ts
+++ b/apps/web/app/lib/knowledge-api.ts
@@ -1,0 +1,162 @@
+/*
+ * Read/write client for the knowledge API (documents, collections, search). Built on the shared
+ * `apiGet`/`apiWrite`/`apiDelete` primitives in `api.ts` (cookie-first auth, CSRF echo, quoted
+ * If-Match concurrency). React/Remix-free so it is unit-testable by mocking the global `fetch`.
+ */
+import { apiDelete, apiGet, apiSend, apiWrite } from "./api";
+
+export type IndexingStatus = "indexed" | "lexical-only" | "pending";
+export type KnowledgeSource = "authored" | "resource" | "conversation";
+
+export type KnowledgeDocument = {
+  id: string;
+  title: string;
+  content: string;
+  source: KnowledgeSource;
+  sourceId: string;
+  domain: string | null;
+  tags: string[];
+  active: boolean;
+  alwaysLoadForAgents: boolean;
+  version: number;
+  createdAt: string;
+  updatedAt: string;
+  // Derived server-side from the document's chunks (read-only). Absent on older payloads.
+  indexingStatus?: IndexingStatus;
+};
+
+export type KnowledgeCollection = {
+  id: string;
+  name: string;
+  description: string | null;
+  domain: string | null;
+  version: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type CollectionWithCount = KnowledgeCollection & { docCount: number };
+
+export type SearchHit = {
+  documentId: string;
+  chunkId: string;
+  title: string;
+  content: string;
+  source: KnowledgeSource;
+  score: number;
+};
+
+export type SearchResponse = { results: SearchHit[]; warnings: string[] };
+
+export type DocPage = { items: KnowledgeDocument[]; nextCursor: string | null };
+export type CollectionPage = { items: KnowledgeCollection[]; nextCursor: string | null };
+
+export type DocumentInput = {
+  title: string;
+  content: string;
+  domain?: string | null;
+  tags?: string[];
+  alwaysLoadForAgents?: boolean;
+};
+
+export type CollectionInput = {
+  name: string;
+  description?: string | null;
+  domain?: string | null;
+};
+
+const BASE = "/api/v1/knowledge";
+const enc = encodeURIComponent;
+
+function pageQuery(cursor: string | undefined, limit: number): string {
+  const q = new URLSearchParams({ limit: String(limit) });
+  if (cursor) q.set("cursor", cursor);
+  return q.toString();
+}
+
+// ── documents ────────────────────────────────────────────────────────────────
+
+export function listDocuments(cursor?: string, limit = 50): Promise<DocPage> {
+  return apiGet<DocPage>(`${BASE}/documents?${pageQuery(cursor, limit)}`);
+}
+
+export function getDocument(id: string): Promise<KnowledgeDocument> {
+  return apiGet<KnowledgeDocument>(`${BASE}/documents/${enc(id)}`);
+}
+
+export function createDocument(body: DocumentInput): Promise<KnowledgeDocument> {
+  return apiWrite<KnowledgeDocument>("POST", `${BASE}/documents`, body);
+}
+
+// Full-replace update with optimistic concurrency; `version` becomes the quoted If-Match header.
+export function updateDocument(
+  id: string,
+  version: number,
+  body: Partial<DocumentInput>
+): Promise<KnowledgeDocument> {
+  return apiWrite<KnowledgeDocument>("PUT", `${BASE}/documents/${enc(id)}`, body, version);
+}
+
+export function deleteDocument(id: string): Promise<void> {
+  return apiDelete(`${BASE}/documents/${enc(id)}`);
+}
+
+// Semantic search is a POST that reads — it still carries the CSRF echo header via `apiWrite`.
+export function searchDocuments(query: string, limit = 10): Promise<SearchResponse> {
+  return apiWrite<SearchResponse>("POST", `${BASE}/search`, { query, limit });
+}
+
+// ── collections ──────────────────────────────────────────────────────────────
+
+export function listCollections(cursor?: string, limit = 50): Promise<CollectionPage> {
+  return apiGet<CollectionPage>(`${BASE}/collections?${pageQuery(cursor, limit)}`);
+}
+
+export function getCollection(id: string): Promise<KnowledgeCollection> {
+  return apiGet<KnowledgeCollection>(`${BASE}/collections/${enc(id)}`);
+}
+
+export function createCollection(body: CollectionInput): Promise<KnowledgeCollection> {
+  return apiWrite<KnowledgeCollection>("POST", `${BASE}/collections`, body);
+}
+
+export function updateCollection(
+  id: string,
+  version: number,
+  body: Partial<CollectionInput>
+): Promise<KnowledgeCollection> {
+  return apiWrite<KnowledgeCollection>("PUT", `${BASE}/collections/${enc(id)}`, body, version);
+}
+
+export function deleteCollection(id: string): Promise<void> {
+  return apiDelete(`${BASE}/collections/${enc(id)}`);
+}
+
+export function getCollectionDocumentIds(id: string): Promise<{ documentIds: string[] }> {
+  return apiGet<{ documentIds: string[] }>(`${BASE}/collections/${enc(id)}/documents`);
+}
+
+export function addDocToCollection(id: string, documentId: string): Promise<void> {
+  // 204 (no body) → use apiSend, which sends a JSON body but parses no response.
+  return apiSend("POST", `${BASE}/collections/${enc(id)}/documents`, { documentId });
+}
+
+export function removeDocFromCollection(id: string, docId: string): Promise<void> {
+  return apiDelete(`${BASE}/collections/${enc(id)}/documents/${enc(docId)}`);
+}
+
+// Collections list enriched with a document count. No batch count endpoint exists, so we fan out one
+// `documentIds` request per collection (N+1 — acceptable: collections are few). Documented, not optimized.
+export async function listCollectionsWithCounts(
+  cursor?: string,
+  limit = 50
+): Promise<{ items: CollectionWithCount[]; nextCursor: string | null }> {
+  const page = await listCollections(cursor, limit);
+  const items = await Promise.all(
+    page.items.map(async (c) => {
+      const { documentIds } = await getCollectionDocumentIds(c.id);
+      return { ...c, docCount: documentIds.length };
+    })
+  );
+  return { items, nextCursor: page.nextCursor };
+}

--- a/apps/web/app/routes/_app.knowledge._index.tsx
+++ b/apps/web/app/routes/_app.knowledge._index.tsx
@@ -1,0 +1,6 @@
+import { Navigate } from "@remix-run/react";
+
+// /knowledge has no pane of its own — land on the documents tab (codebase index-redirect convention).
+export default function KnowledgeIndex() {
+  return <Navigate to="/knowledge/documents" replace />;
+}

--- a/apps/web/app/routes/_app.knowledge.collections.$id.edit.tsx
+++ b/apps/web/app/routes/_app.knowledge.collections.$id.edit.tsx
@@ -1,0 +1,89 @@
+import {
+  type ClientLoaderFunctionArgs,
+  type MetaFunction,
+  useLoaderData,
+  useNavigate,
+  useParams,
+  useRouteError,
+} from "@remix-run/react";
+import { useState } from "react";
+import { CollectionForm } from "~/components/knowledge/collection-form";
+import { writeErrorState } from "~/components/resource-form";
+import { ResourcePanel } from "~/components/resource-panel";
+import { ErrorState, NotFoundState } from "~/components/states";
+import { ApiError } from "~/lib/api";
+import { type CollectionInput, getCollection, updateCollection } from "~/lib/knowledge-api";
+
+export const meta: MetaFunction = () => [{ title: "Edit · Collections · Knowledge · tulipfarm" }];
+
+export async function clientLoader({ params }: ClientLoaderFunctionArgs) {
+  const id = params.id;
+  if (!id) throw new ApiError(404, "missing collection id");
+  const collection = await getCollection(id);
+  return { collection };
+}
+
+export default function CollectionEdit() {
+  const { collection } = useLoaderData<typeof clientLoader>();
+  const navigate = useNavigate();
+  const [submitting, setSubmitting] = useState(false);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const detailPath = `/knowledge/collections/${encodeURIComponent(collection.id)}`;
+
+  async function onSubmit(body: CollectionInput) {
+    setSubmitting(true);
+    setFieldErrors({});
+    setFormError(null);
+    try {
+      await updateCollection(collection.id, collection.version, body);
+      navigate(detailPath);
+    } catch (err) {
+      const next = writeErrorState(err);
+      setFieldErrors(next.fieldErrors);
+      setFormError(next.formError || null);
+      setSubmitting(false);
+    }
+  }
+
+  const crumbs = [
+    { label: "knowledge", to: "/knowledge" },
+    { label: "collections", to: "/knowledge/collections" },
+    { label: collection.name, to: detailPath },
+    { label: "edit" },
+  ];
+
+  return (
+    <ResourcePanel
+      crumbs={crumbs}
+      command={`tulipfarm knowledge collections edit ${collection.id}`}
+    >
+      <CollectionForm
+        mode="edit"
+        initial={{
+          name: collection.name,
+          description: collection.description,
+          domain: collection.domain,
+        }}
+        onSubmit={onSubmit}
+        submitting={submitting}
+        fieldErrors={fieldErrors}
+        formError={formError}
+        cancelTo={detailPath}
+      />
+    </ResourcePanel>
+  );
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+  const params = useParams();
+  const command = `tulipfarm knowledge collections edit ${params.id ?? ""}`;
+  if (error instanceof ApiError && error.status === 404) {
+    return <NotFoundState section="knowledge" command={command} />;
+  }
+  const status = error instanceof ApiError ? error.status : undefined;
+  const message = error instanceof Error ? error.message : undefined;
+  return <ErrorState section="knowledge" command={command} status={status} message={message} />;
+}

--- a/apps/web/app/routes/_app.knowledge.collections.$id.tsx
+++ b/apps/web/app/routes/_app.knowledge.collections.$id.tsx
@@ -1,0 +1,110 @@
+import {
+  type ClientLoaderFunctionArgs,
+  type MetaFunction,
+  useLoaderData,
+  useParams,
+  useRevalidator,
+  useRouteError,
+} from "@remix-run/react";
+import { useState } from "react";
+import { CollectionDetail } from "~/components/knowledge/collection-detail";
+import { ResourcePanel } from "~/components/resource-panel";
+import { ErrorState, NotFoundState } from "~/components/states";
+import { ApiError } from "~/lib/api";
+import {
+  addDocToCollection,
+  getCollection,
+  getCollectionDocumentIds,
+  getDocument,
+  type KnowledgeDocument,
+  removeDocFromCollection,
+} from "~/lib/knowledge-api";
+
+export const meta: MetaFunction = () => [{ title: "Collection · Knowledge · tulipfarm" }];
+
+export async function clientLoader({ params }: ClientLoaderFunctionArgs) {
+  const id = params.id;
+  if (!id) throw new ApiError(404, "missing collection id");
+  const collection = await getCollection(id);
+  const { documentIds } = await getCollectionDocumentIds(id);
+  // Resolve member ids to documents for a title+link list; skip any that 404 (soft-deleted).
+  const resolved = await Promise.all(
+    documentIds.map(async (did) => {
+      try {
+        return await getDocument(did);
+      } catch {
+        return null;
+      }
+    })
+  );
+  const documents = resolved.filter((d): d is KnowledgeDocument => d !== null);
+  return { collection, documents };
+}
+
+export default function CollectionDetailRoute() {
+  const { collection, documents } = useLoaderData<typeof clientLoader>();
+  const revalidator = useRevalidator();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onAdd(documentId: string) {
+    setBusy(true);
+    setError(null);
+    try {
+      await addDocToCollection(collection.id, documentId);
+      revalidator.revalidate();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "add failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onRemove(documentId: string) {
+    setBusy(true);
+    setError(null);
+    try {
+      await removeDocFromCollection(collection.id, documentId);
+      revalidator.revalidate();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "remove failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const crumbs = [
+    { label: "knowledge", to: "/knowledge" },
+    { label: "collections", to: "/knowledge/collections" },
+    { label: collection.name },
+  ];
+
+  return (
+    <ResourcePanel
+      crumbs={crumbs}
+      command={`tulipfarm knowledge collections show ${collection.id}`}
+    >
+      {error ? <p className="text-destructive">error: {error}</p> : null}
+      <CollectionDetail
+        collection={collection}
+        documents={documents}
+        editTo={`/knowledge/collections/${encodeURIComponent(collection.id)}/edit`}
+        onAdd={onAdd}
+        onRemove={onRemove}
+        busy={busy}
+      />
+    </ResourcePanel>
+  );
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+  const params = useParams();
+  const command = `tulipfarm knowledge collections show ${params.id ?? ""}`;
+  if (error instanceof ApiError && error.status === 404) {
+    return <NotFoundState section="knowledge" command={command} />;
+  }
+  const status = error instanceof ApiError ? error.status : undefined;
+  const message = error instanceof Error ? error.message : undefined;
+  return <ErrorState section="knowledge" command={command} status={status} message={message} />;
+}

--- a/apps/web/app/routes/_app.knowledge.collections._index.tsx
+++ b/apps/web/app/routes/_app.knowledge.collections._index.tsx
@@ -1,0 +1,74 @@
+import { Link, type MetaFunction, useLoaderData, useRouteError } from "@remix-run/react";
+import { useState } from "react";
+import { CollectionList } from "~/components/knowledge/collection-list";
+import { ResourcePanel } from "~/components/resource-panel";
+import { ErrorState } from "~/components/states";
+import { Button } from "~/components/ui/button";
+import { ApiError } from "~/lib/api";
+import { type CollectionWithCount, listCollectionsWithCounts } from "~/lib/knowledge-api";
+
+export const meta: MetaFunction = () => [{ title: "Collections · Knowledge · tulipfarm" }];
+
+const command = "tulipfarm knowledge collections --list";
+
+export async function clientLoader() {
+  const page = await listCollectionsWithCounts();
+  return { items: page.items, nextCursor: page.nextCursor };
+}
+
+export default function CollectionsIndex() {
+  const { items, nextCursor } = useLoaderData<typeof clientLoader>();
+  const [cols, setCols] = useState<CollectionWithCount[]>(items);
+  const [cursor, setCursor] = useState<string | null>(nextCursor);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function loadMore() {
+    if (!cursor) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const batch = await listCollectionsWithCounts(cursor);
+      setCols((prev) => [...prev, ...batch.items]);
+      setCursor(batch.nextCursor);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "failed to load more");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const crumbs = [{ label: "knowledge", to: "/knowledge" }, { label: "collections" }];
+
+  return (
+    <ResourcePanel crumbs={crumbs} command={command}>
+      <div>
+        <Button asChild variant="outline" size="sm">
+          <Link to="/knowledge/collections/new">New collection</Link>
+        </Button>
+      </div>
+      {error ? <p className="text-destructive">error: {error}</p> : null}
+      {cols.length === 0 ? (
+        <p className="text-muted-foreground">0 results</p>
+      ) : (
+        <>
+          <CollectionList items={cols} />
+          {cursor ? (
+            <div>
+              <Button variant="outline" size="sm" onClick={loadMore} disabled={loading}>
+                {loading ? "loading…" : "Load more"}
+              </Button>
+            </div>
+          ) : null}
+        </>
+      )}
+    </ResourcePanel>
+  );
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+  const status = error instanceof ApiError ? error.status : undefined;
+  const message = error instanceof Error ? error.message : undefined;
+  return <ErrorState section="knowledge" command={command} status={status} message={message} />;
+}

--- a/apps/web/app/routes/_app.knowledge.collections.new.tsx
+++ b/apps/web/app/routes/_app.knowledge.collections.new.tsx
@@ -1,0 +1,60 @@
+import { type MetaFunction, useNavigate, useRouteError } from "@remix-run/react";
+import { useState } from "react";
+import { CollectionForm } from "~/components/knowledge/collection-form";
+import { writeErrorState } from "~/components/resource-form";
+import { ResourcePanel } from "~/components/resource-panel";
+import { ErrorState } from "~/components/states";
+import { ApiError } from "~/lib/api";
+import { type CollectionInput, createCollection } from "~/lib/knowledge-api";
+
+export const meta: MetaFunction = () => [{ title: "New · Collections · Knowledge · tulipfarm" }];
+
+const command = "tulipfarm knowledge collections create";
+
+export default function CollectionNew() {
+  const navigate = useNavigate();
+  const [submitting, setSubmitting] = useState(false);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const [formError, setFormError] = useState<string | null>(null);
+
+  async function onSubmit(body: CollectionInput) {
+    setSubmitting(true);
+    setFieldErrors({});
+    setFormError(null);
+    try {
+      const c = await createCollection(body);
+      navigate(`/knowledge/collections/${encodeURIComponent(c.id)}`);
+    } catch (err) {
+      const next = writeErrorState(err);
+      setFieldErrors(next.fieldErrors);
+      setFormError(next.formError || null);
+      setSubmitting(false);
+    }
+  }
+
+  const crumbs = [
+    { label: "knowledge", to: "/knowledge" },
+    { label: "collections", to: "/knowledge/collections" },
+    { label: "new" },
+  ];
+
+  return (
+    <ResourcePanel crumbs={crumbs} command={command}>
+      <CollectionForm
+        mode="create"
+        onSubmit={onSubmit}
+        submitting={submitting}
+        fieldErrors={fieldErrors}
+        formError={formError}
+        cancelTo="/knowledge/collections"
+      />
+    </ResourcePanel>
+  );
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+  const status = error instanceof ApiError ? error.status : undefined;
+  const message = error instanceof Error ? error.message : undefined;
+  return <ErrorState section="knowledge" command={command} status={status} message={message} />;
+}

--- a/apps/web/app/routes/_app.knowledge.documents.$id.edit.tsx
+++ b/apps/web/app/routes/_app.knowledge.documents.$id.edit.tsx
@@ -1,0 +1,88 @@
+import {
+  type ClientLoaderFunctionArgs,
+  type MetaFunction,
+  useLoaderData,
+  useNavigate,
+  useParams,
+  useRouteError,
+} from "@remix-run/react";
+import { useState } from "react";
+import { DocForm } from "~/components/knowledge/doc-form";
+import { writeErrorState } from "~/components/resource-form";
+import { ResourcePanel } from "~/components/resource-panel";
+import { ErrorState, NotFoundState } from "~/components/states";
+import { ApiError } from "~/lib/api";
+import { type DocumentInput, getDocument, updateDocument } from "~/lib/knowledge-api";
+
+export const meta: MetaFunction = () => [{ title: "Edit · Documents · Knowledge · tulipfarm" }];
+
+export async function clientLoader({ params }: ClientLoaderFunctionArgs) {
+  const id = params.id;
+  if (!id) throw new ApiError(404, "missing document id");
+  const doc = await getDocument(id);
+  return { doc };
+}
+
+export default function DocumentEdit() {
+  const { doc } = useLoaderData<typeof clientLoader>();
+  const navigate = useNavigate();
+  const [submitting, setSubmitting] = useState(false);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const detailPath = `/knowledge/documents/${encodeURIComponent(doc.id)}`;
+
+  async function onSubmit(body: DocumentInput) {
+    setSubmitting(true);
+    setFieldErrors({});
+    setFormError(null);
+    try {
+      await updateDocument(doc.id, doc.version, body);
+      navigate(detailPath);
+    } catch (err) {
+      const next = writeErrorState(err);
+      setFieldErrors(next.fieldErrors);
+      setFormError(next.formError || null);
+      setSubmitting(false);
+    }
+  }
+
+  const crumbs = [
+    { label: "knowledge", to: "/knowledge" },
+    { label: "documents", to: "/knowledge/documents" },
+    { label: doc.title, to: detailPath },
+    { label: "edit" },
+  ];
+
+  return (
+    <ResourcePanel crumbs={crumbs} command={`tulipfarm knowledge documents edit ${doc.id}`}>
+      <DocForm
+        mode="edit"
+        initial={{
+          title: doc.title,
+          content: doc.content,
+          tags: doc.tags,
+          domain: doc.domain,
+          alwaysLoadForAgents: doc.alwaysLoadForAgents,
+        }}
+        onSubmit={onSubmit}
+        submitting={submitting}
+        fieldErrors={fieldErrors}
+        formError={formError}
+        cancelTo={detailPath}
+      />
+    </ResourcePanel>
+  );
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+  const params = useParams();
+  const command = `tulipfarm knowledge documents edit ${params.id ?? ""}`;
+  if (error instanceof ApiError && error.status === 404) {
+    return <NotFoundState section="knowledge" command={command} />;
+  }
+  const status = error instanceof ApiError ? error.status : undefined;
+  const message = error instanceof Error ? error.message : undefined;
+  return <ErrorState section="knowledge" command={command} status={status} message={message} />;
+}

--- a/apps/web/app/routes/_app.knowledge.documents.$id.tsx
+++ b/apps/web/app/routes/_app.knowledge.documents.$id.tsx
@@ -1,0 +1,72 @@
+import {
+  type ClientLoaderFunctionArgs,
+  type MetaFunction,
+  useLoaderData,
+  useNavigate,
+  useParams,
+  useRouteError,
+} from "@remix-run/react";
+import { useState } from "react";
+import { DocDetail } from "~/components/knowledge/doc-detail";
+import { ResourcePanel } from "~/components/resource-panel";
+import { ErrorState, NotFoundState } from "~/components/states";
+import { ApiError } from "~/lib/api";
+import { deleteDocument, getDocument } from "~/lib/knowledge-api";
+
+export const meta: MetaFunction = () => [{ title: "Document · Knowledge · tulipfarm" }];
+
+export async function clientLoader({ params }: ClientLoaderFunctionArgs) {
+  const id = params.id;
+  if (!id) throw new ApiError(404, "missing document id");
+  const doc = await getDocument(id);
+  return { doc };
+}
+
+export default function DocumentDetail() {
+  const { doc } = useLoaderData<typeof clientLoader>();
+  const navigate = useNavigate();
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onDelete() {
+    setDeleting(true);
+    setError(null);
+    try {
+      await deleteDocument(doc.id);
+      navigate("/knowledge/documents");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "delete failed");
+      setDeleting(false);
+    }
+  }
+
+  const crumbs = [
+    { label: "knowledge", to: "/knowledge" },
+    { label: "documents", to: "/knowledge/documents" },
+    { label: doc.title },
+  ];
+
+  return (
+    <ResourcePanel crumbs={crumbs} command={`tulipfarm knowledge documents show ${doc.id}`}>
+      {error ? <p className="text-destructive">error: {error}</p> : null}
+      <DocDetail
+        doc={doc}
+        editTo={`/knowledge/documents/${encodeURIComponent(doc.id)}/edit`}
+        onDelete={onDelete}
+        deleting={deleting}
+      />
+    </ResourcePanel>
+  );
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+  const params = useParams();
+  const command = `tulipfarm knowledge documents show ${params.id ?? ""}`;
+  if (error instanceof ApiError && error.status === 404) {
+    return <NotFoundState section="knowledge" command={command} />;
+  }
+  const status = error instanceof ApiError ? error.status : undefined;
+  const message = error instanceof Error ? error.message : undefined;
+  return <ErrorState section="knowledge" command={command} status={status} message={message} />;
+}

--- a/apps/web/app/routes/_app.knowledge.documents._index.tsx
+++ b/apps/web/app/routes/_app.knowledge.documents._index.tsx
@@ -1,0 +1,165 @@
+import { Link, type MetaFunction, useLoaderData, useRouteError } from "@remix-run/react";
+import { type FormEvent, useMemo, useState } from "react";
+import { DocTable, SearchResults } from "~/components/knowledge/doc-list";
+import { ResourcePanel } from "~/components/resource-panel";
+import { ErrorState } from "~/components/states";
+import { Button } from "~/components/ui/button";
+import { ApiError } from "~/lib/api";
+import {
+  type KnowledgeDocument,
+  listDocuments,
+  type SearchHit,
+  searchDocuments,
+} from "~/lib/knowledge-api";
+import type { SortState } from "~/lib/schema";
+
+export const meta: MetaFunction = () => [{ title: "Documents · Knowledge · tulipfarm" }];
+
+export async function clientLoader() {
+  const page = await listDocuments();
+  return { items: page.items, nextCursor: page.nextCursor };
+}
+
+const command = "tulipfarm knowledge documents --list";
+const inputClass =
+  "h-8 flex-1 rounded-sm border border-border bg-background px-2 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring";
+
+export default function DocumentsIndex() {
+  const { items, nextCursor } = useLoaderData<typeof clientLoader>();
+  const [docs, setDocs] = useState<KnowledgeDocument[]>(items);
+  const [cursor, setCursor] = useState<string | null>(nextCursor);
+  const [loading, setLoading] = useState(false);
+  const [sort, setSort] = useState<SortState | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const [query, setQuery] = useState("");
+  const [hits, setHits] = useState<SearchHit[] | null>(null);
+  const [warnings, setWarnings] = useState<string[]>([]);
+  const [searching, setSearching] = useState(false);
+
+  const sorted = useMemo(() => sortDocuments(docs, sort), [docs, sort]);
+
+  function toggleSort(column: string) {
+    setSort((prev) =>
+      prev?.field === column
+        ? { field: column, dir: prev.dir === "asc" ? "desc" : "asc" }
+        : { field: column, dir: "asc" }
+    );
+  }
+
+  async function loadMore() {
+    if (!cursor) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const batch = await listDocuments(cursor);
+      setDocs((prev) => [...prev, ...batch.items]);
+      setCursor(batch.nextCursor);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "failed to load more");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function onSearch(e: FormEvent) {
+    e.preventDefault();
+    const q = query.trim();
+    if (!q) {
+      setHits(null);
+      setWarnings([]);
+      return;
+    }
+    setSearching(true);
+    setError(null);
+    try {
+      const res = await searchDocuments(q);
+      setHits(res.results);
+      setWarnings(res.warnings);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "search failed");
+    } finally {
+      setSearching(false);
+    }
+  }
+
+  function clearSearch() {
+    setQuery("");
+    setHits(null);
+    setWarnings([]);
+  }
+
+  const crumbs = [{ label: "knowledge", to: "/knowledge" }, { label: "documents" }];
+
+  return (
+    <ResourcePanel crumbs={crumbs} command={command}>
+      <div>
+        <Button asChild variant="outline" size="sm">
+          <Link to="/knowledge/documents/new">New document</Link>
+        </Button>
+      </div>
+
+      <form onSubmit={onSearch} className="flex items-center gap-2">
+        <input
+          type="search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="search knowledge…"
+          aria-label="search documents"
+          className={inputClass}
+        />
+        <Button type="submit" variant="outline" size="sm" disabled={searching}>
+          {searching ? "…" : "Search"}
+        </Button>
+        {hits !== null ? (
+          <Button type="button" variant="ghost" size="sm" onClick={clearSearch}>
+            Clear
+          </Button>
+        ) : null}
+      </form>
+
+      {error ? <p className="text-destructive">error: {error}</p> : null}
+
+      {hits !== null ? (
+        <>
+          {warnings.includes("embedding-unavailable") ? (
+            <p className="text-xs text-muted-foreground">
+              ⚠ embeddings unavailable — showing keyword (lexical) results.
+            </p>
+          ) : null}
+          <SearchResults hits={hits} />
+        </>
+      ) : docs.length === 0 ? (
+        <p className="text-muted-foreground">0 results</p>
+      ) : (
+        <>
+          <DocTable documents={sorted} sort={sort ?? undefined} onToggleSort={toggleSort} />
+          {cursor ? (
+            <div>
+              <Button variant="outline" size="sm" onClick={loadMore} disabled={loading}>
+                {loading ? "loading…" : "Load more"}
+              </Button>
+            </div>
+          ) : null}
+        </>
+      )}
+    </ResourcePanel>
+  );
+}
+
+// Client-side sort over the loaded set by a string column (title/domain/updatedAt).
+function sortDocuments(docs: KnowledgeDocument[], sort: SortState | null): KnowledgeDocument[] {
+  if (!sort) return docs;
+  const dir = sort.dir === "asc" ? 1 : -1;
+  const key = sort.field as "title" | "domain" | "updatedAt";
+  return [...docs].sort(
+    (a, b) => ((a[key] ?? "") as string).localeCompare((b[key] ?? "") as string) * dir
+  );
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+  const status = error instanceof ApiError ? error.status : undefined;
+  const message = error instanceof Error ? error.message : undefined;
+  return <ErrorState section="knowledge" command={command} status={status} message={message} />;
+}

--- a/apps/web/app/routes/_app.knowledge.documents.new.tsx
+++ b/apps/web/app/routes/_app.knowledge.documents.new.tsx
@@ -1,0 +1,60 @@
+import { type MetaFunction, useNavigate, useRouteError } from "@remix-run/react";
+import { useState } from "react";
+import { DocForm } from "~/components/knowledge/doc-form";
+import { writeErrorState } from "~/components/resource-form";
+import { ResourcePanel } from "~/components/resource-panel";
+import { ErrorState } from "~/components/states";
+import { ApiError } from "~/lib/api";
+import { createDocument, type DocumentInput } from "~/lib/knowledge-api";
+
+export const meta: MetaFunction = () => [{ title: "New · Documents · Knowledge · tulipfarm" }];
+
+const command = "tulipfarm knowledge documents create";
+
+export default function DocumentNew() {
+  const navigate = useNavigate();
+  const [submitting, setSubmitting] = useState(false);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const [formError, setFormError] = useState<string | null>(null);
+
+  async function onSubmit(body: DocumentInput) {
+    setSubmitting(true);
+    setFieldErrors({});
+    setFormError(null);
+    try {
+      const doc = await createDocument(body);
+      navigate(`/knowledge/documents/${encodeURIComponent(doc.id)}`);
+    } catch (err) {
+      const next = writeErrorState(err);
+      setFieldErrors(next.fieldErrors);
+      setFormError(next.formError || null);
+      setSubmitting(false);
+    }
+  }
+
+  const crumbs = [
+    { label: "knowledge", to: "/knowledge" },
+    { label: "documents", to: "/knowledge/documents" },
+    { label: "new" },
+  ];
+
+  return (
+    <ResourcePanel crumbs={crumbs} command={command}>
+      <DocForm
+        mode="create"
+        onSubmit={onSubmit}
+        submitting={submitting}
+        fieldErrors={fieldErrors}
+        formError={formError}
+        cancelTo="/knowledge/documents"
+      />
+    </ResourcePanel>
+  );
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+  const status = error instanceof ApiError ? error.status : undefined;
+  const message = error instanceof Error ? error.message : undefined;
+  return <ErrorState section="knowledge" command={command} status={status} message={message} />;
+}

--- a/apps/web/app/routes/_app.knowledge.tsx
+++ b/apps/web/app/routes/_app.knowledge.tsx
@@ -1,14 +1,38 @@
-import type { MetaFunction } from "@remix-run/react";
-import { EmptyState } from "~/components/empty-state";
+import { type MetaFunction, NavLink, Outlet } from "@remix-run/react";
 
 export const meta: MetaFunction = () => [{ title: "Knowledge · tulipfarm" }];
 
-export default function KnowledgePage() {
+const TABS = [
+  { to: "/knowledge/documents", label: "documents" },
+  { to: "/knowledge/collections", label: "collections" },
+];
+
+/*
+ * Layout for the Knowledge subtree: a bracket sub-nav (documents | collections) over the child
+ * outlet. The active tab wears ruby brackets, matching the terminal `[section]` motif. Children own
+ * their own data + panels; `_index` redirects to /knowledge/documents.
+ */
+export default function KnowledgeLayout() {
   return (
-    <EmptyState
-      section="knowledge"
-      title="Knowledge"
-      hint="No documents indexed yet. Authored docs and synced resources will be searchable here."
-    />
+    <div className="flex flex-col">
+      <nav className="mx-auto flex w-full max-w-4xl items-center gap-4 px-6 pt-8 text-xs uppercase tracking-[0.2em]">
+        {TABS.map((t) => (
+          <NavLink key={t.to} to={t.to} className="transition-colors">
+            {({ isActive }) => (
+              <span
+                className={
+                  isActive ? "text-primary" : "text-muted-foreground hover:text-foreground"
+                }
+              >
+                {isActive ? "[ " : ""}
+                {t.label}
+                {isActive ? " ]" : ""}
+              </span>
+            )}
+          </NavLink>
+        ))}
+      </nav>
+      <Outlet />
+    </div>
   );
 }

--- a/apps/web/app/routes/knowledge.collections.routes.test.tsx
+++ b/apps/web/app/routes/knowledge.collections.routes.test.tsx
@@ -1,0 +1,100 @@
+import * as remix from "@remix-run/react";
+import { createRemixStub } from "@remix-run/testing";
+import { render, screen } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { expect, test, vi } from "vitest";
+import { ApiError } from "~/lib/api";
+import type {
+  CollectionWithCount,
+  KnowledgeCollection,
+  KnowledgeDocument,
+} from "~/lib/knowledge-api";
+import CollectionsIndex, {
+  ErrorBoundary as IndexErrorBoundary,
+} from "./_app.knowledge.collections._index";
+import CollectionDetailRoute, {
+  ErrorBoundary as DetailErrorBoundary,
+} from "./_app.knowledge.collections.$id";
+
+vi.mock("@remix-run/react", async () => {
+  const actual = await vi.importActual<typeof import("@remix-run/react")>("@remix-run/react");
+  return {
+    ...actual,
+    useLoaderData: vi.fn(),
+    useRouteError: vi.fn(),
+    useParams: vi.fn(() => ({})),
+  };
+});
+
+const collection: KnowledgeCollection = {
+  id: "c1",
+  name: "Support KB",
+  description: "Help-center articles",
+  domain: null,
+  version: 1,
+  createdAt: "2026-06-01T00:00:00Z",
+  updatedAt: "2026-06-01T00:00:00Z",
+};
+
+const member: KnowledgeDocument = {
+  id: "d1",
+  title: "Refund policy",
+  content: "text",
+  source: "authored",
+  sourceId: "d1",
+  domain: null,
+  tags: [],
+  active: true,
+  alwaysLoadForAgents: false,
+  version: 1,
+  createdAt: "2026-06-01T00:00:00Z",
+  updatedAt: "2026-06-01T00:00:00Z",
+  indexingStatus: "pending",
+};
+
+function renderWithData(node: ReactElement, data: unknown) {
+  vi.mocked(remix.useLoaderData).mockReturnValue(data);
+  const Stub = createRemixStub([{ path: "/", Component: () => node }]);
+  render(<Stub initialEntries={["/"]} />);
+}
+
+function renderError(node: ReactElement, error: unknown) {
+  vi.mocked(remix.useRouteError).mockReturnValue(error);
+  render(node);
+}
+
+test("collections index lists rows with a document count and a New link", () => {
+  const items: CollectionWithCount[] = [{ ...collection, docCount: 3 }];
+  renderWithData(<CollectionsIndex />, { items, nextCursor: null });
+  expect(screen.getByRole("link", { name: /Support KB/ })).toHaveAttribute(
+    "href",
+    "/knowledge/collections/c1"
+  );
+  expect(screen.getByText("3")).toBeInTheDocument();
+  expect(screen.getByRole("link", { name: /New collection/i })).toBeInTheDocument();
+});
+
+test("collections index with zero rows shows 0 results", () => {
+  renderWithData(<CollectionsIndex />, { items: [], nextCursor: null });
+  expect(screen.getByText("0 results")).toBeInTheDocument();
+});
+
+test("collections index ErrorBoundary surfaces 401 as authentication required", () => {
+  renderError(<IndexErrorBoundary />, new ApiError(401, "unauthorized"));
+  expect(screen.getByText(/authentication required/i)).toBeInTheDocument();
+});
+
+test("collection detail renders the name, member documents, and an add control", () => {
+  renderWithData(<CollectionDetailRoute />, { collection, documents: [member] });
+  expect(screen.getByRole("heading", { name: "Support KB" })).toBeInTheDocument();
+  expect(screen.getByRole("link", { name: /Refund policy/ })).toHaveAttribute(
+    "href",
+    "/knowledge/documents/d1"
+  );
+  expect(screen.getByRole("button", { name: /^add$/i })).toBeInTheDocument();
+});
+
+test("collection detail ErrorBoundary renders 404 not found", () => {
+  renderError(<DetailErrorBoundary />, new ApiError(404, "not found"));
+  expect(screen.getByText(/404 not found/i)).toBeInTheDocument();
+});

--- a/apps/web/app/routes/knowledge.documents.routes.test.tsx
+++ b/apps/web/app/routes/knowledge.documents.routes.test.tsx
@@ -1,0 +1,98 @@
+import * as remix from "@remix-run/react";
+import { createRemixStub } from "@remix-run/testing";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { expect, test, vi } from "vitest";
+import { ApiError } from "~/lib/api";
+import type { KnowledgeDocument } from "~/lib/knowledge-api";
+import DocumentsIndex, {
+  ErrorBoundary as IndexErrorBoundary,
+} from "./_app.knowledge.documents._index";
+import DocumentDetail, {
+  ErrorBoundary as DetailErrorBoundary,
+} from "./_app.knowledge.documents.$id";
+
+/*
+ * Route smoke tests, mirroring resources.routes.test.tsx: mock useLoaderData/useRouteError and render
+ * each Component / ErrorBoundary directly (Link needs router context → createRemixStub at "/").
+ */
+vi.mock("@remix-run/react", async () => {
+  const actual = await vi.importActual<typeof import("@remix-run/react")>("@remix-run/react");
+  return {
+    ...actual,
+    useLoaderData: vi.fn(),
+    useRouteError: vi.fn(),
+    useParams: vi.fn(() => ({})),
+  };
+});
+
+const doc: KnowledgeDocument = {
+  id: "d1",
+  title: "Onboarding",
+  content: "# Hello\n\nbody text",
+  source: "authored",
+  sourceId: "d1",
+  domain: "sales",
+  tags: ["a", "b"],
+  active: true,
+  alwaysLoadForAgents: false,
+  version: 2,
+  createdAt: "2026-06-01T00:00:00Z",
+  updatedAt: "2026-06-08T00:00:00Z",
+  indexingStatus: "indexed",
+};
+
+function renderWithData(node: ReactElement, data: unknown) {
+  vi.mocked(remix.useLoaderData).mockReturnValue(data);
+  const Stub = createRemixStub([{ path: "/", Component: () => node }]);
+  render(<Stub initialEntries={["/"]} />);
+}
+
+function renderError(node: ReactElement, error: unknown) {
+  vi.mocked(remix.useRouteError).mockReturnValue(error);
+  render(node);
+}
+
+test("documents index lists rows with status badge, a New link, and Load more when paginated", () => {
+  renderWithData(<DocumentsIndex />, { items: [doc], nextCursor: "next-page" });
+  expect(screen.getByRole("link", { name: /Onboarding/ })).toHaveAttribute(
+    "href",
+    "/knowledge/documents/d1"
+  );
+  expect(screen.getByText("indexed")).toBeInTheDocument();
+  expect(screen.getByRole("link", { name: /New document/i })).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: /load more/i })).toBeInTheDocument();
+});
+
+test("documents index with zero rows shows 0 results and no Load more", () => {
+  renderWithData(<DocumentsIndex />, { items: [], nextCursor: null });
+  expect(screen.getByText("0 results")).toBeInTheDocument();
+  expect(screen.queryByRole("button", { name: /load more/i })).not.toBeInTheDocument();
+});
+
+test("documents index ErrorBoundary surfaces 401 as authentication required", () => {
+  renderError(<IndexErrorBoundary />, new ApiError(401, "unauthorized"));
+  expect(screen.getByText(/authentication required/i)).toBeInTheDocument();
+});
+
+test("document detail renders title, rendered markdown, status badge, and edit link", () => {
+  renderWithData(<DocumentDetail />, { doc });
+  expect(screen.getByRole("heading", { name: "Onboarding" })).toBeInTheDocument();
+  expect(screen.getByRole("heading", { name: "Hello" })).toBeInTheDocument(); // markdown body
+  expect(screen.getByText("indexed")).toBeInTheDocument();
+  expect(screen.getByRole("link", { name: /edit/i })).toHaveAttribute(
+    "href",
+    "/knowledge/documents/d1/edit"
+  );
+});
+
+test("document detail Delete reveals an inline confirm", () => {
+  renderWithData(<DocumentDetail />, { doc });
+  fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+  expect(screen.getByRole("button", { name: /confirm delete/i })).toBeInTheDocument();
+});
+
+test("document detail ErrorBoundary renders 404 not found", () => {
+  renderError(<DetailErrorBoundary />, new ApiError(404, "not found"));
+  expect(screen.getByText(/404 not found/i)).toBeInTheDocument();
+});


### PR DESCRIPTION
Tabbed /knowledge section over the existing backend: documents (browse + semantic search, markdown create/edit with write/preview, tags/domain/alwaysLoadForAgents, soft-delete, per-doc index badge) and collections (list with doc counts, drill-in add/remove membership, CRUD). New lib/knowledge-api.ts client + apiSend primitive for 204 POSTs. No file upload (AC-V1-004).

Backend (additive, read-only): derive indexingStatus (indexed|lexical-only|pending) from chunks on document create/get/list/update; add GET /collections/:id; reject adding soft-deleted docs to a collection.

Tests: +25 web, +5 api knowledge; lint + typecheck green.