### PR TITLE
feat(install): one-line curl|bash OCI installer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -472,6 +472,60 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  # Installer smoke (issue 186 / AC-001): run the real OCI installer
+  # (scripts/get.tulipfarm.sh) against the locally-built image into a throwaway dir and
+  # assert /health (+ idempotent re-run). Standalone, non-tag refs only (like the other
+  # quality jobs); not part of the publish path.
+  installer-smoke:
+    name: Installer smoke
+    runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: docker/setup-buildx-action@v3
+      # Build app image as :ci into the daemon; the smoke harness reuses it (no rebuild).
+      - name: Build app image (load into daemon)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: ghcr.io/tulipfarm/app:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Run installer smoke test
+        run: |
+          set -o pipefail
+          bash scripts/test/installer-smoke.sh 2>&1 | tee installer-smoke.log
+      - name: Job summary
+        if: always()
+        env:
+          STATUS: ${{ job.status }}
+        run: |
+          {
+            echo "## Installer smoke"
+            if [ "$STATUS" = "success" ]; then
+              echo "✅ **Installer brought up the stack and /health passed**"
+            else
+              echo "❌ **Installer smoke failed** — last 100 lines:"
+              echo ""
+              echo '<details><summary>Log tail</summary>'
+              echo ""
+              echo '```'
+              tail -n 100 installer-smoke.log 2>/dev/null || echo "(no log captured)"
+              echo '```'
+              echo ""
+              echo '</details>'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: log-installer-smoke
+          path: installer-smoke.log
+          if-no-files-found: ignore
+          retention-days: 7
+
   # Multi-arch publish (INST-001/011, AC-003): build the single bundled image for
   # linux/amd64 + linux/arm64 and push to GHCR under one pinned version tag (no skew).
   # Tags only (v*); gated on `compose-parity` so only health-checked images ship.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,32 @@
   Your business' control panel where autonomous agents run your operations.
 </p>
 
+## Install (self-host)
+
+One line stands up the full stack (the `app` image + bundled PostgreSQL 17 + pgvector)
+with Docker or Podman, generates all secrets, and prints the setup-wizard URL — zero
+config questions. Re-running is the upgrade path (preserves `.env` + data).
+
+**Linux / macOS:**
+```bash
+curl -fsSL https://raw.githubusercontent.com/TulipFarm/tulipfarm/main/scripts/get.tulipfarm.sh | sudo bash
+```
+On Linux with no engine it auto-installs Podman; on macOS install Docker Desktop or
+Podman first (the no-VM native lane is not yet available).
+
+**Windows (WSL2)** — from PowerShell:
+```powershell
+irm https://raw.githubusercontent.com/TulipFarm/tulipfarm/main/scripts/install.ps1 | iex
+```
+Verifies WSL2 + a distro, then runs the Linux installer inside WSL.
+
+Overrides (env vars): `TF_VERSION` (image tag, default `latest`), `TF_PORT` (default
+`8080`), `TF_INSTALL_DIR` (default `/opt/tulipfarm`), `TF_RUNTIME` (`docker`|`podman`),
+`TF_BASE_URL`/`TF_REF`. Full guide: [docs/installation](apps/docs/content/docs/installation.mdx).
+
+> Note: the published image + compose land on `main` with the deploy milestone; until
+> then, install from a branch with `TF_REF=<branch>` or test locally via `TF_LOCAL_SRC`.
+
 ## Local Development
 
 ### Prerequisites

--- a/apps/docs/content/docs/getting-started.mdx
+++ b/apps/docs/content/docs/getting-started.mdx
@@ -18,9 +18,14 @@ Install these first:
 
 - **Node.js 24** (the version pinned in `.node-version`)
 - **pnpm** — `npm install -g pnpm`
-- **Homebrew** (macOS only) — the setup script uses it to install PostgreSQL
+- **Docker with Compose v2** (recommended) — the setup script starts a bundled `pgvector/pgvector:pg17` container so nothing needs installing on the host
 
-The setup script installs **PostgreSQL 17 + pgvector** for you.
+If you prefer a native PostgreSQL install instead, Docker is not required. The setup script will prompt you.
+
+<Callout type="info">
+  On macOS with native mode, you also need **Homebrew** — the script uses it to
+  install PostgreSQL 17 + pgvector.
+</Callout>
 
 <Steps>
 
@@ -34,10 +39,31 @@ cd tulipfarm
 bash scripts/setup-dev.sh
 ```
 
-The script installs PostgreSQL 17 + pgvector, starts the database service, creates the
-`tulipfarm` database, initializes your soul repository at `~/.tulipfarm/soul`, and
-generates a `.env.local` file with random bootstrap secrets (`ENCRYPTION_KEY`,
-`JWT_SECRET`, `WEBHOOK_SIGNING_SECRET`).
+The script prompts you to choose how to run PostgreSQL:
+
+- **Docker** (default) — starts a `pgvector/pgvector:pg17` container exposed on `localhost:5432`.
+  No system packages are installed. This is the same image CI and production use.
+- **Native** — installs PostgreSQL 17 + pgvector via Homebrew (macOS) or apt/yum (Linux) and
+  starts the system service.
+
+Either way, the script initializes your soul repository at `~/.tulipfarm/soul` and generates a
+`.env.local` file with random bootstrap secrets (`ENCRYPTION_KEY`, `JWT_SECRET`,
+`WEBHOOK_SIGNING_SECRET`).
+
+For a non-interactive run (CI, scripted environments), set `DB_MODE` before running:
+
+```bash
+DB_MODE=docker bash scripts/setup-dev.sh
+```
+
+Confirm the database is accepting connections:
+
+```bash
+# Docker mode
+pg_isready -h localhost -p 5432 -U tulipfarm
+# Native mode
+psql tulipfarm -c 'select 1'
+```
 
 </Step>
 

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -28,7 +28,8 @@ record in the datastore. Read [Concepts](/docs/concepts) for the full picture.
 ## Where to start
 
 <Cards>
-  <Card title="Get started" href="/docs/getting-started" description="Install TulipFarm, run it, and define your first resource type." />
+  <Card title="Install" href="/docs/installation" description="One-line self-hosted install on Linux, macOS, or Windows (WSL2)." />
+  <Card title="Get started" href="/docs/getting-started" description="Set up a local dev environment and define your first resource type." />
   <Card title="Concepts" href="/docs/concepts" description="How the soul, resources, agents, skills, knowledge, and LLM tiers fit together." />
   <Card title="Guides" href="/docs/guides" description="Task recipes: define a resource, install a skill, configure providers." />
   <Card title="Reference" href="/docs/reference" description="Environment variables and the commands that run the project." />

--- a/apps/docs/content/docs/installation.mdx
+++ b/apps/docs/content/docs/installation.mdx
@@ -1,0 +1,92 @@
+---
+title: Install (self-host)
+description: One-line install of the TulipFarm OCI stack on Linux, macOS, or Windows (WSL2).
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+The one-line installer stands up the full TulipFarm stack (the `app` image + a bundled
+PostgreSQL 17 + pgvector) with Docker or Podman, generates all secrets for you, and
+prints the setup-wizard URL. It asks **zero configuration questions**.
+
+<Callout type="info">
+  Re-running the installer is the upgrade path: it preserves your `.env` (never
+  re-generates secrets) and your database, then pulls the pinned version and restarts.
+</Callout>
+
+## Linux / macOS
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/TulipFarm/tulipfarm/main/scripts/get.tulipfarm.sh | sudo bash
+```
+
+What it does: detects a container engine (on Linux, auto-installs Podman if neither
+Docker nor Podman is present), writes `/opt/tulipfarm/{docker-compose.yml,.env}`,
+generates `ENCRYPTION_KEY` / `JWT_SECRET` / `WEBHOOK_SIGNING_SECRET` / `POSTGRES_PASSWORD`,
+brings the stack up, polls `/health`, and prints the URL to open.
+
+<Callout type="warn">
+  On macOS with no container runtime, install Docker Desktop or Podman first. The
+  no-VM native lane is not yet available.
+</Callout>
+
+## Windows (WSL2)
+
+From PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/TulipFarm/tulipfarm/main/scripts/install.ps1 | iex
+```
+
+This verifies WSL2 (and a Linux distro) is installed, then runs the Linux installer
+inside WSL. If WSL is missing it prints the `wsl --install` steps to run first.
+
+## Finish setup
+
+Open the printed URL. While no admin exists, the setup wizard lets you create the first
+admin (no auth), then set the business name, LLM provider key, and optional soul git
+remote. After the first admin is created the setup route locks.
+
+<Callout type="warn">
+  If the installer detected a public IP it prints a TLS warning: the instance is
+  reachable over HTTP and the first visitor becomes admin — complete setup immediately
+  and put a reverse proxy with TLS in front for production.
+</Callout>
+
+## Overrides
+
+### Linux / macOS
+
+All optional, set as environment variables before running:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `TF_VERSION` | `latest` | App image tag to run (`ghcr.io/tulipfarm/app:<tag>`). |
+| `TF_PORT` | `8080` | Host port to publish. |
+| `TF_INSTALL_DIR` | `/opt/tulipfarm` | Install directory. |
+| `TF_RUNTIME` | auto | Force `docker` or `podman`. |
+| `TF_BASE_URL` / `TF_REF` | GitHub raw / `main` | Where compose + `.env.example` are fetched from. |
+
+Example — pin a version on a custom port:
+
+```bash
+TF_VERSION=v0.1.0 TF_PORT=9000 \
+  bash -c "curl -fsSL https://raw.githubusercontent.com/TulipFarm/tulipfarm/main/scripts/get.tulipfarm.sh | sudo -E bash"
+```
+
+### Windows (WSL2)
+
+The PowerShell script accepts named parameters. Download it first, then run with the parameters you need:
+
+```powershell
+Invoke-WebRequest https://raw.githubusercontent.com/TulipFarm/tulipfarm/main/scripts/install.ps1 -OutFile install.ps1
+.\install.ps1 -Version v0.1.0
+```
+
+| Parameter | Default | Purpose |
+| --- | --- | --- |
+| `-Version` | `latest` | App image tag (`TF_VERSION` inside WSL). |
+| `-BaseUrl` | GitHub raw | Base URL for fetched files. |
+| `-Ref` | `main` | Git ref under `-BaseUrl`. |
+
+To set `TF_PORT`, `TF_INSTALL_DIR`, or `TF_RUNTIME`, open your WSL terminal and run the bash installer directly with those env vars instead.

--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -1,3 +1,11 @@
 {
-  "pages": ["index", "getting-started", "concepts", "guides", "reference", "security"]
+  "pages": [
+    "index",
+    "installation",
+    "getting-started",
+    "concepts",
+    "guides",
+    "reference",
+    "security"
+  ]
 }

--- a/scripts/get.tulipfarm.sh
+++ b/scripts/get.tulipfarm.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+# TulipFarm one-line installer — OCI lane (Docker/Podman + Compose v2).
+# Spec: specs/INSTALLATION.md INST-002/003, AC-001. Native lane is deferred.
+#
+#   curl -fsSL https://raw.githubusercontent.com/TulipFarm/tulipfarm/main/scripts/get.tulipfarm.sh | sudo bash
+#
+# Detects/installs a container engine, fetches docker-compose.yml + .env.example,
+# generates bootstrap secrets (zero questions), brings the 2-service stack up, polls
+# /health, and prints the setup-wizard URL. Re-running = update (preserves .env, PGDATA).
+#
+# Overrides (env):
+#   TF_BASE_URL   raw base URL for fetched files (default: GitHub raw; later get.tulipfarm.site)
+#   TF_REF        git ref under TF_BASE_URL (default: main)
+#   TF_VERSION    app image tag → TULIPFARM_VERSION (default: latest)
+#   TF_INSTALL_DIR install dir (default: /opt/tulipfarm)
+#   TF_PORT / HOST_PORT  host port to publish (default: 8080)
+#   TF_RUNTIME    force engine: docker | podman
+#   TF_LOCAL_SRC  copy compose/.env.example from a local repo instead of curl (testing)
+set -euo pipefail
+
+# ---- config (all overridable) ------------------------------------------------
+TF_BASE_URL="${TF_BASE_URL:-https://raw.githubusercontent.com/TulipFarm/tulipfarm}"
+TF_REF="${TF_REF:-main}"
+TF_VERSION="${TF_VERSION:-latest}"
+INSTALL_DIR="${TF_INSTALL_DIR:-/opt/tulipfarm}"
+PORT="${TF_PORT:-${HOST_PORT:-8080}}"
+TF_RUNTIME="${TF_RUNTIME:-}"
+TF_LOCAL_SRC="${TF_LOCAL_SRC:-}"
+
+# ---- logging -----------------------------------------------------------------
+log()  { printf '\033[0;32m▸\033[0m %s\n' "$*"; }
+warn() { printf '\033[0;33m⚠\033[0m  %s\n' "$*"; }
+die()  { printf '\033[0;31m✗\033[0m %s\n' "$*" >&2; exit 1; }
+need() { command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"; }
+
+# ---- privilege ---------------------------------------------------------------
+SUDO=""
+detect_sudo() {
+  # No privilege needed when the install dir (or its parent) is already writable.
+  local probe="$INSTALL_DIR"
+  [ -d "$probe" ] || probe="$(dirname "$probe")"
+  if [ -w "$probe" ]; then SUDO=""; return; fi
+  [ "$(id -u)" -eq 0 ] && { SUDO=""; return; }
+  command -v sudo >/dev/null 2>&1 && { SUDO="sudo"; return; }
+  die "need root or sudo to write ${INSTALL_DIR} — re-run with sudo"
+}
+
+# ---- detection ---------------------------------------------------------------
+OS=""
+detect_os() {
+  case "$(uname -s)" in
+    Linux)  OS=linux ;;
+    Darwin) OS=darwin ;;
+    *) die "unsupported OS: $(uname -s) — on Windows run inside WSL2 (see scripts/install.ps1)" ;;
+  esac
+}
+
+ENGINE=""
+has_engine() { command -v "$1" >/dev/null 2>&1 && "$1" compose version >/dev/null 2>&1; }
+detect_engine() {
+  if [ -n "$TF_RUNTIME" ]; then
+    has_engine "$TF_RUNTIME" || die "TF_RUNTIME=${TF_RUNTIME} but '${TF_RUNTIME} compose' is unavailable"
+    ENGINE="$TF_RUNTIME"; return
+  fi
+  if has_engine docker; then ENGINE=docker; return; fi
+  if has_engine podman; then ENGINE=podman; return; fi
+  ENGINE=""
+}
+
+detect_pkg_mgr() {
+  local m
+  for m in apt-get dnf zypper pacman apk; do
+    command -v "$m" >/dev/null 2>&1 && { echo "$m"; return; }
+  done
+  echo ""
+}
+
+install_podman_linux() {
+  local pkg; pkg="$(detect_pkg_mgr)"
+  [ -n "$pkg" ] || die "no supported package manager (apt/dnf/zypper/pacman/apk) — install Docker or Podman manually, then re-run"
+  log "No container engine found — installing Podman via ${pkg}…"
+  case "$pkg" in
+    apt-get) $SUDO apt-get update -y && $SUDO apt-get install -y podman podman-compose ;;
+    dnf)     $SUDO dnf install -y podman podman-compose ;;
+    zypper)  $SUDO zypper --non-interactive install podman podman-compose ;;
+    pacman)  $SUDO pacman -Sy --noconfirm podman podman-compose ;;
+    apk)     $SUDO apk add podman podman-compose ;;
+  esac
+  has_engine podman || die "Podman install did not yield a working 'podman compose'"
+  ENGINE=podman
+}
+
+ensure_engine() {
+  detect_engine
+  if [ -z "$ENGINE" ]; then
+    if [ "$OS" = linux ]; then
+      install_podman_linux
+    else
+      die "no container engine found — on macOS install Docker Desktop or Podman, then re-run (the native lane is not yet available)"
+    fi
+  fi
+  log "Using container engine: ${ENGINE}"
+}
+
+# ---- file acquisition --------------------------------------------------------
+fetch_file() {
+  local rel="$1" dest="$2"
+  if [ -n "$TF_LOCAL_SRC" ]; then
+    $SUDO cp "${TF_LOCAL_SRC}/${rel}" "$dest"
+  else
+    $SUDO curl -fsSL "${TF_BASE_URL}/${TF_REF}/${rel}" -o "$dest"
+  fi
+}
+
+# ---- secrets + .env ----------------------------------------------------------
+gen_secret() { openssl rand -base64 32; }
+# URL-safe (no /+= so it embeds in DATABASE_URL without escaping).
+gen_pw()     { openssl rand -base64 24 | tr -dc 'A-Za-z0-9' | head -c 32; }
+
+PUBLIC_URL=""
+PUBLIC_IP_DETECTED=0
+detect_public_url() {
+  local ip="" iface
+  if command -v ip >/dev/null 2>&1; then
+    ip="$(ip -4 route get 1.1.1.1 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i=="src"){print $(i+1); exit}}')" || true
+  fi
+  if [ -z "$ip" ] && command -v route >/dev/null 2>&1; then  # macOS
+    iface="$(route -n get 1.1.1.1 2>/dev/null | awk '/interface:/{print $2}')" || true
+    [ -n "$iface" ] && ip="$(ipconfig getifaddr "$iface" 2>/dev/null || true)"
+  fi
+  if [ -n "$ip" ] && [ "$ip" != "127.0.0.1" ]; then
+    PUBLIC_URL="http://${ip}:${PORT}"; PUBLIC_IP_DETECTED=1
+  else
+    PUBLIC_URL="http://localhost:${PORT}"; PUBLIC_IP_DETECTED=0
+  fi
+}
+
+write_env() {
+  # Update mode: a real prior install has BOTH .env and .lane. Preserve secrets/PGDATA.
+  if $SUDO test -f "${INSTALL_DIR}/.env" && $SUDO test -f "${INSTALL_DIR}/.lane"; then
+    log "Existing install found — preserving .env (update mode)"
+    return
+  fi
+  need openssl
+  detect_public_url
+  # Generate into vars first so `set -e` catches a failed openssl (a failure inside the
+  # heredoc would be masked by tee's exit status).
+  local pw enc jwt webhook
+  pw="$(gen_pw)"; enc="$(gen_secret)"; jwt="$(gen_secret)"; webhook="$(gen_secret)"
+  log "Generating secrets + .env (PUBLIC_URL=${PUBLIC_URL})"
+  # Create mode-600 BEFORE writing so secrets are never briefly world-readable.
+  $SUDO install -m 600 /dev/null "${INSTALL_DIR}/.env"
+  $SUDO tee "${INSTALL_DIR}/.env" >/dev/null <<EOF
+PUBLIC_URL=${PUBLIC_URL}
+CORS_ORIGIN=${PUBLIC_URL}
+HOST_PORT=${PORT}
+TULIPFARM_VERSION=${TF_VERSION}
+COMPOSE_PROFILES=bundled
+EXTERNAL_DATASTORE=false
+POSTGRES_PASSWORD=${pw}
+DATABASE_URL=postgresql://tulipfarm:${pw}@postgres:5432/tulipfarm
+ENCRYPTION_KEY=${enc}
+JWT_SECRET=${jwt}
+WEBHOOK_SIGNING_SECRET=${webhook}
+SETUP_MODE=wizard
+EOF
+}
+
+# Authoritative PORT (health poll) + PUBLIC_URL (final message) read back from .env —
+# correct in both fresh and update (preserved-.env) modes.
+load_runtime_info() {
+  local p u
+  p="$($SUDO grep -E '^HOST_PORT=' "${INSTALL_DIR}/.env" 2>/dev/null | head -1 | cut -d= -f2- || true)"
+  u="$($SUDO grep -E '^PUBLIC_URL=' "${INSTALL_DIR}/.env" 2>/dev/null | head -1 | cut -d= -f2- || true)"
+  [ -n "$p" ] && PORT="$p"
+  [ -n "$u" ] && PUBLIC_URL="$u"
+}
+
+# ---- compose -----------------------------------------------------------------
+# shellcheck disable=SC2086  # $SUDO may be empty and $ENGINE is a bare word — both must split
+compose() { ( cd "$INSTALL_DIR" && $SUDO $ENGINE compose "$@" ); }
+
+bring_up() {
+  log "Pulling images and starting the stack…"
+  compose pull || warn "image pull failed (rate limit / unpublished tag) — trying cached images"
+  compose up -d || die "compose up failed — see logs above"
+}
+
+wait_health() {
+  log "Waiting for TulipFarm to become healthy…"
+  local _
+  for _ in $(seq 1 60); do
+    if curl -fsS "http://localhost:${PORT}/health" >/dev/null 2>&1; then
+      log "TulipFarm is up."
+      if [ "$PUBLIC_IP_DETECTED" = "1" ]; then
+        warn "Reachable on a public IP over HTTP with no TLS — complete setup NOW"
+        warn "(the first visitor becomes admin) and put a reverse proxy in front for production."
+      fi
+      log "Open ${PUBLIC_URL} to finish setup (create the first admin)."
+      return 0
+    fi
+    sleep 3
+  done
+  warn "Health check timed out. Recent logs:"
+  compose logs --tail 40 app || true
+  die "TulipFarm did not become healthy — see logs above."
+}
+
+# ---- main --------------------------------------------------------------------
+main() {
+  need curl
+  detect_os
+  detect_sudo
+  ensure_engine
+  $SUDO mkdir -p "$INSTALL_DIR"
+  fetch_file docker-compose.yml "${INSTALL_DIR}/docker-compose.yml"
+  fetch_file .env.example "${INSTALL_DIR}/.env.example" || true
+  write_env
+  printf 'oci\n' | $SUDO tee "${INSTALL_DIR}/.lane" >/dev/null
+  load_runtime_info
+  bring_up
+  wait_health
+}
+
+main "$@"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,60 @@
+#Requires -Version 5
+<#
+.SYNOPSIS
+  TulipFarm installer for Windows — thin WSL2 bootstrap.
+.DESCRIPTION
+  Per spec INSTALLATION.md INST-002, Windows runs the Linux install path inside WSL2.
+  This script verifies WSL2 (+ a distro) is present and then runs the bash one-liner
+  (scripts/get.tulipfarm.sh) inside WSL, forwarding version/host overrides.
+
+  Usage (PowerShell):
+    irm https://raw.githubusercontent.com/TulipFarm/tulipfarm/main/scripts/install.ps1 | iex
+  To override defaults, download then run with params:
+    ./install.ps1 -Version v0.1.0
+.PARAMETER Version
+  App image tag (TF_VERSION). Default: latest.
+.PARAMETER BaseUrl
+  Raw base URL for fetched files. Default: GitHub raw.
+.PARAMETER Ref
+  Git ref under BaseUrl. Default: main.
+#>
+[CmdletBinding()]
+param(
+  [string]$Version = "latest",
+  [string]$BaseUrl = "https://raw.githubusercontent.com/TulipFarm/tulipfarm",
+  [string]$Ref = "main"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Write-Info($m) { Write-Host "> $m" -ForegroundColor Green }
+function Write-Note($m) { Write-Host "! $m" -ForegroundColor Yellow }
+function Die($m) { Write-Host "x $m" -ForegroundColor Red; exit 1 }
+
+# 1. WSL present?
+if (-not (Get-Command wsl.exe -ErrorAction SilentlyContinue)) {
+  Write-Note "WSL2 is required to run TulipFarm on Windows."
+  Write-Host "Install it from an elevated PowerShell, reboot, then re-run this installer:"
+  Write-Host "    wsl --install"
+  Die "WSL2 not found."
+}
+
+# 2. A Linux distro installed?  (`wsl -l -q` lists installed distros; empty => none)
+$distros = (& wsl.exe -l -q) 2>$null | Where-Object { $_ -and $_.Trim() -ne "" }
+if (-not $distros) {
+  Write-Note "WSL is present but no Linux distribution is installed."
+  Write-Host "Install one, then re-run this installer:"
+  Write-Host "    wsl --install -d Ubuntu"
+  Die "No WSL distribution found."
+}
+
+Write-Info "WSL detected - running the Linux installer inside WSL..."
+
+# 3. Run the bash one-liner inside WSL, forwarding overrides. `sudo -E` keeps the TF_* env.
+$inner = "export TF_VERSION='$Version' TF_BASE_URL='$BaseUrl' TF_REF='$Ref'; " +
+         "curl -fsSL `"$BaseUrl/$Ref/scripts/get.tulipfarm.sh`" | sudo -E bash"
+& wsl.exe -e bash -lc $inner
+if ($LASTEXITCODE -ne 0) { Die "installer failed inside WSL (exit $LASTEXITCODE)" }
+
+Write-Info "Done. Open the printed URL in your Windows browser to finish setup."

--- a/scripts/test/installer-smoke.sh
+++ b/scripts/test/installer-smoke.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Smoke test for the OCI installer (scripts/get.tulipfarm.sh) — the real AC-001 path,
+# exercised hermetically: build the app image locally as :ci, run the installer against
+# this repo (TF_LOCAL_SRC) into a throwaway dir on a throwaway port, and assert /health.
+#
+# Mirrors ci.yml's compose-parity: no GHCR pull of the not-yet-published app image, only
+# the bundled postgres base is pulled. Used both locally and by the CI `installer-smoke` job.
+#
+# Env:
+#   SMOKE_REBUILD=1   force `docker build` even if ghcr.io/tulipfarm/app:ci already exists
+#   TF_PORT=<port>    host port to bind (default 8099, off the usual 8080 to dodge clashes)
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+IMAGE="ghcr.io/tulipfarm/app:ci"
+PORT="${TF_PORT:-8099}"
+INSTALL_DIR="$(mktemp -d)"
+
+# Isolate the smoke's compose project + named volumes from any real `tulipfarm` install
+# on this host, so teardown's `down -v` can never wipe real data. Both COMPOSE_PROJECT_NAME
+# and `-p` override the compose file's top-level `name: tulipfarm`; exporting it scopes the
+# installer's `compose up` AND this harness's `compose down -v` to a throwaway project.
+export COMPOSE_PROJECT_NAME="tulipfarm-smoke-$$"
+
+log() { printf '\033[0;36m[smoke]\033[0m %s\n' "$*"; }
+fail() { printf '\033[0;31m[smoke] FAIL:\033[0m %s\n' "$*" >&2; exit 1; }
+
+cleanup() {
+  if [ -f "${INSTALL_DIR}/docker-compose.yml" ]; then
+    log "tearing down stack…"
+    ( cd "$INSTALL_DIR" && docker compose down -v ) >/dev/null 2>&1 || true
+  fi
+  rm -rf "$INSTALL_DIR"
+}
+trap cleanup EXIT
+
+# Fail fast (and meaningfully) before the slow image build when the script is absent.
+[ -f "${REPO_ROOT}/scripts/get.tulipfarm.sh" ] \
+  || fail "scripts/get.tulipfarm.sh not found — implement the installer (AW-002)"
+command -v docker >/dev/null 2>&1 || fail "docker not on PATH"
+docker compose version >/dev/null 2>&1 || fail "docker compose v2 plugin required"
+
+# 1. Build the app image as :ci (reuse if already present, e.g. from compose-parity).
+if [ "${SMOKE_REBUILD:-0}" = "1" ] || ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+  log "building ${IMAGE} (can take a few minutes)…"
+  docker build -t "$IMAGE" "$REPO_ROOT"
+else
+  log "reusing existing ${IMAGE} (SMOKE_REBUILD=1 to force a rebuild)"
+fi
+
+# 2. Run the installer hermetically: local source, pinned :ci image, temp dir + port.
+#    User-writable INSTALL_DIR ⇒ the installer runs without sudo.
+log "running installer into ${INSTALL_DIR} on port ${PORT}…"
+TF_LOCAL_SRC="$REPO_ROOT" \
+TF_VERSION="ci" \
+TF_RUNTIME="docker" \
+TF_INSTALL_DIR="$INSTALL_DIR" \
+TF_PORT="$PORT" \
+  bash "${REPO_ROOT}/scripts/get.tulipfarm.sh" \
+  || fail "installer exited non-zero"
+
+# 3. Re-assert /health on the host port (the installer already gates on this).
+log "asserting /health on :${PORT}…"
+curl -fsS --retry 5 --retry-connrefused --retry-delay 2 \
+  "http://localhost:${PORT}/health" >/dev/null \
+  || fail "/health did not return 200 on :${PORT}"
+
+# 4. Assert idempotency: a second run preserves the generated .env (update mode).
+env_before="$(sha256sum "${INSTALL_DIR}/.env" | awk '{print $1}')"
+log "re-running installer (idempotency check)…"
+TF_LOCAL_SRC="$REPO_ROOT" TF_VERSION="ci" TF_RUNTIME="docker" \
+TF_INSTALL_DIR="$INSTALL_DIR" TF_PORT="$PORT" \
+  bash "${REPO_ROOT}/scripts/get.tulipfarm.sh" >/dev/null 2>&1 \
+  || fail "installer re-run exited non-zero"
+env_after="$(sha256sum "${INSTALL_DIR}/.env" | awk '{print $1}')"
+[ "$env_before" = "$env_after" ] || fail "re-run mutated .env (secrets not preserved)"
+
+log "PASS — stack healthy and re-run preserved secrets"


### PR DESCRIPTION
## What

Adds the self-host **install lane** (AC-001, spec `INSTALLATION.md` INST-002/003) — one line stands up the full stack with zero config questions.

Tracking: TulipFarm/project#186

## Changes

- **`scripts/get.tulipfarm.sh`** — OCI installer. Detects/installs a container engine (Docker/Podman + Compose v2; auto-installs Podman on Linux via the system package manager), fetches `docker-compose.yml` + `.env.example`, generates all bootstrap secrets (`ENCRYPTION_KEY`/`JWT_SECRET`/`WEBHOOK_SIGNING_SECRET`/`POSTGRES_PASSWORD`) with **zero questions**, brings the 2-service stack up, polls `/health`, and prints the setup-wizard URL. Smart-detects public IP for `PUBLIC_URL` and warns on public-IP-over-HTTP. **Re-running is the update path** — preserves `.env` + PGDATA.
- **`scripts/install.ps1`** — Windows thin WSL2 bootstrap; verifies WSL2 + a distro, then runs the bash installer inside WSL forwarding `TF_*` overrides.
- **`scripts/test/installer-smoke.sh`** — hermetic smoke: build app image as `:ci`, run the installer into a throwaway dir/port (no sudo), assert `/health` + idempotent re-run preserves secrets. Project-isolated so teardown can never wipe real data.
- **`.github/workflows/ci.yml`** — `installer-smoke` job (non-tag refs) wiring the smoke into CI against the locally-built image.
- **Docs** — `installation.mdx`, README install section, docs nav entry.

## Verification

Verified end-to-end against the **live GHCR-published multi-arch image** (`v0.1.0-build-test.0`), not just a local build:

- Real `curl` fetch of `docker-compose.yml` + `.env.example` from `raw.githubusercontent.com`
- `compose pull` from GHCR (local copy deleted first to force a registry pull); multi-arch manifest (amd64 + arm64) confirmed
- Stack healthy (postgres → app), `/health` → `{"status":"ok"}`, SPA root → `200 text/html`
- `.env` mode `600`, `.lane` = `oci`
- Idempotent re-run preserved secrets, stack stayed healthy

## Notes

- The documented `curl … /main/ … | bash` one-liner works once this merges to `main`. Until then, install from a branch with `TF_REF=<branch>` or test locally via `TF_LOCAL_SRC`.
- `:latest` ships only when a real `v*` release tag is cut (`release.yml` → ci.yml `publish-image`).
- Native (no-VM) lane is deferred.