### PR TITLE
feat(integrations): setup guides, per-field hints, and OAuth flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,22 +31,22 @@ WEBHOOK_SIGNING_SECRET=CHANGE_ME_BASE64
 
 # --- Soul ---
 SOUL_PATH=/opt/tulipfarm/soul
-# Optional git remote for soul backup/sync (INST-014). Token stored encrypted by
-# the wizard; for managed mode supply here.
+# Optional git remote for soul backup/sync. Activate by setting both; restart to apply.
 # GIT_REMOTE_URL=
 # GIT_CREDENTIALS=
 
-# --- Bootstrap mode (INST-003b) ---
-# wizard  : CLI install — the web setup/onboarding wizard runs (default).
-# managed : container-platform / BYO — no wizard; seed from env below, /api/v1/setup/* -> 404.
-SETUP_MODE=wizard
-# Managed-mode seed fields (required when SETUP_MODE=managed):
+# --- Headless seeding (container platforms: Cloud Run, Fly, App Service) ---
+# Set ALL THREE to skip the web setup wizard and seed on first boot automatically.
+# The app detects these at startup: if ADMIN_EMAIL + ADMIN_PASSWORD + LLM_API_KEY are
+# all present it seeds and marks setup complete; the web wizard never appears.
+# Partial (admin creds without LLM_API_KEY) → refused at startup with a clear error.
+# Leave all three unset to use the interactive web setup wizard (curl|bash installs).
 # ADMIN_EMAIL=
 # ADMIN_PASSWORD=
-# BUSINESS_NAME=
-# BUSINESS_DESCRIPTION=
 # LLM_PROVIDER=anthropic
 # LLM_API_KEY=
+# BUSINESS_NAME=
+# BUSINESS_DESCRIPTION=
 
 # --- Misc ---
 PORT=8080

--- a/.env.local.example
+++ b/.env.local.example
@@ -2,6 +2,8 @@
 
 # Datastore (local via Homebrew or Docker)
 # Postgres is the single V1 datastore (pgvector + pg-boss).
+# setup-dev.sh rewrites this value — Docker gets a TCP URL with credentials,
+# Linux native gets a Unix-socket URL (postgres:///tulipfarm?host=<socket-dir>).
 DATABASE_URL=postgres://localhost:5432/tulipfarm
 
 # Soul repo path — MUST be an absolute path to a dedicated directory OUTSIDE this project, so the
@@ -16,11 +18,10 @@ JWT_SECRET=<generate: openssl rand -base64 32>
 WEBHOOK_SIGNING_SECRET=<generate: openssl rand -base64 32>
 
 # Session auth (issue #7)
-# Bootstrap admin: first user created on boot if no users exist.
-# Must be a valid email (login validates format: "email" — a no-TLD address
-# like admin@localhost is rejected with 400, so the admin could never log in).
-ADMIN_EMAIL=admin@tulipfarm.dev
-ADMIN_PASSWORD=<set a strong password>
+# Bootstrap admin: bypasses the setup wizard — only set these for headless/CI deployments.
+# Leave commented to use the first-run setup wizard in the browser.
+# ADMIN_EMAIL=admin@tulipfarm.dev
+# ADMIN_PASSWORD=<set a strong password>
 # Session cookie TTL in seconds (default 604800 = 7 days)
 SESSION_TTL_SECONDS=604800
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -16,6 +16,7 @@
     "@fastify/helmet": "^13.0.2",
     "@fastify/static": "^8.2.0",
     "@fastify/swagger": "^9.7.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@node-rs/argon2": "^2.0.2",
     "@scalar/fastify-api-reference": "^1.59.2",
     "@tulipfarm/llm": "workspace:*",

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -40,6 +40,8 @@ import type { RateLimiter } from "./rate-limit";
 import type { CounterStore, ResourceRepoFactory } from "./resources/repo";
 import { registerResourceRoutes } from "./resources/routes";
 import { registerSecretsRoutes } from "./secrets/routes";
+import { registerSetupRoutes, registerSetupStatusRoute } from "./setup/routes";
+import { isHeadlessBoot } from "./setup/service";
 import { registerAgentRoutes } from "./soul/agents/routes";
 import { makeLlmCascadeOnSecretDelete } from "./soul/llm-config/cascade";
 import { registerLlmConfigRoutes } from "./soul/llm-config/routes";
@@ -194,6 +196,23 @@ export async function buildApp(opts: AppOptions = {}) {
       rateLimiter: opts.rateLimiter,
     });
     const requireAuth = makeRequireAuth(opts.sessionStore, opts.userRepo, opts.tokenRepo);
+    // Setup status: always registered so the web app gets an explicit 200 in all boot modes.
+    // In headless boot the wizard step routes below are absent (404), but status is always reachable.
+    const soulPath = process.env.SOUL_PATH;
+    if (soulPath) {
+      registerSetupStatusRoute(app, { userRepo: opts.userRepo, soulPath });
+    }
+    // Wizard step routes: only registered when NOT in headless boot (AC-005).
+    if (!isHeadlessBoot() && opts.secretsService && opts.gitSync && soulPath) {
+      registerSetupRoutes(app, {
+        userRepo: opts.userRepo,
+        sessionStore: opts.sessionStore,
+        secretsService: opts.secretsService,
+        gitSync: opts.gitSync,
+        soulPath,
+        requireAuth,
+      });
+    }
     if (opts.secretsService) {
       registerSecretsRoutes(app, opts.secretsService, requireAuth, {
         onSecretDeleted:

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -200,7 +200,11 @@ export async function buildApp(opts: AppOptions = {}) {
     // In headless boot the wizard step routes below are absent (404), but status is always reachable.
     const soulPath = process.env.SOUL_PATH;
     if (soulPath) {
-      registerSetupStatusRoute(app, { userRepo: opts.userRepo, soulPath });
+      registerSetupStatusRoute(app, {
+        userRepo: opts.userRepo,
+        soulPath,
+        rateLimiter: opts.rateLimiter,
+      });
     }
     // Wizard step routes: only registered when NOT in headless boot (AC-005).
     if (!isHeadlessBoot() && opts.secretsService && opts.gitSync && soulPath) {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -289,6 +289,16 @@ export async function buildApp(opts: AppOptions = {}) {
           mcpClient: mcpClientSvc,
           soulLoader: opts.soulLoader,
         });
+      // When an external registry is provided (e.g. from index.ts which builds the full registry
+      // separately), the inner buildToolRegistry above is skipped, so mcpClientSvc never gets its
+      // registry wired. Do it here so integration tools registered on connect/disconnect land in
+      // the same registry the chat turn uses.
+      if (opts.toolRegistry) {
+        mcpClientSvc.setRegistry(opts.toolRegistry);
+        if (opts.soulLoader?.integrations) {
+          void mcpClientSvc.startAll(opts.soulLoader.integrations);
+        }
+      }
       const approvalRegistry = opts.approvalRegistry ?? new ApprovalRegistry();
       registerChatRoutes(
         app,

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -30,6 +30,7 @@ import type { FeedbackRepo } from "./feedback/repo";
 import { registerFeedbackRoutes } from "./feedback/routes";
 import type { GuardrailsService } from "./guardrails";
 import type { HookExecutor } from "./hooks/hook-executor";
+import { McpClientService } from "./integrations/mcp-client-service";
 import { registerKnowledgeRoutes } from "./knowledge/routes";
 import type { KnowledgeService } from "./knowledge/service";
 import { registerKvRoutes } from "./kv/routes";
@@ -43,6 +44,7 @@ import { registerSecretsRoutes } from "./secrets/routes";
 import { registerSetupRoutes, registerSetupStatusRoute } from "./setup/routes";
 import { isHeadlessBoot } from "./setup/service";
 import { registerAgentRoutes } from "./soul/agents/routes";
+import { registerIntegrationRoutes } from "./soul/integrations/routes";
 import { makeLlmCascadeOnSecretDelete } from "./soul/llm-config/cascade";
 import { registerLlmConfigRoutes } from "./soul/llm-config/routes";
 import { registerResourceTypeRoutes } from "./soul/resource-types/routes";
@@ -74,6 +76,7 @@ export interface AppOptions {
   kvService?: KvService;
   knowledgeService?: KnowledgeService;
   toolRegistry?: ToolRegistry;
+  mcpClient?: McpClientService;
   approvalRegistry?: ApprovalRegistry;
   guardrailsService?: GuardrailsService;
   pendingInteractionRepo?: PendingInteractionRepo;
@@ -196,6 +199,9 @@ export async function buildApp(opts: AppOptions = {}) {
       rateLimiter: opts.rateLimiter,
     });
     const requireAuth = makeRequireAuth(opts.sessionStore, opts.userRepo, opts.tokenRepo);
+    // MCP client service: created once, shared between integration routes (connect/disconnect) and
+    // the tool registry (dynamic tool registration). Accepts an optional override for testing.
+    const mcpClientSvc = opts.mcpClient ?? new McpClientService(app.log);
     // Setup status: always registered so the web app gets an explicit 200 in all boot modes.
     // In headless boot the wizard step routes below are absent (404), but status is always reachable.
     const soulPath = process.env.SOUL_PATH;
@@ -246,6 +252,7 @@ export async function buildApp(opts: AppOptions = {}) {
         );
         registerAgentRoutes(app, opts.soulLoader, requireAuth);
         registerOnboardingRoutes(app, opts.soulLoader, requireAuth);
+        registerIntegrationRoutes(app, opts.soulLoader, opts.gitSync, mcpClientSvc, requireAuth);
         if (opts.llmService) {
           registerSkillRoutes(app, opts.soulLoader, opts.gitSync, opts.llmService, requireAuth);
           if (opts.secretsService) {
@@ -279,6 +286,8 @@ export async function buildApp(opts: AppOptions = {}) {
           workingMemory: opts.workingMemoryService,
           kv: opts.kvService,
           knowledge: opts.knowledgeService,
+          mcpClient: mcpClientSvc,
+          soulLoader: opts.soulLoader,
         });
       const approvalRegistry = opts.approvalRegistry ?? new ApprovalRegistry();
       registerChatRoutes(

--- a/apps/api/src/context/assemble.ts
+++ b/apps/api/src/context/assemble.ts
@@ -202,7 +202,7 @@ function renderSoulContext(ctx: AssembleContext): string {
  * `<available-tools>` budget — total chars across all tool `name`+`description` pairs. Over this
  * the whole block is dropped (never half-rendered), matching `renderAvailableSkills`.
  */
-const MAX_AVAILABLE_TOOLS_CHARS = 8000;
+const MAX_AVAILABLE_TOOLS_CHARS = 24000;
 
 /**
  * `<available-tools>` block (Tools, CONTEXT-ENGINE §1). The tool L1 index: one `- name: description`

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -14,7 +14,7 @@ import { PgA2uiSurfaceStore } from "./a2ui/surface-store";
 import { buildApp } from "./app";
 import { PgTokenRepo } from "./auth/api-tokens";
 import { DEFAULT_SESSION_TTL_SECONDS, PgSessionStore } from "./auth/session-store";
-import { bootstrapAdmin, PgUserRepo } from "./auth/users";
+import { PgUserRepo } from "./auth/users";
 import { PgConversationRepo } from "./chat/conversations";
 import { PgMessageRepo } from "./chat/messages";
 import { PgPendingInteractionRepo } from "./chat/pending-interactions";
@@ -45,6 +45,7 @@ import { runPgMigrations } from "./pg-migrate";
 import { PgRateLimiter } from "./rate-limit";
 import { reconcileResourceTables, registerResourceReconcile } from "./resources/reconcile";
 import { PgCounterStore, PgResourceRepoFactory } from "./resources/repo";
+import { bootstrapFromEnv } from "./setup/bootstrap";
 import { PLATFORM_AGENTS } from "./soul/agents/platform-agents";
 import { BUILTIN_SKILLS } from "./soul/skills/builtin-skills";
 import { registerSoulSync } from "./soul-sync";
@@ -206,7 +207,12 @@ async function boot() {
     registerGuardrailsReload(gitSync, soulLoader, guardrailsService, app.log);
     registerResourceReconcile(gitSync, soulLoader, pool, app.log);
     logEnvironmentStatus(app.log);
-    await bootstrapAdmin(userRepo, app.log);
+    await bootstrapFromEnv({
+      userRepo,
+      secretsService,
+      soulPath: process.env.SOUL_PATH as string,
+      log: app.log,
+    });
 
     await registerSoulSync(boss, gitSync, process.env.GIT_REMOTE_URL);
     await registerStreamGc(boss, streamResumeRepo);

--- a/apps/api/src/integrations/mcp-client-service.ts
+++ b/apps/api/src/integrations/mcp-client-service.ts
@@ -89,6 +89,10 @@ export class McpClientService {
     return this.connections.get(name)?.errorMessage;
   }
 
+  getToolNames(name: string): string[] {
+    return this.connections.get(name)?.toolNames ?? [];
+  }
+
   async connect(
     name: string,
     manifest: IntegrationManifest,

--- a/apps/api/src/integrations/mcp-client-service.ts
+++ b/apps/api/src/integrations/mcp-client-service.ts
@@ -1,0 +1,219 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type {
+  IntegrationConnection,
+  IntegrationManifest,
+  Logger,
+  McpEntry,
+  SoulIntegration,
+} from "@tulipfarm/soul";
+import type { ToolRegistry } from "../tools/registry";
+import type { ToolDef } from "../tools/types";
+import { ok, err as toolErr } from "../tools/types";
+
+export type McpConnectionStatus = "connecting" | "connected" | "error" | "disconnected";
+
+interface ConnectionEntry {
+  client: Client;
+  transport: { close(): Promise<void> };
+  status: McpConnectionStatus;
+  errorMessage?: string;
+  toolNames: string[];
+}
+
+function integrationToolName(integrationName: string, mcpToolName: string): string {
+  return `integration_${integrationName}_${mcpToolName}`;
+}
+
+function buildToolDefs(
+  integrationName: string,
+  mcpTools: Array<{ name: string; description?: string; inputSchema?: Record<string, unknown> }>,
+  callFn: (toolName: string, args: unknown) => Promise<ReturnType<typeof ok | typeof toolErr>>
+): ToolDef[] {
+  return mcpTools.map((t) => ({
+    name: integrationToolName(integrationName, t.name),
+    tier: "integration" as const,
+    mutating: true, // conservative: MCP tools may mutate; individual tools can't declare otherwise
+    description: t.description ?? `${integrationName}: ${t.name}`,
+    inputSchema: t.inputSchema ?? { type: "object", properties: {} },
+    execute: async (args: unknown) => callFn(t.name, args),
+  }));
+}
+
+/**
+ * Manages MCP client connections for `type: mcp` integrations. Lifecycle:
+ *   startAll() → connect all enabled soul integrations at startup
+ *   connect()  → start a single integration (also called by the connect route)
+ *   disconnect() → stop and unregister
+ *
+ * Crash isolation: a server crash marks the entry as `error` but never throws to the caller.
+ */
+export class McpClientService {
+  private readonly connections = new Map<string, ConnectionEntry>();
+  private registry: ToolRegistry | null = null;
+
+  constructor(private readonly logger: Logger) {}
+
+  /** Called once after ToolRegistry is built. McpClientService then registers/unregisters tools directly. */
+  setRegistry(registry: ToolRegistry): void {
+    this.registry = registry;
+  }
+
+  /** Connect all soul integrations that have connection.enabled = true. Non-fatal on individual failures. */
+  async startAll(integrations: Map<string, SoulIntegration>): Promise<void> {
+    for (const integration of integrations.values()) {
+      if (integration.connection?.enabled) {
+        try {
+          await this.connect(integration.name, integration.manifest, integration.connection);
+        } catch (e) {
+          this.logger.warn(
+            `MCP: failed to start integration "${integration.name}" at startup — ${e instanceof Error ? e.message : String(e)}`
+          );
+        }
+      }
+    }
+  }
+
+  getStatus(name: string): McpConnectionStatus {
+    return this.connections.get(name)?.status ?? "disconnected";
+  }
+
+  getStatusAll(): Map<string, McpConnectionStatus> {
+    const out = new Map<string, McpConnectionStatus>();
+    for (const [name, entry] of this.connections) out.set(name, entry.status);
+    return out;
+  }
+
+  getErrorMessage(name: string): string | undefined {
+    return this.connections.get(name)?.errorMessage;
+  }
+
+  async connect(
+    name: string,
+    manifest: IntegrationManifest,
+    connection: IntegrationConnection
+  ): Promise<void> {
+    // Disconnect existing connection first (idempotent re-connect)
+    if (this.connections.has(name)) await this.disconnect(name);
+
+    const entry: ConnectionEntry = {
+      client: new Client({ name: "tulipfarm", version: "1" }),
+      transport: null as unknown as { close(): Promise<void> },
+      status: "connecting",
+      toolNames: [],
+    };
+    this.connections.set(name, entry);
+
+    try {
+      const transport = buildTransport(manifest.entry, connection.env ?? {});
+      entry.transport = transport;
+
+      // Crash isolation: if the server closes unexpectedly, mark as error
+      entry.client.onclose = () => {
+        const e = this.connections.get(name);
+        if (e && e.status === "connected") {
+          e.status = "error";
+          e.errorMessage = "MCP server closed unexpectedly";
+          this.logger.warn(`MCP: server "${name}" closed unexpectedly`);
+          if (this.registry) {
+            for (const toolName of e.toolNames) this.registry.unregister(toolName);
+          }
+          e.toolNames = [];
+        }
+      };
+
+      await entry.client.connect(transport);
+
+      const { tools } = await entry.client.listTools();
+      const mcpTools = tools.map((t) => ({
+        name: t.name,
+        description: t.description,
+        inputSchema: t.inputSchema as Record<string, unknown>,
+      }));
+
+      const toolDefs = buildToolDefs(name, mcpTools, (toolName, args) =>
+        this.callTool(name, toolName, args)
+      );
+
+      if (this.registry) {
+        for (const def of toolDefs) this.registry.register(def);
+      }
+
+      entry.toolNames = toolDefs.map((d) => d.name);
+      entry.status = "connected";
+
+      this.logger.info(`MCP: integration "${name}" connected (${tools.length} tool(s))`);
+    } catch (e) {
+      entry.status = "error";
+      entry.errorMessage = e instanceof Error ? e.message : String(e);
+      throw e;
+    }
+  }
+
+  async disconnect(name: string): Promise<void> {
+    const entry = this.connections.get(name);
+    if (!entry) return;
+
+    if (this.registry) {
+      for (const toolName of entry.toolNames) this.registry.unregister(toolName);
+    }
+    entry.toolNames = [];
+    entry.status = "disconnected";
+
+    try {
+      await entry.transport?.close();
+    } catch {
+      // best-effort close
+    }
+    try {
+      await entry.client?.close();
+    } catch {
+      // best-effort close
+    }
+
+    this.connections.delete(name);
+    this.logger.info(`MCP: integration "${name}" disconnected`);
+  }
+
+  private async callTool(
+    integrationName: string,
+    toolName: string,
+    args: unknown
+  ): Promise<ReturnType<typeof ok> | ReturnType<typeof toolErr>> {
+    const entry = this.connections.get(integrationName);
+    if (entry?.status !== "connected") {
+      return toolErr(
+        "internal_error",
+        `integration "${integrationName}" is not connected (status: ${entry ? entry.status : "disconnected"})`
+      );
+    }
+    try {
+      const result = await entry.client.callTool({
+        name: toolName,
+        arguments: args as Record<string, unknown>,
+      });
+      return ok(result);
+    } catch (e) {
+      return toolErr("internal_error", e instanceof Error ? e.message : String(e));
+    }
+  }
+}
+
+function buildTransport(
+  entry: McpEntry,
+  env: Record<string, string>
+): { close(): Promise<void> } & Parameters<Client["connect"]>[0] {
+  if (entry.transport === "stdio") {
+    return new StdioClientTransport({
+      command: entry.command,
+      args: entry.args ?? [],
+      env: { ...process.env, ...env } as Record<string, string>,
+      stderr: "pipe",
+    });
+  }
+  // SSE / StreamableHTTP
+  const url = new URL(entry.url);
+  const headers: Record<string, string> = { ...(entry.headers ?? {}), ...env };
+  return new StreamableHTTPClientTransport(url, { requestInit: { headers } });
+}

--- a/apps/api/src/setup/bootstrap.test.ts
+++ b/apps/api/src/setup/bootstrap.test.ts
@@ -1,0 +1,131 @@
+import crypto, { randomBytes, randomUUID } from "node:crypto";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type SecretDoc,
+  type SecretEnvelopeFields,
+  type SecretMeta,
+  type SecretRepo,
+  SecretsService,
+} from "@tulipfarm/secrets";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { parse } from "yaml";
+import type { UserDoc, UserRepo } from "../auth/users";
+import { bootstrapFromEnv } from "./bootstrap";
+
+class FakeUserRepo implements UserRepo {
+  users: UserDoc[] = [];
+  async findByEmail(e: string) {
+    return this.users.find((u) => u.email === e.trim().toLowerCase()) ?? null;
+  }
+  async findById(id: string) {
+    return this.users.find((u) => u._id === id) ?? null;
+  }
+  async count() {
+    return this.users.length;
+  }
+  async insert(u: UserDoc) {
+    this.users.push(u);
+  }
+}
+
+class FakeSecretRepo implements SecretRepo {
+  map = new Map<string, SecretDoc>();
+  async list(): Promise<SecretMeta[]> {
+    return [...this.map.values()].map((d) => ({
+      key: d.key,
+      type: d.type,
+      createdAt: d.createdAt,
+      updatedAt: d.updatedAt,
+    }));
+  }
+  async findByKey(key: string) {
+    return this.map.get(key) ?? null;
+  }
+  async upsert(key: string, fields: SecretEnvelopeFields) {
+    const now = new Date();
+    this.map.set(key, {
+      _id: key,
+      key,
+      ...fields,
+      dekId: fields.dekId ?? null,
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
+  async delete(key: string) {
+    this.map.delete(key);
+  }
+  async listLegacyKeys() {
+    return [];
+  }
+}
+
+let dir: string;
+function deps() {
+  return {
+    userRepo: new FakeUserRepo(),
+    secretsService: new SecretsService(new FakeSecretRepo(), {
+      dekId: randomUUID(),
+      key: randomBytes(32),
+    }),
+    soulPath: path.join(dir, "soul"),
+  };
+}
+
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), "bootstrap-"));
+  vi.stubEnv("ENCRYPTION_KEY", crypto.randomBytes(32).toString("base64"));
+  vi.stubEnv("NODE_ENV", "production");
+});
+afterEach(async () => {
+  await fs.rm(dir, { recursive: true, force: true });
+  vi.unstubAllEnvs();
+});
+
+describe("bootstrapFromEnv", () => {
+  it("no env vars → no-op (wizard handles first-run)", async () => {
+    const d = deps();
+    await bootstrapFromEnv(d);
+    expect(await d.userRepo.count()).toBe(0);
+  });
+
+  it("seeds admin + business + llm from env and marks setupComplete (idempotent)", async () => {
+    vi.stubEnv("ADMIN_EMAIL", "admin@acme.io");
+    vi.stubEnv("ADMIN_PASSWORD", "supersecret");
+    vi.stubEnv("BUSINESS_NAME", "Acme");
+    vi.stubEnv("LLM_API_KEY", "sk-ant-xyz");
+    const d = deps();
+    await bootstrapFromEnv(d);
+    await bootstrapFromEnv(d); // second call is a no-op (user already exists)
+    expect(await d.userRepo.count()).toBe(1);
+    const cfg = parse(await fs.readFile(path.join(dir, "soul", "soul.yaml"), "utf8")) as {
+      businessName?: string;
+      setupComplete?: boolean;
+    };
+    expect(cfg.businessName).toBe("Acme");
+    expect(cfg.setupComplete).toBe(true);
+    expect(await d.secretsService.get("anthropic-api-key")).toBe("sk-ant-xyz");
+  });
+
+  it("production: admin creds set but LLM_API_KEY missing → fail loud", async () => {
+    vi.stubEnv("ADMIN_EMAIL", "admin@acme.io");
+    vi.stubEnv("ADMIN_PASSWORD", "supersecret");
+    // LLM_API_KEY intentionally omitted
+    await expect(bootstrapFromEnv(deps())).rejects.toThrow(/LLM_API_KEY/);
+  });
+
+  it("non-production: admin creds set, LLM_API_KEY missing → seed admin + mark complete", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("ADMIN_EMAIL", "admin@acme.io");
+    vi.stubEnv("ADMIN_PASSWORD", "supersecret");
+    const d = deps();
+    await bootstrapFromEnv(d);
+    expect(await d.userRepo.count()).toBe(1);
+    const cfg = parse(await fs.readFile(path.join(dir, "soul", "soul.yaml"), "utf8")) as {
+      setupComplete?: boolean;
+    };
+    expect(cfg.setupComplete).toBe(true);
+  });
+});

--- a/apps/api/src/setup/bootstrap.ts
+++ b/apps/api/src/setup/bootstrap.ts
@@ -1,0 +1,64 @@
+import type { SecretsService } from "@tulipfarm/secrets";
+import { createUser, normalizeEmail, type UserRepo } from "../auth/users";
+import { isProductionMode } from "./service";
+import { patchSoulConfig } from "./soul-config";
+
+export interface BootstrapDeps {
+  userRepo: UserRepo;
+  secretsService: SecretsService;
+  soulPath: string;
+  log?: { info: (msg: string) => void; error: (msg: string) => void };
+}
+
+function llmProvider(): "anthropic" | "openai" {
+  return process.env.LLM_PROVIDER === "openai" ? "openai" : "anthropic";
+}
+
+// Seeds the instance from env vars on first boot. Idempotent (no-op once users exist).
+//
+// Trigger conditions:
+//   - ADMIN_EMAIL + ADMIN_PASSWORD + LLM_API_KEY all set → full headless seed (any env)
+//   - ADMIN_EMAIL + ADMIN_PASSWORD set, LLM_API_KEY missing:
+//       production → fail loud (refuse to boot)
+//       non-production → seed admin only; developer configures LLM via Settings
+//   - None of the above → no-op; wizard handles first-run via web UI
+//
+// After seeding, marks setupComplete=true in soul.yaml so the wizard never shows.
+export async function bootstrapFromEnv(deps: BootstrapDeps): Promise<void> {
+  const adminEmail = process.env.ADMIN_EMAIL;
+  const adminPass = process.env.ADMIN_PASSWORD;
+  const llmKey = process.env.LLM_API_KEY;
+
+  if (!adminEmail || !adminPass) return;
+
+  // Partial headless: admin creds present but no LLM key → fail loud in production
+  if (!llmKey && isProductionMode()) {
+    throw new Error(
+      "ADMIN_EMAIL + ADMIN_PASSWORD are set but LLM_API_KEY is missing. " +
+        "Production headless deployments require all three. " +
+        "Add LLM_API_KEY or remove ADMIN_EMAIL/ADMIN_PASSWORD to use the setup wizard."
+    );
+  }
+
+  if ((await deps.userRepo.count()) === 0) {
+    await createUser(deps.userRepo, adminEmail, adminPass, "admin");
+    deps.log?.info(`Bootstrapped admin user ${normalizeEmail(adminEmail)}`);
+  }
+
+  if (process.env.BUSINESS_NAME) {
+    await patchSoulConfig(deps.soulPath, {
+      businessName: process.env.BUSINESS_NAME,
+      businessDescription: process.env.BUSINESS_DESCRIPTION ?? "",
+    });
+  }
+
+  if (llmKey) {
+    await deps.secretsService.set(`${llmProvider()}-api-key`, llmKey);
+    deps.log?.info(`Seeded ${llmProvider()} LLM API key from env`);
+  } else {
+    deps.log?.info("LLM_API_KEY not set — configure LLM via Settings > LLM Config");
+  }
+
+  // Mark setup complete so the web wizard never appears
+  await patchSoulConfig(deps.soulPath, { setupComplete: true });
+}

--- a/apps/api/src/setup/routes.test.ts
+++ b/apps/api/src/setup/routes.test.ts
@@ -1,0 +1,285 @@
+import crypto, { randomBytes, randomUUID } from "node:crypto";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type SecretDoc,
+  type SecretEnvelopeFields,
+  type SecretMeta,
+  type SecretRepo,
+  SecretsService,
+} from "@tulipfarm/secrets";
+import { GitSyncService } from "@tulipfarm/soul";
+import type { FastifyInstance } from "fastify";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { parse } from "yaml";
+import { buildApp } from "../app";
+import type { TokenDoc, TokenRepo } from "../auth/api-tokens";
+import { CSRF_COOKIE, CSRF_HEADER } from "../auth/csrf";
+import { MemorySessionStore } from "../auth/session-store";
+import type { UserDoc, UserRepo } from "../auth/users";
+import type { PaginatedResult } from "../pagination";
+
+class FakeUserRepo implements UserRepo {
+  users: UserDoc[] = [];
+  async findByEmail(e: string) {
+    return this.users.find((u) => u.email === e.trim().toLowerCase()) ?? null;
+  }
+  async findById(id: string) {
+    return this.users.find((u) => u._id === id) ?? null;
+  }
+  async count() {
+    return this.users.length;
+  }
+  async insert(u: UserDoc) {
+    this.users.push(u);
+  }
+}
+
+class StubTokenRepo implements TokenRepo {
+  async create() {}
+  async findByHash() {
+    return null;
+  }
+  async findByUserId() {
+    return [];
+  }
+  async findAll() {
+    return [];
+  }
+  async findById() {
+    return null;
+  }
+  async deleteById() {}
+  async findAllPaginated(): Promise<PaginatedResult<TokenDoc>> {
+    return { items: [], nextCursor: null };
+  }
+  async findByUserIdPaginated(): Promise<PaginatedResult<TokenDoc>> {
+    return { items: [], nextCursor: null };
+  }
+}
+
+class FakeSecretRepo implements SecretRepo {
+  map = new Map<string, SecretDoc>();
+  async list(): Promise<SecretMeta[]> {
+    return [...this.map.values()].map((d) => ({
+      key: d.key,
+      type: d.type,
+      createdAt: d.createdAt,
+      updatedAt: d.updatedAt,
+    }));
+  }
+  async findByKey(key: string) {
+    return this.map.get(key) ?? null;
+  }
+  async upsert(key: string, fields: SecretEnvelopeFields) {
+    const now = new Date();
+    const prev = this.map.get(key);
+    this.map.set(key, {
+      _id: key,
+      key,
+      ...fields,
+      dekId: fields.dekId ?? null,
+      createdAt: prev?.createdAt ?? now,
+      updatedAt: now,
+    });
+  }
+  async delete(key: string) {
+    this.map.delete(key);
+  }
+  async listLegacyKeys() {
+    return [];
+  }
+}
+
+function cookieHeader(cookies: { name: string; value: string }[]): string {
+  return cookies.map((c) => `${c.name}=${c.value}`).join("; ");
+}
+
+async function makeApp(dir: string): Promise<FastifyInstance> {
+  const soulPath = path.join(dir, "soul");
+  vi.stubEnv("SOUL_PATH", soulPath);
+  vi.stubEnv("ENCRYPTION_KEY", crypto.randomBytes(32).toString("base64"));
+  return buildApp({
+    sessionStore: new MemorySessionStore(),
+    userRepo: new FakeUserRepo(),
+    tokenRepo: new StubTokenRepo(),
+    secretsService: new SecretsService(new FakeSecretRepo(), {
+      dekId: randomUUID(),
+      key: randomBytes(32),
+    }),
+    gitSync: new GitSyncService(soulPath, undefined, undefined, console),
+  });
+}
+
+let dir: string;
+let app: FastifyInstance;
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), "setup-"));
+  app = await makeApp(dir);
+});
+afterEach(async () => {
+  await app.close();
+  await fs.rm(dir, { recursive: true, force: true });
+  vi.unstubAllEnvs();
+});
+
+async function createAdmin(): Promise<{ name: string; value: string }[]> {
+  const res = await app.inject({
+    method: "POST",
+    url: "/api/v1/setup/admin",
+    payload: { email: "admin@acme.io", password: "supersecret" },
+  });
+  expect(res.statusCode).toBe(201);
+  return res.cookies;
+}
+
+function authHeaders(cookies: { name: string; value: string }[]) {
+  return {
+    cookie: cookieHeader(cookies),
+    [CSRF_HEADER]: cookies.find((c) => c.name === CSRF_COOKIE)?.value ?? "",
+  };
+}
+
+describe("setup routes", () => {
+  it("status reports needsSetup=true before any admin", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/v1/setup/status" });
+    expect(res.json()).toEqual({ needsSetup: true });
+  });
+
+  it("status reports needsSetup=false when setupComplete is set in soul.yaml", async () => {
+    // Simulate a dev setup (setup-dev.sh writes setupComplete: true)
+    await fs.mkdir(path.join(dir, "soul"), { recursive: true });
+    await fs.writeFile(path.join(dir, "soul", "soul.yaml"), "setupComplete: true\n", "utf8");
+    // Rebuild app so it reads the pre-existing soul
+    await app.close();
+    app = await makeApp(dir);
+    const res = await app.inject({ method: "GET", url: "/api/v1/setup/status" });
+    expect(res.json()).toEqual({ needsSetup: false });
+  });
+
+  it("creates the first admin, auto-logs in, then locks (403)", async () => {
+    const cookies = await createAdmin();
+    expect(cookies.some((c) => c.name === "tf_sid")).toBe(true);
+    const status = await app.inject({ method: "GET", url: "/api/v1/setup/status" });
+    // admin exists but setupComplete not set yet
+    expect(status.json()).toEqual({ needsSetup: false });
+    const again = await app.inject({
+      method: "POST",
+      url: "/api/v1/setup/admin",
+      payload: { email: "evil@acme.io", password: "supersecret" },
+    });
+    expect(again.statusCode).toBe(403);
+  });
+
+  it("business step persists name + description to soul.yaml", async () => {
+    const cookies = await createAdmin();
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/setup/business",
+      headers: authHeaders(cookies),
+      payload: { name: "Acme Tulips", description: "We sell tulips." },
+    });
+    expect(res.statusCode).toBe(204);
+    const cfg = parse(await fs.readFile(path.join(dir, "soul", "soul.yaml"), "utf8")) as {
+      businessName?: string;
+      businessDescription?: string;
+    };
+    expect(cfg.businessName).toBe("Acme Tulips");
+    expect(cfg.businessDescription).toBe("We sell tulips.");
+  });
+
+  it("llm step stores the key (no live call in unit tests)", async () => {
+    const cookies = await createAdmin();
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/setup/llm",
+      headers: authHeaders(cookies),
+      payload: { provider: "anthropic", apiKey: "sk-ant-test" },
+    });
+    // In unit tests the generateText call will fail (no real API); it's a transient error
+    // so the route returns 204 anyway (key kept)
+    expect(res.statusCode).toBe(204);
+  });
+
+  it("llm step rejects an empty key", async () => {
+    const cookies = await createAdmin();
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/setup/llm",
+      headers: authHeaders(cookies),
+      payload: { provider: "anthropic", apiKey: "" },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("git step stores remote URL in soul.yaml", async () => {
+    const cookies = await createAdmin();
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/setup/git",
+      headers: authHeaders(cookies),
+      payload: { remoteUrl: "https://github.com/acme/soul.git" },
+    });
+    expect(res.statusCode).toBe(204);
+    const cfg = parse(await fs.readFile(path.join(dir, "soul", "soul.yaml"), "utf8")) as {
+      gitRemoteUrl?: string;
+    };
+    expect(cfg.gitRemoteUrl).toBe("https://github.com/acme/soul.git");
+  });
+
+  it("business step requires auth", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/setup/business",
+      payload: { name: "X" },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("wizard steps lock once setup is complete", async () => {
+    const cookies = await createAdmin();
+    await app.inject({
+      method: "POST",
+      url: "/api/v1/setup/complete",
+      headers: authHeaders(cookies),
+    });
+    const after = await app.inject({
+      method: "POST",
+      url: "/api/v1/setup/business",
+      headers: authHeaders(cookies),
+      payload: { name: "Late" },
+    });
+    expect(after.statusCode).toBe(403);
+  });
+
+  it("complete marks setupComplete=true in soul.yaml", async () => {
+    const cookies = await createAdmin();
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/setup/complete",
+      headers: authHeaders(cookies),
+    });
+    expect(res.statusCode).toBe(204);
+    const cfg = parse(await fs.readFile(path.join(dir, "soul", "soul.yaml"), "utf8")) as {
+      setupComplete?: boolean;
+    };
+    expect(cfg.setupComplete).toBe(true);
+    const status = await app.inject({ method: "GET", url: "/api/v1/setup/status" });
+    expect(status.json()).toEqual({ needsSetup: false });
+  });
+
+  it("headless boot: status returns 200 needsSetup=false even when wizard routes absent", async () => {
+    await app.close();
+    vi.stubEnv("ADMIN_EMAIL", "admin@acme.io");
+    vi.stubEnv("ADMIN_PASSWORD", "supersecret");
+    vi.stubEnv("LLM_API_KEY", "sk-ant-test");
+    app = await makeApp(dir);
+    const res = await app.inject({ method: "GET", url: "/api/v1/setup/status" });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ needsSetup: false });
+    // Wizard step routes remain absent in headless mode
+    const adminRes = await app.inject({ method: "POST", url: "/api/v1/setup/admin", payload: {} });
+    expect(adminRes.statusCode).toBe(404);
+  });
+});

--- a/apps/api/src/setup/routes.ts
+++ b/apps/api/src/setup/routes.ts
@@ -8,6 +8,7 @@ import { SESSION_COOKIE } from "../auth/middleware";
 import { ErrorSchema, PublicUserSchema } from "../auth/schemas";
 import { DEFAULT_SESSION_TTL_SECONDS, type SessionStore } from "../auth/session-store";
 import { createUser, toPublicUser, type UserRepo } from "../auth/users";
+import { makeRateLimitHook, type RateLimiter } from "../rate-limit";
 import { isHeadlessBoot } from "./service";
 import { patchSoulConfig, readSoulConfig } from "./soul-config";
 
@@ -45,9 +46,13 @@ function setSessionCookies(reply: FastifyReply, sid: string, ttlSeconds: number)
 // so the web client can rely on an explicit 200 rather than treating 404 as "not needed".
 export function registerSetupStatusRoute(
   app: FastifyInstance,
-  deps: Pick<SetupDeps, "userRepo" | "soulPath">
+  deps: Pick<SetupDeps, "userRepo" | "soulPath"> & { rateLimiter?: RateLimiter }
 ): void {
-  const { userRepo, soulPath } = deps;
+  const { userRepo, soulPath, rateLimiter } = deps;
+  // 30 req/min per IP — generous for a status poll, protects DB/FS on cold path.
+  const preHandler = rateLimiter
+    ? makeRateLimitHook(rateLimiter, (req) => `rl:setup:${req.ip}`, 30, 60_000)
+    : undefined;
   // Closure-scoped cache: once setup is confirmed complete, skip all I/O for the
   // lifetime of this process. Resets naturally on restart (one cold check per boot).
   let done = false;
@@ -55,6 +60,7 @@ export function registerSetupStatusRoute(
   app.get(
     "/api/v1/setup/status",
     {
+      ...(preHandler ? { preHandler } : {}),
       schema: {
         description: "Whether first-run setup is still required.",
         tags: ["setup"],

--- a/apps/api/src/setup/routes.ts
+++ b/apps/api/src/setup/routes.ts
@@ -1,0 +1,332 @@
+import { createModel, LlmCredentialError } from "@tulipfarm/llm";
+import type { SecretsService } from "@tulipfarm/secrets";
+import type { GitSyncService } from "@tulipfarm/soul";
+import { generateText } from "ai";
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { generateCsrfToken, setCsrfCookie } from "../auth/csrf";
+import { SESSION_COOKIE } from "../auth/middleware";
+import { ErrorSchema, PublicUserSchema } from "../auth/schemas";
+import { DEFAULT_SESSION_TTL_SECONDS, type SessionStore } from "../auth/session-store";
+import { createUser, toPublicUser, type UserRepo } from "../auth/users";
+import { isHeadlessBoot } from "./service";
+import { patchSoulConfig, readSoulConfig } from "./soul-config";
+
+// Cheapest models per provider, used only to validate the API key on setup.
+const PROBE_MODEL: Record<string, string> = {
+  anthropic: "claude-haiku-4-5-20251001",
+  openai: "gpt-4o-mini",
+};
+
+type PreHandler = (req: FastifyRequest, reply: FastifyReply) => Promise<void>;
+
+export interface SetupDeps {
+  userRepo: UserRepo;
+  sessionStore: SessionStore;
+  secretsService: SecretsService;
+  gitSync: GitSyncService;
+  soulPath: string;
+  requireAuth: PreHandler;
+  ttlSeconds?: number;
+}
+
+function setSessionCookies(reply: FastifyReply, sid: string, ttlSeconds: number): void {
+  reply.setCookie(SESSION_COOKIE, sid, {
+    httpOnly: true,
+    sameSite: "strict",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: ttlSeconds,
+  });
+  setCsrfCookie(reply, generateCsrfToken(), ttlSeconds);
+}
+
+// Always-registered: returns needsSetup regardless of boot mode.
+// In headless boot all wizard step routes are absent (404), but this endpoint is always available
+// so the web client can rely on an explicit 200 rather than treating 404 as "not needed".
+export function registerSetupStatusRoute(
+  app: FastifyInstance,
+  deps: Pick<SetupDeps, "userRepo" | "soulPath">
+): void {
+  const { userRepo, soulPath } = deps;
+  // Closure-scoped cache: once setup is confirmed complete, skip all I/O for the
+  // lifetime of this process. Resets naturally on restart (one cold check per boot).
+  let done = false;
+
+  app.get(
+    "/api/v1/setup/status",
+    {
+      schema: {
+        description: "Whether first-run setup is still required.",
+        tags: ["setup"],
+        response: {
+          200: {
+            type: "object",
+            properties: { needsSetup: { type: "boolean" } },
+            required: ["needsSetup"],
+          },
+        },
+      },
+    },
+    async () => {
+      if (done) return { needsSetup: false };
+      if (isHeadlessBoot()) {
+        done = true;
+        return { needsSetup: false };
+      }
+      const cfg = await readSoulConfig(soulPath);
+      if (cfg.setupComplete === true) {
+        done = true;
+        return { needsSetup: false };
+      }
+      const hasUsers = (await userRepo.count()) > 0;
+      if (hasUsers) {
+        // Users exist but setupComplete missing from soul.yaml — soul.yaml was likely lost
+        // (e.g. volume loss after wizard completed). Treat as done; cache for this process
+        // lifetime but do NOT write setupComplete here: only POST /setup/complete owns that flag.
+        // On next restart a single DB query runs again, which is acceptable.
+        done = true;
+        return { needsSetup: false };
+      }
+      return { needsSetup: true };
+    }
+  );
+}
+
+// First-run setup wizard (INST-003). Routes are only registered when NOT in headless
+// boot mode (isHeadlessBoot() === false, checked by caller in app.ts).
+//
+// Guard hierarchy:
+//   POST /admin   → open only while no users exist (requireSetupOpen)
+//   POST /business, /llm, /git → auth + admin + setupComplete=false (wizardStep)
+//   POST /complete → auth + admin
+export function registerSetupRoutes(app: FastifyInstance, deps: SetupDeps): void {
+  const {
+    userRepo,
+    sessionStore,
+    secretsService,
+    gitSync,
+    soulPath,
+    requireAuth,
+    ttlSeconds = DEFAULT_SESSION_TTL_SECONDS,
+  } = deps;
+
+  async function requireSetupOpen(_req: FastifyRequest, reply: FastifyReply): Promise<void> {
+    if ((await userRepo.count()) > 0) {
+      return reply.code(403).send({ error: "setup already complete" });
+    }
+  }
+
+  async function requireAdmin(req: FastifyRequest, reply: FastifyReply): Promise<void> {
+    if (req.user?.role !== "admin") {
+      return reply.code(403).send({ error: "admin role required" });
+    }
+  }
+
+  async function requireSetupIncomplete(_req: FastifyRequest, reply: FastifyReply): Promise<void> {
+    if ((await readSoulConfig(soulPath)).setupComplete === true) {
+      return reply.code(403).send({ error: "setup already complete" });
+    }
+  }
+
+  const wizardStep: PreHandler[] = [requireAuth, requireAdmin, requireSetupIncomplete];
+
+  // Step 1: create the first admin and auto-login (sets session + CSRF cookies).
+  app.post(
+    "/api/v1/setup/admin",
+    {
+      preHandler: requireSetupOpen,
+      schema: {
+        description: "Create the first admin account and auto-login. Open until any admin exists.",
+        tags: ["setup"],
+        body: {
+          type: "object",
+          required: ["email", "password"],
+          properties: {
+            email: { type: "string", format: "email" },
+            password: { type: "string", minLength: 8 },
+          },
+        },
+        response: {
+          201: { type: "object", properties: { user: PublicUserSchema }, required: ["user"] },
+          400: ErrorSchema,
+          403: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const body = (req.body ?? {}) as { email?: unknown; password?: unknown };
+      const email = typeof body.email === "string" ? body.email : "";
+      const password = typeof body.password === "string" ? body.password : "";
+      if (!email || password.length < 8) {
+        return reply
+          .code(400)
+          .send({ error: "email and a password of at least 8 characters are required" });
+      }
+      const user = await createUser(userRepo, email, password, "admin");
+      const sid = await sessionStore.create(user._id);
+      setSessionCookies(reply, sid, ttlSeconds);
+      return reply.code(201).send({ user: toPublicUser(user) });
+    }
+  );
+
+  // Step 2: record business name + description in soul.yaml.
+  app.post(
+    "/api/v1/setup/business",
+    {
+      preHandler: wizardStep,
+      schema: {
+        description: "Record the business name + description in the soul.",
+        tags: ["setup"],
+        security: [{ sessionCookie: [] }],
+        body: {
+          type: "object",
+          required: ["name"],
+          properties: {
+            name: { type: "string", minLength: 1 },
+            description: { type: "string" },
+          },
+        },
+        response: {
+          204: { type: "null" },
+          400: ErrorSchema,
+          401: ErrorSchema,
+          403: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const body = (req.body ?? {}) as { name?: unknown; description?: unknown };
+      const name = typeof body.name === "string" ? body.name.trim() : "";
+      const description = typeof body.description === "string" ? body.description : "";
+      if (!name) return reply.code(400).send({ error: "name is required" });
+      await patchSoulConfig(soulPath, { businessName: name, businessDescription: description });
+      await gitSync.commit("chore: set business profile").catch(() => {});
+      return reply.code(204).send();
+    }
+  );
+
+  // Step 3: store + live-validate the LLM API key.
+  // Saves key first, then probes with a minimal generateText call.
+  // On credential error: removes key and returns 400 with a clear message.
+  // On transient error (network, rate-limit, 5xx): keeps the key and returns 204 with a warning
+  // so a bad network at setup time doesn't block the user.
+  app.post(
+    "/api/v1/setup/llm",
+    {
+      preHandler: wizardStep,
+      schema: {
+        description: "Store an LLM provider API key and validate it with a live probe.",
+        tags: ["setup"],
+        security: [{ sessionCookie: [] }],
+        body: {
+          type: "object",
+          required: ["provider", "apiKey"],
+          properties: {
+            provider: { type: "string", enum: ["anthropic", "openai"] },
+            apiKey: { type: "string", minLength: 1 },
+          },
+        },
+        response: {
+          204: { type: "null" },
+          400: ErrorSchema,
+          401: ErrorSchema,
+          403: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const body = (req.body ?? {}) as { provider?: unknown; apiKey?: unknown };
+      const provider = body.provider === "openai" ? "openai" : "anthropic";
+      const apiKey = typeof body.apiKey === "string" ? body.apiKey.trim() : "";
+      if (!apiKey) return reply.code(400).send({ error: "apiKey is required" });
+
+      const secretKey = `${provider}-api-key`;
+      await secretsService.set(secretKey, apiKey);
+
+      // Live probe: validate the key is accepted by the provider.
+      const probeModelId = PROBE_MODEL[provider] ?? "claude-haiku-4-5-20251001";
+      try {
+        const model = await createModel(
+          { provider, model: probeModelId, api_key_ref: secretKey },
+          secretsService
+        );
+        await generateText({ model, prompt: "ping" });
+      } catch (err) {
+        if (err instanceof LlmCredentialError) {
+          // Key is wrong — clean up and report the problem
+          await secretsService.delete(secretKey).catch(() => {});
+          return reply.code(400).send({ error: `API key is invalid: ${err.message}` });
+        }
+        // Transient (network, 5xx, rate-limit) — keep the key, let first chat surface any real issue
+        app.log.warn({ err }, "LLM probe returned a transient error during setup; key kept");
+      }
+
+      return reply.code(204).send();
+    }
+  );
+
+  // Step 4 (optional): configure soul git backup. Stores remote URL in soul.yaml and
+  // credentials as an encrypted secret. Git sync activates on next restart with
+  // GIT_REMOTE_URL + GIT_CREDENTIALS env vars; the stored values are for reference.
+  app.post(
+    "/api/v1/setup/git",
+    {
+      preHandler: wizardStep,
+      schema: {
+        description: "Configure soul git backup (optional). Persists remote URL + credentials.",
+        tags: ["setup"],
+        security: [{ sessionCookie: [] }],
+        body: {
+          type: "object",
+          required: ["remoteUrl"],
+          properties: {
+            remoteUrl: { type: "string", minLength: 1 },
+            credentials: { type: "string" },
+          },
+        },
+        response: {
+          204: { type: "null" },
+          400: ErrorSchema,
+          401: ErrorSchema,
+          403: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const body = (req.body ?? {}) as { remoteUrl?: unknown; credentials?: unknown };
+      const remoteUrl = typeof body.remoteUrl === "string" ? body.remoteUrl.trim() : "";
+      const credentials = typeof body.credentials === "string" ? body.credentials.trim() : "";
+      if (!remoteUrl) return reply.code(400).send({ error: "remoteUrl is required" });
+
+      await patchSoulConfig(soulPath, { gitRemoteUrl: remoteUrl });
+      if (credentials) {
+        await secretsService.set("git-credentials", credentials);
+      }
+      await gitSync.commit("chore: set git remote config").catch(() => {});
+      return reply.code(204).send();
+    }
+  );
+
+  // Final step: mark setup complete. Wizard steps become 403 after this.
+  app.post(
+    "/api/v1/setup/complete",
+    {
+      preHandler: [requireAuth, requireAdmin],
+      schema: {
+        description: "Mark first-run setup as complete.",
+        tags: ["setup"],
+        security: [{ sessionCookie: [] }],
+        response: {
+          204: { type: "null" },
+          401: ErrorSchema,
+          403: ErrorSchema,
+        },
+      },
+    },
+    async (_req, reply) => {
+      await patchSoulConfig(soulPath, { setupComplete: true });
+      await gitSync.commit("chore: complete first-run setup").catch(() => {});
+      return reply.code(204).send();
+    }
+  );
+}

--- a/apps/api/src/setup/service.ts
+++ b/apps/api/src/setup/service.ts
@@ -1,0 +1,12 @@
+// Headless boot: all three required together trigger automatic seeding and skip the wizard.
+// Container platforms (Cloud Run, Fly, App Service) supply all three via platform env config.
+// curl|bash installs supply none → wizard opens.
+// Partial: ADMIN creds set but no LLM_API_KEY → fail loud in production; allowed in dev
+// (developer configures LLM via Settings after first boot).
+export function isHeadlessBoot(): boolean {
+  return !!(process.env.ADMIN_EMAIL && process.env.ADMIN_PASSWORD && process.env.LLM_API_KEY);
+}
+
+export function isProductionMode(): boolean {
+  return process.env.NODE_ENV === "production";
+}

--- a/apps/api/src/setup/soul-config.ts
+++ b/apps/api/src/setup/soul-config.ts
@@ -1,0 +1,29 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { parse, stringify } from "yaml";
+
+export interface SoulConfig {
+  businessName?: string;
+  businessDescription?: string;
+  setupComplete?: boolean;
+  gitRemoteUrl?: string;
+  [key: string]: unknown;
+}
+
+function soulYamlPath(soulPath: string): string {
+  return path.join(soulPath, "soul.yaml");
+}
+
+export async function readSoulConfig(soulPath: string): Promise<SoulConfig> {
+  try {
+    return (parse(await fs.readFile(soulYamlPath(soulPath), "utf8")) as SoulConfig) ?? {};
+  } catch {
+    return {};
+  }
+}
+
+export async function patchSoulConfig(soulPath: string, patch: SoulConfig): Promise<void> {
+  await fs.mkdir(soulPath, { recursive: true });
+  const next = { ...(await readSoulConfig(soulPath)), ...patch };
+  await fs.writeFile(soulYamlPath(soulPath), stringify(next), "utf8");
+}

--- a/apps/api/src/soul/catalogue.test.ts
+++ b/apps/api/src/soul/catalogue.test.ts
@@ -31,9 +31,14 @@ const routine = (name: string, config: Record<string, unknown>): SoulRoutine => 
   config,
   hasHooks: false,
 });
-const integration = (name: string, connection: Record<string, unknown>): SoulIntegration => ({
+const integration = (name: string, description?: string): SoulIntegration => ({
   name,
-  connection,
+  manifest: {
+    name,
+    type: "mcp",
+    description,
+    entry: { transport: "stdio", command: "echo" },
+  },
 });
 
 function fakeLoader(
@@ -67,7 +72,7 @@ describe("buildSoulCatalogue", () => {
         ],
         resources: [resource("ticket", {}), resource("invoice", {})],
         routines: [routine("nightly", {}), routine("hourly", {})],
-        integrations: [integration("slack", {}), integration("github", {})],
+        integrations: [integration("slack"), integration("github")],
       })
     );
     // Platform agents are always present, sorted in among soul agents by name.
@@ -93,7 +98,7 @@ describe("buildSoulCatalogue", () => {
           resource("bare", {}),
         ],
         routines: [routine("r", { title: "Routine title" })],
-        integrations: [integration("i", { title: "Integration title" })],
+        integrations: [integration("i", "Integration title")],
       })
     );
     expect(cat.skills[0]?.description).toBe("Skill desc");

--- a/apps/api/src/soul/catalogue.ts
+++ b/apps/api/src/soul/catalogue.ts
@@ -75,7 +75,7 @@ export function buildSoulCatalogue(soulLoader: SoulLoader | undefined): SoulCata
   const integrations = values(soulLoader?.integrations)
     .map((i) => ({
       name: i.name,
-      description: asDesc(i.connection.description) || asDesc(i.connection.title),
+      description: asDesc(i.manifest.description),
     }))
     .sort(byName);
 

--- a/apps/api/src/soul/integrations/lock.ts
+++ b/apps/api/src/soul/integrations/lock.ts
@@ -1,0 +1,47 @@
+import { createHash } from "node:crypto";
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+export interface IntegrationLockEntry {
+  sourceUrl?: string;
+  sourceType?: string;
+  manifestPath?: string;
+  ref?: string;
+  hash?: string;
+}
+
+export interface IntegrationsLock {
+  version: number;
+  integrations: Record<string, IntegrationLockEntry>;
+}
+
+export async function readIntegrationsLock(soulPath: string): Promise<IntegrationsLock> {
+  try {
+    const parsed = JSON.parse(await readFile(join(soulPath, "integrations-lock.json"), "utf8")) as {
+      version?: number;
+      integrations?: Record<string, IntegrationLockEntry>;
+    };
+    return { version: parsed.version ?? 1, integrations: parsed.integrations ?? {} };
+  } catch {
+    return { version: 1, integrations: {} };
+  }
+}
+
+export async function writeIntegrationsLock(
+  soulPath: string,
+  lock: IntegrationsLock
+): Promise<void> {
+  await writeFile(
+    join(soulPath, "integrations-lock.json"),
+    `${JSON.stringify(lock, null, 2)}\n`,
+    "utf8"
+  );
+}
+
+export function hashContent(content: string): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+export function sourceType(source: string): "github" | "git" {
+  return /github\.com|^[\w.-]+\/[\w.-]+$/.test(source) ? "github" : "git";
+}

--- a/apps/api/src/soul/integrations/routes.ts
+++ b/apps/api/src/soul/integrations/routes.ts
@@ -377,6 +377,7 @@ export function registerIntegrationRoutes(
               manifest: { type: "object", additionalProperties: true },
               connected: { type: "boolean" },
               setupGuide: { type: "string" },
+              toolNames: { type: "array", items: { type: "string" } },
             },
           },
           401: ErrorSchema,
@@ -397,6 +398,7 @@ export function registerIntegrationRoutes(
         manifest: integration.manifest,
         connected: integration.connection?.enabled === true,
         setupGuide: integration.setupGuide,
+        toolNames: mcpClient.getToolNames(name),
       };
     }
   );
@@ -614,7 +616,7 @@ export function registerIntegrationRoutes(
         });
       }
 
-      return { status: mcpClient.getStatus(name), toolCount: 0 };
+      return { status: mcpClient.getStatus(name), toolCount: mcpClient.getToolNames(name).length };
     }
   );
 

--- a/apps/api/src/soul/integrations/routes.ts
+++ b/apps/api/src/soul/integrations/routes.ts
@@ -4,7 +4,7 @@ import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promis
 import { tmpdir } from "node:os";
 import { basename, dirname, join, relative } from "node:path";
 import { promisify } from "node:util";
-import type { GitSyncService, IntegrationManifest, SoulLoader } from "@tulipfarm/soul";
+import type { GitSyncService, IntegrationManifest, OAuthConfig, SoulLoader } from "@tulipfarm/soul";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { stringify as toYaml } from "yaml";
 import { ErrorSchema } from "../../auth/schemas";
@@ -24,6 +24,7 @@ type PreHandler = (req: FastifyRequest, reply: FastifyReply) => Promise<void>;
 
 const NAME_RE = /^[a-z][a-z0-9-]*$/;
 const SCAN_TTL_MS = 10 * 60 * 1000;
+const OAUTH_TTL_MS = 10 * 60 * 1000;
 const CLONE_TIMEOUT_MS = 60_000;
 const MAX_SCANS = 25;
 
@@ -33,6 +34,23 @@ export interface DiscoveredIntegration {
   type: string;
   manifestPath: string;
   content: string;
+  setupGuideContent?: string;
+}
+
+interface OAuthStateEntry {
+  name: string;
+  env: Record<string, string>;
+  oauthConfig: OAuthConfig;
+  redirectUri: string;
+  expires: number;
+}
+
+const oauthStates = new Map<string, OAuthStateEntry>();
+
+function pruneOAuthStates(now: number): void {
+  for (const [id, entry] of oauthStates) {
+    if (entry.expires <= now) oauthStates.delete(id);
+  }
 }
 
 interface ScanEntry {
@@ -104,12 +122,24 @@ export async function discoverIntegrations(root: string): Promise<DiscoveredInte
           if (parsed.type !== "mcp") continue; // V1: mcp only
           const name = asString(parsed.name) ?? basename(dirname(full));
           if (!NAME_RE.test(name)) continue;
+          let setupGuideContent: string | undefined;
+          if (parsed.setup_guide_path) {
+            try {
+              setupGuideContent = await readFile(
+                join(dirname(full), parsed.setup_guide_path),
+                "utf8"
+              );
+            } catch {
+              // setup guide is optional
+            }
+          }
           out.push({
             name,
             description: asString(parsed.description),
             type: "mcp",
             manifestPath: relative(root, full),
             content,
+            setupGuideContent,
           });
         } catch {
           // skip invalid manifests
@@ -346,6 +376,7 @@ export function registerIntegrationRoutes(
               type: { type: "string" },
               manifest: { type: "object", additionalProperties: true },
               connected: { type: "boolean" },
+              setupGuide: { type: "string" },
             },
           },
           401: ErrorSchema,
@@ -365,6 +396,7 @@ export function registerIntegrationRoutes(
         errorMessage: mcpClient.getErrorMessage(name),
         manifest: integration.manifest,
         connected: integration.connection?.enabled === true,
+        setupGuide: integration.setupGuide,
       };
     }
   );
@@ -501,6 +533,9 @@ export function registerIntegrationRoutes(
         const dir = join(gitSync.path, "integrations", integration.name);
         await mkdir(dir, { recursive: true });
         await writeFile(join(dir, "manifest.json"), integration.content, "utf8");
+        if (integration.setupGuideContent) {
+          await writeFile(join(dir, "setup-guide.md"), integration.setupGuideContent, "utf8");
+        }
         installed.push(integration.name);
       }
 
@@ -621,6 +656,194 @@ export function registerIntegrationRoutes(
       }
 
       return { status: "disconnected" };
+    }
+  );
+
+  // Start OAuth authorization flow for an integration
+  app.post(
+    "/api/v1/integrations/:name/oauth/start",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description:
+          "Begin OAuth authorization flow. Returns an authUrl to open in a new tab. The user's client_id and other env values must be supplied so the redirect can be pre-filled on callback.",
+        tags: ["integrations"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        params: { type: "object", required: ["name"], properties: { name: { type: "string" } } },
+        body: {
+          type: "object",
+          required: ["env"],
+          additionalProperties: false,
+          properties: {
+            env: { type: "object", additionalProperties: { type: "string" } },
+          },
+        },
+        response: {
+          200: {
+            type: "object",
+            required: ["authUrl"],
+            properties: { authUrl: { type: "string" } },
+          },
+          400: ErrorSchema,
+          401: ErrorSchema,
+          404: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const { name } = req.params as { name: string };
+      const integration = soulLoader.integrations.get(name);
+      if (!integration) return reply.code(404).send({ error: `integration not found: ${name}` });
+
+      const oauthConfig = integration.manifest.oauth;
+      if (!oauthConfig) {
+        return reply.code(400).send({ error: `integration "${name}" does not support OAuth` });
+      }
+
+      const { env } = req.body as { env: Record<string, string> };
+      const clientId = env[oauthConfig.client_id_env];
+      if (!clientId) {
+        return reply
+          .code(400)
+          .send({ error: `missing required env field: ${oauthConfig.client_id_env}` });
+      }
+
+      const publicUrl = process.env.PUBLIC_URL ?? "http://localhost:8080";
+      const redirectUri = `${publicUrl}/api/v1/integrations/${name}/oauth/callback`;
+      const state = randomUUID();
+      const now = Date.now();
+      pruneOAuthStates(now);
+      oauthStates.set(state, {
+        name,
+        env,
+        oauthConfig,
+        redirectUri,
+        expires: now + OAUTH_TTL_MS,
+      });
+
+      const params = new URLSearchParams({
+        response_type: "code",
+        client_id: clientId,
+        redirect_uri: redirectUri,
+        scope: oauthConfig.scopes.join(" "),
+        state,
+      });
+      const authUrl = `${oauthConfig.authorization_url}?${params.toString()}`;
+      return { authUrl };
+    }
+  );
+
+  // OAuth callback — exchanges code for token, writes connection.yaml, starts MCP
+  app.get(
+    "/api/v1/integrations/:name/oauth/callback",
+    {
+      schema: {
+        description:
+          "OAuth callback handler. Exchanges the authorization code for an access token, writes connection.yaml, and starts the MCP server. Redirects to the integration detail page.",
+        tags: ["integrations"],
+        params: { type: "object", required: ["name"], properties: { name: { type: "string" } } },
+        querystring: {
+          type: "object",
+          properties: {
+            code: { type: "string" },
+            state: { type: "string" },
+            error: { type: "string" },
+            error_description: { type: "string" },
+          },
+        },
+      },
+    },
+    async (req, reply) => {
+      const { name } = req.params as { name: string };
+      const query = req.query as {
+        code?: string;
+        state?: string;
+        error?: string;
+        error_description?: string;
+      };
+
+      const webBase = process.env.PUBLIC_URL ?? "http://localhost:8080";
+
+      if (query.error) {
+        const msg = encodeURIComponent(query.error_description ?? query.error);
+        return reply.redirect(`${webBase}/integrations/${name}?error=${msg}`);
+      }
+
+      const { code, state } = query;
+      if (!code || !state) {
+        return reply.redirect(
+          `${webBase}/integrations/${name}?error=${encodeURIComponent("missing code or state")}`
+        );
+      }
+
+      const stateEntry = oauthStates.get(state);
+      if (!stateEntry || stateEntry.expires <= Date.now() || stateEntry.name !== name) {
+        return reply.redirect(
+          `${webBase}/integrations/${name}?error=${encodeURIComponent("invalid or expired state")}`
+        );
+      }
+      oauthStates.delete(state);
+
+      const { oauthConfig, env, redirectUri } = stateEntry;
+      const clientId = env[oauthConfig.client_id_env] ?? "";
+      const clientSecret = env[oauthConfig.client_secret_env] ?? "";
+
+      // Exchange code for token via form-encoded POST
+      let tokenData: Record<string, unknown>;
+      try {
+        const tokenRes = await fetch(oauthConfig.token_url, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+            Accept: "application/json",
+          },
+          body: new URLSearchParams({
+            grant_type: "authorization_code",
+            code,
+            redirect_uri: redirectUri,
+            client_id: clientId,
+            client_secret: clientSecret,
+          }).toString(),
+        });
+        tokenData = (await tokenRes.json()) as Record<string, unknown>;
+      } catch (e) {
+        const msg = encodeURIComponent(
+          `token exchange failed: ${e instanceof Error ? e.message : String(e)}`
+        );
+        return reply.redirect(`${webBase}/integrations/${name}?error=${msg}`);
+      }
+
+      // Extract token via dot-path (default "access_token")
+      const tokenPath = oauthConfig.token_response_path ?? "access_token";
+      const token = tokenPath.split(".").reduce<unknown>((obj, key) => {
+        return obj && typeof obj === "object" ? (obj as Record<string, unknown>)[key] : undefined;
+      }, tokenData);
+
+      if (typeof token !== "string" || !token) {
+        const msg = encodeURIComponent("token not found in OAuth response");
+        return reply.redirect(`${webBase}/integrations/${name}?error=${msg}`);
+      }
+
+      // Merge token into env and write connection.yaml
+      const mergedEnv = { ...env, [oauthConfig.token_env]: token };
+      const connection = { enabled: true, env: mergedEnv };
+      const connPath = join(gitSync.path, "integrations", name, "connection.yaml");
+      try {
+        await writeFile(connPath, toYaml(connection), "utf8");
+        await gitSync.withSync(`soul: connect integration ${name} via OAuth`);
+        await soulLoader.reload();
+        const integration = soulLoader.integrations.get(name);
+        if (integration) {
+          await mcpClient.connect(name, integration.manifest, connection);
+        }
+      } catch (e) {
+        const msg = encodeURIComponent(
+          `connect failed: ${e instanceof Error ? e.message : String(e)}`
+        );
+        return reply.redirect(`${webBase}/integrations/${name}?error=${msg}`);
+      }
+
+      return reply.redirect(`${webBase}/integrations/${name}?connected=true`);
     }
   );
 

--- a/apps/api/src/soul/integrations/routes.ts
+++ b/apps/api/src/soul/integrations/routes.ts
@@ -1,0 +1,661 @@
+import { execFile } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, dirname, join, relative } from "node:path";
+import { promisify } from "node:util";
+import type { GitSyncService, IntegrationManifest, SoulLoader } from "@tulipfarm/soul";
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { stringify as toYaml } from "yaml";
+import { ErrorSchema } from "../../auth/schemas";
+import type { McpClientService } from "../../integrations/mcp-client-service";
+import { hashContent, readIntegrationsLock, sourceType, writeIntegrationsLock } from "./lock";
+
+/*
+ * Integrations HTTP surface (INT-V1 / MCP-V1-001). V1 supports type=mcp only.
+ * Lifecycle: scan a git repo → install (write manifest.json to soul) → connect (write
+ * connection.yaml + start MCP subprocess) → disconnect → delete.
+ * No audit gate: MCP is process-isolated by construction (INT-V1-001).
+ */
+
+const execFileP = promisify(execFile);
+
+type PreHandler = (req: FastifyRequest, reply: FastifyReply) => Promise<void>;
+
+const NAME_RE = /^[a-z][a-z0-9-]*$/;
+const SCAN_TTL_MS = 10 * 60 * 1000;
+const CLONE_TIMEOUT_MS = 60_000;
+const MAX_SCANS = 25;
+
+export interface DiscoveredIntegration {
+  name: string;
+  description?: string;
+  type: string;
+  manifestPath: string;
+  content: string;
+}
+
+interface ScanEntry {
+  source: string;
+  ref: string;
+  integrations: DiscoveredIntegration[];
+  expires: number;
+}
+
+const scans = new Map<string, ScanEntry>();
+
+function pruneScans(now: number): void {
+  for (const [id, entry] of scans) {
+    if (entry.expires <= now) scans.delete(id);
+  }
+  while (scans.size > MAX_SCANS) {
+    const oldest = scans.keys().next().value;
+    if (oldest === undefined) break;
+    scans.delete(oldest);
+  }
+}
+
+function asString(v: unknown): string | undefined {
+  return typeof v === "string" && v.length > 0 ? v : undefined;
+}
+
+// Only GitHub slugs or http(s)/file URLs allowed — same SSRF rule as skills.
+function isAllowedSource(source: string): boolean {
+  return /^[\w.-]+\/[\w.-]+$/.test(source) || /^(https?|file):\/\//.test(source);
+}
+
+function normalizeGitUrl(source: string): string {
+  if (/^[\w.-]+\/[\w.-]+$/.test(source)) return `https://github.com/${source}.git`;
+  return source;
+}
+
+async function cloneToTemp(source: string): Promise<{ dir: string; ref: string }> {
+  const dir = await mkdtemp(join(tmpdir(), "integration-scan-"));
+  await execFileP("git", ["clone", "--depth", "1", normalizeGitUrl(source), dir], {
+    timeout: CLONE_TIMEOUT_MS,
+    env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
+  });
+  const { stdout } = await execFileP("git", ["rev-parse", "HEAD"], { cwd: dir });
+  return { dir, ref: stdout.trim() };
+}
+
+/**
+ * Walk a directory for manifest.json files (type=mcp only). Exported for testing.
+ */
+export async function discoverIntegrations(root: string): Promise<DiscoveredIntegration[]> {
+  const out: DiscoveredIntegration[] = [];
+  async function walk(dir: string, depth: number): Promise<void> {
+    if (depth > 6) return;
+    let entries: Array<{ name: string; isDirectory(): boolean }>;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (entry.name === ".git" || entry.name === "node_modules") continue;
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(full, depth + 1);
+      } else if (entry.name === "manifest.json") {
+        try {
+          const content = await readFile(full, "utf8");
+          const parsed = JSON.parse(content) as Partial<IntegrationManifest>;
+          if (parsed.type !== "mcp") continue; // V1: mcp only
+          const name = asString(parsed.name) ?? basename(dirname(full));
+          if (!NAME_RE.test(name)) continue;
+          out.push({
+            name,
+            description: asString(parsed.description),
+            type: "mcp",
+            manifestPath: relative(root, full),
+            content,
+          });
+        } catch {
+          // skip invalid manifests
+        }
+      }
+    }
+  }
+  await walk(root, 0);
+  return out;
+}
+
+function installStatus(
+  integration: DiscoveredIntegration,
+  lock: Awaited<ReturnType<typeof readIntegrationsLock>>,
+  soulLoader: SoulLoader
+): { installed: boolean; updateAvailable: boolean } {
+  const installed = soulLoader.integrations.has(integration.name);
+  const lockedHash = lock.integrations[integration.name]?.hash;
+  const updateAvailable =
+    installed &&
+    !!lockedHash &&
+    lockedHash !== createHash("sha256").update(integration.content).digest("hex");
+  return { installed, updateAvailable };
+}
+
+// Marketplace registry.json — parallel to marketplace.json for skills
+interface RegistryEntry {
+  name?: string;
+  description?: string;
+  type?: string;
+  verified?: boolean;
+}
+
+async function readRegistry(dir: string): Promise<Map<string, RegistryEntry>> {
+  const byName = new Map<string, RegistryEntry>();
+  try {
+    const parsed = JSON.parse(await readFile(join(dir, "registry.json"), "utf8")) as {
+      integrations?: RegistryEntry[];
+    };
+    for (const entry of Array.isArray(parsed.integrations) ? parsed.integrations : []) {
+      const key = asString(entry.name);
+      if (key && !byName.has(key)) byName.set(key, entry);
+    }
+  } catch {
+    // missing registry.json is fine
+  }
+  return byName;
+}
+
+function marketplaceSource(): string {
+  return process.env.INTEGRATIONS_MARKETPLACE_SOURCE ?? "tulipfarm/integrations";
+}
+
+interface MarketplaceResponse {
+  scanId: string;
+  source: string;
+  integrations: {
+    name: string;
+    description?: string;
+    verified?: boolean;
+    installed: boolean;
+    updateAvailable: boolean;
+  }[];
+}
+
+const marketplaceCache = new Map<
+  string,
+  { scanId: string; expires: number; response: MarketplaceResponse }
+>();
+
+const IntegrationSummaryProps = {
+  name: { type: "string" },
+  description: { type: "string" },
+  status: { type: "string", enum: ["connected", "connecting", "error", "disconnected"] },
+  errorMessage: { type: "string" },
+} as const;
+
+export function registerIntegrationRoutes(
+  app: FastifyInstance,
+  soulLoader: SoulLoader,
+  gitSync: GitSyncService,
+  mcpClient: McpClientService,
+  requireAuth: PreHandler
+): void {
+  // List all installed integrations with runtime status
+  app.get(
+    "/api/v1/integrations",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description:
+          "List MCP integrations installed in the soul repo, with runtime connection status.",
+        tags: ["integrations"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        response: {
+          200: {
+            type: "object",
+            required: ["integrations"],
+            properties: {
+              integrations: {
+                type: "array",
+                items: {
+                  type: "object",
+                  required: ["name", "type", "status"],
+                  properties: {
+                    ...IntegrationSummaryProps,
+                    type: { type: "string" },
+                    version: { type: "string" },
+                    maintainer: { type: "string" },
+                  },
+                },
+              },
+            },
+          },
+          401: ErrorSchema,
+        },
+      },
+    },
+    async () => {
+      const integrations = Array.from(soulLoader.integrations.values()).map((i) => ({
+        name: i.name,
+        type: i.manifest.type,
+        description: i.manifest.description,
+        version: i.manifest.version,
+        maintainer: i.manifest.maintainer,
+        status: mcpClient.getStatus(i.name),
+        errorMessage: mcpClient.getErrorMessage(i.name),
+      }));
+      return { integrations };
+    }
+  );
+
+  // Browse the official integrations marketplace
+  app.get(
+    "/api/v1/integrations/marketplace",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description:
+          "Browse the official integrations marketplace (tulipfarm/integrations). Returns a scanId usable with the install endpoint.",
+        tags: ["integrations"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        response: {
+          200: {
+            type: "object",
+            required: ["scanId", "source", "integrations"],
+            properties: {
+              scanId: { type: "string" },
+              source: { type: "string" },
+              integrations: {
+                type: "array",
+                items: {
+                  type: "object",
+                  required: ["name", "installed", "updateAvailable"],
+                  properties: {
+                    name: { type: "string" },
+                    description: { type: "string" },
+                    verified: { type: "boolean" },
+                    installed: { type: "boolean" },
+                    updateAvailable: { type: "boolean" },
+                  },
+                },
+              },
+            },
+          },
+          401: ErrorSchema,
+          502: ErrorSchema,
+        },
+      },
+    },
+    async (_req, reply) => {
+      reply.header("cache-control", "no-store");
+      const source = marketplaceSource();
+      const now = Date.now();
+      const cached = marketplaceCache.get(source);
+      if (cached && cached.expires > now && scans.has(cached.scanId)) return cached.response;
+
+      let dir: string | undefined;
+      try {
+        const clone = await cloneToTemp(source);
+        dir = clone.dir;
+        const discovered = await discoverIntegrations(dir);
+        const registry = await readRegistry(dir);
+        const lock = await readIntegrationsLock(gitSync.path);
+        const scanId = randomUUID();
+        pruneScans(now);
+        scans.set(scanId, {
+          source,
+          ref: clone.ref,
+          integrations: discovered,
+          expires: now + SCAN_TTL_MS,
+        });
+        const response: MarketplaceResponse = {
+          scanId,
+          source,
+          integrations: discovered.map((i) => {
+            const meta = registry.get(i.name);
+            return {
+              name: i.name,
+              description: i.description ?? asString(meta?.description),
+              verified: meta?.verified,
+              ...installStatus(i, lock, soulLoader),
+            };
+          }),
+        };
+        marketplaceCache.set(source, { scanId, expires: now + SCAN_TTL_MS, response });
+        return response;
+      } catch (e) {
+        return reply.code(502).send({
+          error: `marketplace unavailable: ${e instanceof Error ? e.message : String(e)}`,
+        });
+      } finally {
+        if (dir) await rm(dir, { recursive: true, force: true });
+      }
+    }
+  );
+
+  // Get single integration detail
+  app.get(
+    "/api/v1/integrations/:name",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description: "Get a single integration including its manifest and connection status.",
+        tags: ["integrations"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        params: { type: "object", required: ["name"], properties: { name: { type: "string" } } },
+        response: {
+          200: {
+            type: "object",
+            required: ["name", "type", "status", "manifest"],
+            properties: {
+              ...IntegrationSummaryProps,
+              type: { type: "string" },
+              manifest: { type: "object", additionalProperties: true },
+              connected: { type: "boolean" },
+            },
+          },
+          401: ErrorSchema,
+          404: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const { name } = req.params as { name: string };
+      const integration = soulLoader.integrations.get(name);
+      if (!integration) return reply.code(404).send({ error: `integration not found: ${name}` });
+      return {
+        name: integration.name,
+        type: integration.manifest.type,
+        description: integration.manifest.description,
+        status: mcpClient.getStatus(name),
+        errorMessage: mcpClient.getErrorMessage(name),
+        manifest: integration.manifest,
+        connected: integration.connection?.enabled === true,
+      };
+    }
+  );
+
+  // Scan a git repo for MCP integrations
+  app.post(
+    "/api/v1/integrations/scan",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description:
+          "Clone a git repo and discover installable MCP integration manifest.json files.",
+        tags: ["integrations"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        body: {
+          type: "object",
+          required: ["source"],
+          additionalProperties: false,
+          properties: { source: { type: "string", minLength: 1 } },
+        },
+        response: {
+          200: {
+            type: "object",
+            required: ["scanId", "integrations"],
+            properties: {
+              scanId: { type: "string" },
+              integrations: {
+                type: "array",
+                items: {
+                  type: "object",
+                  required: ["name", "type", "installed", "updateAvailable"],
+                  properties: {
+                    name: { type: "string" },
+                    type: { type: "string" },
+                    description: { type: "string" },
+                    installed: { type: "boolean" },
+                    updateAvailable: { type: "boolean" },
+                  },
+                },
+              },
+            },
+          },
+          400: ErrorSchema,
+          401: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const { source } = req.body as { source: string };
+      if (!isAllowedSource(source)) {
+        return reply.code(400).send({
+          error: "source must be a github owner/repo slug or an http(s)/file URL",
+        });
+      }
+      let dir: string | undefined;
+      try {
+        const clone = await cloneToTemp(source);
+        dir = clone.dir;
+        const discovered = await discoverIntegrations(dir);
+        if (discovered.length === 0) {
+          return reply.code(400).send({ error: "no MCP manifest.json files found in repo" });
+        }
+        const lock = await readIntegrationsLock(gitSync.path);
+        const scanId = randomUUID();
+        pruneScans(Date.now());
+        scans.set(scanId, {
+          source,
+          ref: clone.ref,
+          integrations: discovered,
+          expires: Date.now() + SCAN_TTL_MS,
+        });
+        return {
+          scanId,
+          integrations: discovered.map((i) => ({
+            name: i.name,
+            type: i.type,
+            description: i.description,
+            ...installStatus(i, lock, soulLoader),
+          })),
+        };
+      } catch (e) {
+        return reply.code(400).send({
+          error: `scan failed: ${e instanceof Error ? e.message : String(e)}`,
+        });
+      } finally {
+        if (dir) await rm(dir, { recursive: true, force: true });
+      }
+    }
+  );
+
+  // Install integrations from a scan
+  app.post(
+    "/api/v1/integrations/install",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description: "Install the named integrations from a scan into the soul repo.",
+        tags: ["integrations"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        body: {
+          type: "object",
+          required: ["scanId", "names"],
+          additionalProperties: false,
+          properties: {
+            scanId: { type: "string" },
+            names: { type: "array", items: { type: "string" }, minItems: 1 },
+          },
+        },
+        response: {
+          200: {
+            type: "object",
+            required: ["installed"],
+            properties: { installed: { type: "array", items: { type: "string" } } },
+          },
+          400: ErrorSchema,
+          401: ErrorSchema,
+          404: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const { scanId, names } = req.body as { scanId: string; names: string[] };
+      const entry = scans.get(scanId);
+      if (!entry) return reply.code(404).send({ error: "scan not found (it may have expired)" });
+
+      const unique = [...new Set(names)];
+      const chosen = unique.map((n) => entry.integrations.find((i) => i.name === n));
+      const missing = unique.filter((_, idx) => !chosen[idx]);
+      if (missing.length > 0)
+        return reply.code(400).send({ error: `not in scan: ${missing.join(", ")}` });
+
+      const installed: string[] = [];
+      for (const integration of chosen as DiscoveredIntegration[]) {
+        const dir = join(gitSync.path, "integrations", integration.name);
+        await mkdir(dir, { recursive: true });
+        await writeFile(join(dir, "manifest.json"), integration.content, "utf8");
+        installed.push(integration.name);
+      }
+
+      const lock = await readIntegrationsLock(gitSync.path);
+      for (const integration of chosen as DiscoveredIntegration[]) {
+        lock.integrations[integration.name] = {
+          sourceUrl: entry.source,
+          sourceType: sourceType(entry.source),
+          manifestPath: integration.manifestPath,
+          ref: entry.ref,
+          hash: hashContent(integration.content),
+        };
+      }
+      await writeIntegrationsLock(gitSync.path, lock);
+      await gitSync.withSync(`soul: install integration(s) ${installed.join(", ")}`);
+      await soulLoader.reload();
+      return { installed };
+    }
+  );
+
+  // Connect an installed integration (write connection.yaml + start MCP server)
+  app.post(
+    "/api/v1/integrations/:name/connect",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description:
+          "Connect an installed integration: write connection config and start the MCP server.",
+        tags: ["integrations"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        params: { type: "object", required: ["name"], properties: { name: { type: "string" } } },
+        body: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            env: { type: "object", additionalProperties: { type: "string" } },
+          },
+        },
+        response: {
+          200: {
+            type: "object",
+            required: ["status"],
+            properties: {
+              status: { type: "string" },
+              toolCount: { type: "number" },
+            },
+          },
+          400: ErrorSchema,
+          401: ErrorSchema,
+          404: ErrorSchema,
+          502: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const { name } = req.params as { name: string };
+      if (!NAME_RE.test(name) || !soulLoader.integrations.has(name)) {
+        return reply.code(404).send({ error: `integration not found: ${name}` });
+      }
+      const integration = soulLoader.integrations.get(name);
+      if (!integration) return reply.code(404).send({ error: `integration not found: ${name}` });
+      const body = (req.body as { env?: Record<string, string> } | null) ?? {};
+      const connection = { enabled: true, env: body.env ?? {} };
+
+      // Persist connection.yaml before starting (so a restart re-connects)
+      const connPath = join(gitSync.path, "integrations", name, "connection.yaml");
+      await writeFile(connPath, toYaml(connection), "utf8");
+      await gitSync.withSync(`soul: connect integration ${name}`);
+      await soulLoader.reload();
+
+      try {
+        await mcpClient.connect(name, integration.manifest, connection);
+      } catch (e) {
+        return reply.code(502).send({
+          error: `MCP server failed to start: ${e instanceof Error ? e.message : String(e)}`,
+        });
+      }
+
+      return { status: mcpClient.getStatus(name), toolCount: 0 };
+    }
+  );
+
+  // Disconnect a connected integration
+  app.post(
+    "/api/v1/integrations/:name/disconnect",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description: "Disconnect an integration: stop the MCP server and mark as disabled.",
+        tags: ["integrations"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        params: { type: "object", required: ["name"], properties: { name: { type: "string" } } },
+        response: {
+          200: { type: "object", required: ["status"], properties: { status: { type: "string" } } },
+          401: ErrorSchema,
+          404: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const { name } = req.params as { name: string };
+      if (!NAME_RE.test(name) || !soulLoader.integrations.has(name)) {
+        return reply.code(404).send({ error: `integration not found: ${name}` });
+      }
+
+      await mcpClient.disconnect(name);
+
+      // Update connection.yaml to disabled
+      const connPath = join(gitSync.path, "integrations", name, "connection.yaml");
+      try {
+        const integration = soulLoader.integrations.get(name);
+        const existing = integration?.connection ?? {};
+        await writeFile(connPath, toYaml({ ...existing, enabled: false }), "utf8");
+        await gitSync.withSync(`soul: disconnect integration ${name}`);
+        await soulLoader.reload();
+      } catch {
+        // best-effort persist
+      }
+
+      return { status: "disconnected" };
+    }
+  );
+
+  // Delete an integration from soul
+  app.delete(
+    "/api/v1/integrations/:name",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description: "Remove an integration from the soul repo (disconnects first if connected).",
+        tags: ["integrations"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        params: { type: "object", required: ["name"], properties: { name: { type: "string" } } },
+        response: {
+          204: { type: "null" },
+          401: ErrorSchema,
+          404: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const { name } = req.params as { name: string };
+      if (!NAME_RE.test(name) || !soulLoader.integrations.has(name)) {
+        return reply.code(404).send({ error: `integration not found: ${name}` });
+      }
+
+      await mcpClient.disconnect(name);
+      await rm(join(gitSync.path, "integrations", name), { recursive: true, force: true });
+
+      const lock = await readIntegrationsLock(gitSync.path);
+      delete lock.integrations[name];
+      await writeIntegrationsLock(gitSync.path, lock);
+      await gitSync.withSync(`soul: remove integration ${name}`);
+      await soulLoader.reload();
+      return reply.code(204).send();
+    }
+  );
+}

--- a/apps/api/src/tools/registry.ts
+++ b/apps/api/src/tools/registry.ts
@@ -55,6 +55,11 @@ export class ToolRegistry {
     this.validators.set(tool.name, ajv.compile(tool.inputSchema));
   }
 
+  unregister(name: string): void {
+    this.tools.delete(name);
+    this.validators.delete(name);
+  }
+
   getAll(): ToolDef[] {
     return [...this.tools.values()];
   }

--- a/apps/api/src/tools/setup.ts
+++ b/apps/api/src/tools/setup.ts
@@ -1,3 +1,5 @@
+import type { SoulLoader } from "@tulipfarm/soul";
+import type { McpClientService } from "../integrations/mcp-client-service";
 import type { KnowledgeService } from "../knowledge/service";
 import { KNOWLEDGE_TOOLS } from "../knowledge/tools";
 import type { KvService } from "../kv/service";
@@ -26,6 +28,8 @@ export function buildToolRegistry(services: {
   agentTools?: AgentToolContext;
   skillTools?: SkillToolContext;
   platform?: PlatformToolContext;
+  mcpClient?: McpClientService;
+  soulLoader?: SoulLoader;
 }): ToolRegistry {
   const registry = new ToolRegistry();
 
@@ -148,6 +152,18 @@ export function buildToolRegistry(services: {
   // (client context) and return client-action descriptors. No services to close over.
   for (const t of FRONTEND_TOOLS) {
     registry.register(t);
+  }
+
+  // MCP integration tools: give the McpClientService the registry so it can register/unregister
+  // tools dynamically when integrations connect/disconnect at runtime, then start all currently
+  // enabled integrations from soul.
+  if (services.mcpClient) {
+    const mcpClient = services.mcpClient;
+    mcpClient.setRegistry(registry);
+    if (services.soulLoader?.integrations) {
+      // Non-blocking: failures are logged inside startAll, not thrown.
+      void mcpClient.startAll(services.soulLoader.integrations);
+    }
   }
 
   return registry;

--- a/apps/docs/content/docs/concepts/integrations.mdx
+++ b/apps/docs/content/docs/concepts/integrations.mdx
@@ -1,0 +1,99 @@
+---
+title: Integrations
+description: MCP servers that give agents access to external tools, connected through the soul.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+An integration connects TulipFarm to an external service — Slack, GitHub, or any
+[Model Context Protocol](https://modelcontextprotocol.io) server — so agents can call
+that service's tools directly during a conversation. When an integration is connected,
+its tools appear in the agent's context alongside TulipFarm's built-in tools.
+
+## What lives in the soul
+
+Each installed integration occupies a directory under `soul/integrations/{name}/`:
+
+```text
+soul/
+  integrations/
+    slack/
+      manifest.json      definition: what the server is and how to start it
+      connection.yaml    credential env vars + enabled flag
+      setup-guide.md     optional credential walkthrough
+```
+
+`manifest.json` is written once at install time. `connection.yaml` is written when you
+connect the integration; it holds the environment variables the MCP server needs (tokens,
+IDs) and the `enabled: true` flag that tells the runtime to start it on boot.
+
+## Install vs. connect
+
+Installing and connecting are two separate steps.
+
+**Install** copies the integration's `manifest.json` into the soul repo and records it in
+`integrations-lock.json` with its source URL and ref. No server starts. No credentials
+are needed yet.
+
+**Connect** writes the credentials into `connection.yaml`, starts the MCP subprocess, and
+registers its tools in the tool registry. From that point on, any agent turn can call
+those tools.
+
+Disconnecting stops the server and removes its tools from the registry. The soul entry
+stays; you can reconnect later without reinstalling.
+
+## Credentials: two paths
+
+A connected integration needs credentials. TulipFarm supports two ways to supply them.
+
+**Direct token** — paste a long-lived token (or any other static value) directly into the
+connect form. This is the fastest path and works for any integration.
+
+**OAuth** — for integrations that declare an `oauth` block in their manifest, you can
+register your own OAuth app with the external service and let TulipFarm drive the
+authorization code flow. You supply the Client ID and Client Secret; TulipFarm opens the
+service's authorization page in a new tab, exchanges the code, and stores the resulting
+access token automatically.
+
+<Callout type="info">
+TulipFarm does not manage a shared OAuth app. You register your own — this keeps
+your tokens scoped to your account and your data.
+</Callout>
+
+Credentials are stored in `connection.yaml` in the soul repo. Treat that file like any
+other secrets file: restrict access to the soul directory.
+
+## Tools in the agent context
+
+When an integration connects, TulipFarm lists the tools the MCP server exposes and
+registers each one in the tool registry under the name
+`integration_{integration-name}_{tool-name}`. For example, Slack's `post_message` tool
+becomes `integration_slack_post_message`.
+
+Those tools are available to every agent on the next turn, right alongside the built-in
+resource, memory, and skill tools. The agent calls them the same way it calls any other
+tool — by name, with arguments — and the result is returned from the running MCP server
+process.
+
+If the MCP server exits unexpectedly, its tools are unregistered and the integration
+status changes to `error`. Reconnecting restarts the server and re-registers the tools.
+
+## Installing from the marketplace
+
+The official TulipFarm integrations are published at `tulipfarm/integrations` on GitHub.
+You can browse and install from there in the web UI, or scan any git URL that contains
+a `manifest.json` file at depth ≤ 6.
+
+<Callout type="info">
+Scanning clones the repository temporarily. Nothing is written to the soul until you
+explicitly confirm the install.
+</Callout>
+
+## V1 limits
+
+- Only `type: mcp` integrations are supported. HTTP/SSE transports are accepted alongside
+  stdio; other types are ignored with a warning.
+- Every agent gets access to all connected integration tools. Per-agent tool restriction
+  is not yet available.
+- TulipFarm does not rotate or refresh tokens. If an OAuth access token expires, you need
+  to reconnect.

--- a/apps/docs/content/docs/concepts/meta.json
+++ b/apps/docs/content/docs/concepts/meta.json
@@ -1,4 +1,14 @@
 {
   "title": "Concepts",
-  "pages": ["index", "soul", "resources", "agents", "skills", "knowledge", "llm", "secrets"]
+  "pages": [
+    "index",
+    "soul",
+    "setup",
+    "resources",
+    "agents",
+    "skills",
+    "knowledge",
+    "llm",
+    "secrets"
+  ]
 }

--- a/apps/docs/content/docs/concepts/meta.json
+++ b/apps/docs/content/docs/concepts/meta.json
@@ -7,6 +7,7 @@
     "resources",
     "agents",
     "skills",
+    "integrations",
     "knowledge",
     "llm",
     "secrets"

--- a/apps/docs/content/docs/concepts/setup.mdx
+++ b/apps/docs/content/docs/concepts/setup.mdx
@@ -1,0 +1,111 @@
+---
+title: First-run setup and boot modes
+description: How TulipFarm decides whether to open the setup wizard or seed from environment variables.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+When TulipFarm starts for the first time it has no admin and no configuration. It needs
+to reach a usable state before it can serve requests. There are two paths to get there:
+**wizard mode** (the default) and **headless mode** (for automated deployments).
+
+## How the instance decides which mode to use
+
+At startup the API checks three signals, in order:
+
+1. **Environment variables** — if `ADMIN_EMAIL`, `ADMIN_PASSWORD`, and `LLM_API_KEY` are
+   all set, the instance enters headless mode. It seeds the admin account and LLM key from
+   those values and writes `setupComplete: true` to `soul.yaml`. The web wizard never
+   appears.
+
+2. **`setupComplete` in `soul.yaml`** — if the flag is `true` and the env check did not
+   trigger, setup is already done. Normal boot proceeds.
+
+3. **User count** — if no users exist in the database and no env vars are set, the wizard
+   is still open. The instance registers the setup-wizard routes and returns
+   `needsSetup: true` from `GET /api/v1/setup/status`.
+
+The result of the first check that resolves to "done" is cached for the life of the
+process so subsequent requests never re-query the database or filesystem.
+
+<Callout type="info">
+`GET /api/v1/setup/status` is always registered, regardless of boot mode. The web client
+polls it on load to decide whether to redirect to `/setup` or to the main app.
+</Callout>
+
+## Wizard mode
+
+Wizard mode is the default for `curl | bash` self-hosted installs and local development.
+No environment variables need to be set. When `GET /api/v1/setup/status` returns
+`needsSetup: true`, the web app redirects to `/setup` and walks the operator through
+four steps:
+
+1. **Admin account** — creates the first user and logs them in. The route locks once any
+   user exists, so it cannot be used to create a second admin.
+2. **Business profile** — stores `businessName` and `businessDescription` in `soul.yaml`.
+3. **LLM provider** — stores the provider credentials (API key, resource name, or base URL
+   depending on the provider) and writes a default `llm.config.yaml` with all three tiers
+   pointing to the chosen provider and model. This step can be skipped and configured later
+   in **Settings → LLM Config**.
+4. **Soul backup** — sets a git remote URL and optional credentials so the soul syncs to
+   a private repository. This step can also be skipped.
+
+After step 4, the wizard calls `POST /api/v1/setup/complete`, which writes
+`setupComplete: true` to `soul.yaml`. Subsequent wizard-step routes return `403`.
+
+## Headless mode
+
+Headless mode is designed for container platforms (Cloud Run, Fly.io, Azure App Service,
+Kubernetes) where all configuration is injected as environment variables and no browser
+interaction is possible.
+
+Set all three required variables:
+
+| Variable | Purpose |
+|---|---|
+| `ADMIN_EMAIL` | Email for the first admin account. |
+| `ADMIN_PASSWORD` | Password for the first admin account. |
+| `LLM_API_KEY` | API key for the default LLM provider (`anthropic` unless `LLM_PROVIDER=openai`). |
+
+On the first boot with these variables present, the instance:
+
+1. Creates the admin account.
+2. Stores the LLM API key in the secrets store.
+3. Optionally writes `businessName`/`businessDescription` to `soul.yaml` if
+   `BUSINESS_NAME` is set.
+4. Writes `setupComplete: true` to `soul.yaml`.
+
+The operation is idempotent. If the admin already exists (a restart of a running instance),
+the seed step is skipped.
+
+<Callout type="warn">
+In production (`NODE_ENV=production`), setting `ADMIN_EMAIL` and `ADMIN_PASSWORD` without
+`LLM_API_KEY` causes the API to refuse to start with a clear error message. This prevents
+a silently half-configured instance. Outside production (local dev), the partial combination
+is allowed: the admin is seeded and you configure LLM credentials later via **Settings**.
+</Callout>
+
+## The `setupComplete` flag
+
+`soul.yaml` holds a `setupComplete: true` key once setup is done. This is the persistent,
+cross-restart signal that the wizard has run. The key is written by:
+
+- `POST /api/v1/setup/complete` (final wizard step), or
+- `bootstrapFromEnv` (headless seeding on first boot).
+
+Nothing else writes it. If you need to re-run the wizard on an existing instance, you must
+manually remove the key from `soul.yaml` and delete all users from the database.
+
+### Recovery when `soul.yaml` is lost
+
+If the soul directory is deleted or restored from a backup that predates setup, `soul.yaml`
+will not have `setupComplete`. The instance falls back to the user-count check: if users
+exist in the database, setup is treated as complete and normal boot proceeds. On the next
+restart a single database query runs to confirm this; the result is then cached for the
+process lifetime.
+
+<Callout type="info">
+The soul directory is the right thing to back up regularly. Losing `soul.yaml` while the
+database is intact is recoverable; losing the database is not. See [Soul](/docs/concepts/soul)
+for backup options.
+</Callout>

--- a/apps/docs/content/docs/getting-started.mdx
+++ b/apps/docs/content/docs/getting-started.mdx
@@ -69,25 +69,6 @@ psql tulipfarm -c 'select 1'
 
 <Step>
 
-### Set your admin credentials
-
-Open `.env.local` and set a password for the bootstrap admin. The first user is created
-on boot from these values:
-
-```bash title=".env.local"
-ADMIN_EMAIL=admin@tulipfarm.dev
-ADMIN_PASSWORD=choose-a-strong-password
-```
-
-<Callout type="warn">
-`ADMIN_EMAIL` must be a real email format. An address with no TLD such as
-`admin@localhost` is rejected, and the admin would never be able to log in.
-</Callout>
-
-</Step>
-
-<Step>
-
 ### Install dependencies and start TulipFarm
 
 ```bash
@@ -116,17 +97,23 @@ You should see:
 
 <Step>
 
-### Log in
+### Complete the setup wizard
 
-Open `http://localhost:4000` and sign in with the `ADMIN_EMAIL` and `ADMIN_PASSWORD`
-you set. You land on the workspace: a sidebar with Chat, Resources, Agents, Skills, and
-Settings.
+Open `http://localhost:4000`. Because no admin exists yet, the app redirects to the
+setup wizard at `/setup`. Work through the four steps:
 
-<Callout title="Chat is coming">
-The chat composer is visible but not yet wired — it is flagged `soon`. For now you drive
-your instance through the workspace sections and the soul repo, which is what the rest of
-this guide does.
-</Callout>
+1. **Admin account** — enter an email and password. This creates the first admin and logs
+   you in.
+2. **Business profile** — give your instance a name and optional description.
+3. **LLM provider** — choose a provider (Anthropic, OpenAI, Azure OpenAI, or an
+   OpenAI-compatible endpoint), enter the credentials, and pick a model. You can skip this
+   and configure it later in **Settings → LLM Config**.
+4. **Soul backup** — optionally point the soul at a git remote for backup. You can skip
+   this and set it up later in **Settings**.
+
+After step 4, the wizard calls `POST /api/v1/setup/complete` and redirects to the main
+workspace. The setup route locks — a second browser visitor cannot create another admin
+through the wizard.
 
 </Step>
 

--- a/apps/docs/content/docs/guides/connect-an-integration.mdx
+++ b/apps/docs/content/docs/guides/connect-an-integration.mdx
@@ -1,0 +1,85 @@
+---
+title: Connect an integration
+description: Install an MCP integration from the marketplace and connect it so agents can use its tools.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+This guide walks through installing the Slack integration from the TulipFarm marketplace
+and connecting it with a bot token. The same steps apply to any integration.
+
+## Prerequisites
+
+- TulipFarm is running and you are signed in
+- You have an integration's required credentials ready (for Slack, a bot token that starts
+  with `xoxb-`)
+
+## Install from the marketplace
+
+1. Open the web UI and go to **Integrations** in the sidebar.
+2. Click the **Marketplace** tab.
+3. Locate the integration you want. Click **Install**.
+
+TulipFarm clones the official `tulipfarm/integrations` repository, reads the integration's
+`manifest.json`, and writes it into your soul repo under
+`soul/integrations/{name}/manifest.json`. No server starts yet; no credentials are needed.
+
+<Callout type="info">
+You can also install from any GitHub repository. Click **Add from URL**, enter a GitHub
+URL (`owner/repo` shorthand or a full HTTPS URL), and TulipFarm will scan it for
+integrations.
+</Callout>
+
+After install, the integration appears on the **Installed** tab with status **Disconnected**.
+
+## Connect the integration
+
+1. Click the integration name to open its detail page.
+2. Fill in the required credential fields. For Slack this is **Slack Bot Token**.
+3. Click **Connect**.
+
+TulipFarm writes your credentials into `soul/integrations/slack/connection.yaml`, starts
+the MCP server subprocess, and lists its tools. The status badge changes to **Connected**
+and a tool count appears (Slack exposes eight tools).
+
+<Callout type="warn">
+Credentials are stored in the soul repo. If you push your soul to a remote, make sure the
+remote is private or the soul directory is excluded from tracking.
+</Callout>
+
+## Verify the connection
+
+Ask the agent a question that would require the integration. For Slack, try:
+
+> What channels are available in Slack?
+
+The agent calls `integration_slack_slack_list_channels` and returns the list. If the agent
+says it cannot find a Slack tool, see [Troubleshooting](#troubleshooting) below.
+
+You can also check the detail page: it shows the current status and the list of tools
+the MCP server registered.
+
+## Disconnect
+
+Open the integration's detail page and click **Disconnect**. TulipFarm stops the MCP
+server and removes its tools from the tool registry. The soul entry is preserved — you
+can reconnect without reinstalling.
+
+## Uninstall
+
+To remove an integration entirely, click **Uninstall** (or **Delete**) on the detail page.
+This disconnects the server if it is running, removes `soul/integrations/{name}/`, and
+removes the entry from `integrations-lock.json`.
+
+## Troubleshooting
+
+**Status shows "Error"** — the MCP server exited unexpectedly. Check that the required
+credentials are correct. Click **Disconnect** then **Connect** to restart the server.
+
+**Agent says it cannot use the integration's tools** — the integration may have
+disconnected after a server restart. Check the **Integrations** page. If status is
+**Disconnected**, click **Connect** to re-establish. The server reconnects automatically on
+the next boot once you connect it once.
+
+**Marketplace is empty or cannot load** — TulipFarm clones from GitHub to browse the
+marketplace. Check that the host running TulipFarm has outbound internet access.

--- a/apps/docs/content/docs/guides/deploy-headless.mdx
+++ b/apps/docs/content/docs/guides/deploy-headless.mdx
@@ -1,0 +1,100 @@
+---
+title: Deploy without the setup wizard
+description: Seed the first admin and LLM key from environment variables for automated and container-platform deployments.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+Container platforms (Cloud Run, Fly.io, Azure App Service, Kubernetes) inject
+configuration as environment variables and do not support a browser interaction at
+first boot. TulipFarm's headless mode seeds the instance automatically when it detects
+the right variables.
+
+## Before you begin
+
+You need:
+
+- A running TulipFarm deployment reachable over HTTPS (or HTTP for local testing).
+- The ability to set environment variables in your platform's configuration.
+- An API key for an LLM provider (Anthropic or OpenAI).
+
+## Set the headless seeding variables
+
+Add all three to your deployment's environment:
+
+```bash
+ADMIN_EMAIL=admin@your-domain.com
+ADMIN_PASSWORD=a-strong-password
+LLM_API_KEY=sk-ant-...          # or an OpenAI key
+```
+
+For OpenAI instead of Anthropic:
+
+```bash
+LLM_PROVIDER=openai
+LLM_API_KEY=sk-...
+```
+
+To set the business name at the same time:
+
+```bash
+BUSINESS_NAME=Acme Corp
+BUSINESS_DESCRIPTION=We sell widgets.   # optional
+```
+
+<Callout type="warn">
+**All three** (`ADMIN_EMAIL`, `ADMIN_PASSWORD`, `LLM_API_KEY`) must be set together.
+In production (`NODE_ENV=production`), providing `ADMIN_EMAIL` and `ADMIN_PASSWORD`
+without `LLM_API_KEY` causes the API to refuse to start.
+</Callout>
+
+## Deploy and verify
+
+Deploy your instance. On the first boot the API logs confirm seeding:
+
+```
+Bootstrapped admin user admin@your-domain.com
+Seeded anthropic LLM API key from env
+```
+
+Confirm the status endpoint returns `needsSetup: false`:
+
+```bash
+curl https://your-instance/api/v1/setup/status
+```
+
+```json
+{ "needsSetup": false }
+```
+
+The web app will load the main workspace directly, bypassing the setup wizard.
+
+## What happens on restart
+
+The seed operation is idempotent. If `ADMIN_EMAIL` and `ADMIN_PASSWORD` are still set on
+a subsequent restart, the API checks whether a user already exists before creating one. If
+the user exists, the seed step is skipped silently.
+
+`setupComplete: true` is written to `soul.yaml` on the first successful seed. On later
+boots, the instance reads this flag and skips all setup checks without touching the
+database.
+
+## Configure LLM tiers after deployment
+
+Headless seeding stores the LLM key and writes a default `llm.config.yaml` with the
+provider in all three tiers (quick, standard, complex) pointing to a default model. To
+adjust the model or add a fallback chain, sign in as the admin and go to
+**Settings → LLM Config**.
+
+## Remove the wizard permanently
+
+Once you have signed in and confirmed the workspace is functional, you can remove
+`ADMIN_EMAIL` and `ADMIN_PASSWORD` from your deployment environment. Keeping them present
+is harmless (the seed is idempotent), but removing them is good hygiene — there is no
+reason for a password to sit in an environment variable indefinitely.
+
+<Callout type="info">
+Removing the variables after the first boot does not affect the running instance. The
+`setupComplete` flag in `soul.yaml` is the permanent signal; the env vars are only read
+during the seed step.
+</Callout>

--- a/apps/docs/content/docs/guides/meta.json
+++ b/apps/docs/content/docs/guides/meta.json
@@ -6,6 +6,7 @@
     "install-a-skill",
     "configure-llm-providers",
     "store-a-secret",
-    "issue-an-api-token"
+    "issue-an-api-token",
+    "deploy-headless"
   ]
 }

--- a/apps/docs/content/docs/guides/meta.json
+++ b/apps/docs/content/docs/guides/meta.json
@@ -4,6 +4,7 @@
     "define-a-resource-type",
     "work-with-records",
     "install-a-skill",
+    "connect-an-integration",
     "configure-llm-providers",
     "store-a-secret",
     "issue-an-api-token",

--- a/apps/docs/content/docs/installation.mdx
+++ b/apps/docs/content/docs/installation.mdx
@@ -43,9 +43,20 @@ inside WSL. If WSL is missing it prints the `wsl --install` steps to run first.
 
 ## Finish setup
 
-Open the printed URL. While no admin exists, the setup wizard lets you create the first
-admin (no auth), then set the business name, LLM provider key, and optional soul git
-remote. After the first admin is created the setup route locks.
+Open the printed URL. The app redirects to the setup wizard at `/setup`. Work through
+the four steps:
+
+1. **Admin account** — enter an email and password. This is the only step that requires
+   no authentication; the route locks once any admin exists.
+2. **Business profile** — give your instance a name and optional description.
+3. **LLM provider** — choose a provider (Anthropic, OpenAI, Azure OpenAI, or an
+   OpenAI-compatible endpoint), enter your credentials, and pick a model. You can skip
+   this step and configure it later in **Settings → LLM Config**.
+4. **Soul backup** — optionally set a git remote URL for soul backup and sync. Skippable.
+
+After step 4, the wizard marks setup complete in `soul.yaml` and redirects to the main
+workspace. The setup routes lock — no second visitor can claim the instance through the
+wizard.
 
 <Callout type="warn">
   If the installer detected a public IP it prints a TLS warning: the instance is

--- a/apps/docs/content/docs/reference/environment-variables.mdx
+++ b/apps/docs/content/docs/reference/environment-variables.mdx
@@ -1,33 +1,62 @@
 ---
 title: Environment variables
-description: Every variable TulipFarm reads from .env.local, with defaults.
+description: Every variable TulipFarm reads, with defaults and descriptions.
 ---
 
-TulipFarm reads configuration from `.env.local`. The setup script generates this file and
-fills the random secrets; the table below documents every variable, its default, and
-whether it is required.
+TulipFarm is configured through environment variables. In self-hosted installs the
+installer writes these to `/opt/tulipfarm/.env`; in local development they live in
+`.env.local`. The tables below cover every variable the `app` reads.
 
-## Required
+## Required (all deployments)
 
 | Variable | Default | Description |
 |---|---|---|
-| `DATABASE_URL` | `postgres://localhost:5432/tulipfarm` | PostgreSQL connection string. The single datastore (pgvector + pg-boss). |
-| `SOUL_PATH` | `~/.tulipfarm/soul` | Absolute path to the soul git repository. Must be outside the project repo — a relative or in-repo path is rejected at boot. |
-| `ENCRYPTION_KEY` | — | Base64 key for encrypting application secrets. Must be 32 bytes; startup fails fast if it is not. Generate with `openssl rand -base64 32`. |
-| `JWT_SECRET` | — | Signing secret for tokens. Generate with `openssl rand -base64 32`. |
-| `WEBHOOK_SIGNING_SECRET` | — | Secret for signing webhooks. Generate with `openssl rand -base64 32`. |
-| `ADMIN_EMAIL` | `admin@tulipfarm.dev` | Email of the bootstrap admin, created on first boot if no users exist. Must be a valid email format (an address with no TLD is rejected). |
-| `ADMIN_PASSWORD` | — | Password for the bootstrap admin. |
+| `DATABASE_URL` | — | PostgreSQL 17 connection string. The single datastore (pgvector + pg-boss). Must allow the `vector` and `citext` extensions — the app creates them at boot. |
+| `SOUL_PATH` | — | Absolute path to the soul git repository. Must be outside the project repo — a relative or in-repo path is rejected at boot. |
+| `ENCRYPTION_KEY` | — | Base64-encoded 32-byte key for encrypting application secrets. Startup fails fast if the key is absent or not 32 bytes. Generate with `openssl rand -base64 32`. |
+| `JWT_SECRET` | — | Signing secret for API tokens. Generate with `openssl rand -base64 32`. |
+| `WEBHOOK_SIGNING_SECRET` | — | Secret for signing outbound webhooks. Generate with `openssl rand -base64 32`. |
 
-## Optional
+## Headless seeding
+
+Set **all three** together to skip the web setup wizard and seed the first admin
+account automatically on first boot. Leave all three unset (the default for `curl | bash`
+installs) to use the interactive browser wizard instead.
+
+See [First-run setup and boot modes](/docs/concepts/setup) for a full explanation of how
+the instance decides which path to take.
+
+| Variable | Default | Description |
+|---|---|---|
+| `ADMIN_EMAIL` | — | Email for the first admin account. Must be a valid email format. |
+| `ADMIN_PASSWORD` | — | Password for the first admin account. |
+| `LLM_API_KEY` | — | API key for the default LLM provider. Required alongside `ADMIN_EMAIL` + `ADMIN_PASSWORD` in production — omitting it in production causes the API to refuse to start. |
+| `LLM_PROVIDER` | `anthropic` | Provider for `LLM_API_KEY`. Accepts `anthropic` or `openai`. |
+| `BUSINESS_NAME` | — | Written to `soul.yaml` as `businessName` during headless seeding. Optional. |
+| `BUSINESS_DESCRIPTION` | — | Written to `soul.yaml` as `businessDescription`. Only used when `BUSINESS_NAME` is also set. |
+
+## OCI / production
+
+Variables used by the Docker Compose stack and the production image. The installer
+generates and writes these; they are documented here for reference.
+
+| Variable | Default | Description |
+|---|---|---|
+| `PUBLIC_URL` | `http://localhost:8080` | The externally reachable URL for this instance. Drives CORS and the cookie `Secure` flag. Set to an `https://` URL once behind TLS. |
+| `CORS_ORIGIN` | value of `PUBLIC_URL` | Allowed browser origin for the API. Override only if the web UI is served from a different origin than the API. |
+| `COMPOSE_PROFILES` | `bundled` | Set to `bundled` to start the included `postgres` container. Set to empty (`COMPOSE_PROFILES=`) to use an external database (see `EXTERNAL_DATASTORE`). |
+| `EXTERNAL_DATASTORE` | `false` | Set to `true` when `COMPOSE_PROFILES` is empty and `DATABASE_URL` points to a managed Postgres. Suppresses the bundled container. |
+| `POSTGRES_PASSWORD` | — | Password for the bundled Postgres container. Installer-generated; not used when `EXTERNAL_DATASTORE=true`. |
+| `PORT` | `8080` | Port the API listens on inside the container. |
+| `NODE_ENV` | `production` | Runtime environment. Affects logging, cookie flags, and headless-seeding validation. |
+
+## Optional (all deployments)
 
 | Variable | Default | Description |
 |---|---|---|
 | `SESSION_TTL_SECONDS` | `604800` | Session cookie lifetime in seconds (7 days). |
-| `PORT` | `4010` | Port the API listens on. |
-| `VITE_PORT` | `4000` | Port the web UI listens on. |
-| `CORS_ORIGIN` | `http://localhost:4000` | Allowed browser origin for the API. Defaults to the web UI on `VITE_PORT`. |
-| `GIT_REMOTE_URL` | — | Remote for the soul repo. When set, the instance syncs the soul to and from it. |
-| `GIT_CREDENTIALS` | — | Credentials for pushing to `GIT_REMOTE_URL`. |
-| `ENCRYPTION_KEY_PREVIOUS` | — | The prior `ENCRYPTION_KEY` during a key rotation. Decryption tries the current key, then this one. See [Secrets](/docs/concepts/secrets). |
-| `API_TOKEN_PEPPER` | — | Base64 server secret. When set, API tokens are hashed with `HMAC-SHA256(token, pepper)` instead of plain SHA-256. Must be 32 bytes. See [Hashing](/docs/security/hashing). |
+| `VITE_PORT` | `4000` | Port the web UI dev server listens on (local development only). |
+| `GIT_REMOTE_URL` | — | Remote for the soul repository. When set, the instance clones on first boot and syncs on a schedule. |
+| `GIT_CREDENTIALS` | — | Credentials for pushing to `GIT_REMOTE_URL` (e.g. a GitHub personal access token). |
+| `ENCRYPTION_KEY_PREVIOUS` | — | The prior `ENCRYPTION_KEY` during a key rotation. Decryption tries the current key first, then this one. See [Secrets](/docs/concepts/secrets). |
+| `API_TOKEN_PEPPER` | — | Base64 server secret (32 bytes). When set, API tokens are hashed with `HMAC-SHA256(token, pepper)` instead of plain SHA-256. See [Hashing](/docs/security/hashing). |

--- a/apps/web/app/components/integrations-tabs.tsx
+++ b/apps/web/app/components/integrations-tabs.tsx
@@ -1,0 +1,31 @@
+import { NavLink } from "@remix-run/react";
+import { cn } from "~/lib/utils";
+
+const tabs = [
+  { to: "/integrations", label: "Installed", end: true },
+  { to: "/integrations/marketplace", label: "Marketplace", end: false },
+];
+
+export function IntegrationsTabs() {
+  return (
+    <nav className="flex gap-1 border-b border-border">
+      {tabs.map((tab) => (
+        <NavLink
+          key={tab.to}
+          to={tab.to}
+          end={tab.end}
+          className={({ isActive }) =>
+            cn(
+              "-mb-px border-b-2 px-3 py-2 text-sm transition-colors",
+              isActive
+                ? "border-primary text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground"
+            )
+          }
+        >
+          {tab.label}
+        </NavLink>
+      ))}
+    </nav>
+  );
+}

--- a/apps/web/app/lib/integrations.ts
+++ b/apps/web/app/lib/integrations.ts
@@ -22,14 +22,29 @@ export type RequiredEnvVar = {
   label: string;
   description?: string;
   secret?: boolean;
+  setup_url?: string;
+  steps?: string[];
+};
+
+export type OAuthConfig = {
+  authorization_url: string;
+  token_url: string;
+  scopes: string[];
+  client_id_env: string;
+  client_secret_env: string;
+  token_env: string;
+  token_response_path?: string;
 };
 
 export type IntegrationDetail = IntegrationSummary & {
   manifest: {
     required_env?: RequiredEnvVar[];
     entry: Record<string, unknown>;
+    setup_guide_path?: string;
+    oauth?: OAuthConfig;
   };
   connected: boolean;
+  setupGuide?: string;
 };
 
 export type ScannedIntegration = {
@@ -106,4 +121,15 @@ export async function deleteIntegration(name: string): Promise<void> {
 
 export async function marketplaceIntegrations(): Promise<MarketplaceCatalog> {
   return apiGet<MarketplaceCatalog>("/api/v1/integrations/marketplace");
+}
+
+export async function startOAuth(
+  name: string,
+  env: Record<string, string>
+): Promise<{ authUrl: string }> {
+  return apiWrite<{ authUrl: string }>(
+    "POST",
+    `/api/v1/integrations/${encodeURIComponent(name)}/oauth/start`,
+    { env }
+  );
 }

--- a/apps/web/app/lib/integrations.ts
+++ b/apps/web/app/lib/integrations.ts
@@ -1,0 +1,109 @@
+import { apiDelete, apiGet, apiWrite } from "./api";
+
+/*
+ * Client for the integrations API (INT-V1 / MCP-V1-001). V1 supports type=mcp only.
+ * Lifecycle: scan a git repo → install → connect (write env + start MCP server) → disconnect → delete.
+ */
+
+export type McpConnectionStatus = "connected" | "connecting" | "error" | "disconnected";
+
+export type IntegrationSummary = {
+  name: string;
+  type: string;
+  description?: string;
+  version?: string;
+  maintainer?: string;
+  status: McpConnectionStatus;
+  errorMessage?: string;
+};
+
+export type RequiredEnvVar = {
+  name: string;
+  label: string;
+  description?: string;
+  secret?: boolean;
+};
+
+export type IntegrationDetail = IntegrationSummary & {
+  manifest: {
+    required_env?: RequiredEnvVar[];
+    entry: Record<string, unknown>;
+  };
+  connected: boolean;
+};
+
+export type ScannedIntegration = {
+  name: string;
+  type: string;
+  description?: string;
+  installed: boolean;
+  updateAvailable: boolean;
+};
+
+export type ScanResult = { scanId: string; integrations: ScannedIntegration[] };
+
+export type MarketplaceIntegration = {
+  name: string;
+  description?: string;
+  verified?: boolean;
+  installed: boolean;
+  updateAvailable: boolean;
+};
+
+export type MarketplaceCatalog = {
+  scanId: string;
+  source: string;
+  integrations: MarketplaceIntegration[];
+};
+
+export type IntegrationInstallStatus = { installed: boolean; updateAvailable: boolean };
+
+export async function listIntegrations(): Promise<IntegrationSummary[]> {
+  const body = await apiGet<{ integrations: IntegrationSummary[] }>("/api/v1/integrations");
+  return body.integrations;
+}
+
+export async function getIntegration(name: string): Promise<IntegrationDetail> {
+  return apiGet<IntegrationDetail>(`/api/v1/integrations/${encodeURIComponent(name)}`);
+}
+
+export async function scanIntegrations(source: string): Promise<ScanResult> {
+  return apiWrite<ScanResult>("POST", "/api/v1/integrations/scan", { source });
+}
+
+export async function installIntegrations(
+  scanId: string,
+  names: string[]
+): Promise<{ installed: string[] }> {
+  return apiWrite<{ installed: string[] }>("POST", "/api/v1/integrations/install", {
+    scanId,
+    names,
+  });
+}
+
+export async function connectIntegration(
+  name: string,
+  env: Record<string, string>
+): Promise<{ status: McpConnectionStatus; toolCount: number }> {
+  return apiWrite<{ status: McpConnectionStatus; toolCount: number }>(
+    "POST",
+    `/api/v1/integrations/${encodeURIComponent(name)}/connect`,
+    { env }
+  );
+}
+
+export async function disconnectIntegration(name: string): Promise<{ status: string }> {
+  return apiWrite<{ status: string }>(
+    "POST",
+    `/api/v1/integrations/${encodeURIComponent(name)}/disconnect`,
+    {}
+  );
+}
+
+export async function deleteIntegration(name: string): Promise<void> {
+  return apiDelete(`/api/v1/integrations/${encodeURIComponent(name)}`);
+}
+
+export async function marketplaceIntegrations(): Promise<MarketplaceCatalog> {
+  return apiGet<MarketplaceCatalog>("/api/v1/integrations/marketplace");
+}

--- a/apps/web/app/lib/setup.ts
+++ b/apps/web/app/lib/setup.ts
@@ -1,0 +1,24 @@
+import { apiGet, apiSend, apiWrite } from "./api";
+
+export type SetupStatus = { needsSetup: boolean };
+
+export async function getSetupStatus(): Promise<SetupStatus> {
+  return apiGet<SetupStatus>("/api/v1/setup/status");
+}
+
+export async function setupAdmin(email: string, password: string): Promise<void> {
+  // 201 with user body — use apiWrite; we don't need the response body
+  await apiWrite("POST", "/api/v1/setup/admin", { email, password });
+}
+
+export async function setupBusiness(name: string, description: string): Promise<void> {
+  await apiSend("POST", "/api/v1/setup/business", { name, description });
+}
+
+export async function setupGit(remoteUrl: string, credentials?: string): Promise<void> {
+  await apiSend("POST", "/api/v1/setup/git", { remoteUrl, credentials });
+}
+
+export async function completeSetup(): Promise<void> {
+  await apiSend("POST", "/api/v1/setup/complete", {});
+}

--- a/apps/web/app/routes/_app.integrations.$name.tsx
+++ b/apps/web/app/routes/_app.integrations.$name.tsx
@@ -1,15 +1,17 @@
 import {
   type ClientLoaderFunctionArgs,
-  Link,
   type MetaFunction,
   useLoaderData,
   useRevalidator,
   useRouteError,
+  useSearchParams,
 } from "@remix-run/react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { MarkdownView } from "~/components/markdown-view";
 import { ResourcePanel } from "~/components/resource-panel";
 import { ErrorState } from "~/components/states";
 import { Button } from "~/components/ui/button";
+import { Modal } from "~/components/ui/modal";
 import { ApiError } from "~/lib/api";
 import {
   connectIntegration,
@@ -17,6 +19,7 @@ import {
   disconnectIntegration,
   getIntegration,
   type McpConnectionStatus,
+  startOAuth,
 } from "~/lib/integrations";
 
 export const meta: MetaFunction = () => [{ title: "Integration · tulipfarm" }];
@@ -53,15 +56,33 @@ function errMessage(e: unknown): string {
 export default function IntegrationDetailPage() {
   const { integration } = useLoaderData<typeof clientLoader>();
   const revalidator = useRevalidator();
+  const [searchParams, setSearchParams] = useSearchParams();
 
   const requiredEnv = integration.manifest.required_env ?? [];
   const [envValues, setEnvValues] = useState<Record<string, string>>(() =>
     Object.fromEntries(requiredEnv.map((e) => [e.name, ""]))
   );
   const [connecting, setConnecting] = useState(false);
+  const [oauthPending, setOauthPending] = useState(false);
   const [disconnecting, setDisconnecting] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [actionError, setActionError] = useState<string>();
+  const [guideOpen, setGuideOpen] = useState(false);
+
+  // Handle OAuth callback redirect: ?connected=true or ?error=...
+  useEffect(() => {
+    const connected = searchParams.get("connected");
+    const error = searchParams.get("error");
+    if (connected === "true") {
+      setOauthPending(false);
+      setSearchParams({}, { replace: true });
+      revalidator.revalidate();
+    } else if (error) {
+      setOauthPending(false);
+      setActionError(decodeURIComponent(error));
+      setSearchParams({}, { replace: true });
+    }
+  }, [searchParams, setSearchParams, revalidator]);
 
   async function handleConnect(e: React.FormEvent) {
     e.preventDefault();
@@ -74,6 +95,18 @@ export default function IntegrationDetailPage() {
       setActionError(errMessage(err));
     } finally {
       setConnecting(false);
+    }
+  }
+
+  async function handleOAuth() {
+    setActionError(undefined);
+    setOauthPending(true);
+    try {
+      const { authUrl } = await startOAuth(integration.name, envValues);
+      window.open(authUrl, "_blank", "noopener,noreferrer");
+    } catch (err) {
+      setActionError(errMessage(err));
+      setOauthPending(false);
     }
   }
 
@@ -105,6 +138,7 @@ export default function IntegrationDetailPage() {
 
   const isConnected = integration.status === "connected";
   const entry = integration.manifest.entry as Record<string, unknown>;
+  const oauthConfig = integration.manifest.oauth;
 
   return (
     <ResourcePanel
@@ -158,7 +192,18 @@ export default function IntegrationDetailPage() {
         {/* Connect form (only when not connected) */}
         {!isConnected && (
           <form onSubmit={handleConnect} className="flex flex-col gap-3">
-            <h2 className="text-sm font-medium text-foreground">Connect</h2>
+            <div className="flex items-center gap-2">
+              <h2 className="text-sm font-medium text-foreground">Connect</h2>
+              {integration.setupGuide && (
+                <button
+                  type="button"
+                  onClick={() => setGuideOpen(true)}
+                  className="text-xs text-primary underline underline-offset-2 hover:opacity-80"
+                >
+                  Setup guide →
+                </button>
+              )}
+            </div>
             {requiredEnv.length === 0 ? (
               <p className="text-xs text-muted-foreground">
                 No configuration required. Click Connect to start the MCP server.
@@ -185,12 +230,53 @@ export default function IntegrationDetailPage() {
                     }
                     autoComplete={field.secret ? "off" : undefined}
                   />
+                  {(field.steps?.length || field.setup_url) && (
+                    <details className="mt-0.5">
+                      <summary className="cursor-pointer select-none text-xs text-muted-foreground hover:text-foreground">
+                        How to get this
+                      </summary>
+                      <div className="mt-1.5 flex flex-col gap-1 pl-3 text-xs text-muted-foreground">
+                        {field.steps?.map((step, i) => (
+                          // biome-ignore lint/suspicious/noArrayIndexKey: static ordered list
+                          <p key={i}>
+                            {i + 1}. {step}
+                          </p>
+                        ))}
+                        {field.setup_url && (
+                          <a
+                            href={field.setup_url}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="mt-0.5 text-primary underline underline-offset-2 hover:opacity-80"
+                          >
+                            Open docs →
+                          </a>
+                        )}
+                      </div>
+                    </details>
+                  )}
                 </div>
               ))
             )}
             {actionError && <p className="text-sm text-destructive">{actionError}</p>}
+            {oauthPending && (
+              <p className="text-xs text-muted-foreground">
+                Waiting for authorization in the new tab…
+              </p>
+            )}
             <div className="flex gap-2">
-              <Button type="submit" size="sm" disabled={connecting}>
+              {oauthConfig && (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  disabled={oauthPending || connecting}
+                  onClick={handleOAuth}
+                >
+                  {oauthPending ? "Authorizing…" : "Connect with OAuth"}
+                </Button>
+              )}
+              <Button type="submit" size="sm" disabled={connecting || oauthPending}>
                 {connecting ? "Connecting…" : "Connect"}
               </Button>
             </div>
@@ -235,6 +321,20 @@ export default function IntegrationDetailPage() {
           </Button>
         </div>
       </div>
+
+      {/* Setup guide modal */}
+      {integration.setupGuide && (
+        <Modal
+          open={guideOpen}
+          onClose={() => setGuideOpen(false)}
+          title="Setup guide"
+          className="max-w-2xl"
+        >
+          <div className="max-h-[70vh] overflow-y-auto">
+            <MarkdownView>{integration.setupGuide}</MarkdownView>
+          </div>
+        </Modal>
+      )}
     </ResourcePanel>
   );
 }

--- a/apps/web/app/routes/_app.integrations.$name.tsx
+++ b/apps/web/app/routes/_app.integrations.$name.tsx
@@ -19,6 +19,8 @@ import {
   disconnectIntegration,
   getIntegration,
   type McpConnectionStatus,
+  type OAuthConfig,
+  type RequiredEnvVar,
   startOAuth,
 } from "~/lib/integrations";
 
@@ -53,12 +55,93 @@ function errMessage(e: unknown): string {
   return e instanceof Error ? e.message : "request failed";
 }
 
+function FieldHints({ field }: { field: RequiredEnvVar }) {
+  if (!field.steps?.length && !field.setup_url) return null;
+  return (
+    <details className="mt-0.5">
+      <summary className="cursor-pointer select-none text-xs text-muted-foreground hover:text-foreground">
+        How to get this
+      </summary>
+      <div className="mt-1.5 flex flex-col gap-1 pl-3 text-xs text-muted-foreground">
+        {field.steps?.map((step, i) => (
+          <p key={step}>
+            {i + 1}. {step}
+          </p>
+        ))}
+        {field.setup_url && (
+          <a
+            href={field.setup_url}
+            target="_blank"
+            rel="noreferrer"
+            className="mt-0.5 text-primary underline underline-offset-2 hover:opacity-80"
+          >
+            Open docs →
+          </a>
+        )}
+      </div>
+    </details>
+  );
+}
+
+function EnvField({
+  field,
+  value,
+  onChange,
+}: {
+  field: RequiredEnvVar;
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <label className="text-xs font-medium text-foreground" htmlFor={field.name}>
+        {field.label}
+        {field.description && (
+          <span className="ml-1 font-normal text-muted-foreground">— {field.description}</span>
+        )}
+      </label>
+      <input
+        id={field.name}
+        className={inputClass}
+        type={field.secret ? "password" : "text"}
+        placeholder={field.name}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        autoComplete={field.secret ? "off" : undefined}
+      />
+      <FieldHints field={field} />
+    </div>
+  );
+}
+
+/** Split required_env into shared / oauth-only / token (direct-only) groups. */
+function splitFields(
+  fields: RequiredEnvVar[],
+  oauth: OAuthConfig | undefined
+): {
+  shared: RequiredEnvVar[];
+  oauthOnly: RequiredEnvVar[];
+  directOnly: RequiredEnvVar[];
+} {
+  if (!oauth) return { shared: fields, oauthOnly: [], directOnly: [] };
+  const oauthKeys = new Set([oauth.client_id_env, oauth.client_secret_env]);
+  const tokenKey = oauth.token_env;
+  return {
+    shared: fields.filter((f) => !oauthKeys.has(f.name) && f.name !== tokenKey),
+    oauthOnly: fields.filter((f) => oauthKeys.has(f.name)),
+    directOnly: fields.filter((f) => f.name === tokenKey),
+  };
+}
+
 export default function IntegrationDetailPage() {
   const { integration } = useLoaderData<typeof clientLoader>();
   const revalidator = useRevalidator();
   const [searchParams, setSearchParams] = useSearchParams();
 
   const requiredEnv = integration.manifest.required_env ?? [];
+  const oauthConfig = integration.manifest.oauth;
+  const { shared, oauthOnly, directOnly } = splitFields(requiredEnv, oauthConfig);
+
   const [envValues, setEnvValues] = useState<Record<string, string>>(() =>
     Object.fromEntries(requiredEnv.map((e) => [e.name, ""]))
   );
@@ -68,6 +151,9 @@ export default function IntegrationDetailPage() {
   const [deleting, setDeleting] = useState(false);
   const [actionError, setActionError] = useState<string>();
   const [guideOpen, setGuideOpen] = useState(false);
+
+  const setField = (name: string) => (v: string) =>
+    setEnvValues((prev) => ({ ...prev, [name]: v }));
 
   // Handle OAuth callback redirect: ?connected=true or ?error=...
   useEffect(() => {
@@ -88,8 +174,15 @@ export default function IntegrationDetailPage() {
     e.preventDefault();
     setConnecting(true);
     setActionError(undefined);
+    // Exclude oauth-only fields (client_id / client_secret) from direct connect env
+    const oauthKeys = new Set(
+      oauthConfig ? [oauthConfig.client_id_env, oauthConfig.client_secret_env] : []
+    );
+    const directEnv = Object.fromEntries(
+      Object.entries(envValues).filter(([k]) => !oauthKeys.has(k))
+    );
     try {
-      await connectIntegration(integration.name, envValues);
+      await connectIntegration(integration.name, directEnv);
       revalidator.revalidate();
     } catch (err) {
       setActionError(errMessage(err));
@@ -138,7 +231,6 @@ export default function IntegrationDetailPage() {
 
   const isConnected = integration.status === "connected";
   const entry = integration.manifest.entry as Record<string, unknown>;
-  const oauthConfig = integration.manifest.oauth;
 
   return (
     <ResourcePanel
@@ -191,7 +283,7 @@ export default function IntegrationDetailPage() {
 
         {/* Connect form (only when not connected) */}
         {!isConnected && (
-          <form onSubmit={handleConnect} className="flex flex-col gap-3">
+          <div className="flex flex-col gap-3">
             <div className="flex items-center gap-2">
               <h2 className="text-sm font-medium text-foreground">Connect</h2>
               {integration.setupGuide && (
@@ -204,83 +296,98 @@ export default function IntegrationDetailPage() {
                 </button>
               )}
             </div>
-            {requiredEnv.length === 0 ? (
-              <p className="text-xs text-muted-foreground">
-                No configuration required. Click Connect to start the MCP server.
-              </p>
-            ) : (
-              requiredEnv.map((field) => (
-                <div key={field.name} className="flex flex-col gap-1">
-                  <label className="text-xs font-medium text-foreground" htmlFor={field.name}>
-                    {field.label}
-                    {field.description && (
-                      <span className="ml-1 font-normal text-muted-foreground">
-                        — {field.description}
-                      </span>
-                    )}
-                  </label>
-                  <input
-                    id={field.name}
-                    className={inputClass}
-                    type={field.secret ? "password" : "text"}
-                    placeholder={field.name}
-                    value={envValues[field.name] ?? ""}
-                    onChange={(e) =>
-                      setEnvValues((prev) => ({ ...prev, [field.name]: e.target.value }))
-                    }
-                    autoComplete={field.secret ? "off" : undefined}
-                  />
-                  {(field.steps?.length || field.setup_url) && (
-                    <details className="mt-0.5">
-                      <summary className="cursor-pointer select-none text-xs text-muted-foreground hover:text-foreground">
-                        How to get this
-                      </summary>
-                      <div className="mt-1.5 flex flex-col gap-1 pl-3 text-xs text-muted-foreground">
-                        {field.steps?.map((step, i) => (
-                          // biome-ignore lint/suspicious/noArrayIndexKey: static ordered list
-                          <p key={i}>
-                            {i + 1}. {step}
-                          </p>
-                        ))}
-                        {field.setup_url && (
-                          <a
-                            href={field.setup_url}
-                            target="_blank"
-                            rel="noreferrer"
-                            className="mt-0.5 text-primary underline underline-offset-2 hover:opacity-80"
-                          >
-                            Open docs →
-                          </a>
-                        )}
-                      </div>
-                    </details>
-                  )}
-                </div>
-              ))
-            )}
+
+            {/* Shared fields (e.g. Team ID) — always shown */}
+            {shared.map((field) => (
+              <EnvField
+                key={field.name}
+                field={field}
+                value={envValues[field.name] ?? ""}
+                onChange={setField(field.name)}
+              />
+            ))}
+
             {actionError && <p className="text-sm text-destructive">{actionError}</p>}
             {oauthPending && (
               <p className="text-xs text-muted-foreground">
                 Waiting for authorization in the new tab…
               </p>
             )}
-            <div className="flex gap-2">
-              {oauthConfig && (
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="outline"
-                  disabled={oauthPending || connecting}
-                  onClick={handleOAuth}
-                >
-                  {oauthPending ? "Authorizing…" : "Connect with OAuth"}
+
+            {oauthConfig ? (
+              /* Two-path layout when OAuth is available */
+              <div className="flex flex-col gap-4">
+                {/* OAuth path */}
+                <div className="flex flex-col gap-3 rounded-sm border border-border p-3">
+                  <p className="text-xs font-medium text-foreground">
+                    Option A — Connect with OAuth
+                  </p>
+                  {oauthOnly.map((field) => (
+                    <EnvField
+                      key={field.name}
+                      field={field}
+                      value={envValues[field.name] ?? ""}
+                      onChange={setField(field.name)}
+                    />
+                  ))}
+                  <Button
+                    type="button"
+                    size="sm"
+                    disabled={oauthPending || connecting}
+                    onClick={handleOAuth}
+                  >
+                    {oauthPending ? "Authorizing…" : "Connect with OAuth"}
+                  </Button>
+                </div>
+
+                {/* Direct token path */}
+                <div className="flex flex-col gap-3 rounded-sm border border-border p-3">
+                  <p className="text-xs font-medium text-foreground">
+                    Option B — Paste token directly
+                  </p>
+                  {directOnly.map((field) => (
+                    <EnvField
+                      key={field.name}
+                      field={field}
+                      value={envValues[field.name] ?? ""}
+                      onChange={setField(field.name)}
+                    />
+                  ))}
+                  <form onSubmit={handleConnect}>
+                    <Button
+                      type="submit"
+                      size="sm"
+                      variant="outline"
+                      disabled={connecting || oauthPending}
+                    >
+                      {connecting ? "Connecting…" : "Connect"}
+                    </Button>
+                  </form>
+                </div>
+              </div>
+            ) : (
+              /* Simple layout when no OAuth */
+              <form onSubmit={handleConnect} className="flex flex-col gap-3">
+                {requiredEnv.length === 0 ? (
+                  <p className="text-xs text-muted-foreground">
+                    No configuration required. Click Connect to start the MCP server.
+                  </p>
+                ) : (
+                  requiredEnv.map((field) => (
+                    <EnvField
+                      key={field.name}
+                      field={field}
+                      value={envValues[field.name] ?? ""}
+                      onChange={setField(field.name)}
+                    />
+                  ))
+                )}
+                <Button type="submit" size="sm" disabled={connecting}>
+                  {connecting ? "Connecting…" : "Connect"}
                 </Button>
-              )}
-              <Button type="submit" size="sm" disabled={connecting || oauthPending}>
-                {connecting ? "Connecting…" : "Connect"}
-              </Button>
-            </div>
-          </form>
+              </form>
+            )}
+          </div>
         )}
 
         {/* Disconnect */}

--- a/apps/web/app/routes/_app.integrations.$name.tsx
+++ b/apps/web/app/routes/_app.integrations.$name.tsx
@@ -1,0 +1,247 @@
+import {
+  type ClientLoaderFunctionArgs,
+  Link,
+  type MetaFunction,
+  useLoaderData,
+  useRevalidator,
+  useRouteError,
+} from "@remix-run/react";
+import { useState } from "react";
+import { ResourcePanel } from "~/components/resource-panel";
+import { ErrorState } from "~/components/states";
+import { Button } from "~/components/ui/button";
+import { ApiError } from "~/lib/api";
+import {
+  connectIntegration,
+  deleteIntegration,
+  disconnectIntegration,
+  getIntegration,
+  type McpConnectionStatus,
+} from "~/lib/integrations";
+
+export const meta: MetaFunction = () => [{ title: "Integration · tulipfarm" }];
+
+export async function clientLoader({ params }: ClientLoaderFunctionArgs) {
+  const name = params.name;
+  if (!name) throw new ApiError(404, "missing integration name");
+  const integration = await getIntegration(name);
+  return { integration };
+}
+
+const inputClass =
+  "w-full rounded-sm border border-border bg-background px-3 py-2 text-sm outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50";
+
+const STATUS_LABEL: Record<McpConnectionStatus, string> = {
+  connected: "Connected",
+  connecting: "Connecting…",
+  error: "Error",
+  disconnected: "Not connected",
+};
+
+const STATUS_CLASS: Record<McpConnectionStatus, string> = {
+  connected: "text-muted-foreground",
+  connecting: "text-primary",
+  error: "text-destructive",
+  disconnected: "text-muted-foreground",
+};
+
+function errMessage(e: unknown): string {
+  if (e instanceof ApiError) return e.message;
+  return e instanceof Error ? e.message : "request failed";
+}
+
+export default function IntegrationDetailPage() {
+  const { integration } = useLoaderData<typeof clientLoader>();
+  const revalidator = useRevalidator();
+
+  const requiredEnv = integration.manifest.required_env ?? [];
+  const [envValues, setEnvValues] = useState<Record<string, string>>(() =>
+    Object.fromEntries(requiredEnv.map((e) => [e.name, ""]))
+  );
+  const [connecting, setConnecting] = useState(false);
+  const [disconnecting, setDisconnecting] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [actionError, setActionError] = useState<string>();
+
+  async function handleConnect(e: React.FormEvent) {
+    e.preventDefault();
+    setConnecting(true);
+    setActionError(undefined);
+    try {
+      await connectIntegration(integration.name, envValues);
+      revalidator.revalidate();
+    } catch (err) {
+      setActionError(errMessage(err));
+    } finally {
+      setConnecting(false);
+    }
+  }
+
+  async function handleDisconnect() {
+    setDisconnecting(true);
+    setActionError(undefined);
+    try {
+      await disconnectIntegration(integration.name);
+      revalidator.revalidate();
+    } catch (err) {
+      setActionError(errMessage(err));
+    } finally {
+      setDisconnecting(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!window.confirm(`Remove integration "${integration.name}"?`)) return;
+    setDeleting(true);
+    setActionError(undefined);
+    try {
+      await deleteIntegration(integration.name);
+      window.location.href = "/integrations";
+    } catch (err) {
+      setActionError(errMessage(err));
+      setDeleting(false);
+    }
+  }
+
+  const isConnected = integration.status === "connected";
+  const entry = integration.manifest.entry as Record<string, unknown>;
+
+  return (
+    <ResourcePanel
+      crumbs={[{ label: "integrations", to: "/integrations" }, { label: integration.name }]}
+    >
+      <div className="flex flex-col gap-4">
+        {/* Header */}
+        <div className="flex items-start gap-3">
+          <div className="flex flex-col gap-1">
+            <h1 className="text-lg font-semibold text-foreground">{integration.name}</h1>
+            {integration.description && (
+              <p className="text-sm text-muted-foreground">{integration.description}</p>
+            )}
+          </div>
+          <div className="ml-auto flex items-center gap-2">
+            <span className={`text-sm ${STATUS_CLASS[integration.status]}`}>
+              {STATUS_LABEL[integration.status]}
+            </span>
+            {integration.errorMessage && (
+              <span className="text-xs text-destructive">{integration.errorMessage}</span>
+            )}
+          </div>
+        </div>
+
+        {/* Manifest details */}
+        <div className="flex flex-col gap-1 rounded-sm border border-border p-3 text-sm">
+          <div className="flex gap-2">
+            <span className="w-24 text-muted-foreground">type</span>
+            <span className="text-foreground">{integration.type}</span>
+          </div>
+          {integration.version && (
+            <div className="flex gap-2">
+              <span className="w-24 text-muted-foreground">version</span>
+              <span className="text-foreground">{integration.version}</span>
+            </div>
+          )}
+          {integration.maintainer && (
+            <div className="flex gap-2">
+              <span className="w-24 text-muted-foreground">maintainer</span>
+              <span className="text-foreground">{integration.maintainer}</span>
+            </div>
+          )}
+          {typeof entry.transport === "string" && (
+            <div className="flex gap-2">
+              <span className="w-24 text-muted-foreground">transport</span>
+              <span className="text-foreground">{entry.transport}</span>
+            </div>
+          )}
+        </div>
+
+        {/* Connect form (only when not connected) */}
+        {!isConnected && (
+          <form onSubmit={handleConnect} className="flex flex-col gap-3">
+            <h2 className="text-sm font-medium text-foreground">Connect</h2>
+            {requiredEnv.length === 0 ? (
+              <p className="text-xs text-muted-foreground">
+                No configuration required. Click Connect to start the MCP server.
+              </p>
+            ) : (
+              requiredEnv.map((field) => (
+                <div key={field.name} className="flex flex-col gap-1">
+                  <label className="text-xs font-medium text-foreground" htmlFor={field.name}>
+                    {field.label}
+                    {field.description && (
+                      <span className="ml-1 font-normal text-muted-foreground">
+                        — {field.description}
+                      </span>
+                    )}
+                  </label>
+                  <input
+                    id={field.name}
+                    className={inputClass}
+                    type={field.secret ? "password" : "text"}
+                    placeholder={field.name}
+                    value={envValues[field.name] ?? ""}
+                    onChange={(e) =>
+                      setEnvValues((prev) => ({ ...prev, [field.name]: e.target.value }))
+                    }
+                    autoComplete={field.secret ? "off" : undefined}
+                  />
+                </div>
+              ))
+            )}
+            {actionError && <p className="text-sm text-destructive">{actionError}</p>}
+            <div className="flex gap-2">
+              <Button type="submit" size="sm" disabled={connecting}>
+                {connecting ? "Connecting…" : "Connect"}
+              </Button>
+            </div>
+          </form>
+        )}
+
+        {/* Disconnect */}
+        {isConnected && (
+          <div className="flex flex-col gap-2">
+            <h2 className="text-sm font-medium text-foreground">Connection</h2>
+            <p className="text-xs text-muted-foreground">
+              MCP server is running. Disconnect to stop it.
+            </p>
+            {actionError && <p className="text-sm text-destructive">{actionError}</p>}
+            <div className="flex gap-2">
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={disconnecting}
+                onClick={handleDisconnect}
+              >
+                {disconnecting ? "Disconnecting…" : "Disconnect"}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* Danger zone */}
+        <div className="flex flex-col gap-2 rounded-sm border border-destructive/30 p-3">
+          <h2 className="text-sm font-medium text-destructive">Remove</h2>
+          <p className="text-xs text-muted-foreground">
+            Removes the integration from the soul repo. Disconnects first if connected.
+          </p>
+          <Button
+            size="sm"
+            variant="outline"
+            className="self-start border-destructive text-destructive hover:bg-destructive/10"
+            disabled={deleting}
+            onClick={handleDelete}
+          >
+            {deleting ? "Removing…" : "Remove integration"}
+          </Button>
+        </div>
+      </div>
+    </ResourcePanel>
+  );
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+  const status = error instanceof ApiError ? error.status : undefined;
+  const message = error instanceof Error ? error.message : undefined;
+  return <ErrorState section="integrations" status={status} message={message} />;
+}

--- a/apps/web/app/routes/_app.integrations._index.tsx
+++ b/apps/web/app/routes/_app.integrations._index.tsx
@@ -1,0 +1,137 @@
+import {
+  Link,
+  type MetaFunction,
+  useLoaderData,
+  useRevalidator,
+  useRouteError,
+} from "@remix-run/react";
+import { useState } from "react";
+import { IntegrationsTabs } from "~/components/integrations-tabs";
+import { ResourcePanel } from "~/components/resource-panel";
+import { ErrorState } from "~/components/states";
+import { Button } from "~/components/ui/button";
+import { ApiError } from "~/lib/api";
+import {
+  connectIntegration,
+  disconnectIntegration,
+  type IntegrationSummary,
+  listIntegrations,
+  type McpConnectionStatus,
+} from "~/lib/integrations";
+
+export const meta: MetaFunction = () => [{ title: "Integrations · tulipfarm" }];
+
+export async function clientLoader() {
+  const integrations = await listIntegrations();
+  return { integrations };
+}
+
+const STATUS_CLASS: Record<McpConnectionStatus, string> = {
+  connected: "border-border text-muted-foreground",
+  connecting: "border-primary text-primary",
+  error: "border-destructive text-destructive",
+  disconnected: "border-border text-muted-foreground",
+};
+
+function StatusBadge({ status }: { status: McpConnectionStatus }) {
+  return (
+    <span
+      className={`shrink-0 rounded-sm border px-1.5 py-0.5 text-xs uppercase tracking-[0.15em] ${STATUS_CLASS[status]}`}
+    >
+      {status}
+    </span>
+  );
+}
+
+function IntegrationRow({ integration }: { integration: IntegrationSummary }) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string>();
+  const revalidator = useRevalidator();
+
+  async function handleDisconnect(e: React.MouseEvent) {
+    e.preventDefault();
+    setBusy(true);
+    setError(undefined);
+    try {
+      await disconnectIntegration(integration.name);
+      revalidator.revalidate();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "disconnect failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <li className="flex flex-col">
+      <div className="group flex items-baseline gap-2 px-3 py-2">
+        <span aria-hidden className="text-primary">
+          ▸
+        </span>
+        <Link
+          to={`/integrations/${encodeURIComponent(integration.name)}`}
+          className="font-medium text-foreground hover:underline"
+        >
+          {integration.name}
+        </Link>
+        {integration.description ? (
+          <span className="min-w-0 flex-1 truncate text-muted-foreground">
+            {integration.description}
+          </span>
+        ) : (
+          <span className="flex-1" />
+        )}
+        <StatusBadge status={integration.status} />
+        {integration.status === "connected" ? (
+          <Button size="sm" variant="outline" disabled={busy} onClick={handleDisconnect}>
+            {busy ? "Disconnecting…" : "Disconnect"}
+          </Button>
+        ) : (
+          <Button asChild size="sm">
+            <Link to={`/integrations/${encodeURIComponent(integration.name)}`}>Connect</Link>
+          </Button>
+        )}
+      </div>
+      {integration.errorMessage && (
+        <p className="px-3 pb-2 text-xs text-destructive">{integration.errorMessage}</p>
+      )}
+      {error && <p className="px-3 pb-2 text-xs text-destructive">{error}</p>}
+    </li>
+  );
+}
+
+export default function IntegrationsIndex() {
+  const { integrations } = useLoaderData<typeof clientLoader>();
+
+  return (
+    <ResourcePanel crumbs={[{ label: "integrations" }]}>
+      <IntegrationsTabs />
+      <div className="flex items-center justify-between">
+        <p className="text-xs text-muted-foreground">
+          {integrations.length} {integrations.length === 1 ? "integration" : "integrations"}
+        </p>
+        <Button asChild size="sm">
+          <Link to="/integrations/marketplace">Browse marketplace</Link>
+        </Button>
+      </div>
+      {integrations.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          No integrations installed yet — browse the marketplace to add one.
+        </p>
+      ) : (
+        <ul className="flex flex-col divide-y divide-border rounded-sm border border-border">
+          {integrations.map((i) => (
+            <IntegrationRow key={i.name} integration={i} />
+          ))}
+        </ul>
+      )}
+    </ResourcePanel>
+  );
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+  const status = error instanceof ApiError ? error.status : undefined;
+  const message = error instanceof Error ? error.message : undefined;
+  return <ErrorState section="integrations" status={status} message={message} />;
+}

--- a/apps/web/app/routes/_app.integrations.marketplace.tsx
+++ b/apps/web/app/routes/_app.integrations.marketplace.tsx
@@ -1,0 +1,218 @@
+import { type MetaFunction, useLoaderData } from "@remix-run/react";
+import { useState } from "react";
+import { IntegrationsTabs } from "~/components/integrations-tabs";
+import { ResourcePanel } from "~/components/resource-panel";
+import { Button } from "~/components/ui/button";
+import { ApiError } from "~/lib/api";
+import {
+  installIntegrations,
+  type MarketplaceCatalog,
+  marketplaceIntegrations,
+  type ScannedIntegration,
+  type ScanResult,
+  scanIntegrations,
+} from "~/lib/integrations";
+
+export const meta: MetaFunction = () => [{ title: "Marketplace · tulipfarm" }];
+
+export async function clientLoader() {
+  return { catalog: await marketplaceIntegrations().catch(() => null) };
+}
+
+const inputClass =
+  "w-full rounded-sm border border-border bg-background px-3 py-2 text-sm outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50";
+
+function errMessage(e: unknown): string {
+  if (e instanceof ApiError) return e.message;
+  return e instanceof Error ? e.message : "request failed";
+}
+
+function InstallBadge({
+  installed,
+  updateAvailable,
+}: {
+  installed: boolean;
+  updateAvailable: boolean;
+}) {
+  if (updateAvailable) {
+    return (
+      <span className="shrink-0 rounded-sm border border-primary px-1.5 py-0.5 text-xs uppercase tracking-[0.15em] text-primary">
+        update available
+      </span>
+    );
+  }
+  if (installed) {
+    return (
+      <span className="shrink-0 rounded-sm border border-border px-1.5 py-0.5 text-xs uppercase tracking-[0.15em] text-muted-foreground">
+        installed ✓
+      </span>
+    );
+  }
+  return null;
+}
+
+function IntegrationList({
+  items,
+  onSelect,
+  selected,
+}: {
+  items: Array<{
+    name: string;
+    description?: string;
+    installed: boolean;
+    updateAvailable: boolean;
+    verified?: boolean;
+  }>;
+  onSelect: (name: string) => void;
+  selected: Set<string>;
+}) {
+  return (
+    <ul className="flex flex-col divide-y divide-border rounded-sm border border-border">
+      {items.map((i) => (
+        <li key={i.name} className="flex items-baseline gap-2 px-3 py-2">
+          <input
+            type="checkbox"
+            className="mt-0.5 shrink-0"
+            checked={selected.has(i.name)}
+            onChange={() => onSelect(i.name)}
+            disabled={i.installed && !i.updateAvailable}
+          />
+          <span className="font-medium text-foreground">{i.name}</span>
+          {i.verified && (
+            <span className="shrink-0 rounded-sm border border-border px-1.5 py-0.5 text-xs uppercase tracking-[0.15em] text-muted-foreground">
+              verified
+            </span>
+          )}
+          {i.description ? (
+            <span className="min-w-0 flex-1 truncate text-muted-foreground">{i.description}</span>
+          ) : (
+            <span className="flex-1" />
+          )}
+          <InstallBadge installed={i.installed} updateAvailable={i.updateAvailable} />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export default function IntegrationsMarketplace() {
+  const { catalog } = useLoaderData<typeof clientLoader>();
+
+  const [scanUrl, setScanUrl] = useState("");
+  const [scanning, setScanning] = useState(false);
+  const [scanResult, setScanResult] = useState<ScanResult | null>(null);
+  const [catalogScan, setCatalogScan] = useState<MarketplaceCatalog | null>(catalog);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [installing, setInstalling] = useState(false);
+  const [scanError, setScanError] = useState<string>();
+  const [installError, setInstallError] = useState<string>();
+  const [installed, setInstalled] = useState<string[]>([]);
+
+  function toggleSelect(name: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) next.delete(name);
+      else next.add(name);
+      return next;
+    });
+  }
+
+  async function handleScan(e: React.FormEvent) {
+    e.preventDefault();
+    if (!scanUrl.trim()) return;
+    setScanning(true);
+    setScanError(undefined);
+    setScanResult(null);
+    setCatalogScan(null);
+    setSelected(new Set());
+    try {
+      const result = await scanIntegrations(scanUrl.trim());
+      setScanResult(result);
+    } catch (err) {
+      setScanError(errMessage(err));
+    } finally {
+      setScanning(false);
+    }
+  }
+
+  async function handleInstall() {
+    const scanId = scanResult?.scanId ?? catalogScan?.scanId;
+    if (!scanId || selected.size === 0) return;
+    setInstalling(true);
+    setInstallError(undefined);
+    try {
+      const result = await installIntegrations(scanId, [...selected]);
+      setInstalled(result.installed);
+      setSelected(new Set());
+    } catch (err) {
+      setInstallError(errMessage(err));
+    } finally {
+      setInstalling(false);
+    }
+  }
+
+  const activeItems = scanResult?.integrations ?? catalogScan?.integrations ?? [];
+  const installable = activeItems.filter((i) => !i.installed || i.updateAvailable);
+
+  return (
+    <ResourcePanel crumbs={[{ label: "integrations" }, { label: "marketplace" }]}>
+      <IntegrationsTabs />
+
+      <form onSubmit={handleScan} className="flex gap-2">
+        <input
+          className={inputClass}
+          placeholder="owner/repo or https://..."
+          value={scanUrl}
+          onChange={(e) => setScanUrl(e.target.value)}
+        />
+        <Button type="submit" size="sm" disabled={scanning || !scanUrl.trim()}>
+          {scanning ? "Scanning…" : "Scan"}
+        </Button>
+      </form>
+
+      {scanError && <p className="text-sm text-destructive">{scanError}</p>}
+
+      {activeItems.length > 0 && (
+        <div className="flex flex-col gap-3">
+          {catalogScan && !scanResult && (
+            <p className="text-xs text-muted-foreground">
+              Official integrations from{" "}
+              <span className="font-medium text-foreground">{catalogScan.source}</span>
+            </p>
+          )}
+          <IntegrationList items={activeItems} onSelect={toggleSelect} selected={selected} />
+          {installable.length > 0 && (
+            <div className="flex items-center gap-3">
+              <Button
+                size="sm"
+                disabled={installing || selected.size === 0}
+                onClick={handleInstall}
+              >
+                {installing
+                  ? "Installing…"
+                  : selected.size > 0
+                    ? `Install ${selected.size} integration${selected.size > 1 ? "s" : ""}`
+                    : "Select integrations to install"}
+              </Button>
+              {installError && <p className="text-sm text-destructive">{installError}</p>}
+            </div>
+          )}
+          {installed.length > 0 && (
+            <p className="text-sm text-muted-foreground">
+              Installed: {installed.join(", ")} —{" "}
+              <a href="/integrations" className="text-foreground underline">
+                connect them now
+              </a>
+            </p>
+          )}
+        </div>
+      )}
+
+      {catalog === null && !scanResult && (
+        <p className="text-sm text-muted-foreground">
+          Official marketplace unavailable — enter a git URL above to scan a custom repo.
+        </p>
+      )}
+    </ResourcePanel>
+  );
+}

--- a/apps/web/app/routes/_app.integrations.tsx
+++ b/apps/web/app/routes/_app.integrations.tsx
@@ -1,14 +1,7 @@
-import type { MetaFunction } from "@remix-run/react";
-import { EmptyState } from "~/components/empty-state";
+import { type MetaFunction, Outlet } from "@remix-run/react";
 
 export const meta: MetaFunction = () => [{ title: "Integrations · tulipfarm" }];
 
-export default function IntegrationsPage() {
-  return (
-    <EmptyState
-      section="integrations"
-      title="Integrations"
-      hint="No integrations connected. Slack, GitHub, and third-party services connect here."
-    />
-  );
+export default function IntegrationsLayout() {
+  return <Outlet />;
 }

--- a/apps/web/app/routes/_app.tsx
+++ b/apps/web/app/routes/_app.tsx
@@ -3,12 +3,15 @@ import { AppSidebar } from "~/components/app-sidebar";
 import { ApiError, getSession } from "~/lib/api";
 import { ApprovalsProvider } from "~/lib/approvals-context";
 import { ConversationsProvider } from "~/lib/conversations-context";
+import { getSetupStatus } from "~/lib/setup";
 
-// Auth gate for the whole app shell: every /app/* route runs this parent loader first. An
-// unauthenticated session (401) redirects to /login (preserving where the user was headed); a dev
-// Bearer token (VITE_API_TOKEN) authenticates too, so that path keeps working. Other errors bubble
-// to the route ErrorBoundary.
+// Auth gate for the whole app shell: every /app/* route runs this parent loader first.
+// Checks setup status first: if the instance needs first-run setup, redirect to /setup.
+// Then checks auth: unauthenticated session (401) redirects to /login.
 export async function clientLoader() {
+  const { needsSetup } = await getSetupStatus();
+  if (needsSetup) throw redirect("/setup");
+
   try {
     return { user: await getSession() };
   } catch (err) {

--- a/apps/web/app/routes/setup.tsx
+++ b/apps/web/app/routes/setup.tsx
@@ -1,0 +1,437 @@
+import { type MetaFunction, redirect, useNavigate } from "@remix-run/react";
+import { type FormEvent, useEffect, useState } from "react";
+import { Button } from "~/components/ui/button";
+import { ApiError } from "~/lib/api";
+import { type LlmProviderInfo, listProviders, putLlmConfig, putSecret } from "~/lib/settings";
+import { completeSetup, getSetupStatus, setupAdmin, setupBusiness, setupGit } from "~/lib/setup";
+
+export const meta: MetaFunction = () => [{ title: "Setup · tulipfarm" }];
+
+// Redirect to / if setup is already complete (both headless and wizard paths).
+export async function clientLoader() {
+  const { needsSetup } = await getSetupStatus();
+  if (!needsSetup) throw redirect("/");
+  return null;
+}
+
+const STEPS = ["Admin account", "Business profile", "LLM setup", "Soul backup"] as const;
+type Step = 0 | 1 | 2 | 3;
+
+const inputClass =
+  "w-full rounded-sm border border-border bg-background px-3 py-2 text-sm outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:opacity-60";
+
+function StepIndicator({ current }: { current: Step }) {
+  return (
+    <div className="flex items-center gap-2 mb-8">
+      {STEPS.map((label, i) => (
+        <div key={label} className="flex items-center gap-2">
+          <div
+            className={[
+              "flex h-6 w-6 items-center justify-center rounded-full text-[0.625rem] font-medium",
+              i < current
+                ? "bg-primary text-primary-foreground"
+                : i === current
+                  ? "border-2 border-primary text-primary"
+                  : "border border-border text-muted-foreground",
+            ].join(" ")}
+          >
+            {i < current ? "✓" : i + 1}
+          </div>
+          <span
+            className={`hidden text-xs sm:inline ${i === current ? "text-foreground" : "text-muted-foreground"}`}
+          >
+            {label}
+          </span>
+          {i < STEPS.length - 1 && <div className="h-px w-4 bg-border" />}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ErrorAlert({ message }: { message: string }) {
+  return (
+    <p
+      role="alert"
+      className="rounded-sm border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+    >
+      {message}
+    </p>
+  );
+}
+
+// Step 1: admin account
+function AdminStep({ onNext }: { onNext: () => void }) {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (password !== confirm) {
+      setError("Passwords do not match.");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      await setupAdmin(email.trim(), password);
+      onNext();
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : "Setup failed — is the API reachable?");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="flex flex-col gap-3">
+      {error && <ErrorAlert message={error} />}
+      <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+        email
+        <input
+          type="email"
+          autoComplete="username"
+          className={inputClass}
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+      </label>
+      <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+        password (min 8 characters)
+        <input
+          type="password"
+          autoComplete="new-password"
+          className={inputClass}
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          minLength={8}
+          required
+        />
+      </label>
+      <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+        confirm password
+        <input
+          type="password"
+          autoComplete="new-password"
+          className={inputClass}
+          value={confirm}
+          onChange={(e) => setConfirm(e.target.value)}
+          required
+        />
+      </label>
+      <Button
+        type="submit"
+        className="mt-1 rounded-sm"
+        disabled={busy || !email || password.length < 8 || !confirm}
+      >
+        {busy ? "Creating account…" : "Continue"}
+      </Button>
+    </form>
+  );
+}
+
+// Step 2: business profile
+function BusinessStep({ onNext }: { onNext: () => void }) {
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    setBusy(true);
+    setError(null);
+    try {
+      await setupBusiness(name.trim(), description.trim());
+      onNext();
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : "Failed to save business profile.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="flex flex-col gap-3">
+      {error && <ErrorAlert message={error} />}
+      <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+        business name
+        <input
+          type="text"
+          className={inputClass}
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Acme Corp"
+          required
+        />
+      </label>
+      <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+        brief description
+        <textarea
+          className={`${inputClass} resize-none`}
+          rows={3}
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="What does your business do?"
+        />
+      </label>
+      <Button type="submit" className="mt-1 rounded-sm" disabled={busy || !name.trim()}>
+        {busy ? "Saving…" : "Continue"}
+      </Button>
+    </form>
+  );
+}
+
+const DEFAULT_MODEL: Record<string, string> = {
+  anthropic: "claude-sonnet-4-6",
+  openai: "gpt-4o",
+  azure: "gpt-4o",
+  "openai-compatible": "",
+};
+
+// Step 3: LLM setup — uses the same registry and storage endpoints as Settings › Secrets + LLM Config.
+function LlmStep({ onNext }: { onNext: () => void }) {
+  const [providers, setProviders] = useState<LlmProviderInfo[]>([]);
+  const [providerId, setProviderId] = useState("anthropic");
+  const [fieldValues, setFieldValues] = useState<Record<string, string>>({});
+  const [model, setModel] = useState(DEFAULT_MODEL["anthropic"] ?? "");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    listProviders()
+      .then((list) => {
+        setProviders(list);
+        if (list.length > 0 && list[0]) {
+          setProviderId(list[0].id);
+          setModel(DEFAULT_MODEL[list[0].id] ?? "");
+        }
+      })
+      .catch(() => {});
+  }, []);
+
+  const selected = providers.find((p) => p.id === providerId);
+
+  function setVal(key: string, v: string) {
+    setFieldValues((prev) => ({ ...prev, [key]: v }));
+  }
+
+  function onProviderChange(id: string) {
+    setProviderId(id);
+    setFieldValues({});
+    setModel(DEFAULT_MODEL[id] ?? "");
+  }
+
+  const canSubmit =
+    !!selected &&
+    selected.fields
+      .filter((f) => !f.optional)
+      .every((f) => (fieldValues[f.key] ?? "").trim().length > 0) &&
+    model.trim().length > 0;
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!selected) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const filled = selected.fields.filter((f) => (fieldValues[f.key] ?? "").trim().length > 0);
+      await Promise.all(filled.map((f) => putSecret(f.key, fieldValues[f.key]!.trim())));
+      const entry = { provider: providerId, model: model.trim() };
+      await putLlmConfig({
+        tiers: {
+          quick: { providers: [entry] },
+          standard: { providers: [entry] },
+          complex: { providers: [entry] },
+        },
+      });
+      onNext();
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : "Failed to save LLM configuration.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="flex flex-col gap-3">
+      {error && <ErrorAlert message={error} />}
+      <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+        LLM provider
+        <select
+          className={inputClass}
+          value={providerId}
+          onChange={(e) => onProviderChange(e.target.value)}
+        >
+          {providers.length > 0 ? (
+            providers.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.label}
+              </option>
+            ))
+          ) : (
+            <>
+              <option value="anthropic">Anthropic</option>
+              <option value="openai">OpenAI</option>
+            </>
+          )}
+        </select>
+      </label>
+      {selected?.fields.map((field) => (
+        <label key={field.key} className="flex flex-col gap-1 text-xs text-muted-foreground">
+          {field.label}
+          {field.optional ? " (optional)" : ""}
+          <input
+            className={inputClass}
+            type={field.kind === "secret" ? "password" : "text"}
+            value={fieldValues[field.key] ?? ""}
+            onChange={(e) => setVal(field.key, e.target.value)}
+            placeholder={field.placeholder ?? (field.kind === "secret" ? "sk-…" : "")}
+            autoComplete="off"
+          />
+        </label>
+      ))}
+      <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+        model
+        <input
+          className={inputClass}
+          value={model}
+          onChange={(e) => setModel(e.target.value)}
+          placeholder={DEFAULT_MODEL[providerId] ?? "e.g. gpt-4o"}
+          autoComplete="off"
+        />
+      </label>
+      <Button type="submit" className="mt-1 rounded-sm" disabled={busy || !canSubmit}>
+        {busy ? "Saving…" : "Continue"}
+      </Button>
+      <Button type="button" variant="ghost" className="rounded-sm text-xs" onClick={onNext}>
+        Skip for now — configure in Settings later
+      </Button>
+    </form>
+  );
+}
+
+// Step 4: soul git backup (optional)
+function GitStep({ onNext }: { onNext: () => void }) {
+  const [remoteUrl, setRemoteUrl] = useState("");
+  const [credentials, setCredentials] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    setBusy(true);
+    setError(null);
+    try {
+      await setupGit(remoteUrl.trim(), credentials.trim() || undefined);
+      onNext();
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : "Failed to save git config.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="flex flex-col gap-3">
+      {error && <ErrorAlert message={error} />}
+      <p className="text-sm text-muted-foreground">
+        Back up your soul (agents, resources, config) to a private git repository. You can configure
+        this later in Settings.
+      </p>
+      <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+        git remote URL (HTTPS)
+        <input
+          type="url"
+          className={inputClass}
+          value={remoteUrl}
+          onChange={(e) => setRemoteUrl(e.target.value)}
+          placeholder="https://github.com/your-org/soul.git"
+        />
+      </label>
+      <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+        access token (optional)
+        <input
+          type="password"
+          autoComplete="off"
+          className={inputClass}
+          value={credentials}
+          onChange={(e) => setCredentials(e.target.value)}
+          placeholder="ghp_…"
+        />
+      </label>
+      <div className="flex gap-2">
+        <Button type="submit" className="flex-1 rounded-sm" disabled={busy || !remoteUrl.trim()}>
+          {busy ? "Saving…" : "Continue"}
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          className="rounded-sm"
+          onClick={onNext}
+          disabled={busy}
+        >
+          Skip
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+export default function SetupRoute() {
+  const navigate = useNavigate();
+  const [step, setStep] = useState<Step>(0);
+  const [finishing, setFinishing] = useState(false);
+  const [finishError, setFinishError] = useState<string | null>(null);
+
+  async function finish() {
+    setFinishing(true);
+    setFinishError(null);
+    try {
+      await completeSetup();
+      navigate("/", { replace: true });
+    } catch (err) {
+      setFinishError(err instanceof ApiError ? err.message : "Failed to complete setup.");
+      setFinishing(false);
+    }
+  }
+
+  const advance = () => {
+    if (step < 3) {
+      setStep((s) => (s + 1) as Step);
+    } else {
+      void finish();
+    }
+  };
+
+  return (
+    <section className="mx-auto flex min-h-svh max-w-sm flex-col justify-center px-6 py-16">
+      <p className="text-[0.625rem] font-medium uppercase tracking-[0.2em] text-primary">
+        [ SETUP ]
+      </p>
+      <h1 className="mt-1 text-2xl font-semibold text-foreground">tulipfarm</h1>
+      <p className="mt-1 text-sm text-muted-foreground">Let's get you set up.</p>
+
+      <div className="mt-8">
+        <StepIndicator current={step} />
+
+        <h2 className="mb-4 text-base font-medium">{STEPS[step]}</h2>
+
+        {finishError && <ErrorAlert message={finishError} />}
+
+        {step === 0 && <AdminStep onNext={advance} />}
+        {step === 1 && <BusinessStep onNext={advance} />}
+        {step === 2 && <LlmStep onNext={advance} />}
+        {step === 3 && <GitStep onNext={advance} />}
+
+        {step === 3 && finishing && (
+          <p className="mt-4 text-sm text-muted-foreground">Finishing setup…</p>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/packages/soul/src/index.ts
+++ b/packages/soul/src/index.ts
@@ -7,6 +7,7 @@ export type {
   IntegrationManifest,
   Logger,
   McpEntry,
+  OAuthConfig,
   RequiredEnvVar,
   SoulAgent,
   SoulIntegration,

--- a/packages/soul/src/index.ts
+++ b/packages/soul/src/index.ts
@@ -3,7 +3,11 @@ export type { SoulMigration } from "./migrations/index";
 export { SoulLoader } from "./soul-loader";
 export { runSoulMigrations } from "./soul-migrations";
 export type {
+  IntegrationConnection,
+  IntegrationManifest,
   Logger,
+  McpEntry,
+  RequiredEnvVar,
   SoulAgent,
   SoulIntegration,
   SoulResource,

--- a/packages/soul/src/soul-loader.test.ts
+++ b/packages/soul/src/soul-loader.test.ts
@@ -223,12 +223,20 @@ describe("SoulLoader", () => {
   describe("integrations", () => {
     it("parses connection.yaml", async () => {
       await write(
+        join(TMP, "integrations", "github", "manifest.json"),
+        JSON.stringify({
+          name: "github",
+          type: "mcp",
+          entry: { transport: "stdio", command: "echo" },
+        })
+      );
+      await write(
         join(TMP, "integrations", "github", "connection.yaml"),
-        "token: ghp_xxx\nowner: tulipfarm\n"
+        "enabled: true\nenv:\n  token: ghp_xxx\n  owner: tulipfarm\n"
       );
       const loader = new SoulLoader(TMP, makeLogger());
       await loader.load();
-      expect(loader.integrations.get("github")?.connection).toMatchObject({
+      expect(loader.integrations.get("github")?.connection?.env).toMatchObject({
         token: "ghp_xxx",
         owner: "tulipfarm",
       });

--- a/packages/soul/src/soul-loader.ts
+++ b/packages/soul/src/soul-loader.ts
@@ -4,7 +4,10 @@ import { join } from "node:path";
 import { validateResourceSchema } from "@tulipfarm/validation";
 import { parse as parseYaml } from "yaml";
 import type {
+  IntegrationConnection,
+  IntegrationManifest,
   Logger,
+  McpEntry,
   SoulAgent,
   SoulIntegration,
   SoulResource,
@@ -187,11 +190,35 @@ export class SoulLoader {
     const map = new Map<string, SoulIntegration>();
     const names = await subdirs(join(this.soulPath, "integrations"));
     for (const name of names) {
-      const connPath = join(this.soulPath, "integrations", name, "connection.yaml");
+      const manifestPath = join(this.soulPath, "integrations", name, "manifest.json");
       try {
-        const content = await readFile(connPath, "utf8");
-        const connection = (parseYaml(content) ?? {}) as Record<string, unknown>;
-        map.set(name, { name, connection });
+        const manifestRaw = JSON.parse(await readFile(manifestPath, "utf8")) as IntegrationManifest;
+        if (manifestRaw.type !== "mcp") {
+          this.logger.warn(
+            `Soul: skipping integration "${name}" — unsupported type "${manifestRaw.type}" (V1 supports mcp only)`
+          );
+          continue;
+        }
+        // Validate entry shape minimally — must have transport
+        const entry = manifestRaw.entry as McpEntry;
+        if (!entry?.transport) {
+          this.logger.warn(
+            `Soul: skipping integration "${name}" — manifest.entry.transport missing`
+          );
+          continue;
+        }
+
+        let connection: IntegrationConnection | undefined;
+        const connPath = join(this.soulPath, "integrations", name, "connection.yaml");
+        try {
+          const connRaw = (parseYaml(await readFile(connPath, "utf8")) ??
+            {}) as IntegrationConnection;
+          connection = connRaw;
+        } catch {
+          // connection.yaml is optional — integration is installed but not yet connected
+        }
+
+        map.set(name, { name, manifest: manifestRaw, connection });
       } catch (err) {
         this.logger.warn(
           `Soul: skipping integration "${name}" — ${err instanceof Error ? err.message : String(err)}`

--- a/packages/soul/src/soul-loader.ts
+++ b/packages/soul/src/soul-loader.ts
@@ -218,7 +218,17 @@ export class SoulLoader {
           // connection.yaml is optional — integration is installed but not yet connected
         }
 
-        map.set(name, { name, manifest: manifestRaw, connection });
+        let setupGuide: string | undefined;
+        try {
+          setupGuide = await readFile(
+            join(this.soulPath, "integrations", name, "setup-guide.md"),
+            "utf8"
+          );
+        } catch {
+          // setup-guide.md is optional
+        }
+
+        map.set(name, { name, manifest: manifestRaw, connection, setupGuide });
       } catch (err) {
         this.logger.warn(
           `Soul: skipping integration "${name}" — ${err instanceof Error ? err.message : String(err)}`

--- a/packages/soul/src/types.ts
+++ b/packages/soul/src/types.ts
@@ -25,9 +25,36 @@ export interface SoulRoutine {
   hasHooks: boolean;
 }
 
+export type McpEntry =
+  | { transport: "stdio"; command: string; args?: string[] }
+  | { transport: "sse"; url: string; headers?: Record<string, string> };
+
+export interface RequiredEnvVar {
+  name: string;
+  label: string;
+  description?: string;
+  secret?: boolean;
+}
+
+export interface IntegrationManifest {
+  name: string;
+  type: "mcp";
+  version?: string;
+  description?: string;
+  maintainer?: string;
+  entry: McpEntry;
+  required_env?: RequiredEnvVar[];
+}
+
+export interface IntegrationConnection {
+  enabled: boolean;
+  env?: Record<string, string>;
+}
+
 export interface SoulIntegration {
   name: string;
-  connection: Record<string, unknown>;
+  manifest: IntegrationManifest;
+  connection?: IntegrationConnection;
 }
 
 /** Minimal logger surface (pino/console compatible) shared across soul services. */

--- a/packages/soul/src/types.ts
+++ b/packages/soul/src/types.ts
@@ -34,6 +34,18 @@ export interface RequiredEnvVar {
   label: string;
   description?: string;
   secret?: boolean;
+  setup_url?: string;
+  steps?: string[];
+}
+
+export interface OAuthConfig {
+  authorization_url: string;
+  token_url: string;
+  scopes: string[];
+  client_id_env: string;
+  client_secret_env: string;
+  token_env: string;
+  token_response_path?: string;
 }
 
 export interface IntegrationManifest {
@@ -44,6 +56,8 @@ export interface IntegrationManifest {
   maintainer?: string;
   entry: McpEntry;
   required_env?: RequiredEnvVar[];
+  setup_guide_path?: string;
+  oauth?: OAuthConfig;
 }
 
 export interface IntegrationConnection {
@@ -55,6 +69,7 @@ export interface SoulIntegration {
   name: string;
   manifest: IntegrationManifest;
   connection?: IntegrationConnection;
+  setupGuide?: string;
 }
 
 /** Minimal logger surface (pino/console compatible) shared across soul services. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       '@fastify/swagger':
         specifier: ^9.7.0
         version: 9.7.0
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.4.3)
       '@node-rs/argon2':
         specifier: ^2.0.2
         version: 2.0.2
@@ -1552,6 +1555,12 @@ packages:
       tailwindcss:
         optional: true
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
@@ -1884,6 +1893,16 @@ packages:
 
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -3411,6 +3430,10 @@ packages:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -3585,6 +3608,10 @@ packages:
   body-parser@1.20.5:
     resolution: {integrity: sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
 
   boxen@7.0.0:
     resolution: {integrity: sha512-j//dBVuyacJbvW+tvZ9HuH03fZ46QcaKvvhZickZqtB271DxJ7SNRSNxrV/dZX0085m7hISRZWbzWlJvx/rHSg==}
@@ -3842,6 +3869,10 @@ packages:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
     engines: {node: '>= 0.6'}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
@@ -3906,6 +3937,10 @@ packages:
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cosmiconfig-typescript-loader@6.3.0:
     resolution: {integrity: sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA==}
@@ -4292,6 +4327,10 @@ packages:
     resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
     engines: {node: '>=18.0.0'}
 
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -4304,9 +4343,19 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
   express@4.22.2:
     resolution: {integrity: sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==}
     engines: {node: '>= 0.10.0'}
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
@@ -4377,6 +4426,10 @@ packages:
     resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
     engines: {node: '>= 0.8'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-my-way@9.6.0:
     resolution: {integrity: sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==}
     engines: {node: '>=20'}
@@ -4418,6 +4471,10 @@ packages:
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -4704,6 +4761,10 @@ packages:
     resolution: {integrity: sha512-DRgTIUgnWcJ62KyarxxziuqYxKGnR6Rgg19BlbucN/dpmJbl1XOit6qvoOX0ZT+HhWe5OUVhU/a1zpGyc1xA0Q==}
     engines: {node: '>=18.0.0'}
 
+  hono@4.12.26:
+    resolution: {integrity: sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==}
+    engines: {node: '>=16.9.0'}
+
   hosted-git-info@6.1.3:
     resolution: {integrity: sha512-HVJyzUrLIL1c0QmviVh5E8VGyUS7xCFPS6yydaVd1UegW+ibV/CohqTH9MkOLDp5o+rb82DMo77PTuc9F/8GKw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -4910,6 +4971,9 @@ packages:
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
 
@@ -4992,6 +5056,9 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
@@ -5032,6 +5099,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
@@ -5410,12 +5480,20 @@ packages:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
   meow@13.2.0:
     resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
     engines: {node: '>=18'}
 
   merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -5778,6 +5856,10 @@ packages:
     resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
     engines: {node: '>= 0.6'}
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
@@ -5867,6 +5949,10 @@ packages:
     resolution: {integrity: sha512-s3ds97SD5pd1dULE+tHUk1DrV0cSHOnsfpcdGATJ8JpBo21DoKqN9exTH4/2nhPQNOLomBdTFMicN94S4DrZrQ==}
     engines: {node: '>=18'}
     hasBin: true
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -6018,6 +6104,9 @@ packages:
   path-to-regexp@3.3.0:
     resolution: {integrity: sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==}
 
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
 
@@ -6097,6 +6186,10 @@ packages:
   pino@10.3.1:
     resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
     hasBin: true
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
@@ -6328,6 +6421,10 @@ packages:
   raw-body@2.5.3:
     resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
     engines: {node: '>= 0.8'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   rc9@2.1.2:
     resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
@@ -6561,6 +6658,10 @@ packages:
   rope-sequence@1.3.4:
     resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   run-applescript@7.1.0:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
     engines: {node: '>=18'}
@@ -6621,6 +6722,10 @@ packages:
     resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
     engines: {node: '>= 0.8.0'}
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   serialize-error@13.0.1:
     resolution: {integrity: sha512-bBZaRwLH9PN5HbLCjPId4dP5bNGEtumcErgOX952IsvOhVPrm3/AeK1y0UHA/QaPG701eg0yEnOKsCOC6X/kaA==}
     engines: {node: '>=20'}
@@ -6631,6 +6736,10 @@ packages:
   serve-static@1.16.3:
     resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
     engines: {node: '>= 0.8.0'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
 
   serve@14.2.6:
     resolution: {integrity: sha512-QEjUSA+sD4Rotm1znR8s50YqA3kYpRGPmtd5GlFxbaL9n/FdUNbqMhxClqdditSk0LlZyA/dhud6XNRTOC9x2Q==}
@@ -6979,6 +7088,10 @@ packages:
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
+
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
 
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
@@ -7478,6 +7591,11 @@ packages:
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -8363,6 +8481,10 @@ snapshots:
       '@tailwindcss/oxide': 4.3.0
       tailwindcss: 4.3.0
 
+  '@hono/node-server@1.19.14(hono@4.12.26)':
+    dependencies:
+      hono: 4.12.26
+
   '@img/colour@1.1.0':
     optional: true
 
@@ -8672,6 +8794,28 @@ snapshots:
       unist-util-stringify-position: 4.0.0
       unist-util-visit: 5.1.0
       vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.26)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.26
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -10210,6 +10354,11 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -10371,6 +10520,20 @@ snapshots:
       raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.0.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.2
+      raw-body: 3.0.2
+      type-is: 2.1.0
     transitivePeerDependencies:
       - supports-color
 
@@ -10644,6 +10807,8 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  content-disposition@1.1.0: {}
+
   content-type@1.0.5: {}
 
   content-type@2.0.0: {}
@@ -10706,6 +10871,11 @@ snapshots:
   cookie@1.1.1: {}
 
   core-util-is@1.0.3: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cosmiconfig-typescript-loader@6.3.0(@types/node@22.19.20)(cosmiconfig@9.0.2(typescript@6.0.3))(typescript@6.0.3):
     dependencies:
@@ -11136,6 +11306,10 @@ snapshots:
 
   eventsource-parser@3.1.0: {}
 
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
+
   execa@5.1.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -11151,6 +11325,11 @@ snapshots:
   exit-hook@2.2.1: {}
 
   expect-type@1.3.0: {}
+
+  express-rate-limit@8.5.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
 
   express@4.22.2:
     dependencies:
@@ -11184,6 +11363,39 @@ snapshots:
       statuses: 2.0.2
       type-is: 1.6.18
       utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.2
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
@@ -11277,6 +11489,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-my-way@9.6.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -11311,6 +11534,8 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
 
   fresh@0.5.2: {}
+
+  fresh@2.0.0: {}
 
   fs-constants@1.0.0: {}
 
@@ -11702,6 +11927,8 @@ snapshots:
 
   helmet@8.2.0: {}
 
+  hono@4.12.26: {}
+
   hosted-git-info@6.1.3:
     dependencies:
       lru-cache: 7.18.3
@@ -11865,6 +12092,8 @@ snapshots:
 
   is-potential-custom-element-name@1.0.1: {}
 
+  is-promise@4.0.0: {}
+
   is-reference@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
@@ -11945,6 +12174,8 @@ snapshots:
 
   jiti@2.7.0: {}
 
+  jose@6.2.3: {}
+
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
@@ -11998,6 +12229,8 @@ snapshots:
       - supports-color
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-schema@0.4.0: {}
 
@@ -12508,9 +12741,13 @@ snapshots:
 
   media-typer@0.3.0: {}
 
+  media-typer@1.1.0: {}
+
   meow@13.2.0: {}
 
   merge-descriptors@1.0.3: {}
+
+  merge-descriptors@2.0.0: {}
 
   merge-stream@2.0.0: {}
 
@@ -13115,6 +13352,8 @@ snapshots:
 
   negotiator@0.6.4: {}
 
+  negotiator@1.0.0: {}
+
   neo-async@2.6.2: {}
 
   netmask@2.1.1: {}
@@ -13205,6 +13444,8 @@ snapshots:
       citty: 0.2.2
       pathe: 2.0.3
       tinyexec: 1.2.4
+
+  object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
 
@@ -13380,6 +13621,8 @@ snapshots:
 
   path-to-regexp@3.3.0: {}
 
+  path-to-regexp@8.4.2: {}
+
   pathe@1.1.2: {}
 
   pathe@2.0.3: {}
@@ -13468,6 +13711,8 @@ snapshots:
       safe-stable-stringify: 2.5.0
       sonic-boom: 4.2.1
       thread-stream: 4.2.0
+
+  pkce-challenge@5.0.1: {}
 
   pkg-types@1.3.1:
     dependencies:
@@ -13724,6 +13969,13 @@ snapshots:
       bytes: 3.1.2
       http-errors: 2.0.1
       iconv-lite: 0.4.24
+      unpipe: 1.0.0
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
       unpipe: 1.0.0
 
   rc9@2.1.2:
@@ -14099,6 +14351,16 @@ snapshots:
 
   rope-sequence@1.3.4: {}
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   run-applescript@7.1.0: {}
 
   sade@1.8.1:
@@ -14159,6 +14421,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   serialize-error@13.0.1:
     dependencies:
       non-error: 0.1.0
@@ -14180,6 +14458,15 @@ snapshots:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.19.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
     transitivePeerDependencies:
       - supports-color
 
@@ -14582,6 +14869,12 @@ snapshots:
     dependencies:
       media-typer: 0.3.0
       mime-types: 2.1.35
+
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
 
   typedarray@0.0.6: {}
 
@@ -15076,6 +15369,10 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yoctocolors@2.1.2: {}
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
 
   zod@4.4.3: {}
 

--- a/scripts/admin-user.sh
+++ b/scripts/admin-user.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Dev-only helper for admin user management.
+# NOT included in production images — for local troubleshooting only.
+#
+# Reads DATABASE_URL, POSTGRES_PASSWORD, COMPOSE_PROFILES, and ADMIN_PASSWORD
+# from .env / .env.local at the repo root. CLI env vars take precedence.
+#
+# URI resolution rules:
+#   1. DATABASE_URL set and hostname is not 'postgres' (Docker-internal) → use as-is
+#   2. DATABASE_URL set but hostname is 'postgres' → replace host with localhost:5432
+#   3. DATABASE_URL absent / hostname is 'postgres' + COMPOSE_PROFILES=bundled
+#      + POSTGRES_PASSWORD → build postgresql://tulipfarm:<pw>@localhost:5432/tulipfarm
+#   4. Otherwise → error
+#
+# Usage:
+#   ./scripts/admin-user.sh get-email
+#   ./scripts/admin-user.sh set-password        # uses ADMIN_PASSWORD from .env
+#   ./scripts/admin-user.sh set-password <pw>   # uses the given password
+set -euo pipefail
+
+COMMAND="${1:-}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$SCRIPT_DIR/.."
+ARGON2_MODULE="$ROOT/apps/api/node_modules/@node-rs/argon2"
+
+# Source .env then .env.local (local overrides base), skipping comments and blank lines.
+# Existing env vars (set before the script runs) are NOT overwritten.
+load_env() {
+  local file="$1"
+  [[ -f "$file" ]] || return 0
+  while IFS= read -r line; do
+    # Skip comments and blank lines
+    [[ "$line" =~ ^\s*# ]] && continue
+    [[ -z "${line// }" ]] && continue
+    # Only export if not already set in the environment
+    local key="${line%%=*}"
+    if [[ -z "${!key+x}" ]]; then
+      export "$line" 2>/dev/null || true
+    fi
+  done < "$file"
+}
+load_env "$ROOT/.env"
+load_env "$ROOT/.env.local"
+
+# Resolve the database URL from the available env vars.
+resolve_db_url() {
+  local url="${DATABASE_URL:-}"
+  local pw="${POSTGRES_PASSWORD:-}"
+  local profiles="${COMPOSE_PROFILES:-}"
+
+  # Substitute CHANGE_ME_POSTGRES placeholder if the real password is known.
+  if [[ "$url" == *"CHANGE_ME_POSTGRES"* && -n "$pw" ]]; then
+    url="${url//CHANGE_ME_POSTGRES/$pw}"
+  fi
+
+  # Docker-internal hostname 'postgres' is not reachable from the host — rewrite to localhost.
+  if [[ "$url" == *"@postgres:"* ]]; then
+    url="${url/@postgres:/@localhost:}"
+  fi
+
+  # If still no usable URL but we have enough pieces to build one, do it.
+  if [[ -z "$url" ]] || [[ "$url" == *"CHANGE_ME"* ]]; then
+    if [[ "$profiles" == *"bundled"* && -n "$pw" ]]; then
+      url="postgresql://tulipfarm:${pw}@localhost:5432/tulipfarm"
+    else
+      echo "Error: cannot resolve DATABASE_URL." >&2
+      echo "  Set DATABASE_URL directly, or ensure POSTGRES_PASSWORD + COMPOSE_PROFILES=bundled are in .env." >&2
+      exit 1
+    fi
+  fi
+
+  echo "$url"
+}
+
+DB_URL="$(resolve_db_url)"
+
+case "$COMMAND" in
+  get-email)
+    psql "$DB_URL" --tuples-only --no-align \
+      -c "SELECT email FROM users WHERE role = 'admin' ORDER BY created_at ASC LIMIT 1"
+    ;;
+
+  set-password)
+    PASSWORD="${2:-${ADMIN_PASSWORD:-}}"
+    if [[ -z "$PASSWORD" ]]; then
+      echo "Error: no password given and ADMIN_PASSWORD is not set in .env" >&2
+      echo "Usage: $0 set-password <pw>" >&2
+      exit 1
+    fi
+    # Hash with argon2id — same @node-rs/argon2 the API uses at runtime.
+    HASH=$(node --input-type=module <<EOF
+import { hash } from "$ARGON2_MODULE/index.js";
+process.stdout.write(await hash(${PASSWORD@Q}));
+EOF
+)
+    # argon2id hashes contain only [A-Za-z0-9$,./+=] — no single quotes — so
+    # direct interpolation into a SQL string literal is safe.
+    psql "$DB_URL" -c "UPDATE users SET password_hash = '$HASH' WHERE role = 'admin'"
+    ;;
+
+  *)
+    echo "Commands:"
+    echo "  get-email              Print the admin email address"
+    echo "  set-password [pw]      Set the admin password (reads ADMIN_PASSWORD from .env if pw omitted)"
+    exit 1
+    ;;
+esac

--- a/scripts/get.tulipfarm.sh
+++ b/scripts/get.tulipfarm.sh
@@ -162,7 +162,6 @@ DATABASE_URL=postgresql://tulipfarm:${pw}@postgres:5432/tulipfarm
 ENCRYPTION_KEY=${enc}
 JWT_SECRET=${jwt}
 WEBHOOK_SIGNING_SECRET=${webhook}
-SETUP_MODE=wizard
 EOF
 }
 

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -153,15 +153,37 @@ else
   # Give services a moment to start
   sleep 2
 
-  # Create the Postgres database (idempotent)
-  if command -v createdb &> /dev/null; then
+  # On Linux, apt-installed Postgres uses peer auth via Unix socket for the postgres superuser.
+  # The current OS user has no Postgres role yet, so we must create one via sudo -u postgres.
+  # We switch DATABASE_URL to a Unix socket URL with ?host=<socket-dir> because node-postgres
+  # treats an empty host as TCP localhost — the explicit socket path triggers peer auth.
+  if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    if sudo -u postgres createuser --superuser "$USER" 2>/dev/null; then
+      echo "✅ Created Postgres role '$USER'"
+    else
+      echo "✅ Postgres role '$USER' already exists"
+    fi
     if createdb tulipfarm 2>/dev/null; then
       echo "✅ Created Postgres database 'tulipfarm'"
     else
       echo "✅ Postgres database 'tulipfarm' already exists"
     fi
+    # node-postgres ignores an empty host and falls back to TCP; we must pass the socket
+    # directory explicitly via ?host= so peer auth is used (no password required).
+    PG_SOCKET_DIR="$(psql -Atqc "SHOW unix_socket_directories" 2>/dev/null | tr ',' '\n' | head -1 | tr -d ' ')"
+    PG_SOCKET_DIR="${PG_SOCKET_DIR:-/var/run/postgresql}"
+    DATABASE_URL_OVERRIDE="postgres:///tulipfarm?host=${PG_SOCKET_DIR}"
   else
-    echo "⚠ createdb not on PATH — create the 'tulipfarm' database manually"
+    # macOS Homebrew: initdb creates a superuser role for the OS user automatically
+    if command -v createdb &> /dev/null; then
+      if createdb tulipfarm 2>/dev/null; then
+        echo "✅ Created Postgres database 'tulipfarm'"
+      else
+        echo "✅ Postgres database 'tulipfarm' already exists"
+      fi
+    else
+      echo "⚠ createdb not on PATH — create the 'tulipfarm' database manually"
+    fi
   fi
 fi
 
@@ -174,9 +196,9 @@ if [ ! -d "$SOUL_DIR/.git" ]; then
 
   # Create stub files. NOTE: no llm.config.yaml stub — an empty/comment-only one fails LLM-config
   # validation (requires `tiers`). Absent config = LLM features disabled until the UI wizard writes it.
+  # soul.yaml is intentionally minimal — setupComplete is set by the setup wizard, not here.
   cat > "$SOUL_DIR/soul.yaml" << 'EOF'
 # TulipFarm Soul Configuration
-# Root soul manifest — populated during UI setup
 EOF
 
   cat > "$SOUL_DIR/skills-lock.json" << 'EOF'
@@ -204,10 +226,6 @@ if [ ! -f ".env.local" ]; then
   ENCRYPTION_KEY=$(openssl rand -base64 32)
   JWT_SECRET=$(openssl rand -base64 32)
   WEBHOOK_SECRET=$(openssl rand -base64 32)
-  # Fixed dev admin password — deterministic, not random (matches the app's bootstrapAdmin dev
-  # default and the login screen's prefilled value). Hashed with Argon2id at boot. Change it in
-  # .env.local for anything beyond local dev.
-  ADMIN_PASSWORD=password123
 
   # Replace placeholders by matching each full KEY=<placeholder> line so every substitution
   # is unique and order-independent (a bare s/// on the shared placeholder would overwrite
@@ -217,12 +235,10 @@ if [ ! -f ".env.local" ]; then
     sed -i '' "s|ENCRYPTION_KEY=<generate: openssl rand -base64 32>|ENCRYPTION_KEY=$ENCRYPTION_KEY|" .env.local
     sed -i '' "s|JWT_SECRET=<generate: openssl rand -base64 32>|JWT_SECRET=$JWT_SECRET|" .env.local
     sed -i '' "s|WEBHOOK_SIGNING_SECRET=<generate: openssl rand -base64 32>|WEBHOOK_SIGNING_SECRET=$WEBHOOK_SECRET|" .env.local
-    sed -i '' "s|ADMIN_PASSWORD=<set a strong password>|ADMIN_PASSWORD=$ADMIN_PASSWORD|" .env.local
   else
     sed -i "s|ENCRYPTION_KEY=<generate: openssl rand -base64 32>|ENCRYPTION_KEY=$ENCRYPTION_KEY|" .env.local
     sed -i "s|JWT_SECRET=<generate: openssl rand -base64 32>|JWT_SECRET=$JWT_SECRET|" .env.local
     sed -i "s|WEBHOOK_SIGNING_SECRET=<generate: openssl rand -base64 32>|WEBHOOK_SIGNING_SECRET=$WEBHOOK_SECRET|" .env.local
-    sed -i "s|ADMIN_PASSWORD=<set a strong password>|ADMIN_PASSWORD=$ADMIN_PASSWORD|" .env.local
   fi
 
   # Docker mode: point the dev app at the bundled container (host port + password).
@@ -243,14 +259,9 @@ if [ ! -f ".env.local" ]; then
     sed -i "s|^SOUL_PATH=.*|SOUL_PATH=$SOUL_DIR|" .env.local
   fi
 
-  ADMIN_EMAIL=$(grep -E '^ADMIN_EMAIL=' .env.local | cut -d= -f2-)
   echo "✅ .env.local created with generated secrets"
-  echo ""
-  echo "   🔑 Sign in with these admin credentials (also saved in .env.local):"
-  echo "        email:    ${ADMIN_EMAIL:-admin@tulipfarm.dev}"
-  echo "        password: $ADMIN_PASSWORD"
 else
-  echo "✅ .env.local already exists (sign-in creds: ADMIN_EMAIL / ADMIN_PASSWORD in .env.local)"
+  echo "✅ .env.local already exists"
   if [ -n "$DATABASE_URL_OVERRIDE" ]; then
     echo "ℹ Docker mode: ensure DATABASE_URL in .env.local is:"
     echo "    $DATABASE_URL_OVERRIDE"
@@ -270,9 +281,8 @@ echo "✨ Setup complete!"
 echo ""
 echo "Next steps:"
 echo "  1. Run: pnpm dev"
-echo "  2. Web UI:  http://localhost:4000   (API: http://localhost:4010)"
-echo "  3. Sign in at /login with the admin email + password above"
-echo "     (or read them from .env.local: ADMIN_EMAIL / ADMIN_PASSWORD)"
+echo "  2. Open: http://localhost:4000"
+echo "  3. Complete the setup wizard in the browser (creates your admin account)"
 echo ""
 echo "To verify the datastore is running:"
 if [ "$DB_MODE" = "docker" ]; then


### PR DESCRIPTION
## Summary

Adds three credential-gathering UX layers to the MCP integrations connect flow, so non-technical users can set up integrations without needing to know where to get secrets.

- **Per-field hints** — each `required_env` field in a manifest can now carry `steps[]` (numbered steps) and `setup_url` (link to service docs). Rendered as a collapsible `<details>` below the input on the connect form.

- **Setup guide modal** — integrations can ship a `SETUP.md` alongside their `manifest.json`. The soul-loader reads it into `SoulIntegration.setupGuide` at load time; the install route copies it from the temp clone; the detail route exposes it; the connect page shows a "Setup guide →" link that opens a full markdown modal.

- **OAuth authorization code flow** — manifests can declare an `oauth` block (`OAuthConfig`) with authorization/token URLs, scopes, and env field references. Users register their own OAuth app (no shared TulipFarm credentials). Two new API routes:
  - `POST /api/v1/integrations/:name/oauth/start` — generates UUID state (10 min TTL), returns `authUrl`
  - `GET /api/v1/integrations/:name/oauth/callback` — exchanges code for token, writes `connection.yaml`, starts MCP, redirects to `/integrations/:name?connected=true`

## Files changed

| File | Change |
|---|---|
| `packages/soul/src/types.ts` | `RequiredEnvVar` + `setup_url/steps`; new `OAuthConfig`; `IntegrationManifest` + `setup_guide_path/oauth`; `SoulIntegration` + `setupGuide` |
| `packages/soul/src/soul-loader.ts` | Read `setup-guide.md` from soul dir → `setupGuide` |
| `packages/soul/src/index.ts` | Export `OAuthConfig` |
| `apps/api/src/soul/integrations/routes.ts` | Setup guide copy in install; `setupGuide` in detail; OAuth start + callback routes |
| `apps/web/app/lib/integrations.ts` | Extended types + `startOAuth()` |
| `apps/web/app/routes/_app.integrations.$name.tsx` | Field hints, setup guide modal, OAuth button, URL param handling |

## Test plan

- [ ] Install slack from marketplace → `setup-guide.md` present in soul dir
- [ ] `/integrations/slack` → "Setup guide →" link → click opens markdown modal with full walkthrough
- [ ] Expand a field hint → numbered steps + "Open docs →" link visible
- [ ] Fill `SLACK_CLIENT_ID` + `SLACK_CLIENT_SECRET` + `SLACK_TEAM_ID` → "Connect with OAuth" → new tab opens Slack auth
- [ ] After Slack approval → page shows `connected=true` → status = connected
- [ ] Direct path: fill `SLACK_BOT_TOKEN` + `SLACK_TEAM_ID` → "Connect" → status = connected
- [ ] OAuth error path: invalid credentials → page shows error message from `?error=...`