### PR TITLE
docs: automated documentation update [2026-06-24]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Guidance for AI coding agents working in this repo. Read before editing.
 
 TulipFarm — AI-native business operating system. pnpm + Turborepo monorepo.
 
-- **Node**: see `.node-version` · **Package manager**: `pnpm@11.1.3` (never use npm/yarn)
+- **Node**: see `.node-version` · **Package manager**: `pnpm@11.5.3` (never use npm/yarn)
 - **Workspaces**: `apps/*`, `packages/*`
 
 ## Layout
@@ -38,10 +38,12 @@ pnpm install            # frozen install in CI: pnpm install --frozen-lockfile
 pnpm dev                # api on :4010, web on :4000
 pnpm dev:api            # api only
 pnpm dev:web            # web only
+pnpm dev:docs           # docs site on :4020
 pnpm lint               # biome check across all workspaces
 pnpm typecheck          # tsc --noEmit across all workspaces
 pnpm test               # vitest run
 pnpm build              # turbo build
+pnpm reset:dev          # wipe local db + soul, then re-run setup (clean slate)
 ```
 
 Single workspace: `pnpm --filter @tulipfarm/api <script>`.
@@ -58,7 +60,7 @@ Tests use **Vitest** (`*.test.ts` colocated with source). `pnpm test` passes wit
 
 ## Lint / format — Biome (read this to avoid churn)
 
-Single source of truth: `biome.json` (Biome 1.9.4). **No ESLint, no Prettier.** Do not add them.
+Single source of truth: `biome.json` (Biome 2.4.16). **No ESLint, no Prettier.** Do not add them.
 
 Auto-fix before hand-fixing:
 

--- a/README.md
+++ b/README.md
@@ -30,10 +30,9 @@ Verifies WSL2 + a distro, then runs the Linux installer inside WSL.
 
 Overrides (env vars): `TF_VERSION` (image tag, default `latest`), `TF_PORT` (default
 `8080`), `TF_INSTALL_DIR` (default `/opt/tulipfarm`), `TF_RUNTIME` (`docker`|`podman`),
-`TF_BASE_URL`/`TF_REF`. Full guide: [docs/installation](apps/docs/content/docs/installation.mdx).
+`TF_BASE_URL`/`TF_REF`. Full guide: see `apps/docs/content/docs/installation.mdx`.
 
-> Note: the published image + compose land on `main` with the deploy milestone; until
-> then, install from a branch with `TF_REF=<branch>` or test locally via `TF_LOCAL_SRC`.
+> To install a specific version or branch, set `TF_VERSION=<tag>` or `TF_REF=<branch>` before running the installer. To test a local build, set `TF_LOCAL_SRC=1`.
 
 ## Local Development
 
@@ -97,21 +96,20 @@ developer's choice (both options satisfy AC-006).
 The `scripts/setup-dev.sh` script automatically:
 - Installs and starts PostgreSQL 17 + pgvector
 - Creates the `tulipfarm` database
-- Initializes a local `./soul` git repository with the required directory structure
+- Initializes the soul git repository at `~/.tulipfarm/soul` with the required directory structure
 - Generates `.env.local` with random bootstrap secrets (`ENCRYPTION_KEY`, `JWT_SECRET`, `WEBHOOK_SIGNING_SECRET`)
 
 **Manual adjustments:** Edit `.env.local` to customize the datastore or add optional variables like `GIT_REMOTE_URL` for syncing soul changes to a remote repository.
 
 ### Soul Repository
 
-The `./soul` directory is a local git repository that stores your system configuration (resources, routines, agents, skills, integrations). By default, it is local-only. To enable remote sync:
+The soul lives at `~/.tulipfarm/soul` — a git repository that stores your system configuration (resources, routines, agents, skills, integrations). By default, it is local-only. To enable remote sync:
 
 1. Create a private GitHub repository for your soul
 2. Add the remote and set `GIT_REMOTE_URL` in `.env.local`:
    ```bash
-   cd soul
-   git remote add origin https://github.com/your-org/your-soul.git
-   git push -u origin main
+   git -C ~/.tulipfarm/soul remote add origin https://github.com/your-org/your-soul.git
+   git -C ~/.tulipfarm/soul push -u origin main
    ```
 3. Update `.env.local`: `GIT_REMOTE_URL=https://github.com/your-org/your-soul.git`
 

--- a/apps/docs/content/docs/concepts/agents.mdx
+++ b/apps/docs/content/docs/concepts/agents.mdx
@@ -53,6 +53,14 @@ Editing the soul — creating or changing an agent, skill, or schema — is neve
 `autonomy` gate applies only to actions on the outside world and your data. In V1 every
 agent has access to the full tool set; there is no per-agent tool restriction yet.
 
+## Guardrails
+
+Independent of autonomy, every turn runs through three guard stages configured in
+`soul/guardrails.yaml`: **input** (before the model sees the message), **tool-call**
+(before each tool executes), and **output** (after the model responds). Guards use
+pattern matching — no extra LLM required. If `guardrails.yaml` is absent or invalid,
+the instance falls back to built-in safe defaults.
+
 ## Creating agents
 
 Agents are created and edited through agent tools and forges, which write the `AGENT.md`

--- a/apps/docs/content/docs/concepts/knowledge.mdx
+++ b/apps/docs/content/docs/concepts/knowledge.mdx
@@ -21,10 +21,9 @@ Knowledge is populated from a few sources, not by file upload:
 There is no file upload in V1, so authored content is markdown text only. Documents carry
 revisions, so edits are tracked over time.
 
-<Callout type="info">
-A knowledge authoring UI is still on the way. Today, documents are created through the
-API or by agents; the web UI shows indexed knowledge once it exists.
-</Callout>
+Knowledge is organised into **collections** — named groups of documents you can target
+for search or inject into agents. Create and manage both documents and collections in
+the **Knowledge** section of the web UI, or through the API.
 
 ## Indexing and search
 

--- a/apps/docs/content/docs/concepts/llm.mdx
+++ b/apps/docs/content/docs/concepts/llm.mdx
@@ -43,8 +43,13 @@ configuration.
 
 ## Credentials
 
-A provider entry references its API key by a logical secret name (for example,
-`anthropic-api-key`), resolved at runtime from the [secrets store](/docs/concepts/secrets)
-and cached after first use. Keys never live in the LLM config file itself. To run, a
-provider must be configured in **Settings → Secrets** before it can be selected in a
-tier — see [Configure LLM providers](/docs/guides/configure-llm-providers).
+A provider entry references its API key with an `api_key_ref` field. Two forms are
+accepted:
+
+- `env://VAR_NAME` — reads directly from the environment variable `VAR_NAME`.
+- A bare name like `anthropic-api-key` — resolved from the [secrets store](/docs/concepts/secrets)
+  at runtime and cached after first use.
+
+Keys never live in the LLM config file itself. A provider must have its credentials
+configured in **Settings → Secrets** before it can be selected in a tier — see
+[Configure LLM providers](/docs/guides/configure-llm-providers).

--- a/apps/docs/content/docs/concepts/resources.mdx
+++ b/apps/docs/content/docs/concepts/resources.mdx
@@ -63,11 +63,13 @@ the UI surfaces it as unresolved rather than blocking the delete.
 Beyond identifiers and links, schemas support declarative transforms applied before a
 write:
 
-- `x-computed` — derive a field's value from others
-- `x-normalize` — clean a value into canonical form
+- **`x-normalize`** — clean a value into canonical form. Supported strategies: `trim`,
+  `lowercase`, `uppercase`, `slugify`, `phone-e164`, `email-normalize`.
+- **`x-computed`** — derive a field's value from others. Supported strategies: `sha256`,
+  `uuid`, `sequence`.
 
 These cover the common before-write cases without code. For arbitrary logic, a resource
-type can include a `hooks.ts` file, executed in a sandboxed environment.
+type can include a `hooks.ts` file executed in an isolated sandbox (`isolated-vm`).
 
 <Callout type="info">
 Resource types are authored in the soul today — there is no in-app form to create a new

--- a/apps/docs/content/docs/concepts/skills.mdx
+++ b/apps/docs/content/docs/concepts/skills.mdx
@@ -23,9 +23,9 @@ for it.
 
 ## Installing from a git repository
 
-The skill marketplace installs skills straight from a git URL. The flow has three steps:
-**scan** a repository for installable skills, **audit** the ones you select, then
-**confirm** the install. An installed skill is written to `soul/skills/{name}/`,
+The **Skills → Marketplace** tab installs skills straight from a git URL. The flow has
+three steps: **scan** a repository for installable skills, **audit** the ones you select,
+then **confirm** the install. An installed skill is written to `soul/skills/{name}/`,
 committed, and recorded in `skills-lock.json` with its source URL, ref, and hash.
 
 See [Install a skill](/docs/guides/install-a-skill) for the walkthrough.

--- a/apps/docs/content/docs/concepts/soul.mdx
+++ b/apps/docs/content/docs/concepts/soul.mdx
@@ -34,6 +34,7 @@ soul/
   routines/{name}/     routine definitions
   integrations/{name}/ connection config
   llm.config.yaml      LLM provider tiers
+  guardrails.yaml      input / tool-call / output guard rules
   soul.yaml            root manifest
   skills-lock.json     installed-skill provenance
 ```

--- a/apps/docs/content/docs/getting-started.mdx
+++ b/apps/docs/content/docs/getting-started.mdx
@@ -119,14 +119,8 @@ You should see:
 ### Log in
 
 Open `http://localhost:4000` and sign in with the `ADMIN_EMAIL` and `ADMIN_PASSWORD`
-you set. You land on the workspace: a sidebar with Chat, Resources, Agents, Skills, and
-Settings.
-
-<Callout title="Chat is coming">
-The chat composer is visible but not yet wired — it is flagged `soon`. For now you drive
-your instance through the workspace sections and the soul repo, which is what the rest of
-this guide does.
-</Callout>
+you set. You land on the chat workspace. The sidebar gives you Chat, Resources, Agents,
+Skills, Knowledge, and Settings.
 
 </Step>
 

--- a/apps/docs/content/docs/guides/configure-llm-providers.mdx
+++ b/apps/docs/content/docs/guides/configure-llm-providers.mdx
@@ -40,5 +40,5 @@ reloads with the new configuration, written to `soul/llm.config.yaml`.
 
 ## Verify
 
-After saving you see a "Saved · LLM service reloaded" confirmation. Your agents now run
+After saving you see a "Saved · LLM service reloaded." confirmation. Your agents now run
 against the providers you configured.

--- a/apps/docs/content/docs/guides/install-a-skill.mdx
+++ b/apps/docs/content/docs/guides/install-a-skill.mdx
@@ -8,9 +8,9 @@ import { Callout } from "fumadocs-ui/components/callout";
 This guide installs a [skill](/docs/concepts/skills) from a git repository through the
 web UI. The flow is always scan, then audit, then confirm.
 
-## Open the installer
+## Open the marketplace
 
-In the sidebar, choose **Skills**, then **Install**.
+In the sidebar, choose **Skills**, then **Marketplace**.
 
 ## Scan a repository
 

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -33,4 +33,5 @@ record in the datastore. Read [Concepts](/docs/concepts) for the full picture.
   <Card title="Concepts" href="/docs/concepts" description="How the soul, resources, agents, skills, knowledge, and LLM tiers fit together." />
   <Card title="Guides" href="/docs/guides" description="Task recipes: define a resource, install a skill, configure providers." />
   <Card title="Reference" href="/docs/reference" description="Environment variables and the commands that run the project." />
+  <Card title="Security" href="/docs/security/encryption" description="How secrets are encrypted, hashed, and rotated." />
 </Cards>

--- a/apps/docs/content/docs/reference/commands.mdx
+++ b/apps/docs/content/docs/reference/commands.mdx
@@ -12,6 +12,7 @@ noted. The package manager is `pnpm` — do not substitute npm or yarn.
 |---|---|
 | `bash scripts/setup-dev.sh` | Installs PostgreSQL 17 + pgvector, starts the database, creates the `tulipfarm` database, initializes the soul repo at `~/.tulipfarm/soul`, and writes `.env.local` with generated secrets. |
 | `pnpm install` | Installs workspace dependencies. Use `--frozen-lockfile` in CI. |
+| `pnpm reset:dev` | Tears down the local dev database and soul, then re-runs setup. Use when you want a clean slate. |
 
 ## Run
 
@@ -41,3 +42,15 @@ pnpm --filter @tulipfarm/api dev
 pnpm --filter @tulipfarm/web test
 pnpm --filter @tulipfarm/docs build
 ```
+
+## Secrets and encryption
+
+These run against a local or production instance. They read `.env.local` and `DATABASE_URL`.
+
+| Command | What it does |
+|---|---|
+| `pnpm --filter @tulipfarm/api keys verify` | Checks that the active DEK unwraps correctly under the current `ENCRYPTION_KEY`. Run after a key rotation to confirm the new key works. |
+| `pnpm --filter @tulipfarm/api keys show-recovery` | Mints the offline recovery key and prints it **once**. Store it in a password manager or sealed vault — it is never shown again. |
+| `pnpm --filter @tulipfarm/api keys rotate-kek` | Re-wraps the DEK under the new `ENCRYPTION_KEY`. Requires both `ENCRYPTION_KEY` (new) and `ENCRYPTION_KEY_PREVIOUS` (old) to be set. |
+| `pnpm --filter @tulipfarm/api keys recover` | Recovers a lost `ENCRYPTION_KEY` using the offline recovery key. Set `RECOVERY_KEY=<base64>` in the environment before running. |
+| `pnpm --filter @tulipfarm/api keys backfill` | Migrates secrets written before envelope encryption onto the DEK. Idempotent and resumable. |

--- a/docs/runbooks/secrets-key-recovery.md
+++ b/docs/runbooks/secrets-key-recovery.md
@@ -3,6 +3,13 @@
 How TulipFarm protects encrypted secrets, and the operator procedures for recovery and rotation.
 Background: `apps/docs/content/docs/security/encryption.mdx`.
 
+## Prerequisites
+
+- Shell access to the machine running the TulipFarm API.
+- `.env.local` (or equivalent) in scope so the process can read `DATABASE_URL` and `ENCRYPTION_KEY`.
+- `node` and `pnpm` installed (same version as the project — check `.node-version`).
+- The API checked out at the relevant version (`git status` should be clean or on the right commit).
+
 ## How it works (1 minute)
 
 - Every secret is encrypted under a single **DEK** (Data Encryption Key).
@@ -64,6 +71,9 @@ keep working. To move them onto the DEK:
 ```bash
 pnpm --filter @tulipfarm/api keys backfill   # idempotent + resumable; reports migrated/failed
 ```
+
+Verify all secrets migrated successfully by checking `dek_id IS NOT NULL` in the output, or run
+`keys verify` to confirm the active DEK covers all wraps.
 
 ## API-token pepper (optional, separate from the above)
 


### PR DESCRIPTION
Auto-generated by the daily docs-update workflow. 14 files improved.

**Stale facts corrected:**
- `AGENTS.md` — Biome `1.9.4` → `2.4.16`, pnpm `11.1.3` → `11.5.3`
- `README.md` — Soul path `./soul` → `~/.tulipfarm/soul`; `git remote add` commands now use `git -C ~/.tulipfarm/soul`; WIP "deploy milestone" note replaced with actionable override instructions

**Inaccurate UI instructions fixed:**
- `getting-started.mdx` — Removed "Chat is coming" callout (chat is live)
- `guides/install-a-skill.mdx` — "Skills → Install" → "Skills → Marketplace" (route moved)
- `concepts/knowledge.mdx` — Removed "authoring UI coming" callout; described the live documents + collections UI
- `guides/configure-llm-providers.mdx` — Confirmation text corrected to match what the UI actually renders

**Completeness gaps filled:**
- `concepts/soul.mdx` — Added `guardrails.yaml` to the soul layout diagram
- `concepts/agents.mdx` — Added a Guardrails section explaining the three stages and `guardrails.yaml`
- `concepts/llm.mdx` — Added `api_key_ref` format detail (`env://VAR` vs bare secret name)
- `concepts/resources.mdx` — Listed all `x-normalize` and `x-computed` strategies
- `concepts/skills.mdx` — Named the Marketplace tab explicitly
- `reference/commands.mdx` — Added `pnpm reset:dev`; added full Secrets and encryption section
- `docs/index.mdx` — Added Security card for discoverability

**Runbook improved:**
- `docs/runbooks/secrets-key-recovery.md` — Added Prerequisites section; added backfill verification step

**AGENTS.md:** Added `pnpm dev:docs` and `pnpm reset:dev` to commands table