### PR TITLE
feat(chat): dev-only debug drawer exposing raw conversation state + s…

### DIFF
--- a/apps/api/src/chat/routes.test.ts
+++ b/apps/api/src/chat/routes.test.ts
@@ -1944,4 +1944,128 @@ describe("chat routes", () => {
       expect(res.json().messages).toHaveLength(2);
     });
   });
+
+  describe("GET /api/v1/conversations/:id/debug-context (dev-only raw state)", () => {
+    // Seeds one of every persisted role, incl. tool-call/tool-result parts and a compaction summary,
+    // so the assertions prove the debug payload surfaces the full raw rows (not just user/assistant).
+    function seedAllRoles(convoId: string): void {
+      const base = Date.now();
+      const at = (i: number) => new Date(base + i * 1000);
+      messageRepo.messages.push(
+        {
+          _id: randomUUID(),
+          conversationId: convoId,
+          role: "user",
+          content: "hi",
+          createdAt: at(0),
+        },
+        {
+          _id: randomUUID(),
+          conversationId: convoId,
+          role: "assistant",
+          content: [
+            { type: "text", text: "on it" },
+            { type: "tool-call", toolCallId: "tc1", toolName: "search", args: { q: "x" } },
+          ] as MessagePart[],
+          createdAt: at(1),
+        },
+        {
+          _id: randomUUID(),
+          conversationId: convoId,
+          role: "tool",
+          content: [
+            { type: "tool-result", toolCallId: "tc1", toolName: "search", result: { hits: 0 } },
+          ] as MessagePart[],
+          createdAt: at(2),
+        },
+        {
+          _id: randomUUID(),
+          conversationId: convoId,
+          role: "summary",
+          content: "earlier turns, summarized",
+          createdAt: at(3),
+        }
+      );
+    }
+
+    it("401 without auth", async () => {
+      const res = await get(`/api/v1/conversations/${randomUUID()}/debug-context`, {
+        session: null,
+      });
+      expect(res.statusCode).toBe(401);
+    });
+
+    it("404 for a missing conversation", async () => {
+      const res = await get(`/api/v1/conversations/${randomUUID()}/debug-context`);
+      expect(res.statusCode).toBe(404);
+      expect(res.json().error).toBe("conversation not found");
+    });
+
+    it("returns the reconstructed system prompt plus the full raw rows (all roles)", async () => {
+      const convoId = randomUUID();
+      const now = new Date();
+      await repo.create({
+        _id: convoId,
+        userId,
+        agentId: "agent-x",
+        createdAt: now,
+        updatedAt: now,
+      });
+      seedAllRoles(convoId);
+
+      const res = await get(`/api/v1/conversations/${convoId}/debug-context`);
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.conversationId).toBe(convoId);
+      expect(typeof body.systemPrompt).toBe("string");
+      expect(body.systemPrompt.length).toBeGreaterThan(0);
+      // All four persisted roles survive to the payload, including summary + tool rows.
+      expect(body.messages.map((m: MessageDoc) => m.role)).toEqual([
+        "user",
+        "assistant",
+        "tool",
+        "summary",
+      ]);
+      // Tool-call/tool-result parts are preserved verbatim.
+      const assistant = body.messages[1];
+      expect(assistant.content).toContainEqual({
+        type: "tool-call",
+        toolCallId: "tc1",
+        toolName: "search",
+        args: { q: "x" },
+      });
+    });
+
+    it("is not registered when NODE_ENV=production (route absent → 404 even for a seeded convo)", async () => {
+      const prev = process.env.NODE_ENV;
+      process.env.NODE_ENV = "production";
+      const prodApp = await buildApp({
+        sessionStore: store,
+        userRepo,
+        tokenRepo,
+        llmService,
+        conversationRepo: repo,
+        messageRepo,
+        streamResumeRepo: streamRepo,
+        streamHub,
+        workingMemoryService: new WorkingMemoryService(workingMemoryRepo),
+      });
+      try {
+        const convoId = randomUUID();
+        const now = new Date();
+        await repo.create({ _id: convoId, userId, createdAt: now, updatedAt: now });
+        // A registered route would 200 for a seeded convo; a 404 here proves the gate omitted it.
+        const res = await prodApp.inject({
+          method: "GET",
+          url: `/api/v1/conversations/${convoId}/debug-context`,
+          cookies: { [SESSION_COOKIE]: sid },
+        });
+        expect(res.statusCode).toBe(404);
+        expect(res.json().error).not.toBe("conversation not found");
+      } finally {
+        await prodApp.close();
+        process.env.NODE_ENV = prev;
+      }
+    });
+  });
 });

--- a/apps/api/src/chat/routes.ts
+++ b/apps/api/src/chat/routes.ts
@@ -8,7 +8,6 @@ import { stringify as stringifyYaml } from "yaml";
 import { type A2uiSurfaceStore, MemoryA2uiSurfaceStore } from "../a2ui/surface-store";
 import { ErrorSchema } from "../auth/schemas";
 import type { UserDoc } from "../auth/users";
-import { assembleSystemPrompt } from "../context/assemble";
 import { DOMAIN_EVENTS } from "../domain-events";
 import type { GuardContext, GuardrailsService } from "../guardrails";
 import type { KnowledgeService } from "../knowledge/service";
@@ -22,7 +21,6 @@ import {
   getPlatformAgent,
   resolveAgent,
 } from "../soul/agents/registry";
-import { BUILTIN_SKILLS } from "../soul/skills/builtin-skills";
 import { type EagerSkill, listAvailableSkills, listEagerSkills } from "../soul/skills/registry";
 import { BatchCoordinator } from "../tools/batch-executor";
 import type { RunToolCallGuard, ToolRegistry } from "../tools/registry";
@@ -47,6 +45,7 @@ import { writeSseHeaders } from "./sse";
 import { makeStreamEmitter } from "./stream-emitter";
 import type { StreamHub } from "./stream-hub";
 import type { StreamResumeRepo } from "./stream-resume";
+import { assembleAgentSystemPrompt } from "./system-prompt";
 import { buildAndStoreTitle } from "./title";
 
 type PreHandler = (req: FastifyRequest, reply: FastifyReply) => Promise<void>;
@@ -460,23 +459,16 @@ export function registerChatRoutes(
         .map((type) => soulLoader?.resources.get(type))
         .filter((r): r is NonNullable<typeof r> => r != null)
         .map((r) => ({ name: r.name, schema: stringifyYaml(r.schema) }));
-      const buildSystemFor = (a: typeof agent, pa: typeof platformAgent): string => {
-        const forgeAvailable = (pa?.forgeSkills ?? [])
-          .map((n) => BUILTIN_SKILLS.get(n))
-          .filter((s): s is NonNullable<typeof s> => s !== undefined)
-          .map((s) => ({ name: s.name, description: s.description }));
-        return assembleSystemPrompt({
-          agentId: a.name,
-          domain: typeof a.frontmatter.domain === "string" ? a.frontmatter.domain : null,
-          tenantId: "default",
-          personality: a.body,
+      const buildSystemFor = (a: typeof agent, pa: typeof platformAgent): string =>
+        assembleAgentSystemPrompt({
+          agent: a,
+          platformAgent: pa,
           memory: memoryList,
           governanceDocs,
-          availableSkills: [...soulAvailableSkills, ...forgeAvailable],
+          availableSkills: soulAvailableSkills,
           eagerSkills: mergedEagerSkills,
           taggedResources: turnTaggedResources,
         });
-      };
       const system = buildSystemFor(agent, platformAgent);
       // Compaction (CTX-V1-001/002): over budget → summarize the oldest turns once into a durable
       // `summary` row; recent turns stay verbatim. Best-effort — a summarize failure falls back to
@@ -1161,4 +1153,68 @@ export function registerChatRoutes(
       return reply.send({ messages: result.items, nextCursor: result.nextCursor });
     }
   );
+
+  // Dev-only raw-state inspector backing the chat debug drawer. Returns the full persisted rows (all
+  // roles incl. system/summary, tool-call/tool-result parts, metadata) PLUS the system prompt the LLM
+  // receives — reconstructed via the same `assembleAgentSystemPrompt` the chat turn uses, so it cannot
+  // drift from reality. The assembled prompt embeds user working-memory + governance docs, so the route
+  // is registered only outside production; the web app's `import.meta.env.DEV` gate does not protect an API.
+  if (process.env.NODE_ENV !== "production") {
+    app.get(
+      "/api/v1/conversations/:id/debug-context",
+      {
+        preHandler: requireAuth,
+        schema: {
+          description:
+            "Dev-only: a conversation's reconstructed system prompt + full raw message rows " +
+            "(not registered in production).",
+          tags: ["chat"],
+          security: [{ sessionCookie: [] }, { bearerToken: [] }],
+          params: {
+            type: "object",
+            required: ["id"],
+            properties: { id: { type: "string" } },
+          },
+          response: {
+            200: {
+              type: "object",
+              properties: {
+                conversationId: { type: "string" },
+                systemPrompt: { type: "string" },
+                messages: { type: "array", items: MessageSchema },
+              },
+              required: ["conversationId", "systemPrompt", "messages"],
+            },
+            401: ErrorSchema,
+            404: ErrorSchema,
+          },
+        },
+      },
+      async (req, reply) => {
+        const { id } = req.params as { id: string };
+        const convo = await repo.findById(id);
+        if (!convo) {
+          return reply.code(404).send({ error: "conversation not found" });
+        }
+        // Reconstruct this conversation's durable system prompt with no per-turn ephemeral skills /
+        // resources (there is no in-flight turn) — mirrors the chat route's front-desk assembly. Memory
+        // is the conversation owner's, so the prompt matches what the LLM actually saw for this chat.
+        const agent = resolveAgent(soulLoader, convo.agentId);
+        const platformAgent = getPlatformAgent(agent.name);
+        const memory = workingMemory && convo.userId ? await workingMemory.list(convo.userId) : [];
+        const governanceDocs = knowledge ? await knowledge.governanceDocuments() : [];
+        const systemPrompt = assembleAgentSystemPrompt({
+          agent,
+          platformAgent,
+          memory,
+          governanceDocs,
+          availableSkills: listAvailableSkills(soulLoader),
+          eagerSkills: listEagerSkills(soulLoader),
+          taggedResources: [],
+        });
+        const history = await messageRepo.listByConversation(id, 1000);
+        return reply.send({ conversationId: id, systemPrompt, messages: history.items });
+      }
+    );
+  }
 }

--- a/apps/api/src/chat/system-prompt.test.ts
+++ b/apps/api/src/chat/system-prompt.test.ts
@@ -1,0 +1,47 @@
+import type { SoulAgent } from "@tulipfarm/soul";
+import { describe, expect, it } from "vitest";
+import { assembleSystemPrompt } from "../context/assemble";
+import { INFORMATION_ARCHITECT } from "../soul/agents/platform-agents";
+import { assembleAgentSystemPrompt } from "./system-prompt";
+
+const agent: SoulAgent = {
+  name: "test-agent",
+  frontmatter: { domain: "testing" },
+  body: "You are a test agent.",
+};
+
+const empty = {
+  memory: [],
+  governanceDocs: [],
+  availableSkills: [],
+  eagerSkills: [],
+  taggedResources: [],
+};
+
+describe("assembleAgentSystemPrompt", () => {
+  it("matches a direct assembleSystemPrompt call when there is no platform agent", () => {
+    // Guards the extraction from `routes.ts`: with no platform agent, forge skills are empty, so the
+    // wrapper must produce byte-identical output to assembling the same durable inputs directly.
+    const got = assembleAgentSystemPrompt({ agent, platformAgent: undefined, ...empty });
+    const expected = assembleSystemPrompt({
+      agentId: "test-agent",
+      domain: "testing",
+      tenantId: "default",
+      personality: "You are a test agent.",
+      ...empty,
+    });
+    expect(got).toBe(expected);
+    expect(got).toContain("You are a test agent.");
+  });
+
+  it("merges the platform agent's forge skills into the available-skills index", () => {
+    const withForge = assembleAgentSystemPrompt({
+      agent,
+      platformAgent: INFORMATION_ARCHITECT,
+      ...empty,
+    });
+    const withoutForge = assembleAgentSystemPrompt({ agent, platformAgent: undefined, ...empty });
+    expect(withForge).toContain("skill-forge");
+    expect(withoutForge).not.toContain("skill-forge");
+  });
+});

--- a/apps/api/src/chat/system-prompt.ts
+++ b/apps/api/src/chat/system-prompt.ts
@@ -1,0 +1,48 @@
+import type { SoulAgent } from "@tulipfarm/soul";
+import { type AssembleContext, assembleSystemPrompt } from "../context/assemble";
+import type { PlatformAgent } from "../soul/agents/platform-agents";
+import { BUILTIN_SKILLS } from "../soul/skills/builtin-skills";
+import type { AvailableSkill } from "../soul/skills/registry";
+
+/**
+ * Assemble one agent's system prompt from already-fetched durable inputs. This is the single source
+ * of truth for the per-agent prompt: the chat turn (`registerChatRoutes`) wraps it in a closure that
+ * is reused for the front desk and each handoff target, and the dev-only debug-context route calls it
+ * to surface the exact prompt the LLM receives. The caller fetches memory / governance / skills once
+ * and passes them in — assembly itself performs no IO, mirroring `assembleSystemPrompt` (AC-V1-001).
+ */
+export function assembleAgentSystemPrompt(args: {
+  agent: SoulAgent;
+  platformAgent: PlatformAgent | undefined;
+  memory: AssembleContext["memory"];
+  governanceDocs: AssembleContext["governanceDocs"];
+  availableSkills: AvailableSkill[];
+  eagerSkills: AssembleContext["eagerSkills"];
+  taggedResources: AssembleContext["taggedResources"];
+}): string {
+  const {
+    agent,
+    platformAgent,
+    memory,
+    governanceDocs,
+    availableSkills,
+    eagerSkills,
+    taggedResources,
+  } = args;
+  // Platform forge skills surface in <available-skills> alongside the soul's own (loadable via load_skill).
+  const forgeAvailable = (platformAgent?.forgeSkills ?? [])
+    .map((n) => BUILTIN_SKILLS.get(n))
+    .filter((s): s is NonNullable<typeof s> => s !== undefined)
+    .map((s) => ({ name: s.name, description: s.description }));
+  return assembleSystemPrompt({
+    agentId: agent.name,
+    domain: typeof agent.frontmatter.domain === "string" ? agent.frontmatter.domain : null,
+    tenantId: "default",
+    personality: agent.body,
+    memory,
+    governanceDocs,
+    availableSkills: [...availableSkills, ...forgeAvailable],
+    eagerSkills,
+    taggedResources,
+  });
+}

--- a/apps/web/app/components/chat/chat-debug-drawer.test.tsx
+++ b/apps/web/app/components/chat/chat-debug-drawer.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, expect, test, vi } from "vitest";
+import { ChatDebugDrawer } from "~/components/chat/chat-debug-drawer";
+import { type DebugContext, getDebugContext } from "~/lib/conversations";
+
+vi.mock("~/lib/conversations", () => ({
+  getDebugContext: vi.fn(),
+}));
+
+const DEBUG: DebugContext = {
+  conversationId: "c1",
+  systemPrompt: "SYS_PROMPT_MARKER",
+  messages: [
+    { _id: "m1", conversationId: "c1", role: "user", content: "hello there", createdAt: "t0" },
+    {
+      _id: "m2",
+      conversationId: "c1",
+      role: "assistant",
+      content: [{ type: "tool-call", toolCallId: "tc1", toolName: "search", args: { q: "x" } }],
+      createdAt: "t1",
+    },
+  ],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getDebugContext).mockResolvedValue(DEBUG);
+});
+
+test("the button is disabled until there is a conversation id", () => {
+  render(<ChatDebugDrawer conversationId={undefined} />);
+  expect(screen.getByRole("button", { name: /open debug drawer/i })).toBeDisabled();
+});
+
+test("opens the drawer and dumps the system prompt + raw rows as JSON", async () => {
+  const user = userEvent.setup();
+  render(<ChatDebugDrawer conversationId="c1" />);
+
+  // Closed initially — no slide-over.
+  expect(screen.queryByRole("complementary")).toBeNull();
+
+  await user.click(screen.getByRole("button", { name: /open debug drawer/i }));
+
+  // Wait for the async fetch+render, then assert on the panel's flattened text (the JSON is now split
+  // across highlight spans, so read textContent off the whole drawer region rather than one node).
+  await screen.findByText(/SYS_PROMPT_MARKER/);
+  const panel = screen.getByRole("complementary");
+  expect(getDebugContext).toHaveBeenCalledWith("c1");
+  expect(panel.textContent).toContain('"role": "system"');
+  expect(panel.textContent).toContain("tool-call");
+  expect(panel.textContent).toContain("hello there");
+});
+
+test("Copy JSON writes the payload to the clipboard", async () => {
+  // userEvent.setup() installs a working navigator.clipboard stub; assert via its readText().
+  const user = userEvent.setup();
+  render(<ChatDebugDrawer conversationId="c1" />);
+  await user.click(screen.getByRole("button", { name: /open debug drawer/i }));
+  await screen.findByText(/SYS_PROMPT_MARKER/);
+
+  await user.click(screen.getByRole("button", { name: /copy json/i }));
+  const copied = await navigator.clipboard.readText();
+  expect(copied).toContain("SYS_PROMPT_MARKER");
+  expect(copied).toContain("hello there");
+});
+
+test("closes via the X button", async () => {
+  const user = userEvent.setup();
+  render(<ChatDebugDrawer conversationId="c1" />);
+  await user.click(screen.getByRole("button", { name: /open debug drawer/i }));
+  await screen.findByText(/SYS_PROMPT_MARKER/);
+
+  await user.click(screen.getByRole("button", { name: /close/i }));
+  expect(screen.queryByRole("complementary")).toBeNull();
+});

--- a/apps/web/app/components/chat/chat-debug-drawer.tsx
+++ b/apps/web/app/components/chat/chat-debug-drawer.tsx
@@ -1,0 +1,211 @@
+import { Bug, Check, Copy, RefreshCw, X } from "lucide-react";
+import { type ReactNode, useCallback, useEffect, useRef, useState } from "react";
+import { type DebugContext, getDebugContext } from "~/lib/conversations";
+import { cn } from "~/lib/utils";
+
+// Minimal, dependency-free JSON syntax highlighter. Tokenizes strings (key vs value), numbers, and
+// literals into React spans — text content is React-escaped, so there is no innerHTML/XSS surface.
+// Colors use the `dark:` variant (wired to [data-theme="dark"] in app.css); structural chars (braces,
+// commas, colons) inherit the <pre>'s muted color so the values pop.
+const JSON_TOKEN =
+  /"(?:\\.|[^"\\])*"|-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?|\btrue\b|\bfalse\b|\bnull\b/g;
+
+function highlightJson(json: string): ReactNode[] {
+  const out: ReactNode[] = [];
+  let last = 0;
+  let key = 0;
+  JSON_TOKEN.lastIndex = 0;
+  for (let m = JSON_TOKEN.exec(json); m !== null; m = JSON_TOKEN.exec(json)) {
+    const tok = m[0];
+    if (m.index > last) out.push(json.slice(last, m.index));
+    let cls: string;
+    if (tok[0] === '"') {
+      // A string immediately followed by `:` is an object key.
+      cls = /^\s*:/.test(json.slice(m.index + tok.length))
+        ? "text-sky-700 dark:text-sky-300"
+        : "text-emerald-700 dark:text-emerald-400";
+    } else if (tok === "true" || tok === "false" || tok === "null") {
+      cls = "text-fuchsia-700 dark:text-fuchsia-300";
+    } else {
+      cls = "text-amber-700 dark:text-amber-300";
+    }
+    out.push(
+      <span key={key} className={cls}>
+        {tok}
+      </span>
+    );
+    key += 1;
+    last = m.index + tok.length;
+  }
+  if (last < json.length) out.push(json.slice(last));
+  return out;
+}
+
+/**
+ * Dev-only chat debug drawer. A floating button opens a non-blocking right slide-over that dumps the
+ * full raw conversation state — the system prompt the LLM receives (reconstructed server-side) plus
+ * every persisted row (all roles, tool calls/results, metadata) — as copyable JSON, so a dev can paste
+ * the exact agent context into external pipelines. Gated on `import.meta.env.DEV`: the whole component
+ * (and its dynamic imports) dead-code-strips out of the production bundle, and the backing API route is
+ * registered only outside production.
+ */
+export function ChatDebugDrawer({ conversationId }: { conversationId?: string }) {
+  if (!import.meta.env.DEV) return null;
+  return <DebugDrawer conversationId={conversationId} />;
+}
+
+function DebugDrawer({ conversationId }: { conversationId?: string }) {
+  const [open, setOpen] = useState(false);
+  const [data, setData] = useState<DebugContext | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const panelRef = useRef<HTMLElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  const load = useCallback(async () => {
+    if (!conversationId) return;
+    setLoading(true);
+    setErr(null);
+    try {
+      setData(await getDebugContext(conversationId));
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : "failed to load debug context");
+    } finally {
+      setLoading(false);
+    }
+  }, [conversationId]);
+
+  // Snapshot on open (and on Refresh). A turn streaming right now shows up once it persists.
+  useEffect(() => {
+    if (open) void load();
+  }, [open, load]);
+
+  // Close on Escape or an outside click — no blocking backdrop, so the chat stays interactive
+  // (mirrors the model-selector dropdown). The listeners attach only while open.
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      const t = e.target as Node;
+      if (!panelRef.current?.contains(t) && !triggerRef.current?.contains(t)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  // Compose the displayed payload in the ticket's shape: the system prompt as the first role:"system"
+  // entry (clearly marked synthetic — it is reconstructed, not a stored row), then the raw rows.
+  const json = data
+    ? JSON.stringify(
+        {
+          conversationId: data.conversationId,
+          messages: [
+            {
+              _id: "system-prompt",
+              role: "system",
+              content: data.systemPrompt,
+              metadata: { synthetic: true },
+              createdAt: null,
+            },
+            ...data.messages,
+          ],
+        },
+        null,
+        2
+      )
+    : "";
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(json);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // clipboard unavailable (non-secure context) — no-op
+    }
+  }
+
+  const iconBtn =
+    "rounded-sm p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-40";
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-label="Open debug drawer"
+        title={conversationId ? "Debug — raw state" : "Send a message first"}
+        disabled={!conversationId}
+        onClick={() => setOpen((o) => !o)}
+        className={cn(
+          "fixed right-3 bottom-3 z-50 inline-flex size-9 items-center justify-center rounded-full border border-border bg-card text-muted-foreground shadow-sm transition-colors",
+          "hover:border-primary/60 hover:text-foreground disabled:opacity-40 disabled:hover:border-border disabled:hover:text-muted-foreground"
+        )}
+      >
+        <Bug className="size-4" />
+      </button>
+
+      {open ? (
+        <aside
+          ref={panelRef}
+          aria-label="Debug — Raw State"
+          className="fixed top-0 right-0 z-50 flex h-svh w-[min(34rem,90vw)] flex-col border-l border-border bg-card shadow-lg motion-safe:animate-in motion-safe:slide-in-from-right motion-safe:duration-200"
+        >
+          <header className="flex shrink-0 items-center gap-2 border-b border-border px-3 py-2">
+            <span className="text-xs font-medium text-foreground">Debug — Raw State</span>
+            <div className="ml-auto flex items-center gap-1">
+              <button
+                type="button"
+                aria-label="Refresh"
+                onClick={() => void load()}
+                disabled={loading}
+                className={iconBtn}
+              >
+                <RefreshCw className={cn("size-3.5", loading && "animate-spin")} />
+              </button>
+              <button
+                type="button"
+                aria-label={copied ? "Copied" : "Copy JSON"}
+                onClick={copy}
+                disabled={!json}
+                className={iconBtn}
+              >
+                {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+              </button>
+              <button
+                type="button"
+                aria-label="Close"
+                onClick={() => setOpen(false)}
+                className={iconBtn}
+              >
+                <X className="size-4" />
+              </button>
+            </div>
+          </header>
+          <div className="min-h-0 flex-1 overflow-auto">
+            {!conversationId ? (
+              <p className="p-3 text-xs text-muted-foreground">
+                No conversation yet — send a message first.
+              </p>
+            ) : loading && !data ? (
+              <p className="p-3 text-xs text-muted-foreground">loading…</p>
+            ) : err ? (
+              <p className="p-3 text-xs text-destructive">[error] {err}</p>
+            ) : (
+              <pre className="whitespace-pre-wrap break-words p-3 text-[0.6875rem] leading-relaxed text-muted-foreground">
+                {highlightJson(json)}
+              </pre>
+            )}
+          </div>
+        </aside>
+      ) : null}
+    </>
+  );
+}

--- a/apps/web/app/components/chat/chat-panel.tsx
+++ b/apps/web/app/components/chat/chat-panel.tsx
@@ -4,6 +4,7 @@ import type { ChatMessage, ModelTier } from "~/lib/chat/types";
 import { useChatStream } from "~/lib/chat/use-chat-stream";
 import { useConversations } from "~/lib/conversations-context";
 import type { Suggestion } from "~/lib/onboarding";
+import { ChatDebugDrawer } from "./chat-debug-drawer";
 import { Composer } from "./composer";
 import { asTier } from "./model-selector";
 import { Transcript } from "./transcript";
@@ -90,6 +91,7 @@ export function ChatPanel({
     status,
     error,
     currentAgent,
+    conversationId,
     send,
     stop,
     approve,
@@ -185,6 +187,7 @@ export function ChatPanel({
         // A `@agent` mention in the composer overrides the panel's active agent for that turn.
         onSend={(text, opts) => send(text, { ...opts, agentId: opts.agentId ?? agentId })}
       />
+      <ChatDebugDrawer conversationId={conversationId} />
     </div>
   );
 }

--- a/apps/web/app/lib/chat/use-chat-stream.ts
+++ b/apps/web/app/lib/chat/use-chat-stream.ts
@@ -339,6 +339,7 @@ export function useChatStream(opts?: UseChatStreamOptions) {
     pendingApprovals: state.pendingApprovals,
     status: state.status,
     currentAgent: state.currentAgent,
+    conversationId: state.conversationId,
     error: state.error,
     send,
     stop,

--- a/apps/web/app/lib/conversations.ts
+++ b/apps/web/app/lib/conversations.ts
@@ -33,6 +33,9 @@ export type ConversationMessage = {
   conversationId: string;
   role: "system" | "user" | "assistant" | "tool" | "summary";
   content: string | WireMessagePart[];
+  // Present on assistant rows (provenance: { model?, agentId }) and summary rows (compactedThrough).
+  // The API already sends this; surfaced here for the dev debug drawer.
+  metadata?: Record<string, unknown>;
   createdAt: string;
 };
 
@@ -76,4 +79,17 @@ export async function getConversationMessages(id: string): Promise<ConversationM
     `/api/v1/conversations/${encodeURIComponent(id)}/messages`
   );
   return body.messages;
+}
+
+// Dev-only raw conversation state for the chat debug drawer: the full persisted rows plus the system
+// prompt the LLM receives (reconstructed server-side). The backing route is registered only outside
+// production (see apps/api/src/chat/routes.ts), so this resolves only in dev.
+export type DebugContext = {
+  conversationId: string;
+  systemPrompt: string;
+  messages: ConversationMessage[];
+};
+
+export function getDebugContext(id: string): Promise<DebugContext> {
+  return apiGet<DebugContext>(`/api/v1/conversations/${encodeURIComponent(id)}/debug-context`);
 }


### PR DESCRIPTION
Fixed #55 

Adds an import.meta.env.DEV-only debug drawer to the chat UI: a bottom-right Bug button opens a non-blocking right slide-over that dumps the full raw conversation state as syntax-highlighted, copyable JSON, so a dev can paste the exact agent context into external pipelines.

The client's useChatStream state is only the rendered timeline (user+assistant parts) — it has no system prompt (assembled per-turn, never persisted), no summary rows, and no raw envelope. So the drawer fetches a new dev-gated endpoint instead.

- api: extract the per-agent system-prompt assembly out of the chat route into assembleAgentSystemPrompt (single source of truth, used by the chat turn and the debug route, so the debug prompt can't drift from what the LLM receives).
- api: GET /conversations/:id/debug-context returns { conversationId, systemPrompt, messages }, registered ONLY when NODE_ENV !== "production" (the assembled prompt embeds user memory + governance docs; the frontend DEV gate doesn't protect an API)
  + requireAuth.
- web: getDebugContext helper + metadata on the wire type; ChatDebugDrawer (DEV-gated, snapshot-on-open + Refresh, close via X/Escape/click-outside, dependency-free JSON highlighter); useChatStream now returns conversationId; mounted in ChatPanel.

Tests: api route (prompt + all roles, 404, prod-unregistered) + assembly parity; web drawer (DEV-gated button, open, JSON render, copy, close).