### PR TITLE
fix(ci): use CLAUDE_CODE_OAUTH_TOKEN for docs-update workflow auth

### DIFF
--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Run absolute-documentations skill
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             Improve all documentation in this repository using the absolute-documentations skill.


### PR DESCRIPTION
## Summary
- Fixes auth failure in the daily docs-update workflow (#74)
- Swaps `anthropic_api_key` input for `claude_code_oauth_token` — the repo uses OAuth token auth, not a bare API key
- Passing an empty `anthropic_api_key` caused validation to fail before the action could fall back to `CLAUDE_CODE_OAUTH_TOKEN`

## Root cause
`claude-code-action` validates inputs explicitly; an empty `anthropic_api_key` param short-circuits the OAuth token path.

## Test plan
- [ ] Merge and trigger "Daily Documentation Update" workflow manually
- [ ] Confirm no auth validation error