### PR TITLE
feat(memory): add Settings → Memory page for user-managed memory & pr…

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -37,6 +37,7 @@ import { registerKnowledgeRoutes } from "./knowledge/routes";
 import type { KnowledgeService } from "./knowledge/service";
 import { registerKvRoutes } from "./kv/routes";
 import type { KvService } from "./kv/service";
+import { registerMemoryRoutes } from "./memory/routes";
 import type { WorkingMemoryService } from "./memory/service";
 import { registerOnboardingRoutes } from "./onboarding/routes";
 import type { RateLimiter } from "./rate-limit";
@@ -86,7 +87,9 @@ export interface AppOptions {
 export async function buildApp(opts: AppOptions = {}) {
   // forceCloseConnections: destroy lingering keep-alive / SSE (chat stream) connections on close,
   // so `app.close()` frees the port immediately instead of hanging on an open EventSource.
-  const app = Fastify({ logger: true, forceCloseConnections: true });
+  // maxParamLength: lift the find-my-way default (100) so path params like a memory `:key` (up to
+  // MAX_KEY_CHARS=128) route instead of 404ing.
+  const app = Fastify({ logger: true, forceCloseConnections: true, maxParamLength: 512 });
 
   // Single-image SPA serving (AC-010 / ARCH-V1-006): when the built web client is
   // bundled into the image, the Dockerfile sets WEB_DIST and Fastify serves it. Unset
@@ -218,6 +221,9 @@ export async function buildApp(opts: AppOptions = {}) {
     }
     if (opts.activityService) {
       registerActivityRoutes(app, opts.activityService, requireAuth);
+    }
+    if (opts.workingMemoryService) {
+      registerMemoryRoutes(app, opts.workingMemoryService, requireAuth);
     }
     if (opts.gitSync) {
       registerSoulRoutes(app, opts.gitSync, requireAuth);

--- a/apps/api/src/context/assemble.test.ts
+++ b/apps/api/src/context/assemble.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { KnowledgePage } from "../knowledge/types";
+import { MAX_TOTAL_CHARS } from "../memory/limits";
 import type { WorkingMemoryDoc } from "../memory/working-memory";
 import { type AssembleContext, assembleSystemPrompt } from "./assemble";
 
@@ -210,9 +211,13 @@ describe("assembleSystemPrompt — memory", () => {
 
   it("keeps the block at exactly MAX_TOTAL_CHARS, drops it one char over", () => {
     // budget = sum(key.length + value.length); "m" key = 1 char, so value pads to the boundary.
-    const atCap = assembleSystemPrompt(baseCtx({ memory: [mem("m", "x".repeat(2047))] }));
+    const atCap = assembleSystemPrompt(
+      baseCtx({ memory: [mem("m", "x".repeat(MAX_TOTAL_CHARS - 1))] })
+    );
     expect(atCap).toContain("<memory>");
-    const overCap = assembleSystemPrompt(baseCtx({ memory: [mem("m", "x".repeat(2048))] }));
+    const overCap = assembleSystemPrompt(
+      baseCtx({ memory: [mem("m", "x".repeat(MAX_TOTAL_CHARS))] })
+    );
     expect(overCap).not.toContain("<memory>");
   });
 });

--- a/apps/api/src/memory/README.md
+++ b/apps/api/src/memory/README.md
@@ -11,19 +11,24 @@ facts the agent reads every turn and writes via two platform tools. Facts are ke
   `PgWorkingMemoryRepo` (table `working_memory`, PK `(user_id, key)`). `assertValidEntry` is the hard
   write-time guard. Mirrors `chat/messages.ts`.
 - **`service.ts`** — `WorkingMemoryService` owns the write policy: oversize rejection, last-write
-  LRU, and the dual cap (≤30 entries **and** ≤~2k total chars; oldest-written evicted first). The
-  repo stays a dumb CRUD store.
+  LRU, and the dual cap (≤100 entries **and** ≤ the derived total-char budget; oldest-written
+  evicted first). The repo stays a dumb CRUD store.
 - **`tool-result.ts`** — the `ToolCallResult` contract (`ok`/`err`). Handlers always resolve, never
   throw, so a bad call is returned to the model for self-correction.
 - **`tools.ts`** — `update_memory` / `delete_memory` `PlatformTool` defs: plain JSON Schema +
   LLM-facing guidance + handlers. Exported as `MEMORY_TOOLS`.
 - **`ai-toolset.ts`** — `buildMemoryToolSet(ctx)` adapts the tools to the Vercel AI SDK tool loop;
   `execute` closes over the per-request user.
+- **`routes.ts`** — `registerMemoryRoutes` exposes the caller's own memory to the web UI
+  (Settings → Memory): `GET /api/v1/memory` (list + `maxValueChars`), `PUT /api/v1/memory/:key`
+  (edit value only — 404 if the key is absent, 422 over `MAX_VALUE_CHARS`, preserves
+  `writtenByAgentId`), `DELETE /api/v1/memory/:key`. Reuses `WorkingMemoryService`; no new table.
 
 ## Caps (`limits.ts`)
 
-`MAX_ENTRIES=30`, `MAX_VALUE_CHARS=1024` (a larger single value is long-form → rejected
-toward `create_knowledge_page`), `MAX_TOTAL_CHARS=2048`, `MAX_TOOL_STEPS=25`.
+`MAX_ENTRIES=100`, `MAX_VALUE_CHARS=256` (a larger single value is long-form → rejected
+toward `create_knowledge_page`), `MAX_TOTAL_CHARS = MAX_ENTRIES × MAX_VALUE_CHARS` (derived
+aggregate ceiling), `MAX_TOOL_STEPS=25`. Count and per-value are the binding caps.
 
 ## Wiring
 

--- a/apps/api/src/memory/limits.ts
+++ b/apps/api/src/memory/limits.ts
@@ -1,13 +1,22 @@
 /**
  * Working-memory caps (MEM-V1-003). Working memory is a tiny, always-injected, per-user
- * store of stable personal facts — these bounds keep the `<memory>` block small.
+ * store of stable personal facts — these bounds keep the `<memory>` block small. The two
+ * binding caps are the entry COUNT and the per-entry VALUE length; `MAX_TOTAL_CHARS` is
+ * derived from them as the aggregate ceiling the render path enforces.
  */
-export const MAX_ENTRIES = 30;
-/** A single value larger than this is "long-form" → rejected toward create_knowledge_page (AC-V1-004). */
-export const MAX_VALUE_CHARS = 1024;
+export const MAX_ENTRIES = 100;
+/**
+ * Per-entry value cap. A memory is one short, stable fact (a sentence, not a paragraph); a single
+ * value larger than this is "long-form" → rejected toward create_knowledge_page (AC-V1-004).
+ */
+export const MAX_VALUE_CHARS = 256;
 export const MAX_KEY_CHARS = 128;
-/** Total key+value chars across a user's entries; over this, oldest entries are LRU-evicted. */
-export const MAX_TOTAL_CHARS = 2048;
+/**
+ * Total key+value chars across a user's entries; over this, oldest entries are LRU-evicted (and the
+ * whole `<memory>` block is dropped at render time). Derived from the count × value caps so it never
+ * binds before them — a full store of max-size entries lands right at this aggregate budget.
+ */
+export const MAX_TOTAL_CHARS = MAX_ENTRIES * MAX_VALUE_CHARS;
 /** Max sequential LLM steps in one chat turn's tool loop (TOOLS spec: max_tool_calls). */
 export const MAX_TOOL_STEPS = 25;
 

--- a/apps/api/src/memory/routes.pg.test.ts
+++ b/apps/api/src/memory/routes.pg.test.ts
@@ -1,0 +1,252 @@
+import type { PGlite } from "@electric-sql/pglite";
+import type { FastifyInstance } from "fastify";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildApp } from "../app";
+import type { TokenDoc, TokenRepo } from "../auth/api-tokens";
+import { CSRF_COOKIE, CSRF_HEADER } from "../auth/csrf";
+import { SESSION_COOKIE } from "../auth/routes";
+import { MemorySessionStore } from "../auth/session-store";
+import { createUser, type UserDoc, type UserRepo } from "../auth/users";
+import type { PaginatedResult } from "../pagination";
+import { runPgMigrations } from "../pg-migrate";
+import { makePglite } from "../test/pglite";
+import { MAX_KEY_CHARS, MAX_VALUE_CHARS } from "./limits";
+import { WorkingMemoryService } from "./service";
+import { PgWorkingMemoryRepo } from "./working-memory";
+
+class FakeUserRepo implements UserRepo {
+  private users: UserDoc[] = [];
+  async findByEmail(email: string): Promise<UserDoc | null> {
+    return this.users.find((u) => u.email === email.trim().toLowerCase()) ?? null;
+  }
+  async findById(id: string): Promise<UserDoc | null> {
+    return this.users.find((u) => u._id === id) ?? null;
+  }
+  async count(): Promise<number> {
+    return this.users.length;
+  }
+  async insert(user: UserDoc): Promise<void> {
+    this.users.push(user);
+  }
+}
+
+class FakeTokenRepo implements TokenRepo {
+  async create(_t: TokenDoc): Promise<void> {}
+  async findByHash(): Promise<TokenDoc | null> {
+    return null;
+  }
+  async findByUserId(): Promise<TokenDoc[]> {
+    return [];
+  }
+  async findAll(): Promise<TokenDoc[]> {
+    return [];
+  }
+  async findById(): Promise<TokenDoc | null> {
+    return null;
+  }
+  async deleteById(): Promise<void> {}
+  async findAllPaginated(): Promise<PaginatedResult<TokenDoc>> {
+    return { items: [], nextCursor: null };
+  }
+  async findByUserIdPaginated(): Promise<PaginatedResult<TokenDoc>> {
+    return { items: [], nextCursor: null };
+  }
+}
+
+const TEST_CSRF = "a".repeat(64);
+
+type ApiEntry = {
+  key: string;
+  value: string;
+  writtenByAgentId: string | null;
+  createdAt: string;
+  lastWrittenAt: string;
+};
+
+describe("memory routes", () => {
+  let app: FastifyInstance;
+  let db: PGlite;
+  let repo: PgWorkingMemoryRepo;
+  let userId: string;
+  let sid: string;
+  let otherUserId: string;
+
+  beforeEach(async () => {
+    db = await makePglite();
+    await runPgMigrations(db);
+    repo = new PgWorkingMemoryRepo(db);
+    const service = new WorkingMemoryService(repo);
+
+    const store = new MemorySessionStore();
+    const userRepo = new FakeUserRepo();
+    const tokenRepo = new FakeTokenRepo();
+    const member = await createUser(userRepo, "member@example.com", "pass", "member");
+    userId = member._id;
+    sid = await store.create(member._id);
+    const other = await createUser(userRepo, "other@example.com", "pass", "member");
+    otherUserId = other._id;
+
+    app = await buildApp({
+      sessionStore: store,
+      userRepo,
+      tokenRepo,
+      workingMemoryService: service,
+    });
+  });
+
+  afterEach(async () => {
+    await app.close();
+    await db.close();
+  });
+
+  async function seed(uid: string, key: string, value: string, agentId?: string): Promise<void> {
+    const now = new Date();
+    await repo.upsert({
+      _id: `${uid}:${key}`,
+      userId: uid,
+      key,
+      value,
+      writtenByAgentId: agentId,
+      createdAt: now,
+      lastWrittenAt: now,
+    });
+  }
+
+  it("returns 401 without auth", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/v1/memory" });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("lists only the current user's entries with the value limit", async () => {
+    await seed(userId, "preferred_name", "Dhruv", "agent-1");
+    await seed(otherUserId, "secret", "not mine");
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/memory",
+      cookies: { [SESSION_COOKIE]: sid },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { entries: ApiEntry[]; maxValueChars: number };
+    expect(body.maxValueChars).toBe(MAX_VALUE_CHARS);
+    expect(body.entries.map((e) => e.key)).toEqual(["preferred_name"]);
+    expect(body.entries[0].writtenByAgentId).toBe("agent-1");
+  });
+
+  it("edits a value and preserves the agent attribution", async () => {
+    await seed(userId, "preferred_name", "Dhruv", "agent-1");
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/v1/memory/preferred_name",
+      cookies: { [SESSION_COOKIE]: sid, [CSRF_COOKIE]: TEST_CSRF },
+      headers: { [CSRF_HEADER]: TEST_CSRF },
+      payload: { value: "DJ" },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as ApiEntry;
+    expect(body.value).toBe("DJ");
+    expect(body.writtenByAgentId).toBe("agent-1");
+    const stored = await repo.listByUser(userId);
+    expect(stored[0].value).toBe("DJ");
+    expect(stored[0].writtenByAgentId).toBe("agent-1");
+  });
+
+  it("rejects a value over the limit with 422", async () => {
+    await seed(userId, "preferred_name", "Dhruv");
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/v1/memory/preferred_name",
+      cookies: { [SESSION_COOKIE]: sid, [CSRF_COOKIE]: TEST_CSRF },
+      headers: { [CSRF_HEADER]: TEST_CSRF },
+      payload: { value: "x".repeat(MAX_VALUE_CHARS + 1) },
+    });
+    expect(res.statusCode).toBe(422);
+    const stored = await repo.listByUser(userId);
+    expect(stored[0].value).toBe("Dhruv");
+  });
+
+  it("upserts a new user-authored key (no agent attribution)", async () => {
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/v1/memory/tone",
+      cookies: { [SESSION_COOKIE]: sid, [CSRF_COOKIE]: TEST_CSRF },
+      headers: { [CSRF_HEADER]: TEST_CSRF },
+      payload: { value: "friendly and direct" },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as ApiEntry;
+    expect(body.key).toBe("tone");
+    expect(body.value).toBe("friendly and direct");
+    expect(body.writtenByAgentId).toBeNull(); // user-authored
+    const stored = await repo.listByUser(userId);
+    expect(stored.map((e) => e.key)).toContain("tone");
+  });
+
+  it("rejects a key over the length limit with 422", async () => {
+    const res = await app.inject({
+      method: "PUT",
+      url: `/api/v1/memory/${encodeURIComponent("k".repeat(MAX_KEY_CHARS + 1))}`,
+      cookies: { [SESSION_COOKIE]: sid, [CSRF_COOKIE]: TEST_CSRF },
+      headers: { [CSRF_HEADER]: TEST_CSRF },
+      payload: { value: "v" },
+    });
+    expect(res.statusCode).toBe(422);
+  });
+
+  it("setting a key another user owns creates the caller's own, leaving the other untouched", async () => {
+    await seed(otherUserId, "secret", "not mine");
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/v1/memory/secret",
+      cookies: { [SESSION_COOKIE]: sid, [CSRF_COOKIE]: TEST_CSRF },
+      headers: { [CSRF_HEADER]: TEST_CSRF },
+      payload: { value: "mine now" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect((await repo.listByUser(userId)).find((e) => e.key === "secret")?.value).toBe("mine now");
+    expect((await repo.listByUser(otherUserId))[0].value).toBe("not mine"); // isolation holds
+  });
+
+  it("deletes an entry and 404s when absent", async () => {
+    await seed(userId, "preferred_name", "Dhruv");
+    const ok = await app.inject({
+      method: "DELETE",
+      url: "/api/v1/memory/preferred_name",
+      cookies: { [SESSION_COOKIE]: sid, [CSRF_COOKIE]: TEST_CSRF },
+      headers: { [CSRF_HEADER]: TEST_CSRF },
+    });
+    expect(ok.statusCode).toBe(204);
+    expect(await repo.listByUser(userId)).toHaveLength(0);
+
+    const gone = await app.inject({
+      method: "DELETE",
+      url: "/api/v1/memory/preferred_name",
+      cookies: { [SESSION_COOKIE]: sid, [CSRF_COOKIE]: TEST_CSRF },
+      headers: { [CSRF_HEADER]: TEST_CSRF },
+    });
+    expect(gone.statusCode).toBe(404);
+  });
+
+  it("handles keys containing a slash via encodeURIComponent", async () => {
+    await seed(userId, "user/preference", "dark mode");
+    const enc = encodeURIComponent("user/preference"); // user%2Fpreference
+
+    const put = await app.inject({
+      method: "PUT",
+      url: `/api/v1/memory/${enc}`,
+      cookies: { [SESSION_COOKIE]: sid, [CSRF_COOKIE]: TEST_CSRF },
+      headers: { [CSRF_HEADER]: TEST_CSRF },
+      payload: { value: "light mode" },
+    });
+    expect(put.statusCode).toBe(200);
+    expect((put.json() as ApiEntry).value).toBe("light mode");
+
+    const del = await app.inject({
+      method: "DELETE",
+      url: `/api/v1/memory/${enc}`,
+      cookies: { [SESSION_COOKIE]: sid, [CSRF_COOKIE]: TEST_CSRF },
+      headers: { [CSRF_HEADER]: TEST_CSRF },
+    });
+    expect(del.statusCode).toBe(204);
+    expect(await repo.listByUser(userId)).toHaveLength(0);
+  });
+});

--- a/apps/api/src/memory/routes.ts
+++ b/apps/api/src/memory/routes.ts
@@ -1,0 +1,166 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { ErrorSchema } from "../auth/schemas";
+import type { UserDoc } from "../auth/users";
+import { MAX_KEY_CHARS, MAX_VALUE_CHARS } from "./limits";
+import type { WorkingMemoryService } from "./service";
+import type { WorkingMemoryDoc } from "./working-memory";
+
+type PreHandler = (req: FastifyRequest, reply: FastifyReply) => Promise<void>;
+
+const MemoryEntrySchema = {
+  type: "object",
+  required: ["key", "value", "writtenByAgentId", "createdAt", "lastWrittenAt"],
+  properties: {
+    key: { type: "string" },
+    value: { type: "string" },
+    writtenByAgentId: { type: "string", nullable: true },
+    createdAt: { type: "string" },
+    lastWrittenAt: { type: "string" },
+  },
+} as const;
+
+function toApiEntry(e: WorkingMemoryDoc): Record<string, unknown> {
+  return {
+    key: e.key,
+    value: e.value,
+    writtenByAgentId: e.writtenByAgentId ?? null,
+    createdAt: e.createdAt.toISOString(),
+    lastWrittenAt: e.lastWrittenAt.toISOString(),
+  };
+}
+
+/**
+ * User-facing CRUD over the caller's own working memory (the `<memory>` facts the assistant
+ * saves, plus preferences the user sets). List + upsert (`PUT` creates or replaces by key) +
+ * delete. The per-entry caps (`MAX_KEY_CHARS`, `MAX_VALUE_CHARS`) are enforced on writes, same
+ * as the agent write path; everything is scoped to the authenticated user.
+ */
+export function registerMemoryRoutes(
+  app: FastifyInstance,
+  service: WorkingMemoryService,
+  requireAuth: PreHandler
+): void {
+  app.get(
+    "/api/v1/memory",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description: "List the current user's saved working-memory entries.",
+        tags: ["memory"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        response: {
+          200: {
+            type: "object",
+            required: ["entries", "maxValueChars"],
+            properties: {
+              entries: { type: "array", items: MemoryEntrySchema },
+              maxValueChars: { type: "number" },
+            },
+          },
+          401: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const userId = (req.user as UserDoc)._id;
+      const entries = await service.list(userId);
+      return reply.send({ entries: entries.map(toApiEntry), maxValueChars: MAX_VALUE_CHARS });
+    }
+  );
+
+  app.put(
+    "/api/v1/memory/:key",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description:
+          "Create or replace one of the current user's memory entries by key (upsert). New keys are user-authored preferences; editing an existing key preserves the assistant's attribution.",
+        tags: ["memory"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        params: {
+          type: "object",
+          required: ["key"],
+          properties: { key: { type: "string" } },
+        },
+        body: {
+          type: "object",
+          required: ["value"],
+          properties: {
+            value: {
+              type: "string",
+              description: `New value. Rejected with 422 if longer than ${MAX_VALUE_CHARS} characters.`,
+            },
+          },
+        },
+        response: {
+          200: MemoryEntrySchema,
+          401: ErrorSchema,
+          422: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const userId = (req.user as UserDoc)._id;
+      const { key } = req.params as { key: string };
+      const { value } = req.body as { value: string };
+
+      if (key.length > MAX_KEY_CHARS) {
+        return reply.code(422).send({ error: `key exceeds the ${MAX_KEY_CHARS}-character limit` });
+      }
+
+      // Upsert: editing an existing key keeps the assistant's attribution; a brand-new key is a
+      // user-authored preference (no agent id).
+      const existing = (await service.list(userId)).find((e) => e.key === key);
+      const outcome = await service.update(userId, key, value, existing?.writtenByAgentId);
+      if (outcome.kind === "rejected_oversize") {
+        return reply
+          .code(422)
+          .send({ error: `value exceeds the ${MAX_VALUE_CHARS}-character limit` });
+      }
+
+      // The just-written key is eviction-protected, so it is present; the fallback only satisfies
+      // the type checker.
+      const saved = (await service.list(userId)).find((e) => e.key === key) ?? {
+        _id: `${userId}:${key}`,
+        userId,
+        key,
+        value,
+        writtenByAgentId: existing?.writtenByAgentId,
+        createdAt: existing?.createdAt ?? new Date(),
+        lastWrittenAt: new Date(),
+      };
+      return reply.send(toApiEntry(saved));
+    }
+  );
+
+  app.delete(
+    "/api/v1/memory/:key",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description: "Delete one of the current user's memory entries.",
+        tags: ["memory"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        params: {
+          type: "object",
+          required: ["key"],
+          properties: { key: { type: "string" } },
+        },
+        response: {
+          204: { type: "null" },
+          401: ErrorSchema,
+          404: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const userId = (req.user as UserDoc)._id;
+      const { key } = req.params as { key: string };
+      const deleted = await service.delete(userId, key);
+      if (!deleted) {
+        return reply.code(404).send({ error: "memory entry not found" });
+      }
+      return reply.code(204).send();
+    }
+  );
+}

--- a/apps/api/src/memory/service.test.ts
+++ b/apps/api/src/memory/service.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { MAX_ENTRIES, MAX_TOTAL_CHARS, MAX_VALUE_CHARS } from "./limits";
 import { WorkingMemoryService } from "./service";
 import { assertValidEntry, type WorkingMemoryDoc, type WorkingMemoryRepo } from "./working-memory";
 
@@ -73,47 +74,46 @@ describe("WorkingMemoryService.update", () => {
     expect(await repo.listByUser(U)).toHaveLength(0);
   });
 
-  it("LRU-evicts the oldest entry once over the 30-entry cap, keeping the just-written key", async () => {
+  it("LRU-evicts the oldest entry once over the entry-count cap, keeping the just-written key", async () => {
     const repo = new FakeWorkingMemoryRepo();
     const svc = new WorkingMemoryService(repo);
 
-    for (let i = 0; i < 30; i++) await svc.update(U, `k${i}`, `v${i}`);
-    expect(await repo.listByUser(U)).toHaveLength(30);
+    // Short values so the COUNT cap binds (not the total-char cap).
+    for (let i = 0; i < MAX_ENTRIES; i++) await svc.update(U, `k${i}`, `v${i}`);
+    expect(await repo.listByUser(U)).toHaveLength(MAX_ENTRIES);
 
-    await svc.update(U, "k30", "v30");
+    await svc.update(U, `k${MAX_ENTRIES}`, "v");
     const keys = (await repo.listByUser(U)).map((e) => e.key);
-    expect(keys).toHaveLength(30);
+    expect(keys).toHaveLength(MAX_ENTRIES);
     expect(keys).not.toContain("k0"); // oldest evicted
-    expect(keys).toContain("k30"); // just-written survives
+    expect(keys).toContain(`k${MAX_ENTRIES}`); // just-written survives
   });
 
-  it("LRU-evicts oldest entries once over the ~2k total-char cap", async () => {
+  it("LRU-evicts to keep within both the count and total-char caps", async () => {
     const repo = new FakeWorkingMemoryRepo();
     const svc = new WorkingMemoryService(repo);
-    const big = "x".repeat(600); // 4 × ~602 chars = ~2408 > 2048
+    const big = "x".repeat(MAX_VALUE_CHARS); // max-size values → keys push the sum over the total cap
 
-    await svc.update(U, "k0", big);
-    await svc.update(U, "k1", big);
-    await svc.update(U, "k2", big);
-    await svc.update(U, "k3", big);
+    for (let i = 0; i <= MAX_ENTRIES; i++) await svc.update(U, `k${i}`, big);
 
     const entries = await repo.listByUser(U);
     const total = entries.reduce((s, e) => s + e.key.length + e.value.length, 0);
-    expect(total).toBeLessThanOrEqual(2048);
+    expect(entries.length).toBeLessThanOrEqual(MAX_ENTRIES);
+    expect(total).toBeLessThanOrEqual(MAX_TOTAL_CHARS);
     const keys = entries.map((e) => e.key);
-    expect(keys).not.toContain("k0");
-    expect(keys).toContain("k3");
+    expect(keys).not.toContain("k0"); // oldest evicted
+    expect(keys).toContain(`k${MAX_ENTRIES}`); // just-written survives
   });
 
   it("re-writing an existing key while at the entry cap does not evict", async () => {
     const repo = new FakeWorkingMemoryRepo();
     const svc = new WorkingMemoryService(repo);
 
-    for (let i = 0; i < 30; i++) await svc.update(U, `k${i}`, `v${i}`);
+    for (let i = 0; i < MAX_ENTRIES; i++) await svc.update(U, `k${i}`, `v${i}`);
     await svc.update(U, "k5", "updated");
 
     const entries = await repo.listByUser(U);
-    expect(entries).toHaveLength(30);
+    expect(entries).toHaveLength(MAX_ENTRIES);
     expect(entries.map((e) => e.key)).toContain("k0");
     expect(entries.find((e) => e.key === "k5")?.value).toBe("updated");
   });

--- a/apps/web/app/lib/memory.ts
+++ b/apps/web/app/lib/memory.ts
@@ -1,0 +1,25 @@
+import { apiDelete, apiGet, apiWrite } from "./api";
+
+export type MemoryEntry = {
+  key: string;
+  value: string;
+  writtenByAgentId: string | null;
+  createdAt: string;
+  lastWrittenAt: string;
+};
+
+export type MemoryData = { entries: MemoryEntry[]; maxValueChars: number };
+
+// The assistant's saved facts about the current user (the `<memory>` block). Read + edit-value
+// + delete only — keys and creation belong to the assistant.
+export async function listMemory(): Promise<MemoryData> {
+  return apiGet<MemoryData>("/api/v1/memory");
+}
+
+export async function updateMemoryEntry(key: string, value: string): Promise<MemoryEntry> {
+  return apiWrite<MemoryEntry>("PUT", `/api/v1/memory/${encodeURIComponent(key)}`, { value });
+}
+
+export async function deleteMemoryEntry(key: string): Promise<void> {
+  return apiDelete(`/api/v1/memory/${encodeURIComponent(key)}`);
+}

--- a/apps/web/app/routes/_app.settings.memory.tsx
+++ b/apps/web/app/routes/_app.settings.memory.tsx
@@ -1,0 +1,323 @@
+import { useLoaderData, useRevalidator, useRouteError } from "@remix-run/react";
+import { Plus, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { ErrorState } from "~/components/states";
+import { Button } from "~/components/ui/button";
+import { ConfirmModal } from "~/components/ui/modal";
+import { ApiError } from "~/lib/api";
+import { deleteMemoryEntry, listMemory, updateMemoryEntry } from "~/lib/memory";
+import { cn } from "~/lib/utils";
+
+const fieldClass =
+  "w-full rounded-sm border border-border bg-background px-3 py-2 text-sm outline-none transition-colors focus-visible:border-primary focus-visible:ring-[3px] focus-visible:ring-ring/30 disabled:opacity-60";
+// Auto-grow with content (modern browsers), capped — no giant empty boxes for one-line values.
+const valueClass = cn(
+  fieldClass,
+  "field-sizing-content min-h-9 max-h-48 resize-none leading-relaxed"
+);
+
+// Suggested preference keys, each with an example value shown as the placeholder.
+const PRESETS: { key: string; example: string }[] = [
+  { key: "language", example: "English" },
+  { key: "verbosity", example: "concise" },
+  { key: "tone", example: "friendly and direct" },
+  { key: "timezone", example: "America/Los_Angeles" },
+  { key: "profile", example: "Staff engineer; prefers code-first answers" },
+];
+
+export async function clientLoader() {
+  return listMemory();
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof ApiError) {
+    if (err.status === 422) return err.message || "that's too long — shorten it and try again";
+    if (err.status === 404) return "that entry no longer exists — refresh the page";
+    return err.message;
+  }
+  return err instanceof Error ? err.message : "request failed";
+}
+
+export default function SettingsMemory() {
+  const { entries, maxValueChars } = useLoaderData<typeof clientLoader>();
+  const revalidator = useRevalidator();
+
+  // Per-key textarea drafts. Absent key → show the saved value (loader is the source of truth).
+  const [drafts, setDrafts] = useState<Record<string, string>>({});
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<string | null>(null);
+
+  // "Set a preference" composer — a new key + value the user authors.
+  const [newKey, setNewKey] = useState("");
+  const [newValue, setNewValue] = useState("");
+  const [newPlaceholder, setNewPlaceholder] = useState("");
+  const newKeyTrimmed = newKey.trim();
+  const newOver = newValue.length > maxValueChars;
+  // Keys are unique per user — block re-adding one that exists (edit it in the list instead) and
+  // drop already-set keys from the suggestions.
+  const existingKeys = new Set(entries.map((e) => e.key));
+  const dupKey = newKeyTrimmed.length > 0 && existingKeys.has(newKeyTrimmed);
+  const availablePresets = PRESETS.filter((p) => !existingKeys.has(p.key));
+  const canSet = !busy && newKeyTrimmed.length > 0 && newValue.length > 0 && !newOver && !dupKey;
+
+  async function run(fn: () => Promise<unknown>, onOk?: () => void) {
+    setBusy(true);
+    setError(null);
+    try {
+      await fn();
+      onOk?.();
+      revalidator.revalidate();
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function clearDraft(key: string) {
+    setDrafts((prev) => {
+      const next = { ...prev };
+      delete next[key];
+      return next;
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-8">
+      <p className="max-w-prose text-sm leading-relaxed text-muted-foreground">
+        What the assistant remembers about you — facts it saved as you chat, plus preferences you
+        set. These ride along on every chat so it can personalize its answers.
+      </p>
+
+      {error ? (
+        <p
+          role="alert"
+          className="rounded-sm border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+        >
+          {error}
+        </p>
+      ) : null}
+
+      {/* Composer — a distinct, lightly-tinted input zone, set apart from the saved list. */}
+      <form
+        className="flex flex-col gap-4 rounded-sm border border-border bg-muted/30 p-5"
+        onSubmit={(e) => {
+          e.preventDefault();
+          if (!canSet) return;
+          void run(
+            () => updateMemoryEntry(newKeyTrimmed, newValue),
+            () => {
+              setNewKey("");
+              setNewValue("");
+              setNewPlaceholder("");
+            }
+          );
+        }}
+      >
+        <h2 className="text-sm font-medium text-foreground">Set a memory or preference</h2>
+
+        {availablePresets.length > 0 ? (
+          <div className="flex flex-wrap items-center gap-1.5">
+            <span className="mr-1 text-xs text-muted-foreground">Try</span>
+            {availablePresets.map((preset) => {
+              const active = newKeyTrimmed === preset.key;
+              return (
+                <button
+                  key={preset.key}
+                  type="button"
+                  disabled={busy}
+                  aria-pressed={active}
+                  className={cn(
+                    "cursor-pointer rounded-sm border px-2 py-0.5 text-xs transition-colors disabled:opacity-60",
+                    active
+                      ? "border-primary bg-primary/10 text-foreground"
+                      : "border-border text-muted-foreground hover:border-primary/60 hover:text-foreground"
+                  )}
+                  onClick={() => {
+                    setNewKey(preset.key);
+                    setNewPlaceholder(preset.example);
+                  }}
+                >
+                  {preset.key}
+                </button>
+              );
+            })}
+          </div>
+        ) : null}
+
+        <div className="flex flex-col gap-1">
+          <input
+            className={cn(
+              fieldClass,
+              dupKey && "border-destructive focus-visible:border-destructive"
+            )}
+            value={newKey}
+            disabled={busy}
+            onChange={(e) => setNewKey(e.target.value)}
+            placeholder="key — e.g. tone"
+            aria-label="memory key"
+          />
+          {dupKey ? (
+            <span className="text-xs text-destructive">
+              “{newKeyTrimmed}” already exists — edit it below instead
+            </span>
+          ) : null}
+        </div>
+
+        <textarea
+          className={valueClass}
+          rows={1}
+          value={newValue}
+          disabled={busy}
+          onChange={(e) => setNewValue(e.target.value)}
+          placeholder={newPlaceholder || "value — what should the assistant remember?"}
+          aria-label="memory value"
+        />
+
+        <div className="flex items-center justify-end gap-3">
+          {newValue.length > 0 ? (
+            <span
+              className={cn(
+                "text-xs tabular-nums",
+                newOver ? "text-destructive" : "text-muted-foreground"
+              )}
+            >
+              {newValue.length} / {maxValueChars}
+            </span>
+          ) : null}
+          <Button type="submit" size="sm" className="cursor-pointer" disabled={!canSet}>
+            <Plus aria-hidden /> {busy ? "Saving…" : "Set"}
+          </Button>
+        </div>
+      </form>
+
+      {/* Saved list */}
+      <section className="flex flex-col gap-3">
+        <div className="flex items-baseline justify-between">
+          <h2 className="text-sm font-medium text-foreground">Remembered</h2>
+          {entries.length > 0 ? (
+            <span className="text-xs tabular-nums text-muted-foreground">
+              {entries.length} {entries.length === 1 ? "entry" : "entries"}
+            </span>
+          ) : null}
+        </div>
+
+        {entries.length === 0 ? (
+          <p className="rounded-sm border border-dashed border-border px-4 py-8 text-center text-sm text-muted-foreground">
+            Nothing yet — set a preference above, or the assistant adds memory as you chat.
+          </p>
+        ) : (
+          <ul className="flex flex-col gap-2.5">
+            {entries.map((entry) => {
+              const value = drafts[entry.key] ?? entry.value;
+              const dirty = value !== entry.value;
+              const over = value.length > maxValueChars;
+              const bySelf = !entry.writtenByAgentId;
+              return (
+                <li
+                  key={entry.key}
+                  className="flex flex-col gap-2 rounded-sm border border-border p-4"
+                >
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium text-foreground">{entry.key}</span>
+                    <span
+                      className="rounded-sm border border-border px-1.5 py-px text-[10px] uppercase tracking-[0.12em] text-muted-foreground"
+                      title={bySelf ? "set by you" : "saved by the assistant"}
+                    >
+                      {entry.writtenByAgentId ?? "you"}
+                    </span>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="ml-auto size-8 cursor-pointer text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+                      disabled={busy}
+                      aria-label={`Delete ${entry.key}`}
+                      onClick={() => setPendingDelete(entry.key)}
+                    >
+                      <Trash2 aria-hidden />
+                    </Button>
+                  </div>
+
+                  <textarea
+                    className={valueClass}
+                    rows={1}
+                    value={value}
+                    disabled={busy}
+                    onChange={(e) =>
+                      setDrafts((prev) => ({ ...prev, [entry.key]: e.target.value }))
+                    }
+                    aria-label={`value for ${entry.key}`}
+                  />
+
+                  {dirty ? (
+                    <div className="flex items-center justify-end gap-3">
+                      <span
+                        className={cn(
+                          "text-xs tabular-nums",
+                          over ? "text-destructive" : "text-muted-foreground"
+                        )}
+                      >
+                        {value.length} / {maxValueChars}
+                      </span>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="cursor-pointer"
+                        disabled={busy}
+                        onClick={() => clearDraft(entry.key)}
+                      >
+                        Cancel
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        className="cursor-pointer"
+                        disabled={busy || over}
+                        onClick={() =>
+                          void run(
+                            () => updateMemoryEntry(entry.key, value),
+                            () => clearDraft(entry.key)
+                          )
+                        }
+                      >
+                        {busy ? "Saving…" : "Save"}
+                      </Button>
+                    </div>
+                  ) : null}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </section>
+
+      <ConfirmModal
+        open={pendingDelete !== null}
+        onClose={() => setPendingDelete(null)}
+        onConfirm={() => {
+          const key = pendingDelete;
+          setPendingDelete(null);
+          if (key) {
+            void run(
+              () => deleteMemoryEntry(key),
+              () => clearDraft(key)
+            );
+          }
+        }}
+        title="Delete memory"
+        description={`Forget "${pendingDelete ?? ""}"? This cannot be undone.`}
+        busy={busy}
+      />
+    </div>
+  );
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+  const status = error instanceof ApiError ? error.status : undefined;
+  const message = error instanceof Error ? error.message : undefined;
+  return <ErrorState section="settings" status={status} message={message} />;
+}

--- a/apps/web/app/routes/_app.settings.tsx
+++ b/apps/web/app/routes/_app.settings.tsx
@@ -8,6 +8,7 @@ const tabs = [
   { to: "/settings/llm", label: "LLM", end: false },
   { to: "/settings/soul", label: "Soul", end: false },
   { to: "/settings/activities", label: "Activities", end: false },
+  { to: "/settings/memory", label: "Memory", end: false },
 ];
 
 // Layout for the Settings subtree: shared header + tab nav, each child owns its own data + form.


### PR DESCRIPTION
…eferences

- Surface per-user working_memory in a new Settings → Memory tab: list, set (upsert), edit, and delete entries; user-set keys are attributed to "you", assistant-written ones show the agent id.
- New REST routes (GET/PUT/DELETE /api/v1/memory) over the existing WorkingMemoryService; PUT is an idempotent upsert with key + value caps.
- Preset preference suggestions (language, verbosity, tone, timezone, profile); client-side duplicate-key guard since keys are unique per user.
- Retune memory caps: MAX_ENTRIES 30→100, MAX_VALUE_CHARS 1024→256, MAX_TOTAL_CHARS derived from them.
- Lift Fastify maxParamLength to 512 so keys up to MAX_KEY_CHARS route instead of 404ing.