### PR TITLE
feat(integrations): manifest v2 — egress/ingress types, slug-keyed instances

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -16,6 +16,7 @@
     "@fastify/helmet": "^13.0.2",
     "@fastify/static": "^9.1.3",
     "@fastify/swagger": "^9.7.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@node-rs/argon2": "^2.0.2",
     "@scalar/fastify-api-reference": "^1.62.0",
     "@tulipfarm/llm": "workspace:*",

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -32,6 +32,7 @@ import type { FeedbackRepo } from "./feedback/repo";
 import { registerFeedbackRoutes } from "./feedback/routes";
 import type { GuardrailsService } from "./guardrails";
 import type { HookExecutor } from "./hooks/hook-executor";
+import { McpClientService } from "./integrations/mcp-client-service";
 import type { PageRetrievalService } from "./knowledge/retrieval-service";
 import { registerKnowledgeRoutes } from "./knowledge/routes";
 import type { KnowledgeService } from "./knowledge/service";
@@ -50,6 +51,7 @@ import { registerSecretsRoutes } from "./secrets/routes";
 import { registerSetupRoutes, registerSetupStatusRoute } from "./setup/routes";
 import { isHeadlessBoot } from "./setup/service";
 import { registerAgentRoutes } from "./soul/agents/routes";
+import { registerIntegrationRoutes } from "./soul/integrations/routes";
 import { makeLlmCascadeOnSecretDelete } from "./soul/llm-config/cascade";
 import { registerLlmConfigRoutes } from "./soul/llm-config/routes";
 import { registerResourceTypeRoutes } from "./soul/resource-types/routes";
@@ -82,6 +84,7 @@ export interface AppOptions {
   knowledgeService?: KnowledgeService;
   retrievalService?: PageRetrievalService;
   toolRegistry?: ToolRegistry;
+  mcpClient?: McpClientService;
   approvalRegistry?: ApprovalRegistry;
   guardrailsService?: GuardrailsService;
   pendingInteractionRepo?: PendingInteractionRepo;
@@ -209,6 +212,9 @@ export async function buildApp(opts: AppOptions = {}) {
       rateLimiter: opts.rateLimiter,
     });
     const requireAuth = makeRequireAuth(opts.sessionStore, opts.userRepo, opts.tokenRepo);
+    // MCP client service: created once, shared between integration routes (connect/disconnect) and
+    // the tool registry (dynamic tool registration). Accepts an optional override for testing.
+    const mcpClientSvc = opts.mcpClient ?? new McpClientService(app.log);
     // Setup status: always registered so the web app gets an explicit 200 in all boot modes.
     // In headless boot the wizard step routes below are absent (404), but status is always reachable.
     const soulPath = process.env.SOUL_PATH;
@@ -280,6 +286,7 @@ export async function buildApp(opts: AppOptions = {}) {
             ? () => knowledgeService.hasAnyKnowledgePage()
             : undefined,
         });
+        registerIntegrationRoutes(app, opts.soulLoader, opts.gitSync, mcpClientSvc, requireAuth);
         if (opts.llmService) {
           registerSkillRoutes(
             app,
@@ -320,7 +327,19 @@ export async function buildApp(opts: AppOptions = {}) {
           workingMemory: opts.workingMemoryService,
           kv: opts.kvService,
           knowledge: opts.knowledgeService,
+          mcpClient: mcpClientSvc,
+          soulLoader: opts.soulLoader,
         });
+      // When an external registry is provided (e.g. from index.ts which builds the full registry
+      // separately), the inner buildToolRegistry above is skipped, so mcpClientSvc never gets its
+      // registry wired. Do it here so integration tools registered on connect/disconnect land in
+      // the same registry the chat turn uses.
+      if (opts.toolRegistry) {
+        mcpClientSvc.setRegistry(opts.toolRegistry);
+        if (opts.soulLoader?.integrations) {
+          void mcpClientSvc.startAll(opts.soulLoader.integrations);
+        }
+      }
       const approvalRegistry = opts.approvalRegistry ?? new ApprovalRegistry();
       registerChatRoutes(
         app,

--- a/apps/api/src/context/assemble.test.ts
+++ b/apps/api/src/context/assemble.test.ts
@@ -532,8 +532,9 @@ describe("assembleSystemPrompt — available-tools (tool L1)", () => {
   });
 
   it("drops the whole block when over the char budget (never half-rendered)", () => {
+    // budget is 24000 chars; use 25000 to exceed it
     const out = assembleSystemPrompt(
-      baseCtx({ availableTools: [{ name: "big", description: "x".repeat(9000) }] })
+      baseCtx({ availableTools: [{ name: "big", description: "x".repeat(25000) }] })
     );
     expect(out).not.toContain("<available-tools>");
   });

--- a/apps/api/src/context/assemble.ts
+++ b/apps/api/src/context/assemble.ts
@@ -215,7 +215,7 @@ function renderSoulContext(ctx: AssembleContext): string {
  * `<available-tools>` budget — total chars across all tool `name`+`description` pairs. Over this
  * the whole block is dropped (never half-rendered), matching `renderAvailableSkills`.
  */
-const MAX_AVAILABLE_TOOLS_CHARS = 8000;
+const MAX_AVAILABLE_TOOLS_CHARS = 24000;
 
 /**
  * `<available-tools>` block (Tools, CONTEXT-ENGINE §1). The tool L1 index: one `- name: description`

--- a/apps/api/src/integrations/mcp-client-service.ts
+++ b/apps/api/src/integrations/mcp-client-service.ts
@@ -1,0 +1,228 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type {
+  IntegrationConnection,
+  IntegrationManifest,
+  Logger,
+  McpEntry,
+  SoulIntegration,
+} from "@tulipfarm/soul";
+import type { ToolRegistry } from "../tools/registry";
+import type { ToolDef } from "../tools/types";
+import { ok, err as toolErr } from "../tools/types";
+
+export type McpConnectionStatus = "connecting" | "connected" | "error" | "disconnected";
+
+interface ConnectionEntry {
+  client: Client;
+  transport: { close(): Promise<void> };
+  status: McpConnectionStatus;
+  errorMessage?: string;
+  toolNames: string[];
+}
+
+function integrationToolName(integrationName: string, mcpToolName: string): string {
+  return `integration_${integrationName}_${mcpToolName}`;
+}
+
+function buildToolDefs(
+  integrationName: string,
+  mcpTools: Array<{ name: string; description?: string; inputSchema?: Record<string, unknown> }>,
+  callFn: (toolName: string, args: unknown) => Promise<ReturnType<typeof ok | typeof toolErr>>
+): ToolDef[] {
+  return mcpTools.map((t) => ({
+    name: integrationToolName(integrationName, t.name),
+    tier: "integration" as const,
+    mutating: true, // conservative: MCP tools may mutate; individual tools can't declare otherwise
+    description: t.description ?? `${integrationName}: ${t.name}`,
+    inputSchema: t.inputSchema ?? { type: "object", properties: {} },
+    execute: async (args: unknown) => callFn(t.name, args),
+  }));
+}
+
+/**
+ * Manages MCP client connections for `type: mcp` integrations. Lifecycle:
+ *   startAll() → connect all enabled soul integrations at startup
+ *   connect()  → start a single integration (also called by the connect route)
+ *   disconnect() → stop and unregister
+ *
+ * Crash isolation: a server crash marks the entry as `error` but never throws to the caller.
+ */
+export class McpClientService {
+  private readonly connections = new Map<string, ConnectionEntry>();
+  private registry: ToolRegistry | null = null;
+
+  constructor(private readonly logger: Logger) {}
+
+  /** Called once after ToolRegistry is built. McpClientService then registers/unregisters tools directly. */
+  setRegistry(registry: ToolRegistry): void {
+    this.registry = registry;
+  }
+
+  /** Connect all soul integrations that have connection.enabled = true. Non-fatal on individual failures. */
+  async startAll(integrations: Map<string, SoulIntegration>): Promise<void> {
+    for (const integration of integrations.values()) {
+      if (integration.connection?.enabled) {
+        try {
+          await this.connect(integration.slug, integration.manifest, integration.connection);
+        } catch (e) {
+          this.logger.warn(
+            `MCP: failed to start integration "${integration.slug}" at startup — ${e instanceof Error ? e.message : String(e)}`
+          );
+        }
+      }
+    }
+  }
+
+  getStatus(name: string): McpConnectionStatus {
+    return this.connections.get(name)?.status ?? "disconnected";
+  }
+
+  getStatusAll(): Map<string, McpConnectionStatus> {
+    const out = new Map<string, McpConnectionStatus>();
+    for (const [name, entry] of this.connections) out.set(name, entry.status);
+    return out;
+  }
+
+  getErrorMessage(name: string): string | undefined {
+    return this.connections.get(name)?.errorMessage;
+  }
+
+  getToolNames(name: string): string[] {
+    return this.connections.get(name)?.toolNames ?? [];
+  }
+
+  async connect(
+    name: string,
+    manifest: IntegrationManifest,
+    connection: IntegrationConnection
+  ): Promise<void> {
+    // Disconnect existing connection first (idempotent re-connect)
+    if (this.connections.has(name)) await this.disconnect(name);
+
+    const entry: ConnectionEntry = {
+      client: new Client({ name: "tulipfarm", version: "1" }),
+      transport: null as unknown as { close(): Promise<void> },
+      status: "connecting",
+      toolNames: [],
+    };
+    this.connections.set(name, entry);
+
+    try {
+      if (manifest.egress.type !== "mcp") {
+        throw new Error(
+          `McpClientService.connect called for non-mcp egress type "${manifest.egress.type}"`
+        );
+      }
+      const transport = buildTransport(manifest.egress.entry, connection.env ?? {});
+      entry.transport = transport;
+
+      // Crash isolation: if the server closes unexpectedly, mark as error
+      entry.client.onclose = () => {
+        const e = this.connections.get(name);
+        if (e && e.status === "connected") {
+          e.status = "error";
+          e.errorMessage = "MCP server closed unexpectedly";
+          this.logger.warn(`MCP: server "${name}" closed unexpectedly`);
+          if (this.registry) {
+            for (const toolName of e.toolNames) this.registry.unregister(toolName);
+          }
+          e.toolNames = [];
+        }
+      };
+
+      await entry.client.connect(transport);
+
+      const { tools } = await entry.client.listTools();
+      const mcpTools = tools.map((t) => ({
+        name: t.name,
+        description: t.description,
+        inputSchema: t.inputSchema as Record<string, unknown>,
+      }));
+
+      const toolDefs = buildToolDefs(name, mcpTools, (toolName, args) =>
+        this.callTool(name, toolName, args)
+      );
+
+      if (this.registry) {
+        for (const def of toolDefs) this.registry.register(def);
+      }
+
+      entry.toolNames = toolDefs.map((d) => d.name);
+      entry.status = "connected";
+
+      this.logger.info(`MCP: integration "${name}" connected (${tools.length} tool(s))`);
+    } catch (e) {
+      entry.status = "error";
+      entry.errorMessage = e instanceof Error ? e.message : String(e);
+      throw e;
+    }
+  }
+
+  async disconnect(name: string): Promise<void> {
+    const entry = this.connections.get(name);
+    if (!entry) return;
+
+    if (this.registry) {
+      for (const toolName of entry.toolNames) this.registry.unregister(toolName);
+    }
+    entry.toolNames = [];
+    entry.status = "disconnected";
+
+    try {
+      await entry.transport?.close();
+    } catch {
+      // best-effort close
+    }
+    try {
+      await entry.client?.close();
+    } catch {
+      // best-effort close
+    }
+
+    this.connections.delete(name);
+    this.logger.info(`MCP: integration "${name}" disconnected`);
+  }
+
+  private async callTool(
+    integrationName: string,
+    toolName: string,
+    args: unknown
+  ): Promise<ReturnType<typeof ok> | ReturnType<typeof toolErr>> {
+    const entry = this.connections.get(integrationName);
+    if (entry?.status !== "connected") {
+      return toolErr(
+        "internal_error",
+        `integration "${integrationName}" is not connected (status: ${entry ? entry.status : "disconnected"})`
+      );
+    }
+    try {
+      const result = await entry.client.callTool({
+        name: toolName,
+        arguments: args as Record<string, unknown>,
+      });
+      return ok(result);
+    } catch (e) {
+      return toolErr("internal_error", e instanceof Error ? e.message : String(e));
+    }
+  }
+}
+
+function buildTransport(
+  entry: McpEntry,
+  env: Record<string, string>
+): { close(): Promise<void> } & Parameters<Client["connect"]>[0] {
+  if (entry.transport === "stdio") {
+    return new StdioClientTransport({
+      command: entry.command,
+      args: entry.args ?? [],
+      env: { ...process.env, ...env } as Record<string, string>,
+      stderr: "pipe",
+    });
+  }
+  // SSE / StreamableHTTP
+  const url = new URL(entry.url);
+  const headers: Record<string, string> = { ...(entry.headers ?? {}), ...env };
+  return new StreamableHTTPClientTransport(url, { requestInit: { headers } });
+}

--- a/apps/api/src/soul/catalogue.test.ts
+++ b/apps/api/src/soul/catalogue.test.ts
@@ -31,9 +31,14 @@ const routine = (name: string, config: Record<string, unknown>): SoulRoutine => 
   config,
   hasHooks: false,
 });
-const integration = (name: string, config: Record<string, unknown>): SoulIntegration => ({
-  name,
-  config,
+const integration = (slug: string, description?: string): SoulIntegration => ({
+  slug,
+  sourceIntegration: slug,
+  manifest: {
+    name: slug,
+    description,
+    egress: { type: "mcp", entry: { transport: "stdio", command: "echo" } },
+  },
 });
 
 function fakeLoader(
@@ -47,12 +52,14 @@ function fakeLoader(
 ): SoulLoader {
   const toMap = <T extends { name: string }>(xs: T[] = []): Map<string, T> =>
     new Map(xs.map((x) => [x.name, x]));
+  const toSlugMap = (xs: SoulIntegration[] = []): Map<string, SoulIntegration> =>
+    new Map(xs.map((x) => [x.slug, x]));
   return {
     agents: toMap(over.agents),
     skills: toMap(over.skills),
     resources: toMap(over.resources),
     routines: toMap(over.routines),
-    integrations: toMap(over.integrations),
+    integrations: toSlugMap(over.integrations),
   } as unknown as SoulLoader;
 }
 
@@ -67,7 +74,7 @@ describe("buildSoulCatalogue", () => {
         ],
         resources: [resource("ticket", {}), resource("invoice", {})],
         routines: [routine("nightly", {}), routine("hourly", {})],
-        integrations: [integration("slack", {}), integration("github", {})],
+        integrations: [integration("slack"), integration("github")],
       })
     );
     // Platform agents are always present, sorted in among soul agents by name.
@@ -93,7 +100,7 @@ describe("buildSoulCatalogue", () => {
           resource("bare", {}),
         ],
         routines: [routine("r", { title: "Routine title" })],
-        integrations: [integration("i", { title: "Integration title" })],
+        integrations: [integration("i", "Integration title")],
       })
     );
     expect(cat.skills[0]?.description).toBe("Skill desc");

--- a/apps/api/src/soul/catalogue.ts
+++ b/apps/api/src/soul/catalogue.ts
@@ -74,8 +74,8 @@ export function buildSoulCatalogue(soulLoader: SoulLoader | undefined): SoulCata
 
   const integrations = values(soulLoader?.integrations)
     .map((i) => ({
-      name: i.name,
-      description: asDesc(i.config.description) || asDesc(i.config.title),
+      name: i.slug,
+      description: asDesc(i.manifest.description),
     }))
     .sort(byName);
 

--- a/apps/api/src/soul/integrations/lock.ts
+++ b/apps/api/src/soul/integrations/lock.ts
@@ -1,0 +1,47 @@
+import { createHash } from "node:crypto";
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+export interface IntegrationLockEntry {
+  sourceUrl?: string;
+  sourceType?: string;
+  manifestPath?: string;
+  ref?: string;
+  hash?: string;
+}
+
+export interface IntegrationsLock {
+  version: number;
+  integrations: Record<string, IntegrationLockEntry>;
+}
+
+export async function readIntegrationsLock(soulPath: string): Promise<IntegrationsLock> {
+  try {
+    const parsed = JSON.parse(await readFile(join(soulPath, "integrations-lock.json"), "utf8")) as {
+      version?: number;
+      integrations?: Record<string, IntegrationLockEntry>;
+    };
+    return { version: parsed.version ?? 1, integrations: parsed.integrations ?? {} };
+  } catch {
+    return { version: 1, integrations: {} };
+  }
+}
+
+export async function writeIntegrationsLock(
+  soulPath: string,
+  lock: IntegrationsLock
+): Promise<void> {
+  await writeFile(
+    join(soulPath, "integrations-lock.json"),
+    `${JSON.stringify(lock, null, 2)}\n`,
+    "utf8"
+  );
+}
+
+export function hashContent(content: string): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+export function sourceType(source: string): "github" | "git" {
+  return /github\.com|^[\w.-]+\/[\w.-]+$/.test(source) ? "github" : "git";
+}

--- a/apps/api/src/soul/integrations/routes.ts
+++ b/apps/api/src/soul/integrations/routes.ts
@@ -1,0 +1,899 @@
+import { execFile } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, dirname, join, relative } from "node:path";
+import { promisify } from "node:util";
+import type { GitSyncService, IntegrationManifest, OAuthConfig, SoulLoader } from "@tulipfarm/soul";
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { parse as parseYaml, stringify as toYaml } from "yaml";
+import { ErrorSchema } from "../../auth/schemas";
+import type { McpClientService } from "../../integrations/mcp-client-service";
+import { hashContent, readIntegrationsLock, sourceType, writeIntegrationsLock } from "./lock";
+
+/*
+ * Integrations HTTP surface (INT-V1 / MCP-V1-001). V1 supports type=mcp only.
+ * Lifecycle: scan a git repo → install (write manifest.json to soul) → connect (write
+ * connection.yaml + start MCP subprocess) → disconnect → delete.
+ * No audit gate: MCP is process-isolated by construction (INT-V1-001).
+ */
+
+const execFileP = promisify(execFile);
+
+type PreHandler = (req: FastifyRequest, reply: FastifyReply) => Promise<void>;
+
+const NAME_RE = /^[a-z][a-z0-9-]*$/;
+const SCAN_TTL_MS = 10 * 60 * 1000;
+const OAUTH_TTL_MS = 10 * 60 * 1000;
+const CLONE_TIMEOUT_MS = 60_000;
+const MAX_SCANS = 25;
+
+export interface DiscoveredIntegration {
+  name: string;
+  description?: string;
+  type: string;
+  manifestPath: string;
+  content: string;
+  setupGuideContent?: string;
+}
+
+interface OAuthStateEntry {
+  name: string;
+  env: Record<string, string>;
+  oauthConfig: OAuthConfig;
+  redirectUri: string;
+  expires: number;
+}
+
+const oauthStates = new Map<string, OAuthStateEntry>();
+
+function pruneOAuthStates(now: number): void {
+  for (const [id, entry] of oauthStates) {
+    if (entry.expires <= now) oauthStates.delete(id);
+  }
+}
+
+interface ScanEntry {
+  source: string;
+  ref: string;
+  integrations: DiscoveredIntegration[];
+  expires: number;
+}
+
+const scans = new Map<string, ScanEntry>();
+
+function pruneScans(now: number): void {
+  for (const [id, entry] of scans) {
+    if (entry.expires <= now) scans.delete(id);
+  }
+  while (scans.size > MAX_SCANS) {
+    const oldest = scans.keys().next().value;
+    if (oldest === undefined) break;
+    scans.delete(oldest);
+  }
+}
+
+function asString(v: unknown): string | undefined {
+  return typeof v === "string" && v.length > 0 ? v : undefined;
+}
+
+// Only GitHub slugs or http(s)/file URLs allowed — same SSRF rule as skills.
+function isAllowedSource(source: string): boolean {
+  return /^[\w.-]+\/[\w.-]+$/.test(source) || /^(https?|file):\/\//.test(source);
+}
+
+function normalizeGitUrl(source: string): string {
+  if (/^[\w.-]+\/[\w.-]+$/.test(source)) return `https://github.com/${source}.git`;
+  return source;
+}
+
+async function cloneToTemp(source: string): Promise<{ dir: string; ref: string }> {
+  const dir = await mkdtemp(join(tmpdir(), "integration-scan-"));
+  await execFileP("git", ["clone", "--depth", "1", normalizeGitUrl(source), dir], {
+    timeout: CLONE_TIMEOUT_MS,
+    env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
+  });
+  const { stdout } = await execFileP("git", ["rev-parse", "HEAD"], { cwd: dir });
+  return { dir, ref: stdout.trim() };
+}
+
+/**
+ * Walk a directory for manifest.json files (type=mcp only). Exported for testing.
+ */
+export async function discoverIntegrations(root: string): Promise<DiscoveredIntegration[]> {
+  const out: DiscoveredIntegration[] = [];
+  async function walk(dir: string, depth: number): Promise<void> {
+    if (depth > 6) return;
+    let entries: Array<{ name: string; isDirectory(): boolean }>;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (entry.name === ".git" || entry.name === "node_modules") continue;
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(full, depth + 1);
+      } else if (entry.name === "manifest.yml") {
+        try {
+          const content = await readFile(full, "utf8");
+          const parsed = (parseYaml(content) ?? {}) as Partial<IntegrationManifest>;
+          const egressType = (parsed.egress as { type?: string } | undefined)?.type;
+          if (!egressType) continue; // must have egress block
+          const name = asString(parsed.name) ?? basename(dirname(full));
+          if (!NAME_RE.test(name)) continue;
+          let setupGuideContent: string | undefined;
+          if (parsed.setup_guide_path) {
+            try {
+              setupGuideContent = await readFile(
+                join(dirname(full), parsed.setup_guide_path),
+                "utf8"
+              );
+            } catch {
+              // setup guide is optional
+            }
+          }
+          out.push({
+            name,
+            description: asString(parsed.description),
+            type: egressType,
+            manifestPath: relative(root, full),
+            content,
+            setupGuideContent,
+          });
+        } catch {
+          // skip invalid manifests
+        }
+      }
+    }
+  }
+  await walk(root, 0);
+  return out;
+}
+
+function installStatus(
+  integration: DiscoveredIntegration,
+  lock: Awaited<ReturnType<typeof readIntegrationsLock>>,
+  soulLoader: SoulLoader
+): { installed: boolean; updateAvailable: boolean } {
+  const installed = soulLoader.integrations.has(integration.name);
+  const lockedHash = lock.integrations[integration.name]?.hash;
+  const updateAvailable =
+    installed &&
+    !!lockedHash &&
+    lockedHash !== createHash("sha256").update(integration.content).digest("hex");
+  return { installed, updateAvailable };
+}
+
+// Marketplace registry.json — parallel to marketplace.json for skills
+interface RegistryEntry {
+  name?: string;
+  description?: string;
+  type?: string;
+  verified?: boolean;
+}
+
+async function readRegistry(dir: string): Promise<Map<string, RegistryEntry>> {
+  const byName = new Map<string, RegistryEntry>();
+  try {
+    const parsed = JSON.parse(await readFile(join(dir, "registry.json"), "utf8")) as {
+      integrations?: RegistryEntry[];
+    };
+    for (const entry of Array.isArray(parsed.integrations) ? parsed.integrations : []) {
+      const key = asString(entry.name);
+      if (key && !byName.has(key)) byName.set(key, entry);
+    }
+  } catch {
+    // missing registry.json is fine
+  }
+  return byName;
+}
+
+function marketplaceSource(): string {
+  return process.env.INTEGRATIONS_MARKETPLACE_SOURCE ?? "tulipfarm/integrations";
+}
+
+interface MarketplaceResponse {
+  scanId: string;
+  source: string;
+  integrations: {
+    name: string;
+    description?: string;
+    verified?: boolean;
+    installed: boolean;
+    updateAvailable: boolean;
+  }[];
+}
+
+const marketplaceCache = new Map<
+  string,
+  { scanId: string; expires: number; response: MarketplaceResponse }
+>();
+
+const IntegrationSummaryProps = {
+  name: { type: "string" },
+  description: { type: "string" },
+  status: { type: "string", enum: ["connected", "connecting", "error", "disconnected"] },
+  errorMessage: { type: "string" },
+} as const;
+
+export function registerIntegrationRoutes(
+  app: FastifyInstance,
+  soulLoader: SoulLoader,
+  gitSync: GitSyncService,
+  mcpClient: McpClientService,
+  requireAuth: PreHandler
+): void {
+  // List all installed integrations with runtime status
+  app.get(
+    "/api/v1/integrations",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description:
+          "List MCP integrations installed in the soul repo, with runtime connection status.",
+        tags: ["integrations"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        response: {
+          200: {
+            type: "object",
+            required: ["integrations"],
+            properties: {
+              integrations: {
+                type: "array",
+                items: {
+                  type: "object",
+                  required: ["name", "type", "status"],
+                  properties: {
+                    ...IntegrationSummaryProps,
+                    type: { type: "string" },
+                    version: { type: "string" },
+                    maintainer: { type: "string" },
+                  },
+                },
+              },
+            },
+          },
+          401: ErrorSchema,
+        },
+      },
+    },
+    async () => {
+      const integrations = Array.from(soulLoader.integrations.values()).map((i) => ({
+        name: i.slug,
+        type: i.manifest.egress.type,
+        description: i.manifest.description,
+        version: i.manifest.version,
+        maintainer: i.manifest.maintainer,
+        status: mcpClient.getStatus(i.slug),
+        errorMessage: mcpClient.getErrorMessage(i.slug),
+      }));
+      return { integrations };
+    }
+  );
+
+  // Browse the official integrations marketplace
+  app.get(
+    "/api/v1/integrations/marketplace",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description:
+          "Browse the official integrations marketplace (tulipfarm/integrations). Returns a scanId usable with the install endpoint.",
+        tags: ["integrations"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        response: {
+          200: {
+            type: "object",
+            required: ["scanId", "source", "integrations"],
+            properties: {
+              scanId: { type: "string" },
+              source: { type: "string" },
+              integrations: {
+                type: "array",
+                items: {
+                  type: "object",
+                  required: ["name", "installed", "updateAvailable"],
+                  properties: {
+                    name: { type: "string" },
+                    description: { type: "string" },
+                    verified: { type: "boolean" },
+                    installed: { type: "boolean" },
+                    updateAvailable: { type: "boolean" },
+                  },
+                },
+              },
+            },
+          },
+          401: ErrorSchema,
+          502: ErrorSchema,
+        },
+      },
+    },
+    async (_req, reply) => {
+      reply.header("cache-control", "no-store");
+      const source = marketplaceSource();
+      const now = Date.now();
+      const cached = marketplaceCache.get(source);
+      if (cached && cached.expires > now && scans.has(cached.scanId)) return cached.response;
+
+      let dir: string | undefined;
+      try {
+        const clone = await cloneToTemp(source);
+        dir = clone.dir;
+        const discovered = await discoverIntegrations(dir);
+        const registry = await readRegistry(dir);
+        const lock = await readIntegrationsLock(gitSync.path);
+        const scanId = randomUUID();
+        pruneScans(now);
+        scans.set(scanId, {
+          source,
+          ref: clone.ref,
+          integrations: discovered,
+          expires: now + SCAN_TTL_MS,
+        });
+        const response: MarketplaceResponse = {
+          scanId,
+          source,
+          integrations: discovered.map((i) => {
+            const meta = registry.get(i.name);
+            return {
+              name: i.name,
+              description: i.description ?? asString(meta?.description),
+              verified: meta?.verified,
+              ...installStatus(i, lock, soulLoader),
+            };
+          }),
+        };
+        marketplaceCache.set(source, { scanId, expires: now + SCAN_TTL_MS, response });
+        return response;
+      } catch (e) {
+        return reply.code(502).send({
+          error: `marketplace unavailable: ${e instanceof Error ? e.message : String(e)}`,
+        });
+      } finally {
+        if (dir) await rm(dir, { recursive: true, force: true });
+      }
+    }
+  );
+
+  // Get single integration detail
+  app.get(
+    "/api/v1/integrations/:name",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description: "Get a single integration including its manifest and connection status.",
+        tags: ["integrations"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        params: { type: "object", required: ["name"], properties: { name: { type: "string" } } },
+        response: {
+          200: {
+            type: "object",
+            required: ["name", "type", "status", "manifest"],
+            properties: {
+              ...IntegrationSummaryProps,
+              type: { type: "string" },
+              manifest: { type: "object", additionalProperties: true },
+              connected: { type: "boolean" },
+              setupGuide: { type: "string" },
+              toolNames: { type: "array", items: { type: "string" } },
+            },
+          },
+          401: ErrorSchema,
+          404: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const { name } = req.params as { name: string };
+      const integration = soulLoader.integrations.get(name);
+      if (!integration) return reply.code(404).send({ error: `integration not found: ${name}` });
+      return {
+        name: integration.slug,
+        type: integration.manifest.egress.type,
+        description: integration.manifest.description,
+        status: mcpClient.getStatus(name),
+        errorMessage: mcpClient.getErrorMessage(name),
+        manifest: integration.manifest,
+        connected: integration.connection?.enabled === true,
+        setupGuide: integration.setupGuide,
+        toolNames: mcpClient.getToolNames(name),
+      };
+    }
+  );
+
+  // Scan a git repo for MCP integrations
+  app.post(
+    "/api/v1/integrations/scan",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description:
+          "Clone a git repo and discover installable MCP integration manifest.json files.",
+        tags: ["integrations"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        body: {
+          type: "object",
+          required: ["source"],
+          additionalProperties: false,
+          properties: { source: { type: "string", minLength: 1 } },
+        },
+        response: {
+          200: {
+            type: "object",
+            required: ["scanId", "integrations"],
+            properties: {
+              scanId: { type: "string" },
+              integrations: {
+                type: "array",
+                items: {
+                  type: "object",
+                  required: ["name", "type", "installed", "updateAvailable"],
+                  properties: {
+                    name: { type: "string" },
+                    type: { type: "string" },
+                    description: { type: "string" },
+                    installed: { type: "boolean" },
+                    updateAvailable: { type: "boolean" },
+                  },
+                },
+              },
+            },
+          },
+          400: ErrorSchema,
+          401: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const { source } = req.body as { source: string };
+      if (!isAllowedSource(source)) {
+        return reply.code(400).send({
+          error: "source must be a github owner/repo slug or an http(s)/file URL",
+        });
+      }
+      let dir: string | undefined;
+      try {
+        const clone = await cloneToTemp(source);
+        dir = clone.dir;
+        const discovered = await discoverIntegrations(dir);
+        if (discovered.length === 0) {
+          return reply.code(400).send({ error: "no MCP manifest.json files found in repo" });
+        }
+        const lock = await readIntegrationsLock(gitSync.path);
+        const scanId = randomUUID();
+        pruneScans(Date.now());
+        scans.set(scanId, {
+          source,
+          ref: clone.ref,
+          integrations: discovered,
+          expires: Date.now() + SCAN_TTL_MS,
+        });
+        return {
+          scanId,
+          integrations: discovered.map((i) => ({
+            name: i.name,
+            type: i.type,
+            description: i.description,
+            ...installStatus(i, lock, soulLoader),
+          })),
+        };
+      } catch (e) {
+        return reply.code(400).send({
+          error: `scan failed: ${e instanceof Error ? e.message : String(e)}`,
+        });
+      } finally {
+        if (dir) await rm(dir, { recursive: true, force: true });
+      }
+    }
+  );
+
+  // Install integrations from a scan
+  app.post(
+    "/api/v1/integrations/install",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description: "Install the named integrations from a scan into the soul repo.",
+        tags: ["integrations"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        body: {
+          type: "object",
+          required: ["scanId", "names"],
+          additionalProperties: false,
+          properties: {
+            scanId: { type: "string" },
+            names: { type: "array", items: { type: "string" }, minItems: 1 },
+          },
+        },
+        response: {
+          200: {
+            type: "object",
+            required: ["installed"],
+            properties: { installed: { type: "array", items: { type: "string" } } },
+          },
+          400: ErrorSchema,
+          401: ErrorSchema,
+          404: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const { scanId, names } = req.body as { scanId: string; names: string[] };
+      const entry = scans.get(scanId);
+      if (!entry) return reply.code(404).send({ error: "scan not found (it may have expired)" });
+
+      const unique = [...new Set(names)];
+      const chosen = unique.map((n) => entry.integrations.find((i) => i.name === n));
+      const missing = unique.filter((_, idx) => !chosen[idx]);
+      if (missing.length > 0)
+        return reply.code(400).send({ error: `not in scan: ${missing.join(", ")}` });
+
+      const installed: string[] = [];
+      for (const integration of chosen as DiscoveredIntegration[]) {
+        const dir = join(gitSync.path, "integrations", integration.name);
+        await mkdir(dir, { recursive: true });
+        await writeFile(join(dir, "manifest.yml"), integration.content, "utf8");
+        if (integration.setupGuideContent) {
+          await writeFile(join(dir, "setup-guide.md"), integration.setupGuideContent, "utf8");
+        }
+        installed.push(integration.name);
+      }
+
+      const lock = await readIntegrationsLock(gitSync.path);
+      for (const integration of chosen as DiscoveredIntegration[]) {
+        lock.integrations[integration.name] = {
+          sourceUrl: entry.source,
+          sourceType: sourceType(entry.source),
+          manifestPath: integration.manifestPath,
+          ref: entry.ref,
+          hash: hashContent(integration.content),
+        };
+      }
+      await writeIntegrationsLock(gitSync.path, lock);
+      await gitSync.withSync(`soul: install integration(s) ${installed.join(", ")}`);
+      await soulLoader.reload();
+      return { installed };
+    }
+  );
+
+  // Connect an installed integration (write connection.yaml + start MCP server)
+  app.post(
+    "/api/v1/integrations/:name/connect",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description:
+          "Connect an installed integration: write connection config and start the MCP server.",
+        tags: ["integrations"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        params: { type: "object", required: ["name"], properties: { name: { type: "string" } } },
+        body: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            env: { type: "object", additionalProperties: { type: "string" } },
+          },
+        },
+        response: {
+          200: {
+            type: "object",
+            required: ["status"],
+            properties: {
+              status: { type: "string" },
+              toolCount: { type: "number" },
+            },
+          },
+          400: ErrorSchema,
+          401: ErrorSchema,
+          404: ErrorSchema,
+          502: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const { name } = req.params as { name: string };
+      if (!NAME_RE.test(name) || !soulLoader.integrations.has(name)) {
+        return reply.code(404).send({ error: `integration not found: ${name}` });
+      }
+      const integration = soulLoader.integrations.get(name);
+      if (!integration) return reply.code(404).send({ error: `integration not found: ${name}` });
+      const body = (req.body as { env?: Record<string, string> } | null) ?? {};
+      const connection = { enabled: true, env: body.env ?? {} };
+
+      // Persist connection.yaml before starting (so a restart re-connects)
+      const connPath = join(gitSync.path, "integrations", name, "connection.yaml");
+      await writeFile(connPath, toYaml(connection), "utf8");
+      await gitSync.withSync(`soul: connect integration ${name}`);
+      await soulLoader.reload();
+
+      try {
+        await mcpClient.connect(name, integration.manifest, connection);
+      } catch (e) {
+        return reply.code(502).send({
+          error: `MCP server failed to start: ${e instanceof Error ? e.message : String(e)}`,
+        });
+      }
+
+      return { status: mcpClient.getStatus(name), toolCount: mcpClient.getToolNames(name).length };
+    }
+  );
+
+  // Disconnect a connected integration
+  app.post(
+    "/api/v1/integrations/:name/disconnect",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description: "Disconnect an integration: stop the MCP server and mark as disabled.",
+        tags: ["integrations"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        params: { type: "object", required: ["name"], properties: { name: { type: "string" } } },
+        response: {
+          200: { type: "object", required: ["status"], properties: { status: { type: "string" } } },
+          401: ErrorSchema,
+          404: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const { name } = req.params as { name: string };
+      if (!NAME_RE.test(name) || !soulLoader.integrations.has(name)) {
+        return reply.code(404).send({ error: `integration not found: ${name}` });
+      }
+
+      await mcpClient.disconnect(name);
+
+      // Update connection.yaml to disabled
+      const connPath = join(gitSync.path, "integrations", name, "connection.yaml");
+      try {
+        const integration = soulLoader.integrations.get(name);
+        const existing = integration?.connection ?? {};
+        await writeFile(connPath, toYaml({ ...existing, enabled: false }), "utf8");
+        await gitSync.withSync(`soul: disconnect integration ${name}`);
+        await soulLoader.reload();
+      } catch {
+        // best-effort persist
+      }
+
+      return { status: "disconnected" };
+    }
+  );
+
+  // Start OAuth authorization flow for an integration
+  app.post(
+    "/api/v1/integrations/:name/oauth/start",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description:
+          "Begin OAuth authorization flow. Returns an authUrl to open in a new tab. The user's client_id and other env values must be supplied so the redirect can be pre-filled on callback.",
+        tags: ["integrations"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        params: { type: "object", required: ["name"], properties: { name: { type: "string" } } },
+        body: {
+          type: "object",
+          required: ["env"],
+          additionalProperties: false,
+          properties: {
+            env: { type: "object", additionalProperties: { type: "string" } },
+          },
+        },
+        response: {
+          200: {
+            type: "object",
+            required: ["authUrl"],
+            properties: { authUrl: { type: "string" } },
+          },
+          400: ErrorSchema,
+          401: ErrorSchema,
+          404: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const { name } = req.params as { name: string };
+      const integration = soulLoader.integrations.get(name);
+      if (!integration) return reply.code(404).send({ error: `integration not found: ${name}` });
+
+      const oauthConfig = integration.manifest.oauth;
+      if (!oauthConfig) {
+        return reply.code(400).send({ error: `integration "${name}" does not support OAuth` });
+      }
+
+      const { env } = req.body as { env: Record<string, string> };
+      const tf = oauthConfig["x-tulipfarm"];
+      const flow = oauthConfig.flows.authorizationCode;
+      if (!flow) {
+        return reply
+          .code(400)
+          .send({ error: `integration "${name}" OAuth config missing authorizationCode flow` });
+      }
+      const clientId = env[tf.client_id_env];
+      if (!clientId) {
+        return reply.code(400).send({ error: `missing required env field: ${tf.client_id_env}` });
+      }
+
+      const publicUrl = process.env.PUBLIC_URL ?? "http://localhost:8080";
+      const redirectUri = `${publicUrl}/api/v1/integrations/${name}/oauth/callback`;
+      const state = randomUUID();
+      const now = Date.now();
+      pruneOAuthStates(now);
+      oauthStates.set(state, {
+        name,
+        env,
+        oauthConfig,
+        redirectUri,
+        expires: now + OAUTH_TTL_MS,
+      });
+
+      const params = new URLSearchParams({
+        response_type: "code",
+        client_id: clientId,
+        redirect_uri: redirectUri,
+        scope: Object.keys(flow.scopes).join(" "),
+        state,
+      });
+      const authUrl = `${flow.authorizationUrl}?${params.toString()}`;
+      return { authUrl };
+    }
+  );
+
+  // OAuth callback — exchanges code for token, writes connection.yaml, starts MCP
+  app.get(
+    "/api/v1/integrations/:name/oauth/callback",
+    {
+      schema: {
+        description:
+          "OAuth callback handler. Exchanges the authorization code for an access token, writes connection.yaml, and starts the MCP server. Redirects to the integration detail page.",
+        tags: ["integrations"],
+        params: { type: "object", required: ["name"], properties: { name: { type: "string" } } },
+        querystring: {
+          type: "object",
+          properties: {
+            code: { type: "string" },
+            state: { type: "string" },
+            error: { type: "string" },
+            error_description: { type: "string" },
+          },
+        },
+      },
+    },
+    async (req, reply) => {
+      const { name } = req.params as { name: string };
+      const query = req.query as {
+        code?: string;
+        state?: string;
+        error?: string;
+        error_description?: string;
+      };
+
+      const webBase = process.env.PUBLIC_URL ?? "http://localhost:8080";
+
+      if (query.error) {
+        const msg = encodeURIComponent(query.error_description ?? query.error);
+        return reply.redirect(`${webBase}/integrations/${name}?error=${msg}`);
+      }
+
+      const { code, state } = query;
+      if (!code || !state) {
+        return reply.redirect(
+          `${webBase}/integrations/${name}?error=${encodeURIComponent("missing code or state")}`
+        );
+      }
+
+      const stateEntry = oauthStates.get(state);
+      if (!stateEntry || stateEntry.expires <= Date.now() || stateEntry.name !== name) {
+        return reply.redirect(
+          `${webBase}/integrations/${name}?error=${encodeURIComponent("invalid or expired state")}`
+        );
+      }
+      oauthStates.delete(state);
+
+      const { oauthConfig, env, redirectUri } = stateEntry;
+      const tf = oauthConfig["x-tulipfarm"];
+      const flow = oauthConfig.flows.authorizationCode;
+      if (!flow) {
+        return reply.redirect(
+          `${webBase}/integrations/${name}?error=${encodeURIComponent("OAuth authorizationCode flow not configured")}`
+        );
+      }
+      const clientId = env[tf.client_id_env] ?? "";
+      const clientSecret = env[tf.client_secret_env] ?? "";
+
+      // Exchange code for token via form-encoded POST
+      let tokenData: Record<string, unknown>;
+      try {
+        const tokenRes = await fetch(flow.tokenUrl, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+            Accept: "application/json",
+          },
+          body: new URLSearchParams({
+            grant_type: "authorization_code",
+            code,
+            redirect_uri: redirectUri,
+            client_id: clientId,
+            client_secret: clientSecret,
+          }).toString(),
+        });
+        tokenData = (await tokenRes.json()) as Record<string, unknown>;
+      } catch (e) {
+        const msg = encodeURIComponent(
+          `token exchange failed: ${e instanceof Error ? e.message : String(e)}`
+        );
+        return reply.redirect(`${webBase}/integrations/${name}?error=${msg}`);
+      }
+
+      // Extract token via dot-path (default "access_token")
+      const tokenPath = tf.token_response_path ?? "access_token";
+      const token = tokenPath.split(".").reduce<unknown>((obj, key) => {
+        return obj && typeof obj === "object" ? (obj as Record<string, unknown>)[key] : undefined;
+      }, tokenData);
+
+      if (typeof token !== "string" || !token) {
+        const msg = encodeURIComponent("token not found in OAuth response");
+        return reply.redirect(`${webBase}/integrations/${name}?error=${msg}`);
+      }
+
+      // Merge token into env and write connection.yaml
+      const mergedEnv = { ...env, [tf.token_env]: token };
+      const connection = { enabled: true, env: mergedEnv };
+      const connPath = join(gitSync.path, "integrations", name, "connection.yaml");
+      try {
+        await writeFile(connPath, toYaml(connection), "utf8");
+        await gitSync.withSync(`soul: connect integration ${name} via OAuth`);
+        await soulLoader.reload();
+        const integration = soulLoader.integrations.get(name);
+        if (integration) {
+          await mcpClient.connect(name, integration.manifest, connection);
+        }
+      } catch (e) {
+        const msg = encodeURIComponent(
+          `connect failed: ${e instanceof Error ? e.message : String(e)}`
+        );
+        return reply.redirect(`${webBase}/integrations/${name}?error=${msg}`);
+      }
+
+      return reply.redirect(`${webBase}/integrations/${name}?connected=true`);
+    }
+  );
+
+  // Delete an integration from soul
+  app.delete(
+    "/api/v1/integrations/:name",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description: "Remove an integration from the soul repo (disconnects first if connected).",
+        tags: ["integrations"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        params: { type: "object", required: ["name"], properties: { name: { type: "string" } } },
+        response: {
+          204: { type: "null" },
+          401: ErrorSchema,
+          404: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const { name } = req.params as { name: string };
+      if (!NAME_RE.test(name) || !soulLoader.integrations.has(name)) {
+        return reply.code(404).send({ error: `integration not found: ${name}` });
+      }
+
+      await mcpClient.disconnect(name);
+      await rm(join(gitSync.path, "integrations", name), { recursive: true, force: true });
+
+      const lock = await readIntegrationsLock(gitSync.path);
+      delete lock.integrations[name];
+      await writeIntegrationsLock(gitSync.path, lock);
+      await gitSync.withSync(`soul: remove integration ${name}`);
+      await soulLoader.reload();
+      return reply.code(204).send();
+    }
+  );
+}

--- a/apps/api/src/tools/registry.ts
+++ b/apps/api/src/tools/registry.ts
@@ -55,6 +55,11 @@ export class ToolRegistry {
     this.validators.set(tool.name, ajv.compile(tool.inputSchema));
   }
 
+  unregister(name: string): void {
+    this.tools.delete(name);
+    this.validators.delete(name);
+  }
+
   getAll(): ToolDef[] {
     return [...this.tools.values()];
   }

--- a/apps/api/src/tools/setup.ts
+++ b/apps/api/src/tools/setup.ts
@@ -1,3 +1,5 @@
+import type { SoulLoader } from "@tulipfarm/soul";
+import type { McpClientService } from "../integrations/mcp-client-service";
 import type { KnowledgeService } from "../knowledge/service";
 import { KNOWLEDGE_TOOLS } from "../knowledge/tools";
 import type { KvService } from "../kv/service";
@@ -26,6 +28,8 @@ export function buildToolRegistry(services: {
   agentTools?: AgentToolContext;
   skillTools?: SkillToolContext;
   platform?: PlatformToolContext;
+  mcpClient?: McpClientService;
+  soulLoader?: SoulLoader;
 }): ToolRegistry {
   const registry = new ToolRegistry();
 
@@ -148,6 +152,18 @@ export function buildToolRegistry(services: {
   // (client context) and return client-action descriptors. No services to close over.
   for (const t of FRONTEND_TOOLS) {
     registry.register(t);
+  }
+
+  // MCP integration tools: give the McpClientService the registry so it can register/unregister
+  // tools dynamically when integrations connect/disconnect at runtime, then start all currently
+  // enabled integrations from soul.
+  if (services.mcpClient) {
+    const mcpClient = services.mcpClient;
+    mcpClient.setRegistry(registry);
+    if (services.soulLoader?.integrations) {
+      // Non-blocking: failures are logged inside startAll, not thrown.
+      void mcpClient.startAll(services.soulLoader.integrations);
+    }
   }
 
   return registry;

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -4,5 +4,10 @@ export default defineConfig({
   test: {
     include: ["src/**/*.test.ts"],
     exclude: ["dist/**"],
+    // Most suites boot a PGlite (WASM Postgres) + run all migrations per test file; with
+    // one worker per core the 5s default flakes under full-suite load. Generous ceilings
+    // keep slow-machine/CI runs honest — genuinely hung tests still fail.
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
   },
 });

--- a/apps/docs/content/docs/concepts/integrations.mdx
+++ b/apps/docs/content/docs/concepts/integrations.mdx
@@ -1,0 +1,99 @@
+---
+title: Integrations
+description: MCP servers that give agents access to external tools, connected through the soul.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+An integration connects TulipFarm to an external service — Slack, GitHub, or any
+[Model Context Protocol](https://modelcontextprotocol.io) server — so agents can call
+that service's tools directly during a conversation. When an integration is connected,
+its tools appear in the agent's context alongside TulipFarm's built-in tools.
+
+## What lives in the soul
+
+Each installed integration occupies a directory under `soul/integrations/{name}/`:
+
+```text
+soul/
+  integrations/
+    slack/
+      manifest.json      definition: what the server is and how to start it
+      connection.yaml    credential env vars + enabled flag
+      setup-guide.md     optional credential walkthrough
+```
+
+`manifest.json` is written once at install time. `connection.yaml` is written when you
+connect the integration; it holds the environment variables the MCP server needs (tokens,
+IDs) and the `enabled: true` flag that tells the runtime to start it on boot.
+
+## Install vs. connect
+
+Installing and connecting are two separate steps.
+
+**Install** copies the integration's `manifest.json` into the soul repo and records it in
+`integrations-lock.json` with its source URL and ref. No server starts. No credentials
+are needed yet.
+
+**Connect** writes the credentials into `connection.yaml`, starts the MCP subprocess, and
+registers its tools in the tool registry. From that point on, any agent turn can call
+those tools.
+
+Disconnecting stops the server and removes its tools from the registry. The soul entry
+stays; you can reconnect later without reinstalling.
+
+## Credentials: two paths
+
+A connected integration needs credentials. TulipFarm supports two ways to supply them.
+
+**Direct token** — paste a long-lived token (or any other static value) directly into the
+connect form. This is the fastest path and works for any integration.
+
+**OAuth** — for integrations that declare an `oauth` block in their manifest, you can
+register your own OAuth app with the external service and let TulipFarm drive the
+authorization code flow. You supply the Client ID and Client Secret; TulipFarm opens the
+service's authorization page in a new tab, exchanges the code, and stores the resulting
+access token automatically.
+
+<Callout type="info">
+TulipFarm does not manage a shared OAuth app. You register your own — this keeps
+your tokens scoped to your account and your data.
+</Callout>
+
+Credentials are stored in `connection.yaml` in the soul repo. Treat that file like any
+other secrets file: restrict access to the soul directory.
+
+## Tools in the agent context
+
+When an integration connects, TulipFarm lists the tools the MCP server exposes and
+registers each one in the tool registry under the name
+`integration_{integration-name}_{tool-name}`. For example, Slack's `post_message` tool
+becomes `integration_slack_post_message`.
+
+Those tools are available to every agent on the next turn, right alongside the built-in
+resource, memory, and skill tools. The agent calls them the same way it calls any other
+tool — by name, with arguments — and the result is returned from the running MCP server
+process.
+
+If the MCP server exits unexpectedly, its tools are unregistered and the integration
+status changes to `error`. Reconnecting restarts the server and re-registers the tools.
+
+## Installing from the marketplace
+
+The official TulipFarm integrations are published at `tulipfarm/integrations` on GitHub.
+You can browse and install from there in the web UI, or scan any git URL that contains
+a `manifest.json` file at depth ≤ 6.
+
+<Callout type="info">
+Scanning clones the repository temporarily. Nothing is written to the soul until you
+explicitly confirm the install.
+</Callout>
+
+## V1 limits
+
+- Only `type: mcp` integrations are supported. HTTP/SSE transports are accepted alongside
+  stdio; other types are ignored with a warning.
+- Every agent gets access to all connected integration tools. Per-agent tool restriction
+  is not yet available.
+- TulipFarm does not rotate or refresh tokens. If an OAuth access token expires, you need
+  to reconnect.

--- a/apps/docs/content/docs/concepts/meta.json
+++ b/apps/docs/content/docs/concepts/meta.json
@@ -8,6 +8,7 @@
     "resources",
     "agents",
     "skills",
+    "integrations",
     "knowledge",
     "llm",
     "secrets"

--- a/apps/docs/content/docs/guides/connect-an-integration.mdx
+++ b/apps/docs/content/docs/guides/connect-an-integration.mdx
@@ -1,0 +1,85 @@
+---
+title: Connect an integration
+description: Install an MCP integration from the marketplace and connect it so agents can use its tools.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+This guide walks through installing the Slack integration from the TulipFarm marketplace
+and connecting it with a bot token. The same steps apply to any integration.
+
+## Prerequisites
+
+- TulipFarm is running and you are signed in
+- You have an integration's required credentials ready (for Slack, a bot token that starts
+  with `xoxb-`)
+
+## Install from the marketplace
+
+1. Open the web UI and go to **Integrations** in the sidebar.
+2. Click the **Marketplace** tab.
+3. Locate the integration you want. Click **Install**.
+
+TulipFarm clones the official `tulipfarm/integrations` repository, reads the integration's
+`manifest.json`, and writes it into your soul repo under
+`soul/integrations/{name}/manifest.json`. No server starts yet; no credentials are needed.
+
+<Callout type="info">
+You can also install from any GitHub repository. Click **Add from URL**, enter a GitHub
+URL (`owner/repo` shorthand or a full HTTPS URL), and TulipFarm will scan it for
+integrations.
+</Callout>
+
+After install, the integration appears on the **Installed** tab with status **Disconnected**.
+
+## Connect the integration
+
+1. Click the integration name to open its detail page.
+2. Fill in the required credential fields. For Slack this is **Slack Bot Token**.
+3. Click **Connect**.
+
+TulipFarm writes your credentials into `soul/integrations/slack/connection.yaml`, starts
+the MCP server subprocess, and lists its tools. The status badge changes to **Connected**
+and a tool count appears (Slack exposes eight tools).
+
+<Callout type="warn">
+Credentials are stored in the soul repo. If you push your soul to a remote, make sure the
+remote is private or the soul directory is excluded from tracking.
+</Callout>
+
+## Verify the connection
+
+Ask the agent a question that would require the integration. For Slack, try:
+
+> What channels are available in Slack?
+
+The agent calls `integration_slack_slack_list_channels` and returns the list. If the agent
+says it cannot find a Slack tool, see [Troubleshooting](#troubleshooting) below.
+
+You can also check the detail page: it shows the current status and the list of tools
+the MCP server registered.
+
+## Disconnect
+
+Open the integration's detail page and click **Disconnect**. TulipFarm stops the MCP
+server and removes its tools from the tool registry. The soul entry is preserved — you
+can reconnect without reinstalling.
+
+## Uninstall
+
+To remove an integration entirely, click **Uninstall** (or **Delete**) on the detail page.
+This disconnects the server if it is running, removes `soul/integrations/{name}/`, and
+removes the entry from `integrations-lock.json`.
+
+## Troubleshooting
+
+**Status shows "Error"** — the MCP server exited unexpectedly. Check that the required
+credentials are correct. Click **Disconnect** then **Connect** to restart the server.
+
+**Agent says it cannot use the integration's tools** — the integration may have
+disconnected after a server restart. Check the **Integrations** page. If status is
+**Disconnected**, click **Connect** to re-establish. The server reconnects automatically on
+the next boot once you connect it once.
+
+**Marketplace is empty or cannot load** — TulipFarm clones from GitHub to browse the
+marketplace. Check that the host running TulipFarm has outbound internet access.

--- a/apps/docs/content/docs/guides/meta.json
+++ b/apps/docs/content/docs/guides/meta.json
@@ -17,6 +17,7 @@
     "routines",
     "---Integrations---",
     "integrations",
+    "connect-an-integration",
     "---Knowledge---",
     "use-the-knowledge-wiki",
     "cite-knowledge-in-chat"

--- a/apps/web/app/components/integrations-tabs.tsx
+++ b/apps/web/app/components/integrations-tabs.tsx
@@ -1,0 +1,31 @@
+import { NavLink } from "@remix-run/react";
+import { cn } from "~/lib/utils";
+
+const tabs = [
+  { to: "/integrations", label: "Installed", end: true },
+  { to: "/integrations/marketplace", label: "Marketplace", end: false },
+];
+
+export function IntegrationsTabs() {
+  return (
+    <nav className="flex gap-1 border-b border-border">
+      {tabs.map((tab) => (
+        <NavLink
+          key={tab.to}
+          to={tab.to}
+          end={tab.end}
+          className={({ isActive }) =>
+            cn(
+              "-mb-px border-b-2 px-3 py-2 text-sm transition-colors",
+              isActive
+                ? "border-primary text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground"
+            )
+          }
+        >
+          {tab.label}
+        </NavLink>
+      ))}
+    </nav>
+  );
+}

--- a/apps/web/app/lib/integrations.ts
+++ b/apps/web/app/lib/integrations.ts
@@ -1,0 +1,135 @@
+import { apiDelete, apiGet, apiWrite } from "./api";
+
+/*
+ * Client for the integrations API (INT-V1 / MCP-V1-001). V1 supports type=mcp only.
+ * Lifecycle: scan a git repo → install → connect (write env + start MCP server) → disconnect → delete.
+ */
+
+export type McpConnectionStatus = "connected" | "connecting" | "error" | "disconnected";
+
+export type IntegrationSummary = {
+  name: string;
+  type: string;
+  description?: string;
+  version?: string;
+  maintainer?: string;
+  status: McpConnectionStatus;
+  errorMessage?: string;
+};
+
+export type RequiredEnvVar = {
+  name: string;
+  label: string;
+  description?: string;
+  secret?: boolean;
+  setup_url?: string;
+  steps?: string[];
+};
+
+export type OAuthConfig = {
+  authorization_url: string;
+  token_url: string;
+  scopes: string[];
+  client_id_env: string;
+  client_secret_env: string;
+  token_env: string;
+  token_response_path?: string;
+};
+
+export type IntegrationDetail = IntegrationSummary & {
+  manifest: {
+    required_env?: RequiredEnvVar[];
+    entry: Record<string, unknown>;
+    setup_guide_path?: string;
+    oauth?: OAuthConfig;
+  };
+  connected: boolean;
+  setupGuide?: string;
+};
+
+export type ScannedIntegration = {
+  name: string;
+  type: string;
+  description?: string;
+  installed: boolean;
+  updateAvailable: boolean;
+};
+
+export type ScanResult = { scanId: string; integrations: ScannedIntegration[] };
+
+export type MarketplaceIntegration = {
+  name: string;
+  description?: string;
+  verified?: boolean;
+  installed: boolean;
+  updateAvailable: boolean;
+};
+
+export type MarketplaceCatalog = {
+  scanId: string;
+  source: string;
+  integrations: MarketplaceIntegration[];
+};
+
+export type IntegrationInstallStatus = { installed: boolean; updateAvailable: boolean };
+
+export async function listIntegrations(): Promise<IntegrationSummary[]> {
+  const body = await apiGet<{ integrations: IntegrationSummary[] }>("/api/v1/integrations");
+  return body.integrations;
+}
+
+export async function getIntegration(name: string): Promise<IntegrationDetail> {
+  return apiGet<IntegrationDetail>(`/api/v1/integrations/${encodeURIComponent(name)}`);
+}
+
+export async function scanIntegrations(source: string): Promise<ScanResult> {
+  return apiWrite<ScanResult>("POST", "/api/v1/integrations/scan", { source });
+}
+
+export async function installIntegrations(
+  scanId: string,
+  names: string[]
+): Promise<{ installed: string[] }> {
+  return apiWrite<{ installed: string[] }>("POST", "/api/v1/integrations/install", {
+    scanId,
+    names,
+  });
+}
+
+export async function connectIntegration(
+  name: string,
+  env: Record<string, string>
+): Promise<{ status: McpConnectionStatus; toolCount: number }> {
+  return apiWrite<{ status: McpConnectionStatus; toolCount: number }>(
+    "POST",
+    `/api/v1/integrations/${encodeURIComponent(name)}/connect`,
+    { env }
+  );
+}
+
+export async function disconnectIntegration(name: string): Promise<{ status: string }> {
+  return apiWrite<{ status: string }>(
+    "POST",
+    `/api/v1/integrations/${encodeURIComponent(name)}/disconnect`,
+    {}
+  );
+}
+
+export async function deleteIntegration(name: string): Promise<void> {
+  return apiDelete(`/api/v1/integrations/${encodeURIComponent(name)}`);
+}
+
+export async function marketplaceIntegrations(): Promise<MarketplaceCatalog> {
+  return apiGet<MarketplaceCatalog>("/api/v1/integrations/marketplace");
+}
+
+export async function startOAuth(
+  name: string,
+  env: Record<string, string>
+): Promise<{ authUrl: string }> {
+  return apiWrite<{ authUrl: string }>(
+    "POST",
+    `/api/v1/integrations/${encodeURIComponent(name)}/oauth/start`,
+    { env }
+  );
+}

--- a/apps/web/app/routes/_app.integrations.$name.tsx
+++ b/apps/web/app/routes/_app.integrations.$name.tsx
@@ -1,0 +1,454 @@
+import {
+  type ClientLoaderFunctionArgs,
+  type MetaFunction,
+  useLoaderData,
+  useRevalidator,
+  useRouteError,
+  useSearchParams,
+} from "@remix-run/react";
+import { useEffect, useState } from "react";
+import { MarkdownView } from "~/components/markdown-view";
+import { ResourcePanel } from "~/components/resource-panel";
+import { ErrorState } from "~/components/states";
+import { Button } from "~/components/ui/button";
+import { Modal } from "~/components/ui/modal";
+import { ApiError } from "~/lib/api";
+import {
+  connectIntegration,
+  deleteIntegration,
+  disconnectIntegration,
+  getIntegration,
+  type McpConnectionStatus,
+  type OAuthConfig,
+  type RequiredEnvVar,
+  startOAuth,
+} from "~/lib/integrations";
+
+export const meta: MetaFunction = () => [{ title: "Integration · tulipfarm" }];
+
+export async function clientLoader({ params }: ClientLoaderFunctionArgs) {
+  const name = params.name;
+  if (!name) throw new ApiError(404, "missing integration name");
+  const integration = await getIntegration(name);
+  return { integration };
+}
+
+const inputClass =
+  "w-full rounded-sm border border-border bg-background px-3 py-2 text-sm outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50";
+
+const STATUS_LABEL: Record<McpConnectionStatus, string> = {
+  connected: "Connected",
+  connecting: "Connecting…",
+  error: "Error",
+  disconnected: "Not connected",
+};
+
+const STATUS_CLASS: Record<McpConnectionStatus, string> = {
+  connected: "text-muted-foreground",
+  connecting: "text-primary",
+  error: "text-destructive",
+  disconnected: "text-muted-foreground",
+};
+
+function errMessage(e: unknown): string {
+  if (e instanceof ApiError) return e.message;
+  return e instanceof Error ? e.message : "request failed";
+}
+
+function FieldHints({ field }: { field: RequiredEnvVar }) {
+  if (!field.steps?.length && !field.setup_url) return null;
+  return (
+    <details className="mt-0.5">
+      <summary className="cursor-pointer select-none text-xs text-muted-foreground hover:text-foreground">
+        How to get this
+      </summary>
+      <div className="mt-1.5 flex flex-col gap-1 pl-3 text-xs text-muted-foreground">
+        {field.steps?.map((step, i) => (
+          <p key={step}>
+            {i + 1}. {step}
+          </p>
+        ))}
+        {field.setup_url && (
+          <a
+            href={field.setup_url}
+            target="_blank"
+            rel="noreferrer"
+            className="mt-0.5 text-primary underline underline-offset-2 hover:opacity-80"
+          >
+            Open docs →
+          </a>
+        )}
+      </div>
+    </details>
+  );
+}
+
+function EnvField({
+  field,
+  value,
+  onChange,
+}: {
+  field: RequiredEnvVar;
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <label className="text-xs font-medium text-foreground" htmlFor={field.name}>
+        {field.label}
+        {field.description && (
+          <span className="ml-1 font-normal text-muted-foreground">— {field.description}</span>
+        )}
+      </label>
+      <input
+        id={field.name}
+        className={inputClass}
+        type={field.secret ? "password" : "text"}
+        placeholder={field.name}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        autoComplete={field.secret ? "off" : undefined}
+      />
+      <FieldHints field={field} />
+    </div>
+  );
+}
+
+/** Split required_env into shared / oauth-only / token (direct-only) groups. */
+function splitFields(
+  fields: RequiredEnvVar[],
+  oauth: OAuthConfig | undefined
+): {
+  shared: RequiredEnvVar[];
+  oauthOnly: RequiredEnvVar[];
+  directOnly: RequiredEnvVar[];
+} {
+  if (!oauth) return { shared: fields, oauthOnly: [], directOnly: [] };
+  const oauthKeys = new Set([oauth.client_id_env, oauth.client_secret_env]);
+  const tokenKey = oauth.token_env;
+  return {
+    shared: fields.filter((f) => !oauthKeys.has(f.name) && f.name !== tokenKey),
+    oauthOnly: fields.filter((f) => oauthKeys.has(f.name)),
+    directOnly: fields.filter((f) => f.name === tokenKey),
+  };
+}
+
+export default function IntegrationDetailPage() {
+  const { integration } = useLoaderData<typeof clientLoader>();
+  const revalidator = useRevalidator();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const requiredEnv = integration.manifest.required_env ?? [];
+  const oauthConfig = integration.manifest.oauth;
+  const { shared, oauthOnly, directOnly } = splitFields(requiredEnv, oauthConfig);
+
+  const [envValues, setEnvValues] = useState<Record<string, string>>(() =>
+    Object.fromEntries(requiredEnv.map((e) => [e.name, ""]))
+  );
+  const [connecting, setConnecting] = useState(false);
+  const [oauthPending, setOauthPending] = useState(false);
+  const [disconnecting, setDisconnecting] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [actionError, setActionError] = useState<string>();
+  const [guideOpen, setGuideOpen] = useState(false);
+
+  const setField = (name: string) => (v: string) =>
+    setEnvValues((prev) => ({ ...prev, [name]: v }));
+
+  // Handle OAuth callback redirect: ?connected=true or ?error=...
+  useEffect(() => {
+    const connected = searchParams.get("connected");
+    const error = searchParams.get("error");
+    if (connected === "true") {
+      setOauthPending(false);
+      setSearchParams({}, { replace: true });
+      revalidator.revalidate();
+    } else if (error) {
+      setOauthPending(false);
+      setActionError(decodeURIComponent(error));
+      setSearchParams({}, { replace: true });
+    }
+  }, [searchParams, setSearchParams, revalidator]);
+
+  async function handleConnect(e: React.FormEvent) {
+    e.preventDefault();
+    setConnecting(true);
+    setActionError(undefined);
+    // Exclude oauth-only fields (client_id / client_secret) from direct connect env
+    const oauthKeys = new Set(
+      oauthConfig ? [oauthConfig.client_id_env, oauthConfig.client_secret_env] : []
+    );
+    const directEnv = Object.fromEntries(
+      Object.entries(envValues).filter(([k]) => !oauthKeys.has(k))
+    );
+    try {
+      await connectIntegration(integration.name, directEnv);
+      revalidator.revalidate();
+    } catch (err) {
+      setActionError(errMessage(err));
+    } finally {
+      setConnecting(false);
+    }
+  }
+
+  async function handleOAuth() {
+    setActionError(undefined);
+    setOauthPending(true);
+    try {
+      const { authUrl } = await startOAuth(integration.name, envValues);
+      window.open(authUrl, "_blank", "noopener,noreferrer");
+    } catch (err) {
+      setActionError(errMessage(err));
+      setOauthPending(false);
+    }
+  }
+
+  async function handleDisconnect() {
+    setDisconnecting(true);
+    setActionError(undefined);
+    try {
+      await disconnectIntegration(integration.name);
+      revalidator.revalidate();
+    } catch (err) {
+      setActionError(errMessage(err));
+    } finally {
+      setDisconnecting(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!window.confirm(`Remove integration "${integration.name}"?`)) return;
+    setDeleting(true);
+    setActionError(undefined);
+    try {
+      await deleteIntegration(integration.name);
+      window.location.href = "/integrations";
+    } catch (err) {
+      setActionError(errMessage(err));
+      setDeleting(false);
+    }
+  }
+
+  const isConnected = integration.status === "connected";
+  const entry = integration.manifest.entry as Record<string, unknown>;
+
+  return (
+    <ResourcePanel
+      crumbs={[{ label: "integrations", to: "/integrations" }, { label: integration.name }]}
+    >
+      <div className="flex flex-col gap-4">
+        {/* Header */}
+        <div className="flex items-start gap-3">
+          <div className="flex flex-col gap-1">
+            <h1 className="text-lg font-semibold text-foreground">{integration.name}</h1>
+            {integration.description && (
+              <p className="text-sm text-muted-foreground">{integration.description}</p>
+            )}
+          </div>
+          <div className="ml-auto flex items-center gap-2">
+            <span className={`text-sm ${STATUS_CLASS[integration.status]}`}>
+              {STATUS_LABEL[integration.status]}
+            </span>
+            {integration.errorMessage && (
+              <span className="text-xs text-destructive">{integration.errorMessage}</span>
+            )}
+          </div>
+        </div>
+
+        {/* Manifest details */}
+        <div className="flex flex-col gap-1 rounded-sm border border-border p-3 text-sm">
+          <div className="flex gap-2">
+            <span className="w-24 text-muted-foreground">type</span>
+            <span className="text-foreground">{integration.type}</span>
+          </div>
+          {integration.version && (
+            <div className="flex gap-2">
+              <span className="w-24 text-muted-foreground">version</span>
+              <span className="text-foreground">{integration.version}</span>
+            </div>
+          )}
+          {integration.maintainer && (
+            <div className="flex gap-2">
+              <span className="w-24 text-muted-foreground">maintainer</span>
+              <span className="text-foreground">{integration.maintainer}</span>
+            </div>
+          )}
+          {typeof entry.transport === "string" && (
+            <div className="flex gap-2">
+              <span className="w-24 text-muted-foreground">transport</span>
+              <span className="text-foreground">{entry.transport}</span>
+            </div>
+          )}
+        </div>
+
+        {/* Connect form (only when not connected) */}
+        {!isConnected && (
+          <div className="flex flex-col gap-3">
+            <div className="flex items-center gap-2">
+              <h2 className="text-sm font-medium text-foreground">Connect</h2>
+              {integration.setupGuide && (
+                <button
+                  type="button"
+                  onClick={() => setGuideOpen(true)}
+                  className="text-xs text-primary underline underline-offset-2 hover:opacity-80"
+                >
+                  Setup guide →
+                </button>
+              )}
+            </div>
+
+            {/* Shared fields (e.g. Team ID) — always shown */}
+            {shared.map((field) => (
+              <EnvField
+                key={field.name}
+                field={field}
+                value={envValues[field.name] ?? ""}
+                onChange={setField(field.name)}
+              />
+            ))}
+
+            {actionError && <p className="text-sm text-destructive">{actionError}</p>}
+            {oauthPending && (
+              <p className="text-xs text-muted-foreground">
+                Waiting for authorization in the new tab…
+              </p>
+            )}
+
+            {oauthConfig ? (
+              /* Two-path layout when OAuth is available */
+              <div className="flex flex-col gap-4">
+                {/* OAuth path */}
+                <div className="flex flex-col gap-3 rounded-sm border border-border p-3">
+                  <p className="text-xs font-medium text-foreground">
+                    Option A — Connect with OAuth
+                  </p>
+                  {oauthOnly.map((field) => (
+                    <EnvField
+                      key={field.name}
+                      field={field}
+                      value={envValues[field.name] ?? ""}
+                      onChange={setField(field.name)}
+                    />
+                  ))}
+                  <Button
+                    type="button"
+                    size="sm"
+                    disabled={oauthPending || connecting}
+                    onClick={handleOAuth}
+                  >
+                    {oauthPending ? "Authorizing…" : "Connect with OAuth"}
+                  </Button>
+                </div>
+
+                {/* Direct token path */}
+                <div className="flex flex-col gap-3 rounded-sm border border-border p-3">
+                  <p className="text-xs font-medium text-foreground">
+                    Option B — Paste token directly
+                  </p>
+                  {directOnly.map((field) => (
+                    <EnvField
+                      key={field.name}
+                      field={field}
+                      value={envValues[field.name] ?? ""}
+                      onChange={setField(field.name)}
+                    />
+                  ))}
+                  <form onSubmit={handleConnect}>
+                    <Button
+                      type="submit"
+                      size="sm"
+                      variant="outline"
+                      disabled={connecting || oauthPending}
+                    >
+                      {connecting ? "Connecting…" : "Connect"}
+                    </Button>
+                  </form>
+                </div>
+              </div>
+            ) : (
+              /* Simple layout when no OAuth */
+              <form onSubmit={handleConnect} className="flex flex-col gap-3">
+                {requiredEnv.length === 0 ? (
+                  <p className="text-xs text-muted-foreground">
+                    No configuration required. Click Connect to start the MCP server.
+                  </p>
+                ) : (
+                  requiredEnv.map((field) => (
+                    <EnvField
+                      key={field.name}
+                      field={field}
+                      value={envValues[field.name] ?? ""}
+                      onChange={setField(field.name)}
+                    />
+                  ))
+                )}
+                <Button type="submit" size="sm" disabled={connecting}>
+                  {connecting ? "Connecting…" : "Connect"}
+                </Button>
+              </form>
+            )}
+          </div>
+        )}
+
+        {/* Disconnect */}
+        {isConnected && (
+          <div className="flex flex-col gap-2">
+            <h2 className="text-sm font-medium text-foreground">Connection</h2>
+            <p className="text-xs text-muted-foreground">
+              MCP server is running. Disconnect to stop it.
+            </p>
+            {actionError && <p className="text-sm text-destructive">{actionError}</p>}
+            <div className="flex gap-2">
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={disconnecting}
+                onClick={handleDisconnect}
+              >
+                {disconnecting ? "Disconnecting…" : "Disconnect"}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* Danger zone */}
+        <div className="flex flex-col gap-2 rounded-sm border border-destructive/30 p-3">
+          <h2 className="text-sm font-medium text-destructive">Remove</h2>
+          <p className="text-xs text-muted-foreground">
+            Removes the integration from the soul repo. Disconnects first if connected.
+          </p>
+          <Button
+            size="sm"
+            variant="outline"
+            className="self-start border-destructive text-destructive hover:bg-destructive/10"
+            disabled={deleting}
+            onClick={handleDelete}
+          >
+            {deleting ? "Removing…" : "Remove integration"}
+          </Button>
+        </div>
+      </div>
+
+      {/* Setup guide modal */}
+      {integration.setupGuide && (
+        <Modal
+          open={guideOpen}
+          onClose={() => setGuideOpen(false)}
+          title="Setup guide"
+          className="max-w-2xl"
+        >
+          <div className="max-h-[70vh] overflow-y-auto">
+            <MarkdownView>{integration.setupGuide}</MarkdownView>
+          </div>
+        </Modal>
+      )}
+    </ResourcePanel>
+  );
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+  const status = error instanceof ApiError ? error.status : undefined;
+  const message = error instanceof Error ? error.message : undefined;
+  return <ErrorState section="integrations" status={status} message={message} />;
+}

--- a/apps/web/app/routes/_app.integrations._index.tsx
+++ b/apps/web/app/routes/_app.integrations._index.tsx
@@ -1,0 +1,137 @@
+import {
+  Link,
+  type MetaFunction,
+  useLoaderData,
+  useRevalidator,
+  useRouteError,
+} from "@remix-run/react";
+import { useState } from "react";
+import { IntegrationsTabs } from "~/components/integrations-tabs";
+import { ResourcePanel } from "~/components/resource-panel";
+import { ErrorState } from "~/components/states";
+import { Button } from "~/components/ui/button";
+import { ApiError } from "~/lib/api";
+import {
+  connectIntegration,
+  disconnectIntegration,
+  type IntegrationSummary,
+  listIntegrations,
+  type McpConnectionStatus,
+} from "~/lib/integrations";
+
+export const meta: MetaFunction = () => [{ title: "Integrations · tulipfarm" }];
+
+export async function clientLoader() {
+  const integrations = await listIntegrations();
+  return { integrations };
+}
+
+const STATUS_CLASS: Record<McpConnectionStatus, string> = {
+  connected: "border-border text-muted-foreground",
+  connecting: "border-primary text-primary",
+  error: "border-destructive text-destructive",
+  disconnected: "border-border text-muted-foreground",
+};
+
+function StatusBadge({ status }: { status: McpConnectionStatus }) {
+  return (
+    <span
+      className={`shrink-0 rounded-sm border px-1.5 py-0.5 text-xs uppercase tracking-[0.15em] ${STATUS_CLASS[status]}`}
+    >
+      {status}
+    </span>
+  );
+}
+
+function IntegrationRow({ integration }: { integration: IntegrationSummary }) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string>();
+  const revalidator = useRevalidator();
+
+  async function handleDisconnect(e: React.MouseEvent) {
+    e.preventDefault();
+    setBusy(true);
+    setError(undefined);
+    try {
+      await disconnectIntegration(integration.name);
+      revalidator.revalidate();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "disconnect failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <li className="flex flex-col">
+      <div className="group flex items-baseline gap-2 px-3 py-2">
+        <span aria-hidden className="text-primary">
+          ▸
+        </span>
+        <Link
+          to={`/integrations/${encodeURIComponent(integration.name)}`}
+          className="font-medium text-foreground hover:underline"
+        >
+          {integration.name}
+        </Link>
+        {integration.description ? (
+          <span className="min-w-0 flex-1 truncate text-muted-foreground">
+            {integration.description}
+          </span>
+        ) : (
+          <span className="flex-1" />
+        )}
+        <StatusBadge status={integration.status} />
+        {integration.status === "connected" ? (
+          <Button size="sm" variant="outline" disabled={busy} onClick={handleDisconnect}>
+            {busy ? "Disconnecting…" : "Disconnect"}
+          </Button>
+        ) : (
+          <Button asChild size="sm">
+            <Link to={`/integrations/${encodeURIComponent(integration.name)}`}>Connect</Link>
+          </Button>
+        )}
+      </div>
+      {integration.errorMessage && (
+        <p className="px-3 pb-2 text-xs text-destructive">{integration.errorMessage}</p>
+      )}
+      {error && <p className="px-3 pb-2 text-xs text-destructive">{error}</p>}
+    </li>
+  );
+}
+
+export default function IntegrationsIndex() {
+  const { integrations } = useLoaderData<typeof clientLoader>();
+
+  return (
+    <ResourcePanel crumbs={[{ label: "integrations" }]}>
+      <IntegrationsTabs />
+      <div className="flex items-center justify-between">
+        <p className="text-xs text-muted-foreground">
+          {integrations.length} {integrations.length === 1 ? "integration" : "integrations"}
+        </p>
+        <Button asChild size="sm">
+          <Link to="/integrations/marketplace">Browse marketplace</Link>
+        </Button>
+      </div>
+      {integrations.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          No integrations installed yet — browse the marketplace to add one.
+        </p>
+      ) : (
+        <ul className="flex flex-col divide-y divide-border rounded-sm border border-border">
+          {integrations.map((i) => (
+            <IntegrationRow key={i.name} integration={i} />
+          ))}
+        </ul>
+      )}
+    </ResourcePanel>
+  );
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+  const status = error instanceof ApiError ? error.status : undefined;
+  const message = error instanceof Error ? error.message : undefined;
+  return <ErrorState section="integrations" status={status} message={message} />;
+}

--- a/apps/web/app/routes/_app.integrations.marketplace.tsx
+++ b/apps/web/app/routes/_app.integrations.marketplace.tsx
@@ -1,0 +1,218 @@
+import { type MetaFunction, useLoaderData } from "@remix-run/react";
+import { useState } from "react";
+import { IntegrationsTabs } from "~/components/integrations-tabs";
+import { ResourcePanel } from "~/components/resource-panel";
+import { Button } from "~/components/ui/button";
+import { ApiError } from "~/lib/api";
+import {
+  installIntegrations,
+  type MarketplaceCatalog,
+  marketplaceIntegrations,
+  type ScannedIntegration,
+  type ScanResult,
+  scanIntegrations,
+} from "~/lib/integrations";
+
+export const meta: MetaFunction = () => [{ title: "Marketplace · tulipfarm" }];
+
+export async function clientLoader() {
+  return { catalog: await marketplaceIntegrations().catch(() => null) };
+}
+
+const inputClass =
+  "w-full rounded-sm border border-border bg-background px-3 py-2 text-sm outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50";
+
+function errMessage(e: unknown): string {
+  if (e instanceof ApiError) return e.message;
+  return e instanceof Error ? e.message : "request failed";
+}
+
+function InstallBadge({
+  installed,
+  updateAvailable,
+}: {
+  installed: boolean;
+  updateAvailable: boolean;
+}) {
+  if (updateAvailable) {
+    return (
+      <span className="shrink-0 rounded-sm border border-primary px-1.5 py-0.5 text-xs uppercase tracking-[0.15em] text-primary">
+        update available
+      </span>
+    );
+  }
+  if (installed) {
+    return (
+      <span className="shrink-0 rounded-sm border border-border px-1.5 py-0.5 text-xs uppercase tracking-[0.15em] text-muted-foreground">
+        installed ✓
+      </span>
+    );
+  }
+  return null;
+}
+
+function IntegrationList({
+  items,
+  onSelect,
+  selected,
+}: {
+  items: Array<{
+    name: string;
+    description?: string;
+    installed: boolean;
+    updateAvailable: boolean;
+    verified?: boolean;
+  }>;
+  onSelect: (name: string) => void;
+  selected: Set<string>;
+}) {
+  return (
+    <ul className="flex flex-col divide-y divide-border rounded-sm border border-border">
+      {items.map((i) => (
+        <li key={i.name} className="flex items-baseline gap-2 px-3 py-2">
+          <input
+            type="checkbox"
+            className="mt-0.5 shrink-0"
+            checked={selected.has(i.name)}
+            onChange={() => onSelect(i.name)}
+            disabled={i.installed && !i.updateAvailable}
+          />
+          <span className="font-medium text-foreground">{i.name}</span>
+          {i.verified && (
+            <span className="shrink-0 rounded-sm border border-border px-1.5 py-0.5 text-xs uppercase tracking-[0.15em] text-muted-foreground">
+              verified
+            </span>
+          )}
+          {i.description ? (
+            <span className="min-w-0 flex-1 truncate text-muted-foreground">{i.description}</span>
+          ) : (
+            <span className="flex-1" />
+          )}
+          <InstallBadge installed={i.installed} updateAvailable={i.updateAvailable} />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export default function IntegrationsMarketplace() {
+  const { catalog } = useLoaderData<typeof clientLoader>();
+
+  const [scanUrl, setScanUrl] = useState("");
+  const [scanning, setScanning] = useState(false);
+  const [scanResult, setScanResult] = useState<ScanResult | null>(null);
+  const [catalogScan, setCatalogScan] = useState<MarketplaceCatalog | null>(catalog);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [installing, setInstalling] = useState(false);
+  const [scanError, setScanError] = useState<string>();
+  const [installError, setInstallError] = useState<string>();
+  const [installed, setInstalled] = useState<string[]>([]);
+
+  function toggleSelect(name: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) next.delete(name);
+      else next.add(name);
+      return next;
+    });
+  }
+
+  async function handleScan(e: React.FormEvent) {
+    e.preventDefault();
+    if (!scanUrl.trim()) return;
+    setScanning(true);
+    setScanError(undefined);
+    setScanResult(null);
+    setCatalogScan(null);
+    setSelected(new Set());
+    try {
+      const result = await scanIntegrations(scanUrl.trim());
+      setScanResult(result);
+    } catch (err) {
+      setScanError(errMessage(err));
+    } finally {
+      setScanning(false);
+    }
+  }
+
+  async function handleInstall() {
+    const scanId = scanResult?.scanId ?? catalogScan?.scanId;
+    if (!scanId || selected.size === 0) return;
+    setInstalling(true);
+    setInstallError(undefined);
+    try {
+      const result = await installIntegrations(scanId, [...selected]);
+      setInstalled(result.installed);
+      setSelected(new Set());
+    } catch (err) {
+      setInstallError(errMessage(err));
+    } finally {
+      setInstalling(false);
+    }
+  }
+
+  const activeItems = scanResult?.integrations ?? catalogScan?.integrations ?? [];
+  const installable = activeItems.filter((i) => !i.installed || i.updateAvailable);
+
+  return (
+    <ResourcePanel crumbs={[{ label: "integrations" }, { label: "marketplace" }]}>
+      <IntegrationsTabs />
+
+      <form onSubmit={handleScan} className="flex gap-2">
+        <input
+          className={inputClass}
+          placeholder="owner/repo or https://..."
+          value={scanUrl}
+          onChange={(e) => setScanUrl(e.target.value)}
+        />
+        <Button type="submit" size="sm" disabled={scanning || !scanUrl.trim()}>
+          {scanning ? "Scanning…" : "Scan"}
+        </Button>
+      </form>
+
+      {scanError && <p className="text-sm text-destructive">{scanError}</p>}
+
+      {activeItems.length > 0 && (
+        <div className="flex flex-col gap-3">
+          {catalogScan && !scanResult && (
+            <p className="text-xs text-muted-foreground">
+              Official integrations from{" "}
+              <span className="font-medium text-foreground">{catalogScan.source}</span>
+            </p>
+          )}
+          <IntegrationList items={activeItems} onSelect={toggleSelect} selected={selected} />
+          {installable.length > 0 && (
+            <div className="flex items-center gap-3">
+              <Button
+                size="sm"
+                disabled={installing || selected.size === 0}
+                onClick={handleInstall}
+              >
+                {installing
+                  ? "Installing…"
+                  : selected.size > 0
+                    ? `Install ${selected.size} integration${selected.size > 1 ? "s" : ""}`
+                    : "Select integrations to install"}
+              </Button>
+              {installError && <p className="text-sm text-destructive">{installError}</p>}
+            </div>
+          )}
+          {installed.length > 0 && (
+            <p className="text-sm text-muted-foreground">
+              Installed: {installed.join(", ")} —{" "}
+              <a href="/integrations" className="text-foreground underline">
+                connect them now
+              </a>
+            </p>
+          )}
+        </div>
+      )}
+
+      {catalog === null && !scanResult && (
+        <p className="text-sm text-muted-foreground">
+          Official marketplace unavailable — enter a git URL above to scan a custom repo.
+        </p>
+      )}
+    </ResourcePanel>
+  );
+}

--- a/apps/web/app/routes/_app.integrations.tsx
+++ b/apps/web/app/routes/_app.integrations.tsx
@@ -1,14 +1,7 @@
-import type { MetaFunction } from "@remix-run/react";
-import { EmptyState } from "~/components/empty-state";
+import { type MetaFunction, Outlet } from "@remix-run/react";
 
 export const meta: MetaFunction = () => [{ title: "Integrations · tulipfarm" }];
 
-export default function IntegrationsPage() {
-  return (
-    <EmptyState
-      section="integrations"
-      title="Integrations"
-      hint="No integrations connected. Slack, GitHub, and third-party services connect here."
-    />
-  );
+export default function IntegrationsLayout() {
+  return <Outlet />;
 }

--- a/packages/soul/src/index.ts
+++ b/packages/soul/src/index.ts
@@ -3,10 +3,21 @@ export type { SoulMigration } from "./migrations/index";
 export { SoulLoader } from "./soul-loader";
 export { runSoulMigrations } from "./soul-migrations";
 export type {
+  EgressConfig,
+  IngressAction,
+  IngressConfig,
+  IntegrationConnection,
+  IntegrationManifest,
   Logger,
+  McpEntry,
+  OAuthConfig,
+  OAuthFlowConfig,
+  RequiredEnvVar,
   SoulAgent,
   SoulIntegration,
   SoulResource,
   SoulRoutine,
   SoulSkill,
+  WebhookConfig,
+  WebhookSecurity,
 } from "./types";

--- a/packages/soul/src/soul-loader.test.ts
+++ b/packages/soul/src/soul-loader.test.ts
@@ -223,12 +223,16 @@ describe("SoulLoader", () => {
   describe("integrations", () => {
     it("parses config.yaml", async () => {
       await write(
-        join(TMP, "integrations", "github", "config.yaml"),
-        "token: ghp_xxx\nowner: tulipfarm\n"
+        join(TMP, "integrations", "github", "manifest.yml"),
+        "name: github\negress:\n  type: mcp\n  entry:\n    transport: stdio\n    command: echo\n"
+      );
+      await write(
+        join(TMP, "integrations", "github", "connection.yaml"),
+        "enabled: true\nenv:\n  token: ghp_xxx\n  owner: tulipfarm\n"
       );
       const loader = new SoulLoader(TMP, makeLogger());
       await loader.load();
-      expect(loader.integrations.get("github")?.config).toMatchObject({
+      expect(loader.integrations.get("github")?.connection?.env).toMatchObject({
         token: "ghp_xxx",
         owner: "tulipfarm",
       });

--- a/packages/soul/src/soul-loader.ts
+++ b/packages/soul/src/soul-loader.ts
@@ -4,6 +4,8 @@ import { join } from "node:path";
 import { validateResourceSchema } from "@tulipfarm/validation";
 import { parse as parseYaml } from "yaml";
 import type {
+  IntegrationConnection,
+  IntegrationManifest,
   Logger,
   SoulAgent,
   SoulIntegration,
@@ -192,16 +194,55 @@ export class SoulLoader {
 
   private async loadIntegrations(): Promise<Map<string, SoulIntegration>> {
     const map = new Map<string, SoulIntegration>();
-    const names = await subdirs(join(this.soulPath, "integrations"));
-    for (const name of names) {
-      const configPath = join(this.soulPath, "integrations", name, "config.yaml");
+    const slugs = await subdirs(join(this.soulPath, "integrations"));
+    for (const slug of slugs) {
+      const dir = join(this.soulPath, "integrations", slug);
+      // manifest.yml is the V2 format; manifest.json is no longer supported
+      const manifestPath = join(dir, "manifest.yml");
       try {
-        const content = await readFile(configPath, "utf8");
-        const config = (parseYaml(content) ?? {}) as Record<string, unknown>;
-        map.set(name, { name, config });
+        const manifestRaw = (parseYaml(await readFile(manifestPath, "utf8")) ??
+          {}) as IntegrationManifest;
+
+        // Validate egress block minimally
+        if (!manifestRaw.egress?.type) {
+          this.logger.warn(`Soul: skipping integration "${slug}" — manifest.egress.type missing`);
+          continue;
+        }
+        if (manifestRaw.egress.type === "mcp" && !manifestRaw.egress.entry?.transport) {
+          this.logger.warn(
+            `Soul: skipping integration "${slug}" — manifest.egress.entry.transport missing`
+          );
+          continue;
+        }
+
+        let connection: IntegrationConnection | undefined;
+        try {
+          const connRaw = (parseYaml(await readFile(join(dir, "connection.yaml"), "utf8")) ??
+            {}) as IntegrationConnection;
+          connection = connRaw;
+        } catch {
+          // connection.yaml is optional — integration is installed but not yet connected
+        }
+
+        let setupGuide: string | undefined;
+        try {
+          setupGuide = await readFile(join(dir, "setup-guide.md"), "utf8");
+        } catch {
+          // setup-guide.md is optional
+        }
+
+        // sourceIntegration is manifest.name (the integration type from the repo).
+        // slug is the directory name (user-assigned at install time, may differ for multi-instance).
+        map.set(slug, {
+          slug,
+          sourceIntegration: manifestRaw.name,
+          manifest: manifestRaw,
+          connection,
+          setupGuide,
+        });
       } catch (err) {
         this.logger.warn(
-          `Soul: skipping integration "${name}" — ${err instanceof Error ? err.message : String(err)}`
+          `Soul: skipping integration "${slug}" — ${err instanceof Error ? err.message : String(err)}`
         );
       }
     }

--- a/packages/soul/src/types.ts
+++ b/packages/soul/src/types.ts
@@ -25,9 +25,106 @@ export interface SoulRoutine {
   hasHooks: boolean;
 }
 
-export interface SoulIntegration {
+export type McpEntry =
+  | { transport: "stdio"; command: string; args?: string[] }
+  | { transport: "sse"; url: string; headers?: Record<string, string> };
+
+// ── Egress ────────────────────────────────────────────────────────────────────
+
+export type EgressConfig =
+  | { type: "mcp"; entry: McpEntry }
+  | { type: "openapi"; spec: string }
+  | { type: "ts-code"; handler: string; toolsSpec: string };
+
+// ── Ingress ───────────────────────────────────────────────────────────────────
+
+export interface WebhookSecurity {
+  type: "hmac_sha256";
+  header: string;
+  secret_env: string;
+}
+
+export interface WebhookConfig {
+  path: string;
+  security?: WebhookSecurity | { type: "none" };
+  dedup_header?: string;
+  verification_protocol?: "slack" | "github";
+}
+
+export type IngressConfig =
+  | { type: "asyncapi"; spec: string; webhook?: WebhookConfig }
+  | { type: "ts-code"; handler: string; webhook?: WebhookConfig }
+  | { type: "none" };
+
+// ── IngressAction (returned by ingress handlers) ──────────────────────────────
+
+export type IngressAction =
+  | { type: "emit_event"; name: string; payload: unknown }
+  | {
+      type: "inject_message";
+      conversationKey: string;
+      message: { role: "user"; content: string };
+      triggerAgent: boolean;
+    }
+  | { type: "respond"; status: number; body: unknown };
+
+// ── Credential helpers ────────────────────────────────────────────────────────
+
+export interface RequiredEnvVar {
   name: string;
-  config: Record<string, unknown>;
+  label: string;
+  description?: string;
+  secret?: boolean;
+  setup_url?: string;
+  steps?: string[];
+}
+
+export interface OAuthFlowConfig {
+  authorizationUrl: string;
+  tokenUrl: string;
+  scopes: Record<string, string>;
+}
+
+export interface OAuthConfig {
+  flows: {
+    authorizationCode?: OAuthFlowConfig;
+    clientCredentials?: OAuthFlowConfig;
+  };
+  "x-tulipfarm": {
+    client_id_env: string;
+    client_secret_env: string;
+    token_env: string;
+    token_response_path?: string;
+  };
+}
+
+// ── Manifest ──────────────────────────────────────────────────────────────────
+
+export interface IntegrationManifest {
+  name: string;
+  version?: string;
+  description?: string;
+  maintainer?: string;
+  egress: EgressConfig;
+  ingress?: IngressConfig;
+  required_env?: RequiredEnvVar[];
+  setup_guide_path?: string;
+  oauth?: OAuthConfig;
+}
+
+export interface IntegrationConnection {
+  enabled: boolean;
+  env?: Record<string, string>;
+}
+
+export interface SoulIntegration {
+  /** Installation slug — unique key, user-assigned at install time (may differ from manifest.name). */
+  slug: string;
+  /** The integration type name from the source repo (manifest.name). */
+  sourceIntegration: string;
+  manifest: IntegrationManifest;
+  connection?: IntegrationConnection;
+  setupGuide?: string;
 }
 
 /** Minimal logger surface (pino/console compatible) shared across soul services. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       '@fastify/swagger':
         specifier: ^9.7.0
         version: 9.7.0
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.4.3)
       '@node-rs/argon2':
         specifier: ^2.0.2
         version: 2.0.2
@@ -1636,6 +1639,12 @@ packages:
       tailwindcss:
         optional: true
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
@@ -1964,6 +1973,16 @@ packages:
 
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -3544,6 +3563,10 @@ packages:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -3718,6 +3741,10 @@ packages:
   body-parser@1.20.5:
     resolution: {integrity: sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
 
   boxen@7.0.0:
     resolution: {integrity: sha512-j//dBVuyacJbvW+tvZ9HuH03fZ46QcaKvvhZickZqtB271DxJ7SNRSNxrV/dZX0085m7hISRZWbzWlJvx/rHSg==}
@@ -4049,6 +4076,10 @@ packages:
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cosmiconfig-typescript-loader@6.3.0:
     resolution: {integrity: sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA==}
@@ -4451,6 +4482,10 @@ packages:
     resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
     engines: {node: '>=18.0.0'}
 
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -4463,9 +4498,19 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
   express@4.22.2:
     resolution: {integrity: sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==}
     engines: {node: '>= 0.10.0'}
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
@@ -4536,6 +4581,10 @@ packages:
     resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
     engines: {node: '>= 0.8'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-my-way@9.6.0:
     resolution: {integrity: sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==}
     engines: {node: '>=20'}
@@ -4577,6 +4626,10 @@ packages:
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -4862,6 +4915,10 @@ packages:
     resolution: {integrity: sha512-DRgTIUgnWcJ62KyarxxziuqYxKGnR6Rgg19BlbucN/dpmJbl1XOit6qvoOX0ZT+HhWe5OUVhU/a1zpGyc1xA0Q==}
     engines: {node: '>=18.0.0'}
 
+  hono@4.12.26:
+    resolution: {integrity: sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==}
+    engines: {node: '>=16.9.0'}
+
   hosted-git-info@6.1.3:
     resolution: {integrity: sha512-HVJyzUrLIL1c0QmviVh5E8VGyUS7xCFPS6yydaVd1UegW+ibV/CohqTH9MkOLDp5o+rb82DMo77PTuc9F/8GKw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -5068,6 +5125,9 @@ packages:
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
 
@@ -5146,6 +5206,9 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
@@ -5186,6 +5249,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
@@ -5569,12 +5635,20 @@ packages:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
   meow@13.2.0:
     resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
     engines: {node: '>=18'}
 
   merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -5937,6 +6011,10 @@ packages:
     resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
     engines: {node: '>= 0.6'}
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
@@ -6047,6 +6125,10 @@ packages:
     resolution: {integrity: sha512-s3ds97SD5pd1dULE+tHUk1DrV0cSHOnsfpcdGATJ8JpBo21DoKqN9exTH4/2nhPQNOLomBdTFMicN94S4DrZrQ==}
     engines: {node: '>=18'}
     hasBin: true
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -6198,6 +6280,9 @@ packages:
   path-to-regexp@3.3.0:
     resolution: {integrity: sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==}
 
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
 
@@ -6280,6 +6365,10 @@ packages:
   pino@10.3.1:
     resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
     hasBin: true
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
@@ -6511,6 +6600,10 @@ packages:
   raw-body@2.5.3:
     resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
     engines: {node: '>= 0.8'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   rc9@2.1.2:
     resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
@@ -6744,6 +6837,10 @@ packages:
   rope-sequence@1.3.4:
     resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   run-applescript@7.1.0:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
     engines: {node: '>=18'}
@@ -6809,6 +6906,10 @@ packages:
     resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
     engines: {node: '>= 0.8.0'}
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   serialize-error@13.0.1:
     resolution: {integrity: sha512-bBZaRwLH9PN5HbLCjPId4dP5bNGEtumcErgOX952IsvOhVPrm3/AeK1y0UHA/QaPG701eg0yEnOKsCOC6X/kaA==}
     engines: {node: '>=20'}
@@ -6819,6 +6920,10 @@ packages:
   serve-static@1.16.3:
     resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
     engines: {node: '>= 0.8.0'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
 
   serve@14.2.6:
     resolution: {integrity: sha512-QEjUSA+sD4Rotm1znR8s50YqA3kYpRGPmtd5GlFxbaL9n/FdUNbqMhxClqdditSk0LlZyA/dhud6XNRTOC9x2Q==}
@@ -7167,6 +7272,10 @@ packages:
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
+
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
 
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
@@ -7669,6 +7778,11 @@ packages:
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -8555,6 +8669,10 @@ snapshots:
       '@tailwindcss/oxide': 4.3.1
       tailwindcss: 4.3.1
 
+  '@hono/node-server@1.19.14(hono@4.12.26)':
+    dependencies:
+      hono: 4.12.26
+
   '@img/colour@1.1.0':
     optional: true
 
@@ -8862,6 +8980,28 @@ snapshots:
       unist-util-stringify-position: 4.0.0
       unist-util-visit: 5.1.0
       vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.26)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.26
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -10445,6 +10585,11 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -10605,6 +10750,20 @@ snapshots:
       raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.0.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.2
+      raw-body: 3.0.2
+      type-is: 2.1.0
     transitivePeerDependencies:
       - supports-color
 
@@ -10954,6 +11113,11 @@ snapshots:
   cookie@1.1.1: {}
 
   core-util-is@1.0.3: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cosmiconfig-typescript-loader@6.3.0(@types/node@22.19.20)(cosmiconfig@9.0.2(typescript@6.0.3))(typescript@6.0.3):
     dependencies:
@@ -11396,6 +11560,10 @@ snapshots:
 
   eventsource-parser@3.1.0: {}
 
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
+
   execa@5.1.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -11411,6 +11579,11 @@ snapshots:
   exit-hook@2.2.1: {}
 
   expect-type@1.3.0: {}
+
+  express-rate-limit@8.5.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
 
   express@4.22.2:
     dependencies:
@@ -11444,6 +11617,39 @@ snapshots:
       statuses: 2.0.2
       type-is: 1.6.18
       utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.2
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
@@ -11537,6 +11743,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-my-way@9.6.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -11571,6 +11788,8 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
 
   fresh@0.5.2: {}
+
+  fresh@2.0.0: {}
 
   fs-constants@1.0.0: {}
 
@@ -11958,6 +12177,8 @@ snapshots:
 
   helmet@8.2.0: {}
 
+  hono@4.12.26: {}
+
   hosted-git-info@6.1.3:
     dependencies:
       lru-cache: 7.18.3
@@ -12121,6 +12342,8 @@ snapshots:
 
   is-potential-custom-element-name@1.0.1: {}
 
+  is-promise@4.0.0: {}
+
   is-reference@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
@@ -12197,6 +12420,8 @@ snapshots:
 
   jiti@2.7.0: {}
 
+  jose@6.2.3: {}
+
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
@@ -12250,6 +12475,8 @@ snapshots:
       - supports-color
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-schema@0.4.0: {}
 
@@ -12762,9 +12989,13 @@ snapshots:
 
   media-typer@0.3.0: {}
 
+  media-typer@1.1.0: {}
+
   meow@13.2.0: {}
 
   merge-descriptors@1.0.3: {}
+
+  merge-descriptors@2.0.0: {}
 
   merge-stream@2.0.0: {}
 
@@ -13369,6 +13600,8 @@ snapshots:
 
   negotiator@0.6.4: {}
 
+  negotiator@1.0.0: {}
+
   neo-async@2.6.2: {}
 
   netmask@2.1.1: {}
@@ -13469,6 +13702,8 @@ snapshots:
       citty: 0.2.2
       pathe: 2.0.3
       tinyexec: 1.2.4
+
+  object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
 
@@ -13644,6 +13879,8 @@ snapshots:
 
   path-to-regexp@3.3.0: {}
 
+  path-to-regexp@8.4.2: {}
+
   pathe@1.1.2: {}
 
   pathe@2.0.3: {}
@@ -13734,6 +13971,8 @@ snapshots:
       safe-stable-stringify: 2.5.0
       sonic-boom: 4.2.1
       thread-stream: 4.2.0
+
+  pkce-challenge@5.0.1: {}
 
   pkg-types@1.3.1:
     dependencies:
@@ -13990,6 +14229,13 @@ snapshots:
       bytes: 3.1.2
       http-errors: 2.0.1
       iconv-lite: 0.4.24
+      unpipe: 1.0.0
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
       unpipe: 1.0.0
 
   rc9@2.1.2:
@@ -14365,6 +14611,16 @@ snapshots:
 
   rope-sequence@1.3.4: {}
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   run-applescript@7.1.0: {}
 
   sade@1.8.1:
@@ -14427,6 +14683,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   serialize-error@13.0.1:
     dependencies:
       non-error: 0.1.0
@@ -14448,6 +14720,15 @@ snapshots:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.19.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
     transitivePeerDependencies:
       - supports-color
 
@@ -14852,6 +15133,12 @@ snapshots:
     dependencies:
       media-typer: 0.3.0
       mime-types: 2.1.35
+
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
 
   typedarray@0.0.6: {}
 
@@ -15378,6 +15665,10 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yoctocolors@2.1.2: {}
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
 
   zod@4.4.3: {}
 

--- a/scripts/admin-user.sh
+++ b/scripts/admin-user.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Dev-only helper for admin user management.
+# NOT included in production images — for local troubleshooting only.
+#
+# Reads DATABASE_URL, POSTGRES_PASSWORD, COMPOSE_PROFILES, and ADMIN_PASSWORD
+# from .env / .env.local at the repo root. CLI env vars take precedence.
+#
+# URI resolution rules:
+#   1. DATABASE_URL set and hostname is not 'postgres' (Docker-internal) → use as-is
+#   2. DATABASE_URL set but hostname is 'postgres' → replace host with localhost:5432
+#   3. DATABASE_URL absent / hostname is 'postgres' + COMPOSE_PROFILES=bundled
+#      + POSTGRES_PASSWORD → build postgresql://tulipfarm:<pw>@localhost:5432/tulipfarm
+#   4. Otherwise → error
+#
+# Usage:
+#   ./scripts/admin-user.sh get-email
+#   ./scripts/admin-user.sh set-password        # uses ADMIN_PASSWORD from .env
+#   ./scripts/admin-user.sh set-password <pw>   # uses the given password
+set -euo pipefail
+
+COMMAND="${1:-}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$SCRIPT_DIR/.."
+ARGON2_MODULE="$ROOT/apps/api/node_modules/@node-rs/argon2"
+
+# Source .env then .env.local (local overrides base), skipping comments and blank lines.
+# Existing env vars (set before the script runs) are NOT overwritten.
+load_env() {
+  local file="$1"
+  [[ -f "$file" ]] || return 0
+  while IFS= read -r line; do
+    # Skip comments and blank lines
+    [[ "$line" =~ ^\s*# ]] && continue
+    [[ -z "${line// }" ]] && continue
+    # Only export if not already set in the environment
+    local key="${line%%=*}"
+    if [[ -z "${!key+x}" ]]; then
+      export "$line" 2>/dev/null || true
+    fi
+  done < "$file"
+}
+load_env "$ROOT/.env"
+load_env "$ROOT/.env.local"
+
+# Resolve the database URL from the available env vars.
+resolve_db_url() {
+  local url="${DATABASE_URL:-}"
+  local pw="${POSTGRES_PASSWORD:-}"
+  local profiles="${COMPOSE_PROFILES:-}"
+
+  # Substitute CHANGE_ME_POSTGRES placeholder if the real password is known.
+  if [[ "$url" == *"CHANGE_ME_POSTGRES"* && -n "$pw" ]]; then
+    url="${url//CHANGE_ME_POSTGRES/$pw}"
+  fi
+
+  # Docker-internal hostname 'postgres' is not reachable from the host — rewrite to localhost.
+  if [[ "$url" == *"@postgres:"* ]]; then
+    url="${url/@postgres:/@localhost:}"
+  fi
+
+  # If still no usable URL but we have enough pieces to build one, do it.
+  if [[ -z "$url" ]] || [[ "$url" == *"CHANGE_ME"* ]]; then
+    if [[ "$profiles" == *"bundled"* && -n "$pw" ]]; then
+      url="postgresql://tulipfarm:${pw}@localhost:5432/tulipfarm"
+    else
+      echo "Error: cannot resolve DATABASE_URL." >&2
+      echo "  Set DATABASE_URL directly, or ensure POSTGRES_PASSWORD + COMPOSE_PROFILES=bundled are in .env." >&2
+      exit 1
+    fi
+  fi
+
+  echo "$url"
+}
+
+DB_URL="$(resolve_db_url)"
+
+case "$COMMAND" in
+  get-email)
+    psql "$DB_URL" --tuples-only --no-align \
+      -c "SELECT email FROM users WHERE role = 'admin' ORDER BY created_at ASC LIMIT 1"
+    ;;
+
+  set-password)
+    PASSWORD="${2:-${ADMIN_PASSWORD:-}}"
+    if [[ -z "$PASSWORD" ]]; then
+      echo "Error: no password given and ADMIN_PASSWORD is not set in .env" >&2
+      echo "Usage: $0 set-password <pw>" >&2
+      exit 1
+    fi
+    # Hash with argon2id — same @node-rs/argon2 the API uses at runtime.
+    HASH=$(node --input-type=module <<EOF
+import { hash } from "$ARGON2_MODULE/index.js";
+process.stdout.write(await hash(${PASSWORD@Q}));
+EOF
+)
+    # argon2id hashes contain only [A-Za-z0-9$,./+=] — no single quotes — so
+    # direct interpolation into a SQL string literal is safe.
+    psql "$DB_URL" -c "UPDATE users SET password_hash = '$HASH' WHERE role = 'admin'"
+    ;;
+
+  *)
+    echo "Commands:"
+    echo "  get-email              Print the admin email address"
+    echo "  set-password [pw]      Set the admin password (reads ADMIN_PASSWORD from .env if pw omitted)"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary

- Introduces manifest v2 format for integrations — `manifest.yml` replaces the old flat `config.yaml`/`connection.yaml` split
- Adds typed egress/ingress config (`EgressConfig`, `IngressConfig`) and OAuth flow support to `@tulipfarm/soul`
- Switches `SoulIntegration` to slug-keyed instances (`slug` + `sourceIntegration` + `manifest`) supporting multi-instance deployments
- Wires `McpClientService` into the app for dynamic tool registration on connect/disconnect
- Adds integration routes (`/soul/integrations/*`) and web UI (index, detail, marketplace tabs)
- Merges additive changes from main: knowledge-aware onboarding routes, new env var docs, reorganised guides sidebar

## Test plan

- [ ] `pnpm lint && pnpm typecheck && pnpm test` passes
- [ ] Integration catalogue entries show correct slug + description from `manifest.yml`
- [ ] MCP integration connect/disconnect registers/unregisters tools in the chat tool registry
- [ ] Web UI: integrations index, detail, and marketplace tabs render without errors

## Updates (2026-07-07)
- **Merged latest `main` back in** (no conflicts): soul.yaml#llm consolidation (#124), business-context prompt injection (#131), a2ui binding fixes (#134), git-sync robustness (#121), login prefill removal (#126).
- **test(api)**: raised vitest timeouts for PGlite suites (same change as feat/routines) — the full suite flaked on the 5s default under one-worker-per-core load.
- Note: this branch is the base of the stack under #135 (`feat/routines`); the marketplace `#branch` scan support and the manifest-v2 web detail fix land there.
