### PR TITLE
fix(ci): move env out of with block in scheduled workflows

### DIFF
--- a/.github/workflows/absolute-audit.yml
+++ b/.github/workflows/absolute-audit.yml
@@ -26,8 +26,6 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: '--allowedTools "Bash,Edit,Write,Read,Glob,Grep"'
-          env:
-            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             Perform a security audit of this repository using the absolute-audit skill.
 

--- a/.github/workflows/absolute-debt.yml
+++ b/.github/workflows/absolute-debt.yml
@@ -35,8 +35,6 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: '--allowedTools "Bash,Edit,Write,Read,Glob,Grep"'
-          env:
-            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             Pay down lint and type debt in this repository using the absolute-debt skill.
 

--- a/.github/workflows/absolute-prune.yml
+++ b/.github/workflows/absolute-prune.yml
@@ -26,8 +26,6 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: '--allowedTools "Bash,Edit,Write,Read,Glob,Grep"'
-          env:
-            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             Remove dead code from this repository using the absolute-prune skill.
 

--- a/.github/workflows/absolute-simplify-cron.yml
+++ b/.github/workflows/absolute-simplify-cron.yml
@@ -37,8 +37,6 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: '--allowedTools "Bash,Edit,Write,Read,Glob,Grep"'
-          env:
-            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             Simplify the code in the directory ${{ steps.target.outputs.dir }} using the
             absolute-simplify skill.

--- a/.github/workflows/absolute-upgrade.yml
+++ b/.github/workflows/absolute-upgrade.yml
@@ -26,8 +26,6 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: '--allowedTools "Bash,Edit,Write,Read,Glob,Grep"'
-          env:
-            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             Upgrade exactly ONE dependency in this repository using the absolute-upgrade skill.
 

--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -26,8 +26,6 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: '--allowedTools "Bash,Edit,Write,Read,Glob,Grep,mcp__github__create_pull_request,mcp__github__list_pull_requests"'
-          env:
-            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           show_full_output: true
           prompt: |
             Improve all documentation in this repository using the absolute-documentations skill.


### PR DESCRIPTION
## Summary

- All 6 scheduled Claude Code workflows (`absolute-audit`, `absolute-debt`, `absolute-prune`, `absolute-simplify-cron`, `absolute-upgrade`, `docs-update`) were silently failing with `jobs: []` — no jobs ever ran
- Root cause: `env` block was nested inside `with`, making it an action input (a YAML mapping object). GitHub Actions rejects this at workflow validation time, before any job starts
- Fix: remove the misplaced `env` block entirely — `GH_TOKEN` is redundant since `github_token` is passed as an action input and the `gh` CLI picks it up automatically inside the action's environment

## Test plan

- [ ] Trigger one of the fixed workflows via `workflow_dispatch` and confirm jobs actually start
- [ ] Verify scheduled runs at 2:00 AM IST produce PRs as expected