### PR TITLE
feat(context): fill <soul-context> + <available-tools> prompt blocks

### DIFF
--- a/apps/api/src/chat/routes.test.ts
+++ b/apps/api/src/chat/routes.test.ts
@@ -808,9 +808,11 @@ describe("chat routes", () => {
       const system = JSON.stringify(prompt[0]?.content);
       // Eager body renders in <skills> (no load_skill needed).
       expect(system).toContain("<skills>\\n## code-review\\nReview carefully.");
-      // Lazy skill stays in the L1 index; the eager one does not leak into it.
-      expect(system).toContain("<available-skills>\\n- data-export: Export data.");
-      expect(system).not.toContain("- code-review");
+      // The L1 index holds ONLY the lazy skill — the eager one does not leak into it (it surfaces
+      // as a full body in <skills>, and by name in the <soul-context> catalogue, but never here).
+      expect(system).toContain(
+        "<available-skills>\\n- data-export: Export data.\\n</available-skills>"
+      );
     });
 
     // Composer tags (`/skill`, `#resource`) — per-turn eager injection. A tagged skill's body lands

--- a/apps/api/src/chat/routes.ts
+++ b/apps/api/src/chat/routes.ts
@@ -19,8 +19,10 @@ import {
   GENERAL_ASSISTANT_NAME,
   getAgent,
   getPlatformAgent,
+  type PlatformAgent,
   resolveAgent,
 } from "../soul/agents/registry";
+import { buildSoulCatalogue } from "../soul/catalogue";
 import { type EagerSkill, listAvailableSkills, listEagerSkills } from "../soul/skills/registry";
 import { BatchCoordinator } from "../tools/batch-executor";
 import type { RunToolCallGuard, ToolRegistry } from "../tools/registry";
@@ -302,6 +304,35 @@ export function registerChatRoutes(
   // is removed when its producer settles (single-instance V1, mirroring the approval registry).
   const streamControllers = new Map<string, AbortController>();
 
+  // Per-agent tool scoping (shared by the chat turn's toolset build, its <available-tools> prompt
+  // block, and the debug-context route): the Information Architect is filtered to its forge
+  // allowlist; every other agent (the GeneralAssistant front desk + user soul agents) gets all
+  // registered tools EXCEPT the IA-exclusive soul writes — so only the IA can author/edit soul
+  // artifacts. `undefined` (no/empty registry) means no scoping — every registered tool is exposed.
+  const allowedToolNamesFor = (pa: PlatformAgent | undefined): ReadonlySet<string> | undefined => {
+    if (!(toolRegistry && toolRegistry.getAll().length > 0)) return undefined;
+    if (pa?.toolAllowlist) return new Set(pa.toolAllowlist);
+    return new Set(
+      toolRegistry
+        .getAll()
+        .map((t) => t.name)
+        .filter((n) => !EXCLUSIVE_SOUL_WRITE_TOOLS.has(n))
+    );
+  };
+  // The same allowed set projected to the `<available-tools>` L1 index — name + description, sorted
+  // for a byte-stable prompt prefix (AC-V1-001). `[]` when no registry → the block is omitted.
+  const availableToolsFor = (
+    pa: PlatformAgent | undefined
+  ): { name: string; description: string }[] => {
+    if (!toolRegistry) return [];
+    const allowed = allowedToolNamesFor(pa);
+    return toolRegistry
+      .getAll()
+      .filter((t) => !allowed || allowed.has(t.name))
+      .map((t) => ({ name: t.name, description: t.description }))
+      .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+  };
+
   app.post(
     "/api/v1/chat",
     {
@@ -434,6 +465,9 @@ export function registerChatRoutes(
       const governanceDocs = knowledge ? await knowledge.governanceDocuments() : [];
       const soulAvailableSkills = listAvailableSkills(soulLoader);
       const soulEagerSkills = listEagerSkills(soulLoader);
+      // Repo catalogue for <soul-context> — conversation-scoped (same for the front desk and any
+      // handoff target), so build it once and reuse across `buildSystemFor` calls.
+      const soulCatalogue = buildSoulCatalogue(soulLoader);
       // Per-turn `/skill` + `#resource` tags (ephemeral). Resolve names → bodies / schemas once and
       // eagerly inject; unknown names are dropped (the composer only offers real ones). Tagged skills
       // are merged with the soul's own eager skills, deduped by name so an already-eager skill isn't
@@ -468,6 +502,9 @@ export function registerChatRoutes(
           availableSkills: soulAvailableSkills,
           eagerSkills: mergedEagerSkills,
           taggedResources: turnTaggedResources,
+          soulCatalogue,
+          // Tools THIS agent may call — per-agent, so a handoff target gets its own scoped index.
+          availableTools: availableToolsFor(pa),
         });
       const system = buildSystemFor(agent, platformAgent);
       // Compaction (CTX-V1-001/002): over budget → summarize the oldest turns once into a durable
@@ -592,20 +629,6 @@ export function registerChatRoutes(
           }
         : undefined;
 
-      // Per-agent tool scoping: the Information Architect is filtered to its forge allowlist; every
-      // other agent (the GeneralAssistant front desk + user soul agents) gets all registered tools
-      // EXCEPT the IA-exclusive soul writes — so only the IA can author/edit soul artifacts.
-      const computeAllowed = (pa: typeof platformAgent): ReadonlySet<string> | undefined => {
-        if (!(toolRegistry && toolRegistry.getAll().length > 0)) return undefined;
-        if (pa?.toolAllowlist) return new Set(pa.toolAllowlist);
-        return new Set(
-          toolRegistry
-            .getAll()
-            .map((t) => t.name)
-            .filter((n) => !EXCLUSIVE_SOUL_WRITE_TOOLS.has(n))
-        );
-      };
-
       // The user's (guarded) request — handed to a transfer target as a clean slate so the front
       // desk's framed history doesn't read as prompt injection (the target's own prompt says who it
       // is, mirroring the canary handoff).
@@ -653,7 +676,7 @@ export function registerChatRoutes(
                   fullResultCache,
                   makeApprovalGate(approvalRegistry, emitter),
                   runToolCallGuard,
-                  computeAllowed(activePlatform)
+                  allowedToolNamesFor(activePlatform)
                 )
               : undefined;
 
@@ -1211,6 +1234,8 @@ export function registerChatRoutes(
           availableSkills: listAvailableSkills(soulLoader),
           eagerSkills: listEagerSkills(soulLoader),
           taggedResources: [],
+          soulCatalogue: buildSoulCatalogue(soulLoader),
+          availableTools: availableToolsFor(platformAgent),
         });
         const history = await messageRepo.listByConversation(id, 1000);
         return reply.send({ conversationId: id, systemPrompt, messages: history.items });

--- a/apps/api/src/chat/system-prompt.test.ts
+++ b/apps/api/src/chat/system-prompt.test.ts
@@ -2,6 +2,7 @@ import type { SoulAgent } from "@tulipfarm/soul";
 import { describe, expect, it } from "vitest";
 import { assembleSystemPrompt } from "../context/assemble";
 import { INFORMATION_ARCHITECT } from "../soul/agents/platform-agents";
+import type { SoulCatalogue } from "../soul/catalogue";
 import { assembleAgentSystemPrompt } from "./system-prompt";
 
 const agent: SoulAgent = {
@@ -10,13 +11,32 @@ const agent: SoulAgent = {
   body: "You are a test agent.",
 };
 
+const emptyCatalogue: SoulCatalogue = {
+  agents: [],
+  skills: [],
+  resourceTypes: [],
+  routines: [],
+  integrations: [],
+};
+
 const empty = {
   memory: [],
   governanceDocs: [],
   availableSkills: [],
   eagerSkills: [],
   taggedResources: [],
+  soulCatalogue: emptyCatalogue,
+  availableTools: [],
 };
+
+/** Inner text of one XML block, or "" when absent — lets a test scope assertions to a single block. */
+function blockBody(prompt: string, tag: string): string {
+  const open = `<${tag}>`;
+  const close = `</${tag}>`;
+  const i = prompt.indexOf(open);
+  const j = prompt.indexOf(close);
+  return i >= 0 && j >= 0 ? prompt.slice(i + open.length, j) : "";
+}
 
 describe("assembleAgentSystemPrompt", () => {
   it("matches a direct assembleSystemPrompt call when there is no platform agent", () => {
@@ -43,5 +63,26 @@ describe("assembleAgentSystemPrompt", () => {
     const withoutForge = assembleAgentSystemPrompt({ agent, platformAgent: undefined, ...empty });
     expect(withForge).toContain("skill-forge");
     expect(withoutForge).not.toContain("skill-forge");
+  });
+
+  it("threads the soul catalogue and tool index into their blocks; forge stays out of soul-context", () => {
+    const out = assembleAgentSystemPrompt({
+      agent,
+      platformAgent: INFORMATION_ARCHITECT,
+      ...empty,
+      soulCatalogue: {
+        agents: [{ name: "GeneralAssistant", description: "Front desk" }],
+        skills: [{ name: "catalogue-skill", description: "Repo skill" }],
+        resourceTypes: [{ name: "invoice", description: "Billable items" }],
+        routines: [],
+        integrations: [],
+      },
+      availableTools: [{ name: "agent_list", description: "list agents" }],
+    });
+    expect(out).toContain("- catalogue-skill: Repo skill");
+    expect(out).toContain("<available-tools>\n- agent_list: list agents\n</available-tools>");
+    // Forge skills surface only in <available-skills>, never the soul-repo catalogue.
+    expect(blockBody(out, "soul-context")).not.toContain("skill-forge");
+    expect(out).toContain("skill-forge");
   });
 });

--- a/apps/api/src/chat/system-prompt.ts
+++ b/apps/api/src/chat/system-prompt.ts
@@ -1,6 +1,7 @@
 import type { SoulAgent } from "@tulipfarm/soul";
 import { type AssembleContext, assembleSystemPrompt } from "../context/assemble";
 import type { PlatformAgent } from "../soul/agents/platform-agents";
+import type { SoulCatalogue } from "../soul/catalogue";
 import { BUILTIN_SKILLS } from "../soul/skills/builtin-skills";
 import type { AvailableSkill } from "../soul/skills/registry";
 
@@ -19,6 +20,8 @@ export function assembleAgentSystemPrompt(args: {
   availableSkills: AvailableSkill[];
   eagerSkills: AssembleContext["eagerSkills"];
   taggedResources: AssembleContext["taggedResources"];
+  soulCatalogue: SoulCatalogue;
+  availableTools: AssembleContext["availableTools"];
 }): string {
   const {
     agent,
@@ -28,6 +31,8 @@ export function assembleAgentSystemPrompt(args: {
     availableSkills,
     eagerSkills,
     taggedResources,
+    soulCatalogue,
+    availableTools,
   } = args;
   // Platform forge skills surface in <available-skills> alongside the soul's own (loadable via load_skill).
   const forgeAvailable = (platformAgent?.forgeSkills ?? [])
@@ -44,5 +49,7 @@ export function assembleAgentSystemPrompt(args: {
     availableSkills: [...availableSkills, ...forgeAvailable],
     eagerSkills,
     taggedResources,
+    soulCatalogue,
+    availableTools,
   });
 }

--- a/apps/api/src/context/README.md
+++ b/apps/api/src/context/README.md
@@ -19,8 +19,8 @@ lazily fetched) makes the rendered prefix deterministic and therefore prompt-cac
 <governance-knowledge>    alwaysLoadForAgents docs (reuses knowledge/governance.ts, 4k/16k caps)
 <skills>                  eager skill bodies — `## name` + body per `eager: true` skill, 32k cap, drop-whole
 <available-skills>        lazy skill L1 — one `- name: description` per soul skill, 8k cap, drop-whole
-<soul-context>            "" — deferred (soul L1 snapshot builder)
-<available-tools>         "" — deferred (Tools v0.8)
+<soul-context>            repo catalogue L1 — `## Agents/Skills/Resource Types/Routines/Integrations`, 16k cap, drop-whole
+<available-tools>         tool L1 — one `- name: description` per allowed tool, 8k cap, drop-whole
 ```
 
 Each block renders to a string or `""`. Empty blocks are **omitted entirely** (filtered before
@@ -33,6 +33,14 @@ projects skills with `eager: true` to their full `{ name, body }` for `<skills>`
 projects the rest to their sorted L1 `{ name, description }` for `<available-skills>` — the two sets are
 disjoint. A lazy skill's body (L2) and reference files (L3) load on demand via the `load_skill` /
 `load_skill_reference` platform tools; per-agent eager-skill election stays deferred post-V1.
+
+`<soul-context>` and `<available-tools>` give the agent **ambient awareness** without a tool
+round-trip. `buildSoulCatalogue` (`../soul/catalogue.ts`) projects every soul artifact — agents
+(via `listAgents`, platform agents included), the full skill set (eager + lazy), resource types,
+routines, integrations — to a sorted `{ name, description }` L1 catalogue; full bodies/schemas stay
+L2 (pulled via `agent_get` / `load_skill` / `resource_type_schema`). `<available-tools>` lists the
+tools the agent may actually call, scoped to its allowlist by `availableToolsFor` in
+`chat/routes.ts` (the same allowed set used to build the toolset, so the two can't drift).
 
 ## Why deterministic order matters
 
@@ -48,5 +56,6 @@ drop **whole** on overflow (never half-rendered) so the prefix can't drift mid-b
 ## Tests
 
 `assemble.test.ts` — pure unit coverage (order, determinism, skip, omit-empty, budgets,
-no-typed-state). The wiring is covered in `chat/routes.test.ts` (working memory, the lazy
-`<available-skills>` list, and the eager `<skills>` block).
+no-typed-state, plus the `<soul-context>` and `<available-tools>` blocks). The catalogue projection
+is covered in `../soul/catalogue.test.ts`, and the wiring in `chat/routes.test.ts` (working memory,
+the lazy `<available-skills>` list, and the eager `<skills>` block).

--- a/apps/api/src/context/assemble.test.ts
+++ b/apps/api/src/context/assemble.test.ts
@@ -314,8 +314,8 @@ describe("assembleSystemPrompt — eager-resources (#resource)", () => {
   });
 });
 
-describe("assembleSystemPrompt — deferred + typed-state (AC-V1-003)", () => {
-  it("omits the still-deferred soul-context and tools blocks", () => {
+describe("assembleSystemPrompt — typed-state (AC-V1-003)", () => {
+  it("omits the soul-context and available-tools blocks when their inputs are unset", () => {
     const out = assembleSystemPrompt(
       baseCtx({ agentId: "sales", memory: [mem("plan", "enterprise")] })
     );
@@ -341,5 +341,140 @@ describe("assembleSystemPrompt — deferred + typed-state (AC-V1-003)", () => {
 
   it("returns an empty string when every block is empty", () => {
     expect(assembleSystemPrompt(baseCtx())).toBe("");
+  });
+});
+
+const emptyCatalogue = {
+  agents: [],
+  skills: [],
+  resourceTypes: [],
+  routines: [],
+  integrations: [],
+};
+
+describe("assembleSystemPrompt — soul-context (repo catalogue L1)", () => {
+  it("renders a ## section per non-empty artifact type, each `- name: description`", () => {
+    const out = assembleSystemPrompt(
+      baseCtx({
+        soulCatalogue: {
+          agents: [{ name: "GeneralAssistant", description: "Front desk" }],
+          skills: [{ name: "code-review", description: "Review code" }],
+          resourceTypes: [{ name: "invoice", description: "Billable items" }],
+          routines: [{ name: "nightly", description: "Runs nightly" }],
+          integrations: [{ name: "slack", description: "Slack workspace" }],
+        },
+      })
+    );
+    expect(out).toContain(
+      "<soul-context>\n" +
+        "## Agents\n- GeneralAssistant: Front desk\n\n" +
+        "## Skills\n- code-review: Review code\n\n" +
+        "## Resource Types\n- invoice: Billable items\n\n" +
+        "## Routines\n- nightly: Runs nightly\n\n" +
+        "## Integrations\n- slack: Slack workspace\n" +
+        "</soul-context>"
+    );
+  });
+
+  it("renders only the sections that have entries", () => {
+    const out = assembleSystemPrompt(
+      baseCtx({
+        soulCatalogue: {
+          ...emptyCatalogue,
+          agents: [{ name: "a", description: "A" }],
+          resourceTypes: [{ name: "r", description: "R" }],
+        },
+      })
+    );
+    expect(out).toContain(
+      "<soul-context>\n## Agents\n- a: A\n\n## Resource Types\n- r: R\n</soul-context>"
+    );
+    expect(out).not.toContain("## Skills");
+    expect(out).not.toContain("## Routines");
+  });
+
+  it("renders just `- name` when an entry has no description", () => {
+    const out = assembleSystemPrompt(
+      baseCtx({ soulCatalogue: { ...emptyCatalogue, agents: [{ name: "a", description: "" }] } })
+    );
+    expect(out).toContain("<soul-context>\n## Agents\n- a\n</soul-context>");
+  });
+
+  it("omits the block when the catalogue is unset or entirely empty", () => {
+    expect(assembleSystemPrompt(baseCtx())).not.toContain("<soul-context>");
+    expect(assembleSystemPrompt(baseCtx({ soulCatalogue: emptyCatalogue }))).not.toContain(
+      "<soul-context>"
+    );
+  });
+
+  it("drops the whole block when over the char budget (never half-rendered)", () => {
+    const out = assembleSystemPrompt(
+      baseCtx({
+        soulCatalogue: {
+          ...emptyCatalogue,
+          agents: [{ name: "big", description: "x".repeat(17000) }],
+        },
+      })
+    );
+    expect(out).not.toContain("<soul-context>");
+  });
+
+  it("renders after <available-skills> and <eager-resources> (CONTEXT-ENGINE §1 order)", () => {
+    const out = assembleSystemPrompt(
+      baseCtx({
+        availableSkills: [{ name: "lazy", description: "lazy desc" }],
+        taggedResources: [{ name: "tickets", schema: "title: string" }],
+        soulCatalogue: { ...emptyCatalogue, agents: [{ name: "a", description: "A" }] },
+      })
+    );
+    expect(out.indexOf("<available-skills>")).toBeLessThan(out.indexOf("<soul-context>"));
+    expect(out.indexOf("<eager-resources>")).toBeLessThan(out.indexOf("<soul-context>"));
+  });
+});
+
+describe("assembleSystemPrompt — available-tools (tool L1)", () => {
+  it("renders one `- name: description` line per tool, in given order", () => {
+    const out = assembleSystemPrompt(
+      baseCtx({
+        availableTools: [
+          { name: "agent_list", description: "list all agents" },
+          { name: "load_skill", description: "load a skill body" },
+        ],
+      })
+    );
+    expect(out).toContain(
+      "<available-tools>\n- agent_list: list all agents\n- load_skill: load a skill body\n</available-tools>"
+    );
+  });
+
+  it("renders just `- name` when a tool has no description", () => {
+    const out = assembleSystemPrompt(
+      baseCtx({ availableTools: [{ name: "bare", description: "" }] })
+    );
+    expect(out).toContain("<available-tools>\n- bare\n</available-tools>");
+  });
+
+  it("omits the block when there are no tools (unset or empty)", () => {
+    expect(assembleSystemPrompt(baseCtx())).not.toContain("<available-tools>");
+    expect(assembleSystemPrompt(baseCtx({ availableTools: [] }))).not.toContain(
+      "<available-tools>"
+    );
+  });
+
+  it("drops the whole block when over the char budget (never half-rendered)", () => {
+    const out = assembleSystemPrompt(
+      baseCtx({ availableTools: [{ name: "big", description: "x".repeat(9000) }] })
+    );
+    expect(out).not.toContain("<available-tools>");
+  });
+
+  it("renders last, after <soul-context> (CONTEXT-ENGINE §1 order)", () => {
+    const out = assembleSystemPrompt(
+      baseCtx({
+        soulCatalogue: { ...emptyCatalogue, agents: [{ name: "a", description: "A" }] },
+        availableTools: [{ name: "agent_list", description: "list agents" }],
+      })
+    );
+    expect(out.indexOf("<soul-context>")).toBeLessThan(out.indexOf("<available-tools>"));
   });
 });

--- a/apps/api/src/context/assemble.ts
+++ b/apps/api/src/context/assemble.ts
@@ -2,6 +2,7 @@ import { buildGovernanceBlock } from "../knowledge/governance";
 import type { KnowledgeDocument } from "../knowledge/types";
 import { MAX_TOTAL_CHARS } from "../memory/limits";
 import type { WorkingMemoryDoc } from "../memory/working-memory";
+import type { SoulCatalogue } from "../soul/catalogue";
 import type { AvailableSkill, EagerSkill } from "../soul/skills/registry";
 
 /**
@@ -43,6 +44,17 @@ export interface AssembleContext {
    * reason over records of that type without a tool round-trip. Ephemeral — set per turn, never cached.
    */
   taggedResources?: { name: string; schema: string }[];
+  /**
+   * L1 repo catalogue for `<soul-context>` — every soul artifact (agents, skills, resource types,
+   * routines, integrations) projected to name + description. Gives the agent ambient awareness of
+   * what already exists; full bodies/schemas stay L2 (pulled on demand). Unset → block omitted.
+   */
+  soulCatalogue?: SoulCatalogue;
+  /**
+   * L1 index of the tools this agent may call for `<available-tools>` — name + one-line description,
+   * scoped to the agent's allowlist (the same set used to build its toolset). Unset → block omitted.
+   */
+  availableTools?: { name: string; description: string }[];
 }
 
 function block(tag: string, body: string): string {
@@ -147,12 +159,74 @@ function renderTaggedResources(ctx: AssembleContext): string {
 }
 
 /**
- * Assemble the agent system prompt from the 9 ordered blocks (specs/CONTEXT-ENGINE.md §1). Pure
- * and synchronous. Each block renders to a string or "" (when empty, over budget, or deferred);
- * empty blocks are omitted entirely so the prefix stays byte-stable across turns. `<skills>` renders
- * eager skill bodies and `<available-skills>` the lazy skill L1 index; the still-deferred blocks —
- * `<soul-context>`, `<available-tools>` — emit empty until the soul L1 snapshot and Tools land. No
- * `<harness-typed-state>` block is ever emitted (deferred MEM-V1-005, AC-V1-003).
+ * `<soul-context>` budget — total chars across every catalogue entry's `name`+`description`. Over
+ * this the whole block is dropped (never half-rendered), matching the other block budgets. The
+ * catalogue spans five artifact types, so the budget is generous; V1 counts sit well under it.
+ */
+const MAX_SOUL_CONTEXT_CHARS = 16000;
+
+/** The five `<soul-context>` sections, in fixed render order, mapped to their catalogue key. */
+const SOUL_CONTEXT_SECTIONS: { heading: string; key: keyof SoulCatalogue }[] = [
+  { heading: "Agents", key: "agents" },
+  { heading: "Skills", key: "skills" },
+  { heading: "Resource Types", key: "resourceTypes" },
+  { heading: "Routines", key: "routines" },
+  { heading: "Integrations", key: "integrations" },
+];
+
+/**
+ * `<soul-context>` block (CONTEXT-ENGINE §1). The repo catalogue: a `## Heading` markdown section
+ * per artifact type, each with one `- name: description` line (just `- name` when no description),
+ * in name-sorted order. Only non-empty sections render; the whole block is omitted when the
+ * catalogue is empty and dropped whole when over budget.
+ */
+function renderSoulContext(ctx: AssembleContext): string {
+  const cat = ctx.soulCatalogue;
+  if (!cat) return "";
+  const total = SOUL_CONTEXT_SECTIONS.reduce(
+    (n, s) => n + cat[s.key].reduce((m, e) => m + e.name.length + e.description.length, 0),
+    0
+  );
+  if (total === 0) return "";
+  if (total > MAX_SOUL_CONTEXT_CHARS) return "";
+  const sections = SOUL_CONTEXT_SECTIONS.filter((s) => cat[s.key].length > 0).map((s) => {
+    const lines = cat[s.key]
+      .map((e) => (e.description ? `- ${e.name}: ${e.description}` : `- ${e.name}`))
+      .join("\n");
+    return `## ${s.heading}\n${lines}`;
+  });
+  return block("soul-context", sections.join("\n\n"));
+}
+
+/**
+ * `<available-tools>` budget — total chars across all tool `name`+`description` pairs. Over this
+ * the whole block is dropped (never half-rendered), matching `renderAvailableSkills`.
+ */
+const MAX_AVAILABLE_TOOLS_CHARS = 8000;
+
+/**
+ * `<available-tools>` block (Tools, CONTEXT-ENGINE §1). The tool L1 index: one `- name: description`
+ * line per tool the agent may call (scoped to its allowlist), in name-sorted order. Omitted when
+ * the agent has no tools; dropped whole when over budget.
+ */
+function renderAvailableTools(ctx: AssembleContext): string {
+  const tools = ctx.availableTools ?? [];
+  if (tools.length === 0) return "";
+  const total = tools.reduce((n, t) => n + t.name.length + t.description.length, 0);
+  if (total > MAX_AVAILABLE_TOOLS_CHARS) return "";
+  const body = tools
+    .map((t) => (t.description ? `- ${t.name}: ${t.description}` : `- ${t.name}`))
+    .join("\n");
+  return block("available-tools", body);
+}
+
+/**
+ * Assemble the agent system prompt from the 10 ordered blocks (specs/CONTEXT-ENGINE.md §1). Pure
+ * and synchronous. Each block renders to a string or "" (when empty or over budget); empty blocks
+ * are omitted entirely so the prefix stays byte-stable across turns. `<skills>` renders eager skill
+ * bodies and `<available-skills>` the lazy skill L1 index; `<soul-context>` renders the repo
+ * catalogue (agents/skills/resource types/routines/integrations) and `<available-tools>` the agent's
+ * tool L1 index. No `<harness-typed-state>` block is ever emitted (deferred MEM-V1-005, AC-V1-003).
  */
 export function assembleSystemPrompt(ctx: AssembleContext): string {
   const blocks = [
@@ -166,8 +240,8 @@ export function assembleSystemPrompt(ctx: AssembleContext): string {
     renderEagerSkills(ctx),
     renderAvailableSkills(ctx),
     renderTaggedResources(ctx),
-    "", // <soul-context> — deferred (soul L1 snapshot builder)
-    "", // <available-tools> — deferred (Tools v0.8)
+    renderSoulContext(ctx),
+    renderAvailableTools(ctx),
   ];
   return blocks.filter((b) => b.length > 0).join("\n");
 }

--- a/apps/api/src/soul/catalogue.test.ts
+++ b/apps/api/src/soul/catalogue.test.ts
@@ -1,0 +1,129 @@
+import type {
+  SoulAgent,
+  SoulIntegration,
+  SoulLoader,
+  SoulResource,
+  SoulRoutine,
+  SoulSkill,
+} from "@tulipfarm/soul";
+import { describe, expect, it } from "vitest";
+import { GENERAL_ASSISTANT_NAME, INFORMATION_ARCHITECT_NAME } from "./agents/registry";
+import { buildSoulCatalogue } from "./catalogue";
+
+const skill = (name: string, frontmatter: Record<string, unknown> = {}): SoulSkill => ({
+  name,
+  frontmatter,
+  body: "",
+});
+const agent = (name: string, description?: string): SoulAgent => ({
+  name,
+  frontmatter: description ? { description } : {},
+  body: "",
+});
+const resource = (name: string, schema: Record<string, unknown>): SoulResource => ({
+  name,
+  schema,
+  hasHooks: false,
+  hooksEnabled: true,
+});
+const routine = (name: string, config: Record<string, unknown>): SoulRoutine => ({
+  name,
+  config,
+  hasHooks: false,
+});
+const integration = (name: string, connection: Record<string, unknown>): SoulIntegration => ({
+  name,
+  connection,
+});
+
+function fakeLoader(
+  over: {
+    agents?: SoulAgent[];
+    skills?: SoulSkill[];
+    resources?: SoulResource[];
+    routines?: SoulRoutine[];
+    integrations?: SoulIntegration[];
+  } = {}
+): SoulLoader {
+  const toMap = <T extends { name: string }>(xs: T[] = []): Map<string, T> =>
+    new Map(xs.map((x) => [x.name, x]));
+  return {
+    agents: toMap(over.agents),
+    skills: toMap(over.skills),
+    resources: toMap(over.resources),
+    routines: toMap(over.routines),
+    integrations: toMap(over.integrations),
+  } as unknown as SoulLoader;
+}
+
+describe("buildSoulCatalogue", () => {
+  it("projects every section sorted by name, with the platform agents first-class", () => {
+    const cat = buildSoulCatalogue(
+      fakeLoader({
+        agents: [agent("zeta", "Last agent"), agent("alpha", "First agent")],
+        skills: [
+          skill("review", { description: "Review" }),
+          skill("export", { description: "CSV" }),
+        ],
+        resources: [resource("ticket", {}), resource("invoice", {})],
+        routines: [routine("nightly", {}), routine("hourly", {})],
+        integrations: [integration("slack", {}), integration("github", {})],
+      })
+    );
+    // Platform agents are always present, sorted in among soul agents by name.
+    expect(cat.agents.map((a) => a.name)).toEqual([
+      GENERAL_ASSISTANT_NAME,
+      INFORMATION_ARCHITECT_NAME,
+      "alpha",
+      "zeta",
+    ]);
+    expect(cat.skills.map((s) => s.name)).toEqual(["export", "review"]);
+    expect(cat.resourceTypes.map((r) => r.name)).toEqual(["invoice", "ticket"]);
+    expect(cat.routines.map((r) => r.name)).toEqual(["hourly", "nightly"]);
+    expect(cat.integrations.map((i) => i.name)).toEqual(["github", "slack"]);
+  });
+
+  it("reads descriptions from each type's metadata, falling back through title then ''", () => {
+    const cat = buildSoulCatalogue(
+      fakeLoader({
+        skills: [skill("s", { description: "Skill desc" })],
+        resources: [
+          resource("with-desc", { description: "Schema desc", title: "Ignored" }),
+          resource("with-title", { title: "Schema title" }),
+          resource("bare", {}),
+        ],
+        routines: [routine("r", { title: "Routine title" })],
+        integrations: [integration("i", { title: "Integration title" })],
+      })
+    );
+    expect(cat.skills[0]?.description).toBe("Skill desc");
+    expect(cat.resourceTypes.find((r) => r.name === "with-desc")?.description).toBe("Schema desc");
+    expect(cat.resourceTypes.find((r) => r.name === "with-title")?.description).toBe(
+      "Schema title"
+    );
+    expect(cat.resourceTypes.find((r) => r.name === "bare")?.description).toBe("");
+    expect(cat.routines[0]?.description).toBe("Routine title");
+    expect(cat.integrations[0]?.description).toBe("Integration title");
+  });
+
+  it("excludes pending-audit skills from the catalogue", () => {
+    const cat = buildSoulCatalogue(
+      fakeLoader({
+        skills: [skill("live", { description: "ok" }), skill("staged", { _pendingAudit: true })],
+      })
+    );
+    expect(cat.skills.map((s) => s.name)).toEqual(["live"]);
+  });
+
+  it("still lists the platform agents when the loader is absent, with every other section empty", () => {
+    const cat = buildSoulCatalogue(undefined);
+    expect(cat.agents.map((a) => a.name)).toEqual([
+      GENERAL_ASSISTANT_NAME,
+      INFORMATION_ARCHITECT_NAME,
+    ]);
+    expect(cat.skills).toEqual([]);
+    expect(cat.resourceTypes).toEqual([]);
+    expect(cat.routines).toEqual([]);
+    expect(cat.integrations).toEqual([]);
+  });
+});

--- a/apps/api/src/soul/catalogue.ts
+++ b/apps/api/src/soul/catalogue.ts
@@ -1,0 +1,83 @@
+import type { SoulLoader } from "@tulipfarm/soul";
+import { listAgents } from "./agents/registry";
+
+/**
+ * One soul artifact projected to its L1 surface — `name` + `description` — for the
+ * `<soul-context>` repo catalogue (specs/CONTEXT-ENGINE.md §1). Full bodies / schemas stay L2,
+ * pulled on demand via `agent_get` / `load_skill` / `resource_type_schema`.
+ */
+export interface SoulCatalogueEntry {
+  name: string;
+  description: string;
+}
+
+/**
+ * The repo catalogue for `<soul-context>`: every soul artifact type the loader exposes, each
+ * projected to its L1 surface. Gives an agent ambient awareness of what already exists without a
+ * tool round-trip (e.g. the Information Architect can reference an existing agent or resource
+ * type by name). Sorted by name within each section for a byte-stable prompt prefix (AC-V1-001).
+ */
+export interface SoulCatalogue {
+  agents: SoulCatalogueEntry[];
+  skills: SoulCatalogueEntry[];
+  resourceTypes: SoulCatalogueEntry[];
+  routines: SoulCatalogueEntry[];
+  integrations: SoulCatalogueEntry[];
+}
+
+/** Read a record field as a string, or "" when absent / non-string. */
+function asDesc(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+/** A map's values as an array, tolerating an absent map — a missing artifact section degrades to
+ * an empty catalogue section rather than throwing (the soul-context block is ambient, not critical). */
+function values<T>(map: Map<string, T> | undefined): T[] {
+  return map ? Array.from(map.values()) : [];
+}
+
+function byName(a: SoulCatalogueEntry, b: SoulCatalogueEntry): number {
+  return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
+}
+
+/**
+ * Project every soul artifact to the `<soul-context>` L1 catalogue. Agents come from `listAgents`
+ * (the two platform agents first, then soul agents) so the catalogue surfaces the GeneralAssistant
+ * / InformationArchitect an agent may hand off to. Skills are the FULL set (eager + lazy) minus
+ * pending-audit; descriptions are read from each type's own metadata (frontmatter / schema /
+ * config / connection), falling back through `title` and then "". An absent loader yields all
+ * empty sections, so the block is omitted entirely.
+ */
+export function buildSoulCatalogue(soulLoader: SoulLoader | undefined): SoulCatalogue {
+  const agents = listAgents(soulLoader)
+    .map((a) => ({ name: a.name, description: asDesc(a.frontmatter.description) }))
+    .sort(byName);
+
+  const skills = values(soulLoader?.skills)
+    .filter((s) => s.frontmatter._pendingAudit !== true)
+    .map((s) => ({ name: s.name, description: asDesc(s.frontmatter.description) }))
+    .sort(byName);
+
+  const resourceTypes = values(soulLoader?.resources)
+    .map((r) => ({
+      name: r.name,
+      description: asDesc(r.schema.description) || asDesc(r.schema.title),
+    }))
+    .sort(byName);
+
+  const routines = values(soulLoader?.routines)
+    .map((r) => ({
+      name: r.name,
+      description: asDesc(r.config.description) || asDesc(r.config.title),
+    }))
+    .sort(byName);
+
+  const integrations = values(soulLoader?.integrations)
+    .map((i) => ({
+      name: i.name,
+      description: asDesc(i.connection.description) || asDesc(i.connection.title),
+    }))
+    .sort(byName);
+
+  return { agents, skills, resourceTypes, routines, integrations };
+}


### PR DESCRIPTION
Fixes #56 
Agents now get an ambient L1 catalogue of soul artifacts (agents, skills, resource types, routines, integrations) and a scoped tool index in their system prompt — no tool round-trip to discover what already exists.

- buildSoulCatalogue (soul/catalogue.ts): pure name+description projection of every soul artifact, sorted, tolerant of absent loader maps (degrades to empty rather than 500-ing the chat turn).
- renderSoulContext + renderAvailableTools (context/assemble.ts): two new drop-whole, byte-stable blocks; <available-skills> unaffected.
- Shared allowedToolNamesFor / availableToolsFor in chat/routes.ts (hoisted from the inline computeAllowed) so the <available-tools> index can't drift from the toolset actually built. Wired at the chat-turn and debug-context call sites.

soul-context is full-catalogue for every agent (soul agents carry no frontmatter access keys to scope by); only <available-tools> is allowlist- scoped (IA -> its allowlist, GA/soul -> all tools minus soul-write set).