### PR TITLE
feat(chat): remove edit user message functionality

### DIFF
--- a/apps/web/app/components/chat/chat-panel.tsx
+++ b/apps/web/app/components/chat/chat-panel.tsx
@@ -98,7 +98,6 @@ export function ChatPanel({
     stop,
     approve,
     regenerate,
-    editResend,
     sendFeedback,
     sendA2uiAgent,
   } = useChatStream({
@@ -162,7 +161,6 @@ export function ChatPanel({
           mentions={entries}
           onApprove={approve}
           onRegenerate={regenerate}
-          onEditResend={editResend}
           onFeedback={sendFeedback}
           onA2uiAgent={sendA2uiAgent}
         />

--- a/apps/web/app/components/chat/transcript.test.tsx
+++ b/apps/web/app/components/chat/transcript.test.tsx
@@ -250,48 +250,4 @@ describe("Transcript message actions", () => {
     expect(screen.queryByRole("button", { name: "Good response" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Bad response" })).toBeNull();
   });
-
-  it("lets you edit a user message and re-runs from it on save", async () => {
-    const user = userEvent.setup();
-    const onEditResend = vi.fn();
-    const state = fold([], "original question");
-    render(
-      <Transcript
-        messages={state.messages}
-        status={state.status}
-        onApprove={vi.fn()}
-        onEditResend={onEditResend}
-      />
-    );
-
-    await user.click(screen.getByRole("button", { name: "edit" }));
-    const box = screen.getByRole("textbox", { name: "Edit message" });
-    await user.clear(box);
-    await user.type(box, "edited question");
-    await user.click(screen.getByRole("button", { name: "save" }));
-
-    expect(onEditResend).toHaveBeenCalledTimes(1);
-    expect(onEditResend).toHaveBeenCalledWith(state.messages[0].id, "edited question");
-  });
-
-  it("cancelling an edit restores the message and fires nothing", async () => {
-    const user = userEvent.setup();
-    const onEditResend = vi.fn();
-    const state = fold([], "keep me");
-    render(
-      <Transcript
-        messages={state.messages}
-        status={state.status}
-        onApprove={vi.fn()}
-        onEditResend={onEditResend}
-      />
-    );
-
-    await user.click(screen.getByRole("button", { name: "edit" }));
-    await user.type(screen.getByRole("textbox", { name: "Edit message" }), " — discarded");
-    await user.click(screen.getByRole("button", { name: "cancel" }));
-
-    expect(onEditResend).not.toHaveBeenCalled();
-    expect(screen.getByText("keep me")).toBeInTheDocument();
-  });
 });

--- a/apps/web/app/components/chat/transcript.tsx
+++ b/apps/web/app/components/chat/transcript.tsx
@@ -1,4 +1,4 @@
-import { Check, Copy, Pencil, RotateCcw, ThumbsDown, ThumbsUp } from "lucide-react";
+import { Check, Copy, RotateCcw, ThumbsDown, ThumbsUp } from "lucide-react";
 import { type ReactNode, useEffect, useRef, useState } from "react";
 import { MarkdownView } from "~/components/markdown-view";
 import type { ChatMessage, ChatStatus, TimelinePart } from "~/lib/chat/types";
@@ -184,71 +184,9 @@ function AssistantActions({
   );
 }
 
-// User turn: a right-aligned bubble with a copy/edit toolbar. Editing swaps the bubble for an inline
-// textarea; saving re-runs the conversation from this turn (a local branch — see useChatStream).
-function UserMessage({
-  message,
-  mentions,
-  onEditResend,
-}: {
-  message: ChatMessage;
-  mentions?: MentionEntry[];
-  onEditResend?: (messageId: string, text: string) => void;
-}) {
+// User turn: a right-aligned bubble with a copy toolbar.
+function UserMessage({ message, mentions }: { message: ChatMessage; mentions?: MentionEntry[] }) {
   const text = messageText(message);
-  const [editing, setEditing] = useState(false);
-  const [draft, setDraft] = useState(text);
-  const ref = useRef<HTMLTextAreaElement>(null);
-
-  useEffect(() => {
-    const ta = ref.current;
-    if (editing && ta) {
-      ta.focus();
-      ta.setSelectionRange(ta.value.length, ta.value.length);
-    }
-  }, [editing]);
-
-  function save() {
-    const trimmed = draft.trim();
-    setEditing(false);
-    if (trimmed) onEditResend?.(message.id, trimmed);
-  }
-  function cancel() {
-    setDraft(text);
-    setEditing(false);
-  }
-
-  if (editing) {
-    return (
-      <div className="flex flex-col gap-1.5">
-        <textarea
-          ref={ref}
-          value={draft}
-          onChange={(e) => setDraft(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" && !e.shiftKey) {
-              e.preventDefault();
-              save();
-            } else if (e.key === "Escape") {
-              e.preventDefault();
-              cancel();
-            }
-          }}
-          rows={Math.min(8, draft.split("\n").length + 1)}
-          aria-label="Edit message"
-          className="w-full resize-none rounded-lg bg-muted px-3.5 py-2 text-sm text-foreground ring-1 ring-border"
-        />
-        <div className="flex items-center justify-end gap-1 text-xs text-muted-foreground">
-          <button type="button" onClick={cancel} className={actionBtn}>
-            cancel
-          </button>
-          <button type="button" onClick={save} className={`${actionBtn} text-primary`}>
-            save
-          </button>
-        </div>
-      </div>
-    );
-  }
 
   return (
     <div className="group flex flex-col items-end gap-1">
@@ -257,11 +195,6 @@ function UserMessage({
       </div>
       <div className={`${toolbar} justify-end`}>
         <CopyButton text={text} />
-        {onEditResend ? (
-          <IconAction label="edit" onClick={() => setEditing(true)}>
-            <Pencil className="size-3.5" />
-          </IconAction>
-        ) : null}
       </div>
     </div>
   );
@@ -274,7 +207,6 @@ function Message({
   mentions,
   onApprove,
   onRegenerate,
-  onEditResend,
   onFeedback,
   onA2uiAgent,
 }: {
@@ -284,12 +216,11 @@ function Message({
   mentions?: MentionEntry[];
   onApprove: (approvalId: string, decision: "approve" | "deny") => void;
   onRegenerate?: () => void;
-  onEditResend?: (messageId: string, text: string) => void;
   onFeedback?: (messageId: string, rating: "up" | "down" | null, note?: string) => void;
   onA2uiAgent?: (payload: unknown) => void;
 }) {
   if (message.role === "user") {
-    return <UserMessage message={message} mentions={mentions} onEditResend={onEditResend} />;
+    return <UserMessage message={message} mentions={mentions} />;
   }
 
   const streaming = !message.sealed && status === "streaming";
@@ -339,7 +270,6 @@ export function Transcript({
   mentions,
   onApprove,
   onRegenerate,
-  onEditResend,
   onFeedback,
   onA2uiAgent,
 }: {
@@ -348,7 +278,6 @@ export function Transcript({
   mentions?: MentionEntry[];
   onApprove: (approvalId: string, decision: "approve" | "deny") => void;
   onRegenerate?: () => void;
-  onEditResend?: (messageId: string, text: string) => void;
   onFeedback?: (messageId: string, rating: "up" | "down" | null, note?: string) => void;
   onA2uiAgent?: (payload: unknown) => void;
 }) {
@@ -378,7 +307,6 @@ export function Transcript({
             mentions={mentions}
             onApprove={onApprove}
             onRegenerate={onRegenerate}
-            onEditResend={onEditResend}
             onFeedback={onFeedback}
             onA2uiAgent={onA2uiAgent}
           />

--- a/apps/web/app/lib/chat/reducer.ts
+++ b/apps/web/app/lib/chat/reducer.ts
@@ -39,7 +39,7 @@ export function appendUserMessage(state: ChatState, text: string): ChatState {
 // Stop / un-send: drop the trailing assistant turn(s) AND the last user message, returning the
 // timeline to a clean pre-send state. The composer restores the original prompt into its editor; this
 // only rewinds the transcript. Local-only — the server keeps its full history, the same V1 trade-off
-// as `regenerate` / `editResend`.
+// as `regenerate`.
 export function rewindLastTurn(state: ChatState): ChatState {
   const messages = state.messages.slice();
   while (messages.length > 0 && messages[messages.length - 1].role === "assistant") messages.pop();

--- a/apps/web/app/lib/chat/use-chat-stream.ts
+++ b/apps/web/app/lib/chat/use-chat-stream.ts
@@ -62,7 +62,6 @@ type ChatAction =
   | { type: "user"; text: string }
   | { type: "meta"; meta: ChatStreamMeta }
   | { type: "regenerate" }
-  | { type: "editResend"; messageId: string; text: string }
   | { type: "stopped" }
   | { type: "reset" };
 
@@ -158,14 +157,6 @@ function reducer(state: ChatState, action: ChatAction): ChatState {
       messages.pop();
     }
     return { ...state, messages, status: "submitted", error: undefined };
-  }
-  if (action.type === "editResend") {
-    // Branch from a prior user turn: drop that message and everything after it, then re-append the
-    // edited text as a fresh turn. Local-only (the server keeps its full history) — the same V1
-    // trade-off as "regenerate", which likewise has no server-side counterpart.
-    const idx = state.messages.findIndex((m) => m.id === action.messageId);
-    if (idx === -1) return state;
-    return appendUserMessage({ ...state, messages: state.messages.slice(0, idx) }, action.text);
   }
   if (action.type === "meta") {
     return {
@@ -275,18 +266,6 @@ export function useChatStream(opts?: UseChatStreamOptions) {
     await runStream(text, lastOptsRef.current);
   }, [runStream]);
 
-  // Edit an earlier user turn and re-run from it, dropping every later turn (a local branch — the
-  // server keeps its history, mirroring regenerate). Reuses the last turn's model/agent options.
-  const editResend = useCallback(
-    async (messageId: string, text: string) => {
-      const trimmed = text.trim();
-      if (!trimmed) return;
-      dispatch({ type: "editResend", messageId, text: trimmed });
-      await runStream(trimmed, lastOptsRef.current);
-    },
-    [runStream]
-  );
-
   // Stop the in-flight turn: best-effort halt the server's LLM (so token burn stops), then abort the
   // local fetch — the catch dispatches `stopped`, rewinding the turn. The streamId arrives via the
   // X-Stream-Id header (onMeta) almost immediately; a stop in the brief window before it lands still
@@ -345,7 +324,6 @@ export function useChatStream(opts?: UseChatStreamOptions) {
     stop,
     approve,
     regenerate,
-    editResend,
     sendFeedback,
     reset,
     sendA2uiAgent,


### PR DESCRIPTION
## Summary

- Removes `editResend` action type, reducer handler, callback, and return value from `useChatStream`
- Removes inline edit UI (textarea, save/cancel, edit button, `Pencil` icon) and the `onEditResend` prop chain through `UserMessage → Message → Transcript`
- Removes prop pass in `chat-panel.tsx`
- Removes 2 related test cases from `transcript.test.tsx`
- Updates stale `editResend` reference in a `reducer.ts` comment

## Test plan

- [ ] TypeScript: `pnpm exec tsc --noEmit` passes (verified clean)
- [ ] No edit button visible on user messages in chat
- [ ] Copy button still works on user messages
- [ ] Regenerate, feedback, and approval flows unaffected