### PR TITLE
feat(knowledge): chunk-hash dedup + reindex/backfill/index-status + c…

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -28,8 +28,11 @@ import { GuardrailsService } from "./guardrails";
 import { registerGuardrailsReload } from "./guardrails/reload";
 import { HookExecutor } from "./hooks/hook-executor";
 import { PgKnowledgeChunkRepo } from "./knowledge/chunks-repo";
+import { buildDefaultRegistry } from "./knowledge/connectors/registry";
+import { PgConnectorStateRepo } from "./knowledge/connectors/state-repo";
+import { registerConnectorSync } from "./knowledge/connectors/sync";
 import { subscribeKnowledgeIndexing } from "./knowledge/events";
-import { enqueueIndex, registerKnowledgeIndexing } from "./knowledge/indexing";
+import { enqueueIndex, makeIndexQueueStats, registerKnowledgeIndexing } from "./knowledge/indexing";
 import { PgKnowledgeLinksRepo } from "./knowledge/links-repo";
 import { PgKnowledgePageRepo, PgKnowledgeRevisionRepo } from "./knowledge/repo";
 import { PageRetrievalService } from "./knowledge/retrieval-service";
@@ -134,6 +137,7 @@ async function boot() {
       overrides: new PgKnowledgeSpaceOverrideRepo(pool),
       embeddings: embeddingService,
       enqueueIndex: (pageId) => enqueueIndex(boss, { kind: "page", pageId }).then(() => undefined),
+      indexQueueStats: makeIndexQueueStats(boss, pool),
     });
 
     // Page-level human search spine (shares the pool; chunk-mode search stays in knowledgeService).
@@ -229,6 +233,11 @@ async function boot() {
       },
     });
     subscribeKnowledgeIndexing(domainEventEmitter, boss);
+    await registerConnectorSync(boss, {
+      registry: buildDefaultRegistry(),
+      state: new PgConnectorStateRepo(pool),
+      service: knowledgeService,
+    });
 
     app.listen({ port, host: "0.0.0.0" }, (err) => {
       if (err) {

--- a/apps/api/src/knowledge/admin-routes.pg.test.ts
+++ b/apps/api/src/knowledge/admin-routes.pg.test.ts
@@ -1,0 +1,120 @@
+import type { PGlite } from "@electric-sql/pglite";
+import Fastify, { type FastifyInstance } from "fastify";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { runPgMigrations } from "../pg-migrate";
+import { makePglite } from "../test/pglite";
+import { PgKnowledgeChunkRepo } from "./chunks-repo";
+import { PgKnowledgePageRepo, PgKnowledgeRevisionRepo } from "./repo";
+import { registerKnowledgeRoutes } from "./routes";
+import { KnowledgeService } from "./service";
+import type { EmbeddingPort } from "./types";
+
+function fakeEmbeddings(): EmbeddingPort {
+  return {
+    isAvailable: () => true,
+    embedMany: async (values) => ({ embeddings: values.map(() => [0.1, 0.1, 0.1]), dimension: 3 }),
+    getActive: () => ({ provider: "fake", model: "m", dimension: 3 }),
+    getDimension: () => 3,
+    consumePendingReindex: () => false,
+  };
+}
+
+const base = "/api/v1/knowledge";
+
+describe("knowledge admin routes (reindex / backfill / index-status)", () => {
+  let db: PGlite;
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    db = await makePglite();
+    await runPgMigrations(db);
+    const service = new KnowledgeService({
+      pages: new PgKnowledgePageRepo(db),
+      chunks: new PgKnowledgeChunkRepo(db),
+      revisions: new PgKnowledgeRevisionRepo(db),
+      embeddings: fakeEmbeddings(),
+    });
+    app = Fastify();
+    // Stub auth: set req.user from the x-role header so the admin guard can be exercised.
+    registerKnowledgeRoutes(app, service, async (req) => {
+      req.user = {
+        _id: "u1",
+        email: "u@example.com",
+        passwordHash: "x",
+        role: req.headers["x-role"] === "admin" ? "admin" : "member",
+        createdAt: new Date(),
+      };
+    });
+    await app.ready();
+  });
+  afterEach(async () => {
+    await app.close();
+    await db.close();
+  });
+
+  const asAdmin = { "x-role": "admin" };
+
+  it("forbids non-admins on every admin endpoint (403)", async () => {
+    for (const [method, url] of [
+      ["POST", `${base}/reindex`],
+      ["POST", `${base}/backfill`],
+      ["GET", `${base}/index-status`],
+    ] as const) {
+      const res = await app.inject({ method, url, payload: method === "POST" ? {} : undefined });
+      expect(res.statusCode).toBe(403);
+    }
+  });
+
+  it("reindexes a single page for an admin", async () => {
+    const created = await app.inject({
+      method: "POST",
+      url: `${base}/pages`,
+      headers: asAdmin,
+      payload: { title: "T", content: "alpha body" },
+    });
+    const pageId = created.json<{ id: string }>().id;
+
+    const res = await app.inject({
+      method: "POST",
+      url: `${base}/reindex`,
+      headers: asAdmin,
+      payload: { pageId },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ reindexed: number }>().reindexed).toBe(1);
+  });
+
+  it("backfill is a 200 no-op count and index-status returns DB-derived health", async () => {
+    await app.inject({
+      method: "POST",
+      url: `${base}/pages`,
+      headers: asAdmin,
+      payload: { title: "T", content: "france body" },
+    });
+
+    const backfill = await app.inject({
+      method: "POST",
+      url: `${base}/backfill`,
+      headers: asAdmin,
+      payload: {},
+    });
+    expect(backfill.statusCode).toBe(200);
+    // Already embedded inline on create → nothing to backfill.
+    expect(backfill.json<{ reindexed: number }>().reindexed).toBe(0);
+
+    const status = await app.inject({
+      method: "GET",
+      url: `${base}/index-status`,
+      headers: asAdmin,
+    });
+    expect(status.statusCode).toBe(200);
+    const body = status.json<{
+      activePages: number;
+      chunks: { total: number; embedded: number; lexicalOnly: number };
+      queue: unknown;
+    }>();
+    expect(body.activePages).toBe(1);
+    expect(body.chunks.embedded).toBe(body.chunks.total);
+    expect(body.queue).toBeNull(); // indexQueueStats not wired in this test
+  });
+});

--- a/apps/api/src/knowledge/chunks-repo.pg.test.ts
+++ b/apps/api/src/knowledge/chunks-repo.pg.test.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import type { PGlite } from "@electric-sql/pglite";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { runPgMigrations } from "../pg-migrate";
@@ -28,7 +28,16 @@ function page(over: Partial<KnowledgePage> = {}): KnowledgePage {
 }
 
 function chunk(over: Partial<ChunkInput> = {}): ChunkInput {
-  return { chunkIndex: 0, content: "hello", embedding: null, model: null, dim: null, ...over };
+  const content = over.content ?? "hello";
+  return {
+    chunkIndex: 0,
+    content,
+    contentHash: createHash("md5").update(content).digest("hex"),
+    embedding: null,
+    model: null,
+    dim: null,
+    ...over,
+  };
 }
 
 describe("PgKnowledgeChunkRepo", () => {

--- a/apps/api/src/knowledge/chunks-repo.ts
+++ b/apps/api/src/knowledge/chunks-repo.ts
@@ -2,11 +2,27 @@ import { randomUUID } from "node:crypto";
 import type { Queryable } from "../db";
 import type {
   ChunkInput,
+  ExistingChunk,
   IndexingStatus,
+  IndexStats,
   KnowledgeSource,
   SearchFilters,
   SearchHit,
 } from "./types";
+
+/** Parse a pgvector value (returned as a `"[1,2,3]"` string) back into a number[] for reuse. */
+function parseVector(value: unknown): number[] | null {
+  if (value === null || value === undefined) return null;
+  if (Array.isArray(value)) return value as number[];
+  const text = String(value).trim();
+  // An empty/degenerate vector string means "no usable embedding" → null, so the reuse check
+  // (`prior.embedding !== null`) correctly treats it as not reusable.
+  if (text.length === 0 || text === "[]") return null;
+  return text
+    .replace(/^\[|\]$/g, "")
+    .split(",")
+    .map((n) => Number(n));
+}
 
 /** Push `p.*` filter conditions onto `params` and return the SQL fragments. */
 export function pageFilterConditions(filters: SearchFilters, params: unknown[]): string[] {
@@ -50,6 +66,8 @@ function rowToHit(row: Record<string, unknown>, score: number): SearchHit {
 export interface KnowledgeChunkRepo {
   deleteByPage(pageId: string): Promise<void>;
   insertMany(pageId: string, chunks: ChunkInput[]): Promise<void>;
+  /** Existing chunks (ordered by chunk_index) projected for the re-index content-hash diff. */
+  listByPageForDiff(pageId: string): Promise<ExistingChunk[]>;
   /** Cosine exact-scan over chunks whose stored dim matches the active model. */
   searchVector(
     queryEmbedding: number[],
@@ -63,6 +81,10 @@ export interface KnowledgeChunkRepo {
   getIndexingStatus(pageId: string): Promise<IndexingStatus>;
   /** Batch variant — one grouped query; ids absent from the result default to "pending". */
   getIndexingStatuses(pageIds: string[]): Promise<Map<string, IndexingStatus>>;
+  /** Active pages with a chunk that is unembedded or embedded under a stale model — backfill targets. */
+  listPageIdsNeedingEmbedding(activeModel: string): Promise<string[]>;
+  /** Aggregate index health (counts + max lag), all from our own tables. */
+  indexStats(): Promise<IndexStats>;
 }
 
 export class PgKnowledgeChunkRepo implements KnowledgeChunkRepo {
@@ -76,19 +98,43 @@ export class PgKnowledgeChunkRepo implements KnowledgeChunkRepo {
     for (const chunk of chunks) {
       await this.q.query(
         `INSERT INTO knowledge_chunks
-           (id, page_id, chunk_index, content, embedding, tsv, model, dim, created_at)
-         VALUES ($1, $2, $3, $4, $5::vector, to_tsvector('english', $4), $6, $7, now())`,
+           (id, page_id, chunk_index, content, content_hash, embedding, tsv, model, dim, created_at)
+         VALUES ($1, $2, $3, $4, $5, $6::vector, to_tsvector('english', $4), $7, $8, now())`,
         [
           randomUUID(),
           pageId,
           chunk.chunkIndex,
           chunk.content,
+          chunk.contentHash,
           chunk.embedding === null ? null : JSON.stringify(chunk.embedding),
           chunk.model,
           chunk.dim,
         ]
       );
     }
+  }
+
+  async listByPageForDiff(pageId: string): Promise<ExistingChunk[]> {
+    const { rows } = await this.q.query(
+      `SELECT chunk_index, content_hash, embedding, model, dim
+       FROM knowledge_chunks WHERE page_id = $1 ORDER BY chunk_index`,
+      [pageId]
+    );
+    return (
+      rows as Array<{
+        chunk_index: number;
+        content_hash: string | null;
+        embedding: unknown;
+        model: string | null;
+        dim: number | null;
+      }>
+    ).map((r) => ({
+      chunkIndex: Number(r.chunk_index),
+      contentHash: r.content_hash,
+      embedding: parseVector(r.embedding),
+      model: r.model,
+      dim: r.dim === null ? null : Number(r.dim),
+    }));
   }
 
   async searchVector(
@@ -152,5 +198,49 @@ export class PgKnowledgeChunkRepo implements KnowledgeChunkRepo {
   async getIndexingStatus(pageId: string): Promise<IndexingStatus> {
     const statuses = await this.getIndexingStatuses([pageId]);
     return statuses.get(pageId) ?? "pending";
+  }
+
+  async listPageIdsNeedingEmbedding(activeModel: string): Promise<string[]> {
+    const { rows } = await this.q.query(
+      `SELECT DISTINCT p.id
+       FROM knowledge_pages p
+       JOIN knowledge_chunks c ON c.page_id = p.id
+       WHERE p.active = true AND (c.embedding IS NULL OR c.model IS DISTINCT FROM $1)`,
+      [activeModel]
+    );
+    return (rows as Array<{ id: string }>).map((r) => r.id);
+  }
+
+  async indexStats(): Promise<IndexStats> {
+    const { rows } = await this.q.query(
+      `WITH per_page AS (
+         SELECT p.id, p.updated_at, MAX(c.created_at) AS last_chunk
+         FROM knowledge_pages p
+         LEFT JOIN knowledge_chunks c ON c.page_id = p.id
+         WHERE p.active = true
+         GROUP BY p.id, p.updated_at
+       )
+       SELECT
+         (SELECT count(*) FROM knowledge_pages WHERE active = true)::int AS active_pages,
+         (SELECT count(*) FROM knowledge_chunks)::int AS total_chunks,
+         (SELECT count(*) FROM knowledge_chunks WHERE embedding IS NOT NULL)::int AS embedded_chunks,
+         (SELECT count(*) FROM knowledge_chunks WHERE embedding IS NULL)::int AS lexical_chunks,
+         (SELECT MAX(EXTRACT(EPOCH FROM (updated_at - last_chunk)))
+            FROM per_page WHERE last_chunk IS NOT NULL AND updated_at > last_chunk) AS max_lag_seconds`
+    );
+    const r = rows[0] as {
+      active_pages: number;
+      total_chunks: number;
+      embedded_chunks: number;
+      lexical_chunks: number;
+      max_lag_seconds: number | null;
+    };
+    return {
+      activePages: Number(r.active_pages),
+      totalChunks: Number(r.total_chunks),
+      embeddedChunks: Number(r.embedded_chunks),
+      lexicalChunks: Number(r.lexical_chunks),
+      maxLagSeconds: r.max_lag_seconds === null ? null : Number(r.max_lag_seconds),
+    };
   }
 }

--- a/apps/api/src/knowledge/connectors/fixtures/sample.json
+++ b/apps/api/src/knowledge/connectors/fixtures/sample.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "welcome",
+    "title": "Welcome to the Sample Source",
+    "body": "This page was ingested by the SampleConnector to exercise the connector framework end to end.",
+    "updatedAt": "2026-06-01T00:00:00.000Z",
+    "tags": ["sample-connector", "intro"],
+    "domain": "sample"
+  },
+  {
+    "id": "runbook",
+    "title": "Sample Runbook",
+    "body": "A second sample record so listChanged returns more than one id and the cursor advances past the newest record.",
+    "updatedAt": "2026-06-02T00:00:00.000Z",
+    "tags": ["sample-connector", "runbook"],
+    "domain": "sample"
+  }
+]

--- a/apps/api/src/knowledge/connectors/registry.ts
+++ b/apps/api/src/knowledge/connectors/registry.ts
@@ -1,0 +1,17 @@
+import { SampleConnector } from "./sample";
+import { ConfluenceConnector, GoogleDocsConnector, NotionConnector } from "./stubs";
+import { ConnectorRegistry } from "./types";
+
+/**
+ * The connectors this process knows about: the working SampleConnector plus the not-yet-implemented
+ * stubs. Registered does not mean enabled — sync only runs connectors flagged enabled in
+ * `knowledge_connectors`.
+ */
+export function buildDefaultRegistry(): ConnectorRegistry {
+  return new ConnectorRegistry([
+    new SampleConnector(),
+    new GoogleDocsConnector(),
+    new ConfluenceConnector(),
+    new NotionConnector(),
+  ]);
+}

--- a/apps/api/src/knowledge/connectors/sample.ts
+++ b/apps/api/src/knowledge/connectors/sample.ts
@@ -1,0 +1,72 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { Connector, ConnectorChanges, ConnectorPage, ConnectorRecord } from "./types";
+
+/** Shape of a record in the sample fixtures file. */
+interface SampleRecord {
+  id: string;
+  title: string;
+  body: string;
+  /** ISO 8601 timestamp; doubles as the incremental cursor. */
+  updatedAt: string;
+  tags?: string[];
+  domain?: string | null;
+}
+
+/** The bundled fixtures file the registry-registered SampleConnector reads by default. */
+export function defaultSampleFixturesPath(): string {
+  return join(__dirname, "fixtures", "sample.json");
+}
+
+/**
+ * Reference connector reading a local JSON fixtures file. It exercises the full framework path —
+ * incremental `listChanged` (by `updatedAt` cursor), `fetch`, and `mapToPage` to a flat page — so
+ * the sync orchestration and indexer can be verified without a live third-party source.
+ */
+export class SampleConnector implements Connector {
+  readonly name = "sample";
+
+  constructor(private readonly fixturesPath: string = defaultSampleFixturesPath()) {}
+
+  async authenticate(): Promise<void> {
+    // Local fixtures need no credentials; a real connector would load them from SecretsService here.
+  }
+
+  async listChanged(cursor: string | null): Promise<ConnectorChanges> {
+    const all = await this.readAll();
+    const changed = all.filter((r) => cursor === null || r.updatedAt > cursor);
+    // Advance the cursor to the newest record so an unchanged re-sync returns nothing.
+    const nextCursor = all.reduce<string | null>(
+      (max, r) => (max === null || r.updatedAt > max ? r.updatedAt : max),
+      cursor
+    );
+    return { ids: changed.map((r) => r.id), cursor: nextCursor };
+  }
+
+  async fetch(id: string): Promise<ConnectorRecord> {
+    const rec = (await this.readAll()).find((r) => r.id === id);
+    if (!rec) throw new Error(`sample connector: record not found: ${id}`);
+    return rec as unknown as ConnectorRecord;
+  }
+
+  mapToPage(record: ConnectorRecord): ConnectorPage {
+    const r = record as unknown as SampleRecord;
+    return {
+      kind: "flat",
+      input: {
+        source: "resource",
+        // Namespaced by connector name so external rows never collide with locally-authored pages.
+        sourceId: `${this.name}:${r.id}`,
+        title: r.title,
+        content: r.body,
+        domain: r.domain ?? null,
+        tags: r.tags ?? ["sample-connector"],
+      },
+    };
+  }
+
+  private async readAll(): Promise<SampleRecord[]> {
+    const raw = await readFile(this.fixturesPath, "utf8");
+    return JSON.parse(raw) as SampleRecord[];
+  }
+}

--- a/apps/api/src/knowledge/connectors/state-repo.ts
+++ b/apps/api/src/knowledge/connectors/state-repo.ts
@@ -1,0 +1,90 @@
+import type { Queryable } from "../../db";
+
+/** One connector's persisted sync state (`knowledge_connectors`). */
+export interface ConnectorState {
+  name: string;
+  enabled: boolean;
+  /** Opaque resume position from the connector's last successful `listChanged`. */
+  cursor: string | null;
+  lastRunAt: Date | null;
+  lastError: string | null;
+}
+
+export interface ConnectorStateRepo {
+  /** Create the row if absent (idempotent registration); never clobbers an existing cursor/enabled. */
+  ensure(name: string): Promise<void>;
+  get(name: string): Promise<ConnectorState | null>;
+  listEnabled(): Promise<ConnectorState[]>;
+  setEnabled(name: string, enabled: boolean): Promise<void>;
+  /** Advance the resume cursor after a successful sync pass. */
+  setCursor(name: string, cursor: string | null): Promise<void>;
+  /** Stamp a successful run: set last_run_at = now, clear last_error. */
+  recordRun(name: string): Promise<void>;
+  /** Stamp a failed run: set last_run_at = now, store the error message. */
+  recordError(name: string, error: string): Promise<void>;
+}
+
+function rowToState(row: Record<string, unknown>): ConnectorState {
+  return {
+    name: row.name as string,
+    enabled: row.enabled as boolean,
+    cursor: (row.cursor as string | null) ?? null,
+    lastRunAt: (row.last_run_at as Date | null) ?? null,
+    lastError: (row.last_error as string | null) ?? null,
+  };
+}
+
+export class PgConnectorStateRepo implements ConnectorStateRepo {
+  constructor(private readonly q: Queryable) {}
+
+  async ensure(name: string): Promise<void> {
+    await this.q.query(
+      `INSERT INTO knowledge_connectors (name, enabled, created_at, updated_at)
+       VALUES ($1, false, now(), now())
+       ON CONFLICT (name) DO NOTHING`,
+      [name]
+    );
+  }
+
+  async get(name: string): Promise<ConnectorState | null> {
+    const { rows } = await this.q.query("SELECT * FROM knowledge_connectors WHERE name = $1", [
+      name,
+    ]);
+    return rows[0] ? rowToState(rows[0] as Record<string, unknown>) : null;
+  }
+
+  async listEnabled(): Promise<ConnectorState[]> {
+    const { rows } = await this.q.query(
+      "SELECT * FROM knowledge_connectors WHERE enabled = true ORDER BY name"
+    );
+    return rows.map((r) => rowToState(r as Record<string, unknown>));
+  }
+
+  async setEnabled(name: string, enabled: boolean): Promise<void> {
+    await this.q.query(
+      "UPDATE knowledge_connectors SET enabled = $2, updated_at = now() WHERE name = $1",
+      [name, enabled]
+    );
+  }
+
+  async setCursor(name: string, cursor: string | null): Promise<void> {
+    await this.q.query(
+      "UPDATE knowledge_connectors SET cursor = $2, updated_at = now() WHERE name = $1",
+      [name, cursor]
+    );
+  }
+
+  async recordRun(name: string): Promise<void> {
+    await this.q.query(
+      "UPDATE knowledge_connectors SET last_run_at = now(), last_error = NULL, updated_at = now() WHERE name = $1",
+      [name]
+    );
+  }
+
+  async recordError(name: string, error: string): Promise<void> {
+    await this.q.query(
+      "UPDATE knowledge_connectors SET last_run_at = now(), last_error = $2, updated_at = now() WHERE name = $1",
+      [name, error]
+    );
+  }
+}

--- a/apps/api/src/knowledge/connectors/stubs.ts
+++ b/apps/api/src/knowledge/connectors/stubs.ts
@@ -1,0 +1,40 @@
+import type { Connector, ConnectorChanges, ConnectorPage, ConnectorRecord } from "./types";
+import { NotImplementedError } from "./types";
+
+/**
+ * Honest stubs for the connectors a future PR will implement. Each one fully satisfies the
+ * `Connector` interface but throws `NotImplementedError` from every method — so they register and
+ * appear in the framework today, and landing a real connector means filling in these 3–4 methods
+ * without touching the indexer or sync orchestration.
+ */
+abstract class StubConnector implements Connector {
+  abstract readonly name: string;
+
+  authenticate(): Promise<void> {
+    throw new NotImplementedError(this.name, "authenticate");
+  }
+
+  listChanged(_cursor: string | null): Promise<ConnectorChanges> {
+    throw new NotImplementedError(this.name, "listChanged");
+  }
+
+  fetch(_id: string): Promise<ConnectorRecord> {
+    throw new NotImplementedError(this.name, "fetch");
+  }
+
+  mapToPage(_record: ConnectorRecord): ConnectorPage {
+    throw new NotImplementedError(this.name, "mapToPage");
+  }
+}
+
+export class GoogleDocsConnector extends StubConnector {
+  readonly name = "google-docs";
+}
+
+export class ConfluenceConnector extends StubConnector {
+  readonly name = "confluence";
+}
+
+export class NotionConnector extends StubConnector {
+  readonly name = "notion";
+}

--- a/apps/api/src/knowledge/connectors/sync.pg.test.ts
+++ b/apps/api/src/knowledge/connectors/sync.pg.test.ts
@@ -1,0 +1,179 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { PGlite } from "@electric-sql/pglite";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { runPgMigrations } from "../../pg-migrate";
+import { makePglite } from "../../test/pglite";
+import { PgKnowledgeChunkRepo } from "../chunks-repo";
+import { PgKnowledgePageRepo, PgKnowledgeRevisionRepo } from "../repo";
+import { KnowledgeService } from "../service";
+import type { EmbeddingPort } from "../types";
+import { SampleConnector } from "./sample";
+import { PgConnectorStateRepo } from "./state-repo";
+import { GoogleDocsConnector } from "./stubs";
+import { runConnectorSync, syncConnector } from "./sync";
+import { type Connector, ConnectorRegistry, NotImplementedError } from "./types";
+
+function fakeEmbeddings(): EmbeddingPort {
+  return {
+    isAvailable: () => true,
+    embedMany: async (values) => ({ embeddings: values.map(() => [0.1, 0.1, 0.1]), dimension: 3 }),
+    getActive: () => ({ provider: "fake", model: "m", dimension: 3 }),
+    getDimension: () => 3,
+    consumePendingReindex: () => false,
+  };
+}
+
+const ONE = {
+  id: "welcome",
+  title: "Welcome",
+  body: "intro body",
+  updatedAt: "2026-06-01T00:00:00.000Z",
+};
+const TWO = {
+  id: "runbook",
+  title: "Runbook",
+  body: "runbook body",
+  updatedAt: "2026-06-02T00:00:00.000Z",
+};
+
+describe("connector sync (SampleConnector)", () => {
+  let db: PGlite;
+  let service: KnowledgeService;
+  let state: PgConnectorStateRepo;
+  let fixtures: string;
+
+  async function writeFixtures(records: unknown[]): Promise<void> {
+    await writeFile(fixtures, JSON.stringify(records), "utf8");
+  }
+
+  function makeRegistry(): ConnectorRegistry {
+    return new ConnectorRegistry([new SampleConnector(fixtures)]);
+  }
+
+  async function enableSample(): Promise<void> {
+    await state.ensure("sample");
+    await state.setEnabled("sample", true);
+  }
+
+  beforeEach(async () => {
+    db = await makePglite();
+    await runPgMigrations(db);
+    service = new KnowledgeService({
+      pages: new PgKnowledgePageRepo(db),
+      chunks: new PgKnowledgeChunkRepo(db),
+      revisions: new PgKnowledgeRevisionRepo(db),
+      embeddings: fakeEmbeddings(),
+    });
+    state = new PgConnectorStateRepo(db);
+    const dir = await mkdtemp(join(tmpdir(), "tf-connector-"));
+    fixtures = join(dir, "sample.json");
+    await writeFixtures([ONE, TWO]);
+  });
+  afterEach(async () => {
+    await db.close();
+  });
+
+  it("creates pages, advances the cursor, and re-syncs idempotently", async () => {
+    await enableSample();
+    const deps = { registry: makeRegistry(), state, service };
+
+    const first = await runConnectorSync(deps);
+    expect(first).toEqual([{ connector: "sample", synced: 2 }]);
+
+    const pages = await service.listPages({ limit: 10 });
+    expect(pages.items).toHaveLength(2);
+    expect(pages.items.map((p) => p.source)).toEqual(["resource", "resource"]);
+    expect(pages.items.map((p) => p.sourceId).sort()).toEqual(["sample:runbook", "sample:welcome"]);
+
+    // Cursor advanced to the newest record.
+    expect((await state.get("sample"))?.cursor).toBe(TWO.updatedAt);
+    expect((await state.get("sample"))?.lastError).toBeNull();
+
+    // Nothing changed → second sync does no work and creates no duplicates.
+    const second = await runConnectorSync(deps);
+    expect(second).toEqual([{ connector: "sample", synced: 0 }]);
+    expect((await service.listPages({ limit: 10 })).items).toHaveLength(2);
+  });
+
+  it("re-syncs a record whose timestamp advanced, upserting in place (no duplicate)", async () => {
+    await enableSample();
+    const deps = { registry: makeRegistry(), state, service };
+    await runConnectorSync(deps);
+
+    // Bump welcome past the cursor with new content.
+    await writeFixtures([
+      { ...ONE, body: "updated intro", updatedAt: "2026-06-03T00:00:00.000Z" },
+      TWO,
+    ]);
+    const res = await runConnectorSync(deps);
+    expect(res).toEqual([{ connector: "sample", synced: 1 }]);
+
+    const pages = await service.listPages({ limit: 10 });
+    expect(pages.items).toHaveLength(2); // upsert, not insert
+    const welcome = pages.items.find((p) => p.sourceId === "sample:welcome");
+    expect(welcome?.content).toBe("updated intro");
+  });
+
+  it("never overwrites a locally-authored page", async () => {
+    const authored = await service.createPage({ title: "Mine", content: "hand-authored body" });
+    await enableSample();
+    await runConnectorSync({ registry: makeRegistry(), state, service });
+
+    const still = await service.getPage(authored._id);
+    expect(still?.source).toBe("authored");
+    expect(still?.content).toBe("hand-authored body");
+    expect(still?.version).toBe(authored.version); // untouched by the sync
+  });
+
+  it("isolates a failing connector: records last_error and keeps its cursor", async () => {
+    await state.ensure("google-docs");
+    await state.setEnabled("google-docs", true);
+    const registry = new ConnectorRegistry([new GoogleDocsConnector()]);
+    const result = await syncConnector(new GoogleDocsConnector(), { registry, state, service });
+    expect(result.error).toContain("not implemented");
+    const row = await state.get("google-docs");
+    expect(row?.lastError).toContain("not implemented");
+    expect(row?.cursor).toBeNull(); // cursor only advances on success
+  });
+
+  it("stub connectors throw NotImplementedError", () => {
+    expect(() => new GoogleDocsConnector().authenticate()).toThrow(NotImplementedError);
+  });
+
+  it("isolates a per-record failure: syncs the good records and still advances the cursor", async () => {
+    // A connector whose fetch throws for one id but succeeds for the others.
+    const connector: Connector = {
+      name: "flaky",
+      authenticate: async () => {},
+      listChanged: async () => ({ ids: ["ok-1", "bad", "ok-2"], cursor: "c2" }),
+      fetch: async (id) => {
+        if (id === "bad") throw new Error("boom");
+        return { id, title: id, body: `body ${id}` };
+      },
+      mapToPage: (record) => ({
+        kind: "flat",
+        input: {
+          source: "resource",
+          sourceId: `flaky:${record.id}`,
+          title: String(record.title),
+          content: String(record.body),
+        },
+      }),
+    };
+    await state.ensure("flaky");
+    const result = await syncConnector(connector, {
+      registry: new ConnectorRegistry([connector]),
+      state,
+      service,
+    });
+    expect(result.synced).toBe(2); // both good records written
+    expect(result.error).toContain("boom");
+    // Cursor advances despite the bad record, so it can't wedge the connector; error is surfaced.
+    const row = await state.get("flaky");
+    expect(row?.cursor).toBe("c2");
+    expect(row?.lastError).toContain("boom");
+    expect((await service.listPages({ limit: 10 })).items).toHaveLength(2);
+  });
+});

--- a/apps/api/src/knowledge/connectors/sync.ts
+++ b/apps/api/src/knowledge/connectors/sync.ts
@@ -1,0 +1,97 @@
+import type { PgBoss } from "pg-boss";
+import type { KnowledgeService } from "../service";
+import type { ConnectorStateRepo } from "./state-repo";
+import type { Connector, ConnectorRegistry } from "./types";
+
+export const CONNECTOR_SYNC_QUEUE = "connector-sync";
+/** Every 15 minutes — connectors are incremental, so a modest cadence is plenty. */
+export const CONNECTOR_SYNC_CRON = "*/15 * * * *";
+
+export interface ConnectorSyncDeps {
+  registry: ConnectorRegistry;
+  state: ConnectorStateRepo;
+  service: KnowledgeService;
+}
+
+export interface ConnectorSyncResult {
+  connector: string;
+  synced: number;
+  error?: string;
+}
+
+/**
+ * Sync one connector: authenticate → listChanged(cursor) → for each changed record fetch + map +
+ * write through the existing funnels (the indexer embeds it) → advance the cursor. A failure is
+ * recorded on the connector's state row and isolated to that connector (never throws to the caller),
+ * so one broken connector can't stall the others. The cursor only advances on success, so a failed
+ * run is retried from the same position next time.
+ */
+export async function syncConnector(
+  connector: Connector,
+  deps: ConnectorSyncDeps
+): Promise<ConnectorSyncResult> {
+  const { state, service } = deps;
+  await state.ensure(connector.name);
+  const existing = await state.get(connector.name);
+  const cursor = existing?.cursor ?? null;
+  try {
+    await connector.authenticate();
+    const changes = await connector.listChanged(cursor);
+    let synced = 0;
+    const failures: string[] = [];
+    for (const id of changes.ids) {
+      try {
+        const record = await connector.fetch(id);
+        const page = connector.mapToPage(record);
+        // Flat pages upsert by (source, sourceId); a connector setting source != "authored" can
+        // never collide with a hand-authored page. OKF pages go through writePage, which owns the
+        // (spaceId, path) — an OKF-kind connector is expected to write into a space it owns (no V1
+        // connector uses this path; the SampleConnector is flat).
+        if (page.kind === "flat") await service.ingestSource(page.input);
+        else await service.writePage(page.input);
+        synced += 1;
+      } catch (recErr) {
+        // Per-record isolation: one bad record is recorded and skipped, never stalling the cursor
+        // for the whole connector. Connector-level failures (auth/listChanged) are caught below.
+        failures.push(`${id}: ${recErr instanceof Error ? recErr.message : String(recErr)}`);
+      }
+    }
+    // Cursor advances even with per-record failures so a permanently-bad record can't wedge the
+    // connector; the failures are surfaced on last_error for visibility.
+    await state.setCursor(connector.name, changes.cursor);
+    if (failures.length > 0) {
+      const message = `${failures.length} record(s) failed: ${failures.join("; ")}`;
+      await state.recordError(connector.name, message);
+      return { connector: connector.name, synced, error: message };
+    }
+    await state.recordRun(connector.name);
+    return { connector: connector.name, synced };
+  } catch (err) {
+    // Connector-level failure (authenticate / listChanged): cursor is NOT advanced, so the run is
+    // retried from the same position next time.
+    const message = err instanceof Error ? err.message : String(err);
+    await state.recordError(connector.name, message);
+    return { connector: connector.name, synced: 0, error: message };
+  }
+}
+
+/** Sync every connector that is both registered and flagged enabled. */
+export async function runConnectorSync(deps: ConnectorSyncDeps): Promise<ConnectorSyncResult[]> {
+  const enabled = await deps.state.listEnabled();
+  const results: ConnectorSyncResult[] = [];
+  for (const s of enabled) {
+    const connector = deps.registry.get(s.name);
+    if (!connector) continue; // enabled in DB but not registered in this build — skip safely
+    results.push(await syncConnector(connector, deps));
+  }
+  return results;
+}
+
+/** Register the scheduled connector-sync job (mirrors soul-sync / stream-gc). */
+export async function registerConnectorSync(boss: PgBoss, deps: ConnectorSyncDeps): Promise<void> {
+  await boss.createQueue(CONNECTOR_SYNC_QUEUE);
+  await boss.work(CONNECTOR_SYNC_QUEUE, async () => {
+    await runConnectorSync(deps);
+  });
+  await boss.schedule(CONNECTOR_SYNC_QUEUE, CONNECTOR_SYNC_CRON);
+}

--- a/apps/api/src/knowledge/connectors/types.ts
+++ b/apps/api/src/knowledge/connectors/types.ts
@@ -1,0 +1,74 @@
+import type { IngestSourceInput, WritePageInput } from "../service";
+
+/**
+ * Connector framework (V1: interface + sample + stubs, no live third-party connector).
+ *
+ * A connector is the only seam an external source needs to fill: pull credentials, enumerate what
+ * changed since a cursor, fetch a record, and map it to a page. Everything downstream — upsert,
+ * chunking, embedding, search — is the existing pipeline. A connector NEVER touches embeddings or
+ * `knowledge_chunks`; it produces pages through the existing funnels (`ingestSource`/`writePage`)
+ * and the indexer embeds them.
+ */
+
+/** A raw external record. `id` is the source-local identifier; the rest is connector-specific. */
+export interface ConnectorRecord {
+  id: string;
+  [key: string]: unknown;
+}
+
+/**
+ * The result of mapping a record to a page. `flat` routes through `ingestSource` (a standalone
+ * page keyed by `(source, sourceId)`); `okf` routes through `writePage` (a page inside an OKF space).
+ */
+export type ConnectorPage =
+  | { kind: "flat"; input: IngestSourceInput }
+  | { kind: "okf"; input: WritePageInput };
+
+/** What `listChanged` returns: the ids that changed plus the cursor to persist for the next run. */
+export interface ConnectorChanges {
+  ids: string[];
+  /** Opaque, connector-defined position to resume from next sync. Null = start from the beginning. */
+  cursor: string | null;
+}
+
+export interface Connector {
+  /** Stable identifier; also the `knowledge_connectors.name` key and secret namespace. */
+  readonly name: string;
+  /** Pull and validate credentials (from `SecretsService`, key `connector:{name}:{cred}`). */
+  authenticate(): Promise<void>;
+  /** Incremental: ids changed since `cursor`, plus the cursor to persist for the next run. */
+  listChanged(cursor: string | null): Promise<ConnectorChanges>;
+  /** Fetch one record's content by id. */
+  fetch(id: string): Promise<ConnectorRecord>;
+  /** Pure mapping from an external record to a page write. */
+  mapToPage(record: ConnectorRecord): ConnectorPage;
+}
+
+/** Thrown by stub connectors whose real implementation has not landed yet. */
+export class NotImplementedError extends Error {
+  constructor(connector: string, method: string) {
+    super(`connector ${connector}: ${method} is not implemented`);
+    this.name = "NotImplementedError";
+  }
+}
+
+/** A tiny in-memory registry of the connectors known to this process. */
+export class ConnectorRegistry {
+  private readonly byName = new Map<string, Connector>();
+
+  constructor(connectors: Connector[] = []) {
+    for (const c of connectors) this.register(c);
+  }
+
+  register(connector: Connector): void {
+    this.byName.set(connector.name, connector);
+  }
+
+  get(name: string): Connector | undefined {
+    return this.byName.get(name);
+  }
+
+  list(): Connector[] {
+    return [...this.byName.values()];
+  }
+}

--- a/apps/api/src/knowledge/index-service.pg.test.ts
+++ b/apps/api/src/knowledge/index-service.pg.test.ts
@@ -28,6 +28,25 @@ function fakeEmbeddings(opts: {
   };
 }
 
+/** Records the size of every embedMany batch so a test can assert how many chunks were embedded. */
+function countingEmbeddings(
+  model = "fake-model",
+  dim = 3
+): { port: EmbeddingPort; batches: number[] } {
+  const batches: number[] = [];
+  const port: EmbeddingPort = {
+    isAvailable: () => true,
+    embedMany: async (values) => {
+      batches.push(values.length);
+      return { embeddings: values.map(() => Array(dim).fill(0.1) as number[]), dimension: dim };
+    },
+    getActive: () => ({ provider: "fake", model, dimension: dim }),
+    getDimension: () => dim,
+    consumePendingReindex: () => false,
+  };
+  return { port, batches };
+}
+
 function page(plainText: string): KnowledgePage {
   const now = new Date();
   return {
@@ -113,6 +132,46 @@ describe("indexPage", () => {
     await pages.insert(p);
     const res = await indexPage(p, chunks, fakeEmbeddings({ available: true }));
     expect(res.chunkCount).toBe(0);
+  });
+
+  it("re-embeds only the changed chunk on re-index (content-hash dedup)", async () => {
+    // 2000 chars → 3 windows (step 700): chunk0 [0,800), chunk1 [700,1500), chunk2 [1400,2000).
+    const text = "x".repeat(2000);
+    const p = page(text);
+    await pages.insert(p);
+    const e = countingEmbeddings();
+
+    const first = await indexPage(p, chunks, e.port);
+    expect(first.chunkCount).toBe(3);
+    expect(e.batches).toEqual([3]); // first index embeds all three chunks
+
+    // Edit one char in chunk0's exclusive region (pos < 700) — keeps length so later windows are
+    // byte-identical and reusable.
+    const editedText = `y${text.slice(1)}`;
+    const edited = { ...p, content: editedText, plainText: editedText };
+    const second = await indexPage(edited, chunks, e.port);
+    expect(second.chunkCount).toBe(3);
+    expect(e.batches).toEqual([3, 1]); // only the changed chunk is re-embedded
+    expect(await embeddedCount()).toBe(3); // 2 reused + 1 fresh — all rows still embedded
+  });
+
+  it("embeds nothing when re-indexing unchanged content under the same model", async () => {
+    const p = page("x".repeat(2000));
+    await pages.insert(p);
+    const e = countingEmbeddings();
+    await indexPage(p, chunks, e.port);
+    await indexPage(p, chunks, e.port);
+    expect(e.batches).toEqual([3]); // second pass reuses every chunk — no new embed call
+  });
+
+  it("re-embeds every chunk when the active model changes", async () => {
+    const p = page("x".repeat(2000));
+    await pages.insert(p);
+    const a = countingEmbeddings("model-a");
+    await indexPage(p, chunks, a.port);
+    const b = countingEmbeddings("model-b");
+    await indexPage(p, chunks, b.port); // same content, different model → no reuse
+    expect(b.batches).toEqual([3]);
   });
 
   it("reindexAll re-embeds every active page", async () => {

--- a/apps/api/src/knowledge/index-service.ts
+++ b/apps/api/src/knowledge/index-service.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { EmbeddingUnavailableError } from "@tulipfarm/llm";
 import { chunkText } from "./chunk";
 import type { KnowledgeChunkRepo } from "./chunks-repo";
@@ -9,10 +10,20 @@ export interface IndexResult {
   embedded: boolean;
 }
 
+/** Content address used to skip re-embedding unchanged chunks. md5 matches the SQL `md5()` backfill. */
+function contentHash(content: string): string {
+  return createHash("md5").update(content).digest("hex");
+}
+
 /**
- * (Re)index one page: chunk its plain text, embed the chunks if a provider is
- * available (else store them lexical-only with NULL embeddings), and replace the
- * page's chunks atomically (delete-then-insert — idempotent for retries/updates).
+ * (Re)index one page: chunk its plain text, then embed only the chunks whose content actually
+ * changed since the last index. A chunk reuses its stored embedding when, at the same `chunkIndex`,
+ * the prior chunk's `content_hash` matches AND it was embedded under the currently-active model —
+ * so a one-line edit to a large page re-embeds one chunk instead of all of them. A model/dimension
+ * swap invalidates every reuse (no prior model matches the active one) → full re-embed.
+ *
+ * Chunks with no available provider (or a provider that vanished mid-flight) store lexical-only with
+ * NULL embeddings. Rows are replaced atomically (delete-then-insert — idempotent for retries).
  */
 export async function indexPage(
   page: KnowledgePage,
@@ -20,25 +31,49 @@ export async function indexPage(
   embeddings: EmbeddingPort
 ): Promise<IndexResult> {
   const textChunks = chunkText(page.plainText);
-  await chunksRepo.deleteByPage(page._id);
-  if (textChunks.length === 0) return { chunkCount: 0, embedded: false };
+  if (textChunks.length === 0) {
+    await chunksRepo.deleteByPage(page._id);
+    return { chunkCount: 0, embedded: false };
+  }
 
-  let vectors: (number[] | null)[] = textChunks.map(() => null);
-  let model: string | null = null;
-  let dim: number | null = null;
-  let embedded = false;
+  const available = embeddings.isAvailable();
+  // Snapshot the active model before embedding so a concurrent reload can't swap it under us.
+  const active = available ? embeddings.getActive() : null;
+  const activeModel = active?.model ?? null;
+  const hashes = textChunks.map((c) => contentHash(c.content));
 
-  if (embeddings.isAvailable()) {
+  // Reuse pass: carry forward embeddings of chunks unchanged under the active model.
+  const existing = await chunksRepo.listByPageForDiff(page._id);
+  const priorByIndex = new Map(existing.map((c) => [c.chunkIndex, c]));
+  const vectors: (number[] | null)[] = textChunks.map(() => null);
+  const dims: (number | null)[] = textChunks.map(() => null);
+  textChunks.forEach((c, i) => {
+    const prior = priorByIndex.get(c.index);
+    if (
+      activeModel !== null &&
+      prior &&
+      prior.embedding !== null &&
+      prior.contentHash === hashes[i] &&
+      prior.model === activeModel
+    ) {
+      vectors[i] = prior.embedding;
+      dims[i] = prior.dim;
+    }
+  });
+
+  // Embed only the chunks that couldn't be reused.
+  const toEmbed = textChunks
+    .map((c, i) => ({ content: c.content, i }))
+    .filter(({ i }) => vectors[i] === null);
+  if (available && toEmbed.length > 0) {
     try {
-      // Snapshot the active model before embedding so a concurrent reload can't swap it under us.
-      const active = embeddings.getActive();
-      const out = await embeddings.embedMany(textChunks.map((c) => c.content));
-      vectors = out.embeddings;
-      model = active?.model ?? null;
-      dim = out.dimension;
-      embedded = true;
+      const out = await embeddings.embedMany(toEmbed.map((t) => t.content));
+      out.embeddings.forEach((vec, j) => {
+        vectors[toEmbed[j].i] = vec;
+        dims[toEmbed[j].i] = out.dimension;
+      });
     } catch (err) {
-      // Provider vanished between isAvailable() and embedMany() → fall back to lexical-only.
+      // Provider vanished between isAvailable() and embedMany() → leave these chunks lexical-only.
       if (!(err instanceof EmbeddingUnavailableError)) throw err;
     }
   }
@@ -46,12 +81,14 @@ export async function indexPage(
   const inputs: ChunkInput[] = textChunks.map((c, i) => ({
     chunkIndex: c.index,
     content: c.content,
-    embedding: embedded ? (vectors[i] ?? null) : null,
-    model: embedded ? model : null,
-    dim: embedded ? dim : null,
+    contentHash: hashes[i],
+    embedding: vectors[i],
+    model: vectors[i] !== null ? activeModel : null,
+    dim: vectors[i] !== null ? dims[i] : null,
   }));
+  await chunksRepo.deleteByPage(page._id);
   await chunksRepo.insertMany(page._id, inputs);
-  return { chunkCount: inputs.length, embedded };
+  return { chunkCount: inputs.length, embedded: vectors.some((v) => v !== null) };
 }
 
 /** Full re-index of every active page (used after a dimension-change guard fires). */

--- a/apps/api/src/knowledge/indexing.ts
+++ b/apps/api/src/knowledge/indexing.ts
@@ -1,7 +1,46 @@
 import type { PgBoss } from "pg-boss";
+import type { Queryable } from "../db";
 import type { KnowledgeService } from "./service";
+import type { IndexQueueStats } from "./types";
 
 export const KNOWLEDGE_INDEX_QUEUE = "knowledge-index";
+
+// pg-boss internal table names are safe identifiers; still validated before interpolation.
+const SAFE_TABLE = /^[A-Za-z0-9_."]+$/;
+
+/**
+ * Operational stats for the index queue, read from pg-boss (`getQueueStats` + the queue's job table).
+ * Degrades to `{ pending: 0, lastError: null }` if the pg-boss schema isn't present or its shape
+ * changes — index-status should never fail because the queue introspection did.
+ */
+export function makeIndexQueueStats(boss: PgBoss, db: Queryable): () => Promise<IndexQueueStats> {
+  return async (): Promise<IndexQueueStats> => {
+    let pending = 0;
+    let lastError: IndexQueueStats["lastError"] = null;
+    try {
+      const stats = await boss.getQueueStats(KNOWLEDGE_INDEX_QUEUE);
+      pending = stats.readyCount + stats.activeCount;
+      if (stats.failedCount > 0 && stats.table && SAFE_TABLE.test(stats.table)) {
+        const table = stats.table.includes(".") ? stats.table : `pgboss.${stats.table}`;
+        const { rows } = await db.query(
+          `SELECT output, completed_on FROM ${table}
+           WHERE state = 'failed' ORDER BY completed_on DESC NULLS LAST LIMIT 1`
+        );
+        const row = rows[0] as { output: unknown; completed_on: Date } | undefined;
+        if (row) {
+          const message =
+            row.output && typeof row.output === "object" && "message" in row.output
+              ? String((row.output as { message: unknown }).message)
+              : JSON.stringify(row.output ?? null);
+          lastError = { message, failedAt: row.completed_on };
+        }
+      }
+    } catch {
+      // pg-boss schema absent (e.g. tests) or shape changed → degrade gracefully.
+    }
+    return { pending, lastError };
+  };
+}
 
 /** What an indexing job carries — one variant per source adapter (KN-V1-003). */
 export type IndexJob =

--- a/apps/api/src/knowledge/migration.pg.test.ts
+++ b/apps/api/src/knowledge/migration.pg.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import type { PGlite } from "@electric-sql/pglite";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { runPgMigrations } from "../pg-migrate";
+import { PG_MIGRATIONS } from "../pg-migrations";
 import { makePglite } from "../test/pglite";
 
 async function seedPage(
@@ -46,9 +47,58 @@ describe("002_knowledge migration on PGlite", () => {
     await db.close();
   });
 
-  it("bumps schema_version to the latest (18)", async () => {
+  it("bumps schema_version to the latest (20)", async () => {
     const { rows } = await db.query("SELECT version FROM schema_version WHERE id = true");
-    expect(Number((rows[0] as { version: number }).version)).toBe(18);
+    expect(Number((rows[0] as { version: number }).version)).toBe(20);
+  });
+
+  it("adds knowledge_chunks.content_hash (019)", async () => {
+    const col = await db.query(
+      "SELECT column_name FROM information_schema.columns WHERE table_name = 'knowledge_chunks' AND column_name = 'content_hash'"
+    );
+    expect((col.rows as { column_name: string }[]).map((r) => r.column_name)).toEqual([
+      "content_hash",
+    ]);
+  });
+
+  it("backfills content_hash with md5(content) for pre-existing chunks (019)", async () => {
+    // Simulate a pre-019 row (NULL hash), then replay just the 019 backfill directly — the runner
+    // won't re-run an already-applied version, so invoke its `up` to exercise the backfill SQL.
+    const pageId = await seedPage(db);
+    await seedChunk(db, pageId, "alpha", null);
+    await db.query("UPDATE knowledge_chunks SET content_hash = NULL");
+    const v019 = PG_MIGRATIONS.find((m) => m.version === 19);
+    if (!v019) throw new Error("migration 019 missing");
+    await v019.up(db);
+    const { rows } = await db.query(
+      "SELECT content_hash, md5(content) AS expected FROM knowledge_chunks WHERE content = 'alpha'"
+    );
+    const row = rows[0] as { content_hash: string; expected: string };
+    expect(row.content_hash).toBe(row.expected);
+  });
+
+  it("creates the knowledge_connectors sync-state table (020)", async () => {
+    const { rows } = await db.query("SELECT to_regclass('knowledge_connectors') AS t");
+    expect((rows[0] as { t: string | null }).t).not.toBeNull();
+  });
+
+  it("knowledge_connectors defaults enabled=false with a nullable cursor (020)", async () => {
+    await db.query(
+      "INSERT INTO knowledge_connectors (name, created_at, updated_at) VALUES ('c', now(), now())"
+    );
+    const { rows } = await db.query(
+      "SELECT enabled, cursor, last_run_at, last_error FROM knowledge_connectors WHERE name = 'c'"
+    );
+    const row = rows[0] as {
+      enabled: boolean;
+      cursor: string | null;
+      last_run_at: Date | null;
+      last_error: string | null;
+    };
+    expect(row.enabled).toBe(false);
+    expect(row.cursor).toBeNull();
+    expect(row.last_run_at).toBeNull();
+    expect(row.last_error).toBeNull();
   });
 
   it("creates the three knowledge content tables (collections retired by 018)", async () => {

--- a/apps/api/src/knowledge/routes.ts
+++ b/apps/api/src/knowledge/routes.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { ErrorSchema } from "../auth/schemas";
+import type { UserDoc } from "../auth/users";
 import { parsePaginationQuery } from "../pagination";
 import type { PageHit, PageRetrievalService } from "./retrieval-service";
 import { type KnowledgeService, SpaceNameTakenError } from "./service";
@@ -741,6 +742,114 @@ export function registerKnowledgeRoutes(
           title: p.title,
           updatedAt: p.updatedAt.toISOString(),
         })),
+      });
+    }
+  );
+
+  // ── admin: reindex / backfill / index-status ─────────────────────────────────────
+  // Operational endpoints. Authenticated AND admin-only (mirrors secrets routes): a non-admin gets
+  // 403 even though requireAuth passed.
+  const isAdmin = (req: FastifyRequest, reply: FastifyReply): boolean => {
+    if ((req.user as UserDoc).role !== "admin") {
+      reply.code(403).send({ error: "forbidden" });
+      return false;
+    }
+    return true;
+  };
+
+  app.post(
+    "/api/v1/knowledge/reindex",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description:
+          "Re-index knowledge (admin). Body { pageId } re-indexes one page, { spaceId } a whole space, neither a full re-index.",
+        tags,
+        security: sec,
+        body: {
+          type: "object",
+          properties: { pageId: { type: "string" }, spaceId: { type: "string" } },
+        },
+        response: {
+          200: {
+            type: "object",
+            properties: { reindexed: { type: "number" } },
+            required: ["reindexed"],
+          },
+          401: ErrorSchema,
+          403: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      if (!isAdmin(req, reply)) return;
+      const b = (req.body ?? {}) as { pageId?: string; spaceId?: string };
+      const reindexed = await service.reindexTargeted({ pageId: b.pageId, spaceId: b.spaceId });
+      return reply.send({ reindexed });
+    }
+  );
+
+  app.post(
+    "/api/v1/knowledge/backfill",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description:
+          "Backfill embeddings (admin): re-index every active page with an unembedded or stale-model chunk. No-op without a provider.",
+        tags,
+        security: sec,
+        response: {
+          200: {
+            type: "object",
+            properties: { reindexed: { type: "number" } },
+            required: ["reindexed"],
+          },
+          401: ErrorSchema,
+          403: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      if (!isAdmin(req, reply)) return;
+      const reindexed = await service.backfillMissing();
+      return reply.send({ reindexed });
+    }
+  );
+
+  app.get(
+    "/api/v1/knowledge/index-status",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description:
+          "Index health (admin): active pages, chunk embed/lexical counts, max index lag, and pg-boss queue stats.",
+        tags,
+        security: sec,
+        response: {
+          200: { type: "object", additionalProperties: true },
+          401: ErrorSchema,
+          403: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      if (!isAdmin(req, reply)) return;
+      const status = await service.indexStatus();
+      return reply.send({
+        activePages: status.activePages,
+        chunks: status.chunks,
+        indexLagSeconds: status.indexLagSeconds,
+        queue: status.queue
+          ? {
+              pending: status.queue.pending,
+              lastError: status.queue.lastError
+                ? {
+                    message: status.queue.lastError.message,
+                    failedAt: status.queue.lastError.failedAt.toISOString(),
+                  }
+                : null,
+            }
+          : null,
       });
     }
   );

--- a/apps/api/src/knowledge/service.pg.test.ts
+++ b/apps/api/src/knowledge/service.pg.test.ts
@@ -113,4 +113,65 @@ describe("KnowledgeService", () => {
     expect(await svc.runReindexIfPending()).toBe(true);
     expect(await svc.runReindexIfPending()).toBe(false); // flag consumed
   });
+
+  async function embeddedCount(): Promise<number> {
+    const { rows } = await db.query(
+      "SELECT count(*)::int AS n FROM knowledge_chunks WHERE embedding IS NOT NULL"
+    );
+    return (rows[0] as { n: number }).n;
+  }
+
+  it("reindexTargeted re-indexes one page, a whole reindex on no args, and 0 for a missing page", async () => {
+    const svc = makeService(db, fakeEmbeddings(true));
+    const a = await svc.createPage({ title: "A", content: "alpha body" });
+    await svc.createPage({ title: "B", content: "beta body" });
+    expect(await svc.reindexTargeted({ pageId: a._id })).toBe(1);
+    expect(await svc.reindexTargeted({})).toBe(2);
+    expect(await svc.reindexTargeted({ pageId: "00000000-0000-0000-0000-000000000000" })).toBe(0);
+  });
+
+  it("backfillMissing embeds pages authored before a provider existed, idempotently", async () => {
+    // Author a page with no provider → chunk stored lexical-only (NULL embedding).
+    const offline = makeService(db, fakeEmbeddings(false));
+    await offline.createPage({ title: "T", content: "france content here" });
+    expect(await embeddedCount()).toBe(0);
+
+    // Provider now available → backfill embeds the stale page.
+    const online = makeService(db, fakeEmbeddings(true));
+    expect(await online.backfillMissing()).toBe(1);
+    expect(await embeddedCount()).toBeGreaterThan(0);
+    // Nothing left to backfill.
+    expect(await online.backfillMissing()).toBe(0);
+  });
+
+  it("backfillMissing is a no-op when no provider is available", async () => {
+    const offline = makeService(db, fakeEmbeddings(false));
+    await offline.createPage({ title: "T", content: "body text" });
+    expect(await offline.backfillMissing()).toBe(0);
+  });
+
+  it("indexStatus reports DB-derived counts and a null queue when unwired", async () => {
+    const svc = makeService(db, fakeEmbeddings(true));
+    await svc.createPage({ title: "A", content: "alpha body" });
+    const status = await svc.indexStatus();
+    expect(status.activePages).toBe(1);
+    expect(status.chunks.total).toBeGreaterThan(0);
+    expect(status.chunks.embedded).toBe(status.chunks.total);
+    expect(status.chunks.lexicalOnly).toBe(0);
+    expect(status.queue).toBeNull();
+  });
+
+  it("indexStatus surfaces pg-boss queue stats when wired", async () => {
+    const failedAt = new Date();
+    const svc = new KnowledgeService({
+      pages: new PgKnowledgePageRepo(db),
+      chunks: new PgKnowledgeChunkRepo(db),
+      revisions: new PgKnowledgeRevisionRepo(db),
+      embeddings: fakeEmbeddings(true),
+      indexQueueStats: async () => ({ pending: 3, lastError: { message: "boom", failedAt } }),
+    });
+    const status = await svc.indexStatus();
+    expect(status.queue?.pending).toBe(3);
+    expect(status.queue?.lastError?.message).toBe("boom");
+  });
 });

--- a/apps/api/src/knowledge/service.ts
+++ b/apps/api/src/knowledge/service.ts
@@ -13,6 +13,8 @@ import type {
   Backlink,
   EmbeddingPort,
   IndexingStatus,
+  IndexQueueStats,
+  IndexStatusReport,
   KnowledgePage,
   KnowledgeRevision,
   KnowledgeSource,
@@ -125,6 +127,8 @@ export interface KnowledgeServiceDeps {
   embeddings: EmbeddingPort;
   /** When set, page writes enqueue async (re)indexing instead of indexing inline. */
   enqueueIndex?: (pageId: string) => Promise<void>;
+  /** Operational stats for the async index queue (pg-boss). Absent → index-status omits queue info. */
+  indexQueueStats?: () => Promise<IndexQueueStats>;
   /** OKF space repos — optional; required only for the OKF space/page methods. */
   spaces?: KnowledgeSpaceRepo;
   links?: KnowledgeLinksRepo;
@@ -617,6 +621,59 @@ export class KnowledgeService {
 
   reindexAll(): Promise<number> {
     return reindexAll(this.deps.pages, this.deps.chunks, this.deps.embeddings);
+  }
+
+  /**
+   * Manual re-index. `pageId` re-indexes one page; `spaceId` re-indexes a whole space; neither
+   * falls back to a full re-index. Returns the number of pages re-indexed.
+   */
+  async reindexTargeted(opts: { pageId?: string; spaceId?: string }): Promise<number> {
+    if (opts.pageId) {
+      const page = await this.deps.pages.getById(opts.pageId);
+      if (!page?.active) return 0;
+      await this.indexPage(page);
+      return 1;
+    }
+    if (opts.spaceId) {
+      const pages = await this.deps.pages.listBySpace(opts.spaceId);
+      for (const page of pages) await this.indexPage(page);
+      return pages.length;
+    }
+    return this.reindexAll();
+  }
+
+  /**
+   * One-shot backfill: (re)index every active page that has a chunk which is unembedded or embedded
+   * under a stale model (covers pages authored while no provider was configured). No-op (returns 0)
+   * when no embedding provider is available. Enqueues async (non-blocking) when a queue is wired,
+   * else indexes inline — same dispatch as a normal write. Returns the number of pages dispatched.
+   */
+  async backfillMissing(): Promise<number> {
+    const active = this.deps.embeddings.isAvailable() ? this.deps.embeddings.getActive() : null;
+    if (!active?.model) return 0;
+    const ids = await this.deps.chunks.listPageIdsNeedingEmbedding(active.model);
+    for (const id of ids) {
+      if (this.deps.enqueueIndex) await this.deps.enqueueIndex(id);
+      else await this.reindexById(id);
+    }
+    return ids.length;
+  }
+
+  /** DB-derived index health (+ pg-boss queue stats when wired). */
+  async indexStatus(): Promise<IndexStatusReport> {
+    const stats = await this.deps.chunks.indexStats();
+    let queue: IndexQueueStats | null = null;
+    if (this.deps.indexQueueStats) queue = await this.deps.indexQueueStats();
+    return {
+      activePages: stats.activePages,
+      chunks: {
+        total: stats.totalChunks,
+        embedded: stats.embeddedChunks,
+        lexicalOnly: stats.lexicalChunks,
+      },
+      indexLagSeconds: stats.maxLagSeconds,
+      queue,
+    };
   }
 
   /** Full re-index when the embedding dimension changed (KN-V1-002 guard). */

--- a/apps/api/src/knowledge/types.ts
+++ b/apps/api/src/knowledge/types.ts
@@ -127,6 +127,20 @@ export interface KnowledgeRevision {
 export interface ChunkInput {
   chunkIndex: number;
   content: string;
+  /** `md5(content)` — content address used to skip re-embedding unchanged chunks on re-index. */
+  contentHash: string;
+  embedding: number[] | null;
+  model: string | null;
+  dim: number | null;
+}
+
+/**
+ * Existing-chunk projection used by the re-index diff: enough to decide whether a new chunk at the
+ * same `chunkIndex` can reuse this chunk's embedding (`contentHash` matches AND `model` is current).
+ */
+export interface ExistingChunk {
+  chunkIndex: number;
+  contentHash: string | null;
   embedding: number[] | null;
   model: string | null;
   dim: number | null;
@@ -154,6 +168,30 @@ export interface SearchHit {
 export interface SearchResults {
   results: SearchHit[];
   warnings: string[];
+}
+
+/** Aggregate index health, all derived from our own tables (no counters). */
+export interface IndexStats {
+  activePages: number;
+  totalChunks: number;
+  embeddedChunks: number;
+  lexicalChunks: number;
+  /** Max seconds an active page's content has been newer than its freshest chunk (0 = caught up). */
+  maxLagSeconds: number | null;
+}
+
+/** Operational view of the async index queue (sourced from pg-boss; null when unavailable). */
+export interface IndexQueueStats {
+  pending: number;
+  lastError: { message: string; failedAt: Date } | null;
+}
+
+/** Combined index-status report surfaced by `GET /api/v1/knowledge/index-status`. */
+export interface IndexStatusReport {
+  activePages: number;
+  chunks: { total: number; embedded: number; lexicalOnly: number };
+  indexLagSeconds: number | null;
+  queue: IndexQueueStats | null;
 }
 
 /** Structural subset of `@tulipfarm/llm` EmbeddingService that knowledge depends on. */

--- a/apps/api/src/pg-migrate.test.ts
+++ b/apps/api/src/pg-migrate.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { runPgMigrations } from "./pg-migrate";
 import { makePglite } from "./test/pglite";
 
-describe("runPgMigrations — 001_init + 002_knowledge + 003_stream_resume + 004_approvals + 005_conversation_title + 006_message_feedback + 007_conversation_starred + 008_hitl + 009_kv_store + 010_wrapped_deks + 011_okf + 012_okf_crosslinks + 013_drop_bundle_domain + 014_drop_okf_type + 015_title_tsv + 016_doc_type + 017_pg_trgm + 018_terminology_rename on PGlite", () => {
+describe("runPgMigrations — 001_init + 002_knowledge + 003_stream_resume + 004_approvals + 005_conversation_title + 006_message_feedback + 007_conversation_starred + 008_hitl + 009_kv_store + 010_wrapped_deks + 011_okf + 012_okf_crosslinks + 013_drop_bundle_domain + 014_drop_okf_type + 015_title_tsv + 016_doc_type + 017_pg_trgm + 018_terminology_rename + 019_chunk_content_hash + 020_knowledge_connectors on PGlite", () => {
   let db: PGlite;
 
   beforeEach(async () => {
@@ -14,10 +14,10 @@ describe("runPgMigrations — 001_init + 002_knowledge + 003_stream_resume + 004
     await db.close();
   });
 
-  it("advances schema_version to the latest (18)", async () => {
+  it("advances schema_version to the latest (20)", async () => {
     await runPgMigrations(db);
     const res = await db.query<{ version: number }>("SELECT version FROM schema_version");
-    expect(res.rows.map((r) => Number(r.version))).toEqual([18]);
+    expect(res.rows.map((r) => Number(r.version))).toEqual([20]);
   });
 
   it("creates the vector and citext extensions", async () => {
@@ -40,6 +40,7 @@ describe("runPgMigrations — 001_init + 002_knowledge + 003_stream_resume + 004
       "conversations",
       "counters",
       "knowledge_chunks",
+      "knowledge_connectors",
       "knowledge_links",
       "knowledge_pages",
       "knowledge_revisions",
@@ -79,11 +80,11 @@ describe("runPgMigrations — 001_init + 002_knowledge + 003_stream_resume + 004
     ]);
   });
 
-  it("is idempotent — a second run does not throw and leaves version at 18", async () => {
+  it("is idempotent — a second run does not throw and leaves version at 20", async () => {
     await runPgMigrations(db);
     await runPgMigrations(db);
     const res = await db.query<{ version: number }>("SELECT version FROM schema_version");
-    expect(res.rows.map((r) => Number(r.version))).toEqual([18]);
+    expect(res.rows.map((r) => Number(r.version))).toEqual([20]);
   });
 
   it("adds knowledge_pages.title_tsv (generated tsvector) + its GIN index (015, renamed by 018)", async () => {

--- a/apps/api/src/pg-migrations/index.ts
+++ b/apps/api/src/pg-migrations/index.ts
@@ -393,6 +393,40 @@ const OKF_CROSSLINK_STATEMENTS: string[] = [
     ON knowledge_links (target_bundle_name) WHERE target_bundle_name IS NOT NULL`,
 ];
 
+/**
+ * Chunk-level content hash (embeddings pipeline hardening). `content_hash` is `md5(content)` —
+ * cheap, non-cryptographic, and matchable in both SQL (`md5()`) and Node (`createHash("md5")`).
+ * On re-index the indexer reuses an existing chunk's embedding when its `(content_hash, model)`
+ * still matches the active model, so a one-line edit re-embeds only the changed chunk instead of
+ * the whole page. The backfill seeds hashes for existing rows so the first post-upgrade re-index
+ * already reuses untouched chunks.
+ */
+const CHUNK_CONTENT_HASH_STATEMENTS = async (q: Queryable): Promise<void> => {
+  await q.query("ALTER TABLE knowledge_chunks ADD COLUMN IF NOT EXISTS content_hash text");
+  await q.query(
+    "UPDATE knowledge_chunks SET content_hash = md5(content) WHERE content_hash IS NULL"
+  );
+};
+
+/**
+ * Connector sync state (connector framework). One row per registered external-source connector,
+ * keyed by `name`. `cursor` persists incremental sync position (opaque per connector) so syncs
+ * resume where they left off; `last_run_at`/`last_error` give the index-status surface operational
+ * visibility. The connector only ever writes pages through the existing funnels — it never touches
+ * `knowledge_chunks` or embeddings.
+ */
+const CONNECTOR_STATE_STATEMENTS: string[] = [
+  `CREATE TABLE IF NOT EXISTS knowledge_connectors (
+    name        text PRIMARY KEY,
+    enabled     boolean NOT NULL DEFAULT false,
+    cursor      text,
+    last_run_at timestamptz,
+    last_error  text,
+    created_at  timestamptz NOT NULL,
+    updated_at  timestamptz NOT NULL
+  )`,
+];
+
 // ── Guarded rename helpers (terminology migration v18) ───────────────────────────────────────
 // ALTER ... RENAME is not naturally idempotent, so each helper checks the catalog first. This
 // keeps a partial-failure re-run safe and runs statement-by-statement on PGlite (no plpgsql DO).
@@ -664,5 +698,21 @@ export const PG_MIGRATIONS: PgMigration[] = [
     description:
       "terminology: rename knowledge bundle→space, document/concept→page (tables, columns, indexes); retire legacy collections",
     up: TERMINOLOGY_RENAME_STATEMENTS,
+  },
+  {
+    version: 19,
+    description:
+      "knowledge: knowledge_chunks.content_hash (md5) + backfill — chunk-level re-index dedup",
+    up: CHUNK_CONTENT_HASH_STATEMENTS,
+  },
+  {
+    version: 20,
+    description:
+      "knowledge: knowledge_connectors sync-state table (name, enabled, cursor, last_run_at, last_error)",
+    up: async (q) => {
+      for (const sql of CONNECTOR_STATE_STATEMENTS) {
+        await q.query(sql);
+      }
+    },
   },
 ];


### PR DESCRIPTION
…onnector framework

content_hash (md5) skips re-embedding unchanged chunks; admin reindex/backfill/ index-status endpoints; ~4-method Connector framework (SampleConnector + stubs + scheduled sync). Migrations v19+v20 -> schema_version 20.