### PR TITLE
feat(chat): summarize-oldest conversation compaction (CTX-V1-001/002)

### DIFF
--- a/apps/api/src/chat/compaction.test.ts
+++ b/apps/api/src/chat/compaction.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it, vi } from "vitest";
+import { MAX_HISTORY_TOKENS } from "../memory/limits";
+import {
+  applySummaryFilter,
+  compactHistory,
+  computeCut,
+  estimateDocsTokens,
+  estimateTokens,
+} from "./compaction";
+import type { CompactionCutoff, MessageDoc, MessagePart, MessageRepo } from "./messages";
+
+const T0 = new Date("2026-06-12T00:00:00Z").getTime();
+let seq = 0;
+
+/** Build a message row at a strictly increasing timestamp. */
+function doc(
+  role: MessageDoc["role"],
+  content: string | MessagePart[],
+  id = `m${seq}`
+): MessageDoc {
+  seq += 1;
+  return { _id: id, conversationId: "c1", role, content, createdAt: new Date(T0 + seq * 1000) };
+}
+
+/** A string whose token estimate is `tokens` (≈ 4 chars/token). */
+const sized = (tokens: number): string => "x".repeat(tokens * 4);
+
+function fakeRepo(): MessageRepo & { created: MessageDoc[] } {
+  const created: MessageDoc[] = [];
+  return {
+    created,
+    create: async (d: MessageDoc) => {
+      created.push(d);
+    },
+    listByConversation: async () => ({ items: [], nextCursor: null }),
+  };
+}
+
+const silentLog = { error: () => {} };
+
+describe("estimateTokens / estimateDocsTokens", () => {
+  it("estimates ~4 chars per token (ceil)", () => {
+    expect(estimateTokens("")).toBe(0);
+    expect(estimateTokens("abcd")).toBe(1);
+    expect(estimateTokens("abcde")).toBe(2);
+  });
+
+  it("sums across rows, serializing non-string content", () => {
+    const docs = [doc("user", "abcd"), doc("assistant", "abcdefgh")];
+    expect(estimateDocsTokens(docs)).toBe(estimateTokens("abcd") + estimateTokens("abcdefgh"));
+  });
+});
+
+describe("applySummaryFilter", () => {
+  it("passes rows through unchanged when there is no summary", () => {
+    const docs = [doc("user", "hi"), doc("assistant", "yo")];
+    expect(applySummaryFilter(docs)).toBe(docs);
+  });
+
+  it("drops rows at/before the cutoff, keeping the summary + newer rows", () => {
+    const u1 = doc("user", "old q");
+    const a1 = doc("assistant", "old a");
+    const cutoff: CompactionCutoff = { createdAt: a1.createdAt, _id: a1._id };
+    const summary: MessageDoc = {
+      _id: "s1",
+      conversationId: "c1",
+      role: "summary",
+      content: "recap",
+      metadata: { compactedThrough: cutoff },
+      createdAt: a1.createdAt,
+    };
+    const u2 = doc("user", "new q");
+    const a2 = doc("assistant", "new a");
+    expect(applySummaryFilter([u1, a1, summary, u2, a2])).toEqual([summary, u2, a2]);
+  });
+
+  it("a newer summary supersedes an older one (only the latest is kept)", () => {
+    const u1 = doc("user", "q1");
+    const a1 = doc("assistant", "a1");
+    const s1: MessageDoc = {
+      _id: "s1",
+      conversationId: "c1",
+      role: "summary",
+      content: "first recap",
+      metadata: { compactedThrough: { createdAt: a1.createdAt, _id: a1._id } },
+      createdAt: a1.createdAt,
+    };
+    const u2 = doc("user", "q2");
+    const a2 = doc("assistant", "a2");
+    const s2: MessageDoc = {
+      _id: "s2",
+      conversationId: "c1",
+      role: "summary",
+      content: "second recap",
+      metadata: { compactedThrough: { createdAt: a2.createdAt, _id: a2._id } },
+      createdAt: a2.createdAt,
+    };
+    const u3 = doc("user", "q3");
+    expect(applySummaryFilter([u1, a1, s1, u2, a2, s2, u3])).toEqual([s2, u3]);
+  });
+});
+
+describe("computeCut", () => {
+  it("keeps the recent window and snaps the boundary to a user row", () => {
+    const u1 = doc("user", sized(MAX_HISTORY_TOKENS)); // huge oldest turn
+    const a1 = doc("assistant", "small");
+    const u2 = doc("user", "small");
+    const a2 = doc("assistant", "small");
+    const cut = computeCut([u1, a1, u2, a2]);
+    expect(cut).toBe(2); // verbatim = [u2, a2]
+    expect([u1, a1, u2, a2][cut].role).toBe("user");
+  });
+
+  it("never splits a tool-call/tool-result pair (cut lands on a user boundary)", () => {
+    const u1 = doc("user", sized(MAX_HISTORY_TOKENS));
+    const a1 = doc("assistant", [
+      { type: "tool-call", toolCallId: "c1", toolName: "search", args: {} },
+    ]);
+    const t1 = doc("tool", [
+      { type: "tool-result", toolCallId: "c1", toolName: "search", result: 1 },
+    ]);
+    const u2 = doc("user", "small");
+    const a2 = doc("assistant", "small");
+    const docs = [u1, a1, t1, u2, a2];
+    const cut = computeCut(docs);
+    expect(docs[cut].role).toBe("user"); // verbatim starts at a user turn
+    // a1 (tool-call) and t1 (tool-result) are on the same side of the cut
+    const a1Side = docs.indexOf(a1) < cut;
+    const t1Side = docs.indexOf(t1) < cut;
+    expect(a1Side).toBe(t1Side);
+  });
+});
+
+describe("compactHistory", () => {
+  it("under budget → returns filtered history, no summarization", async () => {
+    const docs = [doc("user", "hi"), doc("assistant", "hello")];
+    const summarize = vi.fn();
+    const repo = fakeRepo();
+    const out = await compactHistory({
+      docs,
+      conversationId: "c1",
+      extraTokens: 0,
+      messageRepo: repo,
+      summarize,
+      log: silentLog,
+    });
+    expect(out).toBe(docs);
+    expect(summarize).not.toHaveBeenCalled();
+    expect(repo.created).toHaveLength(0);
+  });
+
+  it("over budget → summarizes oldest once, persists a summary row, keeps recent verbatim", async () => {
+    const u1 = doc("user", sized(MAX_HISTORY_TOKENS));
+    const a1 = doc("assistant", "old answer");
+    const u2 = doc("user", "recent q");
+    const a2 = doc("assistant", "recent a");
+    const summarize = vi.fn().mockResolvedValue("RECAP");
+    const repo = fakeRepo();
+    const out = await compactHistory({
+      docs: [u1, a1, u2, a2],
+      conversationId: "c1",
+      extraTokens: 0,
+      messageRepo: repo,
+      summarize,
+      log: silentLog,
+    });
+
+    expect(summarize).toHaveBeenCalledTimes(1);
+    expect(repo.created).toHaveLength(1);
+    const summary = repo.created[0];
+    expect(summary.role).toBe("summary");
+    expect(summary.content).toBe("RECAP");
+    expect(summary.metadata?.compactedThrough).toEqual({ createdAt: a1.createdAt, _id: a1._id });
+    // returned: [summary, ...verbatim]; oldest turns gone, recent kept verbatim
+    expect(out).toEqual([summary, u2, a2]);
+  });
+
+  it("a second turn after compaction does not re-summarize (one pass per overflow)", async () => {
+    const u1 = doc("user", sized(MAX_HISTORY_TOKENS));
+    const a1 = doc("assistant", "old");
+    const u2 = doc("user", "recent");
+    const a2 = doc("assistant", "recent a");
+    const summarize = vi.fn().mockResolvedValue("RECAP");
+    const repo = fakeRepo();
+    const first = await compactHistory({
+      docs: [u1, a1, u2, a2],
+      conversationId: "c1",
+      extraTokens: 0,
+      messageRepo: repo,
+      summarize,
+      log: silentLog,
+    });
+    // Simulate the next turn: the persisted summary row is now part of the loaded history.
+    const second = await compactHistory({
+      docs: [u1, a1, repo.created[0], u2, a2],
+      conversationId: "c1",
+      extraTokens: 0,
+      messageRepo: repo,
+      summarize,
+      log: silentLog,
+    });
+    expect(summarize).toHaveBeenCalledTimes(1); // still one pass total
+    expect(repo.created).toHaveLength(1);
+    expect(second).toEqual(first); // [summary, u2, a2]
+  });
+
+  it("summarize failure → graceful skip to full filtered history, turn continues", async () => {
+    const u1 = doc("user", sized(MAX_HISTORY_TOKENS));
+    const a1 = doc("assistant", "old");
+    const u2 = doc("user", "recent");
+    const docs = [u1, a1, u2];
+    const summarize = vi.fn().mockRejectedValue(new Error("llm down"));
+    const repo = fakeRepo();
+    const out = await compactHistory({
+      docs,
+      conversationId: "c1",
+      extraTokens: 0,
+      messageRepo: repo,
+      summarize,
+      log: silentLog,
+    });
+    expect(summarize).toHaveBeenCalledTimes(1);
+    expect(repo.created).toHaveLength(0); // no summary persisted
+    expect(out).toBe(docs); // unchanged history sent
+  });
+
+  it("persistence failure → graceful skip to full filtered history", async () => {
+    const u1 = doc("user", sized(MAX_HISTORY_TOKENS));
+    const a1 = doc("assistant", "old");
+    const u2 = doc("user", "recent");
+    const docs = [u1, a1, u2];
+    const summarize = vi.fn().mockResolvedValue("RECAP");
+    const repo = fakeRepo();
+    repo.create = vi.fn().mockRejectedValue(new Error("db down"));
+    const out = await compactHistory({
+      docs,
+      conversationId: "c1",
+      extraTokens: 0,
+      messageRepo: repo,
+      summarize,
+      log: silentLog,
+    });
+    expect(out).toBe(docs); // turn continues with full history despite the persist failure
+  });
+});

--- a/apps/api/src/chat/compaction.ts
+++ b/apps/api/src/chat/compaction.ts
@@ -1,0 +1,137 @@
+import { MAX_HISTORY_TOKENS, RECENT_RETENTION_TOKENS } from "../memory/limits";
+import {
+  type CompactionCutoff,
+  fromSummary,
+  type MessageDoc,
+  type MessagePart,
+  type MessageRepo,
+} from "./messages";
+
+/**
+ * Conversation compaction (CTX-V1-001/002). Statelessness is preserved — the prompt is
+ * rebuilt every turn from durable rows; compaction only changes *which* history rows are
+ * included. When a turn's estimated tokens exceed `MAX_HISTORY_TOKENS`, the oldest turns
+ * are summarized once into a durable `summary` row and the recent turns stay verbatim.
+ *
+ * Token counts are a coarse char heuristic (no tokenizer dependency); a generous budget
+ * with headroom under the model's context window makes the imprecision harmless.
+ */
+
+/** Flatten a message's content to the text used for the char-based token estimate. */
+function contentText(content: string | MessagePart[]): string {
+  return typeof content === "string" ? content : JSON.stringify(content);
+}
+
+/** Coarse token estimate for a string: ~4 chars per token. */
+export function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+/** Sum the token estimate across a list of message rows. */
+export function estimateDocsTokens(docs: MessageDoc[]): number {
+  return docs.reduce((n, d) => n + estimateTokens(contentText(d.content)), 0);
+}
+
+/** `(createdAt, _id)` ordering: is `d` strictly newer than the cutoff? */
+function isAfter(d: MessageDoc, cutoff: CompactionCutoff): boolean {
+  const dt = d.createdAt.getTime();
+  const ct = cutoff.createdAt.getTime();
+  if (dt !== ct) return dt > ct;
+  return d._id > cutoff._id;
+}
+
+/**
+ * Read-path filter applied EVERY turn (statelessness). Given the rows ordered oldest→newest,
+ * resolve the effective history: keep only the latest `summary` row plus the non-summary rows
+ * newer than its cutoff. With no summary present, the rows pass through unchanged. A newer
+ * summary therefore supersedes (and drops) any older summary — there is only ever one.
+ */
+export function applySummaryFilter(docs: MessageDoc[]): MessageDoc[] {
+  let latest: MessageDoc | undefined;
+  for (const d of docs) {
+    if (d.role === "summary") latest = d; // rows are ordered, so the last summary seen wins
+  }
+  if (!latest) return docs;
+  const cutoff = (latest.metadata?.compactedThrough ?? {
+    createdAt: latest.createdAt,
+    _id: latest._id,
+  }) as CompactionCutoff;
+  const verbatim = docs.filter((d) => d.role !== "summary" && isAfter(d, cutoff));
+  return [latest, ...verbatim];
+}
+
+/**
+ * Choose the cut between summarized-oldest and kept-verbatim. Walks newest→oldest accumulating
+ * the estimate until it exceeds `RECENT_RETENTION_TOKENS`, then snaps the boundary to a `user`
+ * row so the verbatim region always begins with a user turn (valid message sequence; whole
+ * user→assistant→tool turns stay intact). Returns the index of the first kept (verbatim) row.
+ */
+export function computeCut(docs: MessageDoc[]): number {
+  let acc = 0;
+  let cut = 0;
+  for (let i = docs.length - 1; i >= 0; i--) {
+    acc += estimateTokens(contentText(docs[i].content));
+    if (acc > RECENT_RETENTION_TOKENS) {
+      cut = i + 1;
+      break;
+    }
+  }
+  const userIdx = docs.flatMap((d, i) => (d.role === "user" ? [i] : []));
+  if (userIdx.length === 0) return docs.length; // no safe boundary → caller skips compaction
+  const forward = userIdx.find((i) => i >= cut);
+  return forward ?? userIdx[userIdx.length - 1];
+}
+
+/** Render the to-be-summarized rows to a plain role-labelled transcript for the LLM. */
+function renderTranscript(docs: MessageDoc[]): string {
+  return docs.map((d) => `${d.role}: ${contentText(d.content)}`).join("\n\n");
+}
+
+export interface CompactHistoryArgs {
+  /** Raw rows from `listByConversation`, oldest→newest. */
+  docs: MessageDoc[];
+  conversationId: string;
+  /** Estimated tokens for everything outside history (system prompt + current user message). */
+  extraTokens: number;
+  messageRepo: MessageRepo;
+  /** Summarize a transcript via the LLM quick tier. */
+  summarize: (transcript: string) => Promise<string>;
+  log: { error: (obj: unknown, msg?: string) => void };
+}
+
+/**
+ * Resolve the history rows to render for this turn. Always applies the summary filter; only when
+ * the estimate is over budget does it run exactly one summarization pass: summarize the oldest
+ * turns, persist a durable `summary` row, and return `[summary, ...verbatim]`. A summarize failure
+ * degrades gracefully to the un-summarized (filtered) history so the turn still runs.
+ */
+export async function compactHistory(args: CompactHistoryArgs): Promise<MessageDoc[]> {
+  const { docs, conversationId, extraTokens, messageRepo, summarize, log } = args;
+  const filtered = applySummaryFilter(docs);
+
+  if (estimateDocsTokens(filtered) + extraTokens <= MAX_HISTORY_TOKENS) return filtered;
+
+  const cut = computeCut(filtered);
+  const toSummarize = filtered.slice(0, cut);
+  const verbatim = filtered.slice(cut);
+  if (toSummarize.length === 0 || verbatim.length === 0) return filtered; // nothing safe to compact
+
+  const last = toSummarize[toSummarize.length - 1];
+  // Summarize + persist are both best-effort: any failure (LLM throw, quick tier unconfigured,
+  // or a persistence error) degrades to the un-summarized history so the turn still runs.
+  try {
+    const text = await summarize(renderTranscript(toSummarize));
+    const summary = fromSummary(conversationId, text, {
+      createdAt: last.createdAt,
+      _id: last._id,
+    });
+    await messageRepo.create(summary);
+    return [summary, ...verbatim];
+  } catch (err) {
+    log.error(
+      { err, conversationId },
+      "history compaction: summarize/persist failed; sending full history"
+    );
+    return filtered;
+  }
+}

--- a/apps/api/src/chat/messages.test.ts
+++ b/apps/api/src/chat/messages.test.ts
@@ -3,6 +3,7 @@ import {
   assertValidMessage,
   fromAssistantParts,
   fromAssistantText,
+  fromSummary,
   fromToolResult,
   fromUserText,
   InvalidMessageError,
@@ -22,6 +23,10 @@ describe("assertValidMessage — legal cases", () => {
 
   it("accepts assistant + string", () => {
     expect(() => assertValidMessage("assistant", "hi there")).not.toThrow();
+  });
+
+  it("accepts summary + string", () => {
+    expect(() => assertValidMessage("summary", "earlier: user asked about X")).not.toThrow();
   });
 
   it("accepts assistant + [text part]", () => {
@@ -62,6 +67,11 @@ describe("assertValidMessage — illegal cases", () => {
   it("rejects user + [parts]", () => {
     const content: MessagePart[] = [{ type: "text", text: "no" }];
     expect(() => assertValidMessage("user", content)).toThrow(InvalidMessageError);
+  });
+
+  it("rejects summary + [parts]", () => {
+    const content: MessagePart[] = [{ type: "text", text: "no" }];
+    expect(() => assertValidMessage("summary", content)).toThrow(InvalidMessageError);
   });
 
   it("rejects assistant + [tool-result]", () => {
@@ -121,6 +131,11 @@ describe("toModelMessage", () => {
   it("maps assistant string → assistant message", () => {
     const doc: MessageDoc = { ...base, role: "assistant", content: "Hello" };
     expect(toModelMessage(doc)).toEqual({ role: "assistant", content: "Hello" });
+  });
+
+  it("maps summary → system message (compaction artifact enters as system)", () => {
+    const doc: MessageDoc = { ...base, role: "summary", content: "earlier turns summarized" };
+    expect(toModelMessage(doc)).toEqual({ role: "system", content: "earlier turns summarized" });
   });
 
   it("maps assistant [text, tool-call] → assistant with matching parts", () => {
@@ -188,6 +203,26 @@ describe("fromUserText / fromAssistantText", () => {
     const a = fromUserText("conv1", "x");
     const b = fromUserText("conv1", "x");
     expect(a._id).not.toBe(b._id);
+  });
+});
+
+describe("fromSummary", () => {
+  it("builds a summary row pinned to the cutoff time, with compactedThrough metadata", () => {
+    const cutoff = { createdAt: new Date("2026-06-12T10:00:00Z"), _id: "row-42" };
+    const doc = fromSummary("conv1", "the gist of earlier turns", cutoff);
+    expect(doc.role).toBe("summary");
+    expect(doc.content).toBe("the gist of earlier turns");
+    expect(doc.conversationId).toBe("conv1");
+    expect(doc.createdAt).toEqual(cutoff.createdAt); // pinned so it orders before the verbatim region
+    expect(doc.metadata).toEqual({ compactedThrough: cutoff });
+    expect(doc._id.length).toBeGreaterThan(0);
+  });
+
+  it("round-trips through assertValidMessage + toModelMessage", () => {
+    const cutoff = { createdAt: new Date(), _id: "row-1" };
+    const doc = fromSummary("conv1", "summary text", cutoff);
+    expect(() => assertValidMessage(doc.role, doc.content)).not.toThrow();
+    expect(toModelMessage(doc)).toEqual({ role: "system", content: "summary text" });
   });
 });
 

--- a/apps/api/src/chat/messages.ts
+++ b/apps/api/src/chat/messages.ts
@@ -8,7 +8,13 @@ export type MessagePart =
   | { type: "tool-call"; toolCallId: string; toolName: string; args: unknown }
   | { type: "tool-result"; toolCallId: string; toolName: string; result: unknown };
 
-export type MessageRole = "system" | "user" | "assistant" | "tool";
+export type MessageRole = "system" | "user" | "assistant" | "tool" | "summary";
+
+/** Cutoff marker on a `summary` row: the newest original turn it replaces (CTX-V1-001). */
+export interface CompactionCutoff {
+  createdAt: Date;
+  _id: string;
+}
 
 export interface MessageDoc {
   _id: string;
@@ -33,7 +39,7 @@ export class InvalidMessageError extends Error {
 export function assertValidMessage(role: MessageRole, content: string | MessagePart[]): void {
   const isString = typeof content === "string";
 
-  if (role === "system" || role === "user") {
+  if (role === "system" || role === "user" || role === "summary") {
     if (!isString) {
       throw new InvalidMessageError(`${role} message content must be a string`);
     }
@@ -74,6 +80,12 @@ export function assertValidMessage(role: MessageRole, content: string | MessageP
  */
 export function toModelMessage(doc: MessageDoc): ModelMessage {
   const { role, content } = doc;
+
+  // A `summary` row is a compaction artifact (CTX-V1-001); it enters the prompt as a
+  // system message carrying the summary of the oldest turns it replaced.
+  if (role === "summary") {
+    return { role: "system", content: typeof content === "string" ? content : "" };
+  }
 
   if (role === "system" || role === "user") {
     const text = typeof content === "string" ? content : "";
@@ -134,6 +146,27 @@ export function fromAssistantText(conversationId: string, text: string): Message
     role: "assistant",
     content: text,
     createdAt: new Date(),
+  };
+}
+
+/**
+ * Build the durable `summary` row that replaces the oldest turns during compaction
+ * (CTX-V1-001). `createdAt` is pinned to the cutoff turn's time so natural
+ * `(created_at, id)` ordering places the summary right before the first kept verbatim
+ * turn; `compactedThrough` records the newest original turn it covers.
+ */
+export function fromSummary(
+  conversationId: string,
+  text: string,
+  compactedThrough: CompactionCutoff
+): MessageDoc {
+  return {
+    _id: randomUUID(),
+    conversationId,
+    role: "summary",
+    content: text,
+    metadata: { compactedThrough },
+    createdAt: compactedThrough.createdAt,
   };
 }
 

--- a/apps/api/src/chat/routes.test.ts
+++ b/apps/api/src/chat/routes.test.ts
@@ -11,6 +11,7 @@ import { SESSION_COOKIE } from "../auth/middleware";
 import { MemorySessionStore } from "../auth/session-store";
 import { createUser, type UserDoc, type UserRepo } from "../auth/users";
 import { GuardrailsService } from "../guardrails";
+import { MAX_HISTORY_TOKENS } from "../memory/limits";
 import { WorkingMemoryService } from "../memory/service";
 import {
   assertValidEntry,
@@ -139,6 +140,25 @@ function makeToolThenTextModel(
       ? (makeToolCallStreamResult(toolCalls) as ReturnType<typeof makeStreamResult>)
       : makeStreamResult([followupText]);
   });
+}
+
+// Non-streaming model for the quick-tier compaction summarizer: doGenerate returns fixed text.
+function makeQuickModel(text: string): LanguageModelV3 {
+  return {
+    specificationVersion: "v3",
+    provider: "test",
+    modelId: "quick-model",
+    supportedUrls: {},
+    doStream: vi.fn(async () => {
+      throw new Error("doStream unused on quick model");
+    }),
+    doGenerate: vi.fn(async () => ({
+      content: [{ type: "text", text }],
+      finishReason: { unified: "stop", raw: undefined },
+      usage: V3_USAGE,
+      warnings: [],
+    })),
+  } as unknown as LanguageModelV3;
 }
 
 // ── Fake conversation repo ────────────────────────────────────────────────────
@@ -536,6 +556,94 @@ describe("chat routes", () => {
       expect(texts.some((t) => t.includes("earlier question"))).toBe(true);
       expect(texts.some((t) => t.includes("earlier answer"))).toBe(true);
       expect(texts.some((t) => t.includes("follow up"))).toBe(true);
+    });
+
+    // Compaction (CTX-V1-001/002) — an over-budget conversation summarizes its oldest turns once
+    // into a durable `summary` row, keeps recent turns verbatim, and reuses the summary next turn.
+    it("summarizes oldest turns when over budget, keeps recent verbatim, and reuses next turn", async () => {
+      const convoId = randomUUID();
+      const base = new Date(Date.now() - 100_000);
+      await repo.create({
+        _id: convoId,
+        userId,
+        model: undefined,
+        createdAt: base,
+        updatedAt: base,
+      });
+      // One huge oldest user turn pushes the conversation over MAX_HISTORY_TOKENS.
+      messageRepo.messages.push(userMessage(convoId, "X".repeat(MAX_HISTORY_TOKENS * 4), base));
+      messageRepo.messages.push(
+        assistantMessage(convoId, "old answer", new Date(base.getTime() + 1000))
+      );
+      messageRepo.messages.push(
+        userMessage(convoId, "recent question", new Date(base.getTime() + 2000))
+      );
+      messageRepo.messages.push(
+        assistantMessage(convoId, "recent answer", new Date(base.getTime() + 3000))
+      );
+
+      const quick = makeQuickModel("EARLIER SUMMARY");
+      const getModel = vi.fn(() => quick);
+      (llmService as unknown as { getModel: () => LanguageModelV3 }).getModel = getModel;
+
+      // Turn 1 — overflow → one summarization pass.
+      const r1 = await post({ conversationId: convoId, message: userMsg("follow up") });
+      expect(r1.statusCode).toBe(200);
+      expect(r1.body).toContain("Hello"); // run continues
+      await waitFor(() => messageRepo.byConversation(convoId).some((m) => m.role === "summary"));
+
+      const summaries = messageRepo.byConversation(convoId).filter((m) => m.role === "summary");
+      expect(summaries).toHaveLength(1);
+      expect(summaries[0].content).toBe("EARLIER SUMMARY");
+      expect(
+        (summaries[0].metadata as { compactedThrough?: unknown }).compactedThrough
+      ).toBeDefined();
+
+      // Outgoing model prompt: summary leads, recent turns verbatim, oldest turns gone.
+      await waitFor(() => capturedPrompts.length >= 1);
+      const prompt = capturedPrompts[0] as Array<{ role: string; content: unknown }>;
+      const texts = prompt.map((m) => JSON.stringify(m.content));
+      expect(texts.some((t) => t.includes("EARLIER SUMMARY"))).toBe(true);
+      expect(texts.some((t) => t.includes("recent question"))).toBe(true);
+      expect(texts.some((t) => t.includes("follow up"))).toBe(true);
+      expect(texts.some((t) => t.includes("old answer"))).toBe(false); // summarized away
+
+      // Turn 2 — history is now under budget (summary + small turns) → no second pass (CTX-V1-001).
+      const r2 = await post({ conversationId: convoId, message: userMsg("third") });
+      expect(r2.statusCode).toBe(200);
+      expect(getModel).toHaveBeenCalledTimes(1); // exactly one summarization pass total
+      expect(messageRepo.byConversation(convoId).filter((m) => m.role === "summary")).toHaveLength(
+        1
+      );
+
+      // The durable summary row surfaces in the messages list (schema enum includes "summary").
+      const list = await get(`/api/v1/conversations/${convoId}/messages?limit=100`);
+      expect(list.statusCode).toBe(200);
+      expect(list.json().messages.some((m: MessageDoc) => m.role === "summary")).toBe(true);
+    });
+
+    // Graceful skip — if summarization is unavailable, the turn still runs with full history.
+    it("falls back to full history when the summarizer is unavailable (no summary row)", async () => {
+      const convoId = randomUUID();
+      const base = new Date(Date.now() - 100_000);
+      await repo.create({
+        _id: convoId,
+        userId,
+        model: undefined,
+        createdAt: base,
+        updatedAt: base,
+      });
+      messageRepo.messages.push(userMessage(convoId, "Y".repeat(MAX_HISTORY_TOKENS * 4), base));
+      messageRepo.messages.push(
+        userMessage(convoId, "still here", new Date(base.getTime() + 1000))
+      );
+      // llmService has no getModel in the default harness → summarize throws → graceful skip.
+
+      const res = await post({ conversationId: convoId, message: userMsg("next") });
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toContain("Hello");
+      await waitFor(() => capturedPrompts.length >= 1);
+      expect(messageRepo.byConversation(convoId).some((m) => m.role === "summary")).toBe(false);
     });
 
     // Context engine — the assembled system prompt (CONTEXT-ENGINE §1) leads the model prompt.

--- a/apps/api/src/chat/routes.ts
+++ b/apps/api/src/chat/routes.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import type { EventEmitter } from "node:events";
 import { LlmNotConfiguredError, type LlmService, UnknownModelError } from "@tulipfarm/llm";
 import type { SoulLoader } from "@tulipfarm/soul";
-import { type ModelMessage, streamText } from "ai";
+import { generateText, type ModelMessage, streamText } from "ai";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { ErrorSchema } from "../auth/schemas";
 import type { UserDoc } from "../auth/users";
@@ -19,6 +19,7 @@ import { BatchCoordinator } from "../tools/batch-executor";
 import type { RunToolCallGuard, ToolRegistry } from "../tools/registry";
 import type { ToolCallResult } from "../tools/types";
 import { ApprovalRegistry, makeApprovalGate } from "./approvals";
+import { compactHistory, estimateTokens } from "./compaction";
 import type { ConversationDoc, ConversationRepo } from "./conversations";
 import {
   fromAssistantParts,
@@ -37,6 +38,12 @@ import type { StreamHub } from "./stream-hub";
 import type { StreamResumeRepo } from "./stream-resume";
 
 type PreHandler = (req: FastifyRequest, reply: FastifyReply) => Promise<void>;
+
+/** Instruction prefix for the quick-tier compaction summarizer (CTX-V1-001). */
+const SUMMARY_PROMPT =
+  "Summarize the earlier portion of this conversation transcript into a concise, " +
+  "information-dense recap. Preserve facts, decisions, names, numbers, and any open " +
+  "tasks the assistant must remember to continue. Write only the summary.";
 
 interface ChatBody {
   conversationId?: string;
@@ -293,8 +300,24 @@ export function registerChatRoutes(
         availableSkills: listAvailableSkills(soulLoader),
         eagerSkills: listEagerSkills(soulLoader),
       });
+      // Compaction (CTX-V1-001/002): over budget → summarize the oldest turns once into a durable
+      // `summary` row; recent turns stay verbatim. Best-effort — a summarize failure falls back to
+      // the full (filtered) history so the turn still runs. Statelessness preserved: this only
+      // changes which history rows are rendered, not the per-turn reconstruction.
+      const rendered = await compactHistory({
+        docs: history.items,
+        conversationId: convo._id,
+        extraTokens: estimateTokens(system) + estimateTokens(body.message.content),
+        messageRepo,
+        summarize: (transcript) =>
+          generateText({
+            model: llmService.getModel("quick"),
+            prompt: `${SUMMARY_PROMPT}\n\n${transcript}`,
+          }).then((r) => r.text),
+        log: req.log,
+      });
       if (system) messages.push({ role: "system", content: system });
-      messages.push(...history.items.map(toModelMessage), {
+      messages.push(...rendered.map(toModelMessage), {
         role: "user",
         content: body.message.content,
       });

--- a/apps/api/src/chat/schemas.ts
+++ b/apps/api/src/chat/schemas.ts
@@ -3,7 +3,7 @@ export const MessageSchema = {
   properties: {
     _id: { type: "string" },
     conversationId: { type: "string" },
-    role: { type: "string", enum: ["system", "user", "assistant", "tool"] },
+    role: { type: "string", enum: ["system", "user", "assistant", "tool", "summary"] },
     content: {
       oneOf: [
         { type: "string" },

--- a/apps/api/src/memory/limits.ts
+++ b/apps/api/src/memory/limits.ts
@@ -10,3 +10,17 @@ export const MAX_KEY_CHARS = 128;
 export const MAX_TOTAL_CHARS = 2048;
 /** Max sequential LLM steps in one chat turn's tool loop (TOOLS spec: max_tool_calls). */
 export const MAX_TOOL_STEPS = 25;
+
+/**
+ * Conversation compaction budget (CTX-V1-001). When a turn's estimated history token
+ * count exceeds this, the oldest turns are summarized into one `summary` row. Estimate
+ * is a coarse char heuristic (chars/4); value carries headroom under Anthropic's 200k.
+ */
+export const MAX_HISTORY_TOKENS = 120_000;
+/**
+ * How much recent history (estimated tokens) is kept verbatim during compaction. The
+ * newest turns fitting within this budget survive; everything older is summarized. Half
+ * the budget so the post-compaction estimate lands well under `MAX_HISTORY_TOKENS`,
+ * guaranteeing a single summarization pass per overflow (CTX-V1-001).
+ */
+export const RECENT_RETENTION_TOKENS = 60_000;


### PR DESCRIPTION
## What
Adds basic, durable **summarize-oldest** conversation compaction. When a chat turn's estimated history tokens exceed `MAX_HISTORY_TOKENS`, the oldest turns are summarized **once** via the LLM quick tier into a durable `summary` message row; recent turns stay verbatim. Statelessness is preserved — the prompt is still rebuilt every turn; compaction only changes *which* history rows are included.

refs: `specs/CONTEXT-ENGINE.md` §2 — CTX-V1-001 / CTX-V1-002, AC-V1-002.

## How
- **`chat/compaction.ts`** (new) — char-heuristic token estimate (÷4, no tokenizer dep); `applySummaryFilter` runs every turn (drop non-summary rows ≤ the latest summary's cutoff → supersession); `computeCut` keeps the newest rows within `RECENT_RETENTION_TOKENS` and snaps the boundary **back to a `user` row** (valid sequence, tool-call/result pairs never split); `compactHistory` orchestrates one best-effort pass.
- **`chat/messages.ts`** — new `summary` role: `assertValidMessage`, `toModelMessage` → system message, `fromSummary` builder (pins `createdAt` to the cutoff so it orders before the verbatim region).
- **`chat/routes.ts`** — wiring: `assembleSystemPrompt` → `compactHistory` → build `messages`; `summarize` closure via `getModel("quick")` + `generateText`.
- **`chat/schemas.ts`** — `"summary"` added to `MessageSchema.role` enum (list endpoint surfaces summary rows).
- **`memory/limits.ts`** — `MAX_HISTORY_TOKENS` (≈120k) / `RECENT_RETENTION_TOKENS` (≈60k).
- No DB migration — `messages.role` is free `text` (no CHECK).

**Failure handling:** summarize *or* persist failure → graceful skip to full (filtered) history; the turn still runs.

## Validation
- ✅ Over-budget conversation summarizes oldest, recent stays verbatim, run continues.
- ✅ Summary is durable — next turn reuses it; summarizer called once total (one pass per overflow).
- ✅ Statelessness / cacheable-prefix contract intact (`context/assemble.ts` untouched).
- Tests: `compaction.test.ts` (12) + messages summary cases + routes integration (over-budget, durable, single-pass, list visibility, graceful skip).

## Verify (Node 24)
- `pnpm exec biome check` — clean · `pnpm typecheck` — exit 0 · full API suite — **878 passed**.
- Independent review caught one bug (persist outside the try → would 500 the turn); fixed + covered by test.

## Known limitations (deferred)
- A pathologically verbose summary could re-overflow the next turn (concise prompt bounds size; spec is one-pass-*per-overflow*).
- Multi-tier / hierarchical compaction; web UI rendering of the `summary` role; per-model context-window budgets.