### PR TITLE
fix(ci): propagate GH_TOKEN to Claude actions and reschedule to 2 AM IST

### DIFF
--- a/.github/workflows/absolute-audit.yml
+++ b/.github/workflows/absolute-audit.yml
@@ -2,7 +2,7 @@ name: Daily Security Audit
 
 on:
   schedule:
-    - cron: '0 9 * * *' # 2:30 PM IST daily
+    - cron: '30 20 * * *' # 2:00 AM IST daily
   workflow_dispatch:
 
 permissions:
@@ -26,6 +26,8 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: '--allowedTools "Bash,Edit,Write,Read,Glob,Grep"'
+          env:
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             Perform a security audit of this repository using the absolute-audit skill.
 

--- a/.github/workflows/absolute-debt.yml
+++ b/.github/workflows/absolute-debt.yml
@@ -2,7 +2,7 @@ name: Daily Lint & Type Debt
 
 on:
   schedule:
-    - cron: '0 13 * * *' # 6:30 PM IST daily (30 min after upgrade)
+    - cron: '30 20 * * *' # 2:00 AM IST daily
   workflow_dispatch:
 
 permissions:
@@ -35,6 +35,8 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: '--allowedTools "Bash,Edit,Write,Read,Glob,Grep"'
+          env:
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             Pay down lint and type debt in this repository using the absolute-debt skill.
 

--- a/.github/workflows/absolute-prune.yml
+++ b/.github/workflows/absolute-prune.yml
@@ -2,7 +2,7 @@ name: Prune Dead Code
 
 on:
   schedule:
-    - cron: '0 9 */2 * *' # every alternate day at 2:30 PM IST
+    - cron: '30 20 */2 * *' # every alternate day at 2:00 AM IST
   workflow_dispatch:
 
 permissions:
@@ -26,6 +26,8 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: '--allowedTools "Bash,Edit,Write,Read,Glob,Grep"'
+          env:
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             Remove dead code from this repository using the absolute-prune skill.
 

--- a/.github/workflows/absolute-simplify-cron.yml
+++ b/.github/workflows/absolute-simplify-cron.yml
@@ -2,7 +2,7 @@ name: Scheduled Simplify (Rotation)
 
 on:
   schedule:
-    - cron: '0 */6 * * *' # every 6 hours
+    - cron: '30 20 * * *' # 2:00 AM IST daily
   workflow_dispatch:
 
 permissions:
@@ -37,6 +37,8 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: '--allowedTools "Bash,Edit,Write,Read,Glob,Grep"'
+          env:
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             Simplify the code in the directory ${{ steps.target.outputs.dir }} using the
             absolute-simplify skill.

--- a/.github/workflows/absolute-upgrade.yml
+++ b/.github/workflows/absolute-upgrade.yml
@@ -2,7 +2,7 @@ name: Daily Dependency Upgrade
 
 on:
   schedule:
-    - cron: '30 12 * * *' # 6:00 PM IST daily
+    - cron: '30 20 * * *' # 2:00 AM IST daily
   workflow_dispatch:
 
 permissions:
@@ -26,6 +26,8 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: '--allowedTools "Bash,Edit,Write,Read,Glob,Grep"'
+          env:
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             Upgrade exactly ONE dependency in this repository using the absolute-upgrade skill.
 

--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -2,7 +2,7 @@ name: Daily Documentation Update
 
 on:
   schedule:
-    - cron: '30 10 * * *' # 4:00 PM IST (UTC+5:30) daily
+    - cron: '30 20 * * *' # 2:00 AM IST daily
   workflow_dispatch: # manual trigger for testing
 
 permissions:
@@ -26,6 +26,8 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: '--allowedTools "Bash,Edit,Write,Read,Glob,Grep,mcp__github__create_pull_request,mcp__github__list_pull_requests"'
+          env:
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           show_full_output: true
           prompt: |
             Improve all documentation in this repository using the absolute-documentations skill.


### PR DESCRIPTION
## Summary

- **Root cause**: `GH_TOKEN` was missing from the `env` block of all `claude-code-action` steps. Claude's `Bash` tool couldn't authenticate `gh pr create`, so branches got pushed but PRs were silently dropped.
- **Fix**: Added `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to all 6 workflows.
- **Schedule**: All workflows moved to `30 20 * * *` (2:00 AM IST).

## Affected workflows

| Workflow | Old schedule | New schedule |
|---|---|---|
| `absolute-audit` | 2:30 PM IST | 2:00 AM IST |
| `absolute-debt` | 6:30 PM IST | 2:00 AM IST |
| `absolute-simplify-cron` | every 6h | 2:00 AM IST daily |
| `absolute-prune` | every 2d at 2:30 PM IST | every 2d at 2:00 AM IST |
| `absolute-upgrade` | 6:00 PM IST | 2:00 AM IST |
| `docs-update` | 4:00 PM IST | 2:00 AM IST |

## Orphaned branches from today's failed runs

- `chore/debt-suppressions-unused-2026-06-24` — fixed unused biome-ignore suppression
- `fix/audit-2026-06-24` — removed `file://` from allowed URL schemes (SSRF reduction)

These can be PR'd separately or merged directly.