### PR TITLE
fix(ci): add GitHub MCP tool to docs-update for PR creation

### DIFF
--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -25,7 +25,8 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          claude_args: '--allowedTools "Bash,Edit,Write,Read,Glob,Grep"'
+          claude_args: '--allowedTools "Bash,Edit,Write,Read,Glob,Grep,mcp__github__create_pull_request,mcp__github__list_pull_requests"'
+          show_full_output: true
           prompt: |
             Improve all documentation in this repository using the absolute-documentations skill.
 


### PR DESCRIPTION
## Root cause

Claude was successfully creating the `docs/auto-update-*` branch and pushing commits, but never opened a PR.

**Why:** `--allowedTools "Bash,Edit,Write,Read,Glob,Grep"` triggers this check in the action:
```ts
const hasGitHubMcpTools = allowedToolsList.some((tool) => tool.startsWith("mcp__github__"));
```
Since no `mcp__github__*` tools were listed, the **GitHub MCP server was never loaded**. Without it, Claude fell back to `gh pr create` via Bash — but `gh` CLI is not authenticated in this runner context (the action configures git auth, not `gh` auth).

## Fix

Added `mcp__github__create_pull_request,mcp__github__list_pull_requests` to `allowedTools`. This loads the GitHub MCP server, giving Claude a proper authenticated API tool for PR creation.

Also enabled `show_full_output: true` temporarily to confirm correct behavior on next run (can be removed once verified).

## Test plan

- [ ] Trigger workflow manually → confirm `docs/auto-update-YYYY-MM-DD` PR is opened
- [ ] Remove `show_full_output: true` after confirming it works