### PR TITLE
chore(ci): disable all Claude Code GitHub Actions

### DIFF
--- a/.github/workflows/absolute-audit.yml
+++ b/.github/workflows/absolute-audit.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   audit:
+    if: false
     name: Security audit and fix
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/absolute-debt.yml
+++ b/.github/workflows/absolute-debt.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   debt:
+    if: false
     name: Pay down one lint/type rule
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/absolute-prune.yml
+++ b/.github/workflows/absolute-prune.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   prune:
+    if: false
     name: Remove dead code
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/absolute-simplify-cron.yml
+++ b/.github/workflows/absolute-simplify-cron.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   simplify:
+    if: false
     name: Simplify target directory
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/absolute-simplify-pr.yml
+++ b/.github/workflows/absolute-simplify-pr.yml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   simplify:
+    if: false
     name: Simplify PR diff
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/absolute-upgrade.yml
+++ b/.github/workflows/absolute-upgrade.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   upgrade:
+    if: false
     name: Upgrade one dependency
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,12 +12,7 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
+    if: false
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,7 @@ on:
 
 jobs:
   claude:
-    if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    if: false
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   update-docs:
+    if: false
     name: Auto-update documentation
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

- Adds `if: false` to jobs in all 9 Claude Code workflows
- Affected: `claude.yml`, `claude-code-review.yml`, `absolute-audit.yml`, `absolute-debt.yml`, `absolute-prune.yml`, `absolute-simplify-cron.yml`, `absolute-simplify-pr.yml`, `absolute-upgrade.yml`, `docs-update.yml`
- Files preserved — re-enable by removing `if: false` from each job