### PR TITLE
feat(ci): scheduled GitHub Actions workflows for absolute-* skills

### DIFF
--- a/.github/workflows/absolute-audit.yml
+++ b/.github/workflows/absolute-audit.yml
@@ -1,0 +1,47 @@
+name: Daily Security Audit
+
+on:
+  schedule:
+    - cron: '0 9 * * *' # 2:30 PM IST daily
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: absolute-audit
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    name: Security audit and fix
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Run absolute-audit skill
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_args: '--allowedTools "Bash,Edit,Write,Read,Glob,Grep"'
+          prompt: |
+            Perform a security audit of this repository using the absolute-audit skill.
+
+            Invoke the skill now. This is a fully automated CI run — you MUST NOT pause at
+            any approval gate or intake question. Answer all skill questions yourself using
+            best judgment from the codebase.
+
+            Scope: dependency CVEs, hardcoded secrets, injection vulnerabilities, weak authz.
+
+            After the audit:
+            - If NO vulnerabilities found: exit silently. Do not open a PR.
+            - If vulnerabilities ARE found (any severity):
+              1. Fix them as part of the skill's remediation phase
+              2. Create branch: fix/audit-$(date +%Y-%m-%d)
+              3. Commit with message: "fix(security): remediate audit findings $(date +%Y-%m-%d)"
+              4. Open a PR titled: "fix(security): audit findings $(date +%Y-%m-%d)"
+              5. In the PR body, list each finding with its severity and the fix applied
+              6. Add label "security" to the PR (create it if it doesn't exist)
+              7. Assign the PR to maddhruv

--- a/.github/workflows/absolute-debt.yml
+++ b/.github/workflows/absolute-debt.yml
@@ -1,0 +1,57 @@
+name: Daily Lint & Type Debt
+
+on:
+  schedule:
+    - cron: '0 13 * * *' # 6:30 PM IST daily (30 min after upgrade)
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: absolute-debt
+  cancel-in-progress: true
+
+jobs:
+  debt:
+    name: Pay down one lint/type rule
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Skip if debt PR already open
+        id: check
+        run: |
+          OPEN=$(gh pr list --state open --json title --jq '[.[] | select(.title | startswith("chore(debt):"))] | length')
+          echo "open_debt_prs=$OPEN" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run absolute-debt skill
+        if: steps.check.outputs.open_debt_prs == '0'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_args: '--allowedTools "Bash,Edit,Write,Read,Glob,Grep"'
+          prompt: |
+            Pay down lint and type debt in this repository using the absolute-debt skill.
+
+            Invoke the skill now. This is a fully automated CI run — you MUST NOT pause at
+            any approval gate or intake question. Answer all skill questions yourself using
+            best judgment from the codebase.
+
+            Constraints:
+            1. Fix exactly ONE lint/type rule per run (skill's default wave behavior).
+            2. Fix the root cause — never add suppressions (@ts-ignore, eslint-disable).
+            3. Verify that pnpm exec biome check . and pnpm typecheck pass after fixing.
+
+            After fixing:
+            - If there are NO changes: exit silently.
+            - If there ARE changes:
+              1. Create branch: chore/debt-<rule-name>-$(date +%Y-%m-%d)
+              2. Commit with message: "chore(debt): fix <rule-name> violations"
+              3. Open a PR titled: "chore(debt): fix <rule-name> violations"
+              4. Add label "tech-debt" to the PR (create it if it doesn't exist)
+              5. Assign the PR to maddhruv

--- a/.github/workflows/absolute-prune.yml
+++ b/.github/workflows/absolute-prune.yml
@@ -1,0 +1,48 @@
+name: Prune Dead Code
+
+on:
+  schedule:
+    - cron: '0 9 */2 * *' # every alternate day at 2:30 PM IST
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: absolute-prune
+  cancel-in-progress: true
+
+jobs:
+  prune:
+    name: Remove dead code
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Run absolute-prune skill
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_args: '--allowedTools "Bash,Edit,Write,Read,Glob,Grep"'
+          prompt: |
+            Remove dead code from this repository using the absolute-prune skill.
+
+            Invoke the skill now. This is a fully automated CI run — you MUST NOT pause at
+            any approval gate or intake question. Answer all skill questions yourself using
+            best judgment from the codebase.
+
+            Scope: unused dependencies, unreferenced exports, unreachable code, orphaned files.
+            Only remove what tool evidence confirms is unused — no guessing.
+            Run in reversible waves. Verify tests pass after each wave.
+
+            After pruning:
+            - If there are NO changes: exit silently. Do not open a PR.
+            - If there ARE changes:
+              1. Create branch: chore/prune-$(date +%Y-%m-%d)
+              2. Commit with message: "chore: prune dead code $(date +%Y-%m-%d)"
+              3. Open a PR titled: "chore: prune dead code ($(date +%Y-%m-%d))"
+              4. In the PR body, list what was removed and the evidence used to confirm it was dead
+              5. Add label "cleanup" to the PR (create it if it doesn't exist)
+              6. Assign the PR to maddhruv

--- a/.github/workflows/absolute-simplify-cron.yml
+++ b/.github/workflows/absolute-simplify-cron.yml
@@ -1,0 +1,56 @@
+name: Scheduled Simplify (Rotation)
+
+on:
+  schedule:
+    - cron: '0 */6 * * *' # every 6 hours
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: absolute-simplify-cron
+  cancel-in-progress: true
+
+jobs:
+  simplify:
+    name: Simplify target directory
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Compute target directory
+        id: target
+        run: |
+          SLOT=$(( ($(date +%s) / 3600 / 6) % 10 ))
+          DIRS=(apps/api apps/web packages/llm packages/soul packages/ui packages/utils packages/validation packages/constants packages/secrets packages/types)
+          DIR="${DIRS[$SLOT]}"
+          DIRNAME="${DIR##*/}"
+          echo "dir=$DIR" >> $GITHUB_OUTPUT
+          echo "dirname=$DIRNAME" >> $GITHUB_OUTPUT
+          echo "Selected slot $SLOT → $DIR"
+
+      - name: Run absolute-simplify skill
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_args: '--allowedTools "Bash,Edit,Write,Read,Glob,Grep"'
+          prompt: |
+            Simplify the code in the directory ${{ steps.target.outputs.dir }} using the
+            absolute-simplify skill.
+
+            Invoke the skill now. This is a fully automated CI run — you MUST NOT pause at
+            any approval gate or intake question. Answer all skill questions yourself using
+            best judgment from the codebase. Target path: ${{ steps.target.outputs.dir }}
+
+            After the skill finishes:
+            - If there are NO changes to commit: exit silently. Do not open a PR.
+            - If there ARE changes:
+              1. Create a branch: chore/simplify-${{ steps.target.outputs.dirname }}-$(date +%Y-%m-%d)
+              2. Commit with message: "chore: simplify ${{ steps.target.outputs.dir }}"
+              3. Open a PR targeting main titled:
+                 "chore: simplify ${{ steps.target.outputs.dir }} ($(date +%Y-%m-%d))"
+              4. Assign the PR to maddhruv
+              5. Add PR body: "Automated simplification of ${{ steps.target.outputs.dir }} by scheduled absolute-simplify."

--- a/.github/workflows/absolute-simplify-pr.yml
+++ b/.github/workflows/absolute-simplify-pr.yml
@@ -1,0 +1,54 @@
+name: Simplify PR Changes
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: absolute-simplify-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  simplify:
+    name: Simplify PR diff
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ github.head_ref }}
+
+      - name: Run absolute-simplify skill
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_args: '--allowedTools "Bash,Edit,Write,Read,Glob,Grep"'
+          prompt: |
+            Simplify the changes in this pull request using the absolute-simplify skill.
+
+            Invoke the skill now. This is a fully automated CI run — you MUST NOT pause at
+            any approval gate or intake question. Answer all skill questions yourself using
+            best judgment from the codebase.
+
+            Context:
+            - PR branch: ${{ github.head_ref }}
+            - PR number: ${{ github.event.pull_request.number }}
+            - Base branch: ${{ github.base_ref }}
+
+            The skill should act on the diff between ${{ github.base_ref }} and ${{ github.head_ref }}.
+
+            After the skill finishes:
+            - If there are NO changes to commit: exit silently. Do not open a PR.
+            - If there ARE changes:
+              1. Create a new branch named: chore/simplify-${{ github.head_ref }}-${{ github.event.pull_request.head.sha }}
+                 (truncate the sha to 7 chars)
+              2. Commit with message: "chore: simplify changes from PR #${{ github.event.pull_request.number }}"
+              3. Open a PR targeting ${{ github.head_ref }} (NOT main) titled:
+                 "chore: simplify PR #${{ github.event.pull_request.number }} changes"
+              4. Assign the PR to maddhruv
+              5. Add PR body: "Automated simplification of changes in #${{ github.event.pull_request.number }} by absolute-simplify."

--- a/.github/workflows/absolute-upgrade.yml
+++ b/.github/workflows/absolute-upgrade.yml
@@ -1,0 +1,55 @@
+name: Daily Dependency Upgrade
+
+on:
+  schedule:
+    - cron: '30 12 * * *' # 6:00 PM IST daily
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: absolute-upgrade
+  cancel-in-progress: true
+
+jobs:
+  upgrade:
+    name: Upgrade one dependency
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Run absolute-upgrade skill
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_args: '--allowedTools "Bash,Edit,Write,Read,Glob,Grep"'
+          prompt: |
+            Upgrade exactly ONE dependency in this repository using the absolute-upgrade skill.
+
+            Invoke the skill now. This is a fully automated CI run — you MUST NOT pause at
+            any approval gate or intake question. Answer all skill questions yourself using
+            best judgment from the codebase.
+
+            Constraints:
+            1. Upgrade exactly 1 package per run — do not batch multiple packages.
+            2. Priority order for selecting which package to upgrade:
+               a. Packages with a known critical/high CVE (security vulnerability)
+               b. Packages that are most outdated (largest semver gap from current to latest)
+            3. Before selecting a package, run:
+               gh pr list --state open --label "dependencies" --json title,headRefName
+               Also run: gh pr list --state open --json title,headRefName
+               Check if any existing open PR already upgrades a candidate package.
+               If yes, skip that package and move to the next priority candidate.
+               Keep skipping until you find a package with no open upgrade PR.
+            4. If all high-priority packages already have open upgrade PRs, exit silently.
+
+            After upgrading:
+            1. Run tests to verify nothing is broken: pnpm test
+            2. If tests pass, create branch: chore/upgrade-<package-name>-<new-version>
+            3. Commit with message: "chore(deps): upgrade <package-name> to <new-version>"
+            4. Open a PR titled: "chore(deps): upgrade <package-name> to <new-version>"
+            5. Add label "dependencies" to the PR (create it if it doesn't exist)
+            6. Assign the PR to maddhruv

--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -25,7 +25,8 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          claude_args: '--allowedTools "Bash,Edit,Write,Read,Glob,Grep"'
+          claude_args: '--allowedTools "Bash,Edit,Write,Read,Glob,Grep,mcp__github__create_pull_request,mcp__github__list_pull_requests"'
+          show_full_output: true
           prompt: |
             Improve all documentation in this repository using the absolute-documentations skill.
 

--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -24,7 +24,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GH_PAT }}
           claude_args: '--allowedTools "Bash,Edit,Write,Read,Glob,Grep,mcp__github__create_pull_request,mcp__github__list_pull_requests"'
           show_full_output: true
           prompt: |

--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -24,7 +24,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.GH_PAT }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: '--allowedTools "Bash,Edit,Write,Read,Glob,Grep,mcp__github__create_pull_request,mcp__github__list_pull_requests"'
           show_full_output: true
           prompt: |


### PR DESCRIPTION
## Summary

- Adds 6 GitHub Actions workflows wiring `absolute-*` skills to run automatically via `claude-code-action`
- Follows the exact same pattern as `docs-update.yml`

## Workflows

| Workflow | Skill | Schedule |
|---|---|---|
| `absolute-simplify-pr.yml` | absolute-simplify | On every PR (opened/sync) — opens separate simplify PR targeting original branch |
| `absolute-simplify-cron.yml` | absolute-simplify | Every 6h — clock-derived rotation across 10 dirs |
| `absolute-upgrade.yml` | absolute-upgrade | Daily 6 PM IST — 1 pkg/run, priority CVE→outdated, skips if open upgrade PR exists |
| `absolute-audit.yml` | absolute-audit | Daily 2:30 PM IST — always opens fix PR |
| `absolute-debt.yml` | absolute-debt | Daily 6:30 PM IST — 1 rule/run, skips if debt PR already open |
| `absolute-prune.yml` | absolute-prune | Every 2 days 2:30 PM IST — evidence-based dead code removal |

All PRs auto-assigned to `maddhruv`. Failures → GitHub Actions email only.

## Test plan

- [ ] Trigger each workflow via `workflow_dispatch` in Actions tab
- [ ] Confirm PRs are created and assigned correctly
- [ ] For `absolute-simplify-pr`: open a test PR and verify separate simplify PR targets the original branch