### PR TITLE
fix(llm): prevent boot crash when provider secrets are deleted

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -36,6 +36,7 @@ import type { CounterStore, ResourceRepoFactory } from "./resources/repo";
 import { registerResourceRoutes } from "./resources/routes";
 import { registerSecretsRoutes } from "./secrets/routes";
 import { registerAgentRoutes } from "./soul/agents/routes";
+import { makeLlmCascadeOnSecretDelete } from "./soul/llm-config/cascade";
 import { registerLlmConfigRoutes } from "./soul/llm-config/routes";
 import { registerResourceTypeRoutes } from "./soul/resource-types/routes";
 import { registerSoulRoutes } from "./soul/routes";
@@ -152,7 +153,18 @@ export async function buildApp(opts: AppOptions = {}) {
     });
     const requireAuth = makeRequireAuth(opts.sessionStore, opts.userRepo, opts.tokenRepo);
     if (opts.secretsService) {
-      registerSecretsRoutes(app, opts.secretsService, requireAuth);
+      registerSecretsRoutes(app, opts.secretsService, requireAuth, {
+        onSecretDeleted:
+          opts.soulLoader && opts.gitSync && opts.llmService
+            ? makeLlmCascadeOnSecretDelete(
+                opts.soulLoader,
+                opts.gitSync,
+                opts.llmService,
+                opts.secretsService,
+                app.log
+              )
+            : undefined,
+      });
     }
     if (opts.gitSync) {
       registerSoulRoutes(app, opts.gitSync, requireAuth);

--- a/apps/api/src/secrets/routes.ts
+++ b/apps/api/src/secrets/routes.ts
@@ -20,7 +20,11 @@ const SecretMetaSchema = {
 export function registerSecretsRoutes(
   app: FastifyInstance,
   secretsService: SecretsService,
-  requireAuth: PreHandler
+  requireAuth: PreHandler,
+  opts?: {
+    /** Called after a successful delete; errors are caught and logged — never surface to the caller. */
+    onSecretDeleted?: (key: string) => Promise<void>;
+  }
 ): void {
   app.get(
     "/api/v1/secrets/status",
@@ -139,6 +143,17 @@ export function registerSecretsRoutes(
 
       const { key } = req.params as { key: string };
       await secretsService.delete(key);
+
+      if (opts?.onSecretDeleted) {
+        try {
+          await opts.onSecretDeleted(key);
+        } catch (err) {
+          app.log.error(
+            `[secrets] post-delete cascade for ${key} failed — ${err instanceof Error ? err.message : String(err)}`
+          );
+        }
+      }
+
       return reply.code(204).send();
     }
   );

--- a/apps/api/src/soul/llm-config/cascade.ts
+++ b/apps/api/src/soul/llm-config/cascade.ts
@@ -1,0 +1,65 @@
+import { unlink, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { LlmConfig, LlmService } from "@tulipfarm/llm";
+import type { SecretsService } from "@tulipfarm/secrets";
+import { llmProviderForFieldKey } from "@tulipfarm/secrets";
+import type { GitSyncService, Logger, SoulLoader } from "@tulipfarm/soul";
+import { stringify as stringifyYaml } from "yaml";
+import { pruneLlmConfig } from "./prune";
+
+/**
+ * Returns an `onSecretDeleted` callback that keeps `llm.config.yaml` in sync when a
+ * provider api_key secret is removed.
+ *
+ * On delete the callback:
+ * 1. Checks whether the deleted key is an api_key field for a known LLM provider.
+ * 2. Prunes matching provider entries from the current config.
+ * 3. If every tier still has providers → writes the pruned config and re-inits.
+ *    If any tier is left empty  → deletes the file entirely (clean unconfigured state).
+ * 4. Commits via gitSync and reloads the soul + LLM service.
+ *
+ * Errors are re-thrown so the caller can log and suppress them without crashing the
+ * delete response.
+ */
+export function makeLlmCascadeOnSecretDelete(
+  soulLoader: SoulLoader,
+  gitSync: GitSyncService,
+  llmService: LlmService,
+  secretsService: SecretsService,
+  logger: Logger
+): (deletedKey: string) => Promise<void> {
+  return async (deletedKey: string): Promise<void> => {
+    const currentConfig = soulLoader.llmConfig as LlmConfig | undefined;
+    if (!currentConfig) return;
+
+    const owner = llmProviderForFieldKey(deletedKey);
+    const field = owner?.fields.find((f) => f.key === deletedKey);
+    if (!owner || field?.role !== "api_key") return;
+
+    const result = pruneLlmConfig(currentConfig, deletedKey, owner);
+    if (result.action === "unchanged") return;
+
+    const configPath = join(gitSync.path, "llm.config.yaml");
+    const commitMsg = `soul: remove ${owner.id} provider (secret ${deletedKey} deleted)`;
+
+    if (result.action === "update") {
+      await writeFile(configPath, stringifyYaml(result.config), "utf8");
+    } else {
+      // "delete" — pruning left a tier empty; remove the file for a clean unconfigured state
+      try {
+        await unlink(configPath);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
+        throw err;
+      }
+    }
+
+    await gitSync.withSync(commitMsg);
+    await soulLoader.reload();
+    await llmService.init(soulLoader.llmConfig, secretsService, logger);
+
+    logger.info(
+      `[llm] config ${result.action === "update" ? "pruned" : "removed"} after secret ${deletedKey} deleted`
+    );
+  };
+}

--- a/apps/api/src/soul/llm-config/prune.test.ts
+++ b/apps/api/src/soul/llm-config/prune.test.ts
@@ -1,0 +1,177 @@
+import type { LlmConfig } from "@tulipfarm/llm";
+import type { LlmProviderInfo } from "@tulipfarm/secrets";
+import { describe, expect, it } from "vitest";
+import { pruneLlmConfig } from "./prune";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const azure: LlmProviderInfo = {
+  id: "azure",
+  label: "Azure OpenAI",
+  fields: [
+    { key: "azure-openai-api-key", label: "API key", role: "api_key", kind: "secret" },
+    {
+      key: "azure-openai-resource-name",
+      label: "Resource name",
+      role: "resource_name",
+      kind: "config",
+    },
+  ],
+};
+
+const anthropic: LlmProviderInfo = {
+  id: "anthropic",
+  label: "Anthropic",
+  fields: [{ key: "anthropic-api-key", label: "API key", role: "api_key", kind: "secret" }],
+};
+
+function makeConfig(overrides: Partial<LlmConfig["tiers"]> = {}): LlmConfig {
+  return {
+    tiers: {
+      quick: { providers: [{ provider: "azure", model: "gpt-4o" }] },
+      standard: { providers: [{ provider: "azure", model: "gpt-4o" }] },
+      complex: { providers: [{ provider: "azure", model: "gpt-4o" }] },
+      ...overrides,
+    },
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("pruneLlmConfig", () => {
+  it("returns 'unchanged' when no entries reference the deleted key", () => {
+    const config = makeConfig();
+    const result = pruneLlmConfig(config, "anthropic-api-key", anthropic);
+    expect(result.action).toBe("unchanged");
+  });
+
+  it("returns 'delete' when all tiers have only the affected provider (single-provider setup)", () => {
+    const config = makeConfig();
+    const result = pruneLlmConfig(config, "azure-openai-api-key", azure);
+    expect(result.action).toBe("delete");
+  });
+
+  it("returns 'delete' when any one tier would be left empty after pruning", () => {
+    const config = makeConfig({
+      quick: {
+        providers: [
+          { provider: "azure", model: "gpt-4o" },
+          { provider: "anthropic", model: "claude-haiku-4-5" },
+        ],
+      },
+      standard: {
+        providers: [
+          { provider: "azure", model: "gpt-4o" },
+          { provider: "anthropic", model: "claude-haiku-4-5" },
+        ],
+      },
+      // complex has only azure — will become empty after pruning
+      complex: { providers: [{ provider: "azure", model: "gpt-4o" }] },
+    });
+    const result = pruneLlmConfig(config, "azure-openai-api-key", azure);
+    expect(result.action).toBe("delete");
+  });
+
+  it("returns 'update' when affected entries removed and every tier still has ≥1 provider", () => {
+    const config = makeConfig({
+      quick: {
+        providers: [
+          { provider: "azure", model: "gpt-4o" },
+          { provider: "anthropic", model: "claude-haiku-4-5" },
+        ],
+      },
+      standard: {
+        providers: [
+          { provider: "azure", model: "gpt-4o" },
+          { provider: "anthropic", model: "claude-sonnet-4-6" },
+        ],
+      },
+      complex: {
+        providers: [
+          { provider: "azure", model: "gpt-4o" },
+          { provider: "anthropic", model: "claude-opus-4-8" },
+        ],
+      },
+    });
+    const result = pruneLlmConfig(config, "azure-openai-api-key", azure);
+    expect(result.action).toBe("update");
+    if (result.action !== "update") return;
+
+    for (const tier of ["quick", "standard", "complex"] as const) {
+      expect(result.config.tiers[tier].providers.every((e) => e.provider !== "azure")).toBe(true);
+      expect(result.config.tiers[tier].providers.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("removes entries with an explicit api_key_ref matching the deleted key", () => {
+    const config = makeConfig({
+      quick: {
+        providers: [
+          { provider: "azure", model: "gpt-4o", api_key_ref: "azure-openai-api-key" },
+          { provider: "anthropic", model: "claude-haiku-4-5" },
+        ],
+      },
+      standard: { providers: [{ provider: "anthropic", model: "claude-sonnet-4-6" }] },
+      complex: { providers: [{ provider: "anthropic", model: "claude-opus-4-8" }] },
+    });
+    const result = pruneLlmConfig(config, "azure-openai-api-key", azure);
+    expect(result.action).toBe("update");
+    if (result.action !== "update") return;
+    expect(result.config.tiers.quick.providers).toHaveLength(1);
+    expect(result.config.tiers.quick.providers[0]?.provider).toBe("anthropic");
+  });
+
+  it("does not remove entries using env:// api_key_ref (reads from process.env, not secrets)", () => {
+    const config = makeConfig({
+      quick: {
+        providers: [{ provider: "azure", model: "gpt-4o", api_key_ref: "env://AZURE_API_KEY" }],
+      },
+      standard: { providers: [{ provider: "anthropic", model: "claude-sonnet-4-6" }] },
+      complex: { providers: [{ provider: "anthropic", model: "claude-opus-4-8" }] },
+    });
+    const result = pruneLlmConfig(config, "azure-openai-api-key", azure);
+    expect(result.action).toBe("unchanged");
+  });
+
+  it("does not remove entries using a different explicit api_key_ref", () => {
+    const config = makeConfig({
+      quick: {
+        providers: [{ provider: "azure", model: "gpt-4o", api_key_ref: "my-custom-azure-key" }],
+      },
+      standard: { providers: [{ provider: "anthropic", model: "claude-sonnet-4-6" }] },
+      complex: { providers: [{ provider: "anthropic", model: "claude-opus-4-8" }] },
+    });
+    const result = pruneLlmConfig(config, "azure-openai-api-key", azure);
+    expect(result.action).toBe("unchanged");
+  });
+
+  it("preserves the embeddings field when returning 'update'", () => {
+    const config: LlmConfig = {
+      tiers: {
+        quick: {
+          providers: [
+            { provider: "azure", model: "gpt-4o" },
+            { provider: "anthropic", model: "claude-haiku-4-5" },
+          ],
+        },
+        standard: {
+          providers: [
+            { provider: "azure", model: "gpt-4o" },
+            { provider: "anthropic", model: "claude-sonnet-4-6" },
+          ],
+        },
+        complex: {
+          providers: [
+            { provider: "azure", model: "gpt-4o" },
+            { provider: "anthropic", model: "claude-opus-4-8" },
+          ],
+        },
+      },
+      embeddings: { providers: [{ provider: "openai", model: "text-embedding-3-small" }] },
+    };
+    const result = pruneLlmConfig(config, "azure-openai-api-key", azure);
+    expect(result.action).toBe("update");
+    if (result.action !== "update") return;
+    expect(result.config.embeddings).toEqual(config.embeddings);
+  });
+});

--- a/apps/api/src/soul/llm-config/prune.ts
+++ b/apps/api/src/soul/llm-config/prune.ts
@@ -1,0 +1,55 @@
+import type { LlmConfig, ProviderEntry } from "@tulipfarm/llm";
+import type { LlmProviderInfo } from "@tulipfarm/secrets";
+
+const TIERS = ["quick", "standard", "complex"] as const;
+
+export type PruneResult =
+  | { action: "unchanged" }
+  | { action: "update"; config: LlmConfig }
+  | { action: "delete" };
+
+/**
+ * A provider entry resolves its api key from `api_key_ref` when set, or from the
+ * registry's default key for its provider type when not. Either path becomes broken
+ * when `deletedKey` is removed, so both cases must be pruned.
+ *
+ * Entries with `env://` refs are unaffected — they read from process.env, not the
+ * secrets store.
+ */
+function entryUsesKey(entry: ProviderEntry, deletedKey: string, ownerProviderId: string): boolean {
+  if (entry.api_key_ref === deletedKey) return true;
+  if (!entry.api_key_ref && entry.provider === ownerProviderId) return true;
+  return false;
+}
+
+/**
+ * Computes the effect of deleting a provider api_key secret on the LlmConfig.
+ *
+ * - "unchanged" — no entries reference the deleted key; nothing to do.
+ * - "update"    — affected entries removed; every tier still has ≥1 provider; write pruned config.
+ * - "delete"    — at least one tier is left empty after pruning (can't produce a valid config);
+ *                 delete the file entirely so the server boots in a clean unconfigured state.
+ */
+export function pruneLlmConfig(
+  config: LlmConfig,
+  deletedKey: string,
+  owner: LlmProviderInfo
+): PruneResult {
+  let changed = false;
+  const nextTiers = { ...config.tiers };
+
+  for (const tier of TIERS) {
+    const original = config.tiers[tier].providers;
+    const kept = original.filter((entry) => !entryUsesKey(entry, deletedKey, owner.id));
+    nextTiers[tier] = { ...config.tiers[tier], providers: kept };
+    if (kept.length !== original.length) changed = true;
+  }
+
+  if (!changed) return { action: "unchanged" };
+
+  if (TIERS.some((t) => nextTiers[t].providers.length === 0)) {
+    return { action: "delete" };
+  }
+
+  return { action: "update", config: { ...config, tiers: nextTiers } };
+}

--- a/packages/llm/src/llm-service.test.ts
+++ b/packages/llm/src/llm-service.test.ts
@@ -1,7 +1,12 @@
 import type { LanguageModelV3, LanguageModelV3CallOptions } from "@ai-sdk/provider";
 import { APICallError } from "ai";
 import { describe, expect, it, vi } from "vitest";
-import { LlmConfigValidationError, LlmNotConfiguredError, UnknownModelError } from "./config";
+import {
+  LlmConfigValidationError,
+  LlmCredentialError,
+  LlmNotConfiguredError,
+  UnknownModelError,
+} from "./config";
 import { LlmService } from "./llm-service";
 import { createModel } from "./provider";
 
@@ -69,6 +74,98 @@ describe("LlmService", () => {
   it("invalid config throws LlmConfigValidationError", async () => {
     const svc = new LlmService();
     await expect(svc.init({ tiers: {} }, fakeSecrets)).rejects.toThrow(LlmConfigValidationError);
+  });
+
+  it("LlmCredentialError on a provider skips it and keeps the tier if another provider succeeds", async () => {
+    const okModel = (entry: { provider: string; model: string }) =>
+      Promise.resolve({
+        specificationVersion: "v3",
+        provider: entry.provider,
+        modelId: entry.model,
+        supportedUrls: {},
+        doGenerate: vi.fn(),
+        doStream: vi.fn(),
+      } as unknown as LanguageModelV3);
+
+    // quick has 2 providers (1 rejected, 1 ok) + standard (ok) + complex (ok) = 4 calls total
+    vi.mocked(createModel)
+      .mockRejectedValueOnce(new LlmCredentialError("secret not found: azure-openai-api-key"))
+      .mockImplementationOnce(okModel)
+      .mockImplementationOnce(okModel)
+      .mockImplementationOnce(okModel);
+
+    const config = {
+      tiers: {
+        quick: {
+          providers: [
+            { provider: "azure", model: "gpt-4o", api_key_ref: "azure-openai-api-key" },
+            { provider: "anthropic", model: "claude-haiku-4-5", api_key_ref: "anthropic-api-key" },
+          ],
+        },
+        standard: validConfig.tiers.standard,
+        complex: validConfig.tiers.complex,
+      },
+    };
+
+    const svc = new LlmService();
+    await expect(svc.init(config, fakeSecrets)).resolves.toBeUndefined();
+    expect(svc.getModel("quick")).toBeDefined();
+  });
+
+  it("LlmCredentialError on all providers of a tier skips the tier without throwing", async () => {
+    const okModel = (entry: { provider: string; model: string }) =>
+      Promise.resolve({
+        specificationVersion: "v3",
+        provider: entry.provider,
+        modelId: entry.model,
+        supportedUrls: {},
+        doGenerate: vi.fn(),
+        doStream: vi.fn(),
+      } as unknown as LanguageModelV3);
+
+    // quick has 1 provider (rejected) + standard (ok) + complex (ok) = 3 calls total
+    vi.mocked(createModel)
+      .mockRejectedValueOnce(new LlmCredentialError("secret not found: key"))
+      .mockImplementationOnce(okModel)
+      .mockImplementationOnce(okModel);
+
+    const config = {
+      tiers: {
+        quick: {
+          providers: [{ provider: "azure", model: "gpt-4o", api_key_ref: "key" }],
+        },
+        standard: validConfig.tiers.standard,
+        complex: validConfig.tiers.complex,
+      },
+    };
+
+    const svc = new LlmService();
+    await expect(svc.init(config, fakeSecrets)).resolves.toBeUndefined();
+    expect(() => svc.getModel("quick")).toThrow(LlmNotConfiguredError);
+    expect(svc.getModel("standard")).toBeDefined();
+    expect(svc.getModel("complex")).toBeDefined();
+  });
+
+  it("LlmCredentialError on all tiers disables LLM without throwing", async () => {
+    // validConfig has 1 provider per tier = 3 calls total
+    vi.mocked(createModel)
+      .mockRejectedValueOnce(new LlmCredentialError("secret not found: key"))
+      .mockRejectedValueOnce(new LlmCredentialError("secret not found: key"))
+      .mockRejectedValueOnce(new LlmCredentialError("secret not found: key"));
+
+    const svc = new LlmService();
+    await expect(svc.init(validConfig, fakeSecrets)).resolves.toBeUndefined();
+    expect(() => svc.getModel("quick")).toThrow(LlmNotConfiguredError);
+    expect(() => svc.getModel("standard")).toThrow(LlmNotConfiguredError);
+    expect(() => svc.getModel("complex")).toThrow(LlmNotConfiguredError);
+  });
+
+  it("unexpected errors during provider init still propagate", async () => {
+    // Throws on the first call — init bails before trying the other tiers
+    vi.mocked(createModel).mockRejectedValueOnce(new Error("unexpected network failure"));
+
+    const svc = new LlmService();
+    await expect(svc.init(validConfig, fakeSecrets)).rejects.toThrow("unexpected network failure");
   });
 
   it("threads the injected logger into tier fallback chains", async () => {

--- a/packages/llm/src/llm-service.ts
+++ b/packages/llm/src/llm-service.ts
@@ -1,6 +1,12 @@
 import type { SecretsService } from "@tulipfarm/secrets";
 import type { LanguageModel } from "ai";
-import { LlmNotConfiguredError, UnknownModelError, validateLlmConfig } from "./config";
+import {
+  LlmConfigValidationError,
+  LlmCredentialError,
+  LlmNotConfiguredError,
+  UnknownModelError,
+  validateLlmConfig,
+} from "./config";
 import { type FallbackLogger, FallbackModel } from "./fallback";
 import { createModel } from "./provider";
 import { type ModelSelector, resolveTier, type SelectionContext } from "./selection";
@@ -36,13 +42,45 @@ export class LlmService {
 
     for (const tier of TIERS) {
       const { providers } = config.tiers[tier];
-      const built = await Promise.all(providers.map((entry) => createModel(entry, secrets)));
-      built.forEach((model, i) => {
-        const id = providers[i]?.model;
-        if (id && !byModelId.has(id)) byModelId.set(id, model);
-      });
+
+      // Resolve providers concurrently. Each entry catches expected errors locally and
+      // returns null (skip + warn); unexpected errors re-throw immediately via Promise.all.
+      // Promise.all preserves result order, so the fallback chain stays in config order.
+      const resolved = await Promise.all(
+        providers.map(async (entry) => {
+          try {
+            return { model: await createModel(entry, secrets), id: entry.model };
+          } catch (err) {
+            if (err instanceof LlmCredentialError || err instanceof LlmConfigValidationError) {
+              console.warn(
+                `[llm] skip tier=${tier} provider=${entry.provider} model=${entry.model} — ${err.message}`
+              );
+              return null;
+            }
+            throw err;
+          }
+        })
+      );
+
+      const built: Awaited<ReturnType<typeof createModel>>[] = [];
+      for (const r of resolved) {
+        if (r === null) continue;
+        built.push(r.model);
+        if (!byModelId.has(r.id)) byModelId.set(r.id, r.model);
+      }
+
+      if (built.length === 0) {
+        console.warn(`[llm] tier=${tier} — no providers available, tier skipped`);
+        continue;
+      }
+
       models.set(tier, new FallbackModel(built, logger));
-      console.info(`[llm] tier=${tier} providers=${providers.length}`);
+      console.info(`[llm] tier=${tier} providers=${built.length}`);
+    }
+
+    if (models.size === 0) {
+      console.warn("[llm] no providers available across all tiers — LLM features disabled");
+      return;
     }
 
     this.models = models;


### PR DESCRIPTION
### Bug

Deleting a provider's API key from **Settings → Secrets** caused the server to refuse to start on the next restart.

**Root cause:** Two independent pieces of state had no referential integrity:

1. **Secrets** — stored in PostgreSQL, managed via Settings
2. **LLM config** — stored in `soul/llm.config.yaml`, managed via Settings → LLM

When a secret was deleted, only the database row was removed. The YAML file still referenced the deleted key. On the next boot, `LlmService.init` used `Promise.all` to build all providers — the first missing credential threw `LlmCredentialError`, which bubbled up through `boot()` and called `process.exit(1)`. The entire API refused to start.

---

### Fix 1 — Graceful degradation in `LlmService.init` (safety net)

**File:** `packages/llm/src/llm-service.ts`

Changed `Promise.all` (fail-fast) to `Promise.all` with a per-entry `async` wrapper that catches `LlmCredentialError` and `LlmConfigValidationError` locally, skips that provider with a `console.warn`, and continues.

Three degradation levels — none crash boot:

| Scenario | Outcome |
|---|---|
| One provider in a tier has a missing secret | That provider is skipped; the tier runs with the remaining ones |
| All providers in a tier have missing secrets | That tier is skipped; other tiers still work |
| All providers across all tiers have missing secrets | LLM features disabled (same as no `llm.config.yaml`); API starts normally |

Unexpected errors (DB failures, bugs) still propagate and crash boot — only expected config/credential errors are swallowed.

**Tests added:** 4 new cases in `packages/llm/src/llm-service.test.ts` covering all three degradation levels plus the re-throw path.

---

### Fix 2 — Cascade deletion of stale config entries (root cause fix)

**Files:** `apps/api/src/soul/llm-config/prune.ts`, `cascade.ts`, `apps/api/src/secrets/routes.ts`, `apps/api/src/app.ts`

When a provider's `api_key` secret is deleted via `DELETE /api/v1/secrets/:key`, the server now automatically removes that provider from `llm.config.yaml` and reloads the LLM service.

**`prune.ts`** — pure function, three possible outcomes:
- `"unchanged"` — config has no references to the deleted key
- `"update"` — affected entries removed; every tier still has ≥1 provider; write the trimmed config
- `"delete"` — any tier would be left empty (can't produce a valid config); delete the file entirely for a clean unconfigured state

**`cascade.ts`** — orchestration factory. On delete: checks if the key is an `api_key` role field for a known provider → calls `pruneLlmConfig` → writes or unlinks the file → `gitSync.withSync` → `soulLoader.reload` → `llmService.init`.

**`secrets/routes.ts`** — DELETE handler accepts an opaque `onSecretDeleted` callback. Errors from the cascade are caught and logged; the `204` response is always returned. The secrets domain knows nothing about LLM.

**`app.ts`** — wires the cascade factory into `registerSecretsRoutes` when `soulLoader`, `gitSync`, and `llmService` are all present. Existing tests that call `buildApp({})` without those deps are unaffected.

**Tests added:** 8 cases in `apps/api/src/soul/llm-config/prune.test.ts` covering unchanged/update/delete outcomes, explicit vs implicit key resolution, `env://` refs, and embeddings field preservation.

---

### Why both fixes are needed

Fix 2 handles the normal UI flow and proactively removes stale references. Fix 1 is the permanent safety net for cases Fix 2 cannot cover:

- Fix 2 cascade fails mid-way (network error during git commit)
- Secret deleted directly in the database (bypasses the API entirely)
- `resource_name` deleted without the `api_key` (cascade only watches `api_key` role fields, but `LlmConfigValidationError` is still thrown at boot)
- `llm.config.yaml` edited or synced from a remote branch with a reference to a non-existent key
- Any future deletion path that doesn't go through `DELETE /api/v1/secrets/:key`

> Fix 2 prevents the mess. Fix 1 ensures the server survives any mess that still happens.

Made with [Cursor](https://cursor.com)