### PR TITLE
docs: reframe prompt-first, add prompt block, restructure guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ TulipFarm — AI-native business operating system. pnpm + Turborepo monorepo.
 | --- | --- |
 | [`apps/api`](apps/api/AGENTS.md) | Fastify API server. PostgreSQL (pgvector + pg-boss), migration-on-boot, soul git store. |
 | [`apps/web`](apps/web/AGENTS.md) | Remix + React web UI. |
+| [`apps/docs`](apps/docs/AGENTS.md) | Fumadocs public documentation site (static export). Prompt-first docs conventions. |
 | [`packages/llm`](packages/llm/AGENTS.md) | LLM provider abstraction + tiered fallback chains (`@tulipfarm/llm`). |
 | [`packages/soul`](packages/soul/AGENTS.md) | Soul artifact loader + git sync (`@tulipfarm/soul`). |
 | [`packages/secrets`](packages/secrets/AGENTS.md) | Encrypted secret storage + key rotation (`@tulipfarm/secrets`). |

--- a/apps/docs/AGENTS.md
+++ b/apps/docs/AGENTS.md
@@ -1,0 +1,115 @@
+# Docs Site — Agent Conventions
+
+`@tulipfarm/docs` — the public documentation site. [Fumadocs](https://fumadocs.dev) on
+Next.js, **static export** (`next build` → `out/`). Dev on `:4020`. See root `AGENTS.md`
+for monorepo commands, Biome rules, and git policy; see `README.md` for deployment.
+
+> **Terminology is binding** — [`metadata/terminologies.md`](../../metadata/terminologies.md).
+> In these docs that means: **chat** (never "conversation"), **space** / **page** (never
+> bundle/concept/document/collection), and the platform agents by their display names —
+> **General Assistant** and **Information Architect** (not the PascalCase code names).
+
+## The one rule that governs everything here
+
+**TulipFarm is built by chatting, so the docs lead with prompts, not files.** A user
+describes what they want and agents build it — they do not edit YAML or run git. Write
+every build task that way:
+
+- **Lead with an example prompt**, in a ` ```prompt ` block (see below). "Ask the
+  assistant: *Create a customer resource type with a name and an email.*"
+- **Never put a soul-editing procedure in a user guide** — no `mkdir`/`cat > schema.yml`/
+  `git commit`/restart walls. That is operator territory and reads as "this is how you do
+  it," which is wrong.
+- **YAML/`AGENT.md` appears only as read-only explanation** on *concept* pages ("here is
+  what the assistant writes underneath"), never as a step a reader is told to type.
+- The **soul** (`~/.tulipfarm/soul`, a git repo) is the *result* of those chats, not the
+  interface. Frame it that way.
+
+### How building actually works (verify against `apps/api/src/soul/agents/platform-agents.ts`)
+
+- **General Assistant** — the default chat agent / front desk. Answers, reads, and creates
+  **records + knowledge** directly.
+- It **transfers** any "build/change my system" request (resource type, agent, skill,
+  onboarding) to the **Information Architect**, which loads a **forge**
+  (`resource-forge` / `agent-forge` / `skill-forge` / `onboarding`), interviews the user,
+  and writes the artifact. The handoff is visible to the user.
+- Soul writes commit immediately and reconcile **live — no restart** (`create_resource_type`
+  calls `soulLoader.reload()` + `reconcile()`).
+- **The only non-agentic exception:** secrets and LLM-provider config are set in **Settings**
+  (admin UI), not by chat. Those guides stay UI/CLI-based — do not force prompts onto them.
+
+## The `prompt` block
+
+Any message a reader would type to the assistant goes in a ` ```prompt ` fenced block — it
+renders with an AI icon, a "Prompt" label, a copy button, and a warm gradient underline,
+marking it as a prompt rather than runnable code. Use ` ```bash `/` ```json `/` ```yaml `
+for real commands/config and ` ```text ` only for diagrams (the soul tree, the encryption
+envelope) — **never ` ```text ` for a prompt.**
+
+How it works — do not route prompts through the syntax highlighter:
+
+- `lib/remark-prompt.ts` — remark plugin that rewrites ` ```prompt ` code nodes into
+  `<PromptBlock>` at the mdast stage, before Shiki ever sees the unknown `prompt` language.
+- `components/prompt-block.tsx` — the rendered component.
+- Wired in `source.config.ts` (`mdxOptions.remarkPlugins`) and `components/mdx.tsx`
+  (component map). **Changing `source.config.ts` requires a dev-server restart** (content
+  `.mdx`/`meta.json` edits hot-reload; build config does not).
+
+## Accuracy is non-negotiable
+
+Documentation that lies is worse than none. Before writing any factual claim:
+
+- **Verify it against the code** — tool names in `apps/api/src/**/tools.ts`, LLM behavior in
+  `packages/llm/src`, env vars at their `process.env` read sites, ports in app configs.
+  Copy names exactly (`tulip_` token prefix, not `tf_`; four provider integrations, not
+  "55+").
+- **Never document an unshipped feature.** Routines and Integrations are empty-state
+  placeholders in the app (`apps/web/app/routes/_app.{routines,integrations}.tsx`) — their
+  guides are honest "not yet available" stubs, not invented how-tos. If a feature isn't in
+  the code, it isn't in the docs.
+
+## Structure (Diátaxis)
+
+One reader-need per page; do not mix quadrants.
+
+| Section | Quadrant | Notes |
+| --- | --- | --- |
+| `concepts/` | Explanation | How/why. Links out to guides for steps; never numbered procedures. |
+| `guides/` | How-to | Task recipes. Build tasks are prompt-first. |
+| `reference/` | Reference | Env vars, commands — complete and neutral. |
+| `security/` | Reference + explanation | Encryption, hashing. |
+
+- **Guides are grouped with `meta.json` section separators** (`"---Setup---"` etc.), **not
+  subfolders** — subfolders change `/docs/guides/<slug>` URLs and break every inbound link.
+- Register any new custom MDX component in `components/mdx.tsx`.
+- Internal links must resolve to a real route; anchors to a real heading.
+
+## File map
+
+| Path | What |
+| --- | --- |
+| `content/docs/**/*.mdx` | The docs. `meta.json` per folder sets nav order + separators. |
+| `source.config.ts` | Fumadocs MDX config — frontmatter schema + `remarkPlugins`. |
+| `components/mdx.tsx` | MDX component map (`getMDXComponents`) — register components here. |
+| `components/prompt-block.tsx` | The `prompt` block component. |
+| `lib/remark-prompt.ts` | ` ```prompt ` → `<PromptBlock>` transform. |
+| `app/docs/[[...slug]]/page.tsx` | Docs page renderer. |
+
+## Verify before done
+
+```bash
+pnpm --filter @tulipfarm/docs lint        # biome
+pnpm --filter @tulipfarm/docs typecheck   # fumadocs-mdx + next typegen + tsc (validates MDX + frontmatter)
+pnpm --filter @tulipfarm/docs build        # static export — RUNS the remark plugin; the true test
+```
+
+The full `build` is the only check that exercises ` ```prompt ` transforms and `meta.json`
+separators end-to-end. Grepping `out/` HTML confirms a component actually rendered.
+
+## Design language
+
+Mirrors the web app (see `app/global.css`, mapped onto fumadocs tokens): **JetBrains Mono
+only, no shadows, hairline borders, warm cream/near-black palette, ruby (`--color-fd-primary`)
+as the sole brand accent.** The prompt block's warm ruby→amber gradient underline is the one
+deliberate exception — keep gradients out of everything else. Add `cursor-pointer` to every
+clickable element.

--- a/apps/docs/components/mdx.tsx
+++ b/apps/docs/components/mdx.tsx
@@ -1,9 +1,11 @@
 import defaultMdxComponents from "fumadocs-ui/mdx";
 import type { MDXComponents } from "mdx/types";
+import { PromptBlock } from "@/components/prompt-block";
 
 export function getMDXComponents(components?: MDXComponents) {
   return {
     ...defaultMdxComponents,
+    PromptBlock,
     ...components,
   } satisfies MDXComponents;
 }

--- a/apps/docs/components/prompt-block.tsx
+++ b/apps/docs/components/prompt-block.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { Check, Copy, Sparkles } from "lucide-react";
+import { useState } from "react";
+
+/**
+ * Renders a ```prompt block: an example message a reader types to the assistant.
+ * Distinct from a code block — an AI icon labels it, and a warm ruby→amber
+ * gradient underline (the one place gradient is allowed in the otherwise flat,
+ * ruby-only design language) marks it as a prompt rather than runnable code.
+ */
+export function PromptBlock({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = () => {
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  return (
+    <div className="not-prose relative my-4 overflow-hidden rounded-lg border border-fd-border bg-fd-card">
+      <div className="flex items-center justify-between gap-2 px-4 pt-3 pb-2">
+        <span className="flex items-center gap-1.5 text-xs font-medium tracking-wide text-fd-muted-foreground">
+          <Sparkles className="size-3.5 text-fd-primary" aria-hidden />
+          Prompt
+        </span>
+        <button
+          type="button"
+          onClick={copy}
+          aria-label="Copy prompt"
+          className="cursor-pointer text-fd-muted-foreground transition-colors hover:text-fd-foreground"
+        >
+          {copied ? (
+            <Check className="size-3.5" aria-hidden />
+          ) : (
+            <Copy className="size-3.5" aria-hidden />
+          )}
+        </button>
+      </div>
+      <pre className="overflow-x-auto whitespace-pre-wrap px-4 pb-4 font-mono text-sm leading-relaxed text-fd-foreground">
+        {text}
+      </pre>
+      <div
+        aria-hidden
+        className="absolute inset-x-0 bottom-0 h-0.5 bg-gradient-to-r from-fd-primary via-rose-400 to-amber-400"
+      />
+    </div>
+  );
+}

--- a/apps/docs/content/docs/concepts/agents.mdx
+++ b/apps/docs/content/docs/concepts/agents.mdx
@@ -3,14 +3,20 @@ title: Agents
 description: The actors that run turns, each defined by an AGENT.md file.
 ---
 
-An agent is an actor that runs turns against an LLM with access to TulipFarm's tools.
-Every instance ships with one built-in agent, **GeneralAssistant**, and you can define
-more in the [soul](/docs/concepts/soul).
+An agent is an actor that runs turns against an LLM with access to TulipFarm's tools. Two
+agents are built in: the **General Assistant** (your front desk) and the **Information
+Architect** (the builder) — see [Building by chat](/docs/concepts/building). You create
+your own agents by describing them to the assistant: "create a support agent that answers
+customer questions and files tickets." The Information Architect interviews you and builds
+it.
 
-## Defined by AGENT.md
+## What an agent is made of
 
-A soul agent is a single `AGENT.md` file: YAML frontmatter plus a markdown body. The body
-is the agent's system prompt; the frontmatter is its metadata.
+Each agent the assistant builds is a single `AGENT.md` file in the
+[soul](/docs/concepts/soul): YAML frontmatter plus a markdown body. The body is the
+agent's system prompt; the frontmatter is its metadata. You do not write this — it is what
+the assistant produces from your description, shown here so you know what each setting
+means when you ask for it.
 
 ```markdown title="agents/support/AGENT.md"
 ---
@@ -27,7 +33,7 @@ knowledge base and create tickets as resources when follow-up is needed.
 
 Names are flat and kebab-cased. `domain` is display-only — it groups agents in the UI but
 grants no special access. Agents are loaded into the registry at startup, with
-GeneralAssistant listed first.
+the General Assistant listed first.
 
 ## Autonomy: how much an agent can do unsupervised
 
@@ -63,6 +69,8 @@ the instance falls back to built-in safe defaults.
 
 ## Creating agents
 
-Agents are created and edited through agent tools and forges, which write the `AGENT.md`
-directly and commit it to the soul — no approval step. The web UI lists agents and shows
-each one's prompt, but does not yet edit them.
+Ask the assistant — "create a support agent", "make me an agent that triages bugs". The
+Information Architect loads its `agent-forge`, asks what the agent should do and how much
+autonomy it gets, then writes the `AGENT.md` and commits it to the soul. There is no
+approval step, and the agent is selectable as soon as it is built. The web UI lists your
+agents and shows each one's prompt; to change an agent, ask the assistant to edit it.

--- a/apps/docs/content/docs/concepts/building.mdx
+++ b/apps/docs/content/docs/concepts/building.mdx
@@ -1,0 +1,86 @@
+---
+title: Building by chat
+description: How you build your system in TulipFarm — you describe what you want, and agents build it.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+You do not configure TulipFarm by editing files. You **describe what you want in chat**,
+and agents build it for you — resource types, agents, skills, and your day-to-day
+records and knowledge. The files in the [soul](/docs/concepts/soul) are the *result* of
+those chats, not something you normally write by hand.
+
+## The assistant is your front desk
+
+The default agent in every chat is the **General Assistant**. It answers questions, reads
+your resources and knowledge, and handles everyday data work directly — creating records,
+writing knowledge pages, searching. If your intent is clear, it acts; it does not ask for
+confirmation it does not need.
+
+What the assistant does **not** do is build your system itself. The moment you ask for
+something that changes what your instance *is* — a new resource type, an agent, a skill,
+or first-time setup — it hands the chat to a specialist.
+
+## Building hands off to the Information Architect
+
+When you ask to build or change your system, the assistant transfers the chat to
+the **Information Architect** — the agent that owns system-building. You see the handoff
+in the chat. The Information Architect then interviews you for exactly what it needs,
+builds the artifact, and hands control back.
+
+A request like any of these triggers the handoff on the first turn:
+
+- "Create an invoices resource" · "Track support tickets" · "Store our customers"
+- "Build me a CRM" · "Set up a hiring pipeline"
+- "Create a support agent" · "Make a skill that drafts replies"
+- "Set up my business" (first-time onboarding)
+
+You do not phrase these in any special way and you do not write schema. You say what you
+want in plain language; the Information Architect asks the few questions it needs and
+does the rest.
+
+## Forges guide the build
+
+The Information Architect does not improvise. For each kind of artifact it loads a
+built-in **forge** — a structured interview that walks from intent to a finished
+artifact:
+
+| Forge | Builds |
+|---|---|
+| `resource-forge` | a resource type and its schema |
+| `agent-forge` | an agent |
+| `skill-forge` | a skill |
+| `onboarding` | a whole starter setup, in one guided session |
+
+Forges ship with TulipFarm. They are not something you install or edit — they are how
+building works.
+
+## The result lives in the soul
+
+When the Information Architect finishes, the artifact is written to your
+[soul repository](/docs/concepts/soul) and committed — a resource type becomes
+`resources/{name}/schema.yml`, an agent becomes `agents/{name}/AGENT.md`. There is no
+approval step for soul writes, and the change takes effect immediately — a new resource
+type's table is ready without a restart. The git history is your audit trail of every
+build.
+
+You *can* edit those files by hand if you want to — they are plain text in a git repo —
+but that is the power-user path, not the everyday one. Each concept page shows the
+underlying format for readers who want it.
+
+## What you still do in Settings
+
+Two things are deliberately kept out of chat, because they are operator decisions, not
+building:
+
+<Callout type="info">
+Agents cannot set **secrets** or change your **LLM providers**. You configure those under
+**Settings** as an admin — see [Configure LLM providers](/docs/guides/configure-llm-providers)
+and [Store a secret](/docs/guides/store-a-secret). Everything else, you build by chatting.
+</Callout>
+
+## Where to go next
+
+- [Define a resource type](/docs/guides/define-a-resource-type) — the build chat, step by step.
+- [Resources](/docs/concepts/resources), [Agents](/docs/concepts/agents), [Skills](/docs/concepts/skills) — what you can build, and the format each produces.
+- [Soul](/docs/concepts/soul) — where everything you build is stored and versioned.

--- a/apps/docs/content/docs/concepts/index.mdx
+++ b/apps/docs/content/docs/concepts/index.mdx
@@ -5,22 +5,24 @@ description: How TulipFarm's parts fit together — soul, resources, agents, ski
 
 import { Cards, Card } from "fumadocs-ui/components/card";
 
-TulipFarm models a business as **configuration** and **data**, and lets agents act on
-both. The separation is deliberate, and it is the single idea that explains everything
-else:
+You operate TulipFarm by **talking to it**. You describe what you want, and agents build
+and run it for you — see [Building by chat](/docs/concepts/building). Underneath, two
+things make that work, and the separation between them explains everything else:
 
 - **Definitions live in the soul** (a git repository): resource schemas, agents,
-  skills. These are files you can read, diff, and version.
+  skills. These are files agents write when you ask them to — readable, diffable, and
+  versioned.
 - **Data lives in the datastore** (PostgreSQL): the records your resources hold, your
-  knowledge base, conversations, and secrets.
+  knowledge base, chats, and secrets.
 
-Editing the soul changes what your instance *is*. Writing to the datastore changes what
+Building the soul changes what your instance *is*. Writing to the datastore changes what
 it *knows*. Agents do both — but the two are governed differently. Soul writes are never
 gated; real-world actions an agent takes are gated by its autonomy level.
 
 ## The parts
 
 <Cards>
+  <Card title="Building by chat" href="/docs/concepts/building" description="How you build your system — describe it, and agents build it for you." />
   <Card title="Soul" href="/docs/concepts/soul" description="The git-backed configuration store that defines your instance." />
   <Card title="Resources" href="/docs/concepts/resources" description="Schema-defined data types and the records that fill them." />
   <Card title="Agents" href="/docs/concepts/agents" description="The actors that run turns, defined by an AGENT.md file." />

--- a/apps/docs/content/docs/concepts/knowledge.mdx
+++ b/apps/docs/content/docs/concepts/knowledge.mdx
@@ -1,36 +1,84 @@
 ---
 title: Knowledge
-description: The searchable corpus agents draw on, backed by vector search.
+description: The searchable, interlinked corpus your agents and your team draw on.
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-The knowledge base is the searchable body of text your agents draw on. It is built from
-pages, organized into spaces, indexed in the background, and queried by vector
-search.
+The knowledge base is the searchable body of text your agents and your team draw on. It
+is built from pages, organized into spaces, cross-linked like a wiki, indexed in the
+background, and queried by search.
 
 ## How knowledge gets in
 
 Knowledge is populated from a few sources, not by file upload:
 
-- **Authored pages** — markdown text created through the knowledge API or by an
-  agent tool.
+- **Authored pages** — markdown text created through the knowledge UI, the knowledge
+  API, or an agent tool.
 - **Resource records** — your resource data is indexed so agents can search it.
-- **Agent conversations** — completed conversations are indexed as knowledge.
+- **Chats** — completed chats are indexed as knowledge.
 
-There is no file upload in V1, so authored content is markdown text only. Pages carry
-revisions, so edits are tracked over time.
+There is no file upload in V1, so authored content is markdown text only. Every page
+carries revisions, so edits are tracked over time.
 
-Knowledge is organised into **spaces** — wiki-like groups of cross-linked **pages** you
-can browse, target for search, or inject into agents. Create and manage spaces and pages
-in the **Knowledge** section of the web UI, or through the API.
+## Spaces and pages
+
+Knowledge is organised into **spaces** — wiki-like groups of cross-linked **pages**. A
+page is markdown stored at a path within its space, such as `tables/orders`. You browse
+spaces and pages in the **Knowledge** section of the web UI, target a single space for
+search, or inject a space into an agent. Create and manage them in the UI or through the
+API — see [Use the knowledge wiki](/docs/guides/use-the-knowledge-wiki).
+
+## Pages link to each other
+
+While editing a page, typing `@` opens a menu of other pages, agents, and resource types
+to link to; typing `#` tags the page. A link to a page in the same space points straight
+at it; a link to a page in another space is encoded as `tf:page/<Space>/<path>` and
+resolved when the page is indexed.
+
+Links are kept honest as the wiki changes. Renaming a space rewrites the inbound links
+that pointed at its old name. A link whose target cannot be resolved renders as muted
+text rather than a dead link, so a broken reference is visible instead of silently
+wrong. This is what makes the knowledge base a navigable wiki rather than a flat list.
+
+## Backlinks show what points here
+
+Every inbound link is tracked, so each page shows a **Linked from** list of the pages
+that reference it. Backlinks are the reverse of the links you author — there is nothing
+extra to maintain. They surface context you would otherwise miss: the policies that cite
+a procedure, the runbooks that reference a service.
+
+## Pages keep their history
+
+Every edit snapshots the previous version. A page's overflow menu opens its **History**,
+where you can read any past revision and restore it. Restoring is itself a write: the
+restored content becomes the current version and is snapshotted in turn, so no revision
+is ever lost.
+
+## The space graph
+
+Each space also renders as a graph — pages are nodes and the links between them are
+edges. Links that leave the space appear as faded stub nodes pointing outward. The graph
+is a fast way to see how a body of knowledge hangs together and to spot orphan pages that
+nothing links to.
 
 ## Indexing and search
 
-When a page changes, a background job re-indexes it: it splits the page into
-chunks, embeds each chunk, and stores the vectors. Search then ranks chunks by vector
-similarity and returns the best matches. Indexing is idempotent and retries on failure,
-so a transient error does not leave the index half-written.
+When a page changes, a background job re-indexes it: it splits the page into chunks,
+embeds each chunk, and stores the vectors. Indexing is idempotent and retries on failure,
+so a transient error never leaves the index half-written. An edit only re-embeds the
+chunks that actually changed, so large pages stay cheap to update.
+
+There are two ways to search:
+
+- **Meaning-based search** ranks chunks by vector similarity. Agents use it through the
+  `query_knowledge` tool, and it powers semantic lookups across the corpus.
+- **Lexical page search** ranks whole pages by title, body, and recency, with typo
+  tolerance. The ⌘K command palette and the sidebar search box both use it; you can
+  filter results by space, tag, domain, or source.
+
+Operators can re-index pages or inspect index health through admin API endpoints
+(`reindex`, `backfill`, and `index-status`). There is no UI for these in V1.
 
 ## Embeddings degrade gracefully
 
@@ -43,9 +91,20 @@ you have configured a cloud provider:
    Results come back flagged with an `embedding-unavailable` warning so you know you are
    in fallback mode.
 
+## Knowledge in chat
+
+Agents draw on knowledge during a chat in two ways:
+
+- They search it themselves and **cite what they used** — the answer carries inline `[1]`,
+  `[2]` markers that link to the source pages.
+- You can **pin a specific page** into a turn by typing `~` in the composer, so the agent
+  answers from exactly that page.
+
+See [Cite knowledge in chat](/docs/guides/cite-knowledge-in-chat) for the workflow.
+
 ## Governance knowledge
 
-A page flagged to always load is injected into every agent's context as a
-governance block — your operating rules and policies, available to every turn without the
-agent having to search for them. Injection respects size caps; content that would
-overflow the budget is skipped rather than truncated mid-page.
+A page flagged to always load is injected into every agent's context as a governance
+block — your operating rules and policies, available to every turn without the agent
+having to search for them. Injection respects size caps; content that would overflow the
+budget is skipped rather than truncated mid-page.

--- a/apps/docs/content/docs/concepts/llm.mdx
+++ b/apps/docs/content/docs/concepts/llm.mdx
@@ -3,23 +3,26 @@ title: LLM tiers
 description: How TulipFarm chooses a model and falls back across providers.
 ---
 
-TulipFarm talks to language models through a single adapter (the Vercel AI SDK), so the
-same configuration works across 55+ providers. You do not wire a model into each agent.
-Instead you define **tiers**, and the runtime picks a tier per turn.
+TulipFarm talks to language models through a single adapter (the Vercel AI SDK). It
+ships four provider integrations — **Anthropic**, **OpenAI**, **Azure OpenAI**, and any
+**OpenAI-compatible** endpoint (which covers gateways like OpenRouter, Together, and
+Groq through their compatible APIs). You do not wire a model into each agent. Instead you
+define **tiers**, and the runtime picks a tier per turn.
 
 ## Three tiers
 
 Every instance configures three tiers, from cheapest and fastest to most capable:
 
-| Tier | Default model |
+| Tier | Recommended model |
 |---|---|
 | `quick` | `claude-haiku-4-5` |
 | `standard` | `claude-sonnet-4-6` |
 | `complex` | `claude-opus-4-8` |
 
-The tier configuration lives in `soul/llm.config.yaml` and is edited through
-**Settings → LLM** in the web UI. Each tier is an *ordered list* of providers — and the
-order is the fallback chain.
+These are recommended models, not enforced defaults — each tier needs at least one
+provider and model assigned before agents can run. The tier configuration lives in
+`soul/llm.config.yaml` and is edited through **Settings → LLM** in the web UI. Each tier
+is an *ordered list* of providers — and the order is the fallback chain.
 
 ## Fallback chains
 
@@ -31,10 +34,17 @@ provider outage degrades to the backup instead of failing the turn.
 ## Automatic tier selection
 
 A turn does not have to name a tier. With `model: auto`, TulipFarm picks one from
-context:
+context. The starting point is the agent's [autonomy](/docs/concepts/agents):
 
-- An agent's [autonomy](/docs/concepts/agents) maps to a tier — for example,
-  `supervised` selects `standard`.
+| Autonomy | Starting tier |
+|---|---|
+| `full` | `quick` |
+| `supervised` | `standard` |
+| `approval-required` | `complex` |
+| `manual` | `standard` |
+
+An agent with no autonomy set starts at `standard`. Two adjustments then apply on top:
+
 - Tasks flagged as decisions escalate to `complex`.
 - A `quick` turn is bumped to `standard` when tools are in scope.
 

--- a/apps/docs/content/docs/concepts/meta.json
+++ b/apps/docs/content/docs/concepts/meta.json
@@ -1,4 +1,14 @@
 {
   "title": "Concepts",
-  "pages": ["index", "soul", "resources", "agents", "skills", "knowledge", "llm", "secrets"]
+  "pages": [
+    "index",
+    "building",
+    "soul",
+    "resources",
+    "agents",
+    "skills",
+    "knowledge",
+    "llm",
+    "secrets"
+  ]
 }

--- a/apps/docs/content/docs/concepts/resources.mdx
+++ b/apps/docs/content/docs/concepts/resources.mdx
@@ -5,18 +5,24 @@ description: Schema-defined data types and the records that fill them.
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-A resource is a data type you define with a JSON Schema. A resource *type* is the schema;
-a *record* is one instance of that type. Define a `customer` type once, and you get
-validated storage and a CRUD interface for customer records.
+A resource is a data type, like `customer` or `ticket`. A resource *type* is its shape; a
+*record* is one instance of that type. You create a type by describing it to the
+assistant — "track customers with a name and an email" — and from then on you get
+validated storage and a full interface for its records.
+
+You never have to write the shape yourself. The rest of this page describes what the
+assistant builds on your behalf and how it behaves, so you know what is possible to ask
+for. To do it, see [Define a resource type](/docs/guides/define-a-resource-type).
 
 ## Two halves: schema and data
 
-The schema lives in the [soul](/docs/concepts/soul) as
-`resources/{name}/schema.yml`. The records live in the datastore. When TulipFarm boots,
-it reads each schema and materializes a table for it — this is called reconciliation. Add
-a schema, restart, and the type is ready to hold records.
+Under the hood a type is a **JSON Schema** the assistant writes into the
+[soul](/docs/concepts/soul) at `resources/{name}/schema.yml`; the records live in the
+datastore. TulipFarm reads each schema and materializes a table for it — this is called
+reconciliation. A type the assistant creates is reconciled immediately, ready to hold
+records with no restart.
 
-A schema is plain JSON Schema written in YAML:
+The schema it writes is plain JSON Schema in YAML — for the `customer` example, this:
 
 ```yaml title="resources/customer/schema.yml"
 type: object
@@ -69,11 +75,14 @@ write:
   `uuid`, `sequence`.
 
 These cover the common before-write cases without code. For arbitrary logic, a resource
-type can include a `hooks.ts` file executed in an isolated sandbox (`isolated-vm`).
+type can include a `hooks.ts` file executed in an isolated sandbox (`isolated-vm`). You
+ask for these in plain language too — "auto-number tickets as `TICK-1`", "lowercase the
+email" — and the assistant wires up the right extension.
 
 <Callout type="info">
-Resource types are authored in the soul today — there is no in-app form to create a new
-type yet. See [Define a resource type](/docs/guides/define-a-resource-type) for the
-workflow, and [Work with records](/docs/guides/work-with-records) to manage data once a
-type exists.
+You create resource types by asking the assistant — see
+[Define a resource type](/docs/guides/define-a-resource-type). You can also edit
+`schema.yml` in the soul by hand if you prefer; that is the power-user path. Either way,
+[Work with records](/docs/guides/work-with-records) covers managing data once a type
+exists.
 </Callout>

--- a/apps/docs/content/docs/concepts/skills.mdx
+++ b/apps/docs/content/docs/concepts/skills.mdx
@@ -30,6 +30,14 @@ committed, and recorded in `skills-lock.json` with its source URL, ref, and hash
 
 See [Install a skill](/docs/guides/install-a-skill) for the walkthrough.
 
+## Authoring a skill by chat
+
+You do not have to find a skill in a repository — you can ask for one. Tell the assistant
+"make a skill that drafts refund replies in our tone", and the Information Architect loads
+its `skill-forge`, interviews you, and writes the `SKILL.md`. A skill authored this way
+lands in a **pending** state, runs through SkillAudit just like an installed one, and goes
+live only once you activate it. The audit is part of creation, not an afterthought.
+
 ## SkillAudit: advisory, not a boundary
 
 Every skill — whether installed from a repository or authored locally — is reviewed by a
@@ -40,7 +48,7 @@ rating of low, medium, or high.
 
 <Callout type="warn">
 SkillAudit is advisory, not a guarantee. A skill is natural-language instruction, not
-code, so it cannot be sandboxed — it may read benign yet behave badly in conversation,
+code, so it cannot be sandboxed — it may read benign yet behave badly in a chat,
 and injection can be obscured. A "low risk" rating does not auto-install anything.
 </Callout>
 

--- a/apps/docs/content/docs/concepts/soul.mdx
+++ b/apps/docs/content/docs/concepts/soul.mdx
@@ -10,6 +10,10 @@ definitions that make your TulipFarm what it is: resource schemas, agents, and s
 A fresh instance creates the soul at `~/.tulipfarm/soul`, controlled by the `SOUL_PATH`
 environment variable.
 
+You rarely touch the soul directly — agents write to it when you
+[build by chat](/docs/concepts/building). This page is about what that store *is* and how
+it behaves.
+
 ## Why a git repository
 
 TulipFarm treats the soul as a configuration database that happens to sync over git.
@@ -32,14 +36,14 @@ soul/
   agents/{name}/       AGENT.md
   skills/{name}/       SKILL.md (+ references/)
   routines/{name}/     routine definitions
-  integrations/{name}/ connection config
+  integrations/{name}/ integration config
   llm.config.yaml      LLM provider tiers
   guardrails.yaml      input / tool-call / output guard rules
   soul.yaml            root manifest
   skills-lock.json     installed-skill provenance
 ```
 
-Records, knowledge, and conversations are **not** in the soul — those are data, and
+Records, knowledge, and chats are **not** in the soul — those are data, and
 they live in the datastore.
 
 ## How the soul syncs

--- a/apps/docs/content/docs/getting-started.mdx
+++ b/apps/docs/content/docs/getting-started.mdx
@@ -126,35 +126,32 @@ Skills, Knowledge, and Settings.
 
 <Step>
 
-### Define your first resource type
+### Give the assistant a model
 
-A resource type is a JSON Schema stored in your soul repo. Create one for a simple
-`customer` type:
+You build everything else by talking to the assistant, so it needs a model to run.
+Open **Settings → Secrets**, add an API key for a provider (Anthropic, OpenAI, Azure, or
+any OpenAI-compatible endpoint), then open **Settings → LLM** and assign a model to each
+tier. The walkthrough is in [Configure LLM providers](/docs/guides/configure-llm-providers).
 
-```bash
-mkdir -p ~/.tulipfarm/soul/resources/customer
-cat > ~/.tulipfarm/soul/resources/customer/schema.yml <<'YAML'
-type: object
-properties:
-  name:
-    type: string
-  email:
-    type: string
-    format: email
-required:
-  - name
-YAML
+</Step>
+
+<Step>
+
+### Build your first resource type — by asking
+
+Open **Chat** and type what you want in plain language:
+
+```prompt
+Create a customer resource type with a name and an email.
 ```
 
-Commit it to the soul repo so the change is recorded:
+The assistant hands the request to the **Information Architect**, which confirms a couple
+of details and builds the type for you. There is no schema to write and no restart — the
+new `customer` table is ready the moment it finishes. Open **Resources** and you will see
+`customer` in the list.
 
-```bash
-git -C ~/.tulipfarm/soul add .
-git -C ~/.tulipfarm/soul commit -m "Add customer resource type"
-```
-
-Restart `pnpm dev`. On boot, TulipFarm reconciles the soul: it reads
-`resources/customer/schema.yml` and materializes a `customer` table.
+This is the normal way to build in TulipFarm; see [Building by chat](/docs/concepts/building)
+for the full picture.
 
 </Step>
 
@@ -162,10 +159,14 @@ Restart `pnpm dev`. On boot, TulipFarm reconciles the soul: it reads
 
 ### Create a record
 
-In the web UI, open **Resources**. You now see `customer` in the list. Open it, choose
-**New**, fill in a name and email, and save.
+Ask the assistant to add one:
 
-You have a running TulipFarm instance with a custom resource type and your first record.
+```prompt
+Add a customer named Ada Lovelace with email ada@example.com.
+```
+
+Or open **Resources → customer → New** and fill in the form by hand. Either way you now
+have a running TulipFarm instance with a custom resource type and your first record.
 
 </Step>
 
@@ -173,6 +174,6 @@ You have a running TulipFarm instance with a custom resource type and your first
 
 ## Next steps
 
-- Read how the [soul](/docs/concepts/soul) and [resources](/docs/concepts/resources) work.
-- [Configure an LLM provider](/docs/guides/configure-llm-providers) so agents can run.
+- Read how [building by chat](/docs/concepts/building), the [soul](/docs/concepts/soul), and [resources](/docs/concepts/resources) fit together.
+- Ask the assistant to "create a support agent" — see [Agents](/docs/concepts/agents).
 - [Install a skill](/docs/guides/install-a-skill) from a git repository.

--- a/apps/docs/content/docs/guides/cite-knowledge-in-chat.mdx
+++ b/apps/docs/content/docs/guides/cite-knowledge-in-chat.mdx
@@ -1,0 +1,43 @@
+---
+title: Cite knowledge in chat
+description: Ground an agent's answer in your knowledge base — read its citations and pin a specific page.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+This guide grounds a chat answer in your [knowledge base](/docs/concepts/knowledge). It
+assumes a running instance with at least one knowledge page and an agent that can search
+knowledge — the built-in **General Assistant** can. It uses the chat workspace in the web
+UI.
+
+## Ask, and read the citations
+
+Open a chat and ask a question your knowledge base can answer:
+
+```prompt
+What is our refund policy for orders older than 30 days?
+```
+
+The agent searches knowledge, answers from what it finds, and marks each claim it drew
+from a page with an inline citation — `[1]`, `[2]`, and so on. Each marker links to the
+source page, so you can open the exact page a statement came from.
+
+<Callout type="info">
+If an answer has no citations, the agent did not draw on a stored page — either nothing
+matched, or it answered from the chat alone. Pin a page (below) to force it to use one.
+</Callout>
+
+## Pin a specific page
+
+To make the agent answer from one page in particular, type `~` in the composer. A
+search-powered menu appears; pick the page you want. It is pinned into that turn, and the
+agent answers from its full content rather than from whatever search happens to return.
+Pin more than one page by repeating `~` for each.
+
+## Governance pages load on their own
+
+Some pages are flagged to always load. Those are injected into every agent's turn as
+governance — operating rules and policies the agent sees without searching and without
+your pinning them. You do not need to cite or pin a governance page for the agent to
+follow it. See [Governance knowledge](/docs/concepts/knowledge) for how the injection
+budget works.

--- a/apps/docs/content/docs/guides/create-an-agent.mdx
+++ b/apps/docs/content/docs/guides/create-an-agent.mdx
@@ -1,0 +1,48 @@
+---
+title: Create an agent
+description: Describe an agent to the assistant and have it built for you.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+This guide creates a custom [agent](/docs/concepts/agents) by describing it to the
+assistant. It assumes a running instance with a model configured so agents can run. For
+the bigger picture, see [Building by chat](/docs/concepts/building).
+
+## Ask the assistant
+
+Open **Chat** and describe the agent you want — what it does, and what it should reach
+for:
+
+```prompt
+Create a support agent that answers customer questions from our knowledge base
+and files a ticket when a question needs follow-up.
+```
+
+The assistant hands the request to the **Information Architect**, which loads its
+`agent-forge` and asks the few things it needs: what the agent is responsible for, and how
+much it may do on its own.
+
+## Choose its autonomy
+
+The forge asks for an [autonomy](/docs/concepts/agents) level — how far the agent acts
+before pausing for a human:
+
+- `full` — acts without pausing
+- `supervised` — acts, but surfaces what it does
+- `approval-required` — pauses for explicit approval before a gated action
+- `manual` — driven step by step
+
+Pick the level that matches how much you trust the agent to run unattended. The Information
+Architect writes the `AGENT.md`, commits it to the soul, and the agent is ready — no
+approval step and no restart.
+
+## Use it
+
+Your new agent appears in the **Agents** list. To talk to it, select it in the chat agent
+picker, or mention it with `@` in the composer to route a single turn to it.
+
+<Callout type="info">
+To change an agent later — adjust its prompt, its autonomy, what it focuses on — just ask
+the assistant to edit it. You never edit the `AGENT.md` by hand unless you want to.
+</Callout>

--- a/apps/docs/content/docs/guides/define-a-resource-type.mdx
+++ b/apps/docs/content/docs/guides/define-a-resource-type.mdx
@@ -1,72 +1,48 @@
 ---
 title: Define a resource type
-description: Author a schema in the soul repo and have TulipFarm materialize it.
+description: Create a new resource type by describing it to the assistant.
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-This guide creates a new resource type by writing its schema into the
-[soul repo](/docs/concepts/soul). It assumes a running instance and shell access to the
-soul directory (`~/.tulipfarm/soul` by default).
+This guide creates a new [resource type](/docs/concepts/resources) by asking the
+assistant for it. It assumes a running instance with a model configured (so agents can
+run) and that you are signed in. For the bigger picture, see
+[Building by chat](/docs/concepts/building).
 
-A resource type's name must start with a lowercase letter and contain only lowercase
-letters, digits, and hyphens.
+## Ask the assistant
 
-## Write the schema
+Open **Chat** and describe the type you want in plain language. Name the fields, and call
+out anything special — an auto-numbered reference, a link to another type, a field that
+should be normalized:
 
-Create a directory for the type and a `schema.yml` inside it. The schema is JSON Schema,
-written in YAML:
-
-```bash
-mkdir -p ~/.tulipfarm/soul/resources/ticket
-cat > ~/.tulipfarm/soul/resources/ticket/schema.yml <<'YAML'
-type: object
-properties:
-  ref:
-    type: string
-  subject:
-    type: string
-  status:
-    type: string
-    enum: [open, closed]
-  customerId:
-    type: string
-    "x-links":
-      target: customer
-required:
-  - subject
-"x-id-strategy":
-  field: ref
-  prefix: "TICK-"
-  sequence: true
-YAML
+```prompt
+Create a ticket resource. It has a subject, a status that is either open or closed,
+and a customer it belongs to. Auto-number each ticket as TICK-1, TICK-2, and link the
+customer to our existing customer type.
 ```
 
-This declares a `ticket` type whose `ref` field is auto-assigned as `TICK-1`, `TICK-2`,
-and so on, and whose `customerId` links to a `customer` record.
+The assistant hands the request to the **Information Architect**, which loads its
+`resource-forge` and confirms the details it needs — the fields, which one is the
+human-friendly identifier, and which fields link to other types. Answer its questions,
+and it builds the type.
 
 <Callout type="info">
-A field's `x-links.target` must name a resource type that exists, and on write the linked
-record must exist too — see [Resources](/docs/concepts/resources).
+The Information Architect builds one type at a time, in dependency order. If your `ticket`
+links to a `customer`, create the `customer` type first (or ask for both, and it will
+sequence them) — a link can only point at a type that exists.
 </Callout>
 
-## Commit the change
+## What it builds for you
 
-The soul is a git repository. Commit so the change is recorded:
+From that description the Information Architect writes the schema, wires up the
+extensions, and commits it — no schema for you to write:
 
-```bash
-git -C ~/.tulipfarm/soul add .
-git -C ~/.tulipfarm/soul commit -m "Add ticket resource type"
-```
+- the `subject` and `status` fields, with `status` constrained to `open` or `closed`
+- an auto-assigned `ref` (`TICK-1`, `TICK-2`, …) via the `x-id-strategy` extension
+- a `customerId` that links to the `customer` type, checked on every write
 
-## Reconcile
-
-Restart the instance. On boot, TulipFarm reads the new schema and materializes a table
-for it:
-
-```bash
-pnpm dev
-```
+The new `ticket` table is reconciled immediately — there is no restart.
 
 ## Verify
 

--- a/apps/docs/content/docs/guides/install-a-skill.mdx
+++ b/apps/docs/content/docs/guides/install-a-skill.mdx
@@ -8,6 +8,13 @@ import { Callout } from "fumadocs-ui/components/callout";
 This guide installs a [skill](/docs/concepts/skills) from a git repository through the
 web UI. The flow is always scan, then audit, then confirm.
 
+<Callout type="info">
+Installing is for skills that already exist in a repository. To create a *new* skill, ask
+the assistant — "make a skill that drafts refund replies in our tone" — and it authors one
+for you (see [Authoring a skill by chat](/docs/concepts/skills)). Either way, the skill
+runs through SkillAudit before it goes live.
+</Callout>
+
 ## Open the marketplace
 
 In the sidebar, choose **Skills**, then **Marketplace**.

--- a/apps/docs/content/docs/guides/integrations.mdx
+++ b/apps/docs/content/docs/guides/integrations.mdx
@@ -1,0 +1,20 @@
+---
+title: Integrations
+description: Connect external services like Slack and GitHub — planned, not yet available.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+**Integrations** connect external services to your instance, so agents can pull data in
+and act on third-party systems. The groundwork exists internally, but no integration can
+be connected from the app yet.
+
+<Callout type="warn">
+Integrations are not yet available. The **Integrations** section appears in the app, but it
+is empty until the feature ships — "No integrations connected. Slack, GitHub, and
+third-party services connect here."
+</Callout>
+
+When integrations land, connecting a service and storing its credentials will run through
+the app — and the agents you [build by chat](/docs/concepts/building) will be able to use
+it. This page will become the walkthrough then.

--- a/apps/docs/content/docs/guides/issue-an-api-token.mdx
+++ b/apps/docs/content/docs/guides/issue-an-api-token.mdx
@@ -39,7 +39,7 @@ The response includes the raw token under `token`, alongside the token's name an
 metadata:
 
 ```json
-{ "token": "tf_...", "name": "my-integration" }
+{ "token": "tulip_...", "name": "my-integration" }
 ```
 
 <Callout type="warn">
@@ -54,7 +54,7 @@ cookie or CSRF header is needed:
 
 ```bash
 curl http://localhost:4010/api/v1/auth/tokens \
-  -H "Authorization: Bearer tf_..."
+  -H "Authorization: Bearer tulip_..."
 ```
 
 ## List and revoke tokens

--- a/apps/docs/content/docs/guides/meta.json
+++ b/apps/docs/content/docs/guides/meta.json
@@ -1,11 +1,23 @@
 {
   "title": "Guides",
   "pages": [
-    "define-a-resource-type",
-    "work-with-records",
-    "install-a-skill",
+    "---Setup---",
     "configure-llm-providers",
     "store-a-secret",
-    "issue-an-api-token"
+    "issue-an-api-token",
+    "---Resources---",
+    "define-a-resource-type",
+    "work-with-records",
+    "---Skills---",
+    "install-a-skill",
+    "---Agents---",
+    "create-an-agent",
+    "---Routines---",
+    "routines",
+    "---Integrations---",
+    "integrations",
+    "---Knowledge---",
+    "use-the-knowledge-wiki",
+    "cite-knowledge-in-chat"
   ]
 }

--- a/apps/docs/content/docs/guides/routines.mdx
+++ b/apps/docs/content/docs/guides/routines.mdx
@@ -1,0 +1,20 @@
+---
+title: Routines
+description: Durable, repeatable automations — planned, not yet available.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+A **routine** is a named, repeatable automation — a sequence of steps an agent can run on
+demand instead of improvising each time. The runtime can already trigger routines, but
+there is no way to author one from the app yet.
+
+<Callout type="warn">
+Routines are not yet available to create. The **Routines** section appears in the app, but
+it is empty until the feature ships — "No routines yet. Durable automations appear here
+once defined."
+</Callout>
+
+When routines land, you will build them the same way you build everything else in
+TulipFarm — by [describing what you want to the assistant](/docs/concepts/building), not by
+editing files. This page will become the walkthrough then.

--- a/apps/docs/content/docs/guides/use-the-knowledge-wiki.mdx
+++ b/apps/docs/content/docs/guides/use-the-knowledge-wiki.mdx
@@ -1,0 +1,66 @@
+---
+title: Use the knowledge wiki
+description: Create a space, write linked pages, and navigate them through backlinks, the graph, and search.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+This guide builds a small wiki by hand in the **Knowledge** section of the web UI: a
+space, a few cross-linked pages, and the tools to navigate them. It assumes a running
+instance and an account that can write knowledge. For how knowledge fits the wider system,
+see [Knowledge](/docs/concepts/knowledge).
+
+<Callout type="info">
+You can also just ask the assistant — "create a space for our refund policies and add a
+page on 30-day returns". It writes spaces and pages the same way you do here. This guide
+covers the manual editor for when you want to write knowledge yourself.
+</Callout>
+
+## Create a space
+
+In the sidebar, choose **Knowledge**, then **New space**. Give it a name and an optional
+description, and save. The space opens with an empty page tree.
+
+## Add a page
+
+With the space open, choose **New page**. A page needs a **path** — its address within
+the space, such as `tables/orders` or `policies/refunds`. Give it a title, write the body
+in markdown, and save. The page appears in the space tree at its path.
+
+## Link pages together
+
+Pages link like a wiki, from inside the editor:
+
+- Type `@` to open a menu of pages, agents, and resource types. Pick one to insert a link
+  to it. A page in the same space links directly; a page in another space is linked by
+  name and resolved when the page is indexed.
+- Type `#` to tag the page. Tags become filters you can search by.
+
+<Callout type="info">
+You do not write `tf:` link syntax by hand — selecting a cross-space target from the `@`
+menu encodes it for you.
+</Callout>
+
+## See what links to a page
+
+Open any page. Below its body, a **Linked from** list shows every page that links to it.
+This backlink list is maintained automatically — it is the reverse of the links you
+authored, so there is nothing to keep in sync.
+
+## Browse the space graph
+
+From the space, open its **graph** view. Pages are nodes and links are edges; links that
+leave the space show as faded stub nodes. Use it to see how the space hangs together and
+to find orphan pages that nothing links to.
+
+## Search with ⌘K
+
+Press **⌘K** (or **Ctrl-K**), or click the sidebar search box, to open the knowledge
+command palette. Type to search pages by title and body — results are grouped by space
+and tolerate typos. Filter to a single space when you only want results from there.
+
+## Restore a previous version
+
+Every edit is snapshotted. To roll a page back, open it, open the `⋯` overflow menu, and
+choose **History**. Read any past revision, then **Restore** it. The restored content
+becomes current and is itself snapshotted, so you can always move forward again.

--- a/apps/docs/content/docs/guides/work-with-records.mdx
+++ b/apps/docs/content/docs/guides/work-with-records.mdx
@@ -3,8 +3,23 @@ title: Work with records
 description: Create, edit, and delete records of an existing resource type in the web UI.
 ---
 
-This guide manages records through the web UI. It assumes the resource type already
-exists — if it does not, [define it first](/docs/guides/define-a-resource-type).
+This guide manages records of an existing resource type — if the type does not exist yet,
+[define it first](/docs/guides/define-a-resource-type). There are two ways to work with
+records: ask the assistant, or use the web forms. Both validate against the type's schema.
+
+## Ask the assistant
+
+The fastest path is to tell the assistant what you want in **Chat**:
+
+```prompt
+Add a customer named Ada Lovelace with email ada@example.com.
+Find all open tickets for that customer.
+Mark ticket TICK-3 as closed.
+```
+
+The assistant fills in fields it can reasonably infer and acts, then shows you the result.
+It reads, creates, updates, and deletes records directly — no form needed. The rest of
+this guide covers the web forms for when you prefer to fill fields by hand.
 
 ## Open a resource type
 

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -6,8 +6,9 @@ description: The AI-native business operating system — install it, give it a s
 import { Cards, Card } from "fumadocs-ui/components/card";
 
 TulipFarm is a self-hosted control panel where autonomous agents run your business
-operations. You define your business as data and configuration — resources, agents,
-skills, knowledge — and TulipFarm gives those agents the tools to act on it.
+operations. You **describe what you want in chat** — "track our customers", "create a
+support agent", "set up a hiring pipeline" — and agents build and run it for you. You do
+not configure it by editing files.
 
 It runs on your own machine. A single command sets up the datastore, generates your
 secrets, and boots the API and web UI. The first account you create is the admin.
@@ -17,19 +18,21 @@ secrets, and boots the API and web UI. The first account you create is the admin
 A TulipFarm instance has two halves:
 
 - **The soul** — a git-backed configuration store. Your resource schemas, agents, and
-  skills live here as files. Editing the soul is how you change what your instance
-  knows and can do.
+  skills live here as files. Agents write to the soul when you ask them to build
+  something; the git history is your audit trail.
 - **The runtime** — the API and workers that load the soul, store your records, index
   your knowledge, and run agent turns against your configured LLM providers.
 
-Everything you configure is a file in the soul; everything your business produces is a
-record in the datastore. Read [Concepts](/docs/concepts) for the full picture.
+Everything you build, an agent writes to the soul; everything your business produces is a
+record in the datastore. [Building by chat](/docs/concepts/building) is how the two come
+together — read [Concepts](/docs/concepts) for the full picture.
 
 ## Where to start
 
 <Cards>
   <Card title="Install" href="/docs/installation" description="One-line self-hosted install on Linux, macOS, or Windows (WSL2)." />
-  <Card title="Get started" href="/docs/getting-started" description="Set up a local dev environment and define your first resource type." />
+  <Card title="Get started" href="/docs/getting-started" description="Run it, configure a model, and build your first resource type by chatting." />
+  <Card title="Building by chat" href="/docs/concepts/building" description="The core idea — describe what you want, and agents build it for you." />
   <Card title="Concepts" href="/docs/concepts" description="How the soul, resources, agents, skills, knowledge, and LLM tiers fit together." />
   <Card title="Guides" href="/docs/guides" description="Task recipes: define a resource, install a skill, configure providers." />
   <Card title="Reference" href="/docs/reference" description="Environment variables and the commands that run the project." />

--- a/apps/docs/content/docs/installation.mdx
+++ b/apps/docs/content/docs/installation.mdx
@@ -53,6 +53,9 @@ remote. After the first admin is created the setup route locks.
   and put a reverse proxy with TLS in front for production.
 </Callout>
 
+Once you are in, you run TulipFarm by talking to it — describe what you want and agents
+build it. See [Building by chat](/docs/concepts/building) to get started.
+
 ## Overrides
 
 ### Linux / macOS

--- a/apps/docs/content/docs/reference/environment-variables.mdx
+++ b/apps/docs/content/docs/reference/environment-variables.mdx
@@ -31,3 +31,6 @@ whether it is required.
 | `GIT_CREDENTIALS` | — | Credentials for pushing to `GIT_REMOTE_URL`. |
 | `ENCRYPTION_KEY_PREVIOUS` | — | The prior `ENCRYPTION_KEY` during a key rotation. Decryption tries the current key, then this one. See [Secrets](/docs/concepts/secrets). |
 | `API_TOKEN_PEPPER` | — | Base64 server secret. When set, API tokens are hashed with `HMAC-SHA256(token, pepper)` instead of plain SHA-256. Must be 32 bytes. See [Hashing](/docs/security/hashing). |
+| `HOOKS_DISABLED` | — | Set to `true` to skip resource `hooks.ts` execution entirely. Use to boot an instance whose hooks are failing. |
+| `KNOWLEDGE_TRGM_FALLBACK` | `on` | Typo-tolerance pass (pg_trgm) for lexical page search. Opt-out: set to `0` or `false` to turn it off. |
+| `MARKETPLACE_SOURCE` | `tulipfarm/skills` | The `owner/repo` the Skills marketplace scans by default. |

--- a/apps/docs/lib/remark-prompt.ts
+++ b/apps/docs/lib/remark-prompt.ts
@@ -1,0 +1,38 @@
+/**
+ * Rewrites ```prompt fenced blocks into a <PromptBlock> component before the
+ * code reaches the syntax highlighter. Example prompts are natural language a
+ * reader types to the assistant, not code — so they get a distinct treatment
+ * (AI icon + gradient underline) instead of Shiki tokens. Running at the remark
+ * (mdast) stage means the highlighter never sees the unknown `prompt` language.
+ */
+
+interface MdastNode {
+  type: string;
+  lang?: string | null;
+  value?: string;
+  children?: MdastNode[];
+  [key: string]: unknown;
+}
+
+export function remarkPrompt() {
+  return (tree: MdastNode) => {
+    transform(tree);
+  };
+}
+
+function transform(node: MdastNode): void {
+  if (!Array.isArray(node.children)) return;
+
+  node.children = node.children.map((child) => {
+    if (child.type === "code" && child.lang === "prompt") {
+      return {
+        type: "mdxJsxFlowElement",
+        name: "PromptBlock",
+        attributes: [{ type: "mdxJsxAttribute", name: "text", value: child.value ?? "" }],
+        children: [],
+      } as MdastNode;
+    }
+    transform(child);
+    return child;
+  });
+}

--- a/apps/docs/source.config.ts
+++ b/apps/docs/source.config.ts
@@ -1,5 +1,6 @@
 import { metaSchema, pageSchema } from "fumadocs-core/source/schema";
 import { defineConfig, defineDocs } from "fumadocs-mdx/config";
+import { remarkPrompt } from "./lib/remark-prompt";
 
 // You can customize Zod schemas for frontmatter and `meta.json` here
 // see https://fumadocs.dev/docs/mdx/collections
@@ -18,6 +19,8 @@ export const docs = defineDocs({
 
 export default defineConfig({
   mdxOptions: {
-    // MDX options
+    // Prepend remarkPrompt so ```prompt blocks become <PromptBlock> before the
+    // syntax highlighter runs. Keep fumadocs' built-in remark plugins (`v`).
+    remarkPlugins: (v) => [remarkPrompt, ...v],
   },
 });


### PR DESCRIPTION
TulipFarm is built by chatting, not by editing files — so the docs lead with prompts.

- Lead every build task with example chat prompts; remove soul-edit YAML procedures from user guides (YAML stays only as read-only explanation on concept pages).
- Add 'Building by chat' keystone concept (General Assistant -> Information Architect -> forges); new create-an-agent guide + honest routines/integrations stubs.
- Add a 'prompt' code-block component (remark-prompt plugin + PromptBlock: AI icon, copy button, warm ruby->amber gradient) and convert example prompts to it.
- Group Guides into sections via meta.json separators — no file moves, no URL changes.
- Fix stale facts: tulip_ token prefix, four provider integrations (not 55+), full autonomy->tier table, recommended-not-default models.
- Expand knowledge docs (interlinks, backlinks, history, graph, palette, citations); 'chat' terminology; three advanced env vars.
- Add apps/docs/AGENTS.md with prompt-first authoring conventions; link from root.