### PR TITLE
feat(ui): add Modal component and confirm delete for secrets

### DIFF
--- a/apps/web/app/components/ui/modal.tsx
+++ b/apps/web/app/components/ui/modal.tsx
@@ -29,11 +29,24 @@ export function Modal({
 
   // Drive open/close from props. Guard against calling when already in the
   // desired state to prevent spurious 'close' events triggering onClose.
+  // Falls back to toggling the `open` attribute directly in environments that
+  // don't implement showModal (e.g. jsdom in tests).
   useEffect(() => {
     const d = ref.current;
     if (!d) return;
-    if (open && !d.open) d.showModal();
-    else if (!open && d.open) d.close();
+    if (open && !d.open) {
+      if (typeof d.showModal === "function") {
+        d.showModal();
+      } else {
+        d.setAttribute("open", "");
+      }
+    } else if (!open && d.open) {
+      if (typeof d.close === "function") {
+        d.close();
+      } else {
+        d.removeAttribute("open");
+      }
+    }
   }, [open]);
 
   // Sync parent state when the dialog closes natively (Escape key).

--- a/apps/web/app/components/ui/modal.tsx
+++ b/apps/web/app/components/ui/modal.tsx
@@ -1,0 +1,130 @@
+import { X } from "lucide-react";
+import type * as React from "react";
+import { useEffect, useRef } from "react";
+import { Button } from "~/components/ui/button";
+import { cn } from "~/lib/utils";
+
+/*
+ * Modal — built on the native <dialog> element.
+ *
+ * Using the browser's showModal() gives us focus-trap, Escape-to-close, and
+ * the ::backdrop pseudo-element for free — no Radix or third-party dependency.
+ * Flat/hairline aesthetic: no shadows, rounded-sm panel, border-border.
+ */
+
+export function Modal({
+  open,
+  onClose,
+  title,
+  children,
+  className,
+}: {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  const ref = useRef<HTMLDialogElement>(null);
+
+  // Drive open/close from props. Guard against calling when already in the
+  // desired state to prevent spurious 'close' events triggering onClose.
+  useEffect(() => {
+    const d = ref.current;
+    if (!d) return;
+    if (open && !d.open) d.showModal();
+    else if (!open && d.open) d.close();
+  }, [open]);
+
+  // Sync parent state when the dialog closes natively (Escape key).
+  useEffect(() => {
+    const d = ref.current;
+    if (!d) return;
+    d.addEventListener("close", onClose);
+    return () => d.removeEventListener("close", onClose);
+  }, [onClose]);
+
+  // Close when the user clicks the ::backdrop (click lands on <dialog> itself,
+  // outside its layout rect).
+  function onBackdropClick(e: React.MouseEvent<HTMLDialogElement>) {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const outside =
+      e.clientX < rect.left ||
+      e.clientX > rect.right ||
+      e.clientY < rect.top ||
+      e.clientY > rect.bottom;
+    if (outside) onClose();
+  }
+
+  return (
+    // biome-ignore lint/a11y/useKeyWithClickEvents: <dialog> handles keyboard dismissal natively via the Escape key (cancel → close event)
+    <dialog
+      ref={ref}
+      onClick={onBackdropClick}
+      className={cn(
+        "m-auto w-full max-w-sm rounded-sm border border-border bg-card p-0 text-foreground",
+        "[&::backdrop]:bg-foreground/30",
+        className
+      )}
+    >
+      <div className="flex items-center justify-between border-b border-border px-4 py-3">
+        <h2 className="text-sm font-medium text-foreground">{title}</h2>
+        <button
+          type="button"
+          aria-label="Close"
+          onClick={onClose}
+          className="rounded-sm p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+        >
+          <X className="size-4" />
+        </button>
+      </div>
+      <div className="px-4 py-4 text-sm">{children}</div>
+    </dialog>
+  );
+}
+
+export function ConfirmModal({
+  open,
+  onClose,
+  onConfirm,
+  title,
+  description,
+  confirmLabel = "Delete",
+  busy = false,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  title: string;
+  description: string;
+  confirmLabel?: string;
+  busy?: boolean;
+}) {
+  return (
+    <Modal open={open} onClose={onClose} title={title}>
+      <p className="text-muted-foreground">{description}</p>
+      <div className="mt-4 flex justify-end gap-2">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="rounded-sm"
+          onClick={onClose}
+          disabled={busy}
+        >
+          Cancel
+        </Button>
+        <Button
+          type="button"
+          variant="destructive"
+          size="sm"
+          className="rounded-sm"
+          onClick={onConfirm}
+          disabled={busy}
+        >
+          {busy ? "Deleting…" : confirmLabel}
+        </Button>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/web/app/routes/_app.settings.secrets.tsx
+++ b/apps/web/app/routes/_app.settings.secrets.tsx
@@ -2,6 +2,7 @@ import { useLoaderData, useRevalidator, useRouteError } from "@remix-run/react";
 import { type FormEvent, useMemo, useState } from "react";
 import { ErrorState } from "~/components/states";
 import { Button } from "~/components/ui/button";
+import { ConfirmModal } from "~/components/ui/modal";
 import { ApiError } from "~/lib/api";
 import {
   deleteSecret,
@@ -43,6 +44,10 @@ export default function SettingsSecrets() {
   const [customKey, setCustomKey] = useState("");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<{
+    label: string;
+    fn: () => Promise<unknown>;
+  } | null>(null);
 
   const selected = providers.find((p) => p.id === providerId);
 
@@ -149,7 +154,10 @@ export default function SettingsSecrets() {
                     disabled={busy}
                     onClick={(e) => {
                       e.preventDefault();
-                      void run(() => Promise.all(g.keys.map((k) => deleteSecret(k))));
+                      setPendingDelete({
+                        label: g.provider.label,
+                        fn: () => Promise.all(g.keys.map((k) => deleteSecret(k))),
+                      });
                     }}
                   >
                     Delete
@@ -186,7 +194,12 @@ export default function SettingsSecrets() {
                 size="sm"
                 className="ml-auto rounded-sm"
                 disabled={busy}
-                onClick={() => void run(() => deleteSecret(secret.key))}
+                onClick={() =>
+                  setPendingDelete({
+                    label: secret.key,
+                    fn: () => deleteSecret(secret.key),
+                  })
+                }
               >
                 Delete
               </Button>
@@ -268,6 +281,19 @@ export default function SettingsSecrets() {
           </Button>
         </div>
       </form>
+
+      <ConfirmModal
+        open={pendingDelete !== null}
+        onClose={() => setPendingDelete(null)}
+        onConfirm={() => {
+          const pending = pendingDelete;
+          setPendingDelete(null);
+          if (pending) void run(pending.fn);
+        }}
+        title="Delete secrets"
+        description={`Remove all secrets for "${pendingDelete?.label ?? ""}"? This cannot be undone.`}
+        busy={busy}
+      />
     </div>
   );
 }

--- a/apps/web/app/routes/settings.routes.test.tsx
+++ b/apps/web/app/routes/settings.routes.test.tsx
@@ -1,6 +1,6 @@
 import * as remix from "@remix-run/react";
 import { createRemixStub } from "@remix-run/testing";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactElement } from "react";
 import { afterEach, expect, test, vi } from "vitest";
@@ -133,6 +133,8 @@ test("deleting a provider removes all of its stored field keys", async () => {
     config: {},
   });
   await userEvent.click(screen.getByRole("button", { name: /delete/i }));
+  const dialog = await screen.findByRole("dialog");
+  await userEvent.click(within(dialog).getByRole("button", { name: /delete/i }));
   expect(settings.deleteSecret).toHaveBeenCalledWith("azure-openai-api-key");
   expect(settings.deleteSecret).toHaveBeenCalledWith("azure-openai-resource-name");
 });
@@ -144,6 +146,8 @@ test("a custom (non-provider) secret lists individually and deletes by its key",
     config: {},
   });
   await userEvent.click(screen.getByRole("button", { name: /delete/i }));
+  const dialog = await screen.findByRole("dialog");
+  await userEvent.click(within(dialog).getByRole("button", { name: /delete/i }));
   expect(settings.deleteSecret).toHaveBeenCalledWith("stale-key");
 });
 


### PR DESCRIPTION
### Summary

- Introduces a reusable `Modal` and `ConfirmModal` component in `app/components/ui/modal.tsx`, built on the native `<dialog>` element — no Radix or additional dependency required
- Wires `ConfirmModal` into the secrets settings page so both provider-group and custom-secret delete actions require explicit confirmation before executing

### Motivation

Previously, clicking Delete on the secrets page fired the API call immediately with no guard. Destructive actions should always require a second confirmation step, especially for secrets which cannot be recovered once deleted.

### How it works

The `Modal` uses the browser's native `showModal()` API which provides:
- Focus trap for free
- Escape-to-close (fires the native `cancel → close` event, synced back to React state)
- `::backdrop` pseudo-element for the overlay (styled via `[&::backdrop]:bg-foreground/30` — respects dark mode)
- Backdrop-click-to-close via bounding-rect check on the `<dialog>` click event

Design follows the project's flat/hairline aesthetic: `rounded-sm`, `border-border`, `bg-card`, no shadows.

### Changes

- `apps/web/app/components/ui/modal.tsx` — new file: `Modal` (generic) + `ConfirmModal` (destructive confirmation pattern)
- `apps/web/app/routes/_app.settings.secrets.tsx` — both Delete buttons now set `pendingDelete` state; `ConfirmModal` mounted at component root handles the actual `deleteSecret` call via the existing `run()` helper

### Screenshots

<img width="1468" height="834" alt="image" src="https://github.com/user-attachments/assets/474332d7-7e6b-4dfc-bc2f-6813d964d290" />
