### PR TITLE
refactor(ui): remove faux "tulipfarm <command>" CLI mentions

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -11,7 +11,7 @@ patterns. Tokens live in `apps/web/app/app.css`; this doc explains the intent be
 ## Principles
 
 1. **Terminal-native, not SaaS.** Flat surfaces, no drop shadows, hairline borders, ASCII bracket
-   motifs (`[+]`, `[section]`, `$ … --list`). Depth comes from borders + contrast layers, never shadow.
+   motifs (`[+]`, `[section]`). Depth comes from borders + contrast layers, never shadow.
 2. **Ruby discipline (≤10% of any screen).** Ruby is the brand accent — active nav, focus rings,
    the wordmark, CTAs, `[+]` markers. Everything else is warm near-black ink on a warm cream canvas.
 3. **Coral red = danger only.** The destructive token is the only other saturated color; never
@@ -83,7 +83,7 @@ Ruby is lightened in dark mode (`0.46 → 0.70`) for contrast. The `--ring` toke
 
 - **Lucide** icons for the 8 sidebar nav rows only (`size-4`).
 - **ASCII brackets** are the content iconography: `[+]` (steps/actions), `[section]` (labels),
-  `$ tulipfarm <section> --list` → `0 results` (empty states), `▍`/`|` (cursors).
+  `▍`/`|` (cursors).
 
 ---
 
@@ -108,8 +108,8 @@ attribute. Wiring (`apps/web/app/root.tsx`):
   the nav opens the **session zone** (the scrollable "Recent chats" list); collapsible icon rail
   (`md:w-60 ↔ md:w-14`, persisted) that hides labels and shows a ruby dot for badges; pinned footer
   (synced theme toggle + instance label); responsive mobile drawer with Escape/focus a11y.
-- **Empty state** (`empty-state.tsx`): a terminal-window card — `[section]` title bar →
-  `$ tulipfarm <section> --list` → `0 results` → title + hint. Depth from border + `--card`.
+- **Empty state** (`empty-state.tsx`): a hairline-bordered card — a quiet uppercase section eyebrow
+  → title + hint. Depth from border + `--card`.
 - **Chat welcome** (`_app._index.tsx`): the signature moment — blinking ruby block-cursor wordmark,
   `● ready · GeneralAssistant · 8 sections` status line, a placeholder composer flagged `SOON`
   (`cursor-not-allowed`, non-interactive until chat wiring lands), staggered bracket first-steps.

--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -59,15 +59,9 @@ function SectionLabel({ children }: { children: string }) {
 export default function HomePage() {
   return (
     <main className="flex flex-1 flex-col">
-      {/* ── Hero: the manpage header above a living ASCII tulip field ─────────── */}
+      {/* ── Hero: the wordmark above a living ASCII tulip field ───────────────── */}
       <section className="relative flex min-h-[calc(100dvh-3.5rem)] flex-col">
         <div className="mx-auto flex w-full max-w-5xl flex-1 flex-col justify-center px-4 pt-20 pb-10 sm:px-6">
-          <p
-            className="text-xs uppercase tracking-[0.2em] text-fd-muted-foreground motion-safe:animate-rise"
-            style={{ animationDelay: "100ms" }}
-          >
-            tulipfarm(1) · user commands
-          </p>
           <h1
             className="mt-4 text-4xl font-bold tracking-tight sm:text-6xl motion-safe:animate-rise"
             style={{ animationDelay: "180ms" }}
@@ -81,7 +75,7 @@ export default function HomePage() {
             className="mt-5 max-w-xl text-base text-fd-muted-foreground sm:text-lg motion-safe:animate-rise"
             style={{ animationDelay: "260ms" }}
           >
-            The AI-native business operating system. Install it, give it a soul, put it to work.
+            The AI-native business operating system. Give it a soul, put it to work.
           </p>
           <p
             className="mt-4 text-xs text-fd-muted-foreground motion-safe:animate-rise"
@@ -106,7 +100,7 @@ export default function HomePage() {
               href="/docs/getting-started"
               className="rounded-sm border border-fd-border bg-fd-card px-5 py-2.5 text-sm font-medium transition-colors duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] hover:bg-fd-accent"
             >
-              $ get started
+              get started
             </Link>
           </div>
         </div>

--- a/apps/web/app/components/empty-state.tsx
+++ b/apps/web/app/components/empty-state.tsx
@@ -1,10 +1,10 @@
 import type { ReactNode } from "react";
 
 /*
- * Shared empty state for shell section pages, framed as a small terminal window: a hairline
- * "title bar" + a faux `tulipfarm <section> --list` command resolving to `0 results`. Depth comes
- * from the border + card surface (no shadow). Body content is mocked in V1 (UI-V1-003). The public
- * API (section/title/hint/children) is unchanged so section routes need no edits.
+ * Shared empty state for shell section pages: a quiet section eyebrow on a hairline-bordered card,
+ * then the title + hint that communicate emptiness, plus an optional action slot. Depth comes from
+ * the border + card surface (no shadow). The public API (section/title/hint/children) is unchanged
+ * so section routes need no edits.
  */
 export function EmptyState({
   section,
@@ -20,26 +20,10 @@ export function EmptyState({
   return (
     <section className="mx-auto flex h-full max-w-xl flex-col justify-center px-6 py-16">
       <div className="rounded-sm border border-border bg-card motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-2 motion-safe:duration-500">
-        <div className="flex items-center gap-2 border-b border-border px-4 py-2 text-xs text-muted-foreground">
-          <span className="font-medium uppercase tracking-[0.2em]">
-            <span className="text-primary">[</span>
-            {section}
-            <span className="text-primary">]</span>
-          </span>
-          <span aria-hidden className="ml-auto opacity-60">
-            tulipfarm
-          </span>
-        </div>
+        <p className="border-b border-border px-4 py-2 text-[0.625rem] font-medium uppercase tracking-[0.2em] text-muted-foreground">
+          {section}
+        </p>
         <div className="flex flex-col gap-4 px-4 py-6 text-sm">
-          <div className="flex flex-col gap-1 text-muted-foreground">
-            <p>
-              <span aria-hidden className="text-primary">
-                ${" "}
-              </span>
-              tulipfarm {section} --list
-            </p>
-            <p className="opacity-70">0 results</p>
-          </div>
           <div>
             <h1 className="text-base font-bold text-foreground">{title}</h1>
             <p className="mt-1 text-muted-foreground">{hint}</p>

--- a/apps/web/app/components/resource-panel.tsx
+++ b/apps/web/app/components/resource-panel.tsx
@@ -2,57 +2,40 @@ import { Link } from "@remix-run/react";
 import type { ReactNode } from "react";
 
 /*
- * Shared terminal-window frame for the Resources pages: a `[ crumbs ]` title bar (ruby brackets,
- * breadcrumb Links) + a faux `$ <command>` line, then a body slot. Mirrors empty-state.tsx so the
- * whole section reads as one terminal. Full-width content (list/detail), unlike the centered states.
+ * Shared page frame for the Resources section: a quiet breadcrumb trail header on a hairline-bordered
+ * card, then a body slot. Depth comes from the border + card surface (no shadow). Full-width content
+ * (list/detail), unlike the centered states. Breadcrumbs are a real `crumb / crumb` navigation trail
+ * (links muted, the current crumb in foreground).
  */
 
 export type Crumb = { label: string; to?: string };
 
-export function ResourcePanel({
-  crumbs,
-  command,
-  children,
-}: {
-  crumbs: Crumb[];
-  command?: string;
-  children: ReactNode;
-}) {
+export function ResourcePanel({ crumbs, children }: { crumbs: Crumb[]; children: ReactNode }) {
   return (
     <section className="mx-auto flex w-full max-w-4xl flex-col px-6 py-10">
       <div className="rounded-sm border border-border bg-card motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-2 motion-safe:duration-500">
-        <div className="flex items-center gap-2 border-b border-border px-4 py-2 text-xs text-muted-foreground">
-          <span className="font-medium uppercase tracking-[0.2em]">
-            <span className="text-primary">[</span>
-            {crumbs.map((crumb, i) => (
-              <span key={crumb.label}>
-                {i > 0 ? <span className="opacity-60"> / </span> : null}
-                {crumb.to ? (
-                  <Link to={crumb.to} className="hover:text-foreground">
-                    {crumb.label}
-                  </Link>
-                ) : (
-                  crumb.label
-                )}
-              </span>
-            ))}
-            <span className="text-primary">]</span>
-          </span>
-          <span aria-hidden className="ml-auto opacity-60">
-            tulipfarm
-          </span>
-        </div>
-        <div className="flex flex-col gap-4 px-4 py-6 text-sm">
-          {command ? (
-            <p className="text-muted-foreground">
-              <span aria-hidden className="text-primary">
-                ${" "}
-              </span>
-              {command}
-            </p>
-          ) : null}
-          {children}
-        </div>
+        <nav
+          aria-label="Breadcrumb"
+          className="flex items-center gap-1 border-b border-border px-4 py-2 text-[0.625rem] font-medium uppercase tracking-[0.2em] text-muted-foreground"
+        >
+          {crumbs.map((crumb, i) => (
+            <span key={crumb.label} className="flex items-center gap-1">
+              {i > 0 ? (
+                <span aria-hidden className="opacity-40">
+                  /
+                </span>
+              ) : null}
+              {crumb.to ? (
+                <Link to={crumb.to} className="transition-colors hover:text-foreground">
+                  {crumb.label}
+                </Link>
+              ) : (
+                <span className="text-foreground">{crumb.label}</span>
+              )}
+            </span>
+          ))}
+        </nav>
+        <div className="flex flex-col gap-4 px-4 py-6 text-sm">{children}</div>
       </div>
     </section>
   );

--- a/apps/web/app/components/states.tsx
+++ b/apps/web/app/components/states.tsx
@@ -1,40 +1,18 @@
 /*
- * Full-page states for the Resources pages, framed as a centered terminal card (same idiom as
- * empty-state.tsx). ErrorState handles 401 with explicit "authentication required" copy and a hint
- * to set VITE_API_TOKEN; NotFoundState covers a missing record (404).
+ * Full-page states for the Resources pages: a centered card with a quiet section eyebrow (same plain
+ * idiom as empty-state.tsx), then the error/not-found message. ErrorState handles 401 with explicit
+ * "authentication required" copy and a hint to set VITE_API_TOKEN; NotFoundState covers a missing
+ * record (404).
  */
 
-function Frame({
-  section,
-  command,
-  children,
-}: {
-  section: string;
-  command: string;
-  children: React.ReactNode;
-}) {
+function Frame({ section, children }: { section: string; children: React.ReactNode }) {
   return (
     <section className="mx-auto flex h-full max-w-xl flex-col justify-center px-6 py-16">
       <div className="rounded-sm border border-border bg-card">
-        <div className="flex items-center gap-2 border-b border-border px-4 py-2 text-xs text-muted-foreground">
-          <span className="font-medium uppercase tracking-[0.2em]">
-            <span className="text-primary">[</span>
-            {section}
-            <span className="text-primary">]</span>
-          </span>
-          <span aria-hidden className="ml-auto opacity-60">
-            tulipfarm
-          </span>
-        </div>
-        <div className="flex flex-col gap-4 px-4 py-6 text-sm">
-          <p className="text-muted-foreground">
-            <span aria-hidden className="text-primary">
-              ${" "}
-            </span>
-            {command}
-          </p>
-          {children}
-        </div>
+        <p className="border-b border-border px-4 py-2 text-[0.625rem] font-medium uppercase tracking-[0.2em] text-muted-foreground">
+          {section}
+        </p>
+        <div className="flex flex-col gap-4 px-4 py-6 text-sm">{children}</div>
       </div>
     </section>
   );
@@ -42,18 +20,16 @@ function Frame({
 
 export function ErrorState({
   section,
-  command,
   status,
   message,
 }: {
   section: string;
-  command: string;
   status?: number;
   message?: string;
 }) {
   const isAuth = status === 401;
   return (
-    <Frame section={section} command={command}>
+    <Frame section={section}>
       <p className="text-destructive">
         error: {status ? `${status} ` : ""}
         {isAuth ? "authentication required" : (message ?? "request failed")}
@@ -67,9 +43,9 @@ export function ErrorState({
   );
 }
 
-export function NotFoundState({ section, command }: { section: string; command: string }) {
+export function NotFoundState({ section }: { section: string }) {
   return (
-    <Frame section={section} command={command}>
+    <Frame section={section}>
       <p className="text-destructive">error: 404 not found</p>
       <p className="text-muted-foreground">No record matches that id (it may have been deleted).</p>
     </Frame>

--- a/apps/web/app/routes/_app.agents.$name.tsx
+++ b/apps/web/app/routes/_app.agents.$name.tsx
@@ -3,7 +3,6 @@ import {
   type MetaFunction,
   useLoaderData,
   useNavigate,
-  useParams,
   useRouteError,
 } from "@remix-run/react";
 import { MarkdownView } from "~/components/markdown-view";
@@ -39,10 +38,7 @@ export default function AgentDetail() {
   const hasMeta = Boolean(agent.label || agent.domain || agent.model || agent.autonomy);
 
   return (
-    <ResourcePanel
-      crumbs={[{ label: "agents", to: "/agents" }, { label: agent.name }]}
-      command={`tulipfarm agents show ${agent.name}`}
-    >
+    <ResourcePanel crumbs={[{ label: "agents", to: "/agents" }, { label: agent.name }]}>
       <div>
         {/* Chat is wired in a later ticket; this preselects the agent on the chat surface. */}
         <Button size="sm" onClick={() => navigate(`/?agent=${encodeURIComponent(agent.name)}`)}>
@@ -70,12 +66,10 @@ export default function AgentDetail() {
 
 export function ErrorBoundary() {
   const error = useRouteError();
-  const params = useParams();
-  const command = `tulipfarm agents show ${params.name ?? ""}`;
   if (error instanceof ApiError && error.status === 404) {
-    return <NotFoundState section="agents" command={command} />;
+    return <NotFoundState section="agents" />;
   }
   const status = error instanceof ApiError ? error.status : undefined;
   const message = error instanceof Error ? error.message : undefined;
-  return <ErrorState section="agents" command={command} status={status} message={message} />;
+  return <ErrorState section="agents" status={status} message={message} />;
 }

--- a/apps/web/app/routes/_app.agents._index.tsx
+++ b/apps/web/app/routes/_app.agents._index.tsx
@@ -26,7 +26,7 @@ export default function AgentsIndex() {
   }
 
   return (
-    <ResourcePanel crumbs={[{ label: "agents" }]} command="tulipfarm agents --list">
+    <ResourcePanel crumbs={[{ label: "agents" }]}>
       <p className="text-xs text-muted-foreground">
         {agents.length} {agents.length === 1 ? "agent" : "agents"}
       </p>
@@ -68,12 +68,5 @@ export function ErrorBoundary() {
   const error = useRouteError();
   const status = error instanceof ApiError ? error.status : undefined;
   const message = error instanceof Error ? error.message : undefined;
-  return (
-    <ErrorState
-      section="agents"
-      command="tulipfarm agents --list"
-      status={status}
-      message={message}
-    />
-  );
+  return <ErrorState section="agents" status={status} message={message} />;
 }

--- a/apps/web/app/routes/_app.approvals.test.tsx
+++ b/apps/web/app/routes/_app.approvals.test.tsx
@@ -56,7 +56,6 @@ test("shows a loading line on the first load", () => {
 test("shows the empty state when there are no pending approvals", () => {
   useApprovals.mockReturnValue(state({ loading: false, approvals: [] }));
   renderPage();
-  expect(screen.getByText("0 results")).toBeInTheDocument();
   expect(screen.getByText(/No pending approvals/)).toBeInTheDocument();
 });
 

--- a/apps/web/app/routes/_app.approvals.tsx
+++ b/apps/web/app/routes/_app.approvals.tsx
@@ -9,8 +9,6 @@ import { useApprovals } from "~/lib/approvals-context";
 
 export const meta: MetaFunction = () => [{ title: "Approvals · tulipfarm" }];
 
-const COMMAND = "tulipfarm approvals --pending";
-
 // One-line, truncated args preview for a list row — the standalone approver needs to see WHAT the
 // gated tool will do (the inline chat card shows only the tool name + countdown). Guards non-JSON.
 function describeArgs(args: unknown): string {
@@ -72,7 +70,7 @@ export default function ApprovalsPage() {
 
   if (loading && approvals.length === 0 && !error) {
     return (
-      <ResourcePanel crumbs={[{ label: "approvals" }]} command={COMMAND}>
+      <ResourcePanel crumbs={[{ label: "approvals" }]}>
         <p className="text-xs text-muted-foreground">loading…</p>
       </ResourcePanel>
     );
@@ -80,7 +78,7 @@ export default function ApprovalsPage() {
 
   // Only blank the page for an error when there's nothing cached to show; otherwise prefer stale data.
   if (error && approvals.length === 0) {
-    return <ErrorState section="approvals" command={COMMAND} message={error} />;
+    return <ErrorState section="approvals" message={error} />;
   }
 
   if (approvals.length === 0) {
@@ -94,7 +92,7 @@ export default function ApprovalsPage() {
   }
 
   return (
-    <ResourcePanel crumbs={[{ label: "approvals" }]} command={COMMAND}>
+    <ResourcePanel crumbs={[{ label: "approvals" }]}>
       <p className="text-xs text-muted-foreground">{approvals.length} pending</p>
       <ul className="flex flex-col divide-y divide-border rounded-sm border border-border">
         {approvals.map((item) => (

--- a/apps/web/app/routes/_app.chats.tsx
+++ b/apps/web/app/routes/_app.chats.tsx
@@ -16,7 +16,6 @@ import { cn } from "~/lib/utils";
 
 export const meta: MetaFunction = () => [{ title: "Chats · tulipfarm" }];
 
-const command = "tulipfarm chats --list";
 const inputClass =
   "h-8 w-full rounded-sm border border-border bg-background px-2 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring";
 
@@ -96,7 +95,7 @@ export default function ChatsRoute() {
   const sorted = [...items].sort((a, b) => Number(b.starred) - Number(a.starred));
 
   return (
-    <ResourcePanel crumbs={[{ label: "chats" }]} command={command}>
+    <ResourcePanel crumbs={[{ label: "chats" }]}>
       <input
         type="search"
         value={query}
@@ -342,5 +341,5 @@ export function ErrorBoundary() {
   const error = useRouteError();
   const status = error instanceof ApiError ? error.status : undefined;
   const message = error instanceof Error ? error.message : undefined;
-  return <ErrorState section="chats" command={command} status={status} message={message} />;
+  return <ErrorState section="chats" status={status} message={message} />;
 }

--- a/apps/web/app/routes/_app.knowledge.collections.$id.edit.tsx
+++ b/apps/web/app/routes/_app.knowledge.collections.$id.edit.tsx
@@ -3,7 +3,6 @@ import {
   type MetaFunction,
   useLoaderData,
   useNavigate,
-  useParams,
   useRouteError,
 } from "@remix-run/react";
 import { useState } from "react";
@@ -55,10 +54,7 @@ export default function CollectionEdit() {
   ];
 
   return (
-    <ResourcePanel
-      crumbs={crumbs}
-      command={`tulipfarm knowledge collections edit ${collection.id}`}
-    >
+    <ResourcePanel crumbs={crumbs}>
       <CollectionForm
         mode="edit"
         initial={{
@@ -78,12 +74,10 @@ export default function CollectionEdit() {
 
 export function ErrorBoundary() {
   const error = useRouteError();
-  const params = useParams();
-  const command = `tulipfarm knowledge collections edit ${params.id ?? ""}`;
   if (error instanceof ApiError && error.status === 404) {
-    return <NotFoundState section="knowledge" command={command} />;
+    return <NotFoundState section="knowledge" />;
   }
   const status = error instanceof ApiError ? error.status : undefined;
   const message = error instanceof Error ? error.message : undefined;
-  return <ErrorState section="knowledge" command={command} status={status} message={message} />;
+  return <ErrorState section="knowledge" status={status} message={message} />;
 }

--- a/apps/web/app/routes/_app.knowledge.collections.$id.tsx
+++ b/apps/web/app/routes/_app.knowledge.collections.$id.tsx
@@ -2,7 +2,6 @@ import {
   type ClientLoaderFunctionArgs,
   type MetaFunction,
   useLoaderData,
-  useParams,
   useRevalidator,
   useRouteError,
 } from "@remix-run/react";
@@ -80,10 +79,7 @@ export default function CollectionDetailRoute() {
   ];
 
   return (
-    <ResourcePanel
-      crumbs={crumbs}
-      command={`tulipfarm knowledge collections show ${collection.id}`}
-    >
+    <ResourcePanel crumbs={crumbs}>
       {error ? <p className="text-destructive">error: {error}</p> : null}
       <CollectionDetail
         collection={collection}
@@ -99,12 +95,10 @@ export default function CollectionDetailRoute() {
 
 export function ErrorBoundary() {
   const error = useRouteError();
-  const params = useParams();
-  const command = `tulipfarm knowledge collections show ${params.id ?? ""}`;
   if (error instanceof ApiError && error.status === 404) {
-    return <NotFoundState section="knowledge" command={command} />;
+    return <NotFoundState section="knowledge" />;
   }
   const status = error instanceof ApiError ? error.status : undefined;
   const message = error instanceof Error ? error.message : undefined;
-  return <ErrorState section="knowledge" command={command} status={status} message={message} />;
+  return <ErrorState section="knowledge" status={status} message={message} />;
 }

--- a/apps/web/app/routes/_app.knowledge.collections._index.tsx
+++ b/apps/web/app/routes/_app.knowledge.collections._index.tsx
@@ -9,8 +9,6 @@ import { type CollectionWithCount, listCollectionsWithCounts } from "~/lib/knowl
 
 export const meta: MetaFunction = () => [{ title: "Collections · Knowledge · tulipfarm" }];
 
-const command = "tulipfarm knowledge collections --list";
-
 export async function clientLoader() {
   const page = await listCollectionsWithCounts();
   return { items: page.items, nextCursor: page.nextCursor };
@@ -41,7 +39,7 @@ export default function CollectionsIndex() {
   const crumbs = [{ label: "knowledge", to: "/knowledge" }, { label: "collections" }];
 
   return (
-    <ResourcePanel crumbs={crumbs} command={command}>
+    <ResourcePanel crumbs={crumbs}>
       <div>
         <Button asChild variant="outline" size="sm">
           <Link to="/knowledge/collections/new">New collection</Link>
@@ -70,5 +68,5 @@ export function ErrorBoundary() {
   const error = useRouteError();
   const status = error instanceof ApiError ? error.status : undefined;
   const message = error instanceof Error ? error.message : undefined;
-  return <ErrorState section="knowledge" command={command} status={status} message={message} />;
+  return <ErrorState section="knowledge" status={status} message={message} />;
 }

--- a/apps/web/app/routes/_app.knowledge.collections.new.tsx
+++ b/apps/web/app/routes/_app.knowledge.collections.new.tsx
@@ -9,8 +9,6 @@ import { type CollectionInput, createCollection } from "~/lib/knowledge-api";
 
 export const meta: MetaFunction = () => [{ title: "New · Collections · Knowledge · tulipfarm" }];
 
-const command = "tulipfarm knowledge collections create";
-
 export default function CollectionNew() {
   const navigate = useNavigate();
   const [submitting, setSubmitting] = useState(false);
@@ -39,7 +37,7 @@ export default function CollectionNew() {
   ];
 
   return (
-    <ResourcePanel crumbs={crumbs} command={command}>
+    <ResourcePanel crumbs={crumbs}>
       <CollectionForm
         mode="create"
         onSubmit={onSubmit}
@@ -56,5 +54,5 @@ export function ErrorBoundary() {
   const error = useRouteError();
   const status = error instanceof ApiError ? error.status : undefined;
   const message = error instanceof Error ? error.message : undefined;
-  return <ErrorState section="knowledge" command={command} status={status} message={message} />;
+  return <ErrorState section="knowledge" status={status} message={message} />;
 }

--- a/apps/web/app/routes/_app.knowledge.documents.$id.edit.tsx
+++ b/apps/web/app/routes/_app.knowledge.documents.$id.edit.tsx
@@ -3,7 +3,6 @@ import {
   type MetaFunction,
   useLoaderData,
   useNavigate,
-  useParams,
   useRouteError,
 } from "@remix-run/react";
 import { useState } from "react";
@@ -55,7 +54,7 @@ export default function DocumentEdit() {
   ];
 
   return (
-    <ResourcePanel crumbs={crumbs} command={`tulipfarm knowledge documents edit ${doc.id}`}>
+    <ResourcePanel crumbs={crumbs}>
       <DocForm
         mode="edit"
         initial={{
@@ -77,12 +76,10 @@ export default function DocumentEdit() {
 
 export function ErrorBoundary() {
   const error = useRouteError();
-  const params = useParams();
-  const command = `tulipfarm knowledge documents edit ${params.id ?? ""}`;
   if (error instanceof ApiError && error.status === 404) {
-    return <NotFoundState section="knowledge" command={command} />;
+    return <NotFoundState section="knowledge" />;
   }
   const status = error instanceof ApiError ? error.status : undefined;
   const message = error instanceof Error ? error.message : undefined;
-  return <ErrorState section="knowledge" command={command} status={status} message={message} />;
+  return <ErrorState section="knowledge" status={status} message={message} />;
 }

--- a/apps/web/app/routes/_app.knowledge.documents.$id.tsx
+++ b/apps/web/app/routes/_app.knowledge.documents.$id.tsx
@@ -3,7 +3,6 @@ import {
   type MetaFunction,
   useLoaderData,
   useNavigate,
-  useParams,
   useRouteError,
 } from "@remix-run/react";
 import { useState } from "react";
@@ -47,7 +46,7 @@ export default function DocumentDetail() {
   ];
 
   return (
-    <ResourcePanel crumbs={crumbs} command={`tulipfarm knowledge documents show ${doc.id}`}>
+    <ResourcePanel crumbs={crumbs}>
       {error ? <p className="text-destructive">error: {error}</p> : null}
       <DocDetail
         doc={doc}
@@ -61,12 +60,10 @@ export default function DocumentDetail() {
 
 export function ErrorBoundary() {
   const error = useRouteError();
-  const params = useParams();
-  const command = `tulipfarm knowledge documents show ${params.id ?? ""}`;
   if (error instanceof ApiError && error.status === 404) {
-    return <NotFoundState section="knowledge" command={command} />;
+    return <NotFoundState section="knowledge" />;
   }
   const status = error instanceof ApiError ? error.status : undefined;
   const message = error instanceof Error ? error.message : undefined;
-  return <ErrorState section="knowledge" command={command} status={status} message={message} />;
+  return <ErrorState section="knowledge" status={status} message={message} />;
 }

--- a/apps/web/app/routes/_app.knowledge.documents._index.tsx
+++ b/apps/web/app/routes/_app.knowledge.documents._index.tsx
@@ -20,7 +20,6 @@ export async function clientLoader() {
   return { items: page.items, nextCursor: page.nextCursor };
 }
 
-const command = "tulipfarm knowledge documents --list";
 const inputClass =
   "h-8 flex-1 rounded-sm border border-border bg-background px-2 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring";
 
@@ -92,7 +91,7 @@ export default function DocumentsIndex() {
   const crumbs = [{ label: "knowledge", to: "/knowledge" }, { label: "documents" }];
 
   return (
-    <ResourcePanel crumbs={crumbs} command={command}>
+    <ResourcePanel crumbs={crumbs}>
       <div>
         <Button asChild variant="outline" size="sm">
           <Link to="/knowledge/documents/new">New document</Link>
@@ -161,5 +160,5 @@ export function ErrorBoundary() {
   const error = useRouteError();
   const status = error instanceof ApiError ? error.status : undefined;
   const message = error instanceof Error ? error.message : undefined;
-  return <ErrorState section="knowledge" command={command} status={status} message={message} />;
+  return <ErrorState section="knowledge" status={status} message={message} />;
 }

--- a/apps/web/app/routes/_app.knowledge.documents.new.tsx
+++ b/apps/web/app/routes/_app.knowledge.documents.new.tsx
@@ -9,8 +9,6 @@ import { createDocument, type DocumentInput } from "~/lib/knowledge-api";
 
 export const meta: MetaFunction = () => [{ title: "New · Documents · Knowledge · tulipfarm" }];
 
-const command = "tulipfarm knowledge documents create";
-
 export default function DocumentNew() {
   const navigate = useNavigate();
   const [submitting, setSubmitting] = useState(false);
@@ -39,7 +37,7 @@ export default function DocumentNew() {
   ];
 
   return (
-    <ResourcePanel crumbs={crumbs} command={command}>
+    <ResourcePanel crumbs={crumbs}>
       <DocForm
         mode="create"
         onSubmit={onSubmit}
@@ -56,5 +54,5 @@ export function ErrorBoundary() {
   const error = useRouteError();
   const status = error instanceof ApiError ? error.status : undefined;
   const message = error instanceof Error ? error.message : undefined;
-  return <ErrorState section="knowledge" command={command} status={status} message={message} />;
+  return <ErrorState section="knowledge" status={status} message={message} />;
 }

--- a/apps/web/app/routes/_app.resources.$type.$id.tsx
+++ b/apps/web/app/routes/_app.resources.$type.$id.tsx
@@ -4,7 +4,6 @@ import {
   type MetaFunction,
   useLoaderData,
   useNavigate,
-  useParams,
   useRouteError,
 } from "@remix-run/react";
 import { useState } from "react";
@@ -79,10 +78,9 @@ export default function ResourceDetail() {
     { label: type, to: listPath },
     { label: record.id },
   ];
-  const command = `tulipfarm resources ${type} show ${record.id}`;
 
   return (
-    <ResourcePanel crumbs={crumbs} command={command}>
+    <ResourcePanel crumbs={crumbs}>
       <div className="flex items-center gap-2">
         <Button asChild variant="outline" size="sm">
           <Link to={`/resources/${encodeURIComponent(type)}/${encodeURIComponent(record.id)}/edit`}>
@@ -105,12 +103,10 @@ export default function ResourceDetail() {
 
 export function ErrorBoundary() {
   const error = useRouteError();
-  const params = useParams();
-  const command = `tulipfarm resources ${params.type ?? ""} show ${params.id ?? ""}`;
   if (error instanceof ApiError && error.status === 404) {
-    return <NotFoundState section="resources" command={command} />;
+    return <NotFoundState section="resources" />;
   }
   const status = error instanceof ApiError ? error.status : undefined;
   const message = error instanceof Error ? error.message : undefined;
-  return <ErrorState section="resources" command={command} status={status} message={message} />;
+  return <ErrorState section="resources" status={status} message={message} />;
 }

--- a/apps/web/app/routes/_app.resources.$type.$id_.edit.tsx
+++ b/apps/web/app/routes/_app.resources.$type.$id_.edit.tsx
@@ -3,7 +3,6 @@ import {
   type MetaFunction,
   useLoaderData,
   useNavigate,
-  useParams,
   useRouteError,
 } from "@remix-run/react";
 import { useState } from "react";
@@ -64,7 +63,7 @@ export default function ResourceEdit() {
   ];
 
   return (
-    <ResourcePanel crumbs={crumbs} command={`tulipfarm resources ${type} edit ${record.id}`}>
+    <ResourcePanel crumbs={crumbs}>
       {schemaError ? (
         <p className="text-destructive">error: schema parse failed — {schemaError}</p>
       ) : (
@@ -85,12 +84,10 @@ export default function ResourceEdit() {
 
 export function ErrorBoundary() {
   const error = useRouteError();
-  const params = useParams();
-  const command = `tulipfarm resources ${params.type ?? ""} edit ${params.id ?? ""}`;
   if (error instanceof ApiError && error.status === 404) {
-    return <NotFoundState section="resources" command={command} />;
+    return <NotFoundState section="resources" />;
   }
   const status = error instanceof ApiError ? error.status : undefined;
   const message = error instanceof Error ? error.message : undefined;
-  return <ErrorState section="resources" command={command} status={status} message={message} />;
+  return <ErrorState section="resources" status={status} message={message} />;
 }

--- a/apps/web/app/routes/_app.resources.$type._index.tsx
+++ b/apps/web/app/routes/_app.resources.$type._index.tsx
@@ -4,7 +4,6 @@ import {
   type MetaFunction,
   useLoaderData,
   useNavigate,
-  useParams,
   useRouteError,
 } from "@remix-run/react";
 import { useMemo, useState } from "react";
@@ -123,10 +122,9 @@ export default function ResourceList() {
   }
 
   const crumbs = [{ label: "resources", to: "/resources" }, { label: type }];
-  const command = `tulipfarm resources ${type} --list`;
 
   return (
-    <ResourcePanel crumbs={crumbs} command={command}>
+    <ResourcePanel crumbs={crumbs}>
       <div className="flex flex-wrap items-center gap-2">
         <Button asChild variant="outline" size="sm">
           <Link to={`/resources/${encodeURIComponent(type)}/new`}>New {type}</Link>
@@ -208,15 +206,7 @@ export default function ResourceList() {
 
 export function ErrorBoundary() {
   const error = useRouteError();
-  const params = useParams();
   const status = error instanceof ApiError ? error.status : undefined;
   const message = error instanceof Error ? error.message : undefined;
-  return (
-    <ErrorState
-      section="resources"
-      command={`tulipfarm resources ${params.type ?? ""} --list`}
-      status={status}
-      message={message}
-    />
-  );
+  return <ErrorState section="resources" status={status} message={message} />;
 }

--- a/apps/web/app/routes/_app.resources.$type.new.tsx
+++ b/apps/web/app/routes/_app.resources.$type.new.tsx
@@ -3,7 +3,6 @@ import {
   type MetaFunction,
   useLoaderData,
   useNavigate,
-  useParams,
   useRouteError,
 } from "@remix-run/react";
 import { useState } from "react";
@@ -59,7 +58,7 @@ export default function ResourceCreate() {
   ];
 
   return (
-    <ResourcePanel crumbs={crumbs} command={`tulipfarm resources ${type} create`}>
+    <ResourcePanel crumbs={crumbs}>
       {schemaError ? (
         <p className="text-destructive">error: schema parse failed — {schemaError}</p>
       ) : (
@@ -79,15 +78,7 @@ export default function ResourceCreate() {
 
 export function ErrorBoundary() {
   const error = useRouteError();
-  const params = useParams();
   const status = error instanceof ApiError ? error.status : undefined;
   const message = error instanceof Error ? error.message : undefined;
-  return (
-    <ErrorState
-      section="resources"
-      command={`tulipfarm resources ${params.type ?? ""} create`}
-      status={status}
-      message={message}
-    />
-  );
+  return <ErrorState section="resources" status={status} message={message} />;
 }

--- a/apps/web/app/routes/_app.resources.$type.schema.tsx
+++ b/apps/web/app/routes/_app.resources.$type.schema.tsx
@@ -4,7 +4,6 @@ import {
   type MetaFunction,
   useLoaderData,
   useNavigate,
-  useParams,
   useRouteError,
 } from "@remix-run/react";
 import { type FormEvent, useState } from "react";
@@ -53,7 +52,7 @@ export default function ResourceTypeEdit() {
   ];
 
   return (
-    <ResourcePanel crumbs={crumbs} command={`tulipfarm resources ${type} edit-schema`}>
+    <ResourcePanel crumbs={crumbs}>
       <form onSubmit={onSubmit} className="flex flex-col gap-3">
         <p className="text-xs text-muted-foreground">
           The full JSON Schema (YAML). Editing here is lossless — relationships (x-links), id
@@ -83,12 +82,10 @@ export default function ResourceTypeEdit() {
 
 export function ErrorBoundary() {
   const error = useRouteError();
-  const params = useParams();
-  const command = `tulipfarm resources ${params.type ?? ""} edit-schema`;
   if (error instanceof ApiError && error.status === 404) {
-    return <NotFoundState section="resources" command={command} />;
+    return <NotFoundState section="resources" />;
   }
   const status = error instanceof ApiError ? error.status : undefined;
   const message = error instanceof Error ? error.message : undefined;
-  return <ErrorState section="resources" command={command} status={status} message={message} />;
+  return <ErrorState section="resources" status={status} message={message} />;
 }

--- a/apps/web/app/routes/_app.resources._index.tsx
+++ b/apps/web/app/routes/_app.resources._index.tsx
@@ -27,7 +27,7 @@ export default function ResourcesIndex() {
 
   if (rows.length === 0) {
     return (
-      <ResourcePanel crumbs={[{ label: "resources" }]} command="tulipfarm resources --list">
+      <ResourcePanel crumbs={[{ label: "resources" }]}>
         <p className="text-sm text-muted-foreground">
           No resource types defined yet. Create one here, or ask the assistant to build one in chat.
         </p>
@@ -39,7 +39,7 @@ export default function ResourcesIndex() {
   }
 
   return (
-    <ResourcePanel crumbs={[{ label: "resources" }]} command="tulipfarm resources --list">
+    <ResourcePanel crumbs={[{ label: "resources" }]}>
       <div className="flex items-center justify-between">
         <p className="text-xs text-muted-foreground">
           {rows.length} {rows.length === 1 ? "type" : "types"}
@@ -81,12 +81,5 @@ export function ErrorBoundary() {
   const error = useRouteError();
   const status = error instanceof ApiError ? error.status : undefined;
   const message = error instanceof Error ? error.message : undefined;
-  return (
-    <ErrorState
-      section="resources"
-      command="tulipfarm resources --list"
-      status={status}
-      message={message}
-    />
-  );
+  return <ErrorState section="resources" status={status} message={message} />;
 }

--- a/apps/web/app/routes/_app.resources.new.tsx
+++ b/apps/web/app/routes/_app.resources.new.tsx
@@ -108,7 +108,7 @@ export default function ResourceTypeNew() {
   const crumbs = [{ label: "resources", to: "/resources" }, { label: "new" }];
 
   return (
-    <ResourcePanel crumbs={crumbs} command="tulipfarm resources create">
+    <ResourcePanel crumbs={crumbs}>
       <form onSubmit={onSubmit} className="flex max-w-2xl flex-col gap-4">
         {error ? <p className="text-destructive">error: {error}</p> : null}
 
@@ -223,12 +223,5 @@ export function ErrorBoundary() {
   const error = useRouteError();
   const status = error instanceof ApiError ? error.status : undefined;
   const message = error instanceof Error ? error.message : undefined;
-  return (
-    <ErrorState
-      section="resources"
-      command="tulipfarm resources create"
-      status={status}
-      message={message}
-    />
-  );
+  return <ErrorState section="resources" status={status} message={message} />;
 }

--- a/apps/web/app/routes/_app.settings.llm.tsx
+++ b/apps/web/app/routes/_app.settings.llm.tsx
@@ -57,10 +57,7 @@ export default function SettingsLlm() {
   return (
     <div className="flex flex-col gap-4">
       <p className="text-sm text-muted-foreground">
-        <span aria-hidden className="text-primary">
-          ${" "}
-        </span>
-        tulipfarm llm-config · tiers run their providers as a fallback chain (top first)
+        Tiers run their providers as a fallback chain (top first).
       </p>
       {noneEnabled ? (
         <p className="rounded-sm border border-border bg-muted/40 px-3 py-2 text-sm text-muted-foreground">
@@ -85,12 +82,5 @@ export function ErrorBoundary() {
   const error = useRouteError();
   const status = error instanceof ApiError ? error.status : undefined;
   const message = error instanceof Error ? error.message : undefined;
-  return (
-    <ErrorState
-      section="settings"
-      command="tulipfarm llm-config"
-      status={status}
-      message={message}
-    />
-  );
+  return <ErrorState section="settings" status={status} message={message} />;
 }

--- a/apps/web/app/routes/_app.settings.secrets.tsx
+++ b/apps/web/app/routes/_app.settings.secrets.tsx
@@ -98,12 +98,7 @@ export default function SettingsSecrets() {
 
   return (
     <div className="flex flex-col gap-6">
-      <p className="text-sm text-muted-foreground">
-        <span aria-hidden className="text-primary">
-          ${" "}
-        </span>
-        tulipfarm secrets --list · secret values are never shown
-      </p>
+      <p className="text-sm text-muted-foreground">Secret values are never shown.</p>
 
       {error ? (
         <p
@@ -281,12 +276,5 @@ export function ErrorBoundary() {
   const error = useRouteError();
   const status = error instanceof ApiError ? error.status : undefined;
   const message = error instanceof Error ? error.message : undefined;
-  return (
-    <ErrorState
-      section="settings"
-      command="tulipfarm secrets --list"
-      status={status}
-      message={message}
-    />
-  );
+  return <ErrorState section="settings" status={status} message={message} />;
 }

--- a/apps/web/app/routes/_app.skills.$name.tsx
+++ b/apps/web/app/routes/_app.skills.$name.tsx
@@ -3,7 +3,6 @@ import {
   type MetaFunction,
   useLoaderData,
   useNavigate,
-  useParams,
   useRouteError,
 } from "@remix-run/react";
 import { useState } from "react";
@@ -49,10 +48,7 @@ export default function SkillDetail() {
   }
 
   return (
-    <ResourcePanel
-      crumbs={[{ label: "skills", to: "/skills" }, { label: skill.name }]}
-      command={`tulipfarm skills show ${skill.name}`}
-    >
+    <ResourcePanel crumbs={[{ label: "skills", to: "/skills" }, { label: skill.name }]}>
       {error ? (
         <p className="rounded-sm border border-destructive bg-destructive/10 px-3 py-2 text-destructive">
           error: {error}
@@ -92,12 +88,10 @@ export default function SkillDetail() {
 
 export function ErrorBoundary() {
   const error = useRouteError();
-  const params = useParams();
-  const command = `tulipfarm skills show ${params.name ?? ""}`;
   if (error instanceof ApiError && error.status === 404) {
-    return <NotFoundState section="skills" command={command} />;
+    return <NotFoundState section="skills" />;
   }
   const status = error instanceof ApiError ? error.status : undefined;
   const message = error instanceof Error ? error.message : undefined;
-  return <ErrorState section="skills" command={command} status={status} message={message} />;
+  return <ErrorState section="skills" status={status} message={message} />;
 }

--- a/apps/web/app/routes/_app.skills._index.tsx
+++ b/apps/web/app/routes/_app.skills._index.tsx
@@ -66,12 +66,5 @@ export function ErrorBoundary() {
   const error = useRouteError();
   const status = error instanceof ApiError ? error.status : undefined;
   const message = error instanceof Error ? error.message : undefined;
-  return (
-    <ErrorState
-      section="skills"
-      command="tulipfarm skills --list"
-      status={status}
-      message={message}
-    />
-  );
+  return <ErrorState section="skills" status={status} message={message} />;
 }

--- a/apps/web/app/routes/agents.routes.test.tsx
+++ b/apps/web/app/routes/agents.routes.test.tsx
@@ -59,7 +59,7 @@ test("index lists agents with label, domain, and autonomy", () => {
 
 test("index with no agents shows the empty state", () => {
   renderWithData(<AgentsIndex />, { agents: [] });
-  expect(screen.getByText("0 results")).toBeInTheDocument();
+  expect(screen.getByText(/No agents registered/)).toBeInTheDocument();
 });
 
 test("index ErrorBoundary surfaces 401 as authentication required", () => {


### PR DESCRIPTION
The shell faked a terminal/CLI aesthetic with decorative `$ tulipfarm <section> --list` prompt lines and a "tulipfarm" wordmark in each section frame, implying a CLI that does not exist. Remove all faux CLI command strings and de-terminalize the three shared frame components (resource-panel, empty-state, states) into plain bordered cards with a breadcrumb trail / section eyebrow. Drop the now-unused `command` props and orphaned consts across the route files, update the two settings helper lines, de-CLI the docs landing hero (remove the `tulipfarm(1)` manpage eyebrow and the `$ get started` prompt, reword the tagline), and refresh DESIGN.md. Branding (product name, page titles, sidebar/chat wordmarks) is kept.