### PR TITLE
feat(onboarding): drop SETUP_MODE, auto-detect headless boot, add setup wizard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,22 +31,22 @@ WEBHOOK_SIGNING_SECRET=CHANGE_ME_BASE64
 
 # --- Soul ---
 SOUL_PATH=/opt/tulipfarm/soul
-# Optional git remote for soul backup/sync (INST-014). Token stored encrypted by
-# the wizard; for managed mode supply here.
+# Optional git remote for soul backup/sync. Activate by setting both; restart to apply.
 # GIT_REMOTE_URL=
 # GIT_CREDENTIALS=
 
-# --- Bootstrap mode (INST-003b) ---
-# wizard  : CLI install — the web setup/onboarding wizard runs (default).
-# managed : container-platform / BYO — no wizard; seed from env below, /api/v1/setup/* -> 404.
-SETUP_MODE=wizard
-# Managed-mode seed fields (required when SETUP_MODE=managed):
+# --- Headless seeding (container platforms: Cloud Run, Fly, App Service) ---
+# Set ALL THREE to skip the web setup wizard and seed on first boot automatically.
+# The app detects these at startup: if ADMIN_EMAIL + ADMIN_PASSWORD + LLM_API_KEY are
+# all present it seeds and marks setup complete; the web wizard never appears.
+# Partial (admin creds without LLM_API_KEY) → refused at startup with a clear error.
+# Leave all three unset to use the interactive web setup wizard (curl|bash installs).
 # ADMIN_EMAIL=
 # ADMIN_PASSWORD=
-# BUSINESS_NAME=
-# BUSINESS_DESCRIPTION=
 # LLM_PROVIDER=anthropic
 # LLM_API_KEY=
+# BUSINESS_NAME=
+# BUSINESS_DESCRIPTION=
 
 # --- Misc ---
 PORT=8080

--- a/.env.local.example
+++ b/.env.local.example
@@ -2,6 +2,8 @@
 
 # Datastore (local via Homebrew or Docker)
 # Postgres is the single V1 datastore (pgvector + pg-boss).
+# setup-dev.sh rewrites this value — Docker gets a TCP URL with credentials,
+# Linux native gets a Unix-socket URL (postgres:///tulipfarm?host=<socket-dir>).
 DATABASE_URL=postgres://localhost:5432/tulipfarm
 
 # Soul repo path — MUST be an absolute path to a dedicated directory OUTSIDE this project, so the
@@ -16,11 +18,10 @@ JWT_SECRET=<generate: openssl rand -base64 32>
 WEBHOOK_SIGNING_SECRET=<generate: openssl rand -base64 32>
 
 # Session auth (issue #7)
-# Bootstrap admin: first user created on boot if no users exist.
-# Must be a valid email (login validates format: "email" — a no-TLD address
-# like admin@localhost is rejected with 400, so the admin could never log in).
-ADMIN_EMAIL=admin@tulipfarm.dev
-ADMIN_PASSWORD=<set a strong password>
+# Bootstrap admin: bypasses the setup wizard — only set these for headless/CI deployments.
+# Leave commented to use the first-run setup wizard in the browser.
+# ADMIN_EMAIL=admin@tulipfarm.dev
+# ADMIN_PASSWORD=<set a strong password>
 # Session cookie TTL in seconds (default 604800 = 7 days)
 SESSION_TTL_SECONDS=604800
 

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -47,6 +47,8 @@ import type { RateLimiter } from "./rate-limit";
 import type { CounterStore, ResourceRepoFactory } from "./resources/repo";
 import { registerResourceRoutes } from "./resources/routes";
 import { registerSecretsRoutes } from "./secrets/routes";
+import { registerSetupRoutes, registerSetupStatusRoute } from "./setup/routes";
+import { isHeadlessBoot } from "./setup/service";
 import { registerAgentRoutes } from "./soul/agents/routes";
 import { makeLlmCascadeOnSecretDelete } from "./soul/llm-config/cascade";
 import { registerLlmConfigRoutes } from "./soul/llm-config/routes";
@@ -207,6 +209,27 @@ export async function buildApp(opts: AppOptions = {}) {
       rateLimiter: opts.rateLimiter,
     });
     const requireAuth = makeRequireAuth(opts.sessionStore, opts.userRepo, opts.tokenRepo);
+    // Setup status: always registered so the web app gets an explicit 200 in all boot modes.
+    // In headless boot the wizard step routes below are absent (404), but status is always reachable.
+    const soulPath = process.env.SOUL_PATH;
+    if (soulPath) {
+      registerSetupStatusRoute(app, {
+        userRepo: opts.userRepo,
+        soulPath,
+        rateLimiter: opts.rateLimiter,
+      });
+    }
+    // Wizard step routes: only registered when NOT in headless boot (AC-005).
+    if (!isHeadlessBoot() && opts.secretsService && opts.gitSync && soulPath) {
+      registerSetupRoutes(app, {
+        userRepo: opts.userRepo,
+        sessionStore: opts.sessionStore,
+        secretsService: opts.secretsService,
+        gitSync: opts.gitSync,
+        soulPath,
+        requireAuth,
+      });
+    }
     if (opts.secretsService) {
       registerSecretsRoutes(app, opts.secretsService, requireAuth, {
         onSecretDeleted:

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -17,7 +17,7 @@ import { ActivityService } from "./activity/service";
 import { buildApp } from "./app";
 import { PgTokenRepo } from "./auth/api-tokens";
 import { DEFAULT_SESSION_TTL_SECONDS, PgSessionStore } from "./auth/session-store";
-import { bootstrapAdmin, PgUserRepo } from "./auth/users";
+import { PgUserRepo } from "./auth/users";
 import { PgConversationRepo } from "./chat/conversations";
 import { PgMessageRepo } from "./chat/messages";
 import { PgPendingInteractionRepo } from "./chat/pending-interactions";
@@ -58,6 +58,7 @@ import { runPgMigrations } from "./pg-migrate";
 import { PgRateLimiter } from "./rate-limit";
 import { reconcileResourceTables, registerResourceReconcile } from "./resources/reconcile";
 import { PgCounterStore, PgResourceRepoFactory } from "./resources/repo";
+import { bootstrapFromEnv } from "./setup/bootstrap";
 import { PLATFORM_AGENTS } from "./soul/agents/platform-agents";
 import { BUILTIN_SKILLS } from "./soul/skills/builtin-skills";
 import { registerSoulSync } from "./soul-sync";
@@ -232,7 +233,12 @@ async function boot() {
     registerGuardrailsReload(gitSync, soulLoader, guardrailsService, app.log);
     registerResourceReconcile(gitSync, soulLoader, pool, app.log);
     logEnvironmentStatus(app.log);
-    await bootstrapAdmin(userRepo, app.log);
+    await bootstrapFromEnv({
+      userRepo,
+      secretsService,
+      soulPath: process.env.SOUL_PATH as string,
+      log: app.log,
+    });
 
     await registerSoulSync(boss, gitSync, process.env.GIT_REMOTE_URL, {
       activity: activityService,

--- a/apps/api/src/setup/bootstrap.test.ts
+++ b/apps/api/src/setup/bootstrap.test.ts
@@ -1,0 +1,131 @@
+import crypto, { randomBytes, randomUUID } from "node:crypto";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type SecretDoc,
+  type SecretEnvelopeFields,
+  type SecretMeta,
+  type SecretRepo,
+  SecretsService,
+} from "@tulipfarm/secrets";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { parse } from "yaml";
+import type { UserDoc, UserRepo } from "../auth/users";
+import { bootstrapFromEnv } from "./bootstrap";
+
+class FakeUserRepo implements UserRepo {
+  users: UserDoc[] = [];
+  async findByEmail(e: string) {
+    return this.users.find((u) => u.email === e.trim().toLowerCase()) ?? null;
+  }
+  async findById(id: string) {
+    return this.users.find((u) => u._id === id) ?? null;
+  }
+  async count() {
+    return this.users.length;
+  }
+  async insert(u: UserDoc) {
+    this.users.push(u);
+  }
+}
+
+class FakeSecretRepo implements SecretRepo {
+  map = new Map<string, SecretDoc>();
+  async list(): Promise<SecretMeta[]> {
+    return [...this.map.values()].map((d) => ({
+      key: d.key,
+      type: d.type,
+      createdAt: d.createdAt,
+      updatedAt: d.updatedAt,
+    }));
+  }
+  async findByKey(key: string) {
+    return this.map.get(key) ?? null;
+  }
+  async upsert(key: string, fields: SecretEnvelopeFields) {
+    const now = new Date();
+    this.map.set(key, {
+      _id: key,
+      key,
+      ...fields,
+      dekId: fields.dekId ?? null,
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
+  async delete(key: string) {
+    this.map.delete(key);
+  }
+  async listLegacyKeys() {
+    return [];
+  }
+}
+
+let dir: string;
+function deps() {
+  return {
+    userRepo: new FakeUserRepo(),
+    secretsService: new SecretsService(new FakeSecretRepo(), {
+      dekId: randomUUID(),
+      key: randomBytes(32),
+    }),
+    soulPath: path.join(dir, "soul"),
+  };
+}
+
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), "bootstrap-"));
+  vi.stubEnv("ENCRYPTION_KEY", crypto.randomBytes(32).toString("base64"));
+  vi.stubEnv("NODE_ENV", "production");
+});
+afterEach(async () => {
+  await fs.rm(dir, { recursive: true, force: true });
+  vi.unstubAllEnvs();
+});
+
+describe("bootstrapFromEnv", () => {
+  it("no env vars → no-op (wizard handles first-run)", async () => {
+    const d = deps();
+    await bootstrapFromEnv(d);
+    expect(await d.userRepo.count()).toBe(0);
+  });
+
+  it("seeds admin + business + llm from env and marks setupComplete (idempotent)", async () => {
+    vi.stubEnv("ADMIN_EMAIL", "admin@acme.io");
+    vi.stubEnv("ADMIN_PASSWORD", "supersecret");
+    vi.stubEnv("BUSINESS_NAME", "Acme");
+    vi.stubEnv("LLM_API_KEY", "sk-ant-xyz");
+    const d = deps();
+    await bootstrapFromEnv(d);
+    await bootstrapFromEnv(d); // second call is a no-op (user already exists)
+    expect(await d.userRepo.count()).toBe(1);
+    const cfg = parse(await fs.readFile(path.join(dir, "soul", "soul.yaml"), "utf8")) as {
+      businessName?: string;
+      setupComplete?: boolean;
+    };
+    expect(cfg.businessName).toBe("Acme");
+    expect(cfg.setupComplete).toBe(true);
+    expect(await d.secretsService.get("anthropic-api-key")).toBe("sk-ant-xyz");
+  });
+
+  it("production: admin creds set but LLM_API_KEY missing → fail loud", async () => {
+    vi.stubEnv("ADMIN_EMAIL", "admin@acme.io");
+    vi.stubEnv("ADMIN_PASSWORD", "supersecret");
+    // LLM_API_KEY intentionally omitted
+    await expect(bootstrapFromEnv(deps())).rejects.toThrow(/LLM_API_KEY/);
+  });
+
+  it("non-production: admin creds set, LLM_API_KEY missing → seed admin + mark complete", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("ADMIN_EMAIL", "admin@acme.io");
+    vi.stubEnv("ADMIN_PASSWORD", "supersecret");
+    const d = deps();
+    await bootstrapFromEnv(d);
+    expect(await d.userRepo.count()).toBe(1);
+    const cfg = parse(await fs.readFile(path.join(dir, "soul", "soul.yaml"), "utf8")) as {
+      setupComplete?: boolean;
+    };
+    expect(cfg.setupComplete).toBe(true);
+  });
+});

--- a/apps/api/src/setup/bootstrap.ts
+++ b/apps/api/src/setup/bootstrap.ts
@@ -1,0 +1,64 @@
+import type { SecretsService } from "@tulipfarm/secrets";
+import { createUser, normalizeEmail, type UserRepo } from "../auth/users";
+import { isProductionMode } from "./service";
+import { patchSoulConfig } from "./soul-config";
+
+export interface BootstrapDeps {
+  userRepo: UserRepo;
+  secretsService: SecretsService;
+  soulPath: string;
+  log?: { info: (msg: string) => void; error: (msg: string) => void };
+}
+
+function llmProvider(): "anthropic" | "openai" {
+  return process.env.LLM_PROVIDER === "openai" ? "openai" : "anthropic";
+}
+
+// Seeds the instance from env vars on first boot. Idempotent (no-op once users exist).
+//
+// Trigger conditions:
+//   - ADMIN_EMAIL + ADMIN_PASSWORD + LLM_API_KEY all set → full headless seed (any env)
+//   - ADMIN_EMAIL + ADMIN_PASSWORD set, LLM_API_KEY missing:
+//       production → fail loud (refuse to boot)
+//       non-production → seed admin only; developer configures LLM via Settings
+//   - None of the above → no-op; wizard handles first-run via web UI
+//
+// After seeding, marks setupComplete=true in soul.yaml so the wizard never shows.
+export async function bootstrapFromEnv(deps: BootstrapDeps): Promise<void> {
+  const adminEmail = process.env.ADMIN_EMAIL;
+  const adminPass = process.env.ADMIN_PASSWORD;
+  const llmKey = process.env.LLM_API_KEY;
+
+  if (!adminEmail || !adminPass) return;
+
+  // Partial headless: admin creds present but no LLM key → fail loud in production
+  if (!llmKey && isProductionMode()) {
+    throw new Error(
+      "ADMIN_EMAIL + ADMIN_PASSWORD are set but LLM_API_KEY is missing. " +
+        "Production headless deployments require all three. " +
+        "Add LLM_API_KEY or remove ADMIN_EMAIL/ADMIN_PASSWORD to use the setup wizard."
+    );
+  }
+
+  if ((await deps.userRepo.count()) === 0) {
+    await createUser(deps.userRepo, adminEmail, adminPass, "admin");
+    deps.log?.info(`Bootstrapped admin user ${normalizeEmail(adminEmail)}`);
+  }
+
+  if (process.env.BUSINESS_NAME) {
+    await patchSoulConfig(deps.soulPath, {
+      businessName: process.env.BUSINESS_NAME,
+      businessDescription: process.env.BUSINESS_DESCRIPTION ?? "",
+    });
+  }
+
+  if (llmKey) {
+    await deps.secretsService.set(`${llmProvider()}-api-key`, llmKey);
+    deps.log?.info(`Seeded ${llmProvider()} LLM API key from env`);
+  } else {
+    deps.log?.info("LLM_API_KEY not set — configure LLM via Settings > LLM Config");
+  }
+
+  // Mark setup complete so the web wizard never appears
+  await patchSoulConfig(deps.soulPath, { setupComplete: true });
+}

--- a/apps/api/src/setup/routes.test.ts
+++ b/apps/api/src/setup/routes.test.ts
@@ -1,0 +1,285 @@
+import crypto, { randomBytes, randomUUID } from "node:crypto";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type SecretDoc,
+  type SecretEnvelopeFields,
+  type SecretMeta,
+  type SecretRepo,
+  SecretsService,
+} from "@tulipfarm/secrets";
+import { GitSyncService } from "@tulipfarm/soul";
+import type { FastifyInstance } from "fastify";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { parse } from "yaml";
+import { buildApp } from "../app";
+import type { TokenDoc, TokenRepo } from "../auth/api-tokens";
+import { CSRF_COOKIE, CSRF_HEADER } from "../auth/csrf";
+import { MemorySessionStore } from "../auth/session-store";
+import type { UserDoc, UserRepo } from "../auth/users";
+import type { PaginatedResult } from "../pagination";
+
+class FakeUserRepo implements UserRepo {
+  users: UserDoc[] = [];
+  async findByEmail(e: string) {
+    return this.users.find((u) => u.email === e.trim().toLowerCase()) ?? null;
+  }
+  async findById(id: string) {
+    return this.users.find((u) => u._id === id) ?? null;
+  }
+  async count() {
+    return this.users.length;
+  }
+  async insert(u: UserDoc) {
+    this.users.push(u);
+  }
+}
+
+class StubTokenRepo implements TokenRepo {
+  async create() {}
+  async findByHash() {
+    return null;
+  }
+  async findByUserId() {
+    return [];
+  }
+  async findAll() {
+    return [];
+  }
+  async findById() {
+    return null;
+  }
+  async deleteById() {}
+  async findAllPaginated(): Promise<PaginatedResult<TokenDoc>> {
+    return { items: [], nextCursor: null };
+  }
+  async findByUserIdPaginated(): Promise<PaginatedResult<TokenDoc>> {
+    return { items: [], nextCursor: null };
+  }
+}
+
+class FakeSecretRepo implements SecretRepo {
+  map = new Map<string, SecretDoc>();
+  async list(): Promise<SecretMeta[]> {
+    return [...this.map.values()].map((d) => ({
+      key: d.key,
+      type: d.type,
+      createdAt: d.createdAt,
+      updatedAt: d.updatedAt,
+    }));
+  }
+  async findByKey(key: string) {
+    return this.map.get(key) ?? null;
+  }
+  async upsert(key: string, fields: SecretEnvelopeFields) {
+    const now = new Date();
+    const prev = this.map.get(key);
+    this.map.set(key, {
+      _id: key,
+      key,
+      ...fields,
+      dekId: fields.dekId ?? null,
+      createdAt: prev?.createdAt ?? now,
+      updatedAt: now,
+    });
+  }
+  async delete(key: string) {
+    this.map.delete(key);
+  }
+  async listLegacyKeys() {
+    return [];
+  }
+}
+
+function cookieHeader(cookies: { name: string; value: string }[]): string {
+  return cookies.map((c) => `${c.name}=${c.value}`).join("; ");
+}
+
+async function makeApp(dir: string): Promise<FastifyInstance> {
+  const soulPath = path.join(dir, "soul");
+  vi.stubEnv("SOUL_PATH", soulPath);
+  vi.stubEnv("ENCRYPTION_KEY", crypto.randomBytes(32).toString("base64"));
+  return buildApp({
+    sessionStore: new MemorySessionStore(),
+    userRepo: new FakeUserRepo(),
+    tokenRepo: new StubTokenRepo(),
+    secretsService: new SecretsService(new FakeSecretRepo(), {
+      dekId: randomUUID(),
+      key: randomBytes(32),
+    }),
+    gitSync: new GitSyncService(soulPath, undefined, undefined, console),
+  });
+}
+
+let dir: string;
+let app: FastifyInstance;
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), "setup-"));
+  app = await makeApp(dir);
+});
+afterEach(async () => {
+  await app.close();
+  await fs.rm(dir, { recursive: true, force: true });
+  vi.unstubAllEnvs();
+});
+
+async function createAdmin(): Promise<{ name: string; value: string }[]> {
+  const res = await app.inject({
+    method: "POST",
+    url: "/api/v1/setup/admin",
+    payload: { email: "admin@acme.io", password: "supersecret" },
+  });
+  expect(res.statusCode).toBe(201);
+  return res.cookies;
+}
+
+function authHeaders(cookies: { name: string; value: string }[]) {
+  return {
+    cookie: cookieHeader(cookies),
+    [CSRF_HEADER]: cookies.find((c) => c.name === CSRF_COOKIE)?.value ?? "",
+  };
+}
+
+describe("setup routes", () => {
+  it("status reports needsSetup=true before any admin", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/v1/setup/status" });
+    expect(res.json()).toEqual({ needsSetup: true });
+  });
+
+  it("status reports needsSetup=false when setupComplete is set in soul.yaml", async () => {
+    // Simulate a dev setup (setup-dev.sh writes setupComplete: true)
+    await fs.mkdir(path.join(dir, "soul"), { recursive: true });
+    await fs.writeFile(path.join(dir, "soul", "soul.yaml"), "setupComplete: true\n", "utf8");
+    // Rebuild app so it reads the pre-existing soul
+    await app.close();
+    app = await makeApp(dir);
+    const res = await app.inject({ method: "GET", url: "/api/v1/setup/status" });
+    expect(res.json()).toEqual({ needsSetup: false });
+  });
+
+  it("creates the first admin, auto-logs in, then locks (403)", async () => {
+    const cookies = await createAdmin();
+    expect(cookies.some((c) => c.name === "tf_sid")).toBe(true);
+    const status = await app.inject({ method: "GET", url: "/api/v1/setup/status" });
+    // admin exists but setupComplete not set yet
+    expect(status.json()).toEqual({ needsSetup: false });
+    const again = await app.inject({
+      method: "POST",
+      url: "/api/v1/setup/admin",
+      payload: { email: "evil@acme.io", password: "supersecret" },
+    });
+    expect(again.statusCode).toBe(403);
+  });
+
+  it("business step persists name + description to soul.yaml", async () => {
+    const cookies = await createAdmin();
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/setup/business",
+      headers: authHeaders(cookies),
+      payload: { name: "Acme Tulips", description: "We sell tulips." },
+    });
+    expect(res.statusCode).toBe(204);
+    const cfg = parse(await fs.readFile(path.join(dir, "soul", "soul.yaml"), "utf8")) as {
+      businessName?: string;
+      businessDescription?: string;
+    };
+    expect(cfg.businessName).toBe("Acme Tulips");
+    expect(cfg.businessDescription).toBe("We sell tulips.");
+  });
+
+  it("llm step stores the key (no live call in unit tests)", async () => {
+    const cookies = await createAdmin();
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/setup/llm",
+      headers: authHeaders(cookies),
+      payload: { provider: "anthropic", apiKey: "sk-ant-test" },
+    });
+    // In unit tests the generateText call will fail (no real API); it's a transient error
+    // so the route returns 204 anyway (key kept)
+    expect(res.statusCode).toBe(204);
+  });
+
+  it("llm step rejects an empty key", async () => {
+    const cookies = await createAdmin();
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/setup/llm",
+      headers: authHeaders(cookies),
+      payload: { provider: "anthropic", apiKey: "" },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("git step stores remote URL in soul.yaml", async () => {
+    const cookies = await createAdmin();
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/setup/git",
+      headers: authHeaders(cookies),
+      payload: { remoteUrl: "https://github.com/acme/soul.git" },
+    });
+    expect(res.statusCode).toBe(204);
+    const cfg = parse(await fs.readFile(path.join(dir, "soul", "soul.yaml"), "utf8")) as {
+      gitRemoteUrl?: string;
+    };
+    expect(cfg.gitRemoteUrl).toBe("https://github.com/acme/soul.git");
+  });
+
+  it("business step requires auth", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/setup/business",
+      payload: { name: "X" },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("wizard steps lock once setup is complete", async () => {
+    const cookies = await createAdmin();
+    await app.inject({
+      method: "POST",
+      url: "/api/v1/setup/complete",
+      headers: authHeaders(cookies),
+    });
+    const after = await app.inject({
+      method: "POST",
+      url: "/api/v1/setup/business",
+      headers: authHeaders(cookies),
+      payload: { name: "Late" },
+    });
+    expect(after.statusCode).toBe(403);
+  });
+
+  it("complete marks setupComplete=true in soul.yaml", async () => {
+    const cookies = await createAdmin();
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/setup/complete",
+      headers: authHeaders(cookies),
+    });
+    expect(res.statusCode).toBe(204);
+    const cfg = parse(await fs.readFile(path.join(dir, "soul", "soul.yaml"), "utf8")) as {
+      setupComplete?: boolean;
+    };
+    expect(cfg.setupComplete).toBe(true);
+    const status = await app.inject({ method: "GET", url: "/api/v1/setup/status" });
+    expect(status.json()).toEqual({ needsSetup: false });
+  });
+
+  it("headless boot: status returns 200 needsSetup=false even when wizard routes absent", async () => {
+    await app.close();
+    vi.stubEnv("ADMIN_EMAIL", "admin@acme.io");
+    vi.stubEnv("ADMIN_PASSWORD", "supersecret");
+    vi.stubEnv("LLM_API_KEY", "sk-ant-test");
+    app = await makeApp(dir);
+    const res = await app.inject({ method: "GET", url: "/api/v1/setup/status" });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ needsSetup: false });
+    // Wizard step routes remain absent in headless mode
+    const adminRes = await app.inject({ method: "POST", url: "/api/v1/setup/admin", payload: {} });
+    expect(adminRes.statusCode).toBe(404);
+  });
+});

--- a/apps/api/src/setup/routes.ts
+++ b/apps/api/src/setup/routes.ts
@@ -1,0 +1,338 @@
+import { createModel, LlmCredentialError } from "@tulipfarm/llm";
+import type { SecretsService } from "@tulipfarm/secrets";
+import type { GitSyncService } from "@tulipfarm/soul";
+import { generateText } from "ai";
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { generateCsrfToken, setCsrfCookie } from "../auth/csrf";
+import { SESSION_COOKIE } from "../auth/middleware";
+import { ErrorSchema, PublicUserSchema } from "../auth/schemas";
+import { DEFAULT_SESSION_TTL_SECONDS, type SessionStore } from "../auth/session-store";
+import { createUser, toPublicUser, type UserRepo } from "../auth/users";
+import { makeRateLimitHook, type RateLimiter } from "../rate-limit";
+import { isHeadlessBoot } from "./service";
+import { patchSoulConfig, readSoulConfig } from "./soul-config";
+
+// Cheapest models per provider, used only to validate the API key on setup.
+const PROBE_MODEL: Record<string, string> = {
+  anthropic: "claude-haiku-4-5-20251001",
+  openai: "gpt-4o-mini",
+};
+
+type PreHandler = (req: FastifyRequest, reply: FastifyReply) => Promise<void>;
+
+export interface SetupDeps {
+  userRepo: UserRepo;
+  sessionStore: SessionStore;
+  secretsService: SecretsService;
+  gitSync: GitSyncService;
+  soulPath: string;
+  requireAuth: PreHandler;
+  ttlSeconds?: number;
+}
+
+function setSessionCookies(reply: FastifyReply, sid: string, ttlSeconds: number): void {
+  reply.setCookie(SESSION_COOKIE, sid, {
+    httpOnly: true,
+    sameSite: "strict",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: ttlSeconds,
+  });
+  setCsrfCookie(reply, generateCsrfToken(), ttlSeconds);
+}
+
+// Always-registered: returns needsSetup regardless of boot mode.
+// In headless boot all wizard step routes are absent (404), but this endpoint is always available
+// so the web client can rely on an explicit 200 rather than treating 404 as "not needed".
+export function registerSetupStatusRoute(
+  app: FastifyInstance,
+  deps: Pick<SetupDeps, "userRepo" | "soulPath"> & { rateLimiter?: RateLimiter }
+): void {
+  const { userRepo, soulPath, rateLimiter } = deps;
+  // 30 req/min per IP — generous for a status poll, protects DB/FS on cold path.
+  const preHandler = rateLimiter
+    ? makeRateLimitHook(rateLimiter, (req) => `rl:setup:${req.ip}`, 30, 60_000)
+    : undefined;
+  // Closure-scoped cache: once setup is confirmed complete, skip all I/O for the
+  // lifetime of this process. Resets naturally on restart (one cold check per boot).
+  let done = false;
+
+  app.get(
+    "/api/v1/setup/status",
+    {
+      ...(preHandler ? { preHandler } : {}),
+      schema: {
+        description: "Whether first-run setup is still required.",
+        tags: ["setup"],
+        response: {
+          200: {
+            type: "object",
+            properties: { needsSetup: { type: "boolean" } },
+            required: ["needsSetup"],
+          },
+        },
+      },
+    },
+    async () => {
+      if (done) return { needsSetup: false };
+      if (isHeadlessBoot()) {
+        done = true;
+        return { needsSetup: false };
+      }
+      const cfg = await readSoulConfig(soulPath);
+      if (cfg.setupComplete === true) {
+        done = true;
+        return { needsSetup: false };
+      }
+      const hasUsers = (await userRepo.count()) > 0;
+      if (hasUsers) {
+        // Users exist but setupComplete missing from soul.yaml — soul.yaml was likely lost
+        // (e.g. volume loss after wizard completed). Treat as done; cache for this process
+        // lifetime but do NOT write setupComplete here: only POST /setup/complete owns that flag.
+        // On next restart a single DB query runs again, which is acceptable.
+        done = true;
+        return { needsSetup: false };
+      }
+      return { needsSetup: true };
+    }
+  );
+}
+
+// First-run setup wizard (INST-003). Routes are only registered when NOT in headless
+// boot mode (isHeadlessBoot() === false, checked by caller in app.ts).
+//
+// Guard hierarchy:
+//   POST /admin   → open only while no users exist (requireSetupOpen)
+//   POST /business, /llm, /git → auth + admin + setupComplete=false (wizardStep)
+//   POST /complete → auth + admin
+export function registerSetupRoutes(app: FastifyInstance, deps: SetupDeps): void {
+  const {
+    userRepo,
+    sessionStore,
+    secretsService,
+    gitSync,
+    soulPath,
+    requireAuth,
+    ttlSeconds = DEFAULT_SESSION_TTL_SECONDS,
+  } = deps;
+
+  async function requireSetupOpen(_req: FastifyRequest, reply: FastifyReply): Promise<void> {
+    if ((await userRepo.count()) > 0) {
+      return reply.code(403).send({ error: "setup already complete" });
+    }
+  }
+
+  async function requireAdmin(req: FastifyRequest, reply: FastifyReply): Promise<void> {
+    if (req.user?.role !== "admin") {
+      return reply.code(403).send({ error: "admin role required" });
+    }
+  }
+
+  async function requireSetupIncomplete(_req: FastifyRequest, reply: FastifyReply): Promise<void> {
+    if ((await readSoulConfig(soulPath)).setupComplete === true) {
+      return reply.code(403).send({ error: "setup already complete" });
+    }
+  }
+
+  const wizardStep: PreHandler[] = [requireAuth, requireAdmin, requireSetupIncomplete];
+
+  // Step 1: create the first admin and auto-login (sets session + CSRF cookies).
+  app.post(
+    "/api/v1/setup/admin",
+    {
+      preHandler: requireSetupOpen,
+      schema: {
+        description: "Create the first admin account and auto-login. Open until any admin exists.",
+        tags: ["setup"],
+        body: {
+          type: "object",
+          required: ["email", "password"],
+          properties: {
+            email: { type: "string", format: "email" },
+            password: { type: "string", minLength: 8 },
+          },
+        },
+        response: {
+          201: { type: "object", properties: { user: PublicUserSchema }, required: ["user"] },
+          400: ErrorSchema,
+          403: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const body = (req.body ?? {}) as { email?: unknown; password?: unknown };
+      const email = typeof body.email === "string" ? body.email : "";
+      const password = typeof body.password === "string" ? body.password : "";
+      if (!email || password.length < 8) {
+        return reply
+          .code(400)
+          .send({ error: "email and a password of at least 8 characters are required" });
+      }
+      const user = await createUser(userRepo, email, password, "admin");
+      const sid = await sessionStore.create(user._id);
+      setSessionCookies(reply, sid, ttlSeconds);
+      return reply.code(201).send({ user: toPublicUser(user) });
+    }
+  );
+
+  // Step 2: record business name + description in soul.yaml.
+  app.post(
+    "/api/v1/setup/business",
+    {
+      preHandler: wizardStep,
+      schema: {
+        description: "Record the business name + description in the soul.",
+        tags: ["setup"],
+        security: [{ sessionCookie: [] }],
+        body: {
+          type: "object",
+          required: ["name"],
+          properties: {
+            name: { type: "string", minLength: 1 },
+            description: { type: "string" },
+          },
+        },
+        response: {
+          204: { type: "null" },
+          400: ErrorSchema,
+          401: ErrorSchema,
+          403: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const body = (req.body ?? {}) as { name?: unknown; description?: unknown };
+      const name = typeof body.name === "string" ? body.name.trim() : "";
+      const description = typeof body.description === "string" ? body.description : "";
+      if (!name) return reply.code(400).send({ error: "name is required" });
+      await patchSoulConfig(soulPath, { businessName: name, businessDescription: description });
+      await gitSync.commit("chore: set business profile").catch(() => {});
+      return reply.code(204).send();
+    }
+  );
+
+  // Step 3: store + live-validate the LLM API key.
+  // Saves key first, then probes with a minimal generateText call.
+  // On credential error: removes key and returns 400 with a clear message.
+  // On transient error (network, rate-limit, 5xx): keeps the key and returns 204 with a warning
+  // so a bad network at setup time doesn't block the user.
+  app.post(
+    "/api/v1/setup/llm",
+    {
+      preHandler: wizardStep,
+      schema: {
+        description: "Store an LLM provider API key and validate it with a live probe.",
+        tags: ["setup"],
+        security: [{ sessionCookie: [] }],
+        body: {
+          type: "object",
+          required: ["provider", "apiKey"],
+          properties: {
+            provider: { type: "string", enum: ["anthropic", "openai"] },
+            apiKey: { type: "string", minLength: 1 },
+          },
+        },
+        response: {
+          204: { type: "null" },
+          400: ErrorSchema,
+          401: ErrorSchema,
+          403: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const body = (req.body ?? {}) as { provider?: unknown; apiKey?: unknown };
+      const provider = body.provider === "openai" ? "openai" : "anthropic";
+      const apiKey = typeof body.apiKey === "string" ? body.apiKey.trim() : "";
+      if (!apiKey) return reply.code(400).send({ error: "apiKey is required" });
+
+      const secretKey = `${provider}-api-key`;
+      await secretsService.set(secretKey, apiKey);
+
+      // Live probe: validate the key is accepted by the provider.
+      const probeModelId = PROBE_MODEL[provider] ?? "claude-haiku-4-5-20251001";
+      try {
+        const model = await createModel(
+          { provider, model: probeModelId, api_key_ref: secretKey },
+          secretsService
+        );
+        await generateText({ model, prompt: "ping" });
+      } catch (err) {
+        if (err instanceof LlmCredentialError) {
+          // Key is wrong — clean up and report the problem
+          await secretsService.delete(secretKey).catch(() => {});
+          return reply.code(400).send({ error: `API key is invalid: ${err.message}` });
+        }
+        // Transient (network, 5xx, rate-limit) — keep the key, let first chat surface any real issue
+        app.log.warn({ err }, "LLM probe returned a transient error during setup; key kept");
+      }
+
+      return reply.code(204).send();
+    }
+  );
+
+  // Step 4 (optional): configure soul git backup. Stores remote URL in soul.yaml and
+  // credentials as an encrypted secret. Git sync activates on next restart with
+  // GIT_REMOTE_URL + GIT_CREDENTIALS env vars; the stored values are for reference.
+  app.post(
+    "/api/v1/setup/git",
+    {
+      preHandler: wizardStep,
+      schema: {
+        description: "Configure soul git backup (optional). Persists remote URL + credentials.",
+        tags: ["setup"],
+        security: [{ sessionCookie: [] }],
+        body: {
+          type: "object",
+          required: ["remoteUrl"],
+          properties: {
+            remoteUrl: { type: "string", minLength: 1 },
+            credentials: { type: "string" },
+          },
+        },
+        response: {
+          204: { type: "null" },
+          400: ErrorSchema,
+          401: ErrorSchema,
+          403: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const body = (req.body ?? {}) as { remoteUrl?: unknown; credentials?: unknown };
+      const remoteUrl = typeof body.remoteUrl === "string" ? body.remoteUrl.trim() : "";
+      const credentials = typeof body.credentials === "string" ? body.credentials.trim() : "";
+      if (!remoteUrl) return reply.code(400).send({ error: "remoteUrl is required" });
+
+      await patchSoulConfig(soulPath, { gitRemoteUrl: remoteUrl });
+      if (credentials) {
+        await secretsService.set("git-credentials", credentials);
+      }
+      await gitSync.commit("chore: set git remote config").catch(() => {});
+      return reply.code(204).send();
+    }
+  );
+
+  // Final step: mark setup complete. Wizard steps become 403 after this.
+  app.post(
+    "/api/v1/setup/complete",
+    {
+      preHandler: [requireAuth, requireAdmin],
+      schema: {
+        description: "Mark first-run setup as complete.",
+        tags: ["setup"],
+        security: [{ sessionCookie: [] }],
+        response: {
+          204: { type: "null" },
+          401: ErrorSchema,
+          403: ErrorSchema,
+        },
+      },
+    },
+    async (_req, reply) => {
+      await patchSoulConfig(soulPath, { setupComplete: true });
+      await gitSync.commit("chore: complete first-run setup").catch(() => {});
+      return reply.code(204).send();
+    }
+  );
+}

--- a/apps/api/src/setup/service.ts
+++ b/apps/api/src/setup/service.ts
@@ -1,0 +1,12 @@
+// Headless boot: all three required together trigger automatic seeding and skip the wizard.
+// Container platforms (Cloud Run, Fly, App Service) supply all three via platform env config.
+// curl|bash installs supply none → wizard opens.
+// Partial: ADMIN creds set but no LLM_API_KEY → fail loud in production; allowed in dev
+// (developer configures LLM via Settings after first boot).
+export function isHeadlessBoot(): boolean {
+  return !!(process.env.ADMIN_EMAIL && process.env.ADMIN_PASSWORD && process.env.LLM_API_KEY);
+}
+
+export function isProductionMode(): boolean {
+  return process.env.NODE_ENV === "production";
+}

--- a/apps/api/src/setup/soul-config.ts
+++ b/apps/api/src/setup/soul-config.ts
@@ -1,0 +1,29 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { parse, stringify } from "yaml";
+
+export interface SoulConfig {
+  businessName?: string;
+  businessDescription?: string;
+  setupComplete?: boolean;
+  gitRemoteUrl?: string;
+  [key: string]: unknown;
+}
+
+function soulYamlPath(soulPath: string): string {
+  return path.join(soulPath, "soul.yaml");
+}
+
+export async function readSoulConfig(soulPath: string): Promise<SoulConfig> {
+  try {
+    return (parse(await fs.readFile(soulYamlPath(soulPath), "utf8")) as SoulConfig) ?? {};
+  } catch {
+    return {};
+  }
+}
+
+export async function patchSoulConfig(soulPath: string, patch: SoulConfig): Promise<void> {
+  await fs.mkdir(soulPath, { recursive: true });
+  const next = { ...(await readSoulConfig(soulPath)), ...patch };
+  await fs.writeFile(soulYamlPath(soulPath), stringify(next), "utf8");
+}

--- a/apps/docs/content/docs/concepts/meta.json
+++ b/apps/docs/content/docs/concepts/meta.json
@@ -4,6 +4,7 @@
     "index",
     "building",
     "soul",
+    "setup",
     "resources",
     "agents",
     "skills",

--- a/apps/docs/content/docs/concepts/setup.mdx
+++ b/apps/docs/content/docs/concepts/setup.mdx
@@ -1,0 +1,111 @@
+---
+title: First-run setup and boot modes
+description: How TulipFarm decides whether to open the setup wizard or seed from environment variables.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+When TulipFarm starts for the first time it has no admin and no configuration. It needs
+to reach a usable state before it can serve requests. There are two paths to get there:
+**wizard mode** (the default) and **headless mode** (for automated deployments).
+
+## How the instance decides which mode to use
+
+At startup the API checks three signals, in order:
+
+1. **Environment variables** — if `ADMIN_EMAIL`, `ADMIN_PASSWORD`, and `LLM_API_KEY` are
+   all set, the instance enters headless mode. It seeds the admin account and LLM key from
+   those values and writes `setupComplete: true` to `soul.yaml`. The web wizard never
+   appears.
+
+2. **`setupComplete` in `soul.yaml`** — if the flag is `true` and the env check did not
+   trigger, setup is already done. Normal boot proceeds.
+
+3. **User count** — if no users exist in the database and no env vars are set, the wizard
+   is still open. The instance registers the setup-wizard routes and returns
+   `needsSetup: true` from `GET /api/v1/setup/status`.
+
+The result of the first check that resolves to "done" is cached for the life of the
+process so subsequent requests never re-query the database or filesystem.
+
+<Callout type="info">
+`GET /api/v1/setup/status` is always registered, regardless of boot mode. The web client
+polls it on load to decide whether to redirect to `/setup` or to the main app.
+</Callout>
+
+## Wizard mode
+
+Wizard mode is the default for `curl | bash` self-hosted installs and local development.
+No environment variables need to be set. When `GET /api/v1/setup/status` returns
+`needsSetup: true`, the web app redirects to `/setup` and walks the operator through
+four steps:
+
+1. **Admin account** — creates the first user and logs them in. The route locks once any
+   user exists, so it cannot be used to create a second admin.
+2. **Business profile** — stores `businessName` and `businessDescription` in `soul.yaml`.
+3. **LLM provider** — stores the provider credentials (API key, resource name, or base URL
+   depending on the provider) and writes a default `llm.config.yaml` with all three tiers
+   pointing to the chosen provider and model. This step can be skipped and configured later
+   in **Settings → LLM Config**.
+4. **Soul backup** — sets a git remote URL and optional credentials so the soul syncs to
+   a private repository. This step can also be skipped.
+
+After step 4, the wizard calls `POST /api/v1/setup/complete`, which writes
+`setupComplete: true` to `soul.yaml`. Subsequent wizard-step routes return `403`.
+
+## Headless mode
+
+Headless mode is designed for container platforms (Cloud Run, Fly.io, Azure App Service,
+Kubernetes) where all configuration is injected as environment variables and no browser
+interaction is possible.
+
+Set all three required variables:
+
+| Variable | Purpose |
+|---|---|
+| `ADMIN_EMAIL` | Email for the first admin account. |
+| `ADMIN_PASSWORD` | Password for the first admin account. |
+| `LLM_API_KEY` | API key for the default LLM provider (`anthropic` unless `LLM_PROVIDER=openai`). |
+
+On the first boot with these variables present, the instance:
+
+1. Creates the admin account.
+2. Stores the LLM API key in the secrets store.
+3. Optionally writes `businessName`/`businessDescription` to `soul.yaml` if
+   `BUSINESS_NAME` is set.
+4. Writes `setupComplete: true` to `soul.yaml`.
+
+The operation is idempotent. If the admin already exists (a restart of a running instance),
+the seed step is skipped.
+
+<Callout type="warn">
+In production (`NODE_ENV=production`), setting `ADMIN_EMAIL` and `ADMIN_PASSWORD` without
+`LLM_API_KEY` causes the API to refuse to start with a clear error message. This prevents
+a silently half-configured instance. Outside production (local dev), the partial combination
+is allowed: the admin is seeded and you configure LLM credentials later via **Settings**.
+</Callout>
+
+## The `setupComplete` flag
+
+`soul.yaml` holds a `setupComplete: true` key once setup is done. This is the persistent,
+cross-restart signal that the wizard has run. The key is written by:
+
+- `POST /api/v1/setup/complete` (final wizard step), or
+- `bootstrapFromEnv` (headless seeding on first boot).
+
+Nothing else writes it. If you need to re-run the wizard on an existing instance, you must
+manually remove the key from `soul.yaml` and delete all users from the database.
+
+### Recovery when `soul.yaml` is lost
+
+If the soul directory is deleted or restored from a backup that predates setup, `soul.yaml`
+will not have `setupComplete`. The instance falls back to the user-count check: if users
+exist in the database, setup is treated as complete and normal boot proceeds. On the next
+restart a single database query runs to confirm this; the result is then cached for the
+process lifetime.
+
+<Callout type="info">
+The soul directory is the right thing to back up regularly. Losing `soul.yaml` while the
+database is intact is recoverable; losing the database is not. See [Soul](/docs/concepts/soul)
+for backup options.
+</Callout>

--- a/apps/docs/content/docs/getting-started.mdx
+++ b/apps/docs/content/docs/getting-started.mdx
@@ -69,25 +69,6 @@ psql tulipfarm -c 'select 1'
 
 <Step>
 
-### Set your admin credentials
-
-Open `.env.local` and set a password for the bootstrap admin. The first user is created
-on boot from these values:
-
-```bash title=".env.local"
-ADMIN_EMAIL=admin@tulipfarm.dev
-ADMIN_PASSWORD=choose-a-strong-password
-```
-
-<Callout type="warn">
-`ADMIN_EMAIL` must be a real email format. An address with no TLD such as
-`admin@localhost` is rejected, and the admin would never be able to log in.
-</Callout>
-
-</Step>
-
-<Step>
-
 ### Install dependencies and start TulipFarm
 
 ```bash
@@ -116,11 +97,23 @@ You should see:
 
 <Step>
 
-### Log in
+### Complete the setup wizard
 
-Open `http://localhost:4000` and sign in with the `ADMIN_EMAIL` and `ADMIN_PASSWORD`
-you set. You land on the chat workspace. The sidebar gives you Chat, Resources, Agents,
-Skills, Knowledge, and Settings.
+Open `http://localhost:4000`. Because no admin exists yet, the app redirects to the
+setup wizard at `/setup`. Work through the four steps:
+
+1. **Admin account** — enter an email and password. This creates the first admin and logs
+   you in.
+2. **Business profile** — give your instance a name and optional description.
+3. **LLM provider** — choose a provider (Anthropic, OpenAI, Azure OpenAI, or an
+   OpenAI-compatible endpoint), enter the credentials, and pick a model. You can skip this
+   and configure it later in **Settings → LLM Config**.
+4. **Soul backup** — optionally point the soul at a git remote for backup. You can skip
+   this and set it up later in **Settings**.
+
+After step 4, the wizard calls `POST /api/v1/setup/complete` and redirects to the main
+workspace. The setup route locks — a second browser visitor cannot create another admin
+through the wizard.
 
 </Step>
 

--- a/apps/docs/content/docs/guides/deploy-headless.mdx
+++ b/apps/docs/content/docs/guides/deploy-headless.mdx
@@ -1,0 +1,100 @@
+---
+title: Deploy without the setup wizard
+description: Seed the first admin and LLM key from environment variables for automated and container-platform deployments.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+Container platforms (Cloud Run, Fly.io, Azure App Service, Kubernetes) inject
+configuration as environment variables and do not support a browser interaction at
+first boot. TulipFarm's headless mode seeds the instance automatically when it detects
+the right variables.
+
+## Before you begin
+
+You need:
+
+- A running TulipFarm deployment reachable over HTTPS (or HTTP for local testing).
+- The ability to set environment variables in your platform's configuration.
+- An API key for an LLM provider (Anthropic or OpenAI).
+
+## Set the headless seeding variables
+
+Add all three to your deployment's environment:
+
+```bash
+ADMIN_EMAIL=admin@your-domain.com
+ADMIN_PASSWORD=a-strong-password
+LLM_API_KEY=sk-ant-...          # or an OpenAI key
+```
+
+For OpenAI instead of Anthropic:
+
+```bash
+LLM_PROVIDER=openai
+LLM_API_KEY=sk-...
+```
+
+To set the business name at the same time:
+
+```bash
+BUSINESS_NAME=Acme Corp
+BUSINESS_DESCRIPTION=We sell widgets.   # optional
+```
+
+<Callout type="warn">
+**All three** (`ADMIN_EMAIL`, `ADMIN_PASSWORD`, `LLM_API_KEY`) must be set together.
+In production (`NODE_ENV=production`), providing `ADMIN_EMAIL` and `ADMIN_PASSWORD`
+without `LLM_API_KEY` causes the API to refuse to start.
+</Callout>
+
+## Deploy and verify
+
+Deploy your instance. On the first boot the API logs confirm seeding:
+
+```
+Bootstrapped admin user admin@your-domain.com
+Seeded anthropic LLM API key from env
+```
+
+Confirm the status endpoint returns `needsSetup: false`:
+
+```bash
+curl https://your-instance/api/v1/setup/status
+```
+
+```json
+{ "needsSetup": false }
+```
+
+The web app will load the main workspace directly, bypassing the setup wizard.
+
+## What happens on restart
+
+The seed operation is idempotent. If `ADMIN_EMAIL` and `ADMIN_PASSWORD` are still set on
+a subsequent restart, the API checks whether a user already exists before creating one. If
+the user exists, the seed step is skipped silently.
+
+`setupComplete: true` is written to `soul.yaml` on the first successful seed. On later
+boots, the instance reads this flag and skips all setup checks without touching the
+database.
+
+## Configure LLM tiers after deployment
+
+Headless seeding stores the LLM key and writes a default `llm.config.yaml` with the
+provider in all three tiers (quick, standard, complex) pointing to a default model. To
+adjust the model or add a fallback chain, sign in as the admin and go to
+**Settings → LLM Config**.
+
+## Remove the wizard permanently
+
+Once you have signed in and confirmed the workspace is functional, you can remove
+`ADMIN_EMAIL` and `ADMIN_PASSWORD` from your deployment environment. Keeping them present
+is harmless (the seed is idempotent), but removing them is good hygiene — there is no
+reason for a password to sit in an environment variable indefinitely.
+
+<Callout type="info">
+Removing the variables after the first boot does not affect the running instance. The
+`setupComplete` flag in `soul.yaml` is the permanent signal; the env vars are only read
+during the seed step.
+</Callout>

--- a/apps/docs/content/docs/guides/meta.json
+++ b/apps/docs/content/docs/guides/meta.json
@@ -5,6 +5,7 @@
     "configure-llm-providers",
     "store-a-secret",
     "issue-an-api-token",
+    "deploy-headless",
     "---Resources---",
     "define-a-resource-type",
     "work-with-records",

--- a/apps/docs/content/docs/installation.mdx
+++ b/apps/docs/content/docs/installation.mdx
@@ -43,9 +43,20 @@ inside WSL. If WSL is missing it prints the `wsl --install` steps to run first.
 
 ## Finish setup
 
-Open the printed URL. While no admin exists, the setup wizard lets you create the first
-admin (no auth), then set the business name, LLM provider key, and optional soul git
-remote. After the first admin is created the setup route locks.
+Open the printed URL. The app redirects to the setup wizard at `/setup`. Work through
+the four steps:
+
+1. **Admin account** — enter an email and password. This is the only step that requires
+   no authentication; the route locks once any admin exists.
+2. **Business profile** — give your instance a name and optional description.
+3. **LLM provider** — choose a provider (Anthropic, OpenAI, Azure OpenAI, or an
+   OpenAI-compatible endpoint), enter your credentials, and pick a model. You can skip
+   this step and configure it later in **Settings → LLM Config**.
+4. **Soul backup** — optionally set a git remote URL for soul backup and sync. Skippable.
+
+After step 4, the wizard marks setup complete in `soul.yaml` and redirects to the main
+workspace. The setup routes lock — no second visitor can claim the instance through the
+wizard.
 
 <Callout type="warn">
   If the installer detected a public IP it prints a TLS warning: the instance is

--- a/apps/docs/content/docs/reference/environment-variables.mdx
+++ b/apps/docs/content/docs/reference/environment-variables.mdx
@@ -1,36 +1,65 @@
 ---
 title: Environment variables
-description: Every variable TulipFarm reads from .env.local, with defaults.
+description: Every variable TulipFarm reads, with defaults and descriptions.
 ---
 
-TulipFarm reads configuration from `.env.local`. The setup script generates this file and
-fills the random secrets; the table below documents every variable, its default, and
-whether it is required.
+TulipFarm is configured through environment variables. In self-hosted installs the
+installer writes these to `/opt/tulipfarm/.env`; in local development they live in
+`.env.local`. The tables below cover every variable the `app` reads.
 
-## Required
+## Required (all deployments)
 
 | Variable | Default | Description |
 |---|---|---|
-| `DATABASE_URL` | `postgres://localhost:5432/tulipfarm` | PostgreSQL connection string. The single datastore (pgvector + pg-boss). |
-| `SOUL_PATH` | `~/.tulipfarm/soul` | Absolute path to the soul git repository. Must be outside the project repo — a relative or in-repo path is rejected at boot. |
-| `ENCRYPTION_KEY` | — | Base64 key for encrypting application secrets. Must be 32 bytes; startup fails fast if it is not. Generate with `openssl rand -base64 32`. |
-| `JWT_SECRET` | — | Signing secret for tokens. Generate with `openssl rand -base64 32`. |
-| `WEBHOOK_SIGNING_SECRET` | — | Secret for signing webhooks. Generate with `openssl rand -base64 32`. |
-| `ADMIN_EMAIL` | `admin@tulipfarm.dev` | Email of the bootstrap admin, created on first boot if no users exist. Must be a valid email format (an address with no TLD is rejected). |
-| `ADMIN_PASSWORD` | — | Password for the bootstrap admin. |
+| `DATABASE_URL` | — | PostgreSQL 17 connection string. The single datastore (pgvector + pg-boss). Must allow the `vector` and `citext` extensions — the app creates them at boot. |
+| `SOUL_PATH` | — | Absolute path to the soul git repository. Must be outside the project repo — a relative or in-repo path is rejected at boot. |
+| `ENCRYPTION_KEY` | — | Base64-encoded 32-byte key for encrypting application secrets. Startup fails fast if the key is absent or not 32 bytes. Generate with `openssl rand -base64 32`. |
+| `JWT_SECRET` | — | Signing secret for API tokens. Generate with `openssl rand -base64 32`. |
+| `WEBHOOK_SIGNING_SECRET` | — | Secret for signing outbound webhooks. Generate with `openssl rand -base64 32`. |
 
-## Optional
+## Headless seeding
+
+Set **all three** together to skip the web setup wizard and seed the first admin
+account automatically on first boot. Leave all three unset (the default for `curl | bash`
+installs) to use the interactive browser wizard instead.
+
+See [First-run setup and boot modes](/docs/concepts/setup) for a full explanation of how
+the instance decides which path to take.
+
+| Variable | Default | Description |
+|---|---|---|
+| `ADMIN_EMAIL` | — | Email for the first admin account. Must be a valid email format. |
+| `ADMIN_PASSWORD` | — | Password for the first admin account. |
+| `LLM_API_KEY` | — | API key for the default LLM provider. Required alongside `ADMIN_EMAIL` + `ADMIN_PASSWORD` in production — omitting it in production causes the API to refuse to start. |
+| `LLM_PROVIDER` | `anthropic` | Provider for `LLM_API_KEY`. Accepts `anthropic` or `openai`. |
+| `BUSINESS_NAME` | — | Written to `soul.yaml` as `businessName` during headless seeding. Optional. |
+| `BUSINESS_DESCRIPTION` | — | Written to `soul.yaml` as `businessDescription`. Only used when `BUSINESS_NAME` is also set. |
+
+## OCI / production
+
+Variables used by the Docker Compose stack and the production image. The installer
+generates and writes these; they are documented here for reference.
+
+| Variable | Default | Description |
+|---|---|---|
+| `PUBLIC_URL` | `http://localhost:8080` | The externally reachable URL for this instance. Drives CORS and the cookie `Secure` flag. Set to an `https://` URL once behind TLS. |
+| `CORS_ORIGIN` | value of `PUBLIC_URL` | Allowed browser origin for the API. Override only if the web UI is served from a different origin than the API. |
+| `COMPOSE_PROFILES` | `bundled` | Set to `bundled` to start the included `postgres` container. Set to empty (`COMPOSE_PROFILES=`) to use an external database (see `EXTERNAL_DATASTORE`). |
+| `EXTERNAL_DATASTORE` | `false` | Set to `true` when `COMPOSE_PROFILES` is empty and `DATABASE_URL` points to a managed Postgres. Suppresses the bundled container. |
+| `POSTGRES_PASSWORD` | — | Password for the bundled Postgres container. Installer-generated; not used when `EXTERNAL_DATASTORE=true`. |
+| `PORT` | `8080` | Port the API listens on inside the container. |
+| `NODE_ENV` | `production` | Runtime environment. Affects logging, cookie flags, and headless-seeding validation. |
+
+## Optional (all deployments)
 
 | Variable | Default | Description |
 |---|---|---|
 | `SESSION_TTL_SECONDS` | `604800` | Session cookie lifetime in seconds (7 days). |
-| `PORT` | `4010` | Port the API listens on. |
-| `VITE_PORT` | `4000` | Port the web UI listens on. |
-| `CORS_ORIGIN` | `http://localhost:4000` | Allowed browser origin for the API. Defaults to the web UI on `VITE_PORT`. |
-| `GIT_REMOTE_URL` | — | Remote for the soul repo. When set, the instance syncs the soul to and from it. |
-| `GIT_CREDENTIALS` | — | Credentials for pushing to `GIT_REMOTE_URL`. |
-| `ENCRYPTION_KEY_PREVIOUS` | — | The prior `ENCRYPTION_KEY` during a key rotation. Decryption tries the current key, then this one. See [Secrets](/docs/concepts/secrets). |
-| `API_TOKEN_PEPPER` | — | Base64 server secret. When set, API tokens are hashed with `HMAC-SHA256(token, pepper)` instead of plain SHA-256. Must be 32 bytes. See [Hashing](/docs/security/hashing). |
+| `VITE_PORT` | `4000` | Port the web UI dev server listens on (local development only). |
+| `GIT_REMOTE_URL` | — | Remote for the soul repository. When set, the instance clones on first boot and syncs on a schedule. |
+| `GIT_CREDENTIALS` | — | Credentials for pushing to `GIT_REMOTE_URL` (e.g. a GitHub personal access token). |
+| `ENCRYPTION_KEY_PREVIOUS` | — | The prior `ENCRYPTION_KEY` during a key rotation. Decryption tries the current key first, then this one. See [Secrets](/docs/concepts/secrets). |
+| `API_TOKEN_PEPPER` | — | Base64 server secret (32 bytes). When set, API tokens are hashed with `HMAC-SHA256(token, pepper)` instead of plain SHA-256. See [Hashing](/docs/security/hashing). |
 | `HOOKS_DISABLED` | — | Set to `true` to skip resource `hooks.ts` execution entirely. Use to boot an instance whose hooks are failing. |
 | `KNOWLEDGE_TRGM_FALLBACK` | `on` | Typo-tolerance pass (pg_trgm) for lexical page search. Opt-out: set to `0` or `false` to turn it off. |
 | `MARKETPLACE_SOURCE` | `tulipfarm/skills` | The `owner/repo` the Skills marketplace scans by default. |

--- a/apps/web/app/lib/setup.ts
+++ b/apps/web/app/lib/setup.ts
@@ -1,0 +1,24 @@
+import { apiGet, apiSend, apiWrite } from "./api";
+
+export type SetupStatus = { needsSetup: boolean };
+
+export async function getSetupStatus(): Promise<SetupStatus> {
+  return apiGet<SetupStatus>("/api/v1/setup/status");
+}
+
+export async function setupAdmin(email: string, password: string): Promise<void> {
+  // 201 with user body — use apiWrite; we don't need the response body
+  await apiWrite("POST", "/api/v1/setup/admin", { email, password });
+}
+
+export async function setupBusiness(name: string, description: string): Promise<void> {
+  await apiSend("POST", "/api/v1/setup/business", { name, description });
+}
+
+export async function setupGit(remoteUrl: string, credentials?: string): Promise<void> {
+  await apiSend("POST", "/api/v1/setup/git", { remoteUrl, credentials });
+}
+
+export async function completeSetup(): Promise<void> {
+  await apiSend("POST", "/api/v1/setup/complete", {});
+}

--- a/apps/web/app/routes/_app.tsx
+++ b/apps/web/app/routes/_app.tsx
@@ -3,12 +3,15 @@ import { AppSidebar } from "~/components/app-sidebar";
 import { ApiError, getSession } from "~/lib/api";
 import { ApprovalsProvider } from "~/lib/approvals-context";
 import { ConversationsProvider } from "~/lib/conversations-context";
+import { getSetupStatus } from "~/lib/setup";
 
-// Auth gate for the whole app shell: every /app/* route runs this parent loader first. An
-// unauthenticated session (401) redirects to /login (preserving where the user was headed); a dev
-// Bearer token (VITE_API_TOKEN) authenticates too, so that path keeps working. Other errors bubble
-// to the route ErrorBoundary.
+// Auth gate for the whole app shell: every /app/* route runs this parent loader first.
+// Checks setup status first: if the instance needs first-run setup, redirect to /setup.
+// Then checks auth: unauthenticated session (401) redirects to /login.
 export async function clientLoader() {
+  const { needsSetup } = await getSetupStatus();
+  if (needsSetup) throw redirect("/setup");
+
   try {
     return { user: await getSession() };
   } catch (err) {

--- a/apps/web/app/routes/setup.tsx
+++ b/apps/web/app/routes/setup.tsx
@@ -1,0 +1,437 @@
+import { type MetaFunction, redirect, useNavigate } from "@remix-run/react";
+import { type FormEvent, useEffect, useState } from "react";
+import { Button } from "~/components/ui/button";
+import { ApiError } from "~/lib/api";
+import { type LlmProviderInfo, listProviders, putLlmConfig, putSecret } from "~/lib/settings";
+import { completeSetup, getSetupStatus, setupAdmin, setupBusiness, setupGit } from "~/lib/setup";
+
+export const meta: MetaFunction = () => [{ title: "Setup · tulipfarm" }];
+
+// Redirect to / if setup is already complete (both headless and wizard paths).
+export async function clientLoader() {
+  const { needsSetup } = await getSetupStatus();
+  if (!needsSetup) throw redirect("/");
+  return null;
+}
+
+const STEPS = ["Admin account", "Business profile", "LLM setup", "Soul backup"] as const;
+type Step = 0 | 1 | 2 | 3;
+
+const inputClass =
+  "w-full rounded-sm border border-border bg-background px-3 py-2 text-sm outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:opacity-60";
+
+function StepIndicator({ current }: { current: Step }) {
+  return (
+    <div className="flex items-center gap-2 mb-8">
+      {STEPS.map((label, i) => (
+        <div key={label} className="flex items-center gap-2">
+          <div
+            className={[
+              "flex h-6 w-6 items-center justify-center rounded-full text-[0.625rem] font-medium",
+              i < current
+                ? "bg-primary text-primary-foreground"
+                : i === current
+                  ? "border-2 border-primary text-primary"
+                  : "border border-border text-muted-foreground",
+            ].join(" ")}
+          >
+            {i < current ? "✓" : i + 1}
+          </div>
+          <span
+            className={`hidden text-xs sm:inline ${i === current ? "text-foreground" : "text-muted-foreground"}`}
+          >
+            {label}
+          </span>
+          {i < STEPS.length - 1 && <div className="h-px w-4 bg-border" />}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ErrorAlert({ message }: { message: string }) {
+  return (
+    <p
+      role="alert"
+      className="rounded-sm border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+    >
+      {message}
+    </p>
+  );
+}
+
+// Step 1: admin account
+function AdminStep({ onNext }: { onNext: () => void }) {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (password !== confirm) {
+      setError("Passwords do not match.");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      await setupAdmin(email.trim(), password);
+      onNext();
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : "Setup failed — is the API reachable?");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="flex flex-col gap-3">
+      {error && <ErrorAlert message={error} />}
+      <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+        email
+        <input
+          type="email"
+          autoComplete="username"
+          className={inputClass}
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+      </label>
+      <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+        password (min 8 characters)
+        <input
+          type="password"
+          autoComplete="new-password"
+          className={inputClass}
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          minLength={8}
+          required
+        />
+      </label>
+      <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+        confirm password
+        <input
+          type="password"
+          autoComplete="new-password"
+          className={inputClass}
+          value={confirm}
+          onChange={(e) => setConfirm(e.target.value)}
+          required
+        />
+      </label>
+      <Button
+        type="submit"
+        className="mt-1 rounded-sm"
+        disabled={busy || !email || password.length < 8 || !confirm}
+      >
+        {busy ? "Creating account…" : "Continue"}
+      </Button>
+    </form>
+  );
+}
+
+// Step 2: business profile
+function BusinessStep({ onNext }: { onNext: () => void }) {
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    setBusy(true);
+    setError(null);
+    try {
+      await setupBusiness(name.trim(), description.trim());
+      onNext();
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : "Failed to save business profile.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="flex flex-col gap-3">
+      {error && <ErrorAlert message={error} />}
+      <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+        business name
+        <input
+          type="text"
+          className={inputClass}
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Acme Corp"
+          required
+        />
+      </label>
+      <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+        brief description
+        <textarea
+          className={`${inputClass} resize-none`}
+          rows={3}
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="What does your business do?"
+        />
+      </label>
+      <Button type="submit" className="mt-1 rounded-sm" disabled={busy || !name.trim()}>
+        {busy ? "Saving…" : "Continue"}
+      </Button>
+    </form>
+  );
+}
+
+const DEFAULT_MODEL: Record<string, string> = {
+  anthropic: "claude-sonnet-4-6",
+  openai: "gpt-4o",
+  azure: "gpt-4o",
+  "openai-compatible": "",
+};
+
+// Step 3: LLM setup — uses the same registry and storage endpoints as Settings › Secrets + LLM Config.
+function LlmStep({ onNext }: { onNext: () => void }) {
+  const [providers, setProviders] = useState<LlmProviderInfo[]>([]);
+  const [providerId, setProviderId] = useState("anthropic");
+  const [fieldValues, setFieldValues] = useState<Record<string, string>>({});
+  const [model, setModel] = useState(DEFAULT_MODEL["anthropic"] ?? "");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    listProviders()
+      .then((list) => {
+        setProviders(list);
+        if (list.length > 0 && list[0]) {
+          setProviderId(list[0].id);
+          setModel(DEFAULT_MODEL[list[0].id] ?? "");
+        }
+      })
+      .catch(() => {});
+  }, []);
+
+  const selected = providers.find((p) => p.id === providerId);
+
+  function setVal(key: string, v: string) {
+    setFieldValues((prev) => ({ ...prev, [key]: v }));
+  }
+
+  function onProviderChange(id: string) {
+    setProviderId(id);
+    setFieldValues({});
+    setModel(DEFAULT_MODEL[id] ?? "");
+  }
+
+  const canSubmit =
+    !!selected &&
+    selected.fields
+      .filter((f) => !f.optional)
+      .every((f) => (fieldValues[f.key] ?? "").trim().length > 0) &&
+    model.trim().length > 0;
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!selected) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const filled = selected.fields.filter((f) => (fieldValues[f.key] ?? "").trim().length > 0);
+      await Promise.all(filled.map((f) => putSecret(f.key, fieldValues[f.key]!.trim())));
+      const entry = { provider: providerId, model: model.trim() };
+      await putLlmConfig({
+        tiers: {
+          quick: { providers: [entry] },
+          standard: { providers: [entry] },
+          complex: { providers: [entry] },
+        },
+      });
+      onNext();
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : "Failed to save LLM configuration.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="flex flex-col gap-3">
+      {error && <ErrorAlert message={error} />}
+      <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+        LLM provider
+        <select
+          className={inputClass}
+          value={providerId}
+          onChange={(e) => onProviderChange(e.target.value)}
+        >
+          {providers.length > 0 ? (
+            providers.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.label}
+              </option>
+            ))
+          ) : (
+            <>
+              <option value="anthropic">Anthropic</option>
+              <option value="openai">OpenAI</option>
+            </>
+          )}
+        </select>
+      </label>
+      {selected?.fields.map((field) => (
+        <label key={field.key} className="flex flex-col gap-1 text-xs text-muted-foreground">
+          {field.label}
+          {field.optional ? " (optional)" : ""}
+          <input
+            className={inputClass}
+            type={field.kind === "secret" ? "password" : "text"}
+            value={fieldValues[field.key] ?? ""}
+            onChange={(e) => setVal(field.key, e.target.value)}
+            placeholder={field.placeholder ?? (field.kind === "secret" ? "sk-…" : "")}
+            autoComplete="off"
+          />
+        </label>
+      ))}
+      <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+        model
+        <input
+          className={inputClass}
+          value={model}
+          onChange={(e) => setModel(e.target.value)}
+          placeholder={DEFAULT_MODEL[providerId] ?? "e.g. gpt-4o"}
+          autoComplete="off"
+        />
+      </label>
+      <Button type="submit" className="mt-1 rounded-sm" disabled={busy || !canSubmit}>
+        {busy ? "Saving…" : "Continue"}
+      </Button>
+      <Button type="button" variant="ghost" className="rounded-sm text-xs" onClick={onNext}>
+        Skip for now — configure in Settings later
+      </Button>
+    </form>
+  );
+}
+
+// Step 4: soul git backup (optional)
+function GitStep({ onNext }: { onNext: () => void }) {
+  const [remoteUrl, setRemoteUrl] = useState("");
+  const [credentials, setCredentials] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    setBusy(true);
+    setError(null);
+    try {
+      await setupGit(remoteUrl.trim(), credentials.trim() || undefined);
+      onNext();
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : "Failed to save git config.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="flex flex-col gap-3">
+      {error && <ErrorAlert message={error} />}
+      <p className="text-sm text-muted-foreground">
+        Back up your soul (agents, resources, config) to a private git repository. You can configure
+        this later in Settings.
+      </p>
+      <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+        git remote URL (HTTPS)
+        <input
+          type="url"
+          className={inputClass}
+          value={remoteUrl}
+          onChange={(e) => setRemoteUrl(e.target.value)}
+          placeholder="https://github.com/your-org/soul.git"
+        />
+      </label>
+      <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+        access token (optional)
+        <input
+          type="password"
+          autoComplete="off"
+          className={inputClass}
+          value={credentials}
+          onChange={(e) => setCredentials(e.target.value)}
+          placeholder="ghp_…"
+        />
+      </label>
+      <div className="flex gap-2">
+        <Button type="submit" className="flex-1 rounded-sm" disabled={busy || !remoteUrl.trim()}>
+          {busy ? "Saving…" : "Continue"}
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          className="rounded-sm"
+          onClick={onNext}
+          disabled={busy}
+        >
+          Skip
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+export default function SetupRoute() {
+  const navigate = useNavigate();
+  const [step, setStep] = useState<Step>(0);
+  const [finishing, setFinishing] = useState(false);
+  const [finishError, setFinishError] = useState<string | null>(null);
+
+  async function finish() {
+    setFinishing(true);
+    setFinishError(null);
+    try {
+      await completeSetup();
+      navigate("/", { replace: true });
+    } catch (err) {
+      setFinishError(err instanceof ApiError ? err.message : "Failed to complete setup.");
+      setFinishing(false);
+    }
+  }
+
+  const advance = () => {
+    if (step < 3) {
+      setStep((s) => (s + 1) as Step);
+    } else {
+      void finish();
+    }
+  };
+
+  return (
+    <section className="mx-auto flex min-h-svh max-w-sm flex-col justify-center px-6 py-16">
+      <p className="text-[0.625rem] font-medium uppercase tracking-[0.2em] text-primary">
+        [ SETUP ]
+      </p>
+      <h1 className="mt-1 text-2xl font-semibold text-foreground">tulipfarm</h1>
+      <p className="mt-1 text-sm text-muted-foreground">Let's get you set up.</p>
+
+      <div className="mt-8">
+        <StepIndicator current={step} />
+
+        <h2 className="mb-4 text-base font-medium">{STEPS[step]}</h2>
+
+        {finishError && <ErrorAlert message={finishError} />}
+
+        {step === 0 && <AdminStep onNext={advance} />}
+        {step === 1 && <BusinessStep onNext={advance} />}
+        {step === 2 && <LlmStep onNext={advance} />}
+        {step === 3 && <GitStep onNext={advance} />}
+
+        {step === 3 && finishing && (
+          <p className="mt-4 text-sm text-muted-foreground">Finishing setup…</p>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/scripts/get.tulipfarm.sh
+++ b/scripts/get.tulipfarm.sh
@@ -162,7 +162,6 @@ DATABASE_URL=postgresql://tulipfarm:${pw}@postgres:5432/tulipfarm
 ENCRYPTION_KEY=${enc}
 JWT_SECRET=${jwt}
 WEBHOOK_SIGNING_SECRET=${webhook}
-SETUP_MODE=wizard
 EOF
 }
 

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -153,15 +153,37 @@ else
   # Give services a moment to start
   sleep 2
 
-  # Create the Postgres database (idempotent)
-  if command -v createdb &> /dev/null; then
+  # On Linux, apt-installed Postgres uses peer auth via Unix socket for the postgres superuser.
+  # The current OS user has no Postgres role yet, so we must create one via sudo -u postgres.
+  # We switch DATABASE_URL to a Unix socket URL with ?host=<socket-dir> because node-postgres
+  # treats an empty host as TCP localhost — the explicit socket path triggers peer auth.
+  if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    if sudo -u postgres createuser --superuser "$USER" 2>/dev/null; then
+      echo "✅ Created Postgres role '$USER'"
+    else
+      echo "✅ Postgres role '$USER' already exists"
+    fi
     if createdb tulipfarm 2>/dev/null; then
       echo "✅ Created Postgres database 'tulipfarm'"
     else
       echo "✅ Postgres database 'tulipfarm' already exists"
     fi
+    # node-postgres ignores an empty host and falls back to TCP; we must pass the socket
+    # directory explicitly via ?host= so peer auth is used (no password required).
+    PG_SOCKET_DIR="$(psql -Atqc "SHOW unix_socket_directories" 2>/dev/null | tr ',' '\n' | head -1 | tr -d ' ')"
+    PG_SOCKET_DIR="${PG_SOCKET_DIR:-/var/run/postgresql}"
+    DATABASE_URL_OVERRIDE="postgres:///tulipfarm?host=${PG_SOCKET_DIR}"
   else
-    echo "⚠ createdb not on PATH — create the 'tulipfarm' database manually"
+    # macOS Homebrew: initdb creates a superuser role for the OS user automatically
+    if command -v createdb &> /dev/null; then
+      if createdb tulipfarm 2>/dev/null; then
+        echo "✅ Created Postgres database 'tulipfarm'"
+      else
+        echo "✅ Postgres database 'tulipfarm' already exists"
+      fi
+    else
+      echo "⚠ createdb not on PATH — create the 'tulipfarm' database manually"
+    fi
   fi
 fi
 
@@ -174,9 +196,9 @@ if [ ! -d "$SOUL_DIR/.git" ]; then
 
   # Create stub files. NOTE: no llm.config.yaml stub — an empty/comment-only one fails LLM-config
   # validation (requires `tiers`). Absent config = LLM features disabled until the UI wizard writes it.
+  # soul.yaml is intentionally minimal — setupComplete is set by the setup wizard, not here.
   cat > "$SOUL_DIR/soul.yaml" << 'EOF'
 # TulipFarm Soul Configuration
-# Root soul manifest — populated during UI setup
 EOF
 
   cat > "$SOUL_DIR/skills-lock.json" << 'EOF'
@@ -204,10 +226,6 @@ if [ ! -f ".env.local" ]; then
   ENCRYPTION_KEY=$(openssl rand -base64 32)
   JWT_SECRET=$(openssl rand -base64 32)
   WEBHOOK_SECRET=$(openssl rand -base64 32)
-  # Fixed dev admin password — deterministic, not random (matches the app's bootstrapAdmin dev
-  # default and the login screen's prefilled value). Hashed with Argon2id at boot. Change it in
-  # .env.local for anything beyond local dev.
-  ADMIN_PASSWORD=password123
 
   # Replace placeholders by matching each full KEY=<placeholder> line so every substitution
   # is unique and order-independent (a bare s/// on the shared placeholder would overwrite
@@ -217,12 +235,10 @@ if [ ! -f ".env.local" ]; then
     sed -i '' "s|ENCRYPTION_KEY=<generate: openssl rand -base64 32>|ENCRYPTION_KEY=$ENCRYPTION_KEY|" .env.local
     sed -i '' "s|JWT_SECRET=<generate: openssl rand -base64 32>|JWT_SECRET=$JWT_SECRET|" .env.local
     sed -i '' "s|WEBHOOK_SIGNING_SECRET=<generate: openssl rand -base64 32>|WEBHOOK_SIGNING_SECRET=$WEBHOOK_SECRET|" .env.local
-    sed -i '' "s|ADMIN_PASSWORD=<set a strong password>|ADMIN_PASSWORD=$ADMIN_PASSWORD|" .env.local
   else
     sed -i "s|ENCRYPTION_KEY=<generate: openssl rand -base64 32>|ENCRYPTION_KEY=$ENCRYPTION_KEY|" .env.local
     sed -i "s|JWT_SECRET=<generate: openssl rand -base64 32>|JWT_SECRET=$JWT_SECRET|" .env.local
     sed -i "s|WEBHOOK_SIGNING_SECRET=<generate: openssl rand -base64 32>|WEBHOOK_SIGNING_SECRET=$WEBHOOK_SECRET|" .env.local
-    sed -i "s|ADMIN_PASSWORD=<set a strong password>|ADMIN_PASSWORD=$ADMIN_PASSWORD|" .env.local
   fi
 
   # Docker mode: point the dev app at the bundled container (host port + password).
@@ -243,14 +259,9 @@ if [ ! -f ".env.local" ]; then
     sed -i "s|^SOUL_PATH=.*|SOUL_PATH=$SOUL_DIR|" .env.local
   fi
 
-  ADMIN_EMAIL=$(grep -E '^ADMIN_EMAIL=' .env.local | cut -d= -f2-)
   echo "✅ .env.local created with generated secrets"
-  echo ""
-  echo "   🔑 Sign in with these admin credentials (also saved in .env.local):"
-  echo "        email:    ${ADMIN_EMAIL:-admin@tulipfarm.dev}"
-  echo "        password: $ADMIN_PASSWORD"
 else
-  echo "✅ .env.local already exists (sign-in creds: ADMIN_EMAIL / ADMIN_PASSWORD in .env.local)"
+  echo "✅ .env.local already exists"
   if [ -n "$DATABASE_URL_OVERRIDE" ]; then
     echo "ℹ Docker mode: ensure DATABASE_URL in .env.local is:"
     echo "    $DATABASE_URL_OVERRIDE"
@@ -270,9 +281,8 @@ echo "✨ Setup complete!"
 echo ""
 echo "Next steps:"
 echo "  1. Run: pnpm dev"
-echo "  2. Web UI:  http://localhost:4000   (API: http://localhost:4010)"
-echo "  3. Sign in at /login with the admin email + password above"
-echo "     (or read them from .env.local: ADMIN_EMAIL / ADMIN_PASSWORD)"
+echo "  2. Open: http://localhost:4000"
+echo "  3. Complete the setup wizard in the browser (creates your admin account)"
 echo ""
 echo "To verify the datastore is running:"
 if [ "$DB_MODE" = "docker" ]; then


### PR DESCRIPTION
## Summary

- **Drop `SETUP_MODE` entirely** — the env var was written by the installer but never read by app code. Managed vs wizard were functionally identical outputs anyway.
- **Auto-detect headless boot**: if `ADMIN_EMAIL + ADMIN_PASSWORD + LLM_API_KEY` are all set, `bootstrapFromEnv()` seeds the DB on startup and skips the wizard. Prod fails loud if admin creds are set but `LLM_API_KEY` is missing.
- **`setupComplete: true` in soul.yaml** is the fast-path source of truth — checked before any DB query so every page load doesn't hit Postgres.
- **Web wizard** (`/setup`): 4-step Remix route (Admin → Business → LLM → Git). Writes to DB + soul volume, never touches `.env`. Auto-redirects to `/` on completion; `_app.tsx` redirects to `/setup` when `needsSetup=true`.
- **Dev shortcut**: `setup-dev.sh` now seeds `setupComplete: true` in the soul stub so local dev skips the wizard entirely.

## Files changed

| Area | Change |
|---|---|
| `apps/api/src/setup/` | New module: `soul-config.ts`, `service.ts`, `bootstrap.ts`, `routes.ts` + tests |
| `apps/api/src/app.ts` | Register setup routes conditionally (not in headless mode) |
| `apps/api/src/index.ts` | Call `bootstrapFromEnv()` instead of `bootstrapAdmin()` |
| `apps/web/app/routes/setup.tsx` | New 4-step setup wizard |
| `apps/web/app/lib/setup.ts` | API client helpers for all setup endpoints |
| `apps/web/app/routes/_app.tsx` | Redirect to `/setup` when `needsSetup=true` |
| `.env.example` | Replace `SETUP_MODE` block with headless seeding vars |
| `docker-compose.yml` | Remove `SETUP_MODE` env passthrough |
| `scripts/get.tulipfarm.sh` | Remove `SETUP_MODE=wizard` from `write_env()` |
| `scripts/setup-dev.sh` | Seed `setupComplete: true` in dev soul stub |

## Test plan

- [ ] `pnpm --filter @tulipfarm/api test run -- src/setup/` — 17 tests pass
- [ ] `pnpm --filter @tulipfarm/api exec tsc --noEmit` — no errors
- [ ] `pnpm --filter @tulipfarm/web exec tsc --noEmit` — no errors
- [ ] `pnpm build` — full build green
- [ ] Fresh install (no env vars set) → browser shows `/setup` wizard → completes → `setupComplete: true` written to soul.yaml
- [ ] Headless install (`ADMIN_EMAIL + ADMIN_PASSWORD + LLM_API_KEY` set) → wizard routes return 404, app boots with admin seeded
- [ ] `scripts/setup-dev.sh` run → dev skips wizard (soul stub has `setupComplete: true`)