### PR TITLE
chore: add CLAUDE.md to each AGENTS.md directory

### DIFF
--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/apps/api/src/auth/CLAUDE.md
+++ b/apps/api/src/auth/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/apps/docs/CLAUDE.md
+++ b/apps/docs/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/constants/CLAUDE.md
+++ b/packages/constants/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/llm/CLAUDE.md
+++ b/packages/llm/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/secrets/CLAUDE.md
+++ b/packages/secrets/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/soul/CLAUDE.md
+++ b/packages/soul/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/tsconfig/CLAUDE.md
+++ b/packages/tsconfig/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/types/CLAUDE.md
+++ b/packages/types/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/ui/CLAUDE.md
+++ b/packages/ui/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/utils/CLAUDE.md
+++ b/packages/utils/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/validation/CLAUDE.md
+++ b/packages/validation/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
Mirror the root CLAUDE.md (@AGENTS.md) into every app and package directory that has an AGENTS.md, so Claude Code picks up the local guidance from the nearest directory.