### PR TITLE
feat(knowledge): agent hybrid search + page citations

### DIFF
--- a/apps/api/src/chat/producer.test.ts
+++ b/apps/api/src/chat/producer.test.ts
@@ -146,9 +146,17 @@ describe("sourcesEventForToolResult", () => {
     expect(
       sourcesEventForToolResult("cite_sources", {
         success: true,
-        data: { sources: [{ ref: 1, id: "d", title: "T", url: "/knowledge/pages/d" }] },
+        data: {
+          sources: [
+            { ref: 1, id: "d", title: "T", url: "/knowledge/pages/d", path: "policies/refunds" },
+          ],
+        },
       })
-    ).toEqual({ sources: [{ ref: 1, id: "d", title: "T", url: "/knowledge/pages/d" }] });
+    ).toEqual({
+      sources: [
+        { ref: 1, id: "d", title: "T", url: "/knowledge/pages/d", path: "policies/refunds" },
+      ],
+    });
   });
 
   it("returns null for other tools, failures, and empty/malformed source lists", () => {

--- a/apps/api/src/chat/turn.ts
+++ b/apps/api/src/chat/turn.ts
@@ -455,7 +455,9 @@ export async function runChatTurn(req: FastifyRequest, reply: FastifyReply, ctx:
             (c) =>
               c.toolName === "transfer_to_agent" ||
               c.toolName === "complete_task" ||
-              c.toolName === "ask_user" // HITL: end the turn cleanly with the form rendered
+              c.toolName === "ask_user" || // HITL: end the turn cleanly with the form rendered
+              c.toolName === "cite_sources" // terminal: cite_sources is the answer's last act —
+            // stopping here prevents the model running another step that restates the whole answer
           );
         },
         onError: ({ error }) => {

--- a/apps/api/src/context/assemble.ts
+++ b/apps/api/src/context/assemble.ts
@@ -268,16 +268,23 @@ function renderPinnedKnowledge(ctx: AssembleContext): string {
  */
 const KNOWLEDGE_GROUNDING_TEXT = [
   "When the user asks something that stored knowledge could answer (policies, how-tos, domain facts,",
-  "records, or a named document/runbook), call query_knowledge first and ground your answer in what",
-  "you retrieve. Prefer searching over asking the user to clarify: if a request is terse, abbreviated,",
-  "or ambiguous but could plausibly be answered from stored knowledge, run query_knowledge with your",
-  "best interpretation before asking what they mean. Search with a plain natural-language query and do",
-  "not set domain, tags, or spaceId unless the user named a specific space or category. If a search",
-  "returns nothing, retry once with simpler, broader keywords (and no filters); only ask for",
-  "clarification when that still finds nothing. Do not search for greetings or small talk. Mark each",
-  "claim drawn from a source with an inline [n] reference, numbered from 1 in order of first use. After",
-  "writing the answer, call cite_sources once with { citations: [{ ref, pageId }] }, mapping each",
-  "[n] to the pageId of the result it came from. Cite only pages you actually used.",
+  "records, or a named page/runbook), ground your answer in stored knowledge by running an",
+  "anchor-read-expand-cite loop. Prefer searching over asking the user to clarify: if a request is",
+  "terse, abbreviated, or ambiguous but could plausibly be answered from stored knowledge, search with",
+  "your best interpretation before asking what they mean. Do not search for greetings or small talk.",
+  "ANCHOR: call query_knowledge first with a plain natural-language query. Do not set domain, tags, or",
+  "spaceId unless the user explicitly named a space or category — never invent or guess a spaceId or",
+  "domain value (there is no 'default' space; an unknown filter matches nothing). When unsure, pass the",
+  "query alone with no filters. If a search returns nothing, retry once with simpler, broader keywords",
+  "(and no filters); only ask for clarification when that still finds nothing.",
+  "READ: query_knowledge returns ranked pages each with a short snippet. Call get_page on the top",
+  "hit(s) to read the whole page before answering, and synthesize from the full page, not the snippet.",
+  "EXPAND: when one page is not enough, follow at most 1-2 hops via get_backlinks or get_space_graph to",
+  "pull in curator-linked neighbors, then get_page those that look relevant. Cap traversal at 2 hops",
+  "and stop as soon as you have enough evidence; do not over-expand.",
+  "CITE: mark each claim drawn from a source with an inline [n] reference, numbered from 1 in order of",
+  "first use. After writing the answer, call cite_sources once with { citations: [{ ref, pageId }] },",
+  "mapping each [n] to the pageId of the page it came from. Cite only pages you actually used.",
 ].join(" ");
 
 function renderKnowledgeGrounding(ctx: AssembleContext): string {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -128,6 +128,9 @@ async function boot() {
     const boss = new PgBoss({ connectionString: process.env.DATABASE_URL as string });
     await boss.start();
 
+    // Page-level human search spine (shares the pool; chunk-mode search stays in knowledgeService).
+    const retrievalService = new PageRetrievalService(pool);
+
     const knowledgeService = new KnowledgeService({
       pages: new PgKnowledgePageRepo(pool),
       chunks: new PgKnowledgeChunkRepo(pool),
@@ -136,12 +139,10 @@ async function boot() {
       links: new PgKnowledgeLinksRepo(pool),
       overrides: new PgKnowledgeSpaceOverrideRepo(pool),
       embeddings: embeddingService,
+      retrieval: retrievalService,
       enqueueIndex: (pageId) => enqueueIndex(boss, { kind: "page", pageId }).then(() => undefined),
       indexQueueStats: makeIndexQueueStats(boss, pool),
     });
-
-    // Page-level human search spine (shares the pool; chunk-mode search stays in knowledgeService).
-    const retrievalService = new PageRetrievalService(pool);
 
     // Full chat tool registry: memory + knowledge (platform) plus every forge family
     // (resource records/types, agents, skills, platform tools). Without this, a chat turn only

--- a/apps/api/src/knowledge/admin-routes.pg.test.ts
+++ b/apps/api/src/knowledge/admin-routes.pg.test.ts
@@ -5,6 +5,7 @@ import { runPgMigrations } from "../pg-migrate";
 import { makePglite } from "../test/pglite";
 import { PgKnowledgeChunkRepo } from "./chunks-repo";
 import { PgKnowledgePageRepo, PgKnowledgeRevisionRepo } from "./repo";
+import { PageRetrievalService } from "./retrieval-service";
 import { registerKnowledgeRoutes } from "./routes";
 import { KnowledgeService } from "./service";
 import type { EmbeddingPort } from "./types";
@@ -33,6 +34,7 @@ describe("knowledge admin routes (reindex / backfill / index-status)", () => {
       chunks: new PgKnowledgeChunkRepo(db),
       revisions: new PgKnowledgeRevisionRepo(db),
       embeddings: fakeEmbeddings(),
+      retrieval: new PageRetrievalService(db),
     });
     app = Fastify();
     // Stub auth: set req.user from the x-role header so the admin guard can be exercised.

--- a/apps/api/src/knowledge/connectors/sync.pg.test.ts
+++ b/apps/api/src/knowledge/connectors/sync.pg.test.ts
@@ -7,6 +7,7 @@ import { runPgMigrations } from "../../pg-migrate";
 import { makePglite } from "../../test/pglite";
 import { PgKnowledgeChunkRepo } from "../chunks-repo";
 import { PgKnowledgePageRepo, PgKnowledgeRevisionRepo } from "../repo";
+import { PageRetrievalService } from "../retrieval-service";
 import { KnowledgeService } from "../service";
 import type { EmbeddingPort } from "../types";
 import { SampleConnector } from "./sample";
@@ -65,6 +66,7 @@ describe("connector sync (SampleConnector)", () => {
       chunks: new PgKnowledgeChunkRepo(db),
       revisions: new PgKnowledgeRevisionRepo(db),
       embeddings: fakeEmbeddings(),
+      retrieval: new PageRetrievalService(db),
     });
     state = new PgConnectorStateRepo(db);
     const dir = await mkdtemp(join(tmpdir(), "tf-connector-"));

--- a/apps/api/src/knowledge/hybrid-golden.pg.test.ts
+++ b/apps/api/src/knowledge/hybrid-golden.pg.test.ts
@@ -1,0 +1,215 @@
+// Golden recall@5 eval proving HYBRID retrieval beats LEXICAL-ONLY. One shared bag-of-keywords corpus
+// is searched by three arms — lexical-only, vector-only, hybrid (RRF) — and recall@5 is measured for
+// each. The corpus carries a deliberate VOCABULARY-MISMATCH case: the true page mentions the query's
+// keyword only in its BODY while a crowd of decoy pages match the SAME keyword in their TITLES (which
+// the lexical scorer weights far higher), so the true page falls outside the lexical top-5 — yet the
+// vector arm ranks it #1 because its body's bag-of-keywords is an exact match for the query's. Hybrid
+// fuses the two and recovers it, so recallHybrid strictly exceeds recallLexicalOnly.
+
+import { randomUUID } from "node:crypto";
+import type { PGlite } from "@electric-sql/pglite";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { runPgMigrations } from "../pg-migrate";
+import { makePglite } from "../test/pglite";
+import { PgKnowledgeChunkRepo } from "./chunks-repo";
+import { PgKnowledgePageRepo, PgKnowledgeRevisionRepo } from "./repo";
+import { PageRetrievalService } from "./retrieval-service";
+import { KnowledgeService } from "./service";
+import type { EmbeddingPort } from "./types";
+
+// ── bag-of-keywords embedding (verbatim from hybrid-search.pg.test.ts) ──────────────────────────────
+// Each dim is the count of that keyword in the text. The SAME function embeds chunks AND the query, so
+// a query sharing keywords with a chunk yields a high cosine similarity while an unrelated chunk is near
+// orthogonal — letting the vector arm genuinely RANK pages.
+const VOCAB = ["alpha", "beta", "gamma", "delta", "epsilon", "zeta", "eta", "theta"];
+const DIM = VOCAB.length;
+
+function bagEmbed(text: string): number[] {
+  const words = text.toLowerCase().match(/[a-z]+/g) ?? [];
+  return VOCAB.map((kw) => words.filter((w) => w === kw).length);
+}
+
+function bagEmbeddings(available: boolean): EmbeddingPort {
+  return {
+    isAvailable: () => available,
+    embedMany: async (values) => ({
+      embeddings: values.map((v) => bagEmbed(v)),
+      dimension: DIM,
+    }),
+    getActive: () => (available ? { provider: "fake", model: "m", dimension: DIM } : null),
+    getDimension: () => (available ? DIM : null),
+    consumePendingReindex: () => false,
+  };
+}
+
+function makeService(db: PGlite, embeddings: EmbeddingPort): KnowledgeService {
+  return new KnowledgeService({
+    pages: new PgKnowledgePageRepo(db),
+    chunks: new PgKnowledgeChunkRepo(db),
+    revisions: new PgKnowledgeRevisionRepo(db),
+    embeddings,
+    retrieval: new PageRetrievalService(db),
+  });
+}
+
+async function seedSpace(db: PGlite): Promise<string> {
+  const id = randomUUID();
+  await db.query(
+    `INSERT INTO knowledge_spaces (id, name, description, created_at, updated_at)
+     VALUES ($1, $2, NULL, now(), now())`,
+    [id, `space-${id}`]
+  );
+  return id;
+}
+
+interface SeedPage {
+  spaceId: string;
+  path: string;
+  title: string;
+  /** plain_text + the single chunk body (lexical AND vector source). */
+  body: string;
+}
+
+/** Seed one space page + a single chunk whose embedding is the bag-of-keywords of its body. */
+async function seedPage(db: PGlite, p: SeedPage): Promise<void> {
+  const id = randomUUID();
+  await db.query(
+    `INSERT INTO knowledge_pages
+       (id, title, content, plain_text, source, source_id, tags, active, always_load_for_agents,
+        version, space_id, path, type, frontmatter_extra, created_at, updated_at)
+     VALUES ($1,$2,$3,$3,'authored',$4,'{}',true,false,1,$5,$6,NULL,'{}'::jsonb,now(),now())`,
+    [id, p.title, `${p.title}\n\n${p.body}`, `okf:${p.spaceId}:${p.path}`, p.spaceId, p.path]
+  );
+  await db.query(
+    `INSERT INTO knowledge_chunks
+       (id, page_id, chunk_index, content, content_hash, embedding, tsv, model, dim, created_at)
+     VALUES ($1,$2,0,$3,md5($3),$4::vector,to_tsvector('english',$3),'m',$5,now())`,
+    [randomUUID(), id, p.body, JSON.stringify(bagEmbed(p.body)), DIM]
+  );
+}
+
+// ── Shared corpus ───────────────────────────────────────────────────────────────────────────────────
+// Eight pages over the bag vocabulary. The first seven are "ordinary" — their title carries the same
+// keyword as their body, so BOTH arms find them easily (these keep recall non-trivial for every arm).
+// The eighth, "ledger", is the vocabulary-mismatch trap (see GOLDEN below).
+interface CorpusPage {
+  path: string;
+  title: string;
+  body: string;
+}
+
+const CORPUS: CorpusPage[] = [
+  { path: "alpha-doc", title: "Alpha service overview", body: "alpha alpha alpha runbook" },
+  { path: "beta-doc", title: "Beta migration guide", body: "beta beta beta steps" },
+  { path: "gamma-doc", title: "Gamma rollout plan", body: "gamma gamma gamma notes" },
+  { path: "delta-doc", title: "Delta caching layer", body: "delta delta delta config" },
+  { path: "eta-doc", title: "Eta tracing setup", body: "eta eta eta spans" },
+  { path: "theta-doc", title: "Theta rate limiting", body: "theta theta theta throttle" },
+  { path: "zeta-doc", title: "Zeta auth flow", body: "zeta zeta zeta tokens" },
+
+  // ── Vocabulary-mismatch trap (query: "epsilon") ──
+  // The true page's title says nothing about "epsilon"; the keyword lives ONLY in its body, where the
+  // lexical scorer applies the low body weight (wBody 0.3 vs wTitle 0.7).
+  {
+    path: "ledger",
+    title: "Quarterly accounting summary",
+    body: "epsilon epsilon epsilon epsilon",
+  },
+  // A crowd of decoys whose TITLES all carry "epsilon" (heavy wTitle), so the lexical arm fills its
+  // entire top-5 with them and shoves "ledger" out — while none of them match the query's bag as
+  // strongly (one "epsilon" in body vs the trap's four), so the vector arm keeps "ledger" at #1.
+  { path: "decoy-1", title: "Epsilon greek letter", body: "epsilon glossary" },
+  { path: "decoy-2", title: "Epsilon math constant", body: "epsilon calculus" },
+  { path: "decoy-3", title: "Epsilon naming convention", body: "epsilon style" },
+  { path: "decoy-4", title: "Epsilon transition diagram", body: "epsilon automata" },
+  { path: "decoy-5", title: "Epsilon delta proof", body: "epsilon limit" },
+  { path: "decoy-6", title: "Epsilon release notes", body: "epsilon changelog" },
+];
+
+// query → the path it should retrieve. The first seven are easy (title+body agree). "epsilon" is the
+// vocabulary-mismatch case the lexical arm cannot keep in its top-5 but the vector arm rescues.
+const GOLDEN: Array<[string, string]> = [
+  ["alpha", "alpha-doc"],
+  ["beta", "beta-doc"],
+  ["gamma", "gamma-doc"],
+  ["delta", "delta-doc"],
+  ["eta", "eta-doc"],
+  ["theta", "theta-doc"],
+  ["zeta", "zeta-doc"],
+  ["epsilon", "ledger"], // vocabulary-mismatch trap
+];
+
+describe("hybrid golden recall@5 (hybrid beats lexical-only)", () => {
+  let db: PGlite;
+
+  beforeEach(async () => {
+    db = await makePglite();
+    await runPgMigrations(db);
+    const space = await seedSpace(db);
+    for (const p of CORPUS) {
+      await seedPage(db, { spaceId: space, path: p.path, title: p.title, body: p.body });
+    }
+  });
+  afterEach(async () => {
+    await db.close();
+  });
+
+  it("hybrid strictly outperforms lexical-only, matching vector on the vocab-mismatch set", async () => {
+    const lexical = new PageRetrievalService(db);
+    const chunks = new PgKnowledgeChunkRepo(db);
+    const svc = makeService(db, bagEmbeddings(true));
+
+    const recallOf = async (
+      top5For: (query: string) => Promise<string[]>
+    ): Promise<{ recall: number; misses: string[] }> => {
+      let hits = 0;
+      const misses: string[] = [];
+      for (const [query, expected] of GOLDEN) {
+        const top5 = await top5For(query);
+        if (top5.includes(expected)) hits += 1;
+        else misses.push(`${query} → expected ${expected}, got [${top5.join(", ")}]`);
+      }
+      return { recall: hits / GOLDEN.length, misses };
+    };
+
+    // LEXICAL-ONLY arm.
+    const lex = await recallOf(async (query) =>
+      (await lexical.searchPages({ query, filters: {}, limit: 5 })).flatMap((h) =>
+        h.path ? [h.path] : []
+      )
+    );
+
+    // VECTOR-ONLY arm: chunk hits grouped to pages (max score per page), top-5 page paths.
+    const vec = await recallOf(async (query) => {
+      const hits = await chunks.searchVector(bagEmbed(query), DIM, 50, {});
+      const best = new Map<string, number>();
+      for (const h of hits) best.set(h.pageId, Math.max(best.get(h.pageId) ?? -1, h.score));
+      const top5Ids = [...best.entries()]
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 5)
+        .map(([id]) => id);
+      const pages = await Promise.all(top5Ids.map((id) => new PgKnowledgePageRepo(db).getById(id)));
+      return pages.flatMap((p) => (p?.path ? [p.path] : []));
+    });
+
+    // HYBRID arm (RRF fusion of both).
+    const hyb = await recallOf(async (query) =>
+      (await svc.hybridSearchPages(query, {}, 5)).results.flatMap((r) => (r.path ? [r.path] : []))
+    );
+
+    // ── proof (visible to a reader) ──
+    console.log(`recall@5  lexical-only = ${lex.recall.toFixed(2)}`);
+    console.log(`recall@5  vector-only  = ${vec.recall.toFixed(2)}`);
+    console.log(`recall@5  hybrid       = ${hyb.recall.toFixed(2)}`);
+    if (lex.misses.length) console.log(`lexical-only misses:\n  ${lex.misses.join("\n  ")}`);
+
+    // The vocab-mismatch case is precisely what the lexical arm cannot keep in its top-5.
+    expect(lex.recall, `lexical misses:\n${lex.misses.join("\n")}`).toBeLessThan(1.0);
+    // Hybrid is a STRICT, non-tie win over lexical-only…
+    expect(hyb.recall).toBeGreaterThan(lex.recall);
+    // …at least as good as the vector arm alone…
+    expect(hyb.recall).toBeGreaterThanOrEqual(vec.recall);
+    // …and recovers the whole designed set.
+    expect(hyb.recall).toBe(1.0);
+  });
+});

--- a/apps/api/src/knowledge/hybrid-search.pg.test.ts
+++ b/apps/api/src/knowledge/hybrid-search.pg.test.ts
@@ -1,0 +1,195 @@
+import { randomUUID } from "node:crypto";
+import type { PGlite } from "@electric-sql/pglite";
+import { EMBEDDING_UNAVAILABLE_WARNING } from "@tulipfarm/llm";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { runPgMigrations } from "../pg-migrate";
+import { makePglite } from "../test/pglite";
+import { PgKnowledgeChunkRepo } from "./chunks-repo";
+import { PgKnowledgePageRepo, PgKnowledgeRevisionRepo } from "./repo";
+import { PageRetrievalService } from "./retrieval-service";
+import { KnowledgeService } from "./service";
+import type { EmbeddingPort } from "./types";
+
+// ── bag-of-keywords embedding ──────────────────────────────────────────────────────────────────
+// A deterministic embedding over a tiny fixed vocabulary: each dim is the count of that keyword in
+// the text. The SAME function embeds indexed chunks AND the query, so a query sharing keywords with a
+// chunk yields a high cosine similarity (overlapping non-zero dims) while an unrelated chunk is near
+// orthogonal. This lets the vector arm genuinely RANK pages — unlike a uniform stub.
+const VOCAB = ["alpha", "beta", "gamma", "delta", "epsilon", "zeta", "eta", "theta"];
+const DIM = VOCAB.length;
+
+function bagEmbed(text: string): number[] {
+  const words = text.toLowerCase().match(/[a-z]+/g) ?? [];
+  return VOCAB.map((kw) => words.filter((w) => w === kw).length);
+}
+
+function bagEmbeddings(available: boolean): EmbeddingPort {
+  return {
+    isAvailable: () => available,
+    embedMany: async (values) => ({
+      embeddings: values.map((v) => bagEmbed(v)),
+      dimension: DIM,
+    }),
+    getActive: () => (available ? { provider: "fake", model: "m", dimension: DIM } : null),
+    getDimension: () => (available ? DIM : null),
+    consumePendingReindex: () => false,
+  };
+}
+
+function makeService(db: PGlite, embeddings: EmbeddingPort): KnowledgeService {
+  return new KnowledgeService({
+    pages: new PgKnowledgePageRepo(db),
+    chunks: new PgKnowledgeChunkRepo(db),
+    revisions: new PgKnowledgeRevisionRepo(db),
+    embeddings,
+    retrieval: new PageRetrievalService(db),
+  });
+}
+
+async function seedSpace(db: PGlite): Promise<string> {
+  const id = randomUUID();
+  await db.query(
+    `INSERT INTO knowledge_spaces (id, name, description, created_at, updated_at)
+     VALUES ($1, $2, NULL, now(), now())`,
+    [id, `space-${id}`]
+  );
+  return id;
+}
+
+interface SeedPage {
+  spaceId: string;
+  path: string;
+  title: string;
+  /** plain_text + the single chunk body (lexical AND vector source — both arms see the same text). */
+  body: string;
+  /** When set, the chunk embeds (and the page indexes) lexical-only — no vector. Default embeds. */
+  embed?: boolean;
+}
+
+/** Seed one space page + a single chunk whose embedding is the bag-of-keywords of its body. */
+async function seedPage(db: PGlite, p: SeedPage): Promise<string> {
+  const id = randomUUID();
+  await db.query(
+    `INSERT INTO knowledge_pages
+       (id, title, content, plain_text, source, source_id, tags, active, always_load_for_agents,
+        version, space_id, path, type, frontmatter_extra, created_at, updated_at)
+     VALUES ($1,$2,$3,$3,'authored',$4,'{}',true,false,1,$5,$6,NULL,'{}'::jsonb,now(),now())`,
+    [id, p.title, `${p.title}\n\n${p.body}`, `okf:${p.spaceId}:${p.path}`, p.spaceId, p.path]
+  );
+  const vec = p.embed === false ? null : JSON.stringify(bagEmbed(p.body));
+  await db.query(
+    `INSERT INTO knowledge_chunks
+       (id, page_id, chunk_index, content, content_hash, embedding, tsv, model, dim, created_at)
+     VALUES ($1,$2,0,$3,md5($3),$4::vector,to_tsvector('english',$3),$5,$6,now())`,
+    [randomUUID(), id, p.body, vec, p.embed === false ? null : "m", p.embed === false ? null : DIM]
+  );
+  return id;
+}
+
+describe("KnowledgeService.hybridSearchPages", () => {
+  let db: PGlite;
+
+  beforeEach(async () => {
+    db = await makePglite();
+    await runPgMigrations(db);
+  });
+  afterEach(async () => {
+    await db.close();
+  });
+
+  it("RRF lifts a page agreed by BOTH arms above one matched by only ONE arm", async () => {
+    const space = await seedSpace(db);
+    const svc = makeService(db, bagEmbeddings(true));
+
+    // Query keywords: alpha beta gamma → vector [1,1,1,0,0,0,0,0].
+    const query = "alpha beta gamma";
+
+    // Page A — agreed by BOTH arms. Its title carries the query keywords (→ lexical hit) and its chunk
+    // embeds the very same keywords (→ vector hit). A is therefore a MEMBER of both result sets.
+    const aId = await seedPage(db, {
+      spaceId: space,
+      path: "page-a",
+      title: "Alpha Beta Gamma overview",
+      body: "alpha beta gamma deployment notes",
+    });
+
+    // Page B — matched by EXACTLY ONE arm (lexical). Its title carries the query keywords (→ lexical
+    // hit), but its chunk stores NO embedding (`embed: false`), so the vector arm — which filters on
+    // `embedding IS NOT NULL` — cannot return it at all. B is absent from the vector result set.
+    const bId = await seedPage(db, {
+      spaceId: space,
+      path: "page-b",
+      title: "Alpha Beta Gamma reference",
+      body: "alpha beta gamma appendix",
+      embed: false,
+    });
+
+    // A neutral filler so neither arm degenerates to a 1-element list (keeps the fusion non-trivial).
+    await seedPage(db, {
+      spaceId: space,
+      path: "filler-1",
+      title: "Delta epsilon digest",
+      body: "delta epsilon zeta unrelated",
+    });
+
+    // ── Sanity-check arm MEMBERSHIP (deterministic; no reliance on exact positions or weights) ──
+    const lex = await new PageRetrievalService(db).searchPages({ query, filters: {}, limit: 20 });
+    const lexIds = lex.map((h) => h.pageId);
+    expect(lexIds).toContain(aId); // A is in the lexical arm
+    expect(lexIds).toContain(bId); // B is in the lexical arm
+
+    const { embeddings: qv } = await bagEmbeddings(true).embedMany([query]);
+    const vHits = await new PgKnowledgeChunkRepo(db).searchVector(qv[0], DIM, 20, {});
+    const vIds = [...new Set(vHits.map((h) => h.pageId))];
+    expect(vIds).toContain(aId); // A is in the vector arm (cross-arm agreement)
+    expect(vIds).not.toContain(bId); // B has no embedding → absent from the vector arm
+
+    // Invariant: A is hit by BOTH rankers, B by only one → RRF cross-arm agreement lifts A above B.
+    const { results } = await svc.hybridSearchPages(query, {}, 10);
+    const ids = results.map((r) => r.pageId);
+    expect(ids).toContain(aId);
+    expect(ids).toContain(bId);
+    expect(ids.indexOf(aId)).toBeLessThan(ids.indexOf(bId));
+  });
+
+  it("hydrates a vector-only hit (matched semantically, not lexically)", async () => {
+    const space = await seedSpace(db);
+    const svc = makeService(db, bagEmbeddings(true));
+
+    // Query: zeta — a keyword the lexical arm can't reach because the page's text spells it
+    // differently ("Z-page" / "the seventh letter") yet its chunk embeds with the zeta dim set, so the
+    // vector arm matches it. The hybrid result must still hydrate from pages.getById.
+    const id = await seedPage(db, {
+      spaceId: space,
+      path: "vault/secrets",
+      title: "The seventh letter",
+      body: "zeta zeta zeta",
+    });
+
+    const { results } = await svc.hybridSearchPages("zeta", {}, 10);
+    const hit = results.find((r) => r.pageId === id);
+    expect(hit).toBeDefined();
+    if (!hit) return;
+    expect(hit.title).toBe("The seventh letter"); // hydrated from pages.getById
+    expect(hit.spaceId).toBe(space);
+    expect(hit.path).toBe("vault/secrets");
+    expect(hit.snippet.length).toBeGreaterThan(0);
+  });
+
+  it("degrades to the lexical arm with a warning when embeddings are unavailable", async () => {
+    const space = await seedSpace(db);
+    // Provider unavailable → chunks store lexical-only (NULL embedding), and the vector arm is skipped.
+    const svc = makeService(db, bagEmbeddings(false));
+    const id = await seedPage(db, {
+      spaceId: space,
+      path: "runbook",
+      title: "Deploy runbook",
+      body: "alpha beta gamma deploy steps",
+      embed: false,
+    });
+
+    const { results, warnings } = await svc.hybridSearchPages("alpha", {}, 10);
+    expect(warnings).toContain(EMBEDDING_UNAVAILABLE_WARNING);
+    expect(results.map((r) => r.pageId)).toContain(id);
+  });
+});

--- a/apps/api/src/knowledge/okf-routes.pg.test.ts
+++ b/apps/api/src/knowledge/okf-routes.pg.test.ts
@@ -33,6 +33,7 @@ async function buildApp(db: PGlite): Promise<FastifyInstance> {
     links: new PgKnowledgeLinksRepo(db),
     overrides: new PgKnowledgeSpaceOverrideRepo(db),
     embeddings: lexicalOnly(),
+    retrieval: new PageRetrievalService(db),
   });
   const app = Fastify();
   registerKnowledgeRoutes(app, service, async () => {}, new PageRetrievalService(db));

--- a/apps/api/src/knowledge/okf-service.pg.test.ts
+++ b/apps/api/src/knowledge/okf-service.pg.test.ts
@@ -6,6 +6,7 @@ import { makePglite } from "../test/pglite";
 import { PgKnowledgeChunkRepo } from "./chunks-repo";
 import { PgKnowledgeLinksRepo } from "./links-repo";
 import { PgKnowledgePageRepo, PgKnowledgeRevisionRepo } from "./repo";
+import { PageRetrievalService } from "./retrieval-service";
 import { KnowledgeService } from "./service";
 import { PgKnowledgeSpaceOverrideRepo } from "./space-overrides-repo";
 import { PgKnowledgeSpaceRepo } from "./spaces-repo";
@@ -31,6 +32,7 @@ function makeService(db: PGlite): KnowledgeService {
     links: new PgKnowledgeLinksRepo(db),
     overrides: new PgKnowledgeSpaceOverrideRepo(db),
     embeddings: lexicalOnly(),
+    retrieval: new PageRetrievalService(db),
   });
 }
 

--- a/apps/api/src/knowledge/okf-tools.pg.test.ts
+++ b/apps/api/src/knowledge/okf-tools.pg.test.ts
@@ -6,6 +6,7 @@ import { makePglite } from "../test/pglite";
 import { PgKnowledgeChunkRepo } from "./chunks-repo";
 import { PgKnowledgeLinksRepo } from "./links-repo";
 import { PgKnowledgePageRepo, PgKnowledgeRevisionRepo } from "./repo";
+import { PageRetrievalService } from "./retrieval-service";
 import { KnowledgeService } from "./service";
 import { PgKnowledgeSpaceOverrideRepo } from "./space-overrides-repo";
 import { PgKnowledgeSpaceRepo } from "./spaces-repo";
@@ -43,6 +44,7 @@ describe("OKF agent tools", () => {
       links: new PgKnowledgeLinksRepo(db),
       overrides: new PgKnowledgeSpaceOverrideRepo(db),
       embeddings: lexicalOnly(),
+      retrieval: new PageRetrievalService(db),
     });
     ctx = { userId: "u", service };
   });

--- a/apps/api/src/knowledge/rerank.test.ts
+++ b/apps/api/src/knowledge/rerank.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { NotImplementedError } from "./connectors/types";
+import { NotImplementedRerank, noopRerank, resolveRerank } from "./rerank";
+import type { QueryKnowledgeHit } from "./types";
+
+function hit(over: Partial<QueryKnowledgeHit>): QueryKnowledgeHit {
+  return {
+    pageId: "p1",
+    title: "Page",
+    snippet: "body",
+    source: "authored",
+    score: 1,
+    ...over,
+  };
+}
+
+const pages: QueryKnowledgeHit[] = [
+  hit({ pageId: "a", title: "A", score: 0.9 }),
+  hit({ pageId: "b", title: "B", score: 0.8 }),
+  hit({ pageId: "c", title: "C", score: 0.7 }),
+];
+
+describe("noopRerank", () => {
+  it("returns the same pages, same order, same length (pure identity)", async () => {
+    const out = await noopRerank.rerank("q", pages, 3);
+    expect(out).toBe(pages);
+    expect(out).toEqual(pages);
+    expect(out).toHaveLength(3);
+  });
+
+  it("ignores topK and returns the full list even when topK < length", async () => {
+    const out = await noopRerank.rerank("q", pages, 1);
+    expect(out).toBe(pages);
+    expect(out).toHaveLength(3);
+  });
+});
+
+describe("NotImplementedRerank", () => {
+  it("throws a NotImplementedError when invoked", () => {
+    const stage = new NotImplementedRerank();
+    // `rerank` throws synchronously inside the async-typed method, so the sync assertion is the
+    // honest match. (The async path is covered below for the RerankStage contract.)
+    expect(() => stage.rerank("q", pages, 3)).toThrow(NotImplementedError);
+  });
+
+  it("rejects with a NotImplementedError via the async contract", async () => {
+    const stage = new NotImplementedRerank();
+    await expect(async () => stage.rerank("q", pages, 3)).rejects.toThrow(NotImplementedError);
+  });
+});
+
+describe("resolveRerank", () => {
+  it("returns noopRerank when the flag is unset", () => {
+    expect(resolveRerank({})).toBe(noopRerank);
+  });
+
+  it.each(["1", "true", "on"])("returns NotImplementedRerank when KNOWLEDGE_RERANK=%s", (v) => {
+    expect(resolveRerank({ KNOWLEDGE_RERANK: v })).toBeInstanceOf(NotImplementedRerank);
+  });
+
+  it.each(["off", "0"])("returns noopRerank when KNOWLEDGE_RERANK=%s", (v) => {
+    expect(resolveRerank({ KNOWLEDGE_RERANK: v })).toBe(noopRerank);
+  });
+});

--- a/apps/api/src/knowledge/rerank.ts
+++ b/apps/api/src/knowledge/rerank.ts
@@ -1,0 +1,43 @@
+// Inert, flag-gated rerank seam for the hybrid `query_knowledge` pipeline. Default is a pure no-op
+// (identity) so the off-path is byte-stable; when `KNOWLEDGE_RERANK` is enabled this resolves to an
+// honest stub that throws `NotImplementedError` only if actually invoked. No model call, no real
+// reranking — this is just the wiring for a future cross-encoder/LLM rerank stage.
+
+import { NotImplementedError } from "./connectors/types";
+import type { QueryKnowledgeHit } from "./types";
+
+/** A pluggable reordering stage over page-level hits, applied after hybrid retrieval. */
+export interface RerankStage {
+  rerank(query: string, pages: QueryKnowledgeHit[], topK: number): Promise<QueryKnowledgeHit[]>;
+}
+
+/**
+ * Pure identity: returns `pages` unchanged (no slice, no reorder) so an unset flag is a true
+ * byte-stable no-op. The caller already passes the desired, capped list — `topK` is accepted only
+ * to match the `RerankStage` shape.
+ */
+export const noopRerank: RerankStage = {
+  rerank(_query: string, pages: QueryKnowledgeHit[], _topK: number): Promise<QueryKnowledgeHit[]> {
+    return Promise.resolve(pages);
+  },
+};
+
+/**
+ * Honest stub for the future LLM/cross-encoder rerank. Satisfies `RerankStage` but throws
+ * `NotImplementedError` (the same class the connector stubs use) the moment it's invoked, so the
+ * seam is wired and enableable today without pretending to rerank.
+ */
+export class NotImplementedRerank implements RerankStage {
+  rerank(_query: string, _pages: QueryKnowledgeHit[], _topK: number): Promise<QueryKnowledgeHit[]> {
+    // NotImplementedError's message is `connector <a>: <b> is not implemented`; we reuse the class
+    // verbatim (don't fork the error style) so it reads "...rerank: LLM rerank is not implemented".
+    throw new NotImplementedError("rerank", "LLM rerank");
+  }
+}
+
+/** `KNOWLEDGE_RERANK` is opt-in: "1"/"true"/"on" enables the stub stage; anything else stays a no-op. */
+export function resolveRerank(env: NodeJS.ProcessEnv = process.env): RerankStage {
+  const v = env.KNOWLEDGE_RERANK?.trim().toLowerCase();
+  const enabled = v === "1" || v === "true" || v === "on";
+  return enabled ? new NotImplementedRerank() : noopRerank;
+}

--- a/apps/api/src/knowledge/routes.test.ts
+++ b/apps/api/src/knowledge/routes.test.ts
@@ -31,6 +31,7 @@ async function buildKnowledgeApp(
     chunks: new PgKnowledgeChunkRepo(db),
     revisions: new PgKnowledgeRevisionRepo(db),
     embeddings: fakeEmbeddings(available),
+    retrieval: new PageRetrievalService(db),
   });
   const app = Fastify();
   registerKnowledgeRoutes(

--- a/apps/api/src/knowledge/service.pg.test.ts
+++ b/apps/api/src/knowledge/service.pg.test.ts
@@ -4,6 +4,7 @@ import { runPgMigrations } from "../pg-migrate";
 import { makePglite } from "../test/pglite";
 import { PgKnowledgeChunkRepo } from "./chunks-repo";
 import { PgKnowledgePageRepo, PgKnowledgeRevisionRepo } from "./repo";
+import { PageRetrievalService } from "./retrieval-service";
 import { KnowledgeService } from "./service";
 import type { EmbeddingPort } from "./types";
 
@@ -31,6 +32,7 @@ function makeService(db: PGlite, embeddings: EmbeddingPort): KnowledgeService {
     chunks: new PgKnowledgeChunkRepo(db),
     revisions: new PgKnowledgeRevisionRepo(db),
     embeddings,
+    retrieval: new PageRetrievalService(db),
   });
 }
 
@@ -168,6 +170,7 @@ describe("KnowledgeService", () => {
       chunks: new PgKnowledgeChunkRepo(db),
       revisions: new PgKnowledgeRevisionRepo(db),
       embeddings: fakeEmbeddings(true),
+      retrieval: new PageRetrievalService(db),
       indexQueueStats: async () => ({ pending: 3, lastError: { message: "boom", failedAt } }),
     });
     const status = await svc.indexStatus();

--- a/apps/api/src/knowledge/service.ts
+++ b/apps/api/src/knowledge/service.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { EMBEDDING_UNAVAILABLE_WARNING, EmbeddingUnavailableError } from "@tulipfarm/llm";
 import type { PaginatedResult } from "../pagination";
 import type { KnowledgeChunkRepo } from "./chunks-repo";
 import { indexPage, reindexAll } from "./index-service";
@@ -6,6 +7,8 @@ import type { KnowledgeLinksRepo } from "./links-repo";
 import { parseOkf, resolveLink, rewriteCrossPageSpaceName } from "./okf/parse";
 import { type IndexEntry, renderIndex } from "./okf/synthesize";
 import type { KnowledgePageRepo, KnowledgeRevisionRepo, PageListOpts } from "./repo";
+import { resolveRerank } from "./rerank";
+import type { PageRetrievalService } from "./retrieval-service";
 import { search } from "./search-service";
 import type { KnowledgeSpaceOverrideRepo } from "./space-overrides-repo";
 import type { KnowledgeSpaceRepo, SpacePatch } from "./spaces-repo";
@@ -19,6 +22,7 @@ import type {
   KnowledgeRevision,
   KnowledgeSource,
   KnowledgeSpace,
+  QueryKnowledgeHit,
   RecentPage,
   SearchFilters,
   SearchResults,
@@ -125,6 +129,8 @@ export interface KnowledgeServiceDeps {
   chunks: KnowledgeChunkRepo;
   revisions: KnowledgeRevisionRepo;
   embeddings: EmbeddingPort;
+  /** Page-level lexical retrieval — the lexical arm of `hybridSearchPages`. */
+  retrieval: PageRetrievalService;
   /** When set, page writes enqueue async (re)indexing instead of indexing inline. */
   enqueueIndex?: (pageId: string) => Promise<void>;
   /** Operational stats for the async index queue (pg-boss). Absent → index-status omits queue info. */
@@ -290,6 +296,86 @@ export class KnowledgeService {
         score: 0,
       }));
     return { results: [...base.results, ...extra], warnings: base.warnings };
+  }
+
+  /**
+   * Page-level hybrid retrieval for the `query_knowledge` tool. Runs a vector arm (chunk hits
+   * grouped to their max-score page) and a lexical arm (whole-page FTS) in parallel, then fuses them
+   * with Reciprocal Rank Fusion (k=60, by rank not score) so neither arm's score scale dominates.
+   * The top `limit` pages are hydrated and passed through the (default no-op) rerank seam.
+   */
+  async hybridSearchPages(
+    query: string,
+    filters: SearchFilters,
+    limit: number
+  ): Promise<{ results: QueryKnowledgeHit[]; warnings: string[] }> {
+    const N = Math.max(limit * 4, 20);
+    const warnings: string[] = [];
+
+    // ── vector arm: chunk hits → max-score-per-page, keeping that chunk's content as the snippet ──
+    const vectorSnippet = new Map<string, string>();
+    let pagesV: string[] = [];
+    if (this.deps.embeddings.isAvailable()) {
+      try {
+        const out = await this.deps.embeddings.embedMany([query]);
+        const vec = out.embeddings[0];
+        const hits = vec ? await this.deps.chunks.searchVector(vec, out.dimension, N, filters) : [];
+        const best = new Map<string, { content: string; score: number }>();
+        for (const hit of hits) {
+          const prior = best.get(hit.pageId);
+          if (!prior || hit.score > prior.score) {
+            best.set(hit.pageId, { content: hit.content, score: hit.score });
+          }
+        }
+        pagesV = [...best.entries()].sort((a, b) => b[1].score - a[1].score).map(([id]) => id);
+        for (const [id, { content }] of best) vectorSnippet.set(id, content);
+      } catch (err) {
+        if (!(err instanceof EmbeddingUnavailableError)) throw err;
+        warnings.push(EMBEDDING_UNAVAILABLE_WARNING);
+      }
+    } else {
+      warnings.push(EMBEDDING_UNAVAILABLE_WARNING);
+    }
+
+    // ── lexical arm: whole-page FTS ──
+    const lexHits = await this.deps.retrieval.searchPages({ query, filters, limit: N });
+    const pagesL = lexHits.map((h) => h.pageId);
+    const lexicalSnippet = new Map(lexHits.map((h) => [h.pageId, h.snippet]));
+
+    // ── RRF fuse (k=60), by 0-based rank across both arms ──
+    const K = 60;
+    const fused = new Map<string, number>();
+    for (const list of [pagesV, pagesL]) {
+      list.forEach((id, rank) => {
+        fused.set(id, (fused.get(id) ?? 0) + 1 / (K + rank));
+      });
+    }
+    const topIds = [...fused.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, limit)
+      .map(([id]) => id);
+
+    // ── hydrate (drop pages deleted since indexing) ──
+    const pages = await Promise.all(topIds.map((id) => this.deps.pages.getById(id)));
+    const hits: QueryKnowledgeHit[] = [];
+    for (const page of pages) {
+      if (!page) continue;
+      const snippet =
+        vectorSnippet.get(page._id) ?? lexicalSnippet.get(page._id) ?? page.plainText.slice(0, 800);
+      hits.push({
+        pageId: page._id,
+        title: page.title,
+        snippet,
+        source: page.source,
+        score: fused.get(page._id) ?? 0,
+        spaceId: page.spaceId ?? undefined,
+        path: page.spaceId ? (page.path ?? undefined) : undefined,
+      });
+    }
+
+    // ── rerank seam: default identity; the NotImplemented stub (when enabled) throws by design ──
+    const results = await resolveRerank().rerank(query, hits, limit);
+    return { results, warnings };
   }
 
   governancePages(): Promise<KnowledgePage[]> {

--- a/apps/api/src/knowledge/tools.test.ts
+++ b/apps/api/src/knowledge/tools.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { KnowledgeService } from "./service";
 import { KNOWLEDGE_TOOLS, type KnowledgeTool, type KnowledgeToolContext } from "./tools";
+import type { QueryKnowledgeHit } from "./types";
 
 function getTool(name: string): KnowledgeTool {
   const t = KNOWLEDGE_TOOLS.find((x) => x.name === name);
@@ -29,17 +30,36 @@ describe("knowledge tools", () => {
     ]);
   });
 
-  it("query_knowledge forwards an optional spaceId filter to the service", async () => {
-    const search = vi.fn(async () => ({ results: [], warnings: [] }));
+  it("query_knowledge forwards a valid UUID spaceId filter to the service", async () => {
+    const hybridSearchPages = vi.fn(async () => ({ results: [], warnings: [] }));
+    const uuid = "cf653c1b-e20a-4edd-81ec-dc92c7ae193f";
     await getTool("query_knowledge").handler(
-      { query: "sla", spaceId: "b1" },
-      ctx({ search } as never)
+      { query: "sla", spaceId: uuid },
+      ctx({ hybridSearchPages } as never)
     );
-    expect(search).toHaveBeenCalledWith(
+    expect(hybridSearchPages).toHaveBeenCalledWith(
       "sla",
-      expect.objectContaining({ spaceId: "b1" }),
-      expect.any(Number),
-      expect.anything()
+      expect.objectContaining({ spaceId: uuid }),
+      expect.any(Number)
+    );
+  });
+
+  it("query_knowledge normalizes placeholder filters: ignores non-UUID spaceId and blank domain", async () => {
+    const hybridSearchPages = vi.fn(async () => ({ results: [], warnings: [] }));
+    // Agents often fill optional params with placeholders ("global", "default", "", "*").
+    const res = await getTool("query_knowledge").handler(
+      { query: "pooling", spaceId: "global", domain: "", tags: [] },
+      ctx({ hybridSearchPages } as never)
+    );
+    expect(hybridSearchPages).toHaveBeenCalledWith(
+      "pooling",
+      { spaceId: undefined, domain: undefined, tags: undefined },
+      expect.any(Number)
+    );
+    // No throw, and the dropped spaceId is surfaced as a debuggable warning.
+    expect(res).toMatchObject({ success: true });
+    expect((res as { data: { warnings: string[] } }).data.warnings).toContain(
+      "ignored-invalid-spaceId"
     );
   });
 
@@ -134,11 +154,11 @@ describe("knowledge tools", () => {
     });
   });
 
-  it("cite_sources resolves pageIds to refs (wiki url only for space pages) and dedups by pageId", async () => {
+  it("cite_sources resolves pageIds to refs (wiki url + path for space pages) and dedups by pageId", async () => {
     // getActivePage already filters soft-deleted/missing → returns null for those.
     const getActivePage = vi.fn(async (id: string) =>
       id === "page-1"
-        ? { _id: "page-1", title: "Orders", spaceId: "b1" }
+        ? { _id: "page-1", title: "Orders", spaceId: "b1", path: "tables/orders" }
         : id === "flat-1"
           ? { _id: "flat-1", title: "Memo", spaceId: null }
           : null
@@ -155,12 +175,18 @@ describe("knowledge tools", () => {
       },
       ctx({ getActivePage } as never)
     );
-    // Space page → wiki url; flat page → no url key; soft-deleted + missing → dropped; dup deduped.
+    // Space page → wiki url + path; flat page → no url/path key; soft-deleted + missing → dropped; dup deduped.
     expect(res).toEqual({
       success: true,
       data: {
         sources: [
-          { ref: 1, id: "page-1", title: "Orders", url: "/knowledge/pages/page-1" },
+          {
+            ref: 1,
+            id: "page-1",
+            title: "Orders",
+            url: "/knowledge/pages/page-1",
+            path: "tables/orders",
+          },
           { ref: 2, id: "flat-1", title: "Memo" },
         ],
       },
@@ -180,21 +206,31 @@ describe("knowledge tools", () => {
     ).toMatchObject({ success: false, error: { code: "validation_error" } });
   });
 
-  it("query_knowledge validates input and returns results", async () => {
-    const search = vi.fn(async () => ({
-      results: [
-        { pageId: "d", chunkId: "c", title: "T", content: "x", source: "authored", score: 0.9 },
-      ],
-      warnings: [],
-    }));
+  it("query_knowledge validates input and returns page-level hits (no chunkId)", async () => {
+    const hits: QueryKnowledgeHit[] = [
+      {
+        pageId: "d1",
+        title: "France",
+        snippet: "Paris is the capital",
+        source: "authored",
+        score: 0.9,
+        path: "geo/france",
+        spaceId: "b1",
+      },
+      { pageId: "d2", title: "Memo", snippet: "flat page", source: "conversation", score: 0.5 },
+    ];
+    const hybridSearchPages = vi.fn(async () => ({ results: hits, warnings: [] }));
     const t = getTool("query_knowledge");
     expect(await t.handler({}, ctx({}))).toMatchObject({
       success: false,
       error: { code: "validation_error" },
     });
-    const good = await t.handler({ query: "france" }, ctx({ search } as never));
-    expect(good).toMatchObject({ success: true });
-    expect(search).toHaveBeenCalled();
+    const good = await t.handler({ query: "france" }, ctx({ hybridSearchPages } as never));
+    expect(good).toMatchObject({ success: true, data: { results: hits, warnings: [] } });
+    expect(hybridSearchPages).toHaveBeenCalled();
+    // Page-level hits carry no chunkId.
+    const results = (good as { data: { results: QueryKnowledgeHit[] } }).data.results;
+    for (const hit of results) expect(hit).not.toHaveProperty("chunkId");
   });
 
   it("create_knowledge_page validates and returns the id", async () => {
@@ -206,10 +242,13 @@ describe("knowledge tools", () => {
   });
 
   it("returns internal_error (never throws) when the service fails", async () => {
-    const search = vi.fn(async () => {
+    const hybridSearchPages = vi.fn(async () => {
       throw new Error("db down");
     });
-    const res = await getTool("query_knowledge").handler({ query: "x" }, ctx({ search } as never));
+    const res = await getTool("query_knowledge").handler(
+      { query: "x" },
+      ctx({ hybridSearchPages } as never)
+    );
     expect(res).toMatchObject({
       success: false,
       error: { code: "internal_error", message: "db down" },

--- a/apps/api/src/knowledge/tools.ts
+++ b/apps/api/src/knowledge/tools.ts
@@ -44,9 +44,14 @@ const QUERY_SCHEMA = {
     domain: { type: "string" },
     tags: { type: "array", items: { type: "string" } },
     limit: { type: "number" },
-    spaceId: { type: "string", minLength: 1 },
+    // No minLength: agents tend to fill optional params with placeholders ("", "global", "*").
+    // The handler normalizes these to "no filter" rather than rejecting or crashing on a bad UUID.
+    spaceId: { type: "string" },
   },
 } as const;
+
+/** Canonical UUID shape — a `spaceId` that isn't one is ignored (treated as no space filter). */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const validateQuery = ajv.compile(QUERY_SCHEMA);
 
 const CITE_SOURCES_SCHEMA = {
@@ -87,7 +92,7 @@ const validateCreatePage = ajv.compile(CREATE_PAGE_SCHEMA);
 const queryKnowledge: KnowledgeTool = {
   name: "query_knowledge",
   description:
-    "Search the shared knowledge base by meaning (vector) with a lexical fallback. Returns ranked chunks with their source page. Use to ground answers in stored pages. Pass `spaceId` to scope the search to a single space (wiki).",
+    "Search the shared knowledge base by meaning (vector) with a lexical fallback. Returns ranked pages, each with a matching snippet for orientation — read the whole page with `get_page` before answering. Use to ground answers in stored pages. Pass `spaceId` to scope the search to a single space (wiki).",
   mutating: false,
   inputSchema: QUERY_SCHEMA,
   handler: async (args, ctx) => {
@@ -99,14 +104,20 @@ const queryKnowledge: KnowledgeTool = {
       limit?: number;
       spaceId?: string;
     };
+    // Normalize agent-supplied filters: blank/placeholder values mean "no filter", and a non-UUID
+    // spaceId is ignored (rather than crashing the space_id = $n UUID comparison in the DB).
+    const domain = a.domain?.trim() ? a.domain.trim() : undefined;
+    const tags = a.tags && a.tags.length > 0 ? a.tags : undefined;
+    const rawSpaceId = a.spaceId?.trim();
+    const spaceId = rawSpaceId && UUID_RE.test(rawSpaceId) ? rawSpaceId : undefined;
+    const filterWarnings = rawSpaceId && !spaceId ? ["ignored-invalid-spaceId"] : [];
     try {
-      const res = await ctx.service.search(
+      const res = await ctx.service.hybridSearchPages(
         a.query,
-        { domain: a.domain, tags: a.tags, spaceId: a.spaceId },
-        Math.min(Math.max(a.limit ?? 10, 1), 50),
-        { expandGraph: true }
+        { domain, tags, spaceId },
+        Math.min(Math.max(a.limit ?? 10, 1), 50)
       );
-      return ok({ results: res.results, warnings: res.warnings });
+      return ok({ results: res.results, warnings: [...filterWarnings, ...res.warnings] });
     } catch (e) {
       return err("internal_error", reason(e));
     }
@@ -123,7 +134,7 @@ const citeSources: KnowledgeTool = {
     if (!validateCite(args)) return err("validation_error", firstError(validateCite));
     const a = args as { citations: { ref: number; pageId: string }[] };
     try {
-      const sources: { ref: number; id: string; title: string; url?: string }[] = [];
+      const sources: { ref: number; id: string; title: string; url?: string; path?: string }[] = [];
       const seen = new Set<string>();
       for (const c of a.citations) {
         // Dedup by pageId — a page cited under several [n] refs lists once in the footer (keep the
@@ -134,7 +145,15 @@ const citeSources: KnowledgeTool = {
         const page = await ctx.service.getActivePage(c.pageId);
         if (!page) continue;
         const url = pageUrl(page);
-        sources.push({ ref: c.ref, id: page._id, title: page.title, ...(url ? { url } : {}) });
+        // `path` only for space (OKF) pages — flat pages have no spaceId/path and stay path-less.
+        const path = page.spaceId && page.path ? page.path : undefined;
+        sources.push({
+          ref: c.ref,
+          id: page._id,
+          title: page.title,
+          ...(url ? { url } : {}),
+          ...(path ? { path } : {}),
+        });
       }
       return ok({ sources });
     } catch (e) {

--- a/apps/api/src/knowledge/types.ts
+++ b/apps/api/src/knowledge/types.ts
@@ -165,6 +165,21 @@ export interface SearchHit {
   score: number;
 }
 
+/**
+ * One page-level hit from the hybrid `query_knowledge` tool. Distinct from
+ * `PageHit` in retrieval-service.ts (which carries highlightRanges); named to avoid that collision.
+ * `snippet` is the best-matching chunk content for orientation — read the whole page with get_page.
+ */
+export interface QueryKnowledgeHit {
+  pageId: string;
+  title: string;
+  snippet: string;
+  source: KnowledgeSource;
+  score: number;
+  path?: string;
+  spaceId?: string;
+}
+
 export interface SearchResults {
   results: SearchHit[];
   warnings: string[];

--- a/apps/web/app/components/chat/parts.tsx
+++ b/apps/web/app/components/chat/parts.tsx
@@ -199,6 +199,7 @@ function SourcesPart({ sources }: { sources: SourceRef[] }) {
               ) : (
                 <span className="text-muted-foreground">{label}</span>
               )}
+              {s.path ? <div className="text-xs text-muted-foreground">{s.path}</div> : null}
             </li>
           );
         })}
@@ -228,6 +229,9 @@ export function MessagePartView({
     case "reasoning":
       return <ReasoningPart text={part.text} />;
     case "tool":
+      // cite_sources is citation plumbing — its output already renders as the source chips and the
+      // inline [n] links, so its tool row is noise. Hide it (it never needs approval).
+      if (part.toolName === "cite_sources") return null;
       return (
         <ToolPart
           toolName={part.toolName}

--- a/apps/web/app/components/markdown-view.test.tsx
+++ b/apps/web/app/components/markdown-view.test.tsx
@@ -38,7 +38,8 @@ test("linkifies inline [n] citation markers to their cited page, leaving unknown
   // [1] has a resolved source → in-app link; [2] has no source → stays literal text.
   const cite = screen.getByRole("link", { name: "[1]" });
   expect(cite).toHaveAttribute("href", "/knowledge/pages/d1");
-  expect(cite).not.toHaveAttribute("target", "_blank");
+  // Citations open the source in a new tab (so the chat thread isn't navigated away from).
+  expect(cite).toHaveAttribute("target", "_blank");
   expect(screen.queryByRole("link", { name: "[2]" })).toBeNull();
   expect(screen.getByText(/disputes differ \[2\]\./)).toBeInTheDocument();
 });
@@ -129,8 +130,8 @@ test("wikiLinks + citations compose: both an internal page link and a [n] citati
   const wiki = screen.getByRole("link", { name: "Runbook" });
   expect(wiki).toHaveAttribute("href", "/knowledge/pages/abc/runbook");
   expect(wiki).not.toHaveAttribute("target");
-  // …and the citation marker still linkifies to its cited page.
+  // …and the citation marker still linkifies to its cited page, opening in a new tab.
   const cite = screen.getByRole("link", { name: "[1]" });
   expect(cite).toHaveAttribute("href", "/knowledge/pages/d1");
-  expect(cite).not.toHaveAttribute("target", "_blank");
+  expect(cite).toHaveAttribute("target", "_blank");
 });

--- a/apps/web/app/components/markdown-view.tsx
+++ b/apps/web/app/components/markdown-view.tsx
@@ -34,8 +34,10 @@ function makeAnchorRenderer(opts: { wikiLinks: boolean; citations: boolean }): C
       return (
         <Link
           to={target}
+          target="_blank"
+          rel="noreferrer"
           className="font-medium text-primary no-underline hover:underline cursor-pointer"
-          title="cited source"
+          title={`Open cited source (${target}) in a new tab`}
         >
           {children}
         </Link>

--- a/apps/web/app/lib/chat/hydrate.ts
+++ b/apps/web/app/lib/chat/hydrate.ts
@@ -1,4 +1,4 @@
-import type { ChatMessage, TimelinePart } from "~/lib/chat/types";
+import type { ChatMessage, SourceRef, TimelinePart } from "~/lib/chat/types";
 import type { ConversationMessage, WireMessagePart } from "~/lib/conversations";
 
 /*
@@ -33,7 +33,16 @@ function assistantParts(content: string | WireMessagePart[]): TimelinePart[] {
   return parts;
 }
 
-// Fold a `tool` turn's results into the matching tool parts of the assistant turn it answers.
+// Pull the SourceRef[] out of a persisted cite_sources tool-result (`{ data: { sources } }`), so a
+// restored transcript can rebuild its citation chips. Defensive — unknown/legacy shapes yield [].
+function sourcesFromResult(result: unknown): SourceRef[] {
+  const sources = (result as { data?: { sources?: unknown } })?.data?.sources;
+  return Array.isArray(sources) ? (sources as SourceRef[]) : [];
+}
+
+// Fold a `tool` turn's results into the matching tool parts of the assistant turn it answers. A
+// cite_sources result also reconstructs the `sources` part the live reducer would have appended, so
+// citations (and inline [n] links) survive a page refresh.
 function mergeToolResults(assistant: ChatMessage, content: WireMessagePart[]): void {
   for (const part of content) {
     if (part.type !== "tool-result") continue;
@@ -41,6 +50,10 @@ function mergeToolResults(assistant: ChatMessage, content: WireMessagePart[]): v
       if (p.kind === "tool" && p.toolCallId === part.toolCallId) {
         p.result = part.result;
         p.status = "done";
+        if (p.toolName === "cite_sources") {
+          const sources = sourcesFromResult(part.result);
+          if (sources.length > 0) assistant.parts.push({ kind: "sources", sources });
+        }
       }
     }
   }

--- a/apps/web/app/lib/chat/types.ts
+++ b/apps/web/app/lib/chat/types.ts
@@ -31,7 +31,7 @@ export type StepStatus = "pending" | "running" | "done" | "error";
 
 export type PlanStep = { id: string; label: string; status: StepStatus };
 // `ref` is the inline citation number the agent wrote (`[ref]`); it ties a source to its `[n]` marker.
-export type SourceRef = { id?: string; title?: string; url?: string; ref?: number };
+export type SourceRef = { id?: string; title?: string; url?: string; ref?: number; path?: string };
 
 // Discriminated union over every event the wire can carry; `data` is typed per `type`.
 export type ChatEvent =


### PR DESCRIPTION
Upgrade query_knowledge from vector-or-lexical chunk lookup to page-level hybrid retrieval, and harden the citation/grounding flow end to end.

Retrieval
- KnowledgeService.hybridSearchPages: RRF (k=60, by rank) fusing a vector arm (chunks->page, max-score chunk snippet) with the lexical PageRetrievalService; new required `retrieval` dep wired at all construction sites. No migration.
- query_knowledge returns QueryKnowledgeHit[] (pages + snippet, no chunkId); agents read whole pages via get_page. Degrades to lexical-only with an `embedding-unavailable` warning when no embedding model is configured.
- Defensive filter normalization: blank/placeholder domain/spaceId -> no filter, non-UUID spaceId ignored (was crashing with an invalid-uuid internal_error).
- Inert, flag-gated rerank seam (rerank.ts, KNOWLEDGE_RERANK; noop by default).

Grounding + citations
- KNOWLEDGE_GROUNDING_TEXT rewritten as an anchor->read->expand->cite loop with a 2-hop cap; restores the explicit "do not invent domain/spaceId filters" guard.
- cite_sources + sources SSE event carry page `path`; web SourceRef renders it.
- cite_sources is now a terminal step (stopWhen) so the model can't restate the whole answer after citing (fixes duplicated output).
- hydrate rebuilds the `sources` part from the persisted cite_sources tool-result so citations + inline [n] links survive a page refresh.
- Citation [n] opens the source in a new tab; cite_sources tool row hidden.

Tests: hybrid-search + hybrid-golden (recall@5 hybrid 1.0 > lexical 0.88) + rerank; tool-shape, grounding, producer, and parts coverage updated.