### PR TITLE
feat(settings): add read-only soul explorer with file tree + syntax h…

### DIFF
--- a/apps/api/src/soul/routes.test.ts
+++ b/apps/api/src/soul/routes.test.ts
@@ -1,3 +1,4 @@
+import { readdir, readFile, realpath, stat } from "node:fs/promises";
 import type { GitSyncService } from "@tulipfarm/soul";
 import type { FastifyInstance } from "fastify";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -8,8 +9,64 @@ import { SESSION_COOKIE } from "../auth/middleware";
 import { MemorySessionStore } from "../auth/session-store";
 import { createUser, type UserDoc, type UserRepo } from "../auth/users";
 import type { PaginatedResult } from "../pagination";
+import { inferLanguage } from "./tree";
+
+// Override only the FS calls used by the soul tree/file routes; keep everything else real.
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...actual,
+    readdir: vi.fn(),
+    readFile: vi.fn(),
+    realpath: vi.fn(),
+    stat: vi.fn(),
+  };
+});
 
 const TEST_CSRF = "a".repeat(64);
+
+const SOUL_ROOT = "/soul";
+
+const enoent = () => Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+
+type Kind = "dir" | "file" | "link";
+function dirent(name: string, kind: Kind) {
+  return {
+    name,
+    isDirectory: () => kind === "dir",
+    isFile: () => kind === "file",
+    isSymbolicLink: () => kind === "link",
+  };
+}
+
+// Configure the mocked FS to model a tiny soul repo on disk.
+function mockSoulFs() {
+  vi.mocked(readdir).mockImplementation((async (p: string) => {
+    const key = String(p);
+    if (key === SOUL_ROOT) {
+      return [dirent("agents", "dir"), dirent(".git", "dir"), dirent("soul.yaml", "file")];
+    }
+    if (key === `${SOUL_ROOT}/agents`) return [dirent("demo", "dir"), dirent("AGENT.md", "file")];
+    if (key === `${SOUL_ROOT}/agents/demo`) return [dirent("AGENT.md", "file")];
+    throw enoent();
+  }) as unknown as typeof readdir);
+
+  vi.mocked(stat).mockImplementation((async () => ({
+    isFile: () => true,
+    size: 42,
+  })) as unknown as typeof stat);
+
+  vi.mocked(realpath).mockImplementation((async (p: string) => {
+    const key = String(p);
+    if (key.includes("missing")) throw enoent();
+    return key;
+  }) as unknown as typeof realpath);
+
+  vi.mocked(readFile).mockImplementation((async (p: string) => {
+    if (String(p).includes("data.bin")) return Buffer.from([0x68, 0x69, 0x00, 0x69]);
+    return Buffer.from("name: demo\n", "utf8");
+  }) as unknown as typeof readFile);
+}
 
 // ── Fake dependencies ─────────────────────────────────────────────────────────
 
@@ -59,6 +116,7 @@ class FakeTokenRepo implements TokenRepo {
 
 function makeFakeGitSync(overrides: Partial<{ commit: unknown; push: unknown }> = {}) {
   return {
+    path: SOUL_ROOT,
     commit: vi.fn().mockResolvedValue({ sha: "abc1234", filesChanged: 2 }),
     push: vi.fn().mockResolvedValue(true),
     ...overrides,
@@ -176,6 +234,126 @@ describe("soul routes", () => {
       });
       expect(res.statusCode).toBe(200);
       expect(res.json()).toEqual({ pushed: false });
+    });
+  });
+
+  // ── GET /api/v1/soul/tree ─────────────────────────────────────────────────
+
+  describe("GET /api/v1/soul/tree", () => {
+    beforeEach(() => mockSoulFs());
+
+    it("returns 401 without auth", async () => {
+      const res = await app.inject({ method: "GET", url: "/api/v1/soul/tree" });
+      expect(res.statusCode).toBe(401);
+    });
+
+    it("returns the tree with .git excluded and dirs sorted first", async () => {
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/soul/tree",
+        cookies: { [SESSION_COOKIE]: sid },
+      });
+      expect(res.statusCode).toBe(200);
+      type Node = { name: string; children?: Node[] };
+      const { root } = res.json() as { root: Node[] };
+      expect(root.map((n) => n.name)).toEqual(["agents", "soul.yaml"]);
+      // dirs sorted before files at each level
+      expect(root[0].children?.map((c) => c.name)).toEqual(["demo", "AGENT.md"]);
+      // depth-2 children survive serialization (recursive response schema)
+      expect(root[0].children?.[0].children?.map((c) => c.name)).toEqual(["AGENT.md"]);
+    });
+
+    it("returns an empty tree when the soul directory is missing", async () => {
+      vi.mocked(readdir).mockRejectedValueOnce(enoent());
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/soul/tree",
+        cookies: { [SESSION_COOKIE]: sid },
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ root: [] });
+    });
+  });
+
+  // ── GET /api/v1/soul/file ─────────────────────────────────────────────────
+
+  describe("GET /api/v1/soul/file", () => {
+    beforeEach(() => mockSoulFs());
+
+    it("returns 401 without auth", async () => {
+      const res = await app.inject({ method: "GET", url: "/api/v1/soul/file?path=soul.yaml" });
+      expect(res.statusCode).toBe(401);
+    });
+
+    it("returns raw content with inferred language", async () => {
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/soul/file?path=soul.yaml",
+        cookies: { [SESSION_COOKIE]: sid },
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toMatchObject({
+        path: "soul.yaml",
+        content: "name: demo\n",
+        language: "yaml",
+      });
+    });
+
+    it("flags binary files without returning their bytes", async () => {
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/soul/file?path=data.bin",
+        cookies: { [SESSION_COOKIE]: sid },
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toMatchObject({ binary: true, content: "" });
+    });
+
+    it("rejects path traversal with 400", async () => {
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/soul/file?path=../../../etc/passwd",
+        cookies: { [SESSION_COOKIE]: sid },
+      });
+      expect(res.statusCode).toBe(400);
+    });
+
+    it("rejects .git access with 400", async () => {
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/soul/file?path=.git/config",
+        cookies: { [SESSION_COOKIE]: sid },
+      });
+      expect(res.statusCode).toBe(400);
+    });
+
+    it("rejects nested .git access (e.g. submodules) with 400", async () => {
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/soul/file?path=agents/.git/config",
+        cookies: { [SESSION_COOKIE]: sid },
+      });
+      expect(res.statusCode).toBe(400);
+    });
+
+    it("returns 404 for a missing file", async () => {
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/soul/file?path=missing.yaml",
+        cookies: { [SESSION_COOKIE]: sid },
+      });
+      expect(res.statusCode).toBe(404);
+    });
+  });
+
+  describe("inferLanguage", () => {
+    it("maps soul filenames to Shiki languages", () => {
+      expect(inferLanguage("AGENT.md")).toBe("markdown");
+      expect(inferLanguage("hooks.ts")).toBe("typescript");
+      expect(inferLanguage("schema.yml")).toBe("yaml");
+      expect(inferLanguage("skills-lock.json")).toBe("json");
+      expect(inferLanguage("setup.sh")).toBe("bash");
+      expect(inferLanguage("LICENSE")).toBe("plaintext");
     });
   });
 });

--- a/apps/api/src/soul/routes.ts
+++ b/apps/api/src/soul/routes.ts
@@ -1,14 +1,32 @@
 import type { GitSyncService } from "@tulipfarm/soul";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { ErrorSchema } from "../auth/schemas";
+import { readSoulFile, resolveSafe, UnsafePathError, walkTree } from "./tree";
 
 type PreHandler = (req: FastifyRequest, reply: FastifyReply) => Promise<void>;
+
+function isErrnoException(err: unknown): err is NodeJS.ErrnoException {
+  return err instanceof Error && "code" in err;
+}
 
 export function registerSoulRoutes(
   app: FastifyInstance,
   gitSync: GitSyncService,
   requireAuth: PreHandler
 ): void {
+  // Recursive node schema for the soul tree response (self-referencing children).
+  app.addSchema({
+    $id: "soulTreeNode",
+    type: "object",
+    properties: {
+      name: { type: "string" },
+      path: { type: "string" },
+      type: { type: "string", enum: ["file", "dir"] },
+      size: { type: "number" },
+      children: { type: "array", items: { $ref: "soulTreeNode#" } },
+    },
+    required: ["name", "path", "type"],
+  });
   app.post(
     "/api/v1/soul/commit",
     {
@@ -68,6 +86,89 @@ export function registerSoulRoutes(
     async (_req, reply) => {
       const pushed = await gitSync.push();
       return reply.send({ pushed });
+    }
+  );
+
+  app.get(
+    "/api/v1/soul/tree",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description: "Read-only recursive file tree of the soul git repo (excludes .git).",
+        tags: ["soul"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        response: {
+          200: {
+            type: "object",
+            properties: { root: { type: "array", items: { $ref: "soulTreeNode#" } } },
+            required: ["root"],
+          },
+          401: ErrorSchema,
+        },
+      },
+    },
+    async (_req, reply) => {
+      const soulRoot = gitSync.path;
+      try {
+        const root = await walkTree(soulRoot, soulRoot);
+        return reply.send({ root });
+      } catch (err) {
+        // Uninitialized soul (directory missing) → empty tree, not an error.
+        if (isErrnoException(err) && err.code === "ENOENT") {
+          return reply.send({ root: [] });
+        }
+        throw err;
+      }
+    }
+  );
+
+  app.get(
+    "/api/v1/soul/file",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description: "Read-only raw content of a single soul file (path-traversal guarded).",
+        tags: ["soul"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        querystring: {
+          type: "object",
+          required: ["path"],
+          properties: { path: { type: "string", minLength: 1 } },
+        },
+        response: {
+          200: {
+            type: "object",
+            properties: {
+              path: { type: "string" },
+              content: { type: "string" },
+              size: { type: "number" },
+              language: { type: "string" },
+              binary: { type: "boolean" },
+              tooLarge: { type: "boolean" },
+            },
+            required: ["path", "content", "size", "language"],
+          },
+          400: ErrorSchema,
+          401: ErrorSchema,
+          404: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const { path } = req.query as { path: string };
+      try {
+        const abs = await resolveSafe(gitSync.path, path);
+        const file = await readSoulFile(abs, path);
+        return reply.send(file);
+      } catch (err) {
+        if (err instanceof UnsafePathError) {
+          return reply.code(400).send({ error: err.message });
+        }
+        if (isErrnoException(err) && err.code === "ENOENT") {
+          return reply.code(404).send({ error: "file not found" });
+        }
+        throw err;
+      }
     }
   );
 }

--- a/apps/api/src/soul/tree.ts
+++ b/apps/api/src/soul/tree.ts
@@ -70,6 +70,11 @@ export async function resolveSafe(soulRoot: string, rel: string): Promise<string
   if (decoded.includes("\0")) throw new UnsafePathError("invalid path");
   if (isAbsolute(decoded)) throw new UnsafePathError("absolute path not allowed");
 
+  const inputSegments = decoded.split(/[\\/]+/);
+  if (inputSegments.some((s) => s.length === 0 || s === "." || s === "..")) {
+    throw new UnsafePathError("path traversal not allowed");
+  }
+
   const rootReal = await realpath(soulRoot);
   const candidate = resolve(rootReal, decoded);
   const candReal = await realpath(candidate); // resolves symlinks; ENOENT bubbles → 404

--- a/apps/api/src/soul/tree.ts
+++ b/apps/api/src/soul/tree.ts
@@ -1,0 +1,121 @@
+import { readdir, readFile, realpath, stat } from "node:fs/promises";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
+
+// Read-only soul-repo filesystem helpers backing the Soul Explorer routes.
+// The soul repo is a real git directory on disk; these walk and read it safely.
+
+export type TreeNode = {
+  name: string;
+  path: string; // POSIX relpath from the soul root
+  type: "file" | "dir";
+  size?: number;
+  children?: TreeNode[];
+};
+
+export type SoulFileContent = {
+  path: string;
+  content: string;
+  size: number;
+  language: string;
+  binary?: boolean;
+  tooLarge?: boolean;
+};
+
+const EXCLUDE_DIRS = new Set([".git"]);
+const MAX_FILE_BYTES = 512 * 1024;
+const BINARY_SNIFF_BYTES = 8000;
+
+// Thrown for any rejected/unsafe path — the route maps it to a 400.
+export class UnsafePathError extends Error {}
+
+/** Recursively walk a directory into a sorted tree (dirs first, then files, alphabetical). */
+export async function walkTree(soulRoot: string, dirAbs: string): Promise<TreeNode[]> {
+  const entries = await readdir(dirAbs, { withFileTypes: true });
+  const nodes: TreeNode[] = [];
+  for (const entry of entries) {
+    if (entry.isSymbolicLink()) continue; // never follow symlinks
+    if (entry.isDirectory() && EXCLUDE_DIRS.has(entry.name)) continue;
+    const abs = join(dirAbs, entry.name);
+    const rel = toPosix(relative(soulRoot, abs));
+    if (entry.isDirectory()) {
+      nodes.push({
+        name: entry.name,
+        path: rel,
+        type: "dir",
+        children: await walkTree(soulRoot, abs),
+      });
+    } else if (entry.isFile()) {
+      const info = await stat(abs);
+      nodes.push({ name: entry.name, path: rel, type: "file", size: info.size });
+    }
+  }
+  nodes.sort((a, b) =>
+    a.type !== b.type ? (a.type === "dir" ? -1 : 1) : a.name.localeCompare(b.name)
+  );
+  return nodes;
+}
+
+/**
+ * Resolve a client-supplied relative path to an absolute path that is provably
+ * inside the soul root. Layered defenses against traversal/symlink escape.
+ * Throws UnsafePathError for rejected paths; lets ENOENT bubble (→ 404 in the route).
+ */
+export async function resolveSafe(soulRoot: string, rel: string): Promise<string> {
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(rel);
+  } catch {
+    throw new UnsafePathError("invalid path encoding");
+  }
+  if (decoded.includes("\0")) throw new UnsafePathError("invalid path");
+  if (isAbsolute(decoded)) throw new UnsafePathError("absolute path not allowed");
+
+  const rootReal = await realpath(soulRoot);
+  const candidate = resolve(rootReal, decoded);
+  const candReal = await realpath(candidate); // resolves symlinks; ENOENT bubbles → 404
+
+  const withSep = rootReal.endsWith(sep) ? rootReal : rootReal + sep;
+  if (candReal !== rootReal && !candReal.startsWith(withSep)) {
+    throw new UnsafePathError("path escapes soul root");
+  }
+  const segments = relative(rootReal, candReal).split(sep);
+  if (segments.some((s) => s === ".git")) throw new UnsafePathError("path not allowed");
+  return candReal;
+}
+
+/** Read a single soul file with size + binary guards. `abs` must be pre-resolved via resolveSafe. */
+export async function readSoulFile(abs: string, relPath: string): Promise<SoulFileContent> {
+  const info = await stat(abs);
+  if (!info.isFile()) throw new UnsafePathError("not a file");
+  const language = inferLanguage(relPath);
+  if (info.size > MAX_FILE_BYTES) {
+    return { path: relPath, content: "", size: info.size, language, tooLarge: true };
+  }
+  const buf = await readFile(abs);
+  if (buf.subarray(0, BINARY_SNIFF_BYTES).includes(0)) {
+    return { path: relPath, content: "", size: info.size, language: "plaintext", binary: true };
+  }
+  return { path: relPath, content: buf.toString("utf8"), size: info.size, language };
+}
+
+/** Infer a Shiki language id from a filename. Maps 1:1 onto the langs the client loads. */
+export function inferLanguage(name: string): string {
+  const lower = name.toLowerCase();
+  if (lower.endsWith(".md") || lower.endsWith(".markdown")) return "markdown";
+  if (lower.endsWith(".yaml") || lower.endsWith(".yml")) return "yaml";
+  if (lower.endsWith(".json")) return "json";
+  if (
+    lower.endsWith(".ts") ||
+    lower.endsWith(".tsx") ||
+    lower.endsWith(".mts") ||
+    lower.endsWith(".cts")
+  ) {
+    return "typescript";
+  }
+  if (lower.endsWith(".sh") || lower.endsWith(".bash")) return "bash";
+  return "plaintext";
+}
+
+function toPosix(p: string): string {
+  return p.split(sep).join("/");
+}

--- a/apps/web/app/components/soul/soul-file-viewer.tsx
+++ b/apps/web/app/components/soul/soul-file-viewer.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useState } from "react";
+import { ApiError } from "~/lib/api";
+import { highlight } from "~/lib/shiki";
+import { getSoulFile, type SoulFile } from "~/lib/soul";
+
+/*
+ * Read-only source viewer for a single soul file. Fetches raw content from the API, then renders it
+ * with Shiki (client-side). Markdown is shown as highlighted source — like VS Code, not rendered.
+ * Recolors live on dark-mode toggle via the shared "themechange" window event (theme-toggle.tsx).
+ */
+
+function readTheme(): "light" | "dark" {
+  if (typeof document === "undefined") return "light";
+  return document.documentElement.getAttribute("data-theme") === "dark" ? "dark" : "light";
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  return `${(bytes / 1024).toFixed(1)} KB`;
+}
+
+export function SoulFileViewer({ path }: { path: string | null }) {
+  const [file, setFile] = useState<SoulFile | null>(null);
+  const [html, setHtml] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [theme, setTheme] = useState<"light" | "dark">(readTheme);
+
+  // Track the app theme so the highlighted source recolors in lockstep with the rest of the UI.
+  useEffect(() => {
+    const read = () => setTheme(readTheme());
+    window.addEventListener("themechange", read);
+    return () => window.removeEventListener("themechange", read);
+  }, []);
+
+  // Fetch raw content whenever the selected file changes.
+  useEffect(() => {
+    if (!path) {
+      setFile(null);
+      setHtml(null);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setFile(null); // drop stale size/content from the previous selection immediately
+    setHtml(null);
+    getSoulFile(path)
+      .then((f) => {
+        if (!cancelled) setFile(f);
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setError(err instanceof ApiError ? err.message : "failed to load file");
+          setFile(null);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [path]);
+
+  // (Re)highlight when the content or theme changes; skip non-text files.
+  useEffect(() => {
+    if (!file || file.binary || file.tooLarge) {
+      setHtml(null);
+      return;
+    }
+    let cancelled = false;
+    highlight(file.content, file.language, theme)
+      .then((out) => {
+        if (!cancelled) setHtml(out);
+      })
+      .catch(() => {
+        // Highlighting failed (e.g. WASM load error) — leave the body empty rather than crash.
+        if (!cancelled) setHtml(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [file, theme]);
+
+  if (!path) {
+    return (
+      <div className="flex h-full items-center justify-center p-6 text-sm text-muted-foreground">
+        Select a file to view its source.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center justify-between gap-2 border-b border-border bg-muted px-3 py-2">
+        <span className="truncate font-mono text-xs text-foreground" title={path}>
+          {path}
+        </span>
+        {file ? (
+          <span className="shrink-0 text-xs text-muted-foreground">{formatBytes(file.size)}</span>
+        ) : null}
+      </div>
+      <div className="min-h-0 flex-1 overflow-auto">
+        {loading ? (
+          <p className="p-4 text-sm text-muted-foreground">Loading…</p>
+        ) : error ? (
+          <p
+            role="alert"
+            className="m-3 rounded-sm border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+          >
+            {error}
+          </p>
+        ) : file?.tooLarge ? (
+          <p className="p-4 text-sm text-muted-foreground">
+            File too large to preview ({formatBytes(file.size)}).
+          </p>
+        ) : file?.binary ? (
+          <p className="p-4 text-sm text-muted-foreground">Binary file — not shown.</p>
+        ) : html ? (
+          <div
+            className="text-sm [&_pre]:min-h-full [&_pre]:p-4"
+            // biome-ignore lint/security/noDangerouslySetInnerHtml: Shiki output is static, HTML-escaped source from the user's own authed soul repo.
+            dangerouslySetInnerHTML={{ __html: html }}
+          />
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/components/soul/soul-tree.test.tsx
+++ b/apps/web/app/components/soul/soul-tree.test.tsx
@@ -1,0 +1,39 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { SoulTreeNode } from "~/lib/soul";
+import { SoulTree } from "./soul-tree";
+
+const tree: SoulTreeNode[] = [
+  {
+    name: "agents",
+    path: "agents",
+    type: "dir",
+    children: [{ name: "AGENT.md", path: "agents/AGENT.md", type: "file", size: 12 }],
+  },
+  { name: "soul.yaml", path: "soul.yaml", type: "file", size: 8 },
+];
+
+describe("SoulTree", () => {
+  it("renders top-level entries with directories expanded by default", () => {
+    render(<SoulTree root={tree} selected={null} onSelect={() => {}} />);
+    expect(screen.getByText("agents")).toBeTruthy();
+    expect(screen.getByText("soul.yaml")).toBeTruthy();
+    // top-level dir open → child visible
+    expect(screen.getByText("AGENT.md")).toBeTruthy();
+  });
+
+  it("collapses and expands a directory on chevron click", () => {
+    render(<SoulTree root={tree} selected={null} onSelect={() => {}} />);
+    fireEvent.click(screen.getByLabelText("Collapse"));
+    expect(screen.queryByText("AGENT.md")).toBeNull();
+    fireEvent.click(screen.getByLabelText("Expand"));
+    expect(screen.getByText("AGENT.md")).toBeTruthy();
+  });
+
+  it("calls onSelect with the file path when a file is clicked", () => {
+    const onSelect = vi.fn();
+    render(<SoulTree root={tree} selected={null} onSelect={onSelect} />);
+    fireEvent.click(screen.getByText("soul.yaml"));
+    expect(onSelect).toHaveBeenCalledWith("soul.yaml");
+  });
+});

--- a/apps/web/app/components/soul/soul-tree.tsx
+++ b/apps/web/app/components/soul/soul-tree.tsx
@@ -1,0 +1,113 @@
+import { ChevronRight, FileText, Folder } from "lucide-react";
+import { useState } from "react";
+import type { SoulTreeNode } from "~/lib/soul";
+import { cn } from "~/lib/utils";
+
+/*
+ * Read-only VS Code-style file tree for the soul repo. Fully eager — the whole tree arrives as
+ * props from a single API call. Selecting a file is local panel state (a button), not navigation.
+ * Visual idioms mirror components/knowledge/space-tree.tsx.
+ */
+
+type Props = {
+  root: SoulTreeNode[];
+  selected: string | null;
+  onSelect: (path: string) => void;
+};
+
+export function SoulTree({ root, selected, onSelect }: Props) {
+  return (
+    <ul className="flex flex-col gap-0.5 py-2 text-sm">
+      {root.map((node) => (
+        <Node key={node.path} node={node} depth={0} selected={selected} onSelect={onSelect} />
+      ))}
+    </ul>
+  );
+}
+
+function Node({
+  node,
+  depth,
+  selected,
+  onSelect,
+}: {
+  node: SoulTreeNode;
+  depth: number;
+  selected: string | null;
+  onSelect: (path: string) => void;
+}) {
+  const [open, setOpen] = useState(depth === 0); // top-level dirs open by default
+  const pad = { paddingLeft: `${depth * 0.75 + 0.25}rem` };
+
+  if (node.type === "dir") {
+    const children = node.children ?? [];
+    return (
+      <li>
+        <div className="group flex items-center gap-1 rounded-sm pr-1 hover:bg-accent" style={pad}>
+          <button
+            type="button"
+            onClick={() => setOpen((v) => !v)}
+            aria-expanded={open}
+            aria-label={open ? "Collapse" : "Expand"}
+            className="cursor-pointer rounded-sm p-0.5 text-muted-foreground"
+          >
+            <ChevronRight
+              className={cn("size-3.5 transition-transform", open && "rotate-90")}
+              aria-hidden
+            />
+          </button>
+          <Folder className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+          <button
+            type="button"
+            onClick={() => setOpen((v) => !v)}
+            className="min-w-0 flex-1 cursor-pointer truncate py-1 text-left font-medium text-foreground"
+            title={node.name}
+          >
+            {node.name}
+          </button>
+        </div>
+        {open && children.length > 0 ? (
+          <ul className="flex flex-col gap-0.5">
+            {children.map((child) => (
+              <Node
+                key={child.path}
+                node={child}
+                depth={depth + 1}
+                selected={selected}
+                onSelect={onSelect}
+              />
+            ))}
+          </ul>
+        ) : null}
+      </li>
+    );
+  }
+
+  const isActive = selected === node.path;
+  return (
+    <li>
+      <div
+        className={cn(
+          "group flex items-center gap-1 rounded-sm pr-1",
+          isActive ? "bg-sidebar-accent" : "hover:bg-accent"
+        )}
+        style={pad}
+      >
+        <span className="w-[1.375rem] shrink-0" aria-hidden />
+        <FileText className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+        <button
+          type="button"
+          onClick={() => onSelect(node.path)}
+          aria-current={isActive ? "true" : undefined}
+          className={cn(
+            "min-w-0 flex-1 cursor-pointer truncate py-1 text-left",
+            isActive ? "font-medium text-sidebar-primary" : "text-foreground"
+          )}
+          title={node.name}
+        >
+          {node.name}
+        </button>
+      </div>
+    </li>
+  );
+}

--- a/apps/web/app/lib/shiki.ts
+++ b/apps/web/app/lib/shiki.ts
@@ -1,0 +1,31 @@
+import type { Highlighter } from "shiki";
+
+/*
+ * Lazy, single-instance Shiki highlighter for the Soul Explorer file viewer. Shiki (and its
+ * oniguruma WASM) is dynamically imported so it stays out of the main bundle — loaded only when
+ * the Soul tab opens a file. Both themes are pre-registered so light/dark switching is instant.
+ */
+
+const THEMES = { light: "github-light", dark: "github-dark" } as const;
+const LANGS = ["yaml", "markdown", "typescript", "json", "bash"] as const;
+
+let instance: Promise<Highlighter> | null = null;
+
+function getHighlighter(): Promise<Highlighter> {
+  if (!instance) {
+    instance = import("shiki").then(({ createHighlighter }) =>
+      createHighlighter({ themes: [THEMES.light, THEMES.dark], langs: [...LANGS] })
+    );
+  }
+  return instance;
+}
+
+export async function highlight(
+  code: string,
+  lang: string,
+  theme: "light" | "dark"
+): Promise<string> {
+  const hl = await getHighlighter();
+  const safeLang = (LANGS as readonly string[]).includes(lang) ? lang : "plaintext";
+  return hl.codeToHtml(code, { lang: safeLang, theme: THEMES[theme] });
+}

--- a/apps/web/app/lib/soul.ts
+++ b/apps/web/app/lib/soul.ts
@@ -1,0 +1,33 @@
+import { apiGet } from "./api";
+
+/*
+ * Read-only client for the Soul Explorer API. The soul repo is a git directory on the API
+ * server; these endpoints expose a recursive file tree and raw file contents for browsing.
+ * Mirrors lib/api.ts conventions (cookie-first auth, ApiError on non-2xx).
+ */
+
+export type SoulTreeNode = {
+  name: string;
+  path: string;
+  type: "file" | "dir";
+  size?: number;
+  children?: SoulTreeNode[];
+};
+
+export type SoulFile = {
+  path: string;
+  content: string;
+  size: number;
+  language: string;
+  binary?: boolean;
+  tooLarge?: boolean;
+};
+
+export async function getSoulTree(): Promise<SoulTreeNode[]> {
+  const body = await apiGet<{ root: SoulTreeNode[] }>("/api/v1/soul/tree");
+  return body.root;
+}
+
+export function getSoulFile(path: string): Promise<SoulFile> {
+  return apiGet<SoulFile>(`/api/v1/soul/file?path=${encodeURIComponent(path)}`);
+}

--- a/apps/web/app/routes/_app.settings.soul.tsx
+++ b/apps/web/app/routes/_app.settings.soul.tsx
@@ -1,0 +1,44 @@
+import { useLoaderData, useRouteError } from "@remix-run/react";
+import { useState } from "react";
+import { SoulFileViewer } from "~/components/soul/soul-file-viewer";
+import { SoulTree } from "~/components/soul/soul-tree";
+import { ErrorState } from "~/components/states";
+import { ApiError } from "~/lib/api";
+import { getSoulTree } from "~/lib/soul";
+
+// Read-only Soul Explorer: a VS Code-style file tree of the whole soul repo + Shiki source viewer.
+export async function clientLoader() {
+  const root = await getSoulTree();
+  return { root };
+}
+
+export default function SettingsSoul() {
+  const { root } = useLoaderData<typeof clientLoader>();
+  const [selected, setSelected] = useState<string | null>(null);
+
+  if (root.length === 0) {
+    return (
+      <p className="rounded-sm border border-border bg-card px-4 py-6 text-sm text-muted-foreground">
+        The soul repo is empty or not initialized.
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex h-[70vh] min-h-0 gap-4">
+      <aside className="w-64 shrink-0 overflow-y-auto rounded-sm border border-border bg-card px-1">
+        <SoulTree root={root} selected={selected} onSelect={setSelected} />
+      </aside>
+      <section className="min-w-0 flex-1 overflow-hidden rounded-sm border border-border bg-card">
+        <SoulFileViewer path={selected} />
+      </section>
+    </div>
+  );
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+  const status = error instanceof ApiError ? error.status : undefined;
+  const message = error instanceof Error ? error.message : undefined;
+  return <ErrorState section="settings" status={status} message={message} />;
+}

--- a/apps/web/app/routes/_app.settings.tsx
+++ b/apps/web/app/routes/_app.settings.tsx
@@ -6,6 +6,7 @@ export const meta: MetaFunction = () => [{ title: "Settings · tulipfarm" }];
 const tabs = [
   { to: "/settings/secrets", label: "Secrets", end: false },
   { to: "/settings/llm", label: "LLM", end: false },
+  { to: "/settings/soul", label: "Soul", end: false },
   { to: "/settings/activities", label: "Activities", end: false },
 ];
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -37,6 +37,7 @@
     "react-dom": "^19.2.7",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
+    "shiki": "4.2.0",
     "tailwind-merge": "^3.6.0",
     "yaml": "^2.9.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -271,6 +271,9 @@ importers:
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
+      shiki:
+        specifier: 4.2.0
+        version: 4.2.0
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0


### PR DESCRIPTION
…ighlighting

- API: GET /soul/tree (recursive FS walk, .git excluded) and GET /soul/file (raw content, path-traversal/symlink guarded, size+binary caps)
- Web: Soul tab in Settings with VS Code-style file tree + Shiki source viewer (client-side, lazy dynamic import, dual light/dark themes)