### PR TITLE
chore(deps): upgrade vercel ai sdk to v7

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -22,7 +22,7 @@
     "@tulipfarm/secrets": "workspace:*",
     "@tulipfarm/soul": "workspace:*",
     "@tulipfarm/validation": "workspace:*",
-    "ai": "^6.0.209",
+    "ai": "^7.0.2",
     "dotenv": "^17.4.2",
     "fastify": "^5.8.5",
     "isolated-vm": "^7.0.0",
@@ -31,7 +31,7 @@
     "yaml": "^2.9.0"
   },
   "devDependencies": {
-    "@ai-sdk/provider": "^3.0.10",
+    "@ai-sdk/provider": "^4.0.0",
     "@electric-sql/pglite": "^0.5.3",
     "@electric-sql/pglite-pgvector": "^0.0.4",
     "@tulipfarm/tsconfig": "workspace:*",

--- a/apps/api/src/chat/turn.ts
+++ b/apps/api/src/chat/turn.ts
@@ -440,6 +440,9 @@ export async function runChatTurn(req: FastifyRequest, reply: FastifyReply, ctx:
       const result = streamText({
         model: selected,
         messages: turnMessages,
+        // AI SDK v7 rejects `role: "system"` entries in `messages` by default; the per-turn prompt
+        // is assembled as a leading system message (and re-seeded on handoff), so opt back in.
+        allowSystemInMessages: true,
         tools: turnTools,
         // The stop endpoint aborts this signal to halt generation mid-turn (see streamControllers).
         abortSignal: abortController.signal,

--- a/apps/api/src/tools/registry.test.ts
+++ b/apps/api/src/tools/registry.test.ts
@@ -70,7 +70,7 @@ describe("ToolRegistry", () => {
       const reg = new ToolRegistry();
       reg.register(makeTool({ name: "ctx_check", execute }));
       const ts = reg.buildToolSet(ctx);
-      await ts.ctx_check.execute?.({}, { messages: [], toolCallId: "tc1" });
+      await ts.ctx_check.execute?.({}, { messages: [], context: undefined, toolCallId: "tc1" });
       expect(execute).toHaveBeenCalledWith({}, ctx);
     });
 
@@ -134,8 +134,8 @@ describe("ToolRegistry", () => {
 
       // Simulate SDK: all execute() calls made synchronously before any await
       await Promise.all([
-        ts.read_a.execute?.({}, { messages: [], toolCallId: "tc1" }),
-        ts.read_b.execute?.({}, { messages: [], toolCallId: "tc2" }),
+        ts.read_a.execute?.({}, { messages: [], context: undefined, toolCallId: "tc1" }),
+        ts.read_b.execute?.({}, { messages: [], context: undefined, toolCallId: "tc2" }),
       ]);
 
       expect(log[0]).toBe("a:start");
@@ -176,8 +176,8 @@ describe("ToolRegistry", () => {
       const ts = reg.buildToolSet(ctx, coordinator);
 
       await Promise.all([
-        ts.write_x.execute?.({}, { messages: [], toolCallId: "tc1" }),
-        ts.read_y.execute?.({}, { messages: [], toolCallId: "tc2" }),
+        ts.write_x.execute?.({}, { messages: [], context: undefined, toolCallId: "tc1" }),
+        ts.read_y.execute?.({}, { messages: [], context: undefined, toolCallId: "tc2" }),
       ]);
 
       expect(log).toEqual(["x:start", "x:end", "y:start", "y:end"]);
@@ -201,7 +201,10 @@ describe("ToolRegistry", () => {
       const reg = new ToolRegistry();
       reg.register(schemaedTool({ name: "vt", execute }));
       const ts = reg.buildToolSet(ctx);
-      const result = await ts.vt.execute?.({}, { messages: [], toolCallId: "tc1" });
+      const result = await ts.vt.execute?.(
+        {},
+        { messages: [], context: undefined, toolCallId: "tc1" }
+      );
       expect(result).toMatchObject({ success: false, error: { code: "validation_error" } });
       expect(execute).not.toHaveBeenCalled();
     });
@@ -211,7 +214,10 @@ describe("ToolRegistry", () => {
       const reg = new ToolRegistry();
       reg.register(schemaedTool({ name: "vt2", execute }));
       const ts = reg.buildToolSet(ctx);
-      const result = await ts.vt2.execute?.({ key: "hello" }, { messages: [], toolCallId: "tc2" });
+      const result = await ts.vt2.execute?.(
+        { key: "hello" },
+        { messages: [], context: undefined, toolCallId: "tc2" }
+      );
       expect(result).toEqual({ success: true, data: "reached" });
       expect(execute).toHaveBeenCalledWith({ key: "hello" }, ctx);
     });
@@ -222,7 +228,10 @@ describe("ToolRegistry", () => {
       reg.register(schemaedTool({ name: "vt3", execute }));
       const coordinator = new BatchCoordinator();
       const ts = reg.buildToolSet(ctx, coordinator);
-      const result = await ts.vt3.execute?.({ wrong: 123 }, { messages: [], toolCallId: "tc3" });
+      const result = await ts.vt3.execute?.(
+        { wrong: 123 },
+        { messages: [], context: undefined, toolCallId: "tc3" }
+      );
       expect(result).toMatchObject({ success: false, error: { code: "validation_error" } });
       expect(execute).not.toHaveBeenCalled();
     });
@@ -236,7 +245,10 @@ describe("ToolRegistry", () => {
       reg.register(makeTool({ execute: async () => ({ success: true as const, data: bigList }) }));
       const cache = new Map<string, import("./types").ToolCallResult>();
       const ts = reg.buildToolSet(ctx, undefined, cache);
-      const result = await ts.test_tool.execute?.({}, { messages: [], toolCallId: "tc-full" });
+      const result = await ts.test_tool.execute?.(
+        {},
+        { messages: [], context: undefined, toolCallId: "tc-full" }
+      );
       expect((result as { success: true; data: { total_count: number } }).data.total_count).toBe(
         25
       );
@@ -247,7 +259,10 @@ describe("ToolRegistry", () => {
       const reg = new ToolRegistry();
       reg.register(makeTool({ execute: async () => ({ success: true as const, data: [1, 2] }) }));
       const ts = reg.buildToolSet(ctx);
-      const result = await ts.test_tool.execute?.({}, { messages: [], toolCallId: "tc-small" });
+      const result = await ts.test_tool.execute?.(
+        {},
+        { messages: [], context: undefined, toolCallId: "tc-small" }
+      );
       expect(result).toEqual({ success: true, data: [1, 2] });
     });
 
@@ -266,7 +281,7 @@ describe("ToolRegistry", () => {
       );
       const cache = new Map<string, import("./types").ToolCallResult>();
       const ts = reg.buildToolSet(ctx, undefined, cache);
-      await ts.strict.execute?.({}, { messages: [], toolCallId: "tc-inv" });
+      await ts.strict.execute?.({}, { messages: [], context: undefined, toolCallId: "tc-inv" });
       expect(cache.has("tc-inv")).toBe(false);
     });
   });
@@ -276,7 +291,10 @@ describe("ToolRegistry", () => {
       const reg = new ToolRegistry();
       reg.register(makeTool({ execute: async () => ({ success: true, data: "fast" }) }));
       const ts = reg.buildToolSet(ctx);
-      const result = await ts.test_tool.execute?.({}, { messages: [], toolCallId: "tc" });
+      const result = await ts.test_tool.execute?.(
+        {},
+        { messages: [], context: undefined, toolCallId: "tc" }
+      );
       expect(result).toEqual({ success: true, data: "fast" });
     });
 
@@ -289,7 +307,10 @@ describe("ToolRegistry", () => {
         })
       );
       const ts = reg.buildToolSet(ctx);
-      const resultPromise = ts.test_tool.execute?.({}, { messages: [], toolCallId: "tc" });
+      const resultPromise = ts.test_tool.execute?.(
+        {},
+        { messages: [], context: undefined, toolCallId: "tc" }
+      );
       vi.advanceTimersByTime(TOOL_TIMEOUT_MS);
       const result = await resultPromise;
       expect(result).toEqual({
@@ -328,7 +349,7 @@ describe("ToolRegistry", () => {
       const { gate, calls, resolve } = controllableGate();
       const ts = reg.buildToolSet(approvalCtx, undefined, undefined, gate);
 
-      const p = ts.write_x.execute?.({}, { messages: [], toolCallId: "tc1" });
+      const p = ts.write_x.execute?.({}, { messages: [], context: undefined, toolCallId: "tc1" });
       await Promise.resolve();
       expect(calls).toHaveLength(1);
       expect(calls[0]).toMatchObject({ toolCallId: "tc1", toolName: "write_x" });
@@ -347,7 +368,7 @@ describe("ToolRegistry", () => {
       const cache = new Map<string, import("./types").ToolCallResult>();
       const ts = reg.buildToolSet(approvalCtx, undefined, cache, gate);
 
-      const p = ts.write_x.execute?.({}, { messages: [], toolCallId: "tc1" });
+      const p = ts.write_x.execute?.({}, { messages: [], context: undefined, toolCallId: "tc1" });
       resolve({ outcome: "denied", reason: "denied by operator" });
       const result = await p;
 
@@ -366,7 +387,9 @@ describe("ToolRegistry", () => {
       const { gate, calls } = controllableGate();
       const ts = reg.buildToolSet(approvalCtx, undefined, undefined, gate);
 
-      expect(await ts.read_x.execute?.({}, { messages: [], toolCallId: "tc1" })).toEqual({
+      expect(
+        await ts.read_x.execute?.({}, { messages: [], context: undefined, toolCallId: "tc1" })
+      ).toEqual({
         success: true,
         data: "read",
       });
@@ -380,7 +403,7 @@ describe("ToolRegistry", () => {
       const { gate, calls } = controllableGate();
       const ts = reg.buildToolSet({ ...ctx, autonomy: "full" }, undefined, undefined, gate);
 
-      await ts.write_x.execute?.({}, { messages: [], toolCallId: "tc1" });
+      await ts.write_x.execute?.({}, { messages: [], context: undefined, toolCallId: "tc1" });
       expect(calls).toHaveLength(0);
       expect(execute).toHaveBeenCalledTimes(1);
     });
@@ -389,7 +412,9 @@ describe("ToolRegistry", () => {
       const reg = new ToolRegistry();
       reg.register(makeTool({ name: "write_x", mutating: true }));
       const ts = reg.buildToolSet(approvalCtx);
-      expect(await ts.write_x.execute?.({}, { messages: [], toolCallId: "tc1" })).toEqual({
+      expect(
+        await ts.write_x.execute?.({}, { messages: [], context: undefined, toolCallId: "tc1" })
+      ).toEqual({
         success: true,
         data: "ok",
       });
@@ -404,7 +429,12 @@ describe("ToolRegistry", () => {
       const { gate, calls } = controllableGate();
       const ts = reg.buildToolSet(approvalCtx, undefined, undefined, gate);
 
-      expect(await ts.agent_create.execute?.({}, { messages: [], toolCallId: "tc-soul" })).toEqual({
+      expect(
+        await ts.agent_create.execute?.(
+          {},
+          { messages: [], context: undefined, toolCallId: "tc-soul" }
+        )
+      ).toEqual({
         success: true,
         data: "soul-ran",
       });
@@ -421,7 +451,7 @@ describe("ToolRegistry", () => {
         const { gate, resolve } = controllableGate();
         const ts = reg.buildToolSet(approvalCtx, new BatchCoordinator(), undefined, gate);
 
-        const p = ts.write_x.execute?.({}, { messages: [], toolCallId: "tc1" });
+        const p = ts.write_x.execute?.({}, { messages: [], context: undefined, toolCallId: "tc1" });
         await vi.advanceTimersByTimeAsync(TOOL_TIMEOUT_MS * 3);
         expect(execute).not.toHaveBeenCalled(); // still pending, not timed out
 
@@ -442,7 +472,10 @@ describe("ToolRegistry", () => {
       const cache = new Map<string, import("./types").ToolCallResult>();
       const ts = reg.buildToolSet(ctx, undefined, cache, undefined, guard);
 
-      const result = await ts.guarded.execute?.({}, { messages: [], toolCallId: "tc1" });
+      const result = await ts.guarded.execute?.(
+        {},
+        { messages: [], context: undefined, toolCallId: "tc1" }
+      );
 
       expect(result).toMatchObject({
         success: false,
@@ -473,7 +506,10 @@ describe("ToolRegistry", () => {
       const guard = vi.fn<RunToolCallGuard>(async () => ({ blocked: false, args: { key: "a" } }));
       const ts = reg.buildToolSet(ctx, undefined, undefined, undefined, guard);
 
-      await ts.inspected.execute?.({ key: "a" }, { messages: [], toolCallId: "tc-i" });
+      await ts.inspected.execute?.(
+        { key: "a" },
+        { messages: [], context: undefined, toolCallId: "tc-i" }
+      );
 
       expect(guard).toHaveBeenCalledWith({
         tool: expect.objectContaining({ name: "inspected" }),
@@ -497,6 +533,7 @@ describe("ToolRegistry", () => {
         { key: "original" },
         {
           messages: [],
+          context: undefined,
           toolCallId: "tc2",
         }
       );
@@ -514,7 +551,7 @@ describe("ToolRegistry", () => {
 
       const result = await ts.unguarded.execute?.(
         { key: "v" },
-        { messages: [], toolCallId: "tc3" }
+        { messages: [], context: undefined, toolCallId: "tc3" }
       );
 
       expect(result).toEqual({ success: true, data: "direct" });
@@ -537,7 +574,10 @@ describe("ToolRegistry", () => {
       );
       const ts = reg.buildToolSet(ctx, undefined, undefined, undefined, guard);
 
-      const result = await ts.strict_guarded.execute?.({}, { messages: [], toolCallId: "tc4" });
+      const result = await ts.strict_guarded.execute?.(
+        {},
+        { messages: [], context: undefined, toolCallId: "tc4" }
+      );
 
       expect(result).toMatchObject({ success: false, error: { code: "validation_error" } });
       expect(guard).not.toHaveBeenCalled();
@@ -550,7 +590,10 @@ describe("ToolRegistry", () => {
       const guard = vi.fn<RunToolCallGuard>(async () => ({ blocked: true, reason: "blocklist" }));
       const ts = reg.buildToolSet(ctx, new BatchCoordinator(), undefined, undefined, guard);
 
-      const result = await ts.coord_guarded.execute?.({}, { messages: [], toolCallId: "tc5" });
+      const result = await ts.coord_guarded.execute?.(
+        {},
+        { messages: [], context: undefined, toolCallId: "tc5" }
+      );
 
       expect(result).toMatchObject({
         success: false,

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -9,15 +9,15 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "^3.0.86",
-    "@ai-sdk/azure": "^3.0.77",
-    "@ai-sdk/openai": "^3.0.74",
-    "@ai-sdk/openai-compatible": "^2.0.51",
-    "@ai-sdk/provider": "^3.0.10",
+    "@ai-sdk/anthropic": "^4.0.0",
+    "@ai-sdk/azure": "^4.0.0",
+    "@ai-sdk/openai": "^4.0.0",
+    "@ai-sdk/openai-compatible": "^3.0.0",
+    "@ai-sdk/provider": "^4.0.0",
     "@sinclair/typebox": "^0.34.49",
     "@tulipfarm/secrets": "workspace:*",
     "@tulipfarm/validation": "workspace:*",
-    "ai": "^6.0.209"
+    "ai": "^7.0.2"
   },
   "devDependencies": {
     "@tulipfarm/tsconfig": "workspace:*",

--- a/packages/llm/src/fallback.test.ts
+++ b/packages/llm/src/fallback.test.ts
@@ -1,9 +1,9 @@
-import type { LanguageModelV3, LanguageModelV3CallOptions } from "@ai-sdk/provider";
+import type { LanguageModelV4, LanguageModelV4CallOptions } from "@ai-sdk/provider";
 import { APICallError, LoadAPIKeyError } from "ai";
 import { describe, expect, it, vi } from "vitest";
 import { FallbackModel, isHardFailure } from "./fallback";
 
-const opts = {} as LanguageModelV3CallOptions;
+const opts = {} as LanguageModelV4CallOptions;
 
 function apiError(statusCode: number, isRetryable: boolean): APICallError {
   return new APICallError({
@@ -16,17 +16,17 @@ function apiError(statusCode: number, isRetryable: boolean): APICallError {
 }
 
 function makeModel(
-  overrides: Partial<Pick<LanguageModelV3, "doGenerate" | "doStream">> = {}
-): LanguageModelV3 {
+  overrides: Partial<Pick<LanguageModelV4, "doGenerate" | "doStream">> = {}
+): LanguageModelV4 {
   return {
-    specificationVersion: "v3",
+    specificationVersion: "v4",
     provider: "test",
     modelId: "test-model",
     supportedUrls: {},
     doGenerate: vi.fn().mockRejectedValue(new Error("not implemented")),
     doStream: vi.fn().mockRejectedValue(new Error("not implemented")),
     ...overrides,
-  } as unknown as LanguageModelV3;
+  } as unknown as LanguageModelV4;
 }
 
 function makeStreamResult(chunks: unknown[], failAfterChunks?: number) {

--- a/packages/llm/src/fallback.ts
+++ b/packages/llm/src/fallback.ts
@@ -1,7 +1,7 @@
 import type {
-  LanguageModelV3,
-  LanguageModelV3CallOptions,
-  LanguageModelV3StreamPart,
+  LanguageModelV4,
+  LanguageModelV4CallOptions,
+  LanguageModelV4StreamPart,
 } from "@ai-sdk/provider";
 import { APICallError, LoadAPIKeyError } from "ai";
 
@@ -36,14 +36,14 @@ function errorReason(err: unknown): string {
   return String(err);
 }
 
-export class FallbackModel implements LanguageModelV3 {
-  readonly specificationVersion = "v3" as const;
+export class FallbackModel implements LanguageModelV4 {
+  readonly specificationVersion = "v4" as const;
   readonly provider = "fallback";
   readonly modelId: string;
   readonly supportedUrls: Record<string, RegExp[]> = {};
 
   constructor(
-    private readonly models: LanguageModelV3[],
+    private readonly models: LanguageModelV4[],
     private readonly logger: FallbackLogger = noopLogger
   ) {
     const primary = models[0];
@@ -51,7 +51,7 @@ export class FallbackModel implements LanguageModelV3 {
     this.modelId = models.map((m) => m.modelId).join("|");
   }
 
-  async doGenerate(options: LanguageModelV3CallOptions) {
+  async doGenerate(options: LanguageModelV4CallOptions) {
     let lastError: unknown;
     for (const model of this.models) {
       try {
@@ -66,10 +66,10 @@ export class FallbackModel implements LanguageModelV3 {
     throw lastError;
   }
 
-  async doStream(options: LanguageModelV3CallOptions) {
+  async doStream(options: LanguageModelV4CallOptions) {
     let lastError: unknown;
     for (const model of this.models) {
-      let result: Awaited<ReturnType<LanguageModelV3["doStream"]>>;
+      let result: Awaited<ReturnType<LanguageModelV4["doStream"]>>;
       try {
         result = await model.doStream(options);
       } catch (err) {
@@ -92,7 +92,7 @@ export class FallbackModel implements LanguageModelV3 {
       }
 
       // First chunk received — stream is committed, reconstruct with remaining
-      const stream = new ReadableStream<LanguageModelV3StreamPart>({
+      const stream = new ReadableStream<LanguageModelV4StreamPart>({
         async start(controller) {
           if (!firstChunk.done) controller.enqueue(firstChunk.value);
           try {
@@ -117,7 +117,7 @@ export class FallbackModel implements LanguageModelV3 {
     throw lastError;
   }
 
-  private logFallback(model: LanguageModelV3, err: unknown): void {
+  private logFallback(model: LanguageModelV4, err: unknown): void {
     this.logger.warn(
       `[llm] fallback provider=${model.provider} model=${model.modelId} reason=${errorReason(err)}`
     );

--- a/packages/llm/src/llm-service.test.ts
+++ b/packages/llm/src/llm-service.test.ts
@@ -1,4 +1,4 @@
-import type { LanguageModelV3, LanguageModelV3CallOptions } from "@ai-sdk/provider";
+import type { LanguageModelV4, LanguageModelV4CallOptions } from "@ai-sdk/provider";
 import { APICallError } from "ai";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -13,13 +13,13 @@ import { createModel } from "./provider";
 vi.mock("./provider", () => ({
   createModel: vi.fn((entry: { provider: string; model: string }) =>
     Promise.resolve({
-      specificationVersion: "v3",
+      specificationVersion: "v4",
       provider: entry.provider,
       modelId: entry.model,
       supportedUrls: {},
       doGenerate: vi.fn(),
       doStream: vi.fn(),
-    } as unknown as LanguageModelV3)
+    } as unknown as LanguageModelV4)
   ),
 }));
 
@@ -79,13 +79,13 @@ describe("LlmService", () => {
   it("LlmCredentialError on a provider skips it and keeps the tier if another provider succeeds", async () => {
     const okModel = (entry: { provider: string; model: string }) =>
       Promise.resolve({
-        specificationVersion: "v3",
+        specificationVersion: "v4",
         provider: entry.provider,
         modelId: entry.model,
         supportedUrls: {},
         doGenerate: vi.fn(),
         doStream: vi.fn(),
-      } as unknown as LanguageModelV3);
+      } as unknown as LanguageModelV4);
 
     // quick has 2 providers (1 rejected, 1 ok) + standard (ok) + complex (ok) = 4 calls total
     vi.mocked(createModel)
@@ -115,13 +115,13 @@ describe("LlmService", () => {
   it("LlmCredentialError on all providers of a tier skips the tier without throwing", async () => {
     const okModel = (entry: { provider: string; model: string }) =>
       Promise.resolve({
-        specificationVersion: "v3",
+        specificationVersion: "v4",
         provider: entry.provider,
         modelId: entry.model,
         supportedUrls: {},
         doGenerate: vi.fn(),
         doStream: vi.fn(),
-      } as unknown as LanguageModelV3);
+      } as unknown as LanguageModelV4);
 
     // quick has 1 provider (rejected) + standard (ok) + complex (ok) = 3 calls total
     vi.mocked(createModel)
@@ -178,13 +178,13 @@ describe("LlmService", () => {
     });
     const rejecting = (entry: { provider: string; model: string }) =>
       Promise.resolve({
-        specificationVersion: "v3",
+        specificationVersion: "v4",
         provider: entry.provider,
         modelId: entry.model,
         supportedUrls: {},
         doGenerate: vi.fn().mockRejectedValue(transient),
         doStream: vi.fn(),
-      } as unknown as LanguageModelV3);
+      } as unknown as LanguageModelV4);
     // Only the two quick-tier providers reject; standard/complex use the default mock.
     vi.mocked(createModel).mockImplementationOnce(rejecting).mockImplementationOnce(rejecting);
 
@@ -205,7 +205,7 @@ describe("LlmService", () => {
     const svc = new LlmService();
     await svc.init(twoProviderConfig, fakeSecrets, logger);
     await expect(
-      (svc.getModel("quick") as LanguageModelV3).doGenerate({} as LanguageModelV3CallOptions)
+      (svc.getModel("quick") as LanguageModelV4).doGenerate({} as LanguageModelV4CallOptions)
     ).rejects.toBe(transient);
     expect(logger.warn).toHaveBeenCalled();
   });
@@ -220,14 +220,14 @@ describe("LlmService.select", () => {
 
   it("model auto + supervised resolves to standard (AC-V1-001)", async () => {
     const svc = await init();
-    expect((svc.select({ model: "auto", autonomy: "supervised" }) as LanguageModelV3).modelId).toBe(
+    expect((svc.select({ model: "auto", autonomy: "supervised" }) as LanguageModelV4).modelId).toBe(
       "claude-sonnet-4-6"
     );
   });
 
   it("explicit tier overrides auto rules (AC3)", async () => {
     const svc = await init();
-    expect((svc.select({ model: "complex", autonomy: "full" }) as LanguageModelV3).modelId).toBe(
+    expect((svc.select({ model: "complex", autonomy: "full" }) as LanguageModelV4).modelId).toBe(
       "claude-opus-4-8"
     );
   });
@@ -235,13 +235,13 @@ describe("LlmService.select", () => {
   it("session model overrides configured tier for the turn (AC4)", async () => {
     const svc = await init();
     expect(
-      (svc.select({ model: "complex", sessionModel: "quick" }) as LanguageModelV3).modelId
+      (svc.select({ model: "complex", sessionModel: "quick" }) as LanguageModelV4).modelId
     ).toBe("claude-haiku-4-5");
   });
 
   it("raw model id bypasses tiers via getModelById", async () => {
     const svc = await init();
-    expect((svc.select({ model: "claude-opus-4-8" }) as LanguageModelV3).modelId).toBe(
+    expect((svc.select({ model: "claude-opus-4-8" }) as LanguageModelV4).modelId).toBe(
       "claude-opus-4-8"
     );
   });
@@ -253,7 +253,7 @@ describe("LlmService.select", () => {
 
   it("defaults to auto → standard when no model given", async () => {
     const svc = await init();
-    expect((svc.select({}) as LanguageModelV3).modelId).toBe("claude-sonnet-4-6");
+    expect((svc.select({}) as LanguageModelV4).modelId).toBe("claude-sonnet-4-6");
   });
 
   it("select before init throws LlmNotConfiguredError", () => {

--- a/packages/llm/src/provider.ts
+++ b/packages/llm/src/provider.ts
@@ -2,7 +2,7 @@ import { createAnthropic } from "@ai-sdk/anthropic";
 import { createAzure } from "@ai-sdk/azure";
 import { createOpenAI } from "@ai-sdk/openai";
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
-import type { LanguageModelV3 } from "@ai-sdk/provider";
+import type { LanguageModelV4 } from "@ai-sdk/provider";
 import {
   DecryptError,
   llmProviderById,
@@ -67,7 +67,7 @@ async function resolveStored(
 export async function createModel(
   entry: ProviderEntry,
   secrets: SecretsService
-): Promise<LanguageModelV3> {
+): Promise<LanguageModelV4> {
   const info = llmProviderById(entry.provider);
 
   // API key: an explicit api_key_ref (incl. env://VAR escape) wins; otherwise the provider's

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/validation
       ai:
-        specifier: ^6.0.209
-        version: 6.0.209(zod@4.4.3)
+        specifier: ^7.0.2
+        version: 7.0.2(zod@4.4.3)
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
@@ -97,8 +97,8 @@ importers:
         version: 2.9.0
     devDependencies:
       '@ai-sdk/provider':
-        specifier: ^3.0.10
-        version: 3.0.10
+        specifier: ^4.0.0
+        version: 4.0.0
       '@electric-sql/pglite':
         specifier: ^0.5.3
         version: 0.5.3
@@ -403,20 +403,20 @@ importers:
   packages/llm:
     dependencies:
       '@ai-sdk/anthropic':
-        specifier: ^3.0.86
-        version: 3.0.86(zod@4.4.3)
+        specifier: ^4.0.0
+        version: 4.0.0(zod@4.4.3)
       '@ai-sdk/azure':
-        specifier: ^3.0.77
-        version: 3.0.77(zod@4.4.3)
+        specifier: ^4.0.0
+        version: 4.0.0(zod@4.4.3)
       '@ai-sdk/openai':
-        specifier: ^3.0.74
-        version: 3.0.74(zod@4.4.3)
+        specifier: ^4.0.0
+        version: 4.0.0(zod@4.4.3)
       '@ai-sdk/openai-compatible':
-        specifier: ^2.0.51
-        version: 2.0.51(zod@4.4.3)
+        specifier: ^3.0.0
+        version: 3.0.0(zod@4.4.3)
       '@ai-sdk/provider':
-        specifier: ^3.0.10
-        version: 3.0.10
+        specifier: ^4.0.0
+        version: 4.0.0
       '@sinclair/typebox':
         specifier: ^0.34.49
         version: 0.34.49
@@ -427,8 +427,8 @@ importers:
         specifier: workspace:*
         version: link:../validation
       ai:
-        specifier: ^6.0.209
-        version: 6.0.209(zod@4.4.3)
+        specifier: ^7.0.2
+        version: 7.0.2(zod@4.4.3)
     devDependencies:
       '@tulipfarm/tsconfig':
         specifier: workspace:*
@@ -549,51 +549,51 @@ packages:
   '@adobe/css-tools@4.5.0':
     resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
 
-  '@ai-sdk/anthropic@3.0.86':
-    resolution: {integrity: sha512-IVUaTOz46dNniRaALEvphV5WOqPfKTJRZlJhJabz3kaXk1QiwdnzWQhKMKLiprD+872E9YHqmmyFNFFH1MfnBQ==}
-    engines: {node: '>=18'}
+  '@ai-sdk/anthropic@4.0.0':
+    resolution: {integrity: sha512-N0lT1g6/5DEIZvalpkpwYRCdu7n5qb8qPN3PcTem6k4VkPBLC2+T2LAAyx1GS0eNOxavVa0CP7n2kCiye0yyfw==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/azure@3.0.77':
-    resolution: {integrity: sha512-LsCkguEGxawm4hCQlqywjJ5KUVBpQU83Y88yYD/9oWCf8Yq00Up8U1nAQcGEE0M41GbEtT9PQSsCA5ySCicUAg==}
-    engines: {node: '>=18'}
+  '@ai-sdk/azure@4.0.0':
+    resolution: {integrity: sha512-r5hlyLbDPJwSWNirs3I75XL54IAkbnj81USdAnHK6nQnoFIJKu0fV/nh84GtzEavfz/hZ/u13SBW5OJ2JLaoyQ==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/deepseek@2.0.39':
-    resolution: {integrity: sha512-3wUq1cvqSWkRadCSqcDXBLpOwUAe+JqfWQZS0fK0sWiqDeTIEzsse+r7xcN2x5XpJjefT0d7FQTa3u2lZ/yxbg==}
-    engines: {node: '>=18'}
+  '@ai-sdk/deepseek@3.0.0':
+    resolution: {integrity: sha512-dR/+lmEF2AvEEiL3xphVswyGjoW2WDMaFV4yDoNY/0dvFk9MeRWceNdvNMezRNpDU6yBxqXhf8x350dCZ1Baxg==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/gateway@3.0.134':
-    resolution: {integrity: sha512-PfUkQp01EihEyNM6e+nexXmVANiY5KcHMui/MmaHsC4KVVQYh/MwPeOsD3bTPu63e581BKO+AwaPPNmD4x943A==}
-    engines: {node: '>=18'}
+  '@ai-sdk/gateway@4.0.2':
+    resolution: {integrity: sha512-Jz1BiiTSvhDsCBJrkFRSqLHDRMVjFtYk9GdbSi3UOqY+/epza+oIESMDzfN4m+YHT/1IYmNEmxaMfjXOvxKDjQ==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/openai-compatible@2.0.51':
-    resolution: {integrity: sha512-A6qfyaVs4lxmRxRux6U3ViOa8mMbsSd0OaHghpei2MpiBT6791J4zFH5MN7kaW1tLfQ246rSC2DVTMOavsycjQ==}
-    engines: {node: '>=18'}
+  '@ai-sdk/openai-compatible@3.0.0':
+    resolution: {integrity: sha512-2Ln97FfBrIKTlV/F1uTfUl+Pwk76LqrfnT5+6vu2LnSNwvLdDhTP5uMfryIrxCaYvY2MZeL4ciM1UVd52k7wTQ==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/openai@3.0.74':
-    resolution: {integrity: sha512-LPDBWd2WCv0GQs29K2pHcNrGx24hm4D8QEP386HwUAUPr1URho6bNVXHNmIv0FxaW+xDkLpNMTen+mFCUBp2LA==}
-    engines: {node: '>=18'}
+  '@ai-sdk/openai@4.0.0':
+    resolution: {integrity: sha512-XcI/bJEG+Ymx8ZwQMY9GE9waHdEcSzT6wn2o+YW80hOQPf8IAGQvdNWKaD0mxLi6AmOM0L01y/p626w7rImblQ==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@4.0.30':
-    resolution: {integrity: sha512-VO7I+vPffqI5sMnPoUq5DCSqKIgQIk/naJWRdQVpz2ma2zoprC/lqiJiUEl2s6DfvTD76TbhD3q39ROjlA6rGw==}
-    engines: {node: '>=18'}
+  '@ai-sdk/provider-utils@5.0.0':
+    resolution: {integrity: sha512-zj66M02jc6ASYwIgWZowsooDUwaVngeNZQ3H10GwcPMZ+KR6gHMhcUuKl6tkai+JPXTKDyHY1pnszuxRtw2D4A==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider@3.0.10':
-    resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
-    engines: {node: '>=18'}
+  '@ai-sdk/provider@4.0.0':
+    resolution: {integrity: sha512-fr9Gs89prDWiuox/T+kCA+i2cJkHpxU5S+tr4megjTzRC27ZsvFhwjU/+XrqqMbvBUlfmXxTOYWy8ng45dsjIg==}
+    engines: {node: '>=22'}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -3515,6 +3515,9 @@ packages:
   '@web3-storage/multipart-parser@1.0.0':
     resolution: {integrity: sha512-BEO6al7BYqcnfX15W2cnGR+Q566ACXAT9UQykORCWW80lmkpWsnEob6zJS1ZVBKsSJC8+7vJkHwlp+lXG1UCdw==}
 
+  '@workflow/serde@4.1.0':
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
+
   '@zeit/schemas@2.36.0':
     resolution: {integrity: sha512-7kjMwcChYEzMKjeex9ZFXkt1AyNov9R5HZtjBKVsmVpw7pa7ZtlCGvCBC2vnnXctaYN+aRI61HjIqeetZW5ROg==}
 
@@ -3550,9 +3553,9 @@ packages:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
 
-  ai@6.0.209:
-    resolution: {integrity: sha512-NE7uErmxOe+i77BPT1+AhW4wr7xzilbQLsKVmvGEyil5AjaF6C/m92hlPI4Xwtnv5n77D/29bizwcR27/S/gSQ==}
-    engines: {node: '>=18'}
+  ai@7.0.2:
+    resolution: {integrity: sha512-VMU08jHIDJnnKDrbC9AFa5ZsPpOTfAPRLvTRHtJk4FGAoeldmJROMxvZ2ak5lCjEJ2GP2OLPQbMRyEK8w0+S4A==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
@@ -4749,6 +4752,7 @@ packages:
   git-raw-commits@5.0.1:
     resolution: {integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==}
     engines: {node: '>=18'}
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-up@8.1.1:
@@ -7646,53 +7650,54 @@ snapshots:
 
   '@adobe/css-tools@4.5.0': {}
 
-  '@ai-sdk/anthropic@3.0.86(zod@4.4.3)':
+  '@ai-sdk/anthropic@4.0.0(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.30(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.0
+      '@ai-sdk/provider-utils': 5.0.0(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/azure@3.0.77(zod@4.4.3)':
+  '@ai-sdk/azure@4.0.0(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/deepseek': 2.0.39(zod@4.4.3)
-      '@ai-sdk/openai': 3.0.74(zod@4.4.3)
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.30(zod@4.4.3)
+      '@ai-sdk/deepseek': 3.0.0(zod@4.4.3)
+      '@ai-sdk/openai': 4.0.0(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.0
+      '@ai-sdk/provider-utils': 5.0.0(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/deepseek@2.0.39(zod@4.4.3)':
+  '@ai-sdk/deepseek@3.0.0(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.30(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.0
+      '@ai-sdk/provider-utils': 5.0.0(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/gateway@3.0.134(zod@4.4.3)':
+  '@ai-sdk/gateway@4.0.2(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.30(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.0
+      '@ai-sdk/provider-utils': 5.0.0(zod@4.4.3)
       '@vercel/oidc': 3.2.0
       zod: 4.4.3
 
-  '@ai-sdk/openai-compatible@2.0.51(zod@4.4.3)':
+  '@ai-sdk/openai-compatible@3.0.0(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.30(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.0
+      '@ai-sdk/provider-utils': 5.0.0(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/openai@3.0.74(zod@4.4.3)':
+  '@ai-sdk/openai@4.0.0(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.30(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.0
+      '@ai-sdk/provider-utils': 5.0.0(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/provider-utils@4.0.30(zod@4.4.3)':
+  '@ai-sdk/provider-utils@5.0.0(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider': 4.0.0
       '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
       eventsource-parser: 3.1.0
       zod: 4.4.3
 
-  '@ai-sdk/provider@3.0.10':
+  '@ai-sdk/provider@4.0.0':
     dependencies:
       json-schema: 0.4.0
 
@@ -9027,7 +9032,8 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
-  '@opentelemetry/api@1.9.1': {}
+  '@opentelemetry/api@1.9.1':
+    optional: true
 
   '@orama/orama@3.1.18': {}
 
@@ -10389,6 +10395,8 @@ snapshots:
 
   '@web3-storage/multipart-parser@1.0.0': {}
 
+  '@workflow/serde@4.1.0': {}
+
   '@zeit/schemas@2.36.0': {}
 
   '@zxing/text-encoding@0.9.0':
@@ -10418,12 +10426,11 @@ snapshots:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  ai@6.0.209(zod@4.4.3):
+  ai@7.0.2(zod@4.4.3):
     dependencies:
-      '@ai-sdk/gateway': 3.0.134(zod@4.4.3)
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.30(zod@4.4.3)
-      '@opentelemetry/api': 1.9.1
+      '@ai-sdk/gateway': 4.0.2(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.0
+      '@ai-sdk/provider-utils': 5.0.0(zod@4.4.3)
       zod: 4.4.3
 
   ajv-draft-04@1.0.0(ajv@8.20.0):


### PR DESCRIPTION
- ai ^6.0.209 -> ^7.0.2; @ai-sdk/* providers -> v4 (provider spec LanguageModelV4)
- FallbackModel + provider factory migrated to LanguageModelV4 / specificationVersion v4
- streamText: allowSystemInMessages keeps system-role entries in messages[] (v7 rejects them)
- tests: ToolExecutionOptions now requires context; v3 -> v4 test fakes
- pinned to newest versions passing the 24h minimumReleaseAge policy (7.0.3/4.0.1 held back)