### PR TITLE
fix(ci): allow Bash tool in docs-update workflow

### DIFF
--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_args: '--allowedTools "Bash,Edit,Write,Read,Glob,Grep"'
           prompt: |
             Improve all documentation in this repository using the absolute-documentations skill.
 


### PR DESCRIPTION
## Root cause

The `docs-update` workflow ran successfully (53 turns, \$1.08) but left **11 permission denials** — Claude improved all the docs but couldn't push the branch or open a PR.

Agent mode in `claude-code-action` does **not** set `--permission-mode acceptEdits` (only tag mode does). Without explicit `allowedTools`, bash commands like `git push` and `gh pr create` are blocked by Claude Code's default permission model.

## Fix

Added `claude_args: '--allowedTools "Bash,Edit,Write,Read,Glob,Grep"'` to the workflow step. This explicitly allows bash commands so Claude can push the branch and open the PR after writing docs.

## Test plan

- [ ] Trigger workflow manually via Actions → "Daily Documentation Update" → Run workflow
- [ ] Confirm zero permission denials in the run output
- [ ] Confirm a `docs/auto-update-YYYY-MM-DD` PR is opened