### PR TITLE
chore(debt): fix suppressions/unused violations

### DIFF
--- a/apps/web/app/routes/_app.resources.new.tsx
+++ b/apps/web/app/routes/_app.resources.new.tsx
@@ -144,7 +144,6 @@ export default function ResourceTypeNew() {
             id, createdAt, updatedAt and version are added automatically.
           </p>
           {fields.map((f, i) => (
-            // biome-ignore lint/suspicious/noArrayIndexKey: rows are positional and reorder-free.
             <div
               key={i}
               className="flex flex-wrap items-center gap-2 rounded-sm border border-border p-2"


### PR DESCRIPTION
Remove biome-ignore comment suppressing noArrayIndexKey, which is already disabled globally in biome.json — making the suppression unused/stale.