### PR TITLE
feat(chat): persist, title, and browse chats + sidebar/model polish

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -101,10 +101,13 @@ attribute. Wiring (`apps/web/app/root.tsx`):
 
 ## Component patterns
 
-- **Sidebar** (`app-sidebar.tsx`): `Workspace` / `System` groups; active row = ruby left-border +
-  `bg-sidebar-accent` + medium weight; collapsible icon rail (`md:w-60 ↔ md:w-14`, persisted) that
-  hides labels and shows a ruby dot for badges; pinned footer (synced theme toggle + instance label);
-  responsive mobile drawer with Escape/focus a11y.
+- **Sidebar** (`app-sidebar.tsx`): a compact, dense, **headerless** nav — a ruby-`[+]` "New chat" row
+  at the top, then the Workspace + System items as one flat list (clusters separated by a subtle gap,
+  no `WORKSPACE`/`SYSTEM` labels); active row = `bg-sidebar-accent` + ruby title + medium weight (no
+  side-stripe — selection is a quiet tint, never a colored left-border); a full-bleed hairline below
+  the nav opens the **session zone** (the scrollable "Recent chats" list); collapsible icon rail
+  (`md:w-60 ↔ md:w-14`, persisted) that hides labels and shows a ruby dot for badges; pinned footer
+  (synced theme toggle + instance label); responsive mobile drawer with Escape/focus a11y.
 - **Empty state** (`empty-state.tsx`): a terminal-window card — `[section]` title bar →
   `$ tulipfarm <section> --list` → `0 results` → title + hint. Depth from border + `--card`.
 - **Chat welcome** (`_app._index.tsx`): the signature moment — blinking ruby block-cursor wordmark,

--- a/apps/api/src/chat/conversations.pg.test.ts
+++ b/apps/api/src/chat/conversations.pg.test.ts
@@ -62,4 +62,35 @@ describe("PgConversationRepo", () => {
   it("returns null for an unknown id", async () => {
     expect(await repo.findById(randomUUID())).toBeNull();
   });
+
+  it("setTitle persists the title without bumping updated_at", async () => {
+    const old = new Date("2020-01-01T00:00:00.000Z");
+    const conv = makeConv({ createdAt: old, updatedAt: old });
+    await repo.create(conv);
+    await repo.setTitle(conv._id, "Inventory Planning");
+    const found = await repo.findById(conv._id);
+    expect(found?.title).toBe("Inventory Planning");
+    expect(found?.updatedAt.getTime()).toBe(old.getTime());
+  });
+
+  it("list returns a user's conversations newest-first, scoped to that user", async () => {
+    const userId = randomUUID();
+    const older = makeConv({ userId, updatedAt: new Date("2021-01-01T00:00:00.000Z") });
+    const newer = makeConv({ userId, updatedAt: new Date("2022-01-01T00:00:00.000Z") });
+    const other = makeConv({ userId: randomUUID() });
+    await repo.create(older);
+    await repo.create(newer);
+    await repo.create(other);
+
+    const list = await repo.list(userId, 10);
+    expect(list.map((c) => c._id)).toEqual([newer._id, older._id]);
+  });
+
+  it("list honors the limit", async () => {
+    const userId = randomUUID();
+    for (let i = 0; i < 3; i++) {
+      await repo.create(makeConv({ userId, updatedAt: new Date(2020 + i, 0, 1) }));
+    }
+    expect(await repo.list(userId, 2)).toHaveLength(2);
+  });
 });

--- a/apps/api/src/chat/conversations.ts
+++ b/apps/api/src/chat/conversations.ts
@@ -8,6 +8,8 @@ export interface ConversationDoc {
   // per-turn `model` override bypasses this without mutating it.
   // TODO: agent-config-derived default model is deferred to a later ticket.
   model?: string;
+  // Quick-model title derived from the first message; null until the async generator fills it in.
+  title?: string;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -18,6 +20,10 @@ export interface ConversationRepo {
   touch(id: string): Promise<void>;
   /** Persist the conversation's active agent (the GeneralAssistant ↔ InformationArchitect handoff). */
   setAgent(id: string, agentId: string): Promise<void>;
+  /** Persist the generated title. Does not bump `updated_at` (it lands after the turn, out of band). */
+  setTitle(id: string, title: string): Promise<void>;
+  /** A user's conversations, newest-first, for the Recent chats sidebar. */
+  list(userId: string, limit: number): Promise<ConversationDoc[]>;
 }
 
 export class ConversationOwnerlessError extends Error {
@@ -33,6 +39,7 @@ function rowToConversation(row: Record<string, unknown>): ConversationDoc {
     userId: (row.user_id as string | null) ?? undefined,
     agentId: (row.agent_id as string | null) ?? undefined,
     model: (row.model as string | null) ?? undefined,
+    title: (row.title as string | null) ?? undefined,
     createdAt: row.created_at as Date,
     updatedAt: row.updated_at as Date,
   };
@@ -80,5 +87,17 @@ export class PgConversationRepo implements ConversationRepo {
       id,
       agentId,
     ]);
+  }
+
+  async setTitle(id: string, title: string): Promise<void> {
+    await this.q.query("UPDATE conversations SET title = $2 WHERE id = $1", [id, title]);
+  }
+
+  async list(userId: string, limit: number): Promise<ConversationDoc[]> {
+    const { rows } = await this.q.query(
+      "SELECT * FROM conversations WHERE user_id = $1 ORDER BY updated_at DESC LIMIT $2",
+      [userId, limit]
+    );
+    return rows.map(rowToConversation);
   }
 }

--- a/apps/api/src/chat/routes.test.ts
+++ b/apps/api/src/chat/routes.test.ts
@@ -182,6 +182,16 @@ class FakeConversationRepo implements ConversationRepo {
       doc.updatedAt = new Date();
     }
   }
+  async setTitle(id: string, title: string): Promise<void> {
+    const doc = this.docs.get(id);
+    if (doc) doc.title = title;
+  }
+  async list(userId: string, limit: number): Promise<ConversationDoc[]> {
+    return [...this.docs.values()]
+      .filter((d) => d.userId === userId)
+      .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())
+      .slice(0, limit);
+  }
 }
 
 // ── Fake message repo ─────────────────────────────────────────────────────────
@@ -1268,10 +1278,60 @@ describe("chat routes", () => {
     });
   });
 
+  describe("GET /api/v1/conversations (Recent chats list)", () => {
+    it("401 without auth", async () => {
+      const res = await get("/api/v1/conversations", { session: null });
+      expect(res.statusCode).toBe(401);
+    });
+
+    it("returns the caller's conversations newest-first with titles, scoped to the user", async () => {
+      const older = randomUUID();
+      const newer = randomUUID();
+      await repo.create({
+        _id: older,
+        userId,
+        createdAt: new Date("2021-01-01"),
+        updatedAt: new Date("2021-01-01"),
+      });
+      await repo.create({
+        _id: newer,
+        userId,
+        createdAt: new Date("2022-01-01"),
+        updatedAt: new Date("2022-01-01"),
+      });
+      await repo.setTitle(newer, "Inventory Planning");
+      // A different user's conversation must not leak into the list.
+      await repo.create({
+        _id: randomUUID(),
+        userId: randomUUID(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const res = await get("/api/v1/conversations");
+      expect(res.statusCode).toBe(200);
+      const { conversations } = res.json() as {
+        conversations: Array<{ id: string; title: string | null }>;
+      };
+      expect(conversations.map((c) => c.id)).toEqual([newer, older]);
+      expect(conversations[0].title).toBe("Inventory Planning");
+      expect(conversations[1].title).toBeNull();
+    });
+  });
+
   describe("GET /api/v1/conversations/:id", () => {
     it("401 without auth", async () => {
       const res = await get(`/api/v1/conversations/${randomUUID()}`, { session: null });
       expect(res.statusCode).toBe(401);
+    });
+
+    it("includes the title (null until generated)", async () => {
+      const convoId = randomUUID();
+      const now = new Date();
+      await repo.create({ _id: convoId, userId, createdAt: now, updatedAt: now });
+      await repo.setTitle(convoId, "Budget Review");
+      const res = await get(`/api/v1/conversations/${convoId}`);
+      expect(res.json().title).toBe("Budget Review");
     });
 
     it("200 returns the conversation metadata for a seeded convo", async () => {

--- a/apps/api/src/chat/routes.ts
+++ b/apps/api/src/chat/routes.ts
@@ -42,6 +42,7 @@ import { writeSseHeaders } from "./sse";
 import { makeStreamEmitter } from "./stream-emitter";
 import type { StreamHub } from "./stream-hub";
 import type { StreamResumeRepo } from "./stream-resume";
+import { buildAndStoreTitle } from "./title";
 
 type PreHandler = (req: FastifyRequest, reply: FastifyReply) => Promise<void>;
 
@@ -256,6 +257,16 @@ export function registerChatRoutes(
         };
         await repo.create(convo);
         isNew = true;
+        // Best-effort, off the turn's critical path: derive a title from the first message via the
+        // quick tier and persist it asynchronously. The stream below is never blocked on this, and a
+        // failure (quick tier down, persistence error) degrades to a truncated-prompt fallback.
+        void buildAndStoreTitle({
+          repo,
+          getModel: () => llmService.getModel("quick"),
+          id: convo._id,
+          prompt: body.message.content,
+          log: req.log,
+        });
       }
 
       // 2. Resolve the model synchronously so a bad request returns before headers go out.
@@ -622,6 +633,54 @@ export function registerChatRoutes(
   );
 
   app.get(
+    "/api/v1/conversations",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description: "List the authenticated user's conversations, newest-first (Recent chats).",
+        tags: ["chat"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        response: {
+          200: {
+            type: "object",
+            properties: {
+              conversations: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    id: { type: "string" },
+                    title: { type: ["string", "null"] },
+                    agentId: { type: ["string", "null"] },
+                    createdAt: { type: "string" },
+                    updatedAt: { type: "string" },
+                  },
+                  required: ["id", "title", "agentId", "createdAt", "updatedAt"],
+                },
+              },
+            },
+            required: ["conversations"],
+          },
+          401: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const user = req.user as UserDoc;
+      const convos = await repo.list(user._id, 50);
+      return reply.send({
+        conversations: convos.map((c) => ({
+          id: c._id,
+          title: c.title ?? null,
+          agentId: c.agentId ?? null,
+          createdAt: c.createdAt,
+          updatedAt: c.updatedAt,
+        })),
+      });
+    }
+  );
+
+  app.get(
     "/api/v1/conversations/:id",
     {
       preHandler: requireAuth,
@@ -642,6 +701,7 @@ export function registerChatRoutes(
               userId: { type: ["string", "null"] },
               agentId: { type: ["string", "null"] },
               model: { type: ["string", "null"] },
+              title: { type: ["string", "null"] },
               createdAt: { type: "string" },
               updatedAt: { type: "string" },
             },
@@ -663,6 +723,7 @@ export function registerChatRoutes(
         userId: convo.userId ?? null,
         agentId: convo.agentId ?? null,
         model: convo.model ?? null,
+        title: convo.title ?? null,
         createdAt: convo.createdAt,
         updatedAt: convo.updatedAt,
       });

--- a/apps/api/src/chat/title.test.ts
+++ b/apps/api/src/chat/title.test.ts
@@ -1,0 +1,118 @@
+import type { LanguageModelV3 } from "@ai-sdk/provider";
+import type { LanguageModel } from "ai";
+import { describe, expect, it, vi } from "vitest";
+import { buildAndStoreTitle, buildConversationTitle, fallbackTitle, sanitizeTitle } from "./title";
+
+const silentLog = { warn: () => undefined };
+
+const V3_USAGE = {
+  inputTokens: { total: 1, noCache: undefined, cacheRead: undefined, cacheWrite: undefined },
+  outputTokens: { total: 1, reasoning: undefined },
+};
+
+// Non-streaming fake model whose doGenerate returns fixed text (mirrors the quick-tier mock in
+// routes.test.ts). `null` text simulates a model failure path via a thrown doGenerate.
+function makeTitleModel(text: string | null): LanguageModel {
+  return {
+    specificationVersion: "v3",
+    provider: "test",
+    modelId: "quick-model",
+    supportedUrls: {},
+    doStream: vi.fn(async () => {
+      throw new Error("doStream unused");
+    }),
+    doGenerate: vi.fn(async () => {
+      if (text === null) throw new Error("model exploded");
+      return {
+        content: [{ type: "text", text }],
+        finishReason: { unified: "stop", raw: undefined },
+        usage: V3_USAGE,
+        warnings: [],
+      };
+    }),
+  } as unknown as LanguageModelV3 as unknown as LanguageModel;
+}
+
+describe("sanitizeTitle", () => {
+  it("strips surrounding quotes, collapses whitespace, drops trailing punctuation", () => {
+    expect(sanitizeTitle('  "Inventory   Planning Help."\n')).toBe("Inventory Planning Help");
+  });
+
+  it("bounds the length to 80 chars", () => {
+    expect(sanitizeTitle("x".repeat(120))).toHaveLength(80);
+  });
+});
+
+describe("fallbackTitle", () => {
+  it("uses the first non-empty line, truncated to 60 chars", () => {
+    expect(fallbackTitle("\n\nhelp me plan inventory\nsecond line")).toBe("help me plan inventory");
+    expect(fallbackTitle("y".repeat(90))).toHaveLength(60);
+  });
+
+  it("returns 'New chat' for an empty prompt", () => {
+    expect(fallbackTitle("   \n  ")).toBe("New chat");
+  });
+});
+
+describe("buildConversationTitle", () => {
+  it("returns the sanitized model output", async () => {
+    const title = await buildConversationTitle(makeTitleModel('"Q3 Inventory Plan"'), "...");
+    expect(title).toBe("Q3 Inventory Plan");
+  });
+
+  it("falls back to the truncated prompt when the model throws", async () => {
+    const title = await buildConversationTitle(makeTitleModel(null), "help me plan inventory");
+    expect(title).toBe("help me plan inventory");
+  });
+
+  it("falls back when the model returns blank text", async () => {
+    const title = await buildConversationTitle(makeTitleModel("   "), "fix the budget sheet");
+    expect(title).toBe("fix the budget sheet");
+  });
+});
+
+describe("buildAndStoreTitle", () => {
+  it("persists the generated title", async () => {
+    const setTitle = vi.fn(async () => undefined);
+    await buildAndStoreTitle({
+      repo: { setTitle },
+      getModel: () => makeTitleModel("Q3 Plan"),
+      id: "c1",
+      prompt: "plan q3",
+      log: silentLog,
+    });
+    expect(setTitle).toHaveBeenCalledWith("c1", "Q3 Plan");
+  });
+
+  it("persists the fallback title when the quick tier is unavailable (getModel throws)", async () => {
+    const setTitle = vi.fn(async () => undefined);
+    await buildAndStoreTitle({
+      repo: { setTitle },
+      getModel: () => {
+        throw new Error("quick tier not configured");
+      },
+      id: "c1",
+      prompt: "help me plan inventory",
+      log: silentLog,
+    });
+    expect(setTitle).toHaveBeenCalledWith("c1", "help me plan inventory");
+  });
+
+  it("swallows a persistence failure (a missing title is non-fatal)", async () => {
+    const warn = vi.fn();
+    await expect(
+      buildAndStoreTitle({
+        repo: {
+          setTitle: async () => {
+            throw new Error("db down");
+          },
+        },
+        getModel: () => makeTitleModel("X"),
+        id: "c1",
+        prompt: "p",
+        log: { warn },
+      })
+    ).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/chat/title.ts
+++ b/apps/api/src/chat/title.ts
@@ -1,0 +1,75 @@
+import { generateText, type LanguageModel } from "ai";
+import type { ConversationRepo } from "./conversations";
+
+/*
+ * Conversation title generation. A new chat's title is derived from the user's first message by the
+ * quick LLM tier (mirrors the compaction summarizer's one-shot `generateText` in routes.ts). It is
+ * best-effort and never on the turn's critical path: any failure (model not configured, timeout,
+ * empty output) degrades to a truncated-prompt fallback so a chat always gets a usable label.
+ */
+
+const TITLE_PROMPT =
+  "Write a short, specific title (3-6 words) for a chat that opens with the user message below. " +
+  "Plain text only: no surrounding quotes, no trailing punctuation, no markdown, no preamble. " +
+  "Reply with the title and nothing else.\n\nUser message:";
+
+const MAX_TITLE_LEN = 80;
+const MAX_FALLBACK_LEN = 60;
+
+/** Collapse a raw model title into a single clean line, stripped of quotes/markdown and bounded. */
+export function sanitizeTitle(raw: string): string {
+  return raw
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/^["'`]+|["'`]+$/g, "")
+    .replace(/[.,;:!?]+$/, "")
+    .trim()
+    .slice(0, MAX_TITLE_LEN)
+    .trim();
+}
+
+/** Deterministic title when the model is unavailable: the first line of the prompt, bounded. */
+export function fallbackTitle(firstPrompt: string): string {
+  const firstLine = firstPrompt.split("\n").find((l) => l.trim().length > 0) ?? "";
+  return firstLine.trim().slice(0, MAX_FALLBACK_LEN).trim() || "New chat";
+}
+
+/** Generate a title from the first user message; falls back on any failure or empty output. */
+export async function buildConversationTitle(
+  model: LanguageModel,
+  firstPrompt: string
+): Promise<string> {
+  try {
+    const { text } = await generateText({ model, prompt: `${TITLE_PROMPT} ${firstPrompt}` });
+    return sanitizeTitle(text) || fallbackTitle(firstPrompt);
+  } catch {
+    return fallbackTitle(firstPrompt);
+  }
+}
+
+/**
+ * Detached, best-effort title generation for a freshly created conversation. Fire-and-forget from
+ * the chat route (`void buildAndStoreTitle(...)`) so it never blocks the stream. `getModel` is a thunk
+ * so a quick-tier-not-configured throw degrades to the truncated-prompt fallback; a persistence
+ * failure is swallowed with a warning (a missing title is non-fatal).
+ */
+export async function buildAndStoreTitle(args: {
+  repo: Pick<ConversationRepo, "setTitle">;
+  getModel: () => LanguageModel;
+  id: string;
+  prompt: string;
+  log: { warn: (obj: Record<string, unknown>, msg: string) => void };
+}): Promise<void> {
+  const { repo, getModel, id, prompt, log } = args;
+  try {
+    let title: string;
+    try {
+      title = await buildConversationTitle(getModel(), prompt);
+    } catch {
+      title = fallbackTitle(prompt);
+    }
+    await repo.setTitle(id, title);
+  } catch (err) {
+    log.warn({ err, conversationId: id }, "title persistence failed");
+  }
+}

--- a/apps/api/src/knowledge/migration.pg.test.ts
+++ b/apps/api/src/knowledge/migration.pg.test.ts
@@ -46,9 +46,9 @@ describe("002_knowledge migration on PGlite", () => {
     await db.close();
   });
 
-  it("bumps schema_version to the latest (4)", async () => {
+  it("bumps schema_version to the latest (5)", async () => {
     const { rows } = await db.query("SELECT version FROM schema_version WHERE id = true");
-    expect(Number((rows[0] as { version: number }).version)).toBe(4);
+    expect(Number((rows[0] as { version: number }).version)).toBe(5);
   });
 
   it("creates all five knowledge tables", async () => {

--- a/apps/api/src/pg-migrate.test.ts
+++ b/apps/api/src/pg-migrate.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { runPgMigrations } from "./pg-migrate";
 import { makePglite } from "./test/pglite";
 
-describe("runPgMigrations — 001_init + 002_knowledge + 003_stream_resume + 004_approvals on PGlite", () => {
+describe("runPgMigrations — 001_init + 002_knowledge + 003_stream_resume + 004_approvals + 005_conversation_title on PGlite", () => {
   let db: PGlite;
 
   beforeEach(async () => {
@@ -14,10 +14,10 @@ describe("runPgMigrations — 001_init + 002_knowledge + 003_stream_resume + 004
     await db.close();
   });
 
-  it("advances schema_version to the latest (4)", async () => {
+  it("advances schema_version to the latest (5)", async () => {
     await runPgMigrations(db);
     const res = await db.query<{ version: number }>("SELECT version FROM schema_version");
-    expect(res.rows.map((r) => Number(r.version))).toEqual([4]);
+    expect(res.rows.map((r) => Number(r.version))).toEqual([5]);
   });
 
   it("creates the vector and citext extensions", async () => {
@@ -73,11 +73,23 @@ describe("runPgMigrations — 001_init + 002_knowledge + 003_stream_resume + 004
     ]);
   });
 
-  it("is idempotent — a second run does not throw and leaves version at 4", async () => {
+  it("is idempotent — a second run does not throw and leaves version at 5", async () => {
     await runPgMigrations(db);
     await runPgMigrations(db);
     const res = await db.query<{ version: number }>("SELECT version FROM schema_version");
-    expect(res.rows.map((r) => Number(r.version))).toEqual([4]);
+    expect(res.rows.map((r) => Number(r.version))).toEqual([5]);
+  });
+
+  it("adds the conversations.title column and the user/updated_at index (005)", async () => {
+    await runPgMigrations(db);
+    const col = await db.query<{ column_name: string }>(
+      "SELECT column_name FROM information_schema.columns WHERE table_name = 'conversations' AND column_name = 'title'"
+    );
+    expect(col.rows.map((r) => r.column_name)).toEqual(["title"]);
+    const idx = await db.query<{ indexname: string }>(
+      "SELECT indexname FROM pg_indexes WHERE indexname = 'conversations_user_updated_idx'"
+    );
+    expect(idx.rows.map((r) => r.indexname)).toEqual(["conversations_user_updated_idx"]);
   });
 
   it("enforces the conversations owner CHECK", async () => {

--- a/apps/api/src/pg-migrations/index.ts
+++ b/apps/api/src/pg-migrations/index.ts
@@ -190,6 +190,16 @@ const APPROVALS_STATEMENTS: string[] = [
   "CREATE INDEX IF NOT EXISTS approvals_status_expires_idx ON approvals (status, expires_at)",
 ];
 
+/**
+ * Conversation titles (UUID-chat persistence). A nullable `title` filled in asynchronously by the
+ * quick-tier title generator after the first turn, plus a `(user_id, updated_at)` index backing the
+ * newest-first "Recent chats" sidebar list. Idempotent `ALTER`/`CREATE` so re-runs are safe.
+ */
+const CONVERSATION_TITLE_STATEMENTS: string[] = [
+  "ALTER TABLE conversations ADD COLUMN IF NOT EXISTS title text",
+  "CREATE INDEX IF NOT EXISTS conversations_user_updated_idx ON conversations (user_id, updated_at)",
+];
+
 export const PG_MIGRATIONS: PgMigration[] = [
   {
     version: 1,
@@ -223,6 +233,15 @@ export const PG_MIGRATIONS: PgMigration[] = [
     description: "approvals: approval-gate table for tool-call and routine human_approval states",
     up: async (q) => {
       for (const sql of APPROVALS_STATEMENTS) {
+        await q.query(sql);
+      }
+    },
+  },
+  {
+    version: 5,
+    description: "conversations.title + (user_id, updated_at) index for the Recent chats list",
+    up: async (q) => {
+      for (const sql of CONVERSATION_TITLE_STATEMENTS) {
         await q.query(sql);
       }
     },

--- a/apps/web/app/components/app-sidebar.test.tsx
+++ b/apps/web/app/components/app-sidebar.test.tsx
@@ -4,11 +4,16 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, expect, test, vi } from "vitest";
 import { AppSidebar } from "~/components/app-sidebar";
 import * as approvalsContext from "~/lib/approvals-context";
+import * as conversationsContext from "~/lib/conversations-context";
 
 // The badge count now comes from the live ApprovalsProvider context (inert fallback is covered in
 // approvals-context.test.tsx); mock the hook here for deterministic counts.
 vi.mock("~/lib/approvals-context", () => ({ useApprovals: vi.fn() }));
 const useApprovals = vi.mocked(approvalsContext.useApprovals);
+
+// Recent chats read the shared ConversationsProvider; mock it for deterministic lists.
+vi.mock("~/lib/conversations-context", () => ({ useConversations: vi.fn() }));
+const useConversations = vi.mocked(conversationsContext.useConversations);
 
 const Stub = createRemixStub([{ path: "/", Component: AppSidebar }]);
 
@@ -20,6 +25,16 @@ beforeEach(() => {
     loading: false,
     error: null,
     refresh: vi.fn(),
+  });
+  useConversations.mockReturnValue({
+    conversations: [],
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+    activeChatId: null,
+    setActiveChatId: vi.fn(),
+    newChatNonce: 0,
+    startNewChat: vi.fn(),
   });
 });
 
@@ -63,11 +78,87 @@ test("renders the live Approvals badge count from context", () => {
   expect(within(approvalsLink).getByText("2")).toBeInTheDocument();
 });
 
-test("groups nav into Workspace/System and shows a footer theme toggle", () => {
+test("renders a compact headerless nav (no Workspace/System section labels) + footer theme toggle", () => {
   render(<Stub initialEntries={["/"]} />);
-  expect(screen.getByText("Workspace")).toBeInTheDocument();
-  expect(screen.getByText("System")).toBeInTheDocument();
+  // Section headers were dropped for Claude-style density; the nav items themselves still render.
+  expect(screen.queryByText("Workspace")).not.toBeInTheDocument();
+  expect(screen.queryByText("System")).not.toBeInTheDocument();
+  expect(screen.getByRole("link", { name: "Chat" })).toBeInTheDocument();
   expect(screen.getByRole("button", { name: /toggle dark mode/i })).toBeInTheDocument();
+});
+
+test("renders a Recent chats list linking each conversation to /chat/:id", () => {
+  useConversations.mockReturnValue({
+    conversations: [
+      { id: "c1", title: "Inventory Planning", agentId: null, createdAt: "t", updatedAt: "t" },
+      { id: "c2", title: null, agentId: null, createdAt: "t", updatedAt: "t" },
+    ],
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+    activeChatId: null,
+    setActiveChatId: vi.fn(),
+    newChatNonce: 0,
+    startNewChat: vi.fn(),
+  });
+  render(<Stub initialEntries={["/"]} />);
+  expect(screen.getByText("Recent chats")).toBeInTheDocument();
+  expect(screen.getByRole("link", { name: "Inventory Planning" })).toHaveAttribute(
+    "href",
+    "/chat/c1"
+  );
+  // A conversation whose async title has not landed yet falls back to "New chat".
+  expect(screen.getByRole("link", { name: "New chat" })).toHaveAttribute("href", "/chat/c2");
+});
+
+test("highlights the active conversation and un-highlights Chat (shallow-routing aware)", () => {
+  useConversations.mockReturnValue({
+    conversations: [
+      { id: "c1", title: "Inventory Planning", agentId: null, createdAt: "t", updatedAt: "t" },
+      { id: "c2", title: "Budget Review", agentId: null, createdAt: "t", updatedAt: "t" },
+    ],
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+    // A chat opened via shallow replaceState: router location is still "/".
+    activeChatId: "c1",
+    setActiveChatId: vi.fn(),
+    newChatNonce: 0,
+    startNewChat: vi.fn(),
+  });
+  render(<Stub initialEntries={["/"]} />);
+
+  // The active conversation carries aria-current=page; the other does not.
+  expect(screen.getByRole("link", { name: "Inventory Planning" })).toHaveAttribute(
+    "aria-current",
+    "page"
+  );
+  expect(screen.getByRole("link", { name: "Budget Review" })).not.toHaveAttribute("aria-current");
+  // Even though the router still reads "/", the Chat nav item is NOT marked active.
+  expect(screen.getByRole("link", { name: "Chat" })).not.toHaveAttribute("aria-current", "page");
+});
+
+test("renders a New chat button that calls startNewChat", async () => {
+  const user = userEvent.setup();
+  const startNewChat = vi.fn();
+  useConversations.mockReturnValue({
+    conversations: [],
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+    activeChatId: null,
+    setActiveChatId: vi.fn(),
+    newChatNonce: 0,
+    startNewChat,
+  });
+  render(<Stub initialEntries={["/"]} />);
+  await user.click(screen.getByRole("button", { name: /new chat/i }));
+  expect(startNewChat).toHaveBeenCalledTimes(1);
+});
+
+test("renders no Recent chats section when there are no conversations", () => {
+  render(<Stub initialEntries={["/"]} />);
+  expect(screen.queryByText("Recent chats")).not.toBeInTheDocument();
 });
 
 test("collapsing the sidebar hides labels and persists the choice", async () => {

--- a/apps/web/app/components/app-sidebar.tsx
+++ b/apps/web/app/components/app-sidebar.tsx
@@ -1,10 +1,11 @@
-import { NavLink } from "@remix-run/react";
+import { Link, NavLink } from "@remix-run/react";
 import { Menu, PanelLeftClose, PanelLeftOpen, X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { ThemeToggle } from "~/components/theme-toggle";
 import { useApprovals } from "~/lib/approvals-context";
 import type { BadgeKey } from "~/lib/badges";
-import { type NavItem, navGroups, navItems } from "~/lib/nav";
+import { useConversations } from "~/lib/conversations-context";
+import { type NavItem, navItems } from "~/lib/nav";
 import { cn } from "~/lib/utils";
 
 const COLLAPSED_KEY = "sidebar-collapsed";
@@ -25,32 +26,31 @@ function NavRow({
   item,
   rail,
   onNavigate,
+  activeOverride,
 }: {
   item: NavItem;
   rail: boolean;
   onNavigate: () => void;
+  // When set, replaces the router's `isActive` — used to keep "Chat" un-highlighted while a specific
+  // conversation is open (its URL was shallow-set via replaceState, so the router still reads "/").
+  activeOverride?: boolean;
 }) {
   const { to, label, icon: Icon, end, badgeKey } = item;
   // Live badge counts from the shared ApprovalsProvider (inert 0 when no provider is mounted).
   const { count: approvalsCount } = useApprovals();
   const liveCounts: Partial<Record<BadgeKey, number>> = { approvals: approvalsCount };
   const count = badgeKey ? (liveCounts[badgeKey] ?? 0) : 0;
-  return (
-    <NavLink
-      to={to}
-      end={end}
-      onClick={onNavigate}
-      title={rail ? label : undefined}
-      className={({ isActive }) =>
-        cn(
-          "flex items-center gap-2 rounded-sm border-l-2 py-2 text-sm transition-colors",
-          rail ? "justify-center px-2" : "px-3",
-          isActive
-            ? "border-primary bg-sidebar-accent text-sidebar-primary font-medium"
-            : "border-transparent text-sidebar-foreground hover:bg-sidebar-accent/50"
-        )
-      }
-    >
+
+  const rowClass = (active: boolean) =>
+    cn(
+      "flex items-center gap-2 rounded-sm py-1.5 text-sm transition-colors",
+      rail ? "justify-center px-2" : "px-3",
+      active
+        ? "bg-sidebar-accent font-medium text-sidebar-primary"
+        : "text-sidebar-foreground hover:bg-sidebar-accent/50"
+    );
+  const content = (
+    <>
       <span className="relative flex">
         <Icon className="size-4 shrink-0" />
         {rail && count > 0 ? (
@@ -70,7 +70,106 @@ function NavRow({
           ) : null}
         </>
       )}
+    </>
+  );
+
+  // With an explicit override (the "Chat" item while a shallow-routed conversation is open) the
+  // router's isActive is wrong, so render a plain Link with fully manual active + aria-current.
+  if (activeOverride !== undefined) {
+    return (
+      <Link
+        to={to}
+        onClick={onNavigate}
+        title={rail ? label : undefined}
+        aria-current={activeOverride ? "page" : undefined}
+        className={rowClass(activeOverride)}
+      >
+        {content}
+      </Link>
+    );
+  }
+  return (
+    <NavLink
+      to={to}
+      end={end}
+      onClick={onNavigate}
+      title={rail ? label : undefined}
+      className={({ isActive }) => rowClass(isActive)}
+    >
+      {content}
     </NavLink>
+  );
+}
+
+// The primary "start a fresh chat" action, pinned at the very top of the nav (above Workspace). A
+// quiet borderless row (matching the nav vocabulary, not a heavy boxed CTA); the ruby `[+]` glyph —
+// the project's terminal-native action motif — carries its primary-action weight. Routes to "/" and
+// forces a clean transcript (via startNewChat's remount nonce) even from a shallow-routed chat.
+function NewChatButton({ rail, onNavigate }: { rail: boolean; onNavigate: () => void }) {
+  const { startNewChat } = useConversations();
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        startNewChat();
+        onNavigate();
+      }}
+      title={rail ? "New chat" : undefined}
+      className={cn(
+        "flex shrink-0 items-center gap-2 rounded-sm py-1.5 text-sm text-sidebar-foreground transition-colors hover:bg-sidebar-accent/50",
+        rail ? "justify-center px-2" : "px-3"
+      )}
+    >
+      <span aria-hidden className="font-medium text-primary">
+        [+]
+      </span>
+      {rail ? null : <span className="font-medium">New chat</span>}
+    </button>
+  );
+}
+
+// Persisted chat history (UUID-chat persistence). Reads the shared ConversationsProvider; hidden in
+// the collapsed rail and when there are no chats yet. Titles are quick-model generated (or "New chat"
+// until one lands). Active state lights up the conversation matching the current /chat/:id route.
+function RecentChats({ rail, onNavigate }: { rail: boolean; onNavigate: () => void }) {
+  const { conversations, activeChatId } = useConversations();
+  if (rail || conversations.length === 0) {
+    return null;
+  }
+  return (
+    // The session zone: separated from the persistent nav by a full-bleed hairline (depth from
+    // borders, not boxes; `-mx-2 px-2` bleeds the rule edge-to-edge while keeping content aligned).
+    // flex-1 + min-h-0 claims the leftover height; the label stays pinned, only the list below scrolls.
+    <div className="-mx-2 mt-2 flex min-h-0 flex-1 flex-col border-t border-sidebar-border px-2 pt-2">
+      <p className="shrink-0 px-3 pb-1 text-[0.625rem] font-medium uppercase tracking-[0.2em] text-muted-foreground">
+        Recent chats
+      </p>
+      <div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto">
+        {conversations.map((c) => {
+          // Active state comes from the provider's `activeChatId` (not NavLink's router-only isActive)
+          // so a chat opened via shallow replaceState still highlights correctly. No side-stripe — the
+          // selection reads as a quiet background tint + ruby title, consistent with the nav rows.
+          const active = c.id === activeChatId;
+          return (
+            <Link
+              key={c.id}
+              to={`/chat/${c.id}`}
+              onClick={onNavigate}
+              title={c.title ?? "New chat"}
+              aria-current={active ? "page" : undefined}
+              className={cn(
+                "flex shrink-0 items-center rounded-sm px-3 py-1.5 text-sm transition-colors",
+                active
+                  ? "bg-sidebar-accent font-medium text-sidebar-primary"
+                  : "text-sidebar-foreground hover:bg-sidebar-accent/50"
+              )}
+            >
+              <span className="truncate">{c.title ?? "New chat"}</span>
+            </Link>
+          );
+        })}
+      </div>
+    </div>
   );
 }
 
@@ -81,6 +180,9 @@ export function AppSidebar() {
   const [isDesktop, setIsDesktop] = useState(true);
   const navRef = useRef<HTMLElement>(null);
   const close = () => setOpen(false);
+  // When a conversation is open, the "Chat" item (to "/") must not also light up — its URL was
+  // shallow-set, so the router still reads "/" and would otherwise mark it active.
+  const { activeChatId } = useConversations();
 
   // Collapse only applies on desktop; the mobile drawer always shows full labels.
   const rail = collapsed && isDesktop;
@@ -186,21 +288,23 @@ export function AppSidebar() {
             <X className="size-5" />
           </button>
         </div>
-        <nav className="flex flex-1 flex-col gap-4 overflow-y-auto p-2">
-          {navGroups.map((group) => (
-            <div key={group} className="flex flex-col gap-1">
-              {rail ? null : (
-                <p className="px-3 pb-1 text-[0.625rem] font-medium uppercase tracking-[0.2em] text-muted-foreground">
-                  {group}
-                </p>
-              )}
-              {navItems
-                .filter((item) => item.group === group)
-                .map((item) => (
-                  <NavRow key={item.to} item={item} rail={rail} onNavigate={close} />
-                ))}
-            </div>
-          ))}
+        <nav className="flex min-h-0 flex-1 flex-col p-2">
+          {/* Fixed top: the primary "New chat" action, then one flat, uniformly-spaced nav list (no
+              section headers, no per-group divs — `navItems` is already ordered Workspace→System, so a
+              single map keeps every row gap identical and hover-continuous). Never scrolls. */}
+          <div className="flex shrink-0 flex-col gap-0.5">
+            <NewChatButton rail={rail} onNavigate={close} />
+            {navItems.map((item) => (
+              <NavRow
+                key={item.to}
+                item={item}
+                rail={rail}
+                onNavigate={close}
+                activeOverride={item.to === "/" && activeChatId !== null ? false : undefined}
+              />
+            ))}
+          </div>
+          <RecentChats rail={rail} onNavigate={close} />
         </nav>
 
         {/* Footer: synced theme toggle + instance label (icon-only when railed). */}

--- a/apps/web/app/components/chat/README.md
+++ b/apps/web/app/components/chat/README.md
@@ -17,6 +17,17 @@ POST /api/v1/chat ─SSE→ lib/chat/sse-client.ts (parse frames → ChatEvent)
 transcript on first send. `composer.tsx` has the prompt input + model selector + autonomy control and
 **no attachment affordance** (no blob storage in V1).
 
+## Persistence & history
+
+Conversations persist server-side (UUID id, auto-created on the first turn). On that first turn the API
+generates a **title** from the message via the quick LLM tier (async, non-blocking — see
+`apps/api/src/chat/title.ts`). The shell holds the list in `lib/conversations-context.tsx`
+(`GET /api/v1/conversations`, refetched on route change + on each turn via `onConversationChange`), which
+`app-sidebar.tsx` renders as **Recent chats**. Clicking one opens `/chat/:id` (`_app.chat.$id.tsx`),
+whose loader fetches the conversation + messages and rehydrates the timeline via `lib/chat/hydrate.ts`
+(`messagesToTimeline`) so `useChatStream({ initialMessages })` seeds a sealed transcript; follow-up turns
+reuse the same id. "+ new chat" links back to `/`.
+
 ## Component → event
 
 | Component | Driven by |
@@ -24,7 +35,7 @@ transcript on first send. `composer.tsx` has the prompt input + model selector +
 | `parts.tsx` Response (text) | `text` (live) |
 | `parts.tsx` tool block + `approval-card.tsx` | `tool-call`/`tool-result` + `approval-request`/`approval-resolved` (live) |
 | `parts.tsx` reasoning / plan / task / sources / agent-handoff / a2ui (`<A2uiFrame>`) | **contract-only** — typed + rendered now, light up when the backend emits |
-| `model-selector.tsx` | sets POST `model` (tiers + auto) |
+| `model-selector.tsx` | sets POST `model` — a portalled dropdown over quick/standard/complex (signal-bar intensity icons); each option explains the tier (line 1) and lists its configured models (line 2, from `GET /api/v1/llm-config`) |
 | `autonomy-control.tsx` | sets POST `autonomy`; `approval-required` arms the live tool-approval gate |
 
 ## Approval round-trip (live)

--- a/apps/web/app/components/chat/chat-panel.tsx
+++ b/apps/web/app/components/chat/chat-panel.tsx
@@ -1,4 +1,4 @@
-import type { ModelTier } from "~/lib/chat/types";
+import type { ChatMessage, ModelTier } from "~/lib/chat/types";
 import { useChatStream } from "~/lib/chat/use-chat-stream";
 import type { Suggestion } from "~/lib/onboarding";
 import { Composer } from "./composer";
@@ -53,13 +53,22 @@ export function ChatPanel({
   agentId,
   defaultModel = "standard",
   suggestions = [],
+  initialConversationId,
+  initialMessages,
+  onConversationChange,
 }: {
   agentId?: string;
   defaultModel?: ModelTier;
   suggestions?: Suggestion[];
+  initialConversationId?: string;
+  initialMessages?: ChatMessage[];
+  onConversationChange?: (conversationId: string | undefined) => void;
 }) {
-  const { messages, status, error, send, approve, regenerate, reset, sendA2uiAgent } =
-    useChatStream();
+  const { messages, status, error, send, approve, regenerate, sendA2uiAgent } = useChatStream({
+    initialConversationId,
+    initialMessages,
+    onConversationChange,
+  });
   const busy = status === "submitted" || status === "streaming";
   const agent = agentId || "GeneralAssistant";
   const hasMessages = messages.length > 0;
@@ -70,13 +79,6 @@ export function ChatPanel({
         <header className="flex shrink-0 items-center gap-2 border-b border-border px-6 py-2.5">
           <span aria-hidden className="size-1.5 rounded-full bg-primary" />
           <span className="text-xs text-muted-foreground">{agent}</span>
-          <button
-            type="button"
-            onClick={reset}
-            className="ml-auto inline-flex items-center gap-1 rounded-sm border border-border px-2 py-1 text-xs text-muted-foreground transition-colors hover:border-primary hover:text-foreground"
-          >
-            <span aria-hidden>+</span> new chat
-          </button>
         </header>
       ) : null}
       {hasMessages ? (

--- a/apps/web/app/components/chat/composer.test.tsx
+++ b/apps/web/app/components/chat/composer.test.tsx
@@ -3,12 +3,21 @@ import userEvent from "@testing-library/user-event";
 import { expect, test, vi } from "vitest";
 import { Composer } from "~/components/chat/composer";
 
+// The model selector reads GET /api/v1/llm-config on mount for its tooltips; stub it so the composer
+// renders without a network call.
+vi.mock("~/lib/settings", () => ({
+  getLlmConfig: vi.fn().mockResolvedValue({
+    tiers: { quick: { providers: [] }, standard: { providers: [] }, complex: { providers: [] } },
+  }),
+}));
+
 test("Model Selector sets the per-message model override on send", async () => {
   const user = userEvent.setup();
   const onSend = vi.fn();
   render(<Composer onSend={onSend} />);
 
-  await user.selectOptions(screen.getByLabelText("Model"), "complex");
+  await user.click(screen.getByRole("button", { name: /^Model:/ }));
+  await user.click(screen.getByRole("button", { name: "complex" }));
   await user.type(screen.getByLabelText("Message"), "do it");
   await user.click(screen.getByRole("button", { name: "send" }));
 

--- a/apps/web/app/components/chat/model-selector.test.tsx
+++ b/apps/web/app/components/chat/model-selector.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { expect, test, vi } from "vitest";
+import { ModelSelector } from "~/components/chat/model-selector";
+
+vi.mock("~/lib/settings", () => ({
+  getLlmConfig: vi.fn().mockResolvedValue({
+    tiers: {
+      quick: { providers: [{ provider: "azure", model: "gpt-4o-mini" }] },
+      standard: {
+        providers: [
+          { provider: "anthropic", model: "claude-sonnet-4-6" },
+          { provider: "openai", model: "gpt-4o" },
+        ],
+      },
+      complex: { providers: [] },
+    },
+  }),
+}));
+
+const openMenu = async (user: ReturnType<typeof userEvent.setup>) =>
+  user.click(screen.getByRole("button", { name: /^Model:/ }));
+
+test("the trigger shows the active tier and the menu is closed until opened", () => {
+  render(<ModelSelector value="standard" onChange={vi.fn()} />);
+  expect(screen.getByRole("button", { name: "Model: standard" })).toBeInTheDocument();
+  // Options only exist once the dropdown is open.
+  expect(screen.queryByRole("button", { name: "quick" })).not.toBeInTheDocument();
+});
+
+test("opening the dropdown offers all three tiers including quick", async () => {
+  const user = userEvent.setup();
+  render(<ModelSelector value="standard" onChange={vi.fn()} />);
+  await openMenu(user);
+  for (const tier of ["quick", "standard", "complex"]) {
+    expect(screen.getByRole("button", { name: tier })).toBeInTheDocument();
+  }
+});
+
+test("selecting a tier calls onChange with its id", async () => {
+  const user = userEvent.setup();
+  const onChange = vi.fn();
+  render(<ModelSelector value="standard" onChange={onChange} />);
+  await openMenu(user);
+  await user.click(screen.getByRole("button", { name: "quick" }));
+  expect(onChange).toHaveBeenCalledWith("quick");
+});
+
+test("each option explains the tier (line 1) and lists its models (line 2)", async () => {
+  const user = userEvent.setup();
+  render(<ModelSelector value="standard" onChange={vi.fn()} />);
+  await openMenu(user);
+  // Line 1: what the tier means.
+  expect(screen.getByText("Fast & low-cost — short answers, simple tasks")).toBeInTheDocument();
+  // Line 2: the models configured for the tier (all providers, comma-joined).
+  await waitFor(() => {
+    expect(screen.getByText("azure / gpt-4o-mini")).toBeInTheDocument();
+  });
+  expect(screen.getByText("anthropic / claude-sonnet-4-6, openai / gpt-4o")).toBeInTheDocument();
+  // A tier with no providers configured.
+  expect(screen.getByText("not configured")).toBeInTheDocument();
+});

--- a/apps/web/app/components/chat/model-selector.tsx
+++ b/apps/web/app/components/chat/model-selector.tsx
@@ -1,12 +1,45 @@
+import { Check, ChevronDown } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import type { ModelTier } from "~/lib/chat/types";
+import { getLlmConfig } from "~/lib/settings";
 import { cn } from "~/lib/utils";
 
-const TIERS: ModelTier[] = ["standard", "complex"];
+type Tier = "quick" | "standard" | "complex";
+
+// The three pickable tiers, in ascending capability/intensity. `level` drives the signal-bar icon;
+// `blurb` explains what the tier means. (`auto` exists in the backend selector but isn't offered here.)
+const TIERS: { id: Tier; label: string; level: 1 | 2 | 3; blurb: string }[] = [
+  { id: "quick", label: "quick", level: 1, blurb: "Fast & low-cost — short answers, simple tasks" },
+  { id: "standard", label: "standard", level: 2, blurb: "Balanced default for everyday chat" },
+  { id: "complex", label: "complex", level: 3, blurb: "Deepest reasoning — hard, multi-step work" },
+];
+
+// Three ascending bars, like a volume/signal meter: bars up to `level` are lit, the rest dimmed.
+function SignalBars({ level }: { level: 1 | 2 | 3 }) {
+  const bars = [3, 6, 9];
+  return (
+    <svg width="11" height="11" viewBox="0 0 11 11" aria-hidden="true" className="shrink-0">
+      {bars.map((h, i) => (
+        <rect
+          key={h}
+          x={0.5 + i * 4}
+          y={10 - h}
+          width="2.5"
+          height={h}
+          rx="0.5"
+          className={cn("fill-current", i < level ? "opacity-100" : "opacity-25")}
+        />
+      ))}
+    </svg>
+  );
+}
 
 /**
- * Per-message model override. Maps 1:1 to the POST /chat `model` field. The default is the active
- * agent's tier (e.g. GeneralAssistant → standard); the user can switch between the two surfaced
- * tiers. (`auto`/`quick` exist in the backend selection but are not offered here.)
+ * Per-message model override (maps 1:1 to the POST /chat `model` field). A dropdown over the three
+ * tiers: the trigger shows the active tier with a signal-bar intensity icon, and each menu option
+ * explains what the tier means (line 1) and lists the models configured for it (line 2, read once
+ * from GET /api/v1/llm-config). The menu is portalled so the composer's clipping box never crops it.
  */
 export function ModelSelector({
   value,
@@ -17,27 +50,131 @@ export function ModelSelector({
   onChange: (model: ModelTier) => void;
   disabled?: boolean;
 }) {
+  const [open, setOpen] = useState(false);
+  const [models, setModels] = useState<Record<Tier, string[]>>({
+    quick: [],
+    standard: [],
+    complex: [],
+  });
+  const [rect, setRect] = useState<DOMRect | null>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let alive = true;
+    getLlmConfig()
+      .then((cfg) => {
+        if (!alive) return;
+        const list = (t: Tier) =>
+          (cfg.tiers?.[t]?.providers ?? []).map((p) => `${p.provider} / ${p.model}`);
+        setModels({ quick: list("quick"), standard: list("standard"), complex: list("complex") });
+      })
+      // Non-admins or an unconfigured instance: the models line falls back to "not configured".
+      .catch(() => undefined);
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  // Close on outside click, Escape, or any scroll/resize (the menu is fixed-positioned off the rect).
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (!triggerRef.current?.contains(target) && !menuRef.current?.contains(target)) {
+        setOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    const close = () => setOpen(false);
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    window.addEventListener("scroll", close, true);
+    window.addEventListener("resize", close);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+      window.removeEventListener("scroll", close, true);
+      window.removeEventListener("resize", close);
+    };
+  }, [open]);
+
+  const current = TIERS.find((t) => t.id === value) ?? TIERS[1];
+
+  function toggle() {
+    if (!open && triggerRef.current) setRect(triggerRef.current.getBoundingClientRect());
+    setOpen((o) => !o);
+  }
+
   return (
-    <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
+    <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
       <span aria-hidden className="select-none uppercase tracking-[0.15em]">
         model
       </span>
-      <select
-        aria-label="Model"
-        value={value}
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label={`Model: ${current.label}`}
         disabled={disabled}
-        onChange={(e) => onChange(e.target.value as ModelTier)}
+        onClick={toggle}
         className={cn(
-          "rounded-sm border border-input bg-secondary px-1.5 py-1 text-foreground",
-          "outline-none focus-visible:border-primary disabled:opacity-50"
+          "inline-flex items-center gap-1.5 rounded-sm border border-input bg-secondary px-1.5 py-1 text-foreground transition-colors",
+          "outline-none focus-visible:border-primary disabled:opacity-50 hover:border-primary/60"
         )}
       >
-        {TIERS.map((t) => (
-          <option key={t} value={t}>
-            {t}
-          </option>
-        ))}
-      </select>
-    </label>
+        <SignalBars level={current.level} />
+        <span>{current.label}</span>
+        <ChevronDown aria-hidden className="size-3 opacity-70" />
+      </button>
+
+      {open && rect
+        ? createPortal(
+            <div
+              ref={menuRef}
+              className="fixed z-50 w-72 rounded-sm border border-border bg-card p-1 text-xs"
+              style={{ left: rect.left, bottom: window.innerHeight - rect.top + 6 }}
+            >
+              {TIERS.map((t) => {
+                const active = value === t.id;
+                const tierModels = models[t.id];
+                const modelLine = tierModels.length > 0 ? tierModels.join(", ") : "not configured";
+                return (
+                  <button
+                    key={t.id}
+                    type="button"
+                    aria-label={t.label}
+                    aria-pressed={active}
+                    onClick={() => {
+                      onChange(t.id);
+                      setOpen(false);
+                    }}
+                    className={cn(
+                      "flex w-full flex-col gap-0.5 rounded-sm px-2 py-1.5 text-left transition-colors hover:bg-secondary",
+                      active && "bg-secondary"
+                    )}
+                  >
+                    <span className="flex items-center gap-1.5 text-foreground">
+                      <SignalBars level={t.level} />
+                      <span className="font-medium">{t.label}</span>
+                      {active ? (
+                        <Check aria-hidden className="ml-auto size-3.5 text-primary" />
+                      ) : null}
+                    </span>
+                    <span className="text-muted-foreground">{t.blurb}</span>
+                    <span className="break-words text-[0.6875rem] text-muted-foreground/70">
+                      {modelLine}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>,
+            document.body
+          )
+        : null}
+    </div>
   );
 }

--- a/apps/web/app/components/link-combobox.tsx
+++ b/apps/web/app/components/link-combobox.tsx
@@ -93,7 +93,7 @@ export function LinkCombobox({
       {open ? (
         <ul
           id={listId}
-          className="absolute z-10 mt-1 max-h-60 w-full overflow-y-auto rounded-sm border border-border bg-card text-sm shadow-sm"
+          className="absolute z-10 mt-1 max-h-60 w-full overflow-y-auto rounded-sm border border-border bg-card text-sm"
         >
           {filtered.length === 0 ? (
             <li className="px-3 py-2 text-muted-foreground">no {target} records</li>

--- a/apps/web/app/components/markdown-view.tsx
+++ b/apps/web/app/components/markdown-view.tsx
@@ -55,7 +55,7 @@ const components: Components = {
     </li>
   ),
   blockquote: ({ node: _n, children, ...p }) => (
-    <blockquote className="my-3 border-l-2 border-primary pl-3 text-muted-foreground" {...p}>
+    <blockquote className="my-3 border-l border-border pl-3 text-muted-foreground" {...p}>
       {children}
     </blockquote>
   ),

--- a/apps/web/app/lib/chat/hydrate.test.ts
+++ b/apps/web/app/lib/chat/hydrate.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { messagesToTimeline } from "~/lib/chat/hydrate";
+import type { ConversationMessage } from "~/lib/conversations";
+
+function msg(
+  over: Partial<ConversationMessage> & Pick<ConversationMessage, "role" | "content">
+): ConversationMessage {
+  return { _id: crypto.randomUUID(), conversationId: "c1", createdAt: "t", ...over };
+}
+
+describe("messagesToTimeline", () => {
+  it("maps user + assistant string turns to sealed text messages", () => {
+    const out = messagesToTimeline([
+      msg({ role: "user", content: "hello" }),
+      msg({ role: "assistant", content: "hi there" }),
+    ]);
+    expect(out).toHaveLength(2);
+    expect(out[0]).toMatchObject({
+      role: "user",
+      sealed: true,
+      parts: [{ kind: "text", text: "hello" }],
+    });
+    expect(out[1]).toMatchObject({
+      role: "assistant",
+      sealed: true,
+      parts: [{ kind: "text", text: "hi there" }],
+    });
+  });
+
+  it("pairs an assistant tool-call with the following tool-result", () => {
+    const out = messagesToTimeline([
+      msg({
+        role: "assistant",
+        content: [
+          { type: "text", text: "looking it up" },
+          { type: "tool-call", toolCallId: "tc1", toolName: "search", args: { q: "x" } },
+        ],
+      }),
+      msg({
+        role: "tool",
+        content: [
+          { type: "tool-result", toolCallId: "tc1", toolName: "search", result: { hits: 2 } },
+        ],
+      }),
+    ]);
+    expect(out).toHaveLength(1);
+    const toolPart = out[0].parts.find((p) => p.kind === "tool");
+    expect(toolPart).toMatchObject({
+      kind: "tool",
+      toolCallId: "tc1",
+      status: "done",
+      result: { hits: 2 },
+    });
+  });
+
+  it("drops system and summary rows", () => {
+    const out = messagesToTimeline([
+      msg({ role: "system", content: "you are..." }),
+      msg({ role: "summary", content: "earlier recap" }),
+      msg({ role: "user", content: "go" }),
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].role).toBe("user");
+  });
+
+  it("returns an empty timeline for no messages", () => {
+    expect(messagesToTimeline([])).toEqual([]);
+  });
+});

--- a/apps/web/app/lib/chat/hydrate.ts
+++ b/apps/web/app/lib/chat/hydrate.ts
@@ -1,0 +1,72 @@
+import type { ChatMessage, TimelinePart } from "~/lib/chat/types";
+import type { ConversationMessage, WireMessagePart } from "~/lib/conversations";
+
+/*
+ * Rehydrate a restored conversation's persisted messages into the renderable timeline the chat
+ * reducer would have produced live. Text is the fidelity bar (every user/assistant turn round-trips);
+ * tool calls are reconstructed best-effort — an assistant `tool-call` part pairs with the result in
+ * the following `tool` turn (matched by `toolCallId`). System/summary rows are internal to the prompt
+ * and never rendered, so they are dropped. Every message is `sealed` (no further deltas).
+ */
+
+function newId(): string {
+  return crypto.randomUUID();
+}
+
+// Map a persisted assistant `content` (string or parts) to renderable timeline parts.
+function assistantParts(content: string | WireMessagePart[]): TimelinePart[] {
+  if (typeof content === "string") return [{ kind: "text", text: content }];
+  const parts: TimelinePart[] = [];
+  for (const part of content) {
+    if (part.type === "text") {
+      parts.push({ kind: "text", text: part.text });
+    } else if (part.type === "tool-call") {
+      parts.push({
+        kind: "tool",
+        toolCallId: part.toolCallId,
+        toolName: part.toolName,
+        args: part.args,
+        status: "done",
+      });
+    }
+  }
+  return parts;
+}
+
+// Fold a `tool` turn's results into the matching tool parts of the assistant turn it answers.
+function mergeToolResults(assistant: ChatMessage, content: WireMessagePart[]): void {
+  for (const part of content) {
+    if (part.type !== "tool-result") continue;
+    for (const p of assistant.parts) {
+      if (p.kind === "tool" && p.toolCallId === part.toolCallId) {
+        p.result = part.result;
+        p.status = "done";
+      }
+    }
+  }
+}
+
+export function messagesToTimeline(docs: ConversationMessage[]): ChatMessage[] {
+  const out: ChatMessage[] = [];
+  let lastAssistant: ChatMessage | undefined;
+  for (const doc of docs) {
+    if (doc.role === "user") {
+      const text = typeof doc.content === "string" ? doc.content : "";
+      out.push({ id: newId(), role: "user", parts: [{ kind: "text", text }], sealed: true });
+      lastAssistant = undefined;
+    } else if (doc.role === "assistant") {
+      const message: ChatMessage = {
+        id: newId(),
+        role: "assistant",
+        parts: assistantParts(doc.content),
+        sealed: true,
+      };
+      out.push(message);
+      lastAssistant = message;
+    } else if (doc.role === "tool" && lastAssistant && Array.isArray(doc.content)) {
+      mergeToolResults(lastAssistant, doc.content);
+    }
+    // system / summary / orphan tool rows are not part of the rendered timeline.
+  }
+  return out;
+}

--- a/apps/web/app/lib/chat/use-chat-stream.test.ts
+++ b/apps/web/app/lib/chat/use-chat-stream.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
-import { a2uiAgentToSend } from "~/lib/chat/use-chat-stream";
+import type { ChatMessage } from "~/lib/chat/types";
+import { a2uiAgentToSend, seedState } from "~/lib/chat/use-chat-stream";
 
 describe("a2uiAgentToSend", () => {
   test("maps a choice payload to a user turn using the label", () => {
@@ -23,5 +24,31 @@ describe("a2uiAgentToSend", () => {
     expect(a2uiAgentToSend({ kind: "choice" })).toBeNull();
     expect(a2uiAgentToSend({ kind: "other", label: "x" })).toBeNull();
     expect(a2uiAgentToSend("nope")).toBeNull();
+  });
+});
+
+describe("seedState", () => {
+  const seeded: ChatMessage[] = [
+    { id: "m1", role: "user", parts: [{ kind: "text", text: "hi" }], sealed: true },
+  ];
+
+  test("with no options it is the empty idle timeline", () => {
+    expect(seedState()).toEqual({ messages: [], pendingApprovals: {}, status: "idle" });
+  });
+
+  test("an initial conversation id seeds the id but no messages", () => {
+    expect(seedState({ initialConversationId: "c1" })).toEqual({
+      messages: [],
+      pendingApprovals: {},
+      status: "idle",
+      conversationId: "c1",
+    });
+  });
+
+  test("initial messages seed a sealed, idle transcript bound to the conversation id", () => {
+    const state = seedState({ initialConversationId: "c1", initialMessages: seeded });
+    expect(state.status).toBe("idle");
+    expect(state.conversationId).toBe("c1");
+    expect(state.messages).toEqual(seeded);
   });
 });

--- a/apps/web/app/lib/chat/use-chat-stream.ts
+++ b/apps/web/app/lib/chat/use-chat-stream.ts
@@ -11,9 +11,34 @@ import { useCallback, useReducer, useRef } from "react";
 import { appendUserMessage, chatReducer, initialChatState } from "~/lib/chat/reducer";
 import type { ChatStreamMeta } from "~/lib/chat/sse-client";
 import { postChat, sendApprovalDecision } from "~/lib/chat/sse-client";
-import type { Autonomy, ChatEvent, ChatState, ModelTier } from "~/lib/chat/types";
+import type { Autonomy, ChatEvent, ChatMessage, ChatState, ModelTier } from "~/lib/chat/types";
 
 export type SendOptions = { model?: ModelTier; autonomy?: Autonomy; agentId?: string };
+
+export type UseChatStreamOptions = {
+  // Seed a restored conversation (the `/chat/:id` route) so its transcript renders and follow-up
+  // turns reuse the same id; absent for a fresh chat.
+  initialConversationId?: string;
+  initialMessages?: ChatMessage[];
+  // Fired when a brand-new conversation id arrives and again on each turn's `finish`, so the sidebar
+  // can refresh — picking up the new chat and its async-generated title.
+  onConversationChange?: (conversationId: string | undefined) => void;
+};
+
+// Build the initial reducer state: a seeded transcript for a restored chat, else the empty timeline.
+export function seedState(opts?: UseChatStreamOptions): ChatState {
+  if (opts?.initialMessages && opts.initialMessages.length > 0) {
+    return {
+      messages: opts.initialMessages,
+      pendingApprovals: {},
+      status: "idle",
+      conversationId: opts.initialConversationId,
+    };
+  }
+  return opts?.initialConversationId
+    ? { ...initialChatState, conversationId: opts.initialConversationId }
+    : initialChatState;
+}
 
 // Wire events plus two hook-local actions: a user turn and the one-shot stream metadata. Keeping
 // these out of `chatReducer` lets that reducer stay pure over the `ChatEvent` wire contract.
@@ -67,13 +92,16 @@ function reducer(state: ChatState, action: ChatAction): ChatState {
   return chatReducer(state, action);
 }
 
-export function useChatStream() {
-  const [state, dispatch] = useReducer(reducer, initialChatState);
+export function useChatStream(opts?: UseChatStreamOptions) {
+  const [state, dispatch] = useReducer(reducer, opts, seedState);
   // Latest conversation id + state + last send options, read inside callbacks without re-subscribing.
-  const conversationIdRef = useRef<string | undefined>(undefined);
+  const conversationIdRef = useRef<string | undefined>(opts?.initialConversationId);
   const stateRef = useRef(state);
   stateRef.current = state;
   const lastOptsRef = useRef<SendOptions | undefined>(undefined);
+  // Mirror the latest refresh callback so the stable `runStream` closure always calls the current one.
+  const onConversationChangeRef = useRef(opts?.onConversationChange);
+  onConversationChangeRef.current = opts?.onConversationChange;
 
   // Open the stream for `text` and fold its events into the timeline. Shared by send + regenerate.
   const runStream = useCallback(async (text: string, opts?: SendOptions) => {
@@ -88,10 +116,19 @@ export function useChatStream() {
         },
         {
           onMeta: (meta) => {
-            if (meta.conversationId) conversationIdRef.current = meta.conversationId;
+            if (meta.conversationId) {
+              conversationIdRef.current = meta.conversationId;
+              // First turn of a fresh chat: surface the new conversation to the sidebar immediately.
+              onConversationChangeRef.current?.(meta.conversationId);
+            }
             dispatch({ type: "meta", meta });
           },
-          onEvent: (event) => dispatch(event),
+          onEvent: (event) => {
+            dispatch(event);
+            // On completion the async title has usually landed — refresh so the sidebar shows it.
+            if (event.type === "finish")
+              onConversationChangeRef.current?.(conversationIdRef.current);
+          },
         }
       );
     } catch (err) {

--- a/apps/web/app/lib/conversations-context.test.tsx
+++ b/apps/web/app/lib/conversations-context.test.tsx
@@ -1,0 +1,137 @@
+import { createRemixStub } from "@remix-run/testing";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, expect, test, vi } from "vitest";
+import type { ConversationSummary } from "~/lib/conversations";
+import * as conversations from "~/lib/conversations";
+import { ConversationsProvider, useConversations } from "./conversations-context";
+
+vi.mock("~/lib/conversations", () => ({ listConversations: vi.fn() }));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+const summary = (id: string): ConversationSummary => ({
+  id,
+  title: id,
+  agentId: null,
+  createdAt: "t",
+  updatedAt: "t",
+});
+
+afterEach(() => vi.clearAllMocks());
+
+function Consumer() {
+  const { conversations: list, refresh } = useConversations();
+  return (
+    <>
+      <span data-testid="count">{list.length}</span>
+      <button type="button" onClick={() => void refresh()}>
+        refresh
+      </button>
+    </>
+  );
+}
+
+function renderProvider() {
+  const Stub = createRemixStub([
+    {
+      path: "/",
+      Component: () => (
+        <ConversationsProvider>
+          <Consumer />
+        </ConversationsProvider>
+      ),
+    },
+  ]);
+  render(<Stub initialEntries={["/"]} />);
+}
+
+function ActiveConsumer() {
+  const { activeChatId, setActiveChatId } = useConversations();
+  return (
+    <>
+      <span data-testid="active">{activeChatId ?? "none"}</span>
+      <button type="button" onClick={() => setActiveChatId("shallow-1")}>
+        shallow
+      </button>
+    </>
+  );
+}
+
+function renderActiveAt(path: string) {
+  const provider = (
+    <ConversationsProvider>
+      <ActiveConsumer />
+    </ConversationsProvider>
+  );
+  const Stub = createRemixStub([
+    { path: "/", Component: () => provider },
+    { path: "/chat/:id", Component: () => provider },
+  ]);
+  render(<Stub initialEntries={[path]} />);
+}
+
+test("derives activeChatId from a /chat/:id route", () => {
+  vi.mocked(conversations.listConversations).mockResolvedValue([]);
+  renderActiveAt("/chat/abc-1");
+  expect(screen.getByTestId("active").textContent).toBe("abc-1");
+});
+
+test("activeChatId is null on the new-chat surface, and a shallow setter overrides it", () => {
+  vi.mocked(conversations.listConversations).mockResolvedValue([]);
+  renderActiveAt("/");
+  expect(screen.getByTestId("active").textContent).toBe("none");
+  // Mirrors the index route after replaceState (router location stays "/").
+  act(() => {
+    fireEvent.click(screen.getByText("shallow"));
+  });
+  expect(screen.getByTestId("active").textContent).toBe("shallow-1");
+});
+
+test("fetches once on mount and exposes the list", async () => {
+  const d = deferred<ConversationSummary[]>();
+  vi.mocked(conversations.listConversations).mockReturnValue(d.promise);
+  renderProvider();
+  expect(conversations.listConversations).toHaveBeenCalledTimes(1);
+  await act(async () => {
+    d.resolve([summary("c1"), summary("c2")]);
+  });
+  expect(screen.getByTestId("count").textContent).toBe("2");
+});
+
+test("coalesces refreshes requested during an in-flight fetch into one trailing fetch", async () => {
+  const ds: Array<ReturnType<typeof deferred<ConversationSummary[]>>> = [];
+  vi.mocked(conversations.listConversations).mockImplementation(() => {
+    const d = deferred<ConversationSummary[]>();
+    ds.push(d);
+    return d.promise;
+  });
+
+  renderProvider();
+  // Mount fetch is in flight.
+  expect(conversations.listConversations).toHaveBeenCalledTimes(1);
+
+  // Two refreshes while the first fetch is still pending → both coalesced, no new fetch yet.
+  await act(async () => {
+    fireEvent.click(screen.getByText("refresh"));
+    fireEvent.click(screen.getByText("refresh"));
+  });
+  expect(conversations.listConversations).toHaveBeenCalledTimes(1);
+
+  // Resolving the first fetch triggers exactly one trailing fetch (the coalesced refresh).
+  await act(async () => {
+    ds[0].resolve([summary("c1")]);
+  });
+  expect(conversations.listConversations).toHaveBeenCalledTimes(2);
+
+  await act(async () => {
+    ds[1].resolve([summary("c1"), summary("c2")]);
+  });
+  expect(conversations.listConversations).toHaveBeenCalledTimes(2);
+  expect(screen.getByTestId("count").textContent).toBe("2");
+});

--- a/apps/web/app/lib/conversations-context.tsx
+++ b/apps/web/app/lib/conversations-context.tsx
@@ -1,0 +1,151 @@
+import { useLocation, useNavigate } from "@remix-run/react";
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { type ConversationSummary, listConversations } from "~/lib/conversations";
+
+/*
+ * App-wide source of truth for the "Recent chats" sidebar list. Mounted once in the `_app` shell. It
+ * fetches GET /api/v1/conversations on mount and on every route change (so opening a new chat or
+ * navigating refreshes the list). The chat surface additionally calls `refresh()` when a brand-new
+ * conversation id arrives and again on each turn's finish, so a freshly created chat appears
+ * immediately and its async-generated title fills in. No polling — chats change on user action, not
+ * out of band. Mirrors ApprovalsProvider's inert-fallback shape so the sidebar renders in isolation.
+ *
+ * It also tracks `activeChatId` — the conversation currently on screen — so the sidebar highlights the
+ * right entry. This is derived from the router location for real navigations, plus a shallow override
+ * (`setActiveChatId`) that survives the `history.replaceState` the index route uses to put a freshly
+ * created chat's id in the URL without remounting the live stream. Any real navigation clears the
+ * override, so it never goes stale.
+ */
+
+type ConversationsContextValue = {
+  conversations: ConversationSummary[];
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+  /** The conversation currently being viewed (`/chat/:id`), or null on the new-chat surface. */
+  activeChatId: string | null;
+  /** Shallow-set the active chat after a `replaceState` URL update (router location is unchanged). */
+  setActiveChatId: (id: string) => void;
+  /** Remount key for the index chat surface — bumped by `startNewChat` to force a fresh transcript. */
+  newChatNonce: number;
+  /** Start a fresh chat from anywhere: clear active state, force a remount, and route to "/". */
+  startNewChat: () => void;
+};
+
+const ConversationsContext = createContext<ConversationsContextValue | null>(null);
+
+export function ConversationsProvider({ children }: { children: ReactNode }) {
+  const [conversations, setConversations] = useState<ConversationSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  // Shallow override of the active chat id, set after a replaceState (router location stays "/").
+  const [shallowId, setShallowId] = useState<string | null>(null);
+  // Guards against overlapping fetches; tracks mount so a late resolve skips writes after unmount.
+  const inFlight = useRef(false);
+  // A refresh requested while a fetch is in flight is coalesced into one trailing re-fetch — so the
+  // turn-finish refresh (which picks up the async title) is never dropped just because the new-chat
+  // refresh from `onMeta` is still running.
+  const pending = useRef(false);
+  const mounted = useRef(true);
+  // Bumped by startNewChat to remount the index chat surface (so "+ new chat" always clears, even on a
+  // shallow-routed chat where the router location is still "/").
+  const [newChatNonce, setNewChatNonce] = useState(0);
+  const location = useLocation();
+  const navigate = useNavigate();
+  const pathname = location.pathname;
+
+  const refresh = useCallback(async () => {
+    if (inFlight.current) {
+      pending.current = true;
+      return;
+    }
+    inFlight.current = true;
+    try {
+      do {
+        pending.current = false;
+        try {
+          const items = await listConversations();
+          if (mounted.current) {
+            setConversations(items);
+            setError(null);
+          }
+        } catch (err) {
+          // Keep the last-known list on a transient failure (don't flash empty).
+          if (mounted.current) {
+            setError(err instanceof Error ? err.message : "failed to load conversations");
+          }
+        }
+      } while (pending.current && mounted.current);
+    } finally {
+      if (mounted.current) setLoading(false);
+      inFlight.current = false;
+    }
+  }, []);
+
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  // Refetch on mount and whenever the route changes. `pathname` is the intentional trigger (opening a
+  // chat / navigating refreshes the list) even though the effect body does not read it directly.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: pathname is a deliberate refetch trigger
+  useEffect(() => {
+    void refresh();
+  }, [refresh, pathname]);
+
+  // Any real router navigation (the location object changes even when the path is unchanged, e.g.
+  // "+ new chat" → "/") supersedes a shallow override, so it can never go stale.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: location is a deliberate reset trigger
+  useEffect(() => {
+    setShallowId(null);
+  }, [location]);
+
+  const setActiveChatId = useCallback((id: string) => setShallowId(id), []);
+  const startNewChat = useCallback(() => {
+    setShallowId(null);
+    setNewChatNonce((n) => n + 1);
+    navigate("/");
+  }, [navigate]);
+  // A real /chat/:id route wins; otherwise fall back to the shallow override from a replaceState.
+  const routeMatch = pathname.match(/^\/chat\/([^/]+)$/);
+  const activeChatId = routeMatch ? decodeURIComponent(routeMatch[1]) : shallowId;
+
+  const value: ConversationsContextValue = {
+    conversations,
+    loading,
+    error,
+    refresh,
+    activeChatId,
+    setActiveChatId,
+    newChatNonce,
+    startNewChat,
+  };
+  return <ConversationsContext.Provider value={value}>{children}</ConversationsContext.Provider>;
+}
+
+// Inert fallback when no provider is mounted — lets the sidebar (and its isolated tests) render.
+const INERT: ConversationsContextValue = {
+  conversations: [],
+  loading: false,
+  error: null,
+  refresh: async () => {},
+  activeChatId: null,
+  setActiveChatId: () => {},
+  newChatNonce: 0,
+  startNewChat: () => {},
+};
+
+export function useConversations(): ConversationsContextValue {
+  return useContext(ConversationsContext) ?? INERT;
+}

--- a/apps/web/app/lib/conversations.test.ts
+++ b/apps/web/app/lib/conversations.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getConversation, getConversationMessages, listConversations } from "./conversations";
+
+type Call = { url: string; init: RequestInit };
+
+function mockFetch(responder: (url: string) => unknown): Call[] {
+  const calls: Call[] = [];
+  const fn = vi.fn(async (url: string, init: RequestInit = {}) => {
+    calls.push({ url, init });
+    return { ok: true, status: 200, json: async () => responder(url) } as Response;
+  });
+  vi.stubGlobal("fetch", fn);
+  return calls;
+}
+
+describe("conversations client", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("listConversations GETs the list and unwraps `conversations`", async () => {
+    const calls = mockFetch(() => ({
+      conversations: [
+        { id: "c1", title: "Inventory", agentId: null, createdAt: "t", updatedAt: "t" },
+      ],
+    }));
+    const out = await listConversations();
+    expect(calls[0].url).toContain("/api/v1/conversations");
+    expect(calls[0].init.method ?? "GET").toBe("GET");
+    expect(out).toHaveLength(1);
+    expect(out[0].title).toBe("Inventory");
+  });
+
+  it("getConversation GETs a single conversation by id", async () => {
+    const calls = mockFetch(() => ({
+      id: "c1",
+      title: "Inventory",
+      agentId: "GeneralAssistant",
+      userId: "u1",
+      model: null,
+      createdAt: "t",
+      updatedAt: "t",
+    }));
+    const out = await getConversation("c1");
+    expect(calls[0].url).toContain("/api/v1/conversations/c1");
+    expect(out.agentId).toBe("GeneralAssistant");
+  });
+
+  it("getConversationMessages GETs the messages and unwraps `messages`", async () => {
+    const calls = mockFetch(() => ({
+      messages: [{ _id: "m1", conversationId: "c1", role: "user", content: "hi", createdAt: "t" }],
+      nextCursor: null,
+    }));
+    const out = await getConversationMessages("c1");
+    expect(calls[0].url).toContain("/api/v1/conversations/c1/messages");
+    expect(out[0].role).toBe("user");
+  });
+
+  it("url-encodes the conversation id", async () => {
+    const calls = mockFetch(() => ({
+      id: "a/b",
+      title: null,
+      agentId: null,
+      userId: null,
+      model: null,
+      createdAt: "t",
+      updatedAt: "t",
+    }));
+    await getConversation("a/b");
+    expect(calls[0].url).toContain("/api/v1/conversations/a%2Fb");
+  });
+});

--- a/apps/web/app/lib/conversations.ts
+++ b/apps/web/app/lib/conversations.ts
@@ -1,0 +1,52 @@
+import { apiGet } from "./api";
+
+/*
+ * Read-only client for persisted chats (UUID-chat persistence). The API auto-creates a conversation
+ * on the first turn and fills in a quick-model `title` asynchronously; this client backs the "Recent
+ * chats" sidebar list and the `/chat/:id` restore route. Mirrors lib/onboarding.ts conventions
+ * (cookie-first auth via apiGet, ApiError on non-2xx).
+ */
+
+export type ConversationSummary = {
+  id: string;
+  title: string | null;
+  agentId: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type Conversation = ConversationSummary & {
+  userId: string | null;
+  model: string | null;
+};
+
+// Wire shape of a persisted message (mirrors the API's MessageDoc / MessageSchema). `content` is a
+// plain string for user/system/summary turns and a parts array for assistant/tool turns.
+export type WireMessagePart =
+  | { type: "text"; text: string }
+  | { type: "tool-call"; toolCallId: string; toolName: string; args: unknown }
+  | { type: "tool-result"; toolCallId: string; toolName: string; result: unknown };
+
+export type ConversationMessage = {
+  _id: string;
+  conversationId: string;
+  role: "system" | "user" | "assistant" | "tool" | "summary";
+  content: string | WireMessagePart[];
+  createdAt: string;
+};
+
+export async function listConversations(): Promise<ConversationSummary[]> {
+  const body = await apiGet<{ conversations: ConversationSummary[] }>("/api/v1/conversations");
+  return body.conversations;
+}
+
+export async function getConversation(id: string): Promise<Conversation> {
+  return apiGet<Conversation>(`/api/v1/conversations/${encodeURIComponent(id)}`);
+}
+
+export async function getConversationMessages(id: string): Promise<ConversationMessage[]> {
+  const body = await apiGet<{ messages: ConversationMessage[]; nextCursor: string | null }>(
+    `/api/v1/conversations/${encodeURIComponent(id)}/messages`
+  );
+  return body.messages;
+}

--- a/apps/web/app/routes/_app._index.tsx
+++ b/apps/web/app/routes/_app._index.tsx
@@ -1,7 +1,9 @@
 import { type ClientLoaderFunctionArgs, type MetaFunction, useLoaderData } from "@remix-run/react";
+import { useCallback } from "react";
 import { ChatPanel } from "~/components/chat/chat-panel";
 import { getAgent } from "~/lib/agents";
 import type { ModelTier } from "~/lib/chat/types";
+import { useConversations } from "~/lib/conversations-context";
 import { listOnboardingSuggestions } from "~/lib/onboarding";
 
 export const meta: MetaFunction = () => [{ title: "Chat · tulipfarm" }];
@@ -28,5 +30,32 @@ export async function clientLoader({ request }: ClientLoaderFunctionArgs) {
 
 export default function ChatRoute() {
   const { agentId, defaultModel, suggestions } = useLoaderData<typeof clientLoader>();
-  return <ChatPanel agentId={agentId} defaultModel={defaultModel} suggestions={suggestions} />;
+  const { refresh, setActiveChatId, newChatNonce } = useConversations();
+  // First turn of a fresh chat: refresh the Recent chats sidebar AND reflect the new conversation in
+  // the URL so a reload restores it. We use `history.replaceState` rather than a router navigate so the
+  // in-flight stream keeps streaming on this mounted route — no remount, no message re-fetch race.
+  // `setActiveChatId` shallow-syncs the sidebar highlight (the router location stays "/"). The
+  // `pathname === "/"` guard makes it a one-shot (the follow-up `finish` callback is then a no-op here).
+  const onConversationChange = useCallback(
+    (id: string | undefined) => {
+      void refresh();
+      if (id && window.location.pathname === "/") {
+        window.history.replaceState(null, "", `/chat/${id}`);
+        setActiveChatId(id);
+      }
+    },
+    [refresh, setActiveChatId]
+  );
+  return (
+    // `key` is bumped by startNewChat ("+ new chat") to force a fresh transcript even when the router
+    // location is unchanged (a shallow-routed chat at "/"). It never changes mid-turn, so the live
+    // stream is safe.
+    <ChatPanel
+      key={newChatNonce}
+      agentId={agentId}
+      defaultModel={defaultModel}
+      suggestions={suggestions}
+      onConversationChange={onConversationChange}
+    />
+  );
 }

--- a/apps/web/app/routes/_app._index.url.test.tsx
+++ b/apps/web/app/routes/_app._index.url.test.tsx
@@ -1,0 +1,63 @@
+import * as remix from "@remix-run/react";
+import { createRemixStub } from "@remix-run/testing";
+import { render } from "@testing-library/react";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import ChatRoute from "~/routes/_app._index";
+
+vi.mock("@remix-run/react", async () => {
+  const actual = await vi.importActual<typeof import("@remix-run/react")>("@remix-run/react");
+  return { ...actual, useLoaderData: vi.fn() };
+});
+
+// Stub ChatPanel so the test can fire its `onConversationChange` exactly as the SSE stream would when
+// a new conversation id arrives — isolating the index route's URL-sync behavior.
+let onConversationChange: ((id?: string) => void) | undefined;
+vi.mock("~/components/chat/chat-panel", () => ({
+  ChatPanel: (props: { onConversationChange?: (id?: string) => void }) => {
+    onConversationChange = props.onConversationChange;
+    return null;
+  },
+}));
+
+const Stub = createRemixStub([{ path: "/", Component: ChatRoute }]);
+
+beforeEach(() => {
+  onConversationChange = undefined;
+  window.history.replaceState(null, "", "/");
+  vi.mocked(remix.useLoaderData).mockReturnValue({
+    agentId: undefined,
+    defaultModel: "standard",
+    suggestions: [],
+  });
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+test("reflects a newly created conversation in the URL via replaceState", () => {
+  const spy = vi.spyOn(window.history, "replaceState");
+  render(<Stub initialEntries={["/"]} />);
+
+  onConversationChange?.("abc-123");
+
+  expect(spy).toHaveBeenCalledWith(null, "", "/chat/abc-123");
+});
+
+test("does not rewrite the URL once already on a /chat/:id route", () => {
+  window.history.replaceState(null, "", "/chat/existing");
+  const spy = vi.spyOn(window.history, "replaceState");
+  render(<Stub initialEntries={["/"]} />);
+
+  onConversationChange?.("abc-123");
+
+  // pathname is /chat/existing (≠ "/") → the one-shot guard skips the rewrite.
+  expect(spy).not.toHaveBeenCalled();
+});
+
+test("a callback without an id (e.g. finish before an id) leaves the URL untouched", () => {
+  const spy = vi.spyOn(window.history, "replaceState");
+  render(<Stub initialEntries={["/"]} />);
+
+  onConversationChange?.(undefined);
+
+  expect(spy).not.toHaveBeenCalled();
+});

--- a/apps/web/app/routes/_app.chat.$id.tsx
+++ b/apps/web/app/routes/_app.chat.$id.tsx
@@ -1,0 +1,63 @@
+import {
+  type ClientLoaderFunctionArgs,
+  type MetaFunction,
+  redirect,
+  useLoaderData,
+} from "@remix-run/react";
+import { ChatPanel } from "~/components/chat/chat-panel";
+import { getAgent } from "~/lib/agents";
+import { ApiError } from "~/lib/api";
+import { messagesToTimeline } from "~/lib/chat/hydrate";
+import type { ModelTier } from "~/lib/chat/types";
+import { getConversation, getConversationMessages } from "~/lib/conversations";
+import { useConversations } from "~/lib/conversations-context";
+
+export const meta: MetaFunction = () => [{ title: "Chat · tulipfarm" }];
+
+// Restore a persisted chat (UUID-chat persistence). Fetch the conversation + its messages, rehydrate
+// the timeline, and seed ChatPanel so the transcript renders and follow-up turns reuse the same id. A
+// 404 (unknown/deleted id) redirects to the new-chat surface rather than dead-ending. The default
+// model tier is derived from the conversation's agent, mirroring the index route.
+export async function clientLoader({ params }: ClientLoaderFunctionArgs) {
+  const id = params.id as string;
+  let convo: Awaited<ReturnType<typeof getConversation>>;
+  let messages: Awaited<ReturnType<typeof getConversationMessages>>;
+  try {
+    [convo, messages] = await Promise.all([getConversation(id), getConversationMessages(id)]);
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404) throw redirect("/");
+    throw err;
+  }
+
+  const agentId = convo.agentId ?? undefined;
+  let defaultModel: ModelTier = "standard";
+  try {
+    const agent = await getAgent(agentId ?? "GeneralAssistant");
+    if (agent.model === "complex") defaultModel = "complex";
+  } catch {
+    // Unknown agent / transient API error — keep the standard default rather than break the page.
+  }
+
+  return {
+    id,
+    title: convo.title,
+    agentId,
+    defaultModel,
+    messages: messagesToTimeline(messages),
+  };
+}
+
+export default function ChatConversationRoute() {
+  const { id, agentId, defaultModel, messages } = useLoaderData<typeof clientLoader>();
+  const { refresh } = useConversations();
+  return (
+    <ChatPanel
+      key={id}
+      agentId={agentId}
+      defaultModel={defaultModel}
+      initialConversationId={id}
+      initialMessages={messages}
+      onConversationChange={refresh}
+    />
+  );
+}

--- a/apps/web/app/routes/_app.chat.routes.test.tsx
+++ b/apps/web/app/routes/_app.chat.routes.test.tsx
@@ -1,0 +1,82 @@
+import * as remix from "@remix-run/react";
+import { createRemixStub } from "@remix-run/testing";
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import * as agents from "~/lib/agents";
+import { ApiError } from "~/lib/api";
+import type { ChatMessage } from "~/lib/chat/types";
+import * as conversations from "~/lib/conversations";
+import ChatConversationRoute, { clientLoader } from "./_app.chat.$id";
+
+/*
+ * Restore-route tests: the clientLoader hydrates a persisted conversation (and redirects a missing one
+ * to the new-chat surface), and the Component renders the rehydrated transcript. useLoaderData/lib
+ * calls are mocked; Link needs router context → createRemixStub at "/".
+ */
+vi.mock("@remix-run/react", async () => {
+  const actual = await vi.importActual<typeof import("@remix-run/react")>("@remix-run/react");
+  return { ...actual, useLoaderData: vi.fn() };
+});
+vi.mock("~/lib/conversations", () => ({
+  getConversation: vi.fn(),
+  getConversationMessages: vi.fn(),
+}));
+vi.mock("~/lib/agents", () => ({ getAgent: vi.fn() }));
+
+const loaderArgs = (id: string) =>
+  ({ params: { id } }) as unknown as Parameters<typeof clientLoader>[0];
+
+// jsdom has no layout engine; the transcript's auto-scroll calls scrollIntoView.
+beforeEach(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+afterEach(() => vi.clearAllMocks());
+
+test("clientLoader hydrates the conversation transcript", async () => {
+  vi.mocked(conversations.getConversation).mockResolvedValue({
+    id: "c1",
+    title: "Inventory",
+    agentId: "GeneralAssistant",
+    userId: "u1",
+    model: null,
+    createdAt: "t",
+    updatedAt: "t",
+  });
+  vi.mocked(conversations.getConversationMessages).mockResolvedValue([
+    { _id: "m1", conversationId: "c1", role: "user", content: "hello world", createdAt: "t" },
+    { _id: "m2", conversationId: "c1", role: "assistant", content: "hi back", createdAt: "t" },
+  ]);
+  vi.mocked(agents.getAgent).mockResolvedValue({
+    name: "GeneralAssistant",
+    model: "standard",
+  } as unknown as Awaited<ReturnType<typeof agents.getAgent>>);
+
+  const data = await clientLoader(loaderArgs("c1"));
+  expect(data.id).toBe("c1");
+  expect(data.agentId).toBe("GeneralAssistant");
+  expect(data.messages.map((m) => m.role)).toEqual(["user", "assistant"]);
+});
+
+test("clientLoader redirects to / when the conversation is missing (404)", async () => {
+  vi.mocked(conversations.getConversation).mockRejectedValue(new ApiError(404, "not found"));
+  vi.mocked(conversations.getConversationMessages).mockRejectedValue(
+    new ApiError(404, "not found")
+  );
+  await expect(clientLoader(loaderArgs("missing"))).rejects.toMatchObject({ status: 302 });
+});
+
+test("renders the rehydrated transcript", () => {
+  const messages: ChatMessage[] = [
+    { id: "x", role: "user", parts: [{ kind: "text", text: "hello world" }], sealed: true },
+  ];
+  vi.mocked(remix.useLoaderData).mockReturnValue({
+    id: "c1",
+    agentId: "GeneralAssistant",
+    defaultModel: "standard",
+    messages,
+  });
+  const Stub = createRemixStub([{ path: "/", Component: () => <ChatConversationRoute /> }]);
+  render(<Stub initialEntries={["/"]} />);
+  expect(screen.getByText("hello world")).toBeInTheDocument();
+});

--- a/apps/web/app/routes/_app.tsx
+++ b/apps/web/app/routes/_app.tsx
@@ -1,18 +1,23 @@
 import { Outlet } from "@remix-run/react";
 import { AppSidebar } from "~/components/app-sidebar";
 import { ApprovalsProvider } from "~/lib/approvals-context";
+import { ConversationsProvider } from "~/lib/conversations-context";
 
-// Persistent shell: sidebar + main panel. Wraps every section route. The ApprovalsProvider polls
-// pending approvals once for the whole shell, feeding both the sidebar badge and the Approvals page.
+// Persistent shell: sidebar + main panel. Wraps every section route. ApprovalsProvider polls pending
+// approvals (sidebar badge + Approvals page); ConversationsProvider holds the Recent chats list.
 export default function AppLayout() {
   return (
     <ApprovalsProvider>
-      <div className="md:flex md:min-h-svh">
-        <AppSidebar />
-        <main className="min-h-[calc(100svh-3rem)] flex-1 overflow-auto md:min-h-svh">
-          <Outlet />
-        </main>
-      </div>
+      <ConversationsProvider>
+        {/* Desktop shell is capped to the viewport (h-svh + overflow-hidden) so the sidebar nav and
+            the main panel each scroll internally instead of growing the whole page. */}
+        <div className="md:flex md:h-svh md:overflow-hidden">
+          <AppSidebar />
+          <main className="min-h-[calc(100svh-3rem)] flex-1 overflow-auto md:h-svh md:min-h-0">
+            <Outlet />
+          </main>
+        </div>
+      </ConversationsProvider>
     </ApprovalsProvider>
   );
 }


### PR DESCRIPTION
API
- migration v5: conversations.title + (user_id, updated_at) index
- quick-model auto-title on first turn (async, non-blocking, fallback-safe)
- GET /api/v1/conversations (user-scoped, newest-first); title on GET/:id
- ConversationRepo.setTitle/list

Web
- conversations client + messagesToTimeline hydrator
- ConversationsProvider: active-chat tracking + shallow-routing sidebar highlight
- /chat/:id restore route; replaceState URL sync; startNewChat remount
- model selector: quick/standard/complex dropdown with intensity icons + per-tier configured model
- sidebar: Claude-style compact flat nav, ruby [+] New chat, Recent chats; removed side-stripes/shadows (impeccable pass)

Docs: DESIGN.md sidebar pattern updated.