### PR TITLE
fix(setup): use key-prefixed sed patterns to set distinct env secrets

### DIFF
--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -128,15 +128,18 @@ if [ ! -f ".env.local" ]; then
   JWT_SECRET=$(openssl rand -base64 32)
   WEBHOOK_SECRET=$(openssl rand -base64 32)
 
-  # Replace placeholders (cross-platform sed: macOS uses -i '', Linux uses -i)
+  # Replace placeholders by matching each full KEY=<placeholder> line so every substitution
+  # is unique and order-independent (a bare s/// on the shared placeholder would overwrite
+  # all three lines with the first secret, and the 0,/pattern/ range trick is not supported
+  # by BSD sed on macOS). cross-platform sed: macOS uses -i '', Linux uses -i.
   if [[ "$OSTYPE" == "darwin"* ]]; then
-    sed -i '' "s|<generate: openssl rand -base64 32>|$ENCRYPTION_KEY|" .env.local
-    sed -i '' "0,/<generate: openssl rand -base64 32>/{s|<generate: openssl rand -base64 32>|$JWT_SECRET|;}" .env.local
-    sed -i '' "0,/<generate: openssl rand -base64 32>/{s|<generate: openssl rand -base64 32>|$WEBHOOK_SECRET|;}" .env.local
+    sed -i '' "s|ENCRYPTION_KEY=<generate: openssl rand -base64 32>|ENCRYPTION_KEY=$ENCRYPTION_KEY|" .env.local
+    sed -i '' "s|JWT_SECRET=<generate: openssl rand -base64 32>|JWT_SECRET=$JWT_SECRET|" .env.local
+    sed -i '' "s|WEBHOOK_SIGNING_SECRET=<generate: openssl rand -base64 32>|WEBHOOK_SIGNING_SECRET=$WEBHOOK_SECRET|" .env.local
   else
-    sed -i "s|<generate: openssl rand -base64 32>|$ENCRYPTION_KEY|" .env.local
-    sed -i "0,/<generate: openssl rand -base64 32>/{s|<generate: openssl rand -base64 32>|$JWT_SECRET|;}" .env.local
-    sed -i "0,/<generate: openssl rand -base64 32>/{s|<generate: openssl rand -base64 32>|$WEBHOOK_SECRET|;}" .env.local
+    sed -i "s|ENCRYPTION_KEY=<generate: openssl rand -base64 32>|ENCRYPTION_KEY=$ENCRYPTION_KEY|" .env.local
+    sed -i "s|JWT_SECRET=<generate: openssl rand -base64 32>|JWT_SECRET=$JWT_SECRET|" .env.local
+    sed -i "s|WEBHOOK_SIGNING_SECRET=<generate: openssl rand -base64 32>|WEBHOOK_SIGNING_SECRET=$WEBHOOK_SECRET|" .env.local
   fi
 
   # Expand SOUL_PATH to the absolute soul dir (dotenv does not expand ~).


### PR DESCRIPTION
### Problem

`setup-dev.sh` generates three separate secrets (`ENCRYPTION_KEY`, `JWT_SECRET`, `WEBHOOK_SIGNING_SECRET`) but all three ended up with the same value — the encryption key — due to two compounding bugs in the `sed` substitution block.

**Bug 1 — all-occurrence replace:** The first `sed` call used a bare `s///` against the shared placeholder string `<generate: openssl rand -base64 32>`. Because all three env vars share the same placeholder, this replaced every occurrence in one pass, leaving `$ENCRYPTION_KEY` in all three lines.

**Bug 2 — unsupported BSD range:** The second and third calls used `0,/pattern/{s///}` (a GNU sed extension) to try to replace the "first remaining" occurrence. This syntax is not supported by BSD sed on macOS, so even the intent was broken on the primary dev platform.

The net result: a freshly set-up `.env.local` had the same value for all three secrets, silently undermining encryption, session auth, and webhook verification.

### Changes

- 🐛 Replace each placeholder by matching its full `KEY=<placeholder>` line instead of the bare placeholder value — making every substitution unique and order-independent
- 🔧 Remove the unsupported `0,/pattern/` GNU sed range; plain `s///` now works correctly because each pattern is distinct
- ✅ Fix applied to both the macOS (`-i ''`) and Linux (`-i`) branches

Made with [Cursor](https://cursor.com)