### PR TITLE
feat(kv): generic scoped key-value store (system/user/agent, jsonb, l…

### DIFF
--- a/apps/api/AGENTS.md
+++ b/apps/api/AGENTS.md
@@ -15,6 +15,7 @@ src/
   platform/       # platform-tier tool implementations + tool-result helpers
   hooks/          # isolated-vm hook sandbox + worker
   knowledge/      # RAG: documents, chunks, pgvector + tsvector search; governance block
+  kv/             # generic scoped key-value store (system/user/agent) — see kv/README.md
   memory/         # per-user working memory
   secrets/        # secret storage
   soul/           # soul git ops (commit, push) + agents/, skills/, resource-types/ CRUD
@@ -91,7 +92,7 @@ interface ToolDef {
 `tools/setup.ts` (`buildToolRegistry`). Group module tool arrays by tier (e.g. `PLATFORM_TOOLS`).
 Existing tools by category: system resource/agent/skill/resource-type CRUD (`resources/`,
 `soul/*/`), platform UI/routing/soul-batch (`platform/tools.ts`), memory (`memory/tools.ts`),
-knowledge (`knowledge/tools.ts`).
+knowledge (`knowledge/tools.ts`), kv (`kv/tools.ts` — agent-scoped `kv_get`/`kv_set`/`kv_delete`/`kv_list`).
 
 ## Context & streaming
 

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -29,6 +29,8 @@ import type { GuardrailsService } from "./guardrails";
 import type { HookExecutor } from "./hooks/hook-executor";
 import { registerKnowledgeRoutes } from "./knowledge/routes";
 import type { KnowledgeService } from "./knowledge/service";
+import { registerKvRoutes } from "./kv/routes";
+import type { KvService } from "./kv/service";
 import type { WorkingMemoryService } from "./memory/service";
 import { registerOnboardingRoutes } from "./onboarding/routes";
 import type { RateLimiter } from "./rate-limit";
@@ -64,6 +66,7 @@ export interface AppOptions {
   streamResumeRepo?: StreamResumeRepo;
   streamHub?: StreamHub;
   workingMemoryService?: WorkingMemoryService;
+  kvService?: KvService;
   knowledgeService?: KnowledgeService;
   toolRegistry?: ToolRegistry;
   approvalRegistry?: ApprovalRegistry;
@@ -166,6 +169,9 @@ export async function buildApp(opts: AppOptions = {}) {
             : undefined,
       });
     }
+    if (opts.kvService) {
+      registerKvRoutes(app, opts.kvService, requireAuth);
+    }
     if (opts.gitSync) {
       registerSoulRoutes(app, opts.gitSync, requireAuth);
       if (opts.soulLoader) {
@@ -209,6 +215,7 @@ export async function buildApp(opts: AppOptions = {}) {
         opts.toolRegistry ??
         buildToolRegistry({
           workingMemory: opts.workingMemoryService,
+          kv: opts.kvService,
           knowledge: opts.knowledgeService,
         });
       const approvalRegistry = opts.approvalRegistry ?? new ApprovalRegistry();

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -30,6 +30,8 @@ import {
   PgKnowledgeRevisionRepo,
 } from "./knowledge/repo";
 import { KnowledgeService } from "./knowledge/service";
+import { PgKvRepo } from "./kv/repo";
+import { KvService } from "./kv/service";
 import { registerLlmReload } from "./llm-reload";
 import { WorkingMemoryService } from "./memory/service";
 import { PgWorkingMemoryRepo } from "./memory/working-memory";
@@ -99,6 +101,7 @@ async function boot() {
     const a2uiSurfaceStore = new PgA2uiSurfaceStore(pool);
     const streamHub = new StreamHub();
     const workingMemoryService = new WorkingMemoryService(new PgWorkingMemoryRepo(pool));
+    const kvService = new KvService(new PgKvRepo(pool));
     const resourceRepoFactory = new PgResourceRepoFactory(pool);
     const counterStore = new PgCounterStore(pool);
     const reconcileResources = () => reconcileResourceTables(pool, soulLoader, console);
@@ -124,6 +127,7 @@ async function boot() {
     // (which tools each agent may actually call) are applied per-turn in the chat route.
     const toolRegistry = buildToolRegistry({
       workingMemory: workingMemoryService,
+      kv: kvService,
       knowledge: knowledgeService,
       resources: {
         repoFactory: resourceRepoFactory,
@@ -167,6 +171,7 @@ async function boot() {
       a2uiSurfaceStore,
       streamHub,
       workingMemoryService,
+      kvService,
       knowledgeService,
       toolRegistry,
     });

--- a/apps/api/src/knowledge/migration.pg.test.ts
+++ b/apps/api/src/knowledge/migration.pg.test.ts
@@ -46,9 +46,9 @@ describe("002_knowledge migration on PGlite", () => {
     await db.close();
   });
 
-  it("bumps schema_version to the latest (8)", async () => {
+  it("bumps schema_version to the latest (9)", async () => {
     const { rows } = await db.query("SELECT version FROM schema_version WHERE id = true");
-    expect(Number((rows[0] as { version: number }).version)).toBe(8);
+    expect(Number((rows[0] as { version: number }).version)).toBe(9);
   });
 
   it("creates all five knowledge tables", async () => {

--- a/apps/api/src/kv/README.md
+++ b/apps/api/src/kv/README.md
@@ -1,0 +1,51 @@
+# kv — generic scoped key-value store (KV-V1)
+
+A single Postgres table (`kv_store`) for arbitrary platform values — application salt, install id,
+feature flags, cached/bootstrap state, agent scratch data. Fills the gap left by the three existing
+stores: `secrets` (encrypted), `working_memory` (per-user, char-capped), `resources` (soul-defined
+documents). Plaintext JSONB — anything genuinely secret belongs in `secrets`.
+
+## Model
+
+Identity is the composite PK `(scope, owner_id, namespace, key)`:
+
+- `scope` ∈ `system | user | agent` (CHECK-enforced).
+- `owner_id` is `NOT NULL DEFAULT ''`; the `''` sentinel marks "no owner" for `system`. A nullable
+  column can't sit in a PRIMARY KEY, and NULL is distinct in unique indexes (which would break
+  `ON CONFLICT`) — so the repo maps `'' ↔ undefined` and no caller ever sees the sentinel.
+- `value jsonb` (any JSON), `expires_at timestamptz NULL` (NULL = never).
+
+Reads filter `expires_at IS NULL OR expires_at > now()` (**lazy expiry**, no sweeper in v1). Writes
+are **last-write-wins** upserts; `created_at` is preserved across updates. CHECK
+`((scope='system') = (owner_id=''))` pins the system⇔sentinel invariant.
+
+## Files
+
+- `repo.ts` — `KvEntry`, `KvRepo`, `PgKvRepo` (sentinel mapping, lazy-expiry SQL, upsert/get/delete/list).
+- `service.ts` — `KvService`: charset/length validation, value **byte** cap (`MAX_VALUE_BYTES`), TTL.
+- `limits.ts` — caps + the `KV_NAME_RE` charset.
+- `tools.ts` — `kv_get/kv_set/kv_delete/kv_list` agent tools.
+- `routes.ts` — HTTP routes.
+- `tool-result.ts` — re-export of the shared tool result helpers.
+
+## Surfaces & access control (sandboxed by caller identity)
+
+The caller never names scope/owner — it is derived from identity, so isolation is by construction:
+
+- **Internal** (`PgKvRepo` / `KvService`) — backend code may address any scope.
+- **Agent tools** — hard-wired `scope='agent'`, `owner_id = ctx.agentId`. An agent only ever sees its
+  own private scratch space (shared across that agent's users/conversations — intentional).
+- **User routes** `/api/v1/kv/:namespace/:key` (+ `/:namespace` list) — `scope='user'`, owner = caller.
+- **Admin routes** `/api/v1/admin/kv/...` — `scope='system'`; non-admins get 403. Separate prefix (not
+  `/api/v1/kv/system`) so it can't collide with a user namespace literally named `system`.
+
+## Wiring
+
+Migration v9 (`pg-migrations/index.ts`) creates the table. `index.ts` constructs
+`new KvService(new PgKvRepo(pool))` and threads it into `buildToolRegistry` (agent tools) and
+`buildApp` (HTTP routes). `tools/setup.ts` registers `KV_TOOLS` with `ctx.agentId` as the owner.
+
+## Tests
+
+`repo.pg.test.ts` (PGlite), `service.test.ts` + `tools.test.ts` (in-memory fakes), `routes.test.ts`
+(Fastify inject + PGlite). KV-specific migration assertions live in `../pg-migrate.test.ts`.

--- a/apps/api/src/kv/limits.ts
+++ b/apps/api/src/kv/limits.ts
@@ -1,0 +1,12 @@
+/**
+ * Generic KV caps (KV-V1). Unlike working memory (tiny, always-injected, char-capped), KV holds
+ * arbitrary JSON, so the value cap is a generous BYTE budget on the serialized value — measured with
+ * `Buffer.byteLength`, never `String.length`, since a multibyte value can blow the byte cap while
+ * staying under its character count. Namespace and key share one charset so they are safe to embed
+ * in URL path segments and predictable across every surface (repo, service, tools, routes).
+ */
+export const MAX_VALUE_BYTES = 256 * 1024;
+export const MAX_KEY_CHARS = 256;
+export const MAX_NAMESPACE_CHARS = 128;
+/** Alphanumerics plus `. _ : -`, must start alphanumeric. Path-safe (no `/`) and map-key friendly. */
+export const KV_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;

--- a/apps/api/src/kv/repo.pg.test.ts
+++ b/apps/api/src/kv/repo.pg.test.ts
@@ -1,0 +1,124 @@
+import type { PGlite } from "@electric-sql/pglite";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { runPgMigrations } from "../pg-migrate";
+import { makePglite } from "../test/pglite";
+import { type KvEntry, PgKvRepo } from "./repo";
+
+const USER = "44444444-4444-4444-4444-444444444444";
+
+function entry(overrides: Partial<KvEntry> = {}): KvEntry {
+  const now = new Date();
+  return {
+    scope: "user",
+    ownerId: USER,
+    namespace: "prefs",
+    key: "theme",
+    value: { mode: "dark" },
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+describe("PgKvRepo", () => {
+  let db: PGlite;
+  let repo: PgKvRepo;
+
+  beforeEach(async () => {
+    db = await makePglite();
+    await runPgMigrations(db);
+    repo = new PgKvRepo(db);
+  });
+
+  afterEach(async () => {
+    await db.close();
+  });
+
+  it("round-trips arbitrary JSON (incl. nested) and Date timestamps", async () => {
+    await repo.upsert(entry({ value: { mode: "dark", tags: ["a", "b"], n: 3, nested: { x: 1 } } }));
+    const found = await repo.get("user", USER, "prefs", "theme");
+    expect(found?.value).toEqual({ mode: "dark", tags: ["a", "b"], n: 3, nested: { x: 1 } });
+    expect(found?.createdAt).toBeInstanceOf(Date);
+    expect(found?.updatedAt).toBeInstanceOf(Date);
+    expect(found?.ownerId).toBe(USER);
+    expect(found?.scope).toBe("user");
+  });
+
+  it("stores primitive and null JSON values", async () => {
+    await repo.upsert(entry({ key: "s", value: "just-a-string" }));
+    await repo.upsert(entry({ key: "z", value: null }));
+    expect((await repo.get("user", USER, "prefs", "s"))?.value).toBe("just-a-string");
+    expect((await repo.get("user", USER, "prefs", "z"))?.value).toBeNull();
+  });
+
+  it("last-write-wins update replaces value, advances updated_at, preserves created_at", async () => {
+    const t0 = new Date("2024-01-01T00:00:00.000Z");
+    await repo.upsert(entry({ value: "old", createdAt: t0, updatedAt: t0 }));
+    const t1 = new Date("2024-02-01T00:00:00.000Z");
+    await repo.upsert(entry({ value: "new", createdAt: t1, updatedAt: t1 }));
+    const found = await repo.get("user", USER, "prefs", "theme");
+    expect(found?.value).toBe("new");
+    expect(found?.createdAt.toISOString()).toBe(t0.toISOString());
+    expect(found?.updatedAt.toISOString()).toBe(t1.toISOString());
+  });
+
+  it("upserts a system-scoped entry via ownerId=undefined and never surfaces the sentinel", async () => {
+    await repo.upsert(
+      entry({ scope: "system", ownerId: undefined, namespace: "cfg", key: "salt" })
+    );
+    await repo.upsert(
+      entry({ scope: "system", ownerId: undefined, namespace: "cfg", key: "salt", value: "v2" })
+    );
+    const found = await repo.get("system", undefined, "cfg", "salt");
+    expect(found?.value).toBe("v2");
+    expect(found?.ownerId).toBeUndefined(); // '' sentinel maps back to undefined
+    // ON CONFLICT fired: exactly one system row.
+    const { rows } = await db.query(
+      "SELECT count(*)::int AS n FROM kv_store WHERE scope = 'system'"
+    );
+    expect(Number((rows[0] as { n: number }).n)).toBe(1);
+  });
+
+  it("lazy expiry: a past expiresAt is treated as absent on get/list/delete", async () => {
+    const past = new Date(Date.now() - 60_000);
+    await repo.upsert(entry({ key: "gone", expiresAt: past }));
+    expect(await repo.get("user", USER, "prefs", "gone")).toBeNull();
+    expect(await repo.listByNamespace("user", USER, "prefs")).toHaveLength(0);
+    expect(await repo.delete("user", USER, "prefs", "gone")).toBe(false);
+  });
+
+  it("a future expiresAt is still live", async () => {
+    const future = new Date(Date.now() + 60_000);
+    await repo.upsert(entry({ key: "live", expiresAt: future }));
+    const found = await repo.get("user", USER, "prefs", "live");
+    expect(found?.value).toEqual({ mode: "dark" });
+    expect(found?.expiresAt).toBeInstanceOf(Date);
+  });
+
+  it("isolates scopes: same (namespace,key) under user vs agent are distinct rows", async () => {
+    await repo.upsert(entry({ scope: "user", ownerId: USER, value: "user-val" }));
+    await repo.upsert(entry({ scope: "agent", ownerId: USER, value: "agent-val" }));
+    expect((await repo.get("user", USER, "prefs", "theme"))?.value).toBe("user-val");
+    expect((await repo.get("agent", USER, "prefs", "theme"))?.value).toBe("agent-val");
+  });
+
+  it("prevents cross-owner reads (get for another owner returns null)", async () => {
+    await repo.upsert(entry({ ownerId: USER, value: "mine" }));
+    expect(await repo.get("user", "other-owner", "prefs", "theme")).toBeNull();
+  });
+
+  it("delete is idempotent: true when present, false when already gone", async () => {
+    await repo.upsert(entry({ key: "k" }));
+    expect(await repo.delete("user", USER, "prefs", "k")).toBe(true);
+    expect(await repo.delete("user", USER, "prefs", "k")).toBe(false);
+  });
+
+  it("listByNamespace returns only the matching scope+owner+namespace, key-ordered", async () => {
+    await repo.upsert(entry({ namespace: "prefs", key: "b", value: 2 }));
+    await repo.upsert(entry({ namespace: "prefs", key: "a", value: 1 }));
+    await repo.upsert(entry({ namespace: "other", key: "c", value: 3 }));
+    await repo.upsert(entry({ scope: "agent", ownerId: USER, namespace: "prefs", key: "z" }));
+    const list = await repo.listByNamespace("user", USER, "prefs");
+    expect(list.map((e) => e.key)).toEqual(["a", "b"]);
+  });
+});

--- a/apps/api/src/kv/repo.ts
+++ b/apps/api/src/kv/repo.ts
@@ -1,0 +1,178 @@
+import type { Queryable } from "../db";
+import { KV_NAME_RE, MAX_KEY_CHARS, MAX_NAMESPACE_CHARS } from "./limits";
+
+export type KvScope = "system" | "user" | "agent";
+
+/**
+ * One generic key-value entry (KV-V1). Identity is the composite (scope, ownerId, namespace, key).
+ * `ownerId` is `undefined` for scope='system' (app-wide infra) and required for 'user'/'agent'. The
+ * DB stores a '' sentinel for system rows — a nullable column can't be part of a PRIMARY KEY and NULL
+ * is "distinct" in unique indexes, which would break `ON CONFLICT` upserts — but the sentinel never
+ * leaves the repo: callers always see `undefined` for system. `value` is arbitrary JSON round-tripped
+ * through jsonb. `expiresAt` undefined ⇒ never expires.
+ */
+export interface KvEntry {
+  scope: KvScope;
+  ownerId?: string;
+  namespace: string;
+  key: string;
+  value: unknown;
+  expiresAt?: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export class InvalidKvEntryError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidKvEntryError";
+  }
+}
+
+/** The '' sentinel standing in for "no owner" (scope='system') in the composite primary key. */
+const SYSTEM_OWNER = "";
+
+/** Live-row filter shared by every read: NULL expiry never expires; otherwise it must be in the future. */
+const NOT_EXPIRED = "(expires_at IS NULL OR expires_at > now())";
+
+/**
+ * Write-time hard floor (mirrors working memory's `assertValidEntry`): the structural invariants no
+ * row may break. Charset/length live here; the value byte-cap is a softer service-layer policy.
+ */
+export function assertValidEntry(doc: KvEntry): void {
+  ownerColumn(doc.scope, doc.ownerId); // throws if a user/agent entry is missing an owner
+  if (doc.scope === "system" && doc.ownerId !== undefined && doc.ownerId !== "") {
+    throw new InvalidKvEntryError("system-scoped entry must not carry an ownerId");
+  }
+  assertName("namespace", doc.namespace, MAX_NAMESPACE_CHARS);
+  assertName("key", doc.key, MAX_KEY_CHARS);
+}
+
+function assertName(label: string, value: string, max: number): void {
+  if (!value) throw new InvalidKvEntryError(`kv ${label} must be non-empty`);
+  if (value.length > max) throw new InvalidKvEntryError(`kv ${label} exceeds ${max} characters`);
+  if (!KV_NAME_RE.test(value)) {
+    throw new InvalidKvEntryError(`kv ${label} has invalid characters: ${JSON.stringify(value)}`);
+  }
+}
+
+/** scope='system' → '' sentinel; otherwise the required ownerId (throws if absent). */
+function ownerColumn(scope: KvScope, ownerId: string | undefined): string {
+  if (scope === "system") return SYSTEM_OWNER;
+  if (!ownerId) throw new InvalidKvEntryError(`${scope}-scoped operation requires an ownerId`);
+  return ownerId;
+}
+
+/** Map a row back to a KvEntry. pg + PGlite return jsonb already parsed and timestamptz as a Date. */
+function rowToEntry(row: Record<string, unknown>): KvEntry {
+  const scope = row.scope as KvScope;
+  const owner = row.owner_id as string;
+  const entry: KvEntry = {
+    scope,
+    namespace: row.namespace as string,
+    key: row.key as string,
+    value: row.value,
+    createdAt: row.created_at as Date,
+    updatedAt: row.updated_at as Date,
+  };
+  // Non-system rows always carry a real owner (the CHECK forbids ''); system rows expose none.
+  if (scope !== "system") entry.ownerId = owner;
+  if (row.expires_at != null) entry.expiresAt = row.expires_at as Date;
+  return entry;
+}
+
+export interface KvRepo {
+  /** Last-write-wins upsert on the full composite PK. `created_at` is preserved across updates. */
+  upsert(doc: KvEntry): Promise<void>;
+  /** Returns null if absent OR expired (lazy expiry). */
+  get(
+    scope: KvScope,
+    ownerId: string | undefined,
+    namespace: string,
+    key: string
+  ): Promise<KvEntry | null>;
+  /** True if a live row was removed; false if absent/expired. Idempotent. */
+  delete(
+    scope: KvScope,
+    ownerId: string | undefined,
+    namespace: string,
+    key: string
+  ): Promise<boolean>;
+  /** All non-expired entries in a (scope, owner, namespace), key-ordered. */
+  listByNamespace(
+    scope: KvScope,
+    ownerId: string | undefined,
+    namespace: string
+  ): Promise<KvEntry[]>;
+}
+
+export class PgKvRepo implements KvRepo {
+  constructor(private readonly q: Queryable) {}
+
+  async upsert(doc: KvEntry): Promise<void> {
+    assertValidEntry(doc);
+    // `created_at` is deliberately omitted from the DO UPDATE set, so it is preserved on conflict
+    // (only INSERTs use the supplied created_at). Last-write-wins on value + expiry.
+    await this.q.query(
+      `INSERT INTO kv_store (scope, owner_id, namespace, key, value, expires_at, created_at, updated_at)
+       VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8)
+       ON CONFLICT (scope, owner_id, namespace, key) DO UPDATE SET
+         value = EXCLUDED.value,
+         expires_at = EXCLUDED.expires_at,
+         updated_at = EXCLUDED.updated_at`,
+      [
+        doc.scope,
+        ownerColumn(doc.scope, doc.ownerId),
+        doc.namespace,
+        doc.key,
+        JSON.stringify(doc.value),
+        doc.expiresAt ?? null,
+        doc.createdAt,
+        doc.updatedAt,
+      ]
+    );
+  }
+
+  async get(
+    scope: KvScope,
+    ownerId: string | undefined,
+    namespace: string,
+    key: string
+  ): Promise<KvEntry | null> {
+    const { rows } = await this.q.query(
+      `SELECT * FROM kv_store
+       WHERE scope = $1 AND owner_id = $2 AND namespace = $3 AND key = $4 AND ${NOT_EXPIRED}`,
+      [scope, ownerColumn(scope, ownerId), namespace, key]
+    );
+    return rows[0] ? rowToEntry(rows[0]) : null;
+  }
+
+  async delete(
+    scope: KvScope,
+    ownerId: string | undefined,
+    namespace: string,
+    key: string
+  ): Promise<boolean> {
+    const { rows } = await this.q.query(
+      `DELETE FROM kv_store
+       WHERE scope = $1 AND owner_id = $2 AND namespace = $3 AND key = $4 AND ${NOT_EXPIRED}
+       RETURNING key`,
+      [scope, ownerColumn(scope, ownerId), namespace, key]
+    );
+    return rows.length > 0;
+  }
+
+  async listByNamespace(
+    scope: KvScope,
+    ownerId: string | undefined,
+    namespace: string
+  ): Promise<KvEntry[]> {
+    const { rows } = await this.q.query(
+      `SELECT * FROM kv_store
+       WHERE scope = $1 AND owner_id = $2 AND namespace = $3 AND ${NOT_EXPIRED}
+       ORDER BY key`,
+      [scope, ownerColumn(scope, ownerId), namespace]
+    );
+    return rows.map(rowToEntry);
+  }
+}

--- a/apps/api/src/kv/routes.test.ts
+++ b/apps/api/src/kv/routes.test.ts
@@ -1,0 +1,267 @@
+import type { PGlite } from "@electric-sql/pglite";
+import type { FastifyInstance } from "fastify";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildApp } from "../app";
+import type { TokenDoc, TokenRepo } from "../auth/api-tokens";
+import { CSRF_COOKIE, CSRF_HEADER } from "../auth/csrf";
+import { SESSION_COOKIE } from "../auth/routes";
+import { MemorySessionStore } from "../auth/session-store";
+import { createUser, type UserDoc, type UserRepo } from "../auth/users";
+import type { PaginatedResult } from "../pagination";
+import { runPgMigrations } from "../pg-migrate";
+import { makePglite } from "../test/pglite";
+import { PgKvRepo } from "./repo";
+import { KvService } from "./service";
+
+const TEST_CSRF = "a".repeat(64);
+const write = (sid: string) => ({
+  cookies: { [SESSION_COOKIE]: sid, [CSRF_COOKIE]: TEST_CSRF },
+  headers: { [CSRF_HEADER]: TEST_CSRF },
+});
+
+class FakeUserRepo implements UserRepo {
+  private users: UserDoc[] = [];
+  async findByEmail(email: string): Promise<UserDoc | null> {
+    return this.users.find((u) => u.email === email.trim().toLowerCase()) ?? null;
+  }
+  async findById(id: string): Promise<UserDoc | null> {
+    return this.users.find((u) => u._id === id) ?? null;
+  }
+  async count(): Promise<number> {
+    return this.users.length;
+  }
+  async insert(user: UserDoc): Promise<void> {
+    this.users.push(user);
+  }
+}
+
+class FakeTokenRepo implements TokenRepo {
+  private tokens: TokenDoc[] = [];
+  async create(token: TokenDoc): Promise<void> {
+    this.tokens.push(token);
+  }
+  async findByHash(hash: string): Promise<TokenDoc | null> {
+    return this.tokens.find((t) => t.tokenHash === hash) ?? null;
+  }
+  async findByUserId(userId: string): Promise<TokenDoc[]> {
+    return this.tokens.filter((t) => t.userId === userId);
+  }
+  async findAll(): Promise<TokenDoc[]> {
+    return [...this.tokens];
+  }
+  async findById(id: string): Promise<TokenDoc | null> {
+    return this.tokens.find((t) => t._id === id) ?? null;
+  }
+  async deleteById(id: string): Promise<void> {
+    this.tokens = this.tokens.filter((t) => t._id !== id);
+  }
+  async findAllPaginated(): Promise<PaginatedResult<TokenDoc>> {
+    return { items: [], nextCursor: null };
+  }
+  async findByUserIdPaginated(): Promise<PaginatedResult<TokenDoc>> {
+    return { items: [], nextCursor: null };
+  }
+}
+
+describe("kv routes", () => {
+  let app: FastifyInstance;
+  let db: PGlite;
+  let kvService: KvService;
+  let store: MemorySessionStore;
+  let adminSid: string;
+  let memberSid: string;
+  let otherSid: string;
+  let memberId: string;
+
+  beforeEach(async () => {
+    db = await makePglite();
+    await runPgMigrations(db);
+    kvService = new KvService(new PgKvRepo(db));
+
+    store = new MemorySessionStore();
+    const userRepo = new FakeUserRepo();
+    const tokenRepo = new FakeTokenRepo();
+    const admin = await createUser(userRepo, "admin@example.com", "pass", "admin");
+    const member = await createUser(userRepo, "member@example.com", "pass", "member");
+    const other = await createUser(userRepo, "other@example.com", "pass", "member");
+    memberId = member._id;
+    adminSid = await store.create(admin._id);
+    memberSid = await store.create(member._id);
+    otherSid = await store.create(other._id);
+
+    app = await buildApp({ sessionStore: store, userRepo, tokenRepo, kvService });
+  });
+
+  afterEach(async () => {
+    await app.close();
+    await db.close();
+  });
+
+  // ── User scope ──────────────────────────────────────────────────────────────
+
+  it("returns 401 without auth", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/v1/kv/prefs/theme" });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("round-trips a user entry through PUT then GET", async () => {
+    const put = await app.inject({
+      method: "PUT",
+      url: "/api/v1/kv/prefs/theme",
+      ...write(memberSid),
+      payload: { value: { mode: "dark" } },
+    });
+    expect(put.statusCode).toBe(200);
+    expect(put.json()).toEqual({ namespace: "prefs", key: "theme" });
+
+    const get = await app.inject({
+      method: "GET",
+      url: "/api/v1/kv/prefs/theme",
+      cookies: { [SESSION_COOKIE]: memberSid },
+    });
+    expect(get.statusCode).toBe(200);
+    expect(get.json()).toMatchObject({ namespace: "prefs", key: "theme", value: { mode: "dark" } });
+  });
+
+  it("isolates users: another user cannot read the same path", async () => {
+    await app.inject({
+      method: "PUT",
+      url: "/api/v1/kv/prefs/theme",
+      ...write(memberSid),
+      payload: { value: "mine" },
+    });
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/kv/prefs/theme",
+      cookies: { [SESSION_COOKIE]: otherSid },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns 400 for an oversize value", async () => {
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/v1/kv/prefs/big",
+      ...write(memberSid),
+      payload: { value: "x".repeat(256 * 1024 + 1) },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("honors expiry on the read path (lazy)", async () => {
+    // Seed an already-expired entry directly through the service, then read via the route.
+    await kvService.set("user", memberId, "prefs", "ghost", "v", new Date(Date.now() - 1000));
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/kv/prefs/ghost",
+      cookies: { [SESSION_COOKIE]: memberSid },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("DELETE is idempotent (204 twice)", async () => {
+    await app.inject({
+      method: "PUT",
+      url: "/api/v1/kv/prefs/temp",
+      ...write(memberSid),
+      payload: { value: 1 },
+    });
+    const d1 = await app.inject({
+      method: "DELETE",
+      url: "/api/v1/kv/prefs/temp",
+      ...write(memberSid),
+    });
+    const d2 = await app.inject({
+      method: "DELETE",
+      url: "/api/v1/kv/prefs/temp",
+      ...write(memberSid),
+    });
+    expect(d1.statusCode).toBe(204);
+    expect(d2.statusCode).toBe(204);
+  });
+
+  it("lists entries in a namespace", async () => {
+    await app.inject({
+      method: "PUT",
+      url: "/api/v1/kv/n/a",
+      ...write(memberSid),
+      payload: { value: 1 },
+    });
+    await app.inject({
+      method: "PUT",
+      url: "/api/v1/kv/n/b",
+      ...write(memberSid),
+      payload: { value: 2 },
+    });
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/kv/n",
+      cookies: { [SESSION_COOKIE]: memberSid },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().entries.map((e: { key: string }) => e.key)).toEqual(["a", "b"]);
+  });
+
+  // ── Admin / system scope ──────────────────────────────────────────────────────
+
+  it("forbids non-admins from the system keyspace (403)", async () => {
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/v1/admin/kv/cfg/flag",
+      ...write(memberSid),
+      payload: { value: true },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("lets an admin write and read the system keyspace; repeated PUT updates in place", async () => {
+    const put1 = await app.inject({
+      method: "PUT",
+      url: "/api/v1/admin/kv/cfg/flag",
+      ...write(adminSid),
+      payload: { value: { enabled: false } },
+    });
+    expect(put1.statusCode).toBe(200);
+
+    await app.inject({
+      method: "PUT",
+      url: "/api/v1/admin/kv/cfg/flag",
+      ...write(adminSid),
+      payload: { value: { enabled: true } },
+    });
+
+    const get = await app.inject({
+      method: "GET",
+      url: "/api/v1/admin/kv/cfg/flag",
+      cookies: { [SESSION_COOKIE]: adminSid },
+    });
+    expect(get.statusCode).toBe(200);
+    expect(get.json()).toMatchObject({ value: { enabled: true } });
+
+    const { rows } = await db.query(
+      "SELECT count(*)::int AS n FROM kv_store WHERE scope = 'system'"
+    );
+    expect(Number((rows[0] as { n: number }).n)).toBe(1);
+  });
+
+  it("keeps user and system keyspaces separate (same namespace/key)", async () => {
+    await app.inject({
+      method: "PUT",
+      url: "/api/v1/kv/cfg/flag",
+      ...write(memberSid),
+      payload: { value: "user-value" },
+    });
+    await app.inject({
+      method: "PUT",
+      url: "/api/v1/admin/kv/cfg/flag",
+      ...write(adminSid),
+      payload: { value: "system-value" },
+    });
+    const userGet = await app.inject({
+      method: "GET",
+      url: "/api/v1/kv/cfg/flag",
+      cookies: { [SESSION_COOKIE]: memberSid },
+    });
+    expect(userGet.json().value).toBe("user-value");
+  });
+});

--- a/apps/api/src/kv/routes.ts
+++ b/apps/api/src/kv/routes.ts
@@ -1,0 +1,196 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { ErrorSchema } from "../auth/schemas";
+import type { UserDoc } from "../auth/users";
+import { MAX_VALUE_BYTES } from "./limits";
+import type { KvEntry, KvScope } from "./repo";
+import type { KvService } from "./service";
+
+type PreHandler = (req: FastifyRequest, reply: FastifyReply) => Promise<void>;
+
+interface ScopeConfig {
+  scope: KvScope;
+  prefix: string;
+  /** Owner derived from the authenticated caller — never from the request body/path. */
+  resolveOwner: (req: FastifyRequest) => string | undefined;
+  requireAdmin: boolean;
+  tag: string;
+}
+
+const PARAMS_NS_KEY = {
+  type: "object",
+  required: ["namespace", "key"],
+  properties: { namespace: { type: "string" }, key: { type: "string" } },
+} as const;
+
+const PARAMS_NS = {
+  type: "object",
+  required: ["namespace"],
+  properties: { namespace: { type: "string" } },
+} as const;
+
+// `value` carries no type constraint (any JSON); ttlSeconds is an optional positive TTL.
+const PUT_BODY = {
+  type: "object",
+  required: ["value"],
+  additionalProperties: false,
+  properties: { value: {}, ttlSeconds: { type: "integer", minimum: 1 } },
+} as const;
+
+/** API view of an entry — value passes through untouched (no response schema, so jsonb isn't mangled). */
+function toApi(entry: KvEntry): Record<string, unknown> {
+  return {
+    namespace: entry.namespace,
+    key: entry.key,
+    value: entry.value,
+    ...(entry.expiresAt ? { expiresAt: entry.expiresAt.toISOString() } : {}),
+    createdAt: entry.createdAt.toISOString(),
+    updatedAt: entry.updatedAt.toISOString(),
+  };
+}
+
+/**
+ * Registers the four CRUD routes for one scope under `cfg.prefix`. Scope and owner are pinned from
+ * the caller's identity (never the request), so a user can only ever address their own keyspace and
+ * system scope is admin-gated. Mirrors the secrets-route admin gating (403 for non-admins).
+ */
+function registerScopedKvRoutes(
+  app: FastifyInstance,
+  kvService: KvService,
+  requireAuth: PreHandler,
+  cfg: ScopeConfig
+): void {
+  const { scope, prefix, resolveOwner, requireAdmin, tag } = cfg;
+  const security: { [k: string]: readonly string[] }[] = [
+    { sessionCookie: [] },
+    { bearerToken: [] },
+  ];
+
+  /** Returns true if the caller may proceed; otherwise sends 403 and returns false. */
+  const allowed = (req: FastifyRequest, reply: FastifyReply): boolean => {
+    if (requireAdmin && (req.user as UserDoc).role !== "admin") {
+      reply.code(403).send({ error: "forbidden" });
+      return false;
+    }
+    return true;
+  };
+
+  app.get(
+    `${prefix}/:namespace/:key`,
+    {
+      preHandler: requireAuth,
+      schema: { description: "Read a KV entry.", tags: [tag], security, params: PARAMS_NS_KEY },
+    },
+    async (req, reply) => {
+      if (!allowed(req, reply)) return;
+      const { namespace, key } = req.params as { namespace: string; key: string };
+      const entry = await kvService.get(scope, resolveOwner(req), namespace, key);
+      if (!entry) return reply.code(404).send({ error: "not found" });
+      return reply.send(toApi(entry));
+    }
+  );
+
+  app.put(
+    `${prefix}/:namespace/:key`,
+    {
+      preHandler: requireAuth,
+      schema: {
+        description: "Create or update a KV entry (last-write-wins).",
+        tags: [tag],
+        security,
+        params: PARAMS_NS_KEY,
+        body: PUT_BODY,
+        response: { 400: ErrorSchema, 401: ErrorSchema, 403: ErrorSchema },
+      },
+    },
+    async (req, reply) => {
+      if (!allowed(req, reply)) return;
+      const { namespace, key } = req.params as { namespace: string; key: string };
+      const body = (req.body ?? {}) as { value?: unknown; ttlSeconds?: number };
+      if (body.value === undefined) return reply.code(400).send({ error: "value is required" });
+      const expiresAt =
+        typeof body.ttlSeconds === "number"
+          ? new Date(Date.now() + body.ttlSeconds * 1000)
+          : undefined;
+      const outcome = await kvService.set(
+        scope,
+        resolveOwner(req),
+        namespace,
+        key,
+        body.value,
+        expiresAt
+      );
+      if (outcome.kind === "rejected_oversize") {
+        return reply.code(400).send({ error: `value exceeds the ${MAX_VALUE_BYTES}-byte limit` });
+      }
+      if (outcome.kind === "rejected_invalid") {
+        return reply.code(400).send({ error: outcome.reason });
+      }
+      return reply.send({ namespace, key });
+    }
+  );
+
+  app.delete(
+    `${prefix}/:namespace/:key`,
+    {
+      preHandler: requireAuth,
+      schema: {
+        description: "Delete a KV entry (idempotent).",
+        tags: [tag],
+        security,
+        params: PARAMS_NS_KEY,
+        response: { 204: { type: "null" }, 401: ErrorSchema, 403: ErrorSchema },
+      },
+    },
+    async (req, reply) => {
+      if (!allowed(req, reply)) return;
+      const { namespace, key } = req.params as { namespace: string; key: string };
+      await kvService.delete(scope, resolveOwner(req), namespace, key);
+      return reply.code(204).send();
+    }
+  );
+
+  app.get(
+    `${prefix}/:namespace`,
+    {
+      preHandler: requireAuth,
+      schema: {
+        description: "List all live entries in a namespace.",
+        tags: [tag],
+        security,
+        params: PARAMS_NS,
+      },
+    },
+    async (req, reply) => {
+      if (!allowed(req, reply)) return;
+      const { namespace } = req.params as { namespace: string };
+      const entries = await kvService.list(scope, resolveOwner(req), namespace);
+      return reply.send({ entries: entries.map(toApi) });
+    }
+  );
+}
+
+/**
+ * User-scoped KV under `/api/v1/kv` (owner = authenticated user) and admin-only system-scoped KV under
+ * `/api/v1/admin/kv` (owner = none). The admin prefix is deliberately a separate path — not
+ * `/api/v1/kv/system` — so it can never collide with a user namespace literally named `system`.
+ */
+export function registerKvRoutes(
+  app: FastifyInstance,
+  kvService: KvService,
+  requireAuth: PreHandler
+): void {
+  registerScopedKvRoutes(app, kvService, requireAuth, {
+    scope: "user",
+    prefix: "/api/v1/kv",
+    resolveOwner: (req) => (req.user as UserDoc)._id,
+    requireAdmin: false,
+    tag: "kv",
+  });
+  registerScopedKvRoutes(app, kvService, requireAuth, {
+    scope: "system",
+    prefix: "/api/v1/admin/kv",
+    resolveOwner: () => undefined,
+    requireAdmin: true,
+    tag: "kv-admin",
+  });
+}

--- a/apps/api/src/kv/service.test.ts
+++ b/apps/api/src/kv/service.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+import { assertValidEntry, type KvEntry, type KvRepo, type KvScope } from "./repo";
+import { KvService } from "./service";
+
+/** Owner key as the DB stores it: '' for system, the ownerId otherwise. Mirrors `owner_id`. */
+function ownerKey(scope: KvScope, ownerId: string | undefined): string {
+  return scope === "system" ? "" : (ownerId ?? "");
+}
+
+/** In-memory repo mirroring PgKvRepo semantics: composite identity, lazy expiry, created_at preserved. */
+class FakeKvRepo implements KvRepo {
+  rows: KvEntry[] = [];
+
+  private idx(
+    scope: KvScope,
+    ownerId: string | undefined,
+    namespace: string,
+    key?: string
+  ): number {
+    return this.rows.findIndex(
+      (e) =>
+        e.scope === scope &&
+        ownerKey(e.scope, e.ownerId) === ownerKey(scope, ownerId) &&
+        e.namespace === namespace &&
+        (key === undefined || e.key === key)
+    );
+  }
+
+  private live(e: KvEntry): boolean {
+    return !e.expiresAt || e.expiresAt.getTime() > Date.now();
+  }
+
+  async upsert(doc: KvEntry): Promise<void> {
+    assertValidEntry(doc);
+    const normalized: KvEntry = {
+      ...doc,
+      ownerId: doc.scope === "system" ? undefined : doc.ownerId,
+    };
+    const i = this.idx(normalized.scope, normalized.ownerId, normalized.namespace, normalized.key);
+    if (i >= 0) {
+      // Last-write-wins; created_at is preserved (only value/expiry/updated_at change).
+      this.rows[i] = {
+        ...this.rows[i],
+        value: normalized.value,
+        expiresAt: normalized.expiresAt,
+        updatedAt: normalized.updatedAt,
+      };
+    } else {
+      this.rows.push({ ...normalized });
+    }
+  }
+
+  async get(
+    scope: KvScope,
+    ownerId: string | undefined,
+    namespace: string,
+    key: string
+  ): Promise<KvEntry | null> {
+    const i = this.idx(scope, ownerId, namespace, key);
+    return i >= 0 && this.live(this.rows[i]) ? { ...this.rows[i] } : null;
+  }
+
+  async delete(
+    scope: KvScope,
+    ownerId: string | undefined,
+    namespace: string,
+    key: string
+  ): Promise<boolean> {
+    const i = this.idx(scope, ownerId, namespace, key);
+    if (i < 0 || !this.live(this.rows[i])) return false;
+    this.rows.splice(i, 1);
+    return true;
+  }
+
+  async listByNamespace(
+    scope: KvScope,
+    ownerId: string | undefined,
+    namespace: string
+  ): Promise<KvEntry[]> {
+    return this.rows
+      .filter(
+        (e) =>
+          e.scope === scope &&
+          ownerKey(e.scope, e.ownerId) === ownerKey(scope, ownerId) &&
+          e.namespace === namespace &&
+          this.live(e)
+      )
+      .sort((a, b) => a.key.localeCompare(b.key))
+      .map((e) => ({ ...e }));
+  }
+}
+
+const U = "u1";
+
+describe("KvService.set", () => {
+  it("stores a value and reads it back", async () => {
+    const svc = new KvService(new FakeKvRepo());
+    await expect(svc.set("user", U, "prefs", "theme", { mode: "dark" })).resolves.toEqual({
+      kind: "ok",
+    });
+    expect((await svc.get("user", U, "prefs", "theme"))?.value).toEqual({ mode: "dark" });
+  });
+
+  it("preserves created_at across an update (last-write-wins)", async () => {
+    const svc = new KvService(new FakeKvRepo());
+    await svc.set("user", U, "prefs", "theme", "a");
+    const first = await svc.get("user", U, "prefs", "theme");
+    await new Promise((r) => setTimeout(r, 3));
+    await svc.set("user", U, "prefs", "theme", "b");
+    const second = await svc.get("user", U, "prefs", "theme");
+    expect(second?.value).toBe("b");
+    expect(second?.createdAt.getTime()).toBe(first?.createdAt.getTime());
+    expect((second?.updatedAt.getTime() ?? 0) >= (first?.updatedAt.getTime() ?? 0)).toBe(true);
+  });
+
+  it("rejects an oversize value (by bytes) and writes nothing", async () => {
+    const repo = new FakeKvRepo();
+    const svc = new KvService(repo);
+    const big = "x".repeat(256 * 1024 + 50);
+    const outcome = await svc.set("user", U, "n", "k", big);
+    expect(outcome.kind).toBe("rejected_oversize");
+    expect(repo.rows).toHaveLength(0);
+  });
+
+  it("measures the cap in UTF-8 bytes, not characters (multibyte over byte-cap, under char count)", async () => {
+    const svc = new KvService(new FakeKvRepo());
+    // 200k 'é' = 200k chars (< 262144) but ~400k UTF-8 bytes (> 262144) → must be rejected.
+    const outcome = await svc.set("user", U, "n", "k", "é".repeat(200_000));
+    expect(outcome.kind).toBe("rejected_oversize");
+  });
+
+  it("rejects invalid namespace/key charset and over-length names", async () => {
+    const svc = new KvService(new FakeKvRepo());
+    expect((await svc.set("user", U, "bad space", "k", 1)).kind).toBe("rejected_invalid");
+    expect((await svc.set("user", U, "n", "has/slash", 1)).kind).toBe("rejected_invalid");
+    expect((await svc.set("user", U, "x".repeat(129), "k", 1)).kind).toBe("rejected_invalid");
+    expect((await svc.set("user", U, "n", "x".repeat(257), 1)).kind).toBe("rejected_invalid");
+  });
+
+  it("accepts a system entry with no owner, but a user entry requires one", async () => {
+    const svc = new KvService(new FakeKvRepo());
+    await expect(svc.set("system", undefined, "cfg", "salt", "s")).resolves.toEqual({ kind: "ok" });
+    await expect(svc.set("user", undefined, "cfg", "salt", "s")).rejects.toThrow();
+  });
+
+  it("honors expiry passed through to the store (lazy)", async () => {
+    const svc = new KvService(new FakeKvRepo());
+    await svc.set("user", U, "n", "live", 1, new Date(Date.now() + 60_000));
+    await svc.set("user", U, "n", "dead", 1, new Date(Date.now() - 60_000));
+    expect(await svc.get("user", U, "n", "live")).not.toBeNull();
+    expect(await svc.get("user", U, "n", "dead")).toBeNull();
+  });
+});
+
+describe("KvService.delete", () => {
+  it("is idempotent: true then false", async () => {
+    const svc = new KvService(new FakeKvRepo());
+    await svc.set("user", U, "n", "k", 1);
+    await expect(svc.delete("user", U, "n", "k")).resolves.toBe(true);
+    await expect(svc.delete("user", U, "n", "k")).resolves.toBe(false);
+  });
+});

--- a/apps/api/src/kv/service.ts
+++ b/apps/api/src/kv/service.ts
@@ -1,0 +1,80 @@
+import { Buffer } from "node:buffer";
+import { KV_NAME_RE, MAX_KEY_CHARS, MAX_NAMESPACE_CHARS, MAX_VALUE_BYTES } from "./limits";
+import type { KvEntry, KvRepo, KvScope } from "./repo";
+
+export type SetOutcome =
+  | { kind: "ok" }
+  | { kind: "rejected_oversize"; bytes: number }
+  | { kind: "rejected_invalid"; reason: string };
+
+/**
+ * Owns the KV write policy (KV-V1): namespace/key charset+length validation, the value BYTE cap, and
+ * TTL handling. The repo stays dumb CRUD so this is testable against an in-memory fake. The tool and
+ * route layers pin `scope`+`ownerId` from caller identity before calling in; internal backend callers
+ * may address any scope directly. `created_at` preservation is handled by the repo's upsert (it omits
+ * created_at from the conflict update), so no read-before-write is needed.
+ */
+export class KvService {
+  constructor(private readonly repo: KvRepo) {}
+
+  async set(
+    scope: KvScope,
+    ownerId: string | undefined,
+    namespace: string,
+    key: string,
+    value: unknown,
+    expiresAt?: Date
+  ): Promise<SetOutcome> {
+    const invalid =
+      validateName("namespace", namespace, MAX_NAMESPACE_CHARS) ??
+      validateName("key", key, MAX_KEY_CHARS);
+    if (invalid) return { kind: "rejected_invalid", reason: invalid };
+    // JSON null is a valid storable value; only a genuinely missing value (undefined) is rejected.
+    if (value === undefined) return { kind: "rejected_invalid", reason: "value is required" };
+
+    const bytes = Buffer.byteLength(JSON.stringify(value), "utf8");
+    if (bytes > MAX_VALUE_BYTES) return { kind: "rejected_oversize", bytes };
+
+    const now = new Date();
+    await this.repo.upsert({
+      scope,
+      ownerId,
+      namespace,
+      key,
+      value,
+      expiresAt,
+      createdAt: now, // used only on INSERT; preserved on conflict by the repo
+      updatedAt: now,
+    });
+    return { kind: "ok" };
+  }
+
+  get(
+    scope: KvScope,
+    ownerId: string | undefined,
+    namespace: string,
+    key: string
+  ): Promise<KvEntry | null> {
+    return this.repo.get(scope, ownerId, namespace, key);
+  }
+
+  delete(
+    scope: KvScope,
+    ownerId: string | undefined,
+    namespace: string,
+    key: string
+  ): Promise<boolean> {
+    return this.repo.delete(scope, ownerId, namespace, key);
+  }
+
+  list(scope: KvScope, ownerId: string | undefined, namespace: string): Promise<KvEntry[]> {
+    return this.repo.listByNamespace(scope, ownerId, namespace);
+  }
+}
+
+function validateName(label: string, value: string, max: number): string | null {
+  if (!value) return `${label} must be non-empty`;
+  if (value.length > max) return `${label} exceeds ${max} characters`;
+  if (!KV_NAME_RE.test(value)) return `${label} has invalid characters`;
+  return null;
+}

--- a/apps/api/src/kv/tool-result.ts
+++ b/apps/api/src/kv/tool-result.ts
@@ -1,0 +1,2 @@
+export type { ToolCallResult, ToolErrorCode } from "../tools/types";
+export { err, ok } from "../tools/types";

--- a/apps/api/src/kv/tools.test.ts
+++ b/apps/api/src/kv/tools.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+import { assertValidEntry, type KvEntry, type KvRepo, type KvScope } from "./repo";
+import { KvService } from "./service";
+import {
+  KV_TOOLS,
+  type KvToolContext,
+  kvDeleteTool,
+  kvGetTool,
+  kvListTool,
+  kvSetTool,
+} from "./tools";
+
+function ownerKey(scope: KvScope, ownerId: string | undefined): string {
+  return scope === "system" ? "" : (ownerId ?? "");
+}
+
+/** Minimal in-memory repo for tool tests; exposes `rows` so we can assert how entries were scoped. */
+class FakeKvRepo implements KvRepo {
+  rows: KvEntry[] = [];
+  private idx(s: KvScope, o: string | undefined, ns: string, k?: string): number {
+    return this.rows.findIndex(
+      (e) =>
+        e.scope === s &&
+        ownerKey(e.scope, e.ownerId) === ownerKey(s, o) &&
+        e.namespace === ns &&
+        (k === undefined || e.key === k)
+    );
+  }
+  private live(e: KvEntry): boolean {
+    return !e.expiresAt || e.expiresAt.getTime() > Date.now();
+  }
+  async upsert(doc: KvEntry): Promise<void> {
+    assertValidEntry(doc);
+    const n: KvEntry = { ...doc, ownerId: doc.scope === "system" ? undefined : doc.ownerId };
+    const i = this.idx(n.scope, n.ownerId, n.namespace, n.key);
+    if (i >= 0)
+      this.rows[i] = {
+        ...this.rows[i],
+        value: n.value,
+        expiresAt: n.expiresAt,
+        updatedAt: n.updatedAt,
+      };
+    else this.rows.push({ ...n });
+  }
+  async get(s: KvScope, o: string | undefined, ns: string, k: string): Promise<KvEntry | null> {
+    const i = this.idx(s, o, ns, k);
+    return i >= 0 && this.live(this.rows[i]) ? { ...this.rows[i] } : null;
+  }
+  async delete(s: KvScope, o: string | undefined, ns: string, k: string): Promise<boolean> {
+    const i = this.idx(s, o, ns, k);
+    if (i < 0 || !this.live(this.rows[i])) return false;
+    this.rows.splice(i, 1);
+    return true;
+  }
+  async listByNamespace(s: KvScope, o: string | undefined, ns: string): Promise<KvEntry[]> {
+    return this.rows.filter(
+      (e) =>
+        e.scope === s &&
+        ownerKey(e.scope, e.ownerId) === ownerKey(s, o) &&
+        e.namespace === ns &&
+        this.live(e)
+    );
+  }
+}
+
+function ctxFor(repo: FakeKvRepo, agentId?: string): KvToolContext {
+  return { userId: "u1", agentId, service: new KvService(repo) };
+}
+
+describe("KV agent tools", () => {
+  it("kv_set pins the entry to scope='agent' and owner = ctx.agentId", async () => {
+    const repo = new FakeKvRepo();
+    const res = await kvSetTool.handler(
+      { namespace: "scratch", key: "k", value: { a: 1 } },
+      ctxFor(repo, "agent-x")
+    );
+    expect(res).toMatchObject({ success: true });
+    expect(repo.rows).toHaveLength(1);
+    expect(repo.rows[0]).toMatchObject({
+      scope: "agent",
+      ownerId: "agent-x",
+      namespace: "scratch",
+      key: "k",
+    });
+  });
+
+  it("rejects args that try to specify scope or owner (additionalProperties:false)", async () => {
+    const res = await kvSetTool.handler(
+      { namespace: "scratch", key: "k", value: 1, scope: "system", owner_id: "x" },
+      ctxFor(new FakeKvRepo(), "agent-x")
+    );
+    expect(res).toMatchObject({ success: false, error: { code: "validation_error" } });
+  });
+
+  it("prevents cross-agent reads: agent-y cannot see agent-x's key", async () => {
+    const repo = new FakeKvRepo();
+    await kvSetTool.handler(
+      { namespace: "scratch", key: "secret", value: 42 },
+      ctxFor(repo, "agent-x")
+    );
+    const res = await kvGetTool.handler(
+      { namespace: "scratch", key: "secret" },
+      ctxFor(repo, "agent-y")
+    );
+    expect(res).toEqual({
+      success: true,
+      data: { namespace: "scratch", key: "secret", found: false },
+    });
+  });
+
+  it("kv_get returns the stored value for the owning agent", async () => {
+    const repo = new FakeKvRepo();
+    await kvSetTool.handler(
+      { namespace: "scratch", key: "k", value: { a: 1 } },
+      ctxFor(repo, "agent-x")
+    );
+    const res = await kvGetTool.handler(
+      { namespace: "scratch", key: "k" },
+      ctxFor(repo, "agent-x")
+    );
+    expect(res).toMatchObject({ success: true, data: { found: true, value: { a: 1 } } });
+  });
+
+  it("rejects an oversize value with code oversize_value, storing nothing", async () => {
+    const repo = new FakeKvRepo();
+    const res = await kvSetTool.handler(
+      { namespace: "scratch", key: "big", value: "x".repeat(256 * 1024 + 1) },
+      ctxFor(repo, "agent-x")
+    );
+    expect(res).toMatchObject({ success: false, error: { code: "oversize_value" } });
+    expect(repo.rows).toHaveLength(0);
+  });
+
+  it("errors when the agent identity is missing", async () => {
+    const res = await kvSetTool.handler(
+      { namespace: "scratch", key: "k", value: 1 },
+      ctxFor(new FakeKvRepo(), undefined)
+    );
+    expect(res).toMatchObject({ success: false, error: { code: "internal_error" } });
+  });
+
+  it("kv_delete is idempotent and kv_get reports absence", async () => {
+    const repo = new FakeKvRepo();
+    const del = await kvDeleteTool.handler(
+      { namespace: "n", key: "missing" },
+      ctxFor(repo, "agent-x")
+    );
+    expect(del).toEqual({
+      success: true,
+      data: { namespace: "n", key: "missing", deleted: false },
+    });
+  });
+
+  it("kv_set with ttlSeconds stores an expiry and kv_list returns live entries", async () => {
+    const repo = new FakeKvRepo();
+    await kvSetTool.handler(
+      { namespace: "n", key: "k", value: 1, ttlSeconds: 60 },
+      ctxFor(repo, "agent-x")
+    );
+    expect(repo.rows[0].expiresAt).toBeInstanceOf(Date);
+    const list = await kvListTool.handler({ namespace: "n" }, ctxFor(repo, "agent-x"));
+    expect(list).toMatchObject({ success: true, data: { entries: [{ key: "k", value: 1 }] } });
+  });
+
+  it("exposes exactly the four kv_* tools", () => {
+    expect(KV_TOOLS.map((t) => t.name).sort()).toEqual([
+      "kv_delete",
+      "kv_get",
+      "kv_list",
+      "kv_set",
+    ]);
+  });
+});

--- a/apps/api/src/kv/tools.ts
+++ b/apps/api/src/kv/tools.ts
@@ -1,0 +1,179 @@
+import { ajv } from "@tulipfarm/validation";
+import { KV_NAME_RE, MAX_KEY_CHARS, MAX_NAMESPACE_CHARS, MAX_VALUE_BYTES } from "./limits";
+import type { KvService } from "./service";
+import { err, ok, type ToolCallResult } from "./tool-result";
+
+/**
+ * Per-request context a KV tool handler runs against. `agentId` is the hard-wired owner for the
+ * agent-scoped store — the LLM never supplies scope or owner, so an agent can only ever read/write
+ * its own keyspace (`scope='agent'`, `owner_id=agentId`).
+ */
+export interface KvToolContext {
+  userId: string;
+  agentId?: string;
+  service: KvService;
+}
+
+/** A platform (built-in) tool: schema + LLM-facing guidance + a handler that returns a result. */
+export interface PlatformTool {
+  name: string;
+  description: string;
+  mutating: boolean;
+  inputSchema: Record<string, unknown>;
+  handler: (args: unknown, ctx: KvToolContext) => Promise<ToolCallResult>;
+}
+
+const AGENT = "agent" as const;
+
+const namespaceProp = {
+  type: "string",
+  minLength: 1,
+  maxLength: MAX_NAMESPACE_CHARS,
+  pattern: KV_NAME_RE.source,
+  description: "Logical group for the entry (e.g. 'scratch', 'cache').",
+};
+const keyProp = {
+  type: "string",
+  minLength: 1,
+  maxLength: MAX_KEY_CHARS,
+  pattern: KV_NAME_RE.source,
+  description: "Entry key within the namespace.",
+};
+
+const GET_SCHEMA: Record<string, unknown> = {
+  type: "object",
+  additionalProperties: false,
+  required: ["namespace", "key"],
+  properties: { namespace: namespaceProp, key: keyProp },
+};
+
+const DELETE_SCHEMA: Record<string, unknown> = GET_SCHEMA;
+
+const LIST_SCHEMA: Record<string, unknown> = {
+  type: "object",
+  additionalProperties: false,
+  required: ["namespace"],
+  properties: { namespace: namespaceProp },
+};
+
+// `value` carries NO type constraint (any JSON). It also carries no maxLength — an oversize write must
+// reach the service so the tool returns the byte-cap error rather than a generic schema rejection.
+const SET_SCHEMA: Record<string, unknown> = {
+  type: "object",
+  additionalProperties: false,
+  required: ["namespace", "key", "value"],
+  properties: {
+    namespace: namespaceProp,
+    key: keyProp,
+    value: { description: "Any JSON value to store." },
+    ttlSeconds: {
+      type: "integer",
+      minimum: 1,
+      description: "Optional time-to-live in seconds; omit to persist until deleted.",
+    },
+  },
+};
+
+const validateGet = ajv.compile(GET_SCHEMA);
+const validateDelete = ajv.compile(DELETE_SCHEMA);
+const validateList = ajv.compile(LIST_SCHEMA);
+const validateSet = ajv.compile(SET_SCHEMA);
+
+function firstError(errors: typeof validateGet.errors): string {
+  const e = errors?.[0];
+  if (!e) return "invalid arguments";
+  return `${e.instancePath || "(root)"} ${e.message ?? "is invalid"}`.trim();
+}
+
+const GUIDANCE =
+  "This is the agent's own private key-value scratch space — isolated from other agents and from " +
+  "users. Use it for durable state across turns (cached lookups, counters, working notes). Store " +
+  "small, stable user facts in working memory and business documents in knowledge instead.";
+
+export const kvSetTool: PlatformTool = {
+  name: "kv_set",
+  description: `Store a JSON value under (namespace, key) in your key-value store. Last write wins; optional ttlSeconds expires it. ${GUIDANCE}`,
+  mutating: true,
+  inputSchema: SET_SCHEMA,
+  handler: async (args, ctx) => {
+    if (!validateSet(args)) return err("validation_error", firstError(validateSet.errors));
+    if (!ctx.agentId) return err("internal_error", "agent identity required for kv tools");
+    const { namespace, key, value, ttlSeconds } = args as {
+      namespace: string;
+      key: string;
+      value: unknown;
+      ttlSeconds?: number;
+    };
+    const expiresAt = ttlSeconds ? new Date(Date.now() + ttlSeconds * 1000) : undefined;
+    const outcome = await ctx.service.set(AGENT, ctx.agentId, namespace, key, value, expiresAt);
+    if (outcome.kind === "rejected_oversize") {
+      return err(
+        "oversize_value",
+        `Value for "${namespace}/${key}" exceeds the ${MAX_VALUE_BYTES}-byte KV limit (${outcome.bytes} bytes).`
+      );
+    }
+    if (outcome.kind === "rejected_invalid") {
+      return err("validation_error", outcome.reason);
+    }
+    return ok({ namespace, key, stored: true });
+  },
+};
+
+export const kvGetTool: PlatformTool = {
+  name: "kv_get",
+  description: `Read a JSON value by (namespace, key) from your key-value store. Returns found=false if absent or expired. ${GUIDANCE}`,
+  mutating: false,
+  inputSchema: GET_SCHEMA,
+  handler: async (args, ctx) => {
+    if (!validateGet(args)) return err("validation_error", firstError(validateGet.errors));
+    if (!ctx.agentId) return err("internal_error", "agent identity required for kv tools");
+    const { namespace, key } = args as { namespace: string; key: string };
+    const entry = await ctx.service.get(AGENT, ctx.agentId, namespace, key);
+    if (!entry) return ok({ namespace, key, found: false });
+    return ok({
+      namespace,
+      key,
+      found: true,
+      value: entry.value,
+      expiresAt: entry.expiresAt?.toISOString(),
+    });
+  },
+};
+
+export const kvDeleteTool: PlatformTool = {
+  name: "kv_delete",
+  description: `Delete an entry by (namespace, key) from your key-value store. Idempotent — deleting an absent key still succeeds. ${GUIDANCE}`,
+  mutating: true,
+  inputSchema: DELETE_SCHEMA,
+  handler: async (args, ctx) => {
+    if (!validateDelete(args)) return err("validation_error", firstError(validateDelete.errors));
+    if (!ctx.agentId) return err("internal_error", "agent identity required for kv tools");
+    const { namespace, key } = args as { namespace: string; key: string };
+    const deleted = await ctx.service.delete(AGENT, ctx.agentId, namespace, key);
+    return ok({ namespace, key, deleted });
+  },
+};
+
+export const kvListTool: PlatformTool = {
+  name: "kv_list",
+  description: `List all live entries in a namespace of your key-value store. ${GUIDANCE}`,
+  mutating: false,
+  inputSchema: LIST_SCHEMA,
+  handler: async (args, ctx) => {
+    if (!validateList(args)) return err("validation_error", firstError(validateList.errors));
+    if (!ctx.agentId) return err("internal_error", "agent identity required for kv tools");
+    const { namespace } = args as { namespace: string };
+    const entries = await ctx.service.list(AGENT, ctx.agentId, namespace);
+    return ok({
+      namespace,
+      entries: entries.map((e) => ({
+        key: e.key,
+        value: e.value,
+        expiresAt: e.expiresAt?.toISOString(),
+      })),
+    });
+  },
+};
+
+/** Registry of the KV platform tools, picked up by the chat tool runtime. */
+export const KV_TOOLS: PlatformTool[] = [kvGetTool, kvSetTool, kvDeleteTool, kvListTool];

--- a/apps/api/src/pg-migrate.test.ts
+++ b/apps/api/src/pg-migrate.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { runPgMigrations } from "./pg-migrate";
 import { makePglite } from "./test/pglite";
 
-describe("runPgMigrations — 001_init + 002_knowledge + 003_stream_resume + 004_approvals + 005_conversation_title + 006_message_feedback + 007_conversation_starred + 008_hitl on PGlite", () => {
+describe("runPgMigrations — 001_init + 002_knowledge + 003_stream_resume + 004_approvals + 005_conversation_title + 006_message_feedback + 007_conversation_starred + 008_hitl + 009_kv_store on PGlite", () => {
   let db: PGlite;
 
   beforeEach(async () => {
@@ -14,10 +14,10 @@ describe("runPgMigrations — 001_init + 002_knowledge + 003_stream_resume + 004
     await db.close();
   });
 
-  it("advances schema_version to the latest (8)", async () => {
+  it("advances schema_version to the latest (9)", async () => {
     await runPgMigrations(db);
     const res = await db.query<{ version: number }>("SELECT version FROM schema_version");
-    expect(res.rows.map((r) => Number(r.version))).toEqual([8]);
+    expect(res.rows.map((r) => Number(r.version))).toEqual([9]);
   });
 
   it("creates the vector and citext extensions", async () => {
@@ -44,6 +44,7 @@ describe("runPgMigrations — 001_init + 002_knowledge + 003_stream_resume + 004
       "knowledge_documents",
       "knowledge_documents_collections",
       "knowledge_revisions",
+      "kv_store",
       "message_feedback",
       "messages",
       "pending_interactions",
@@ -76,11 +77,11 @@ describe("runPgMigrations — 001_init + 002_knowledge + 003_stream_resume + 004
     ]);
   });
 
-  it("is idempotent — a second run does not throw and leaves version at 8", async () => {
+  it("is idempotent — a second run does not throw and leaves version at 9", async () => {
     await runPgMigrations(db);
     await runPgMigrations(db);
     const res = await db.query<{ version: number }>("SELECT version FROM schema_version");
-    expect(res.rows.map((r) => Number(r.version))).toEqual([8]);
+    expect(res.rows.map((r) => Number(r.version))).toEqual([9]);
   });
 
   it("adds the conversations.title column and the user/updated_at index (005)", async () => {
@@ -118,5 +119,60 @@ describe("runPgMigrations — 001_init + 002_knowledge + 003_stream_resume + 004
         "INSERT INTO conversations (id, user_id, created_at, updated_at) VALUES (gen_random_uuid(), gen_random_uuid(), now(), now())"
       )
     ).resolves.toBeDefined();
+  });
+
+  it("creates kv_store and its namespace index (009)", async () => {
+    await runPgMigrations(db);
+    const tbl = await db.query<{ table_name: string }>(
+      "SELECT table_name FROM information_schema.tables WHERE table_name = 'kv_store'"
+    );
+    expect(tbl.rows.map((r) => r.table_name)).toEqual(["kv_store"]);
+    const idx = await db.query<{ indexname: string }>(
+      "SELECT indexname FROM pg_indexes WHERE indexname = 'kv_store_owner_ns_idx'"
+    );
+    expect(idx.rows.map((r) => r.indexname)).toEqual(["kv_store_owner_ns_idx"]);
+  });
+
+  it("system rows upsert in place via the '' owner sentinel (ON CONFLICT fires)", async () => {
+    await runPgMigrations(db);
+    const insert = (val: string) =>
+      db.query(
+        `INSERT INTO kv_store (scope, owner_id, namespace, key, value, created_at, updated_at)
+         VALUES ('system', '', 'cfg', 'flag', $1::jsonb, now(), now())
+         ON CONFLICT (scope, owner_id, namespace, key) DO UPDATE SET value = EXCLUDED.value`,
+        [val]
+      );
+    await insert('"a"');
+    await insert('"b"'); // would duplicate (not update) if NULL/sentinel handling were wrong
+    const res = await db.query<{ n: number; value: unknown }>(
+      "SELECT count(*)::int AS n, max(value::text) AS value FROM kv_store WHERE scope = 'system'"
+    );
+    expect(Number(res.rows[0]?.n)).toBe(1);
+    expect(res.rows[0]?.value).toBe('"b"');
+  });
+
+  it("enforces the kv_store scope CHECK", async () => {
+    await runPgMigrations(db);
+    await expect(
+      db.query(
+        "INSERT INTO kv_store (scope, owner_id, namespace, key, value, created_at, updated_at) VALUES ('bogus', 'o', 'n', 'k', '1'::jsonb, now(), now())"
+      )
+    ).rejects.toThrow();
+  });
+
+  it("enforces the kv_store system<=>'' owner CHECK both ways", async () => {
+    await runPgMigrations(db);
+    // system scope must have an empty owner.
+    await expect(
+      db.query(
+        "INSERT INTO kv_store (scope, owner_id, namespace, key, value, created_at, updated_at) VALUES ('system', 'someone', 'n', 'k', '1'::jsonb, now(), now())"
+      )
+    ).rejects.toThrow();
+    // non-system scope must have a non-empty owner.
+    await expect(
+      db.query(
+        "INSERT INTO kv_store (scope, owner_id, namespace, key, value, created_at, updated_at) VALUES ('user', '', 'n', 'k', '1'::jsonb, now(), now())"
+      )
+    ).rejects.toThrow();
   });
 });

--- a/apps/api/src/pg-migrations/index.ts
+++ b/apps/api/src/pg-migrations/index.ts
@@ -263,6 +263,35 @@ const HITL_STATEMENTS: string[] = [
   )`,
 ];
 
+/**
+ * Generic scoped key-value store (KV-V1). Identity is the composite PK
+ * (scope, owner_id, namespace, key). `owner_id` is `NOT NULL DEFAULT ''` rather than nullable: a
+ * nullable column can't be part of a PRIMARY KEY, and NULL is "distinct" in unique indexes — which
+ * would make `ON CONFLICT` never fire for system rows and silently insert duplicates. The empty-string
+ * sentinel keeps the PK legal and last-write-wins upsert reliable across all three scopes; the repo
+ * maps '' <-> undefined so no caller sees it. `value` is plaintext jsonb (secrets live in `secrets`).
+ * `expires_at` NULL = never expires; reads filter `expires_at IS NULL OR expires_at > now()` (lazy
+ * expiry, no sweeper in v1). The CHECKs pin the scope enum and the system<=>'' owner invariant (the
+ * latter mirrors `conversations_owner_check`).
+ */
+const KV_STATEMENTS: string[] = [
+  `CREATE TABLE IF NOT EXISTS kv_store (
+    scope      text NOT NULL,
+    owner_id   text NOT NULL DEFAULT '',
+    namespace  text NOT NULL,
+    key        text NOT NULL,
+    value      jsonb NOT NULL,
+    expires_at timestamptz,
+    created_at timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL,
+    PRIMARY KEY (scope, owner_id, namespace, key),
+    CONSTRAINT kv_store_scope_check CHECK (scope IN ('system', 'user', 'agent')),
+    CONSTRAINT kv_store_owner_check CHECK ((scope = 'system') = (owner_id = ''))
+  )`,
+  // Backs list-by-namespace (scope, owner_id, namespace) lookups.
+  "CREATE INDEX IF NOT EXISTS kv_store_owner_ns_idx ON kv_store (scope, owner_id, namespace)",
+];
+
 export const PG_MIGRATIONS: PgMigration[] = [
   {
     version: 1,
@@ -333,6 +362,16 @@ export const PG_MIGRATIONS: PgMigration[] = [
     description: "HITL: pending_interactions (ask_user suspend/resume) + a2ui_surfaces store",
     up: async (q) => {
       for (const sql of HITL_STATEMENTS) {
+        await q.query(sql);
+      }
+    },
+  },
+  {
+    version: 9,
+    description:
+      "kv_store: generic scoped key-value store (composite PK, lazy expiry, jsonb value)",
+    up: async (q) => {
+      for (const sql of KV_STATEMENTS) {
         await q.query(sql);
       }
     },

--- a/apps/api/src/tools/setup.ts
+++ b/apps/api/src/tools/setup.ts
@@ -1,5 +1,7 @@
 import type { KnowledgeService } from "../knowledge/service";
 import { KNOWLEDGE_TOOLS } from "../knowledge/tools";
+import type { KvService } from "../kv/service";
+import { KV_TOOLS } from "../kv/tools";
 import type { WorkingMemoryService } from "../memory/service";
 import { MEMORY_TOOLS } from "../memory/tools";
 import { FRONTEND_TOOLS } from "../platform/frontend-tools";
@@ -17,6 +19,7 @@ import { ToolRegistry } from "./registry";
  */
 export function buildToolRegistry(services: {
   workingMemory?: WorkingMemoryService;
+  kv?: KvService;
   knowledge?: KnowledgeService;
   resources?: ResourceServices;
   resourceTypes?: ResourceTypeToolContext;
@@ -36,6 +39,20 @@ export function buildToolRegistry(services: {
         description: t.description,
         inputSchema: t.inputSchema,
         execute: (args, { userId, agentId }) => t.handler(args, { userId, service: svc, agentId }),
+      });
+    }
+  }
+
+  if (services.kv) {
+    const svc = services.kv;
+    for (const t of KV_TOOLS) {
+      registry.register({
+        name: t.name,
+        tier: "platform",
+        mutating: t.mutating,
+        description: t.description,
+        inputSchema: t.inputSchema,
+        execute: (args, { userId, agentId }) => t.handler(args, { userId, agentId, service: svc }),
       });
     }
   }


### PR DESCRIPTION
…azy TTL)

Adds a generic key-value primitive (`kv_store`) for arbitrary platform values — application salt, install id, feature flags, cached state, agent scratch — filling the gap left by secrets (encrypted), working_memory (per-user) and resources (soul-defined docs).

- Composite PK (scope, owner_id, namespace, key); scope ∈ system|user|agent. owner_id NOT NULL DEFAULT '' sentinel for system (a nullable PK column is illegal and NULL breaks ON CONFLICT); repo maps '' <-> undefined.
- Plaintext jsonb value, nullable expires_at with lazy expiry, last-write-wins.
- Sandboxed by caller identity: agent tools (kv_get/kv_set/kv_delete/kv_list) pinned to scope='agent'/owner=agentId; user routes /api/v1/kv pinned to the authed user; admin /api/v1/admin/kv for scope='system'.
- 256 KiB value byte cap, namespace/key charset+length validation.
- Migration v9; wired into buildToolRegistry + buildApp.

Tests: repo.pg (10), service (8), tools (9), routes (10) + migration assertions.