### PR TITLE
feat(observability): observability dashboard, Grafana/OTLP export, Li…

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -39,6 +39,9 @@ import { registerKvRoutes } from "./kv/routes";
 import type { KvService } from "./kv/service";
 import { registerMemoryRoutes } from "./memory/routes";
 import type { WorkingMemoryService } from "./memory/service";
+import type { ObservabilityConfig } from "./observability/config";
+import { registerObservabilityRoutes } from "./observability/routes";
+import type { ObservabilityService } from "./observability/service";
 import { registerOnboardingRoutes } from "./onboarding/routes";
 import type { RateLimiter } from "./rate-limit";
 import type { CounterStore, ResourceRepoFactory } from "./resources/repo";
@@ -82,6 +85,8 @@ export interface AppOptions {
   pendingInteractionRepo?: PendingInteractionRepo;
   a2uiSurfaceStore?: A2uiSurfaceStore;
   activityService?: ActivityService;
+  observabilityService?: ObservabilityService;
+  observabilityConfig?: ObservabilityConfig;
 }
 
 export async function buildApp(opts: AppOptions = {}) {
@@ -224,6 +229,14 @@ export async function buildApp(opts: AppOptions = {}) {
     }
     if (opts.workingMemoryService) {
       registerMemoryRoutes(app, opts.workingMemoryService, requireAuth);
+    }
+    if (opts.observabilityService) {
+      registerObservabilityRoutes(
+        app,
+        opts.observabilityService,
+        requireAuth,
+        opts.observabilityConfig
+      );
     }
     if (opts.gitSync) {
       registerSoulRoutes(app, opts.gitSync, requireAuth);

--- a/apps/api/src/chat/routes.test.ts
+++ b/apps/api/src/chat/routes.test.ts
@@ -428,7 +428,15 @@ describe("chat routes", () => {
     otherSid = await store.create(other._id);
 
     select = vi.fn(() => makeFakeModel("claude-opus-4-8"));
-    llmService = { select } as unknown as LlmService;
+    // `resolve` wraps `select` so every test's custom select behavior (throws, specific models)
+    // flows through unchanged — turn.ts calls resolve() and reads `.model`. Mirrors the real
+    // LlmService, where select() delegates to resolve().model.
+    const resolve = vi.fn((req: unknown) => {
+      const model = (select as (r: unknown) => { modelId?: string })(req);
+      const modelId = model.modelId ?? "";
+      return { model, modelId, tier: undefined, chain: [{ provider: "test", modelId }] };
+    });
+    llmService = { select, resolve } as unknown as LlmService;
 
     app = await buildApp({
       sessionStore: store,

--- a/apps/api/src/chat/turn.ts
+++ b/apps/api/src/chat/turn.ts
@@ -1,6 +1,11 @@
 import { randomUUID } from "node:crypto";
 import type { EventEmitter } from "node:events";
-import { LlmNotConfiguredError, type LlmService, UnknownModelError } from "@tulipfarm/llm";
+import {
+  LlmNotConfiguredError,
+  type LlmService,
+  type ResolvedModel,
+  UnknownModelError,
+} from "@tulipfarm/llm";
 import type { SoulLoader } from "@tulipfarm/soul";
 import { generateText, type ModelMessage, streamText } from "ai";
 import type { FastifyReply, FastifyRequest } from "fastify";
@@ -12,6 +17,12 @@ import type { GuardContext, GuardrailsService } from "../guardrails";
 import type { KnowledgeService } from "../knowledge/service";
 import { MAX_TOOL_STEPS } from "../memory/limits";
 import type { WorkingMemoryService } from "../memory/service";
+import {
+  attributeModel,
+  extractStepUsage,
+  extractToolCalls,
+  type ObservableStep,
+} from "../observability/capture";
 import {
   GENERAL_ASSISTANT_NAME,
   getAgent,
@@ -172,9 +183,9 @@ export async function runChatTurn(req: FastifyRequest, reply: FastifyReply, ctx:
 
   // 2. Resolve the model synchronously so a bad request returns before headers go out.
   //    sessionModel = per-turn override (ephemeral); model = conversation default (persisted).
-  let selected: ReturnType<LlmService["select"]>;
+  let resolved: ResolvedModel;
   try {
-    selected = llmService.select({
+    resolved = llmService.resolve({
       sessionModel: body.model,
       model: convo.model,
       autonomy: body.autonomy,
@@ -186,9 +197,10 @@ export async function runChatTurn(req: FastifyRequest, reply: FastifyReply, ctx:
     if (err instanceof LlmNotConfiguredError) return reply.code(503).send({ error: err.message });
     throw err;
   }
-  // The concrete model id that served this turn — stamped into each assistant message's
-  // provenance (the tier is otherwise ephemeral: never persisted on the conversation).
-  const resolvedModelId = (selected as { modelId?: string }).modelId;
+  // The primary model id for this turn — stamped into each assistant message's provenance (the tier
+  // is otherwise ephemeral: never persisted on the conversation). Under fallback the served model
+  // can differ; observability reconciles via `resolved.chain` + the step's response model id.
+  const resolvedModelId = resolved.modelId;
 
   // 3. Per-turn observability log (AC4).
   req.log.info(
@@ -411,6 +423,32 @@ export async function runChatTurn(req: FastifyRequest, reply: FastifyReply, ctx:
     // so the next iteration runs that wrap-up turn and then ends.
     let closingTurn = false;
 
+    // Observability accumulators (best-effort, off the critical path). Each finished step emits an
+    // LLM_STEP_FINISHED; totals roll up across steps + handoffs into one TURN_FINISHED at the end.
+    const turnStart = Date.now();
+    let lastStepAt = turnStart;
+    let turnSteps = 0;
+    let turnTokensIn = 0;
+    let turnTokensOut = 0;
+    // Idempotent: the first call wins. A `finally` (below) emits "aborted" for stop/throw paths that
+    // never reach a normal exit, so the turn always closes out and no trace spans leak.
+    let turnFinishedEmitted = false;
+    const emitTurnFinished = (status: string): void => {
+      if (turnFinishedEmitted) return;
+      turnFinishedEmitted = true;
+      events?.emit(DOMAIN_EVENTS.TURN_FINISHED, {
+        conversationId: convo._id,
+        agentId: activeAgent.name,
+        status,
+        steps: turnSteps,
+        tokensIn: turnTokensIn,
+        tokensOut: turnTokensOut,
+        model: resolvedModelId,
+        tier: resolved.tier,
+        durationMs: Date.now() - turnStart,
+      });
+    };
+
     // A user @mention switched the active agent before the turn began — surface it as the same
     // agent-handoff event a transfer would, ahead of the new agent's first output, so the client
     // renders the inline marker and moves the current-agent indicator.
@@ -423,191 +461,244 @@ export async function runChatTurn(req: FastifyRequest, reply: FastifyReply, ctx:
       };
     }
 
-    for (let depth = 0; depth < MAX_HANDOFF_DEPTH; depth++) {
-      const turnTools =
-        toolRegistry && toolRegistry.getAll().length > 0
-          ? toolRegistry.buildToolSet(
-              {
-                userId: user._id,
-                agentId: activeAgent.name,
-                autonomy: body.autonomy,
-                clientContext: body.clientContext,
-                contextRead,
-              },
-              coordinator,
-              fullResultCache,
-              makeApprovalGate(approvalRegistry, emitter),
-              runToolCallGuard,
-              allowedToolNamesFor(toolRegistry, activePlatform)
-            )
-          : undefined;
+    // The `finally` guarantees a TURN_FINISHED on every exit — including stop-aborts (consumer calls
+    // generator.return() at a `yield`) and unexpected throws — so observability always closes the
+    // turn out and no buffered trace spans leak. emitTurnFinished is idempotent (first status wins).
+    try {
+      for (let depth = 0; depth < MAX_HANDOFF_DEPTH; depth++) {
+        const turnTools =
+          toolRegistry && toolRegistry.getAll().length > 0
+            ? toolRegistry.buildToolSet(
+                {
+                  userId: user._id,
+                  agentId: activeAgent.name,
+                  autonomy: body.autonomy,
+                  clientContext: body.clientContext,
+                  contextRead,
+                },
+                coordinator,
+                fullResultCache,
+                makeApprovalGate(approvalRegistry, emitter),
+                runToolCallGuard,
+                allowedToolNamesFor(toolRegistry, activePlatform)
+              )
+            : undefined;
 
-      const result = streamText({
-        model: selected,
-        messages: turnMessages,
-        // AI SDK v7 rejects `role: "system"` entries in `messages` by default; the per-turn prompt
-        // is assembled as a leading system message (and re-seeded on handoff), so opt back in.
-        allowSystemInMessages: true,
-        tools: turnTools,
-        // The stop endpoint aborts this signal to halt generation mid-turn (see streamControllers).
-        abortSignal: abortController.signal,
-        // Stop the agent's own loop at the step budget, or as soon as it hands off / completes —
-        // so control returns to this loop without the agent rambling after the control tool.
-        stopWhen: ({ steps }) => {
-          if (steps.length >= MAX_TOOL_STEPS) return true;
-          const last = steps[steps.length - 1];
-          return (last?.toolCalls ?? []).some(
-            (c) =>
-              c.toolName === "transfer_to_agent" ||
-              c.toolName === "complete_task" ||
-              c.toolName === "ask_user" || // HITL: end the turn cleanly with the form rendered
-              c.toolName === "cite_sources" // terminal: cite_sources is the answer's last act —
-            // stopping here prevents the model running another step that restates the whole answer
-          );
-        },
-        onError: ({ error }) => {
-          req.log.error({ err: error, conversationId: convo._id }, "chat stream error");
-        },
-        // Persist each finished step (text and/or tool-call + tool-result) so the durable history
-        // captures the whole tool loop across every agent in the chain. `activeAgent.name` is the
-        // agent that produced THIS step (it changes across handoffs), recorded as provenance.
-        onStepFinish: (step) =>
-          persistStep(
-            messageRepo,
-            convo._id,
-            step as unknown as PersistableStep,
-            (e) => req.log.error({ err: e, conversationId: convo._id }, "persist failed"),
-            replyIdHolder,
-            { model: resolvedModelId, agentId: activeAgent.name }
-          ),
-      });
-
-      let control:
-        | { type: "transfer"; target: string; reason?: string }
-        | { type: "complete"; summary?: string }
-        | undefined;
-      // Set when this agent calls `ask_user`: the turn ends with the form rendered and a pending
-      // interaction is persisted so the next request resumes with the user's answer.
-      let pendingAsk:
-        | { toolCallId: string; surfaceId: string | null; schema: Record<string, unknown> }
-        | undefined;
-      let errored = false;
-      for await (const part of result.fullStream) {
-        const p = part as { type?: string; toolName?: string; toolCallId?: string };
-        // Suppress each agent's own terminal `finish`; one synthetic finish closes the whole turn.
-        if (p.type === "finish") continue;
-        if (p.type === "error") errored = true;
-        if (p.type === "tool-result" && p.toolName === "ask_user") {
-          const full = fullResultCache.get(p.toolCallId as string);
-          if (full?.success) {
-            const data = full.data as Record<string, unknown>;
-            pendingAsk = {
-              toolCallId: p.toolCallId as string,
-              surfaceId: typeof data.surfaceId === "string" ? data.surfaceId : null,
-              schema: (data.schema as Record<string, unknown>) ?? {},
-            };
-          }
-        }
-        if (
-          p.type === "tool-result" &&
-          (p.toolName === "transfer_to_agent" || p.toolName === "complete_task")
-        ) {
-          const full = fullResultCache.get(p.toolCallId as string);
-          if (full?.success) {
-            const data = full.data as Record<string, unknown>;
-            control =
-              p.toolName === "transfer_to_agent"
-                ? {
-                    type: "transfer",
-                    target: String(data.agentId),
-                    reason: data.message ? String(data.message) : undefined,
-                  }
-                : {
-                    type: "complete",
-                    summary: data.summary ? String(data.summary) : undefined,
-                  };
-          }
-        }
-        yield part;
-      }
-
-      if (errored) return; // a terminal `error` was already yielded by the producer
-      if (pendingAsk) {
-        // HITL: end the turn with the form on screen and record the pause. The next request injects
-        // the user's answer as this tool-call's result and resumes the run (see the resume path).
-        await pendingInteractions.create({
-          id: randomUUID(),
-          conversationId: convo._id,
-          toolCallId: pendingAsk.toolCallId,
-          toolName: "ask_user",
-          awaitedSchema: pendingAsk.schema,
-          surfaceId: pendingAsk.surfaceId,
-          createdAt: new Date(),
-          resolvedAt: null,
+        const result = streamText({
+          model: resolved.model,
+          messages: turnMessages,
+          // AI SDK v7 rejects `role: "system"` entries in `messages` by default; the per-turn prompt
+          // is assembled as a leading system message (and re-seeded on handoff), so opt back in.
+          allowSystemInMessages: true,
+          tools: turnTools,
+          // The stop endpoint aborts this signal to halt generation mid-turn (see streamControllers).
+          abortSignal: abortController.signal,
+          // Stop the agent's own loop at the step budget, or as soon as it hands off / completes —
+          // so control returns to this loop without the agent rambling after the control tool.
+          stopWhen: ({ steps }) => {
+            if (steps.length >= MAX_TOOL_STEPS) return true;
+            const last = steps[steps.length - 1];
+            return (last?.toolCalls ?? []).some(
+              (c) =>
+                c.toolName === "transfer_to_agent" ||
+                c.toolName === "complete_task" ||
+                c.toolName === "ask_user" || // HITL: end the turn cleanly with the form rendered
+                c.toolName === "cite_sources" // terminal: cite_sources is the answer's last act —
+              // stopping here prevents the model running another step that restates the whole answer
+            );
+          },
+          onError: ({ error }) => {
+            req.log.error({ err: error, conversationId: convo._id }, "chat stream error");
+          },
+          // Persist each finished step (text and/or tool-call + tool-result) so the durable history
+          // captures the whole tool loop across every agent in the chain. `activeAgent.name` is the
+          // agent that produced THIS step (it changes across handoffs), recorded as provenance.
+          onStepFinish: (step) => {
+            // Observability (best-effort, sync emit onto the in-process bus — never blocks the step).
+            // Read usage/response off the real step (PersistableStep omits them) and attribute the
+            // served model against the resolved chain so fallback turns record the real model.
+            const observableStep = step as unknown as ObservableStep;
+            const usage = extractStepUsage(observableStep);
+            const { model, provider, fellBack, entry } = attributeModel(
+              usage.servedModelId,
+              resolved.chain,
+              resolvedModelId
+            );
+            const now = Date.now();
+            turnSteps += 1;
+            turnTokensIn += usage.tokensIn;
+            turnTokensOut += usage.tokensOut;
+            events?.emit(DOMAIN_EVENTS.LLM_STEP_FINISHED, {
+              conversationId: convo._id,
+              agentId: activeAgent.name,
+              model,
+              provider,
+              tier: resolved.tier,
+              tokensIn: usage.tokensIn,
+              tokensOut: usage.tokensOut,
+              durationMs: now - lastStepAt,
+              // A step served by a non-primary provider means the chain fell back (reliability signal).
+              status: fellBack ? "fallback" : "ok",
+              // Authoritative per-token cost from the served model's pinned soul spec (if resolved).
+              costInPerToken: entry?.spec?.input_cost_per_token,
+              costOutPerToken: entry?.spec?.output_cost_per_token,
+              cacheRead: usage.cacheRead,
+              cacheWrite: usage.cacheWrite,
+              reasoning: usage.reasoning,
+              tools: extractToolCalls(observableStep),
+              // In-memory already; the subscriber persists it only when content capture is enabled.
+              completionText: observableStep.text,
+            });
+            lastStepAt = now;
+            return persistStep(
+              messageRepo,
+              convo._id,
+              step as unknown as PersistableStep,
+              (e) => req.log.error({ err: e, conversationId: convo._id }, "persist failed"),
+              replyIdHolder,
+              { model: resolvedModelId, agentId: activeAgent.name }
+            );
+          },
         });
+
+        let control:
+          | { type: "transfer"; target: string; reason?: string }
+          | { type: "complete"; summary?: string }
+          | undefined;
+        // Set when this agent calls `ask_user`: the turn ends with the form rendered and a pending
+        // interaction is persisted so the next request resumes with the user's answer.
+        let pendingAsk:
+          | { toolCallId: string; surfaceId: string | null; schema: Record<string, unknown> }
+          | undefined;
+        let errored = false;
+        for await (const part of result.fullStream) {
+          const p = part as { type?: string; toolName?: string; toolCallId?: string };
+          // Suppress each agent's own terminal `finish`; one synthetic finish closes the whole turn.
+          if (p.type === "finish") continue;
+          if (p.type === "error") errored = true;
+          if (p.type === "tool-result" && p.toolName === "ask_user") {
+            const full = fullResultCache.get(p.toolCallId as string);
+            if (full?.success) {
+              const data = full.data as Record<string, unknown>;
+              pendingAsk = {
+                toolCallId: p.toolCallId as string,
+                surfaceId: typeof data.surfaceId === "string" ? data.surfaceId : null,
+                schema: (data.schema as Record<string, unknown>) ?? {},
+              };
+            }
+          }
+          if (
+            p.type === "tool-result" &&
+            (p.toolName === "transfer_to_agent" || p.toolName === "complete_task")
+          ) {
+            const full = fullResultCache.get(p.toolCallId as string);
+            if (full?.success) {
+              const data = full.data as Record<string, unknown>;
+              control =
+                p.toolName === "transfer_to_agent"
+                  ? {
+                      type: "transfer",
+                      target: String(data.agentId),
+                      reason: data.message ? String(data.message) : undefined,
+                    }
+                  : {
+                      type: "complete",
+                      summary: data.summary ? String(data.summary) : undefined,
+                    };
+            }
+          }
+          yield part;
+        }
+
+        if (errored) {
+          emitTurnFinished("error");
+          return; // a terminal `error` was already yielded by the producer
+        }
+        if (pendingAsk) {
+          // HITL: end the turn with the form on screen and record the pause. The next request injects
+          // the user's answer as this tool-call's result and resumes the run (see the resume path).
+          await pendingInteractions.create({
+            id: randomUUID(),
+            conversationId: convo._id,
+            toolCallId: pendingAsk.toolCallId,
+            toolName: "ask_user",
+            awaitedSchema: pendingAsk.schema,
+            surfaceId: pendingAsk.surfaceId,
+            createdAt: new Date(),
+            resolvedAt: null,
+          });
+          // A HITL pause is not a completed turn — record it as 'paused' so it isn't counted as a
+          // success (the resumed continuation emits its own TURN_FINISHED). Idempotent: wins over the
+          // "ok" below.
+          emitTurnFinished("paused");
+          break;
+        }
+        if (closingTurn) break; // the GeneralAssistant's closing confirmation just streamed
+        if (control?.type === "transfer" && depth < MAX_HANDOFF_DEPTH - 1) {
+          const fromAgent = activeAgent.name;
+          await repo.setAgent(convo._id, control.target);
+          activeAgent = resolveAgent(soulLoader, control.target);
+          activePlatform = getPlatformAgent(activeAgent.name);
+          // Surface the live switch so the client's current-agent indicator follows the handoff.
+          yield {
+            type: "agent-handoff",
+            from: fromAgent,
+            to: activeAgent.name,
+            reason: control.reason,
+          };
+          const handoffUser = control.reason
+            ? `${userContent}\n\n(Handoff context: ${control.reason})`
+            : userContent;
+          // Clean slate for the target: its own system prompt + the user's original request.
+          turnMessages = [
+            { role: "system", content: buildSystemFor(activeAgent, activePlatform) },
+            { role: "user", content: handoffUser },
+          ];
+          continue;
+        }
+        if (control?.type === "complete" && depth < MAX_HANDOFF_DEPTH - 1) {
+          // Control returns to the front desk, which streams a brief confirmation of what the
+          // specialist just did — otherwise the turn ends on a silent (collapsed) tool result.
+          const fromAgent = activeAgent.name;
+          await repo.setAgent(convo._id, GENERAL_ASSISTANT_NAME);
+          activeAgent = resolveAgent(soulLoader, GENERAL_ASSISTANT_NAME);
+          activePlatform = getPlatformAgent(activeAgent.name);
+          // Hand the indicator back to the front desk for the closing confirmation turn.
+          yield { type: "agent-handoff", from: fromAgent, to: activeAgent.name };
+          const summary = control.summary ?? "completed the requested work";
+          turnMessages = [
+            { role: "system", content: buildSystemFor(activeAgent, activePlatform) },
+            { role: "user", content: userContent },
+            {
+              role: "assistant",
+              content: `(Internal note — the Information Architect handled that and reported: ${summary})`,
+            },
+            {
+              role: "user",
+              content:
+                "In one short, friendly sentence, confirm what was just created or done, and suggest one relevant next step. Do not call any tools.",
+            },
+          ];
+          closingTurn = true;
+          continue;
+        }
+        if (control?.type === "complete") {
+          await repo.setAgent(convo._id, GENERAL_ASSISTANT_NAME);
+        }
         break;
       }
-      if (closingTurn) break; // the GeneralAssistant's closing confirmation just streamed
-      if (control?.type === "transfer" && depth < MAX_HANDOFF_DEPTH - 1) {
-        const fromAgent = activeAgent.name;
-        await repo.setAgent(convo._id, control.target);
-        activeAgent = resolveAgent(soulLoader, control.target);
-        activePlatform = getPlatformAgent(activeAgent.name);
-        // Surface the live switch so the client's current-agent indicator follows the handoff.
-        yield {
-          type: "agent-handoff",
-          from: fromAgent,
-          to: activeAgent.name,
-          reason: control.reason,
-        };
-        const handoffUser = control.reason
-          ? `${userContent}\n\n(Handoff context: ${control.reason})`
-          : userContent;
-        // Clean slate for the target: its own system prompt + the user's original request.
-        turnMessages = [
-          { role: "system", content: buildSystemFor(activeAgent, activePlatform) },
-          { role: "user", content: handoffUser },
-        ];
-        continue;
-      }
-      if (control?.type === "complete" && depth < MAX_HANDOFF_DEPTH - 1) {
-        // Control returns to the front desk, which streams a brief confirmation of what the
-        // specialist just did — otherwise the turn ends on a silent (collapsed) tool result.
-        const fromAgent = activeAgent.name;
-        await repo.setAgent(convo._id, GENERAL_ASSISTANT_NAME);
-        activeAgent = resolveAgent(soulLoader, GENERAL_ASSISTANT_NAME);
-        activePlatform = getPlatformAgent(activeAgent.name);
-        // Hand the indicator back to the front desk for the closing confirmation turn.
-        yield { type: "agent-handoff", from: fromAgent, to: activeAgent.name };
-        const summary = control.summary ?? "completed the requested work";
-        turnMessages = [
-          { role: "system", content: buildSystemFor(activeAgent, activePlatform) },
-          { role: "user", content: userContent },
-          {
-            role: "assistant",
-            content: `(Internal note — the Information Architect handled that and reported: ${summary})`,
-          },
-          {
-            role: "user",
-            content:
-              "In one short, friendly sentence, confirm what was just created or done, and suggest one relevant next step. Do not call any tools.",
-          },
-        ];
-        closingTurn = true;
-        continue;
-      }
-      if (control?.type === "complete") {
-        await repo.setAgent(convo._id, GENERAL_ASSISTANT_NAME);
-      }
-      break;
-    }
 
-    // A completed turn feeds the knowledge AgentConversationSource (AC-V1-002).
-    events?.emit(DOMAIN_EVENTS.CONVERSATION_COMPLETED, {
-      conversationId: convo._id,
-      actorId: user._id,
-    });
-    yield { type: "finish", finishReason: "stop" };
+      // A completed turn feeds the knowledge AgentConversationSource (AC-V1-002).
+      events?.emit(DOMAIN_EVENTS.CONVERSATION_COMPLETED, {
+        conversationId: convo._id,
+        actorId: user._id,
+      });
+      emitTurnFinished("ok");
+      yield { type: "finish", finishReason: "stop" };
+    } finally {
+      // No-op when a normal/errored exit already emitted; fires only for stop-aborts and throws.
+      emitTurnFinished("aborted");
+    }
   }
 
   // Attach this connection (live from seq 0) and start the detached producer over the loop.

--- a/apps/api/src/domain-events.ts
+++ b/apps/api/src/domain-events.ts
@@ -7,6 +7,10 @@ export const DOMAIN_EVENTS = {
   RESOURCE_UPDATED: "resource.updated",
   CONVERSATION_CREATED: "conversation.created",
   CONVERSATION_COMPLETED: "conversation.completed",
+  // Observability spine (AI metrics). One LLM_STEP_FINISHED per model step; one TURN_FINISHED per
+  // chat turn. The observability subscriber turns these into obs_event rows; nothing else listens.
+  LLM_STEP_FINISHED: "llm.step_finished",
+  TURN_FINISHED: "turn.finished",
 } as const;
 
 export interface ResourceEventPayload {
@@ -26,4 +30,49 @@ export interface ConversationCreatedPayload {
 export interface ConversationCompletedPayload {
   conversationId: string;
   actorId?: string;
+}
+
+/** One finished model step. `model`/`provider` are already attributed to the served model. */
+export interface LlmStepFinishedPayload {
+  conversationId: string;
+  agentId: string;
+  model: string;
+  provider: string | null;
+  tier?: string;
+  tokensIn: number;
+  tokensOut: number;
+  durationMs?: number;
+  status: string;
+  /** Prompt-cache + reasoning token breakdown, stashed in obs_event.attributes. */
+  cacheRead?: number;
+  cacheWrite?: number;
+  reasoning?: number;
+  /** USD-per-token cost from the served model's pinned soul spec. When present, the subscriber uses
+   *  these for cost (authoritative); otherwise it falls back to the built-in price map. */
+  costInPerToken?: number;
+  costOutPerToken?: number;
+  /** Tools invoked in this step → one tool_call row each. `args`/`result` are stored only when
+   *  content capture is enabled (opt-in); otherwise the subscriber drops them. */
+  tools?: Array<{
+    name: string;
+    status: string;
+    errorCode?: string;
+    args?: unknown;
+    result?: unknown;
+  }>;
+  /** The model's text output this step. Stored only when content capture is enabled. */
+  completionText?: string;
+}
+
+/** One completed chat turn, with totals accumulated across its steps (and any handoffs). */
+export interface TurnFinishedPayload {
+  conversationId: string;
+  agentId: string;
+  status: string;
+  steps: number;
+  tokensIn: number;
+  tokensOut: number;
+  model?: string;
+  tier?: string;
+  durationMs?: number;
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -47,6 +47,13 @@ import { KvService } from "./kv/service";
 import { registerLlmReload } from "./llm-reload";
 import { WorkingMemoryService } from "./memory/service";
 import { PgWorkingMemoryRepo } from "./memory/working-memory";
+import { parseObservabilityConfig } from "./observability/config";
+import { subscribeObservability } from "./observability/events";
+import { OtlpMetricsExporter } from "./observability/metrics";
+import { registerObsPrune } from "./observability/prune";
+import { PgObsRepo } from "./observability/repo";
+import { ObservabilityService } from "./observability/service";
+import { OtlpTracesExporter } from "./observability/traces";
 import { runPgMigrations } from "./pg-migrate";
 import { PgRateLimiter } from "./rate-limit";
 import { reconcileResourceTables, registerResourceReconcile } from "./resources/reconcile";
@@ -123,6 +130,8 @@ async function boot() {
     const workingMemoryService = new WorkingMemoryService(new PgWorkingMemoryRepo(pool));
     const kvService = new KvService(new PgKvRepo(pool));
     const activityService = new ActivityService(new PgActivityRepo(pool));
+    const observabilityService = new ObservabilityService(new PgObsRepo(pool));
+    const obsConfig = parseObservabilityConfig(soulLoader.observabilityConfig);
     const resourceRepoFactory = new PgResourceRepoFactory(pool);
     const counterStore = new PgCounterStore(pool);
     const reconcileResources = () => reconcileResourceTables(pool, soulLoader, console);
@@ -203,6 +212,8 @@ async function boot() {
       retrievalService,
       toolRegistry,
       activityService,
+      observabilityService,
+      observabilityConfig: obsConfig,
     });
 
     // Init after buildApp so fallback events log through Fastify's Pino logger.
@@ -228,6 +239,10 @@ async function boot() {
       soulLoader,
     });
     await registerStreamGc(boss, streamResumeRepo, activityService);
+    await registerObsPrune(boss, new PgObsRepo(pool), activityService, {
+      obs: observabilityService,
+      retentionMs: obsConfig.retentionDays * 24 * 60 * 60 * 1000,
+    });
     await registerKnowledgeIndexing(boss, {
       service: knowledgeService,
       loadConversationText: async (conversationId) => {
@@ -244,6 +259,38 @@ async function boot() {
     });
     subscribeKnowledgeIndexing(domainEventEmitter, boss);
     subscribeActivityLogging(domainEventEmitter, activityService);
+    // Optional Grafana Cloud OTLP metrics export (gated). Only constructed when enabled + targeted +
+    // the token resolves — the default path loads nothing extra.
+    let metricsSink: OtlpMetricsExporter | undefined;
+    let tracesSink: OtlpTracesExporter | undefined;
+    if (obsConfig.enabled && obsConfig.otlp) {
+      const ref = obsConfig.otlp.token;
+      const token = ref.startsWith("env://")
+        ? process.env[ref.slice(6)]
+        : await secretsService.get(ref).catch(() => undefined);
+      if (token) {
+        const target = {
+          endpoint: obsConfig.otlp.endpoint,
+          instanceId: obsConfig.otlp.instanceId,
+          token,
+        };
+        metricsSink = new OtlpMetricsExporter(target);
+        metricsSink.start();
+        tracesSink = new OtlpTracesExporter(target);
+        tracesSink.start();
+        console.info("[observability] OTLP metrics + traces export enabled");
+      } else {
+        console.warn("[observability] OTLP enabled but token unresolved — export disabled");
+      }
+    }
+    // Cost is computed primarily from each model's pinned soul spec (resolved from LiteLLM when the
+    // model was added in Settings); the built-in price map + config overrides are the fallback.
+    subscribeObservability(domainEventEmitter, observabilityService, {
+      pricingOverrides: obsConfig.pricingOverrides,
+      metrics: metricsSink,
+      traces: tracesSink,
+      captureContent: obsConfig.captureContent,
+    });
     await registerConnectorSync(boss, {
       registry: buildDefaultRegistry(),
       state: new PgConnectorStateRepo(pool),
@@ -273,6 +320,11 @@ async function boot() {
       try {
         await app.close();
         await boss.stop({ graceful: false });
+        // Final flush so metrics/spans buffered since the last interval tick aren't lost on exit.
+        await metricsSink?.flush();
+        metricsSink?.stop();
+        await tracesSink?.flush();
+        tracesSink?.stop();
         await hookExecutor?.close();
         await pool.end();
       } catch (err) {

--- a/apps/api/src/knowledge/migration.pg.test.ts
+++ b/apps/api/src/knowledge/migration.pg.test.ts
@@ -47,9 +47,9 @@ describe("002_knowledge migration on PGlite", () => {
     await db.close();
   });
 
-  it("bumps schema_version to the latest (21)", async () => {
+  it("bumps schema_version to the latest (22)", async () => {
     const { rows } = await db.query("SELECT version FROM schema_version WHERE id = true");
-    expect(Number((rows[0] as { version: number }).version)).toBe(21);
+    expect(Number((rows[0] as { version: number }).version)).toBe(22);
   });
 
   it("adds knowledge_chunks.content_hash (019)", async () => {

--- a/apps/api/src/observability/capture.test.ts
+++ b/apps/api/src/observability/capture.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { attributeModel, extractStepUsage, extractToolCalls, type ObservableStep } from "./capture";
+
+describe("extractToolCalls", () => {
+  it("maps tool results to name + ok/error and carries arg/result bodies", () => {
+    const step: ObservableStep = {
+      toolCalls: [{ toolName: "search_knowledge", input: { q: "hi" } }],
+      toolResults: [
+        { toolName: "search_knowledge", output: { success: true, data: { hits: 1 } } },
+        { toolName: "record_create", output: { success: false, error: { code: "not_found" } } },
+      ],
+    };
+    const calls = extractToolCalls(step);
+    expect(calls[0]).toMatchObject({
+      name: "search_knowledge",
+      status: "ok",
+      args: { q: "hi" },
+      result: { success: true, data: { hits: 1 } },
+    });
+    expect(calls[1]).toMatchObject({
+      name: "record_create",
+      status: "error",
+      errorCode: "not_found",
+    });
+  });
+
+  it("returns empty when no tools ran", () => {
+    expect(extractToolCalls({})).toEqual([]);
+  });
+});
+
+describe("extractStepUsage", () => {
+  it("reads flat v7 usage totals + cache details + served model id", () => {
+    const step: ObservableStep = {
+      usage: {
+        inputTokens: 4100,
+        outputTokens: 820,
+        inputTokenDetails: { cacheReadTokens: 3000, cacheWriteTokens: 100 },
+        outputTokenDetails: { reasoningTokens: 200 },
+      },
+      response: { modelId: "claude-opus-4-8" },
+    };
+    expect(extractStepUsage(step)).toEqual({
+      tokensIn: 4100,
+      tokensOut: 820,
+      servedModelId: "claude-opus-4-8",
+      cacheRead: 3000,
+      cacheWrite: 100,
+      reasoning: 200,
+    });
+  });
+
+  it("defaults missing usage/response to zero/null", () => {
+    expect(extractStepUsage({})).toEqual({
+      tokensIn: 0,
+      tokensOut: 0,
+      servedModelId: null,
+      cacheRead: undefined,
+      cacheWrite: undefined,
+      reasoning: undefined,
+    });
+  });
+});
+
+describe("attributeModel", () => {
+  const chain = [
+    { provider: "azure", modelId: "gpt-4o-mini", spec: { input_cost_per_token: 0.001 } },
+    { provider: "anthropic", modelId: "claude-haiku-4-5" },
+  ];
+
+  it("attributes the served model to its provider (primary, no fallback) + carries its spec", () => {
+    expect(attributeModel("gpt-4o-mini", chain, "gpt-4o-mini")).toMatchObject({
+      model: "gpt-4o-mini",
+      provider: "azure",
+      fellBack: false,
+      entry: { provider: "azure", spec: { input_cost_per_token: 0.001 } },
+    });
+  });
+
+  it("attributes a fallback-served model to the right provider + flags fellBack", () => {
+    expect(attributeModel("claude-haiku-4-5", chain, "gpt-4o-mini")).toMatchObject({
+      model: "claude-haiku-4-5",
+      provider: "anthropic",
+      fellBack: true,
+    });
+  });
+
+  it("matches a dated served id to its chain entry by prefix (and flags fallback)", () => {
+    const r = attributeModel("claude-haiku-4-5-20250901", chain, "gpt-4o-mini");
+    expect(r.provider).toBe("anthropic");
+    expect(r.fellBack).toBe(true);
+  });
+
+  it("falls back to the primary model id when the step reports none (not a fallback)", () => {
+    expect(attributeModel(null, chain, "gpt-4o-mini")).toMatchObject({
+      model: "gpt-4o-mini",
+      provider: "azure",
+      fellBack: false,
+    });
+  });
+
+  it("defaults provider to the chain head when the served model is unknown", () => {
+    const r = attributeModel("mystery-model", chain, "gpt-4o-mini");
+    expect(r.provider).toBe("azure");
+    expect(r.fellBack).toBe(false);
+  });
+});

--- a/apps/api/src/observability/capture.ts
+++ b/apps/api/src/observability/capture.ts
@@ -1,0 +1,112 @@
+import type { ResolvedModelEntry } from "@tulipfarm/llm";
+
+/**
+ * The subset of the AI SDK v7 `streamText` StepResult that observability reads. The chat turn's
+ * `PersistableStep` (turn-helpers.ts) deliberately omits `usage`/`response`; we read the real step
+ * via this shape instead. NOTE: the consumer-facing `step.usage` (AI SDK `LanguageModelUsage`) is
+ * FLAT — `inputTokens: number` with cache details nested under `inputTokenDetails` — NOT the nested
+ * provider-level shape. Reading `inputTokens.total` (the provider shape) yields 0 for every call.
+ */
+export interface ObservableUsage {
+  inputTokens?: number | null;
+  outputTokens?: number | null;
+  inputTokenDetails?: {
+    noCacheTokens?: number;
+    cacheReadTokens?: number;
+    cacheWriteTokens?: number;
+  } | null;
+  outputTokenDetails?: { textTokens?: number; reasoningTokens?: number } | null;
+}
+
+export interface ObservableStep {
+  usage?: ObservableUsage | null;
+  response?: { modelId?: string } | null;
+  text?: string;
+  toolCalls?: ReadonlyArray<{ toolName: string; input?: unknown }>;
+  toolResults?: ReadonlyArray<{ toolName: string; output?: unknown }>;
+}
+
+export interface ToolCallInfo {
+  name: string;
+  status: "ok" | "error";
+  errorCode?: string;
+  /** Argument + result bodies — carried for opt-in content capture; the subscriber drops them
+   *  unless capture is enabled. Never persisted by default. */
+  args?: unknown;
+  result?: unknown;
+}
+
+/**
+ * Derive per-tool outcomes from a finished step's tool results: name + ok/error + error code, plus
+ * the arg/result bodies (used only when content capture is on). A `ToolCallResult` is
+ * `{success:false, error:{code}}` on failure; anything else is treated as ok.
+ */
+export function extractToolCalls(step: ObservableStep): ToolCallInfo[] {
+  const argsByName = new Map<string, unknown>();
+  for (const tc of step.toolCalls ?? []) {
+    if (!argsByName.has(tc.toolName)) argsByName.set(tc.toolName, tc.input);
+  }
+  return (step.toolResults ?? []).map((tr) => {
+    const out = tr.output as { success?: boolean; error?: { code?: string } } | undefined;
+    const base = { args: argsByName.get(tr.toolName), result: tr.output };
+    if (out?.success === false) {
+      return { name: tr.toolName, status: "error", errorCode: out.error?.code, ...base };
+    }
+    return { name: tr.toolName, status: "ok", ...base };
+  });
+}
+
+export interface StepUsage {
+  tokensIn: number;
+  tokensOut: number;
+  /** The model the provider actually served (flows through the fallback chain), or null if absent. */
+  servedModelId: string | null;
+  /** Prompt-cache + reasoning breakdown, stashed in attributes for later cache-aware pricing. */
+  cacheRead?: number;
+  cacheWrite?: number;
+  reasoning?: number;
+}
+
+/** Pull token totals + the served model id off a finished step (flat v7 `LanguageModelUsage`). */
+export function extractStepUsage(step: ObservableStep): StepUsage {
+  const u = step.usage ?? undefined;
+  return {
+    tokensIn: u?.inputTokens ?? 0,
+    tokensOut: u?.outputTokens ?? 0,
+    servedModelId: step.response?.modelId ?? null,
+    cacheRead: u?.inputTokenDetails?.cacheReadTokens,
+    cacheWrite: u?.inputTokenDetails?.cacheWriteTokens,
+    reasoning: u?.outputTokenDetails?.reasoningTokens,
+  };
+}
+
+/**
+ * Attribute a finished step to a concrete model + provider, and detect fallback. Under a fallback
+ * chain the served model id (from the step's response) can differ from the primary; we reconcile
+ * against the resolved chain — exact match first, then a prefix-tolerant match (handles dated
+ * provider ids), else fall back to the primary entry. This keeps `llm_call` rows from recording the
+ * joined `"a|b|c"` FallbackModel id. `fellBack` is true when a served id positively matched a
+ * NON-primary chain entry — i.e. an earlier provider failed and the chain advanced.
+ */
+export function attributeModel(
+  servedModelId: string | null,
+  chain: ResolvedModelEntry[],
+  primaryModelId: string
+): { model: string; provider: string | null; fellBack: boolean; entry?: ResolvedModelEntry } {
+  const model = servedModelId ?? primaryModelId;
+  let idx = chain.findIndex((e) => e.modelId === model);
+  if (idx < 0) {
+    idx = chain.findIndex(
+      (e) => model.startsWith(`${e.modelId}-`) || e.modelId.startsWith(`${model}-`)
+    );
+  }
+  const entry = idx >= 0 ? chain[idx] : chain[0];
+  // Only a positively-matched non-primary entry counts as a fallback (a missing served id is
+  // ambiguous → assume primary). `entry` carries the pinned spec (pricing) for the served model.
+  return {
+    model,
+    provider: entry?.provider ?? null,
+    fellBack: servedModelId != null && idx > 0,
+    entry,
+  };
+}

--- a/apps/api/src/observability/config.test.ts
+++ b/apps/api/src/observability/config.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_OBSERVABILITY_CONFIG, parseObservabilityConfig } from "./config";
+
+describe("parseObservabilityConfig", () => {
+  it("returns disabled defaults for null / missing config (zero setup)", () => {
+    expect(parseObservabilityConfig(null)).toEqual(DEFAULT_OBSERVABILITY_CONFIG);
+    expect(parseObservabilityConfig(undefined)).toEqual(DEFAULT_OBSERVABILITY_CONFIG);
+  });
+
+  it("parses a full config, mapping snake_case to camelCase", () => {
+    const cfg = parseObservabilityConfig({
+      enabled: true,
+      retention_days: 30,
+      capture_content: true,
+      spend_alert_usd: 50,
+      otlp: {
+        endpoint: "https://otlp.grafana.net/otlp",
+        instance_id: "123456",
+        token: "env://GRAFANA_OTLP_TOKEN",
+      },
+      pricing_overrides: { "my-model": { in: 1, out: 3 } },
+    });
+    expect(cfg).toEqual({
+      enabled: true,
+      retentionDays: 30,
+      captureContent: true,
+      spendAlertUsd: 50,
+      otlp: {
+        endpoint: "https://otlp.grafana.net/otlp",
+        instanceId: "123456",
+        token: "env://GRAFANA_OTLP_TOKEN",
+      },
+      pricingOverrides: { "my-model": { in: 1, out: 3 } },
+    });
+  });
+
+  it("drops an incomplete otlp block and malformed price overrides", () => {
+    const cfg = parseObservabilityConfig({
+      enabled: true,
+      otlp: { endpoint: "https://x", instance_id: "1" }, // missing token
+      pricing_overrides: { good: { in: 1, out: 2 }, bad: { in: "x" } },
+    });
+    expect(cfg.otlp).toBeNull();
+    expect(cfg.pricingOverrides).toEqual({ good: { in: 1, out: 2 } });
+    expect(cfg.retentionDays).toBe(90); // default preserved
+  });
+});

--- a/apps/api/src/observability/config.ts
+++ b/apps/api/src/observability/config.ts
@@ -1,0 +1,69 @@
+import type { ModelPrice } from "@tulipfarm/llm";
+
+/**
+ * Runtime observability config, parsed from `soul/observability.config.yaml` (all fields optional;
+ * an absent file ⇒ disabled defaults, zero setup). The OTLP `token` is an `env://VAR` / secret ref
+ * resolved at exporter-setup time, not here. snake_case YAML → camelCase here.
+ */
+export interface ObservabilityConfig {
+  /** Master switch for the Grafana Cloud OTLP export. Off ⇒ no OTel deps loaded, no push. */
+  enabled: boolean;
+  /** Raw-event retention window (days) for the prune job. */
+  retentionDays: number;
+  /** When true, prompt/completion/tool bodies may be captured (P3). Off by default. */
+  captureContent: boolean;
+  /** Daily-spend threshold ($) used by the shipped Grafana alert rule; null ⇒ unset. */
+  spendAlertUsd: number | null;
+  /** Grafana Cloud OTLP target; null ⇒ no exporter even if `enabled`. `token` is a ref string. */
+  otlp: { endpoint: string; instanceId: string; token: string } | null;
+  /** Per-model price overrides merged over the built-in map (USD per 1M tokens). */
+  pricingOverrides: Record<string, ModelPrice>;
+}
+
+export const DEFAULT_OBSERVABILITY_CONFIG: ObservabilityConfig = {
+  enabled: false,
+  retentionDays: 90,
+  captureContent: false,
+  spendAlertUsd: null,
+  otlp: null,
+  pricingOverrides: {},
+};
+
+function asNumber(v: unknown, fallback: number): number {
+  return typeof v === "number" && Number.isFinite(v) ? v : fallback;
+}
+
+/** Parse + coerce raw YAML (or null) into a fully-defaulted config. Lenient: bad fields are dropped. */
+export function parseObservabilityConfig(raw: unknown): ObservabilityConfig {
+  if (!raw || typeof raw !== "object") return { ...DEFAULT_OBSERVABILITY_CONFIG };
+  const r = raw as Record<string, unknown>;
+
+  const otlpRaw = r.otlp as Record<string, unknown> | undefined;
+  const otlp =
+    otlpRaw &&
+    typeof otlpRaw.endpoint === "string" &&
+    typeof otlpRaw.instance_id === "string" &&
+    typeof otlpRaw.token === "string"
+      ? { endpoint: otlpRaw.endpoint, instanceId: otlpRaw.instance_id, token: otlpRaw.token }
+      : null;
+
+  const pricingOverrides: Record<string, ModelPrice> = {};
+  if (r.pricing_overrides && typeof r.pricing_overrides === "object") {
+    for (const [k, v] of Object.entries(r.pricing_overrides as Record<string, unknown>)) {
+      const p = v as Record<string, unknown>;
+      if (typeof p?.in === "number" && typeof p?.out === "number") {
+        pricingOverrides[k] = { in: p.in, out: p.out };
+      }
+    }
+  }
+
+  return {
+    enabled: r.enabled === true,
+    // Clamp to ≥1: a 0/negative window would make the prune cutoff `now`, deleting every event.
+    retentionDays: Math.max(1, Math.floor(asNumber(r.retention_days, 90))),
+    captureContent: r.capture_content === true,
+    spendAlertUsd: typeof r.spend_alert_usd === "number" ? r.spend_alert_usd : null,
+    otlp,
+    pricingOverrides,
+  };
+}

--- a/apps/api/src/observability/events.pg.test.ts
+++ b/apps/api/src/observability/events.pg.test.ts
@@ -1,0 +1,237 @@
+import { EventEmitter } from "node:events";
+import type { PGlite } from "@electric-sql/pglite";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DOMAIN_EVENTS } from "../domain-events";
+import { runPgMigrations } from "../pg-migrate";
+import { makePglite } from "../test/pglite";
+import { subscribeObservability } from "./events";
+import { PgObsRepo } from "./repo";
+import { ObservabilityService } from "./service";
+
+const CONVO = "11111111-1111-1111-1111-111111111111";
+
+/** The bus emit is synchronous but the subscriber's record() is async + fire-and-forget. */
+function flush(): Promise<void> {
+  return new Promise((r) => setImmediate(r));
+}
+
+describe("subscribeObservability", () => {
+  let db: PGlite;
+  let emitter: EventEmitter;
+
+  beforeEach(async () => {
+    db = await makePglite();
+    await runPgMigrations(db);
+    emitter = new EventEmitter();
+    subscribeObservability(emitter, new ObservabilityService(new PgObsRepo(db)));
+  });
+
+  afterEach(async () => {
+    await db.close();
+  });
+
+  it("writes an llm_call row with cost frozen from the price map", async () => {
+    emitter.emit(DOMAIN_EVENTS.LLM_STEP_FINISHED, {
+      conversationId: CONVO,
+      agentId: "support-agent",
+      model: "claude-opus-4-8",
+      provider: "anthropic",
+      tier: "complex",
+      tokensIn: 1_000_000,
+      tokensOut: 1_000_000,
+      durationMs: 1240,
+      status: "ok",
+      cacheRead: 500,
+    });
+    await flush();
+
+    const { rows } = await db.query("SELECT * FROM obs_event WHERE type = 'llm_call'");
+    expect(rows).toHaveLength(1);
+    const r = rows[0] as Record<string, unknown>;
+    expect(r.model).toBe("claude-opus-4-8");
+    expect(r.provider).toBe("anthropic");
+    // 1M in @ $15 + 1M out @ $75 = $90
+    expect(Number(r.cost_usd)).toBe(90);
+    expect(r.attributes).toEqual({ cacheRead: 500 });
+  });
+
+  it("writes one tool_call row per tool in the step (metadata-only)", async () => {
+    emitter.emit(DOMAIN_EVENTS.LLM_STEP_FINISHED, {
+      conversationId: CONVO,
+      agentId: "support-agent",
+      model: "claude-opus-4-8",
+      provider: "anthropic",
+      tokensIn: 10,
+      tokensOut: 5,
+      status: "ok",
+      tools: [
+        { name: "search_knowledge", status: "ok" },
+        { name: "record_create", status: "error", errorCode: "not_found" },
+      ],
+    });
+    await flush();
+
+    const { rows } = await db.query(
+      "SELECT tool_name, status, attributes FROM obs_event WHERE type = 'tool_call' ORDER BY tool_name"
+    );
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({ tool_name: "record_create", status: "error" });
+    expect((rows[0] as { attributes: Record<string, unknown> }).attributes).toEqual({
+      errorCode: "not_found",
+    });
+    expect(rows[1]).toMatchObject({ tool_name: "search_knowledge", status: "ok" });
+  });
+
+  it("computes cost from the pinned per-token spec when present (not the built-in map)", async () => {
+    emitter.emit(DOMAIN_EVENTS.LLM_STEP_FINISHED, {
+      conversationId: CONVO,
+      agentId: "a",
+      model: "some-niche-model-not-in-builtin-map",
+      provider: "openai-compatible",
+      tokensIn: 1000,
+      tokensOut: 500,
+      status: "ok",
+      costInPerToken: 0.000002, // $2 / Mtok
+      costOutPerToken: 0.000008, // $8 / Mtok
+    });
+    await flush();
+    const { rows } = await db.query(
+      "SELECT cost_usd FROM obs_event WHERE type = 'llm_call' AND model = 'some-niche-model-not-in-builtin-map'"
+    );
+    // 1000 * 2e-6 + 500 * 8e-6 = 0.002 + 0.004 = 0.006
+    expect(Number((rows[0] as { cost_usd: string }).cost_usd)).toBeCloseTo(0.006, 6);
+  });
+
+  it("flags an unpriced model with null cost + attribute", async () => {
+    emitter.emit(DOMAIN_EVENTS.LLM_STEP_FINISHED, {
+      conversationId: CONVO,
+      agentId: "a",
+      model: "some-unlisted-model",
+      provider: "custom",
+      tokensIn: 1000,
+      tokensOut: 1000,
+      status: "ok",
+    });
+    await flush();
+
+    const { rows } = await db.query("SELECT cost_usd, attributes FROM obs_event");
+    expect(rows[0]).toMatchObject({ cost_usd: null, attributes: { unpriced: true } });
+  });
+
+  it("drops prompt/completion/tool bodies by default (privacy)", async () => {
+    emitter.emit(DOMAIN_EVENTS.LLM_STEP_FINISHED, {
+      conversationId: CONVO,
+      agentId: "a",
+      model: "claude-opus-4-8",
+      provider: "anthropic",
+      tokensIn: 1,
+      tokensOut: 1,
+      status: "ok",
+      completionText: "secret completion",
+      tools: [{ name: "t", status: "ok", args: { a: 1 }, result: { r: 2 } }],
+    });
+    await flush();
+    const { rows } = await db.query("SELECT type, attributes FROM obs_event ORDER BY type");
+    // llm_call attributes carry no completion; tool_call carries no args/result.
+    const all = JSON.stringify(rows);
+    expect(all).not.toContain("secret completion");
+    expect(all).not.toContain('"args"');
+    expect(all).not.toContain('"result"');
+  });
+
+  it("stores prompt/completion/tool bodies when content capture is enabled", async () => {
+    // A second subscriber with capture on, on its own emitter + db.
+    const captureEmitter = new EventEmitter();
+    subscribeObservability(captureEmitter, new ObservabilityService(new PgObsRepo(db)), {
+      captureContent: true,
+    });
+    captureEmitter.emit(DOMAIN_EVENTS.LLM_STEP_FINISHED, {
+      conversationId: CONVO,
+      agentId: "a",
+      model: "claude-opus-4-8",
+      provider: "anthropic",
+      tokensIn: 1,
+      tokensOut: 1,
+      status: "ok",
+      completionText: "captured completion",
+      tools: [{ name: "t", status: "ok", args: { a: 1 }, result: { r: 2 } }],
+    });
+    await flush();
+    const llm = await db.query(
+      "SELECT attributes FROM obs_event WHERE type = 'llm_call' AND attributes ? 'completion'"
+    );
+    expect((llm.rows[0] as { attributes: { completion: string } }).attributes.completion).toBe(
+      "captured completion"
+    );
+    const tool = await db.query(
+      "SELECT attributes FROM obs_event WHERE type = 'tool_call' AND attributes ? 'args'"
+    );
+    expect((tool.rows[0] as { attributes: { args: unknown } }).attributes.args).toEqual({ a: 1 });
+  });
+
+  it("never propagates a throwing metrics sink, and still writes the row", async () => {
+    const throwingEmitter = new EventEmitter();
+    const throwingSink = {
+      recordLlmCall() {
+        throw new Error("sink boom");
+      },
+      recordToolCall() {},
+      recordTurn() {},
+      recordJob() {},
+    };
+    subscribeObservability(throwingEmitter, new ObservabilityService(new PgObsRepo(db)), {
+      metrics: throwingSink,
+    });
+    // emit() runs listeners synchronously; a thrown sink must NOT surface here (would break a turn).
+    expect(() =>
+      throwingEmitter.emit(DOMAIN_EVENTS.LLM_STEP_FINISHED, {
+        conversationId: CONVO,
+        agentId: "a",
+        model: "claude-opus-4-8",
+        provider: "anthropic",
+        tokensIn: 1,
+        tokensOut: 1,
+        status: "ok",
+      })
+    ).not.toThrow();
+    await flush();
+    // The durable row is queued before the sink, so it survives the sink throwing.
+    const { rows } = await db.query(
+      "SELECT count(*)::int AS n FROM obs_event WHERE type='llm_call'"
+    );
+    expect((rows[0] as { n: number }).n).toBe(1);
+  });
+
+  it("writes a turn row (display rollup) that is excluded from cost/token totals", async () => {
+    emitter.emit(DOMAIN_EVENTS.LLM_STEP_FINISHED, {
+      conversationId: CONVO,
+      agentId: "a",
+      model: "claude-sonnet-4-6",
+      provider: "anthropic",
+      tokensIn: 1_000_000,
+      tokensOut: 0,
+      status: "ok",
+    });
+    emitter.emit(DOMAIN_EVENTS.TURN_FINISHED, {
+      conversationId: CONVO,
+      agentId: "a",
+      status: "ok",
+      steps: 1,
+      tokensIn: 1_000_000,
+      tokensOut: 0,
+      model: "claude-sonnet-4-6",
+      tier: "standard",
+    });
+    await flush();
+
+    // Counting rule: sum cost/tokens from llm_call rows only — the turn row must not double-count.
+    const { rows } = await db.query(
+      "SELECT COALESCE(SUM(cost_usd),0) AS cost, COALESCE(SUM(tokens_in),0) AS tin FROM obs_event WHERE type = 'llm_call'"
+    );
+    expect(Number((rows[0] as { cost: string }).cost)).toBe(3); // 1M in @ $3
+    expect(Number((rows[0] as { tin: string }).tin)).toBe(1_000_000);
+
+    const turn = await db.query("SELECT status, attributes FROM obs_event WHERE type = 'turn'");
+    expect(turn.rows[0]).toMatchObject({ status: "ok", attributes: { steps: 1 } });
+  });
+});

--- a/apps/api/src/observability/events.ts
+++ b/apps/api/src/observability/events.ts
@@ -1,0 +1,182 @@
+import type { EventEmitter } from "node:events";
+import { type ModelPrice, priceFor } from "@tulipfarm/llm";
+import {
+  DOMAIN_EVENTS,
+  type LlmStepFinishedPayload,
+  type TurnFinishedPayload,
+} from "../domain-events";
+import type { MetricsSink } from "./metrics";
+import type { ObservabilityService } from "./service";
+import type { TracesSink } from "./traces";
+
+function fireAndForget(p: Promise<unknown>): void {
+  p.catch((err) =>
+    console.error(
+      `[observability] subscriber failed: ${err instanceof Error ? err.message : String(err)}`
+    )
+  );
+}
+
+/**
+ * Run a synchronous listener body, swallowing any throw. Domain events are emitted synchronously from
+ * the chat turn (`events.emit(...)` inside `onStepFinish`), so an unguarded throw here — from the
+ * price map, a metrics/traces sink, etc. — would propagate back and break the turn. Observability
+ * must never do that.
+ */
+function guard(fn: () => void): void {
+  try {
+    fn();
+  } catch (err) {
+    console.error(
+      `[observability] subscriber error: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+}
+
+/** Drop undefined-valued keys so attributes jsonb stays compact (no `"cacheRead": null` noise). */
+function compact(obj: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v !== undefined) out[k] = v;
+  }
+  return out;
+}
+
+/**
+ * Wire the observability spine to the domain-event bus: each finished model step becomes an
+ * `llm_call` row (cost computed + frozen here via the price map) and each finished turn a `turn`
+ * summary row. `ObservabilityService.record` is best-effort, so a failed write only logs and never
+ * affects the chat turn. Mirrors `subscribeActivityLogging`.
+ */
+export function subscribeObservability(
+  emitter: EventEmitter,
+  obs: ObservabilityService,
+  opts: {
+    /** Fallback price map (built-in families + config overrides) used only when the served model has
+     *  no pinned per-token cost on its soul spec. */
+    pricingOverrides?: Record<string, ModelPrice>;
+    metrics?: MetricsSink;
+    traces?: TracesSink;
+    /** Opt-in: persist prompt/completion/tool bodies into attributes. Off by default (privacy). */
+    captureContent?: boolean;
+  } = {}
+): void {
+  const metrics = opts.metrics;
+  const traces = opts.traces;
+  const captureContent = opts.captureContent === true;
+
+  // Cost priority: the served model's pinned per-token soul spec (authoritative), else the built-in
+  // price map + config overrides, else null (unpriced). Rounded to 6 decimals like priceFor.
+  function computeCost(p: LlmStepFinishedPayload): number | null {
+    if (typeof p.costInPerToken === "number" && typeof p.costOutPerToken === "number") {
+      const raw = p.tokensIn * p.costInPerToken + p.tokensOut * p.costOutPerToken;
+      return Math.round(raw * 1_000_000) / 1_000_000;
+    }
+    return priceFor(p.model, p.tokensIn, p.tokensOut, opts.pricingOverrides).costUsd;
+  }
+  emitter.on(DOMAIN_EVENTS.LLM_STEP_FINISHED, (p: LlmStepFinishedPayload): void =>
+    guard(() => onLlmStep(p))
+  );
+  emitter.on(DOMAIN_EVENTS.TURN_FINISHED, (p: TurnFinishedPayload): void =>
+    guard(() => onTurnFinished(p))
+  );
+
+  function onLlmStep(p: LlmStepFinishedPayload): void {
+    const costUsd = computeCost(p);
+    // Queue the durable DB writes FIRST, so a later-throwing metrics/traces sink can't cost us the
+    // row (the whole body is also guard()-wrapped, so nothing here can break the chat turn).
+    fireAndForget(
+      obs.record({
+        type: "llm_call",
+        conversationId: p.conversationId,
+        agentId: p.agentId,
+        model: p.model,
+        provider: p.provider,
+        tier: p.tier ?? null,
+        tokensIn: p.tokensIn,
+        tokensOut: p.tokensOut,
+        costUsd,
+        durationMs: p.durationMs ?? null,
+        status: p.status,
+        attributes: compact({
+          cacheRead: p.cacheRead,
+          cacheWrite: p.cacheWrite,
+          reasoning: p.reasoning,
+          unpriced: costUsd === null ? true : undefined,
+          completion: captureContent ? p.completionText : undefined,
+        }),
+      })
+    );
+    // One tool_call row per tool invoked in this step. Arg/result bodies only when content capture
+    // is enabled; otherwise metadata-only (name + status + error code).
+    for (const tool of p.tools ?? []) {
+      fireAndForget(
+        obs.record({
+          type: "tool_call",
+          conversationId: p.conversationId,
+          agentId: p.agentId,
+          toolName: tool.name,
+          status: tool.status,
+          attributes: compact({
+            errorCode: tool.errorCode,
+            args: captureContent ? tool.args : undefined,
+            result: captureContent ? tool.result : undefined,
+          }),
+        })
+      );
+    }
+    // OTLP export sinks last (in-memory; only run when export is enabled). Bounded labels only.
+    metrics?.recordLlmCall({
+      model: p.model,
+      provider: p.provider,
+      tier: p.tier,
+      status: p.status,
+      tokensIn: p.tokensIn,
+      tokensOut: p.tokensOut,
+      costUsd,
+    });
+    traces?.spanStep(p.conversationId, {
+      name: p.model,
+      kind: "llm_call",
+      durationMs: p.durationMs,
+      status: p.status,
+      attributes: { "tulipfarm.provider": p.provider ?? "unknown" },
+    });
+    for (const tool of p.tools ?? []) {
+      metrics?.recordToolCall({ toolName: tool.name, status: tool.status });
+      traces?.spanStep(p.conversationId, {
+        name: tool.name,
+        kind: "tool_call",
+        status: tool.status,
+        attributes: tool.errorCode ? { "tulipfarm.error_code": tool.errorCode } : {},
+      });
+    }
+  }
+
+  function onTurnFinished(p: TurnFinishedPayload): void {
+    metrics?.recordTurn({ status: p.status });
+    traces?.finishTurn(p.conversationId, {
+      agentId: p.agentId,
+      status: p.status,
+      durationMs: p.durationMs,
+      steps: p.steps,
+      tokensIn: p.tokensIn,
+      tokensOut: p.tokensOut,
+    });
+    fireAndForget(
+      obs.record({
+        type: "turn",
+        conversationId: p.conversationId,
+        agentId: p.agentId,
+        model: p.model ?? null,
+        tier: p.tier ?? null,
+        // Display rollups only — never summed into cost/token totals (those come from llm_call rows).
+        tokensIn: p.tokensIn,
+        tokensOut: p.tokensOut,
+        durationMs: p.durationMs ?? null,
+        status: p.status,
+        attributes: { steps: p.steps },
+      })
+    );
+  }
+}

--- a/apps/api/src/observability/grafana/README.md
+++ b/apps/api/src/observability/grafana/README.md
@@ -1,0 +1,52 @@
+# Grafana Cloud assets — TulipFarm AI Observability
+
+Ready-made dashboard + alert rules for the metrics TulipFarm pushes to Grafana Cloud over OTLP.
+
+## 1. Enable the export
+
+In your soul repo, create `observability.config.yaml`:
+
+```yaml
+enabled: true
+retention_days: 90
+spend_alert_usd: 50
+otlp:
+  endpoint: https://otlp-gateway-<region>.grafana.net/otlp
+  instance_id: "<your-grafana-cloud-instance-id>"
+  token: env://GRAFANA_OTLP_TOKEN # or a secret ref managed in Settings → Secrets
+```
+
+The `token` is a secret reference — set `GRAFANA_OTLP_TOKEN` in the environment, or store it via
+**Settings → Secrets** and reference it here. Restart the API to start the exporter.
+
+## 2. Import the dashboard
+
+Grafana → Dashboards → New → Import → upload [`dashboard.json`](./dashboard.json). Pick your Grafana
+Cloud Prometheus (Mimir) data source when prompted.
+
+## 3. Load the alert rules
+
+[`alerts.yaml`](./alerts.yaml) is in Prometheus/Mimir ruler format. Load it via the Mimir ruler
+(`mimirtool rules load`) or recreate the rules in Grafana Alerting against your Prometheus data
+source. Tune thresholds to your workload.
+
+## Exported metrics (all cumulative counters)
+
+| Metric | Labels | Meaning |
+| --- | --- | --- |
+| `llm_calls_total` | model, provider, tier, status | One per model step (`status` = ok/fallback/error) |
+| `llm_tokens_total` | model | Input + output tokens |
+| `llm_cost_usd_total` | model | Frozen USD cost (priced models only) |
+| `tool_calls_total` | tool_name, status | One per tool invocation |
+| `turns_total` | status | One per chat turn (ok/error/blocked) |
+| `job_runs_total` | queue, status | One per background job run |
+
+Labels are bounded by design — high-cardinality ids (conversation/user/call) are never metric
+labels; use the in-app dashboard or traces to drill into individual conversations.
+
+## Traces (Tempo)
+
+When export is enabled, TulipFarm also pushes one trace per chat turn over OTLP to Tempo: a root
+`turn` span with child `llm_call` / `tool_call` spans (durations, model/provider, status). Open the
+Tempo data source in Grafana to inspect individual turns; the in-app **Settings → Observability →
+Recent turns** drill-down shows the same timeline without leaving TulipFarm.

--- a/apps/api/src/observability/grafana/alerts.yaml
+++ b/apps/api/src/observability/grafana/alerts.yaml
@@ -1,0 +1,62 @@
+# TulipFarm AI Observability — starter alert rules (Prometheus/Mimir ruler format).
+#
+# Import into Grafana Cloud via the Mimir ruler (or paste into a Grafana alert rule group pointed at
+# your Prometheus/Mimir data source). Metrics arrive over OTLP from TulipFarm when observability is
+# enabled (soul/observability.config.yaml). All metrics are cumulative counters, so rates/increases
+# are taken over a window. Tune thresholds (the `> N` values) to your workload.
+groups:
+  - name: tulipfarm-observability
+    rules:
+      # Daily LLM spend crossed the budget. Mirror of spend_alert_usd in observability.config.yaml.
+      - alert: TulipFarmHighDailySpend
+        expr: sum(increase(llm_cost_usd_total[24h])) > 50
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Agent LLM spend over budget"
+          description: "Last-24h spend is {{ $value | printf \"%.2f\" }} USD (threshold 50)."
+
+      # Turn error rate is high — agents are failing to complete turns.
+      - alert: TulipFarmHighTurnErrorRate
+        expr: >
+          sum(increase(turns_total{status="error"}[1h]))
+            / clamp_min(sum(increase(turns_total[1h])), 1) > 0.05
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Chat turn error rate above 5%"
+          description: "{{ $value | humanizePercentage }} of turns errored in the last hour."
+
+      # Provider fallbacks spiking — a primary provider is likely degraded.
+      - alert: TulipFarmFallbackSpike
+        expr: sum(increase(llm_calls_total{status="fallback"}[15m])) > 10
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "LLM provider fallbacks spiking"
+          description: "{{ $value }} fallback calls in the last 15m — check primary provider health."
+
+      # Tool error rate high — a capability is broken.
+      - alert: TulipFarmHighToolErrorRate
+        expr: >
+          sum(increase(tool_calls_total{status="error"}[1h]))
+            / clamp_min(sum(increase(tool_calls_total[1h])), 1) > 0.1
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Tool call error rate above 10%"
+          description: "{{ $value | humanizePercentage }} of tool calls errored in the last hour."
+
+      # Background jobs failing (indexing, connector sync, prune).
+      - alert: TulipFarmJobFailures
+        expr: sum(increase(job_runs_total{status="error"}[1h])) > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Background job failures"
+          description: "{{ $value }} job run(s) failed in the last hour."

--- a/apps/api/src/observability/grafana/dashboard.json
+++ b/apps/api/src/observability/grafana/dashboard.json
@@ -1,0 +1,126 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus / Mimir",
+      "description": "Grafana Cloud Prometheus (Mimir) data source receiving TulipFarm OTLP metrics",
+      "type": "datasource",
+      "pluginId": "prometheus"
+    }
+  ],
+  "title": "TulipFarm — AI Observability",
+  "uid": "tulipfarm-ai-observability",
+  "tags": ["tulipfarm", "ai", "observability"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "1m",
+  "time": { "from": "now-7d", "to": "now" },
+  "templating": { "list": [] },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Spend (last 24h)",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "currencyUSD" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(increase(llm_cost_usd_total[24h]))"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Tokens (last 24h)",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(increase(llm_tokens_total[24h]))"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Turn error rate (1h)",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "percentunit" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(increase(turns_total{status=\"error\"}[1h])) / clamp_min(sum(increase(turns_total[1h])), 1)"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Fallbacks (1h)",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(increase(llm_calls_total{status=\"fallback\"}[1h]))"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Spend over time",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "fieldConfig": { "defaults": { "unit": "currencyUSD" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(increase(llm_cost_usd_total[$__rate_interval])) by (model)",
+          "legendFormat": "{{model}}"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "LLM calls by status",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(rate(llm_calls_total[$__rate_interval])) by (status)",
+          "legendFormat": "{{status}}"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "Cost by model (24h)",
+      "type": "table",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sort_desc(sum(increase(llm_cost_usd_total[24h])) by (model))",
+          "format": "table",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "title": "Tool calls by status",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(rate(tool_calls_total[$__rate_interval])) by (status)",
+          "legendFormat": "{{status}}"
+        }
+      ]
+    }
+  ]
+}

--- a/apps/api/src/observability/job-run.ts
+++ b/apps/api/src/observability/job-run.ts
@@ -1,0 +1,33 @@
+import type { ObservabilityService } from "./service";
+
+/**
+ * Wrap a pg-boss job handler so each run is recorded as a `job` obs_event with its wall-clock
+ * duration and ok/error status (queue name in attributes). Best-effort + decoupled from the
+ * activity feed's `recordJobRun` (a job can be wrapped by both). The obs write is fire-and-forget;
+ * the job's own error is always re-thrown so pg-boss still sees the failure and retries.
+ */
+export async function recordObsJobRun<T>(
+  obs: ObservabilityService | undefined,
+  queue: string,
+  fn: () => Promise<T>
+): Promise<T> {
+  const startedAt = Date.now();
+  try {
+    const result = await fn();
+    void obs?.record({
+      type: "job",
+      status: "ok",
+      durationMs: Date.now() - startedAt,
+      attributes: { queue },
+    });
+    return result;
+  } catch (err) {
+    void obs?.record({
+      type: "job",
+      status: "error",
+      durationMs: Date.now() - startedAt,
+      attributes: { queue, error: err instanceof Error ? err.message : String(err) },
+    });
+    throw err;
+  }
+}

--- a/apps/api/src/observability/metrics.test.ts
+++ b/apps/api/src/observability/metrics.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+import { OtlpMetricsExporter } from "./metrics";
+
+const TARGET = { endpoint: "https://otlp.grafana.net/otlp", instanceId: "123", token: "tok" };
+
+function exporter(fetchImpl?: typeof fetch) {
+  return new OtlpMetricsExporter(TARGET, () => 1_700_000_000_000, fetchImpl ?? (vi.fn() as never));
+}
+
+describe("OtlpMetricsExporter", () => {
+  it("accumulates cumulative counters with bounded labels", () => {
+    const e = exporter();
+    e.recordLlmCall({
+      model: "claude-opus-4-8",
+      provider: "anthropic",
+      tier: "complex",
+      status: "ok",
+      tokensIn: 100,
+      tokensOut: 50,
+      costUsd: 0.02,
+    });
+    e.recordLlmCall({
+      model: "claude-opus-4-8",
+      provider: "anthropic",
+      tier: "complex",
+      status: "ok",
+      tokensIn: 10,
+      tokensOut: 5,
+      costUsd: 0.01,
+    });
+
+    const payload = e.buildPayload() as {
+      resourceMetrics: [
+        {
+          scopeMetrics: [
+            {
+              metrics: Array<{
+                name: string;
+                sum: { dataPoints: Array<{ asDouble: number; attributes: { key: string }[] }> };
+              }>;
+            },
+          ];
+        },
+      ];
+    };
+    const metrics = payload.resourceMetrics[0].scopeMetrics[0].metrics;
+    const byName = Object.fromEntries(metrics.map((m) => [m.name, m]));
+
+    // Two identical-label calls fold into one cumulative point of value 2.
+    expect(byName.llm_calls_total.sum.dataPoints).toHaveLength(1);
+    expect(byName.llm_calls_total.sum.dataPoints[0].asDouble).toBe(2);
+    // tokens cumulative = 165, cost cumulative = 0.03
+    expect(byName.llm_tokens_total.sum.dataPoints[0].asDouble).toBe(165);
+    expect(byName.llm_cost_usd_total.sum.dataPoints[0].asDouble).toBeCloseTo(0.03, 6);
+    // No high-cardinality labels leaked (only model/provider/status/tier on calls).
+    const keys = byName.llm_calls_total.sum.dataPoints[0].attributes.map((a) => a.key).sort();
+    expect(keys).toEqual(["model", "provider", "status", "tier"]);
+  });
+
+  it("omits unpriced cost from the cost counter", () => {
+    const e = exporter();
+    e.recordLlmCall({
+      model: "x",
+      provider: null,
+      status: "ok",
+      tokensIn: 1,
+      tokensOut: 1,
+      costUsd: null,
+    });
+    const payload = e.buildPayload() as {
+      resourceMetrics: [{ scopeMetrics: [{ metrics: Array<{ name: string }> }] }];
+    };
+    const names = payload.resourceMetrics[0].scopeMetrics[0].metrics.map((m) => m.name);
+    expect(names).toContain("llm_calls_total");
+    expect(names).not.toContain("llm_cost_usd_total"); // no cost point ⇒ metric pruned
+  });
+
+  it("POSTs OTLP JSON with basic auth to /v1/metrics", async () => {
+    const fetchMock = vi.fn(async () => new Response(null, { status: 200 }));
+    const e = exporter(fetchMock as unknown as typeof fetch);
+    e.recordTurn({ status: "ok" });
+    await e.flush();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe("https://otlp.grafana.net/otlp/v1/metrics");
+    expect((init.headers as Record<string, string>).authorization).toBe(
+      `Basic ${Buffer.from("123:tok").toString("base64")}`
+    );
+    expect(JSON.parse(init.body as string).resourceMetrics).toBeDefined();
+  });
+
+  it("skips the POST when nothing has been recorded", async () => {
+    const fetchMock = vi.fn(async () => new Response(null, { status: 200 }));
+    const e = exporter(fetchMock as unknown as typeof fetch);
+    await e.flush();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/observability/metrics.ts
+++ b/apps/api/src/observability/metrics.ts
@@ -1,0 +1,189 @@
+/**
+ * Dependency-free OTLP/HTTP-JSON metrics export to Grafana Cloud (Mimir). Counters are accumulated
+ * in-process as cumulative monotonic sums (the temporality Prometheus/Mimir expects) keyed by a
+ * bounded label set, then pushed on an interval. Only loaded/started when observability is enabled,
+ * so the default path carries zero overhead and no OTel SDK weight. Labels are bounded by design
+ * (model/provider/tier/status/tool_name) — high-cardinality ids never become metric labels.
+ */
+
+export interface LlmCallMetric {
+  model: string;
+  provider: string | null;
+  tier?: string;
+  status: string;
+  tokensIn: number;
+  tokensOut: number;
+  costUsd: number | null;
+}
+
+/** A sink the observability subscriber feeds; the OTLP exporter implements it (no-op when absent). */
+export interface MetricsSink {
+  recordLlmCall(d: LlmCallMetric): void;
+  recordToolCall(d: { toolName: string; status: string }): void;
+  recordTurn(d: { status: string }): void;
+  recordJob(d: { queue: string; status: string }): void;
+}
+
+type LabelSet = Record<string, string>;
+interface Point {
+  labels: LabelSet;
+  value: number;
+}
+
+const SERVICE_NAME = "tulipfarm";
+const SCOPE = "tulipfarm.observability";
+
+function labelKey(labels: LabelSet): string {
+  return Object.keys(labels)
+    .sort()
+    .map((k) => `${k}=${labels[k]}`)
+    .join(",");
+}
+
+// Labels are bounded by design, but a provider that returns ever-varying model ids (e.g. dated
+// variants) could still grow a counter slowly. Cap distinct label sets per metric as a hard backstop.
+const MAX_LABEL_SETS = 2000;
+
+/** Finite-safe epoch-ms → nanosecond string (BigInt(NaN/Infinity) would throw). */
+function unixNano(ms: number): string {
+  const safe = Number.isFinite(ms) ? Math.floor(ms) : 0;
+  return `${BigInt(safe) * 1_000_000n}`;
+}
+
+/** Cumulative monotonic counter, sharded by label set. */
+class Counter {
+  private points = new Map<string, Point>();
+  add(labels: LabelSet, value = 1): void {
+    if (!Number.isFinite(value)) return;
+    const key = labelKey(labels);
+    const existing = this.points.get(key);
+    if (existing) existing.value += value;
+    else if (this.points.size < MAX_LABEL_SETS) this.points.set(key, { labels, value });
+  }
+  snapshot(): Point[] {
+    return [...this.points.values()];
+  }
+}
+
+export interface OtlpTarget {
+  /** Grafana Cloud OTLP base, e.g. https://otlp-gateway-<region>.grafana.net/otlp */
+  endpoint: string;
+  instanceId: string;
+  /** Resolved token (already de-referenced from env:///secret). */
+  token: string;
+}
+
+export class OtlpMetricsExporter implements MetricsSink {
+  private readonly counters: Record<string, Counter> = {
+    llm_calls_total: new Counter(),
+    llm_tokens_total: new Counter(),
+    llm_cost_usd_total: new Counter(),
+    tool_calls_total: new Counter(),
+    turns_total: new Counter(),
+    job_runs_total: new Counter(),
+  };
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private readonly startUnixNano: string;
+  private readonly authHeader: string;
+
+  constructor(
+    private readonly target: OtlpTarget,
+    private readonly nowMs: () => number = Date.now,
+    private readonly fetchImpl: typeof fetch = fetch,
+    private readonly log: (msg: string) => void = (m) => console.warn(m)
+  ) {
+    this.startUnixNano = unixNano(this.nowMs());
+    this.authHeader = `Basic ${Buffer.from(`${target.instanceId}:${target.token}`).toString("base64")}`;
+  }
+
+  recordLlmCall(d: LlmCallMetric): void {
+    const labels: LabelSet = {
+      model: d.model,
+      provider: d.provider ?? "unknown",
+      status: d.status,
+    };
+    if (d.tier) labels.tier = d.tier;
+    this.counters.llm_calls_total.add(labels);
+    this.counters.llm_tokens_total.add({ model: d.model }, d.tokensIn + d.tokensOut);
+    if (d.costUsd != null) this.counters.llm_cost_usd_total.add({ model: d.model }, d.costUsd);
+  }
+
+  recordToolCall(d: { toolName: string; status: string }): void {
+    this.counters.tool_calls_total.add({ tool_name: d.toolName, status: d.status });
+  }
+
+  recordTurn(d: { status: string }): void {
+    this.counters.turns_total.add({ status: d.status });
+  }
+
+  recordJob(d: { queue: string; status: string }): void {
+    this.counters.job_runs_total.add({ queue: d.queue, status: d.status });
+  }
+
+  /** Build the OTLP/JSON ExportMetricsServiceRequest for the current cumulative totals. */
+  buildPayload(): Record<string, unknown> {
+    const timeUnixNano = unixNano(this.nowMs());
+    const metrics = Object.entries(this.counters)
+      .map(([name, counter]) => ({
+        name,
+        sum: {
+          aggregationTemporality: 2, // CUMULATIVE
+          isMonotonic: true,
+          dataPoints: counter.snapshot().map((p) => ({
+            attributes: Object.entries(p.labels).map(([key, v]) => ({
+              key,
+              value: { stringValue: v },
+            })),
+            startTimeUnixNano: this.startUnixNano,
+            timeUnixNano,
+            asDouble: p.value,
+          })),
+        },
+      }))
+      .filter((m) => (m.sum.dataPoints as unknown[]).length > 0);
+
+    return {
+      resourceMetrics: [
+        {
+          resource: {
+            attributes: [{ key: "service.name", value: { stringValue: SERVICE_NAME } }],
+          },
+          scopeMetrics: [{ scope: { name: SCOPE }, metrics }],
+        },
+      ],
+    };
+  }
+
+  async flush(): Promise<void> {
+    const payload = this.buildPayload();
+    if (
+      (payload.resourceMetrics as [{ scopeMetrics: [{ metrics: unknown[] }] }])[0].scopeMetrics[0]
+        .metrics.length === 0
+    ) {
+      return; // nothing accumulated yet
+    }
+    try {
+      const res = await this.fetchImpl(`${this.target.endpoint.replace(/\/$/, "")}/v1/metrics`, {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: this.authHeader },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) this.log(`[observability] OTLP push failed: ${res.status} ${res.statusText}`);
+    } catch (err) {
+      this.log(
+        `[observability] OTLP push error: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+
+  start(intervalMs = 60_000): void {
+    if (this.timer) return;
+    this.timer = setInterval(() => void this.flush(), intervalMs);
+    this.timer.unref?.();
+  }
+
+  stop(): void {
+    if (this.timer) clearInterval(this.timer);
+    this.timer = null;
+  }
+}

--- a/apps/api/src/observability/prune.pg.test.ts
+++ b/apps/api/src/observability/prune.pg.test.ts
@@ -1,0 +1,37 @@
+import type { PGlite } from "@electric-sql/pglite";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { runPgMigrations } from "../pg-migrate";
+import { makePglite } from "../test/pglite";
+import { OBS_RETENTION_MS } from "./prune";
+import { PgObsRepo } from "./repo";
+import { ObservabilityService } from "./service";
+
+const DAY = 24 * 60 * 60 * 1000;
+
+describe("obs_event prune (deleteOlderThan)", () => {
+  let db: PGlite;
+  let repo: PgObsRepo;
+  let service: ObservabilityService;
+
+  beforeEach(async () => {
+    db = await makePglite();
+    await runPgMigrations(db);
+    repo = new PgObsRepo(db);
+    service = new ObservabilityService(repo);
+  });
+
+  afterEach(async () => {
+    await db.close();
+  });
+
+  it("deletes rows older than the retention window, keeps recent ones", async () => {
+    await service.record({ type: "llm_call", ts: new Date(Date.now() - 100 * DAY), status: "ok" });
+    await service.record({ type: "llm_call", ts: new Date(Date.now() - 1 * DAY), status: "ok" });
+
+    const deleted = await repo.deleteOlderThan(new Date(Date.now() - OBS_RETENTION_MS));
+    expect(deleted).toBe(1);
+
+    const { rows } = await db.query("SELECT count(*)::int AS n FROM obs_event");
+    expect((rows[0] as { n: number }).n).toBe(1);
+  });
+});

--- a/apps/api/src/observability/prune.ts
+++ b/apps/api/src/observability/prune.ts
@@ -1,0 +1,42 @@
+import type { PgBoss } from "pg-boss";
+import { recordJobRun } from "../activity/job-run";
+import type { ActivityService } from "../activity/service";
+import { recordObsJobRun } from "./job-run";
+import type { ObsRepo } from "./repo";
+import type { ObservabilityService } from "./service";
+
+export const OBS_PRUNE_QUEUE = "obs-event-prune";
+/** Daily at 03:17 — off-peak sweep cadence for the observability event spine. */
+export const OBS_PRUNE_CRON = "17 3 * * *";
+/** Default retention: raw events live 90 days (overridable via observability config). */
+export const OBS_RETENTION_MS = 90 * 24 * 60 * 60 * 1000;
+
+export interface ObsPruneOpts {
+  /** Retention window in ms (default 90d). Sourced from observability config when present. */
+  retentionMs?: number;
+  /** Records the prune run as a `job` obs_event, in addition to the activity feed. */
+  obs?: ObservabilityService;
+}
+
+/**
+ * Register the periodic `obs_event` prune on pg-boss. Each run deletes every event older than the
+ * retention window. Mirrors `registerStreamGc`; the run is recorded to the activity feed
+ * (`recordJobRun`) and, when an obs service is given, as a `job` obs_event (`recordObsJobRun`).
+ */
+export async function registerObsPrune(
+  boss: PgBoss,
+  repo: ObsRepo,
+  activity?: ActivityService,
+  opts: ObsPruneOpts = {}
+): Promise<void> {
+  const retentionMs = opts.retentionMs ?? OBS_RETENTION_MS;
+  await boss.createQueue(OBS_PRUNE_QUEUE);
+  await boss.work(OBS_PRUNE_QUEUE, () =>
+    recordJobRun(activity, OBS_PRUNE_QUEUE, () =>
+      recordObsJobRun(opts.obs, OBS_PRUNE_QUEUE, async () => {
+        await repo.deleteOlderThan(new Date(Date.now() - retentionMs));
+      })
+    )
+  );
+  await boss.schedule(OBS_PRUNE_QUEUE, OBS_PRUNE_CRON);
+}

--- a/apps/api/src/observability/repo.pg.test.ts
+++ b/apps/api/src/observability/repo.pg.test.ts
@@ -1,0 +1,70 @@
+import type { PGlite } from "@electric-sql/pglite";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { runPgMigrations } from "../pg-migrate";
+import { makePglite } from "../test/pglite";
+import { PgObsRepo } from "./repo";
+import { ObservabilityService } from "./service";
+
+describe("ObservabilityService + PgObsRepo", () => {
+  let db: PGlite;
+  let service: ObservabilityService;
+
+  beforeEach(async () => {
+    db = await makePglite();
+    await runPgMigrations(db);
+    service = new ObservabilityService(new PgObsRepo(db));
+  });
+
+  afterEach(async () => {
+    await db.close();
+  });
+
+  it("records an llm_call and round-trips typed columns + jsonb attributes", async () => {
+    await service.record({
+      type: "llm_call",
+      agentId: "support-agent",
+      conversationId: "11111111-1111-1111-1111-111111111111",
+      model: "claude-opus-4-8",
+      provider: "anthropic",
+      tier: "complex",
+      tokensIn: 4100,
+      tokensOut: 820,
+      costUsd: 0.123456,
+      durationMs: 1240,
+      status: "ok",
+      attributes: { cacheRead: 3000, step: 1 },
+    });
+
+    const { rows } = await db.query("SELECT * FROM obs_event WHERE type = 'llm_call'");
+    expect(rows).toHaveLength(1);
+    const r = rows[0] as Record<string, unknown>;
+    expect(r.model).toBe("claude-opus-4-8");
+    expect(r.provider).toBe("anthropic");
+    expect(r.tier).toBe("complex");
+    expect(Number(r.tokens_in)).toBe(4100);
+    expect(Number(r.tokens_out)).toBe(820);
+    expect(Number(r.cost_usd)).toBeCloseTo(0.123456, 6);
+    expect(Number(r.duration_ms)).toBe(1240);
+    expect(r.status).toBe("ok");
+    expect(r.attributes).toEqual({ cacheRead: 3000, step: 1 });
+    expect(r.ts).toBeInstanceOf(Date);
+  });
+
+  it("defaults optional fields to null / empty attributes", async () => {
+    await service.record({ type: "turn", status: "ok" });
+    const { rows } = await db.query("SELECT * FROM obs_event WHERE type = 'turn'");
+    const r = rows[0] as Record<string, unknown>;
+    expect(r.model).toBeNull();
+    expect(r.cost_usd).toBeNull();
+    expect(r.tokens_in).toBeNull();
+    expect(r.attributes).toEqual({});
+  });
+
+  it("never throws into the caller when the insert fails (best-effort)", async () => {
+    // Close the db so the underlying insert rejects; record must still resolve.
+    await db.close();
+    await expect(service.record({ type: "llm_call" })).resolves.toBeUndefined();
+    // Re-open a throwaway db so afterEach's close() has a live handle.
+    db = await makePglite();
+  });
+});

--- a/apps/api/src/observability/repo.ts
+++ b/apps/api/src/observability/repo.ts
@@ -1,0 +1,289 @@
+import type { Queryable } from "../db";
+
+export type ObsEventType = "llm_call" | "tool_call" | "turn" | "job";
+/** Per-type outcome: llm_call ok|error|fallback|timeout; tool_call ok|error; turn ok|error|blocked; job ok|error. */
+export type ObsStatus = "ok" | "error" | "fallback" | "blocked" | "timeout";
+
+/**
+ * One row in the AI observability event spine (`obs_event`). Append-only: written at event time by
+ * `ObservabilityService.record()` and never updated. Hot aggregate/filter fields are typed columns;
+ * the long tail (token cache breakdown, error codes, job names) rides in `attributes` jsonb.
+ * `costUsd` is frozen at write (NULL ⇒ the served model was unpriced). Cost/token totals are summed
+ * from `type='llm_call'` rows only — `turn` rows carry display rollups and must not be re-summed.
+ */
+export interface ObsEventRow {
+  _id: string;
+  ts: Date;
+  type: ObsEventType;
+  agentId: string | null;
+  conversationId: string | null;
+  model: string | null;
+  provider: string | null;
+  tier: string | null;
+  tokensIn: number | null;
+  tokensOut: number | null;
+  costUsd: number | null;
+  durationMs: number | null;
+  status: string | null;
+  toolName: string | null;
+  attributes: Record<string, unknown>;
+  createdAt: Date;
+}
+
+/** Pre-aggregated dashboard data. Cost/token totals come from `llm_call` rows only (counting rule). */
+export interface ObsSummary {
+  totals: { costUsd: number; tokens: number; turns: number; unpricedCalls: number };
+  series: Array<{ bucket: string; costUsd: number; tokens: number }>;
+  byAgent: Array<{ agentId: string; costUsd: number }>;
+  byModel: Array<{ model: string; costUsd: number; calls: number; unpriced: boolean }>;
+  /** Reliability lens: turn/tool/llm error + fallback counts and p95 step latency over the window. */
+  reliability: {
+    turns: number;
+    turnErrors: number;
+    llmCalls: number;
+    llmErrors: number;
+    fallbacks: number;
+    toolCalls: number;
+    toolErrors: number;
+    p95DurationMs: number;
+  };
+}
+
+export interface SummarizeOpts {
+  since: Date;
+  /** date_trunc granularity for the time series — validated to these literals (no injection). */
+  bucket: "hour" | "day";
+}
+
+/** A recent chat turn for the trace list (drill-down entry point). */
+export interface RecentTurn {
+  conversationId: string | null;
+  agentId: string | null;
+  status: string | null;
+  tokensIn: number;
+  tokensOut: number;
+  steps: number;
+  ts: string;
+}
+
+/** One event in a conversation's trace timeline (llm_call / tool_call / turn), oldest-first. */
+export interface TraceEvent {
+  type: ObsEventType;
+  ts: string;
+  agentId: string | null;
+  model: string | null;
+  provider: string | null;
+  tier: string | null;
+  status: string | null;
+  tokensIn: number | null;
+  tokensOut: number | null;
+  costUsd: number | null;
+  durationMs: number | null;
+  toolName: string | null;
+  attributes: Record<string, unknown>;
+}
+
+export interface ObsRepo {
+  insert(row: ObsEventRow): Promise<void>;
+  summarize(opts: SummarizeOpts): Promise<ObsSummary>;
+  /** Prune rows older than the cutoff (retention). Returns the number deleted. */
+  deleteOlderThan(cutoff: Date): Promise<number>;
+  /** Newest-first recent turns (drill-down list). */
+  recentTurns(limit: number): Promise<RecentTurn[]>;
+  /** A conversation's full event timeline, oldest-first (trace drill-down). */
+  traceByConversation(conversationId: string): Promise<TraceEvent[]>;
+}
+
+const num = (v: unknown): number => Number(v ?? 0);
+const numOrNull = (v: unknown): number | null => (v == null ? null : Number(v));
+const iso = (v: unknown): string => (v instanceof Date ? v.toISOString() : String(v));
+
+export class PgObsRepo implements ObsRepo {
+  constructor(private readonly q: Queryable) {}
+
+  async insert(row: ObsEventRow): Promise<void> {
+    await this.q.query(
+      `INSERT INTO obs_event
+         (id, ts, type, agent_id, conversation_id, model, provider, tier,
+          tokens_in, tokens_out, cost_usd, duration_ms, status, tool_name, attributes, created_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15::jsonb, $16)`,
+      [
+        row._id,
+        row.ts,
+        row.type,
+        row.agentId,
+        row.conversationId,
+        row.model,
+        row.provider,
+        row.tier,
+        row.tokensIn,
+        row.tokensOut,
+        row.costUsd,
+        row.durationMs,
+        row.status,
+        row.toolName,
+        JSON.stringify(row.attributes),
+        row.createdAt,
+      ]
+    );
+  }
+
+  async summarize({ since, bucket }: SummarizeOpts): Promise<ObsSummary> {
+    // Cost/token totals + unpriced count from llm_call rows; turns from turn rows. FILTER keeps it
+    // to one scan. `tokens` = input + output. cost_usd is numeric (returned as string) → coerced.
+    const totalsQ = this.q.query(
+      `SELECT
+         COALESCE(SUM(cost_usd) FILTER (WHERE type = 'llm_call'), 0) AS cost,
+         COALESCE(SUM((COALESCE(tokens_in,0) + COALESCE(tokens_out,0))) FILTER (WHERE type = 'llm_call'), 0) AS tokens,
+         COUNT(*) FILTER (WHERE type = 'turn') AS turns,
+         COUNT(*) FILTER (WHERE type = 'llm_call' AND cost_usd IS NULL) AS unpriced
+       FROM obs_event WHERE ts >= $1`,
+      [since]
+    );
+    // date_trunc's unit is a bound param (validated literal) — safe from injection.
+    const seriesQ = this.q.query(
+      `SELECT date_trunc($2, ts) AS bucket,
+         COALESCE(SUM(cost_usd), 0) AS cost,
+         COALESCE(SUM(COALESCE(tokens_in,0) + COALESCE(tokens_out,0)), 0) AS tokens
+       FROM obs_event WHERE type = 'llm_call' AND ts >= $1
+       GROUP BY 1 ORDER BY 1`,
+      [since, bucket]
+    );
+    const byAgentQ = this.q.query(
+      `SELECT COALESCE(agent_id, '(unknown)') AS agent, COALESCE(SUM(cost_usd), 0) AS cost
+       FROM obs_event WHERE type = 'llm_call' AND ts >= $1
+       GROUP BY 1 ORDER BY cost DESC, agent ASC LIMIT 20`,
+      [since]
+    );
+    const byModelQ = this.q.query(
+      `SELECT COALESCE(model, '(unknown)') AS model, COALESCE(SUM(cost_usd), 0) AS cost,
+              COUNT(*) AS calls, bool_and(cost_usd IS NULL) AS unpriced
+       FROM obs_event WHERE type = 'llm_call' AND ts >= $1
+       GROUP BY 1 ORDER BY cost DESC, calls DESC, model ASC LIMIT 20`,
+      [since]
+    );
+    const reliabilityQ = this.q.query(
+      `SELECT
+         COUNT(*) FILTER (WHERE type = 'turn') AS turns,
+         COUNT(*) FILTER (WHERE type = 'turn' AND status = 'error') AS turn_errors,
+         COUNT(*) FILTER (WHERE type = 'llm_call') AS llm_calls,
+         COUNT(*) FILTER (WHERE type = 'llm_call' AND status = 'error') AS llm_errors,
+         COUNT(*) FILTER (WHERE type = 'llm_call' AND status = 'fallback') AS fallbacks,
+         COUNT(*) FILTER (WHERE type = 'tool_call') AS tool_calls,
+         COUNT(*) FILTER (WHERE type = 'tool_call' AND status = 'error') AS tool_errors,
+         COALESCE(
+           percentile_cont(0.95) WITHIN GROUP (ORDER BY duration_ms)
+             FILTER (WHERE type = 'llm_call' AND duration_ms IS NOT NULL),
+           0
+         ) AS p95
+       FROM obs_event WHERE ts >= $1`,
+      [since]
+    );
+
+    const [totals, series, byAgent, byModel, reliability] = await Promise.all([
+      totalsQ,
+      seriesQ,
+      byAgentQ,
+      byModelQ,
+      reliabilityQ,
+    ]);
+    const rel = reliability.rows[0] as Record<string, unknown>;
+
+    const t = totals.rows[0] as Record<string, unknown>;
+    return {
+      totals: {
+        costUsd: num(t.cost),
+        tokens: num(t.tokens),
+        turns: num(t.turns),
+        unpricedCalls: num(t.unpriced),
+      },
+      series: series.rows.map((r) => {
+        const row = r as Record<string, unknown>;
+        const b = row.bucket;
+        return {
+          bucket: b instanceof Date ? b.toISOString() : String(b),
+          costUsd: num(row.cost),
+          tokens: num(row.tokens),
+        };
+      }),
+      byAgent: byAgent.rows.map((r) => {
+        const row = r as Record<string, unknown>;
+        return { agentId: String(row.agent), costUsd: num(row.cost) };
+      }),
+      byModel: byModel.rows.map((r) => {
+        const row = r as Record<string, unknown>;
+        return {
+          model: String(row.model),
+          costUsd: num(row.cost),
+          calls: num(row.calls),
+          unpriced: row.unpriced === true,
+        };
+      }),
+      reliability: {
+        turns: num(rel.turns),
+        turnErrors: num(rel.turn_errors),
+        llmCalls: num(rel.llm_calls),
+        llmErrors: num(rel.llm_errors),
+        fallbacks: num(rel.fallbacks),
+        toolCalls: num(rel.tool_calls),
+        toolErrors: num(rel.tool_errors),
+        p95DurationMs: Math.round(num(rel.p95)),
+      },
+    };
+  }
+
+  async deleteOlderThan(cutoff: Date): Promise<number> {
+    // RETURNING id so the deleted count works across the Queryable contract (pg + PGlite), which
+    // exposes only `rows`, not `rowCount`.
+    const res = await this.q.query("DELETE FROM obs_event WHERE ts < $1 RETURNING id", [cutoff]);
+    return res.rows.length;
+  }
+
+  async recentTurns(limit: number): Promise<RecentTurn[]> {
+    const { rows } = await this.q.query(
+      `SELECT conversation_id, agent_id, status, tokens_in, tokens_out, attributes, ts
+       FROM obs_event WHERE type = 'turn' ORDER BY ts DESC LIMIT $1`,
+      [limit]
+    );
+    return rows.map((r) => {
+      const row = r as Record<string, unknown>;
+      const attrs = (row.attributes as Record<string, unknown> | null) ?? {};
+      return {
+        conversationId: (row.conversation_id as string | null) ?? null,
+        agentId: (row.agent_id as string | null) ?? null,
+        status: (row.status as string | null) ?? null,
+        tokensIn: num(row.tokens_in),
+        tokensOut: num(row.tokens_out),
+        steps: num(attrs.steps),
+        ts: iso(row.ts),
+      };
+    });
+  }
+
+  async traceByConversation(conversationId: string): Promise<TraceEvent[]> {
+    const { rows } = await this.q.query(
+      `SELECT type, ts, agent_id, model, provider, tier, status, tokens_in, tokens_out,
+              cost_usd, duration_ms, tool_name, attributes
+       FROM obs_event WHERE conversation_id = $1 ORDER BY ts ASC`,
+      [conversationId]
+    );
+    return rows.map((r) => {
+      const row = r as Record<string, unknown>;
+      return {
+        type: row.type as ObsEventType,
+        ts: iso(row.ts),
+        agentId: (row.agent_id as string | null) ?? null,
+        model: (row.model as string | null) ?? null,
+        provider: (row.provider as string | null) ?? null,
+        tier: (row.tier as string | null) ?? null,
+        status: (row.status as string | null) ?? null,
+        tokensIn: numOrNull(row.tokens_in),
+        tokensOut: numOrNull(row.tokens_out),
+        costUsd: numOrNull(row.cost_usd),
+        durationMs: numOrNull(row.duration_ms),
+        toolName: (row.tool_name as string | null) ?? null,
+        attributes: (row.attributes as Record<string, unknown> | null) ?? {},
+      };
+    });
+  }
+}

--- a/apps/api/src/observability/routes.test.ts
+++ b/apps/api/src/observability/routes.test.ts
@@ -1,0 +1,219 @@
+import type { PGlite } from "@electric-sql/pglite";
+import type { FastifyInstance } from "fastify";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildApp } from "../app";
+import type { TokenDoc, TokenRepo } from "../auth/api-tokens";
+import { SESSION_COOKIE } from "../auth/routes";
+import { MemorySessionStore } from "../auth/session-store";
+import { createUser, type UserDoc, type UserRepo } from "../auth/users";
+import type { PaginatedResult } from "../pagination";
+import { runPgMigrations } from "../pg-migrate";
+import { makePglite } from "../test/pglite";
+import { PgObsRepo } from "./repo";
+import { ObservabilityService } from "./service";
+
+class FakeUserRepo implements UserRepo {
+  private users: UserDoc[] = [];
+  async findByEmail(email: string): Promise<UserDoc | null> {
+    return this.users.find((u) => u.email === email.trim().toLowerCase()) ?? null;
+  }
+  async findById(id: string): Promise<UserDoc | null> {
+    return this.users.find((u) => u._id === id) ?? null;
+  }
+  async count(): Promise<number> {
+    return this.users.length;
+  }
+  async insert(user: UserDoc): Promise<void> {
+    this.users.push(user);
+  }
+}
+
+class FakeTokenRepo implements TokenRepo {
+  async create(_t: TokenDoc): Promise<void> {}
+  async findByHash(): Promise<TokenDoc | null> {
+    return null;
+  }
+  async findByUserId(): Promise<TokenDoc[]> {
+    return [];
+  }
+  async findAll(): Promise<TokenDoc[]> {
+    return [];
+  }
+  async findById(): Promise<TokenDoc | null> {
+    return null;
+  }
+  async deleteById(): Promise<void> {}
+  async findAllPaginated(): Promise<PaginatedResult<TokenDoc>> {
+    return { items: [], nextCursor: null };
+  }
+  async findByUserIdPaginated(): Promise<PaginatedResult<TokenDoc>> {
+    return { items: [], nextCursor: null };
+  }
+}
+
+describe("observability routes", () => {
+  let app: FastifyInstance;
+  let db: PGlite;
+  let service: ObservabilityService;
+  let adminSid: string;
+  let memberSid: string;
+
+  beforeEach(async () => {
+    db = await makePglite();
+    await runPgMigrations(db);
+    service = new ObservabilityService(new PgObsRepo(db));
+
+    const store = new MemorySessionStore();
+    const userRepo = new FakeUserRepo();
+    const tokenRepo = new FakeTokenRepo();
+    const admin = await createUser(userRepo, "admin@example.com", "pass", "admin");
+    adminSid = await store.create(admin._id);
+    const member = await createUser(userRepo, "member@example.com", "pass", "member");
+    memberSid = await store.create(member._id);
+
+    app = await buildApp({
+      sessionStore: store,
+      userRepo,
+      tokenRepo,
+      observabilityService: service,
+      observabilityConfig: {
+        enabled: true,
+        retentionDays: 30,
+        captureContent: false,
+        spendAlertUsd: 50,
+        otlp: { endpoint: "https://otlp.grafana.net/otlp", instanceId: "1", token: "secret-ref" },
+        pricingOverrides: {},
+      },
+    });
+  });
+
+  afterEach(async () => {
+    await app.close();
+    await db.close();
+  });
+
+  it("returns 401 without auth", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/v1/observability/summary" });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("returns 403 for a non-admin user", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/observability/summary",
+      cookies: { [SESSION_COOKIE]: memberSid },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("returns export config status for an admin without leaking the token", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/observability/config",
+      cookies: { [SESSION_COOKIE]: adminSid },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as Record<string, unknown>;
+    expect(body).toMatchObject({
+      enabled: true,
+      otlpConfigured: true,
+      endpoint: "https://otlp.grafana.net/otlp",
+      retentionDays: 30,
+      captureContent: false,
+      spendAlertUsd: 50,
+    });
+    // The token must never appear in the response.
+    expect(JSON.stringify(body)).not.toContain("secret-ref");
+  });
+
+  it("gates the config endpoint to admins", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/observability/config",
+      cookies: { [SESSION_COOKIE]: memberSid },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("returns an aggregated summary for an admin", async () => {
+    await service.record({
+      type: "llm_call",
+      model: "claude-opus-4-8",
+      agentId: "support-agent",
+      tokensIn: 1000,
+      tokensOut: 500,
+      costUsd: 0.06,
+      status: "ok",
+    });
+    await service.record({ type: "turn", agentId: "support-agent", status: "ok" });
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/observability/summary?range=7d",
+      cookies: { [SESSION_COOKIE]: adminSid },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as {
+      totals: { costUsd: number; turns: number };
+      byModel: { model: string; calls: number }[];
+    };
+    expect(body.totals.costUsd).toBeCloseTo(0.06, 6);
+    expect(body.totals.turns).toBe(1);
+    expect(body.byModel[0].model).toBe("claude-opus-4-8");
+  });
+
+  it("serializes recent turns + a conversation trace for an admin", async () => {
+    const convo = "33333333-3333-3333-3333-333333333333";
+    await service.record({
+      type: "llm_call",
+      conversationId: convo,
+      model: "claude-opus-4-8",
+      tokensIn: 100,
+      tokensOut: 50,
+      costUsd: 0.02,
+      durationMs: 900,
+      status: "ok",
+    });
+    await service.record({
+      type: "turn",
+      conversationId: convo,
+      agentId: "support-agent",
+      status: "ok",
+      attributes: { steps: 1 },
+    });
+
+    const recent = await app.inject({
+      method: "GET",
+      url: "/api/v1/observability/recent?limit=5",
+      cookies: { [SESSION_COOKIE]: adminSid },
+    });
+    expect(recent.statusCode).toBe(200);
+    const turns = recent.json() as Array<{ conversationId: string; steps: number; status: string }>;
+    expect(turns[0]).toMatchObject({ conversationId: convo, steps: 1, status: "ok" });
+
+    const trace = await app.inject({
+      method: "GET",
+      url: `/api/v1/observability/trace/${convo}`,
+      cookies: { [SESSION_COOKIE]: adminSid },
+    });
+    expect(trace.statusCode).toBe(200);
+    const events = trace.json() as Array<{
+      type: string;
+      model: string | null;
+      costUsd: number | null;
+    }>;
+    expect(events.map((e) => e.type)).toEqual(["llm_call", "turn"]);
+    expect(events[0]).toMatchObject({ model: "claude-opus-4-8", costUsd: 0.02 });
+  });
+
+  it("gates recent + trace to admins", async () => {
+    for (const url of ["/api/v1/observability/recent", "/api/v1/observability/trace/x"]) {
+      const res = await app.inject({
+        method: "GET",
+        url,
+        cookies: { [SESSION_COOKIE]: memberSid },
+      });
+      expect(res.statusCode).toBe(403);
+    }
+  });
+});

--- a/apps/api/src/observability/routes.ts
+++ b/apps/api/src/observability/routes.ts
@@ -1,0 +1,212 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { ErrorSchema } from "../auth/schemas";
+import type { UserDoc } from "../auth/users";
+import type { ObservabilityConfig } from "./config";
+import { isSummaryRange, type ObservabilityService } from "./service";
+
+type PreHandler = (req: FastifyRequest, reply: FastifyReply) => Promise<void>;
+
+const ConfigStatusSchema = {
+  type: "object",
+  required: ["enabled", "otlpConfigured", "retentionDays", "captureContent"],
+  properties: {
+    enabled: { type: "boolean" },
+    otlpConfigured: { type: "boolean" },
+    endpoint: { type: "string", nullable: true },
+    retentionDays: { type: "number" },
+    captureContent: { type: "boolean" },
+    spendAlertUsd: { type: "number", nullable: true },
+  },
+} as const;
+
+const SummarySchema = {
+  type: "object",
+  required: ["totals", "series", "byAgent", "byModel", "reliability"],
+  properties: {
+    totals: {
+      type: "object",
+      required: ["costUsd", "tokens", "turns", "unpricedCalls"],
+      properties: {
+        costUsd: { type: "number" },
+        tokens: { type: "number" },
+        turns: { type: "number" },
+        unpricedCalls: { type: "number" },
+      },
+    },
+    series: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["bucket", "costUsd", "tokens"],
+        properties: {
+          bucket: { type: "string" },
+          costUsd: { type: "number" },
+          tokens: { type: "number" },
+        },
+      },
+    },
+    byAgent: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["agentId", "costUsd"],
+        properties: { agentId: { type: "string" }, costUsd: { type: "number" } },
+      },
+    },
+    byModel: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["model", "costUsd", "calls", "unpriced"],
+        properties: {
+          model: { type: "string" },
+          costUsd: { type: "number" },
+          calls: { type: "number" },
+          unpriced: { type: "boolean" },
+        },
+      },
+    },
+    reliability: {
+      type: "object",
+      required: [
+        "turns",
+        "turnErrors",
+        "llmCalls",
+        "llmErrors",
+        "fallbacks",
+        "toolCalls",
+        "toolErrors",
+        "p95DurationMs",
+      ],
+      properties: {
+        turns: { type: "number" },
+        turnErrors: { type: "number" },
+        llmCalls: { type: "number" },
+        llmErrors: { type: "number" },
+        fallbacks: { type: "number" },
+        toolCalls: { type: "number" },
+        toolErrors: { type: "number" },
+        p95DurationMs: { type: "number" },
+      },
+    },
+  },
+} as const;
+
+/**
+ * GET /api/v1/observability/summary?range=24h|7d|30d — pre-aggregated cost/usage dashboard data.
+ * Admin-only (mirrors Settings → Secrets / LLM); the observability dashboard is an admin surface.
+ */
+export function registerObservabilityRoutes(
+  app: FastifyInstance,
+  service: ObservabilityService,
+  requireAuth: PreHandler,
+  config?: ObservabilityConfig
+): void {
+  // GET /api/v1/observability/config — Grafana-export status (admin). Never returns the OTLP token.
+  app.get(
+    "/api/v1/observability/config",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description: "Observability / Grafana export status (admin only; no secrets).",
+        tags: ["observability"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        response: { 200: ConfigStatusSchema, 401: ErrorSchema, 403: ErrorSchema },
+      },
+    },
+    async (req, reply) => {
+      const actor = req.user as UserDoc;
+      if (actor.role !== "admin") {
+        return reply.code(403).send({ error: "forbidden" });
+      }
+      return reply.send({
+        enabled: config?.enabled ?? false,
+        otlpConfigured: config?.otlp != null,
+        endpoint: config?.otlp?.endpoint ?? null,
+        retentionDays: config?.retentionDays ?? 90,
+        captureContent: config?.captureContent ?? false,
+        spendAlertUsd: config?.spendAlertUsd ?? null,
+      });
+    }
+  );
+
+  // GET /api/v1/observability/recent — newest chat turns, drill-down entry points (admin).
+  app.get(
+    "/api/v1/observability/recent",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description: "Recent chat turns for trace drill-down (admin only).",
+        tags: ["observability"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        querystring: { type: "object", properties: { limit: { type: "number" } } },
+        response: {
+          200: { type: "array", items: { type: "object", additionalProperties: true } },
+          401: ErrorSchema,
+          403: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const actor = req.user as UserDoc;
+      if (actor.role !== "admin") return reply.code(403).send({ error: "forbidden" });
+      const q = req.query as { limit?: number };
+      return reply.send(await service.recentTurns(q.limit ?? 25));
+    }
+  );
+
+  // GET /api/v1/observability/trace/:conversationId — a conversation's event timeline (admin).
+  app.get(
+    "/api/v1/observability/trace/:conversationId",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description: "Event timeline (llm_call/tool_call/turn) for one conversation (admin only).",
+        tags: ["observability"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        params: {
+          type: "object",
+          required: ["conversationId"],
+          properties: { conversationId: { type: "string" } },
+        },
+        response: {
+          200: { type: "array", items: { type: "object", additionalProperties: true } },
+          401: ErrorSchema,
+          403: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const actor = req.user as UserDoc;
+      if (actor.role !== "admin") return reply.code(403).send({ error: "forbidden" });
+      const { conversationId } = req.params as { conversationId: string };
+      return reply.send(await service.trace(conversationId));
+    }
+  );
+
+  app.get(
+    "/api/v1/observability/summary",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description: "AI observability cost/usage summary over a trailing window (admin only).",
+        tags: ["observability"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        querystring: {
+          type: "object",
+          properties: { range: { type: "string", enum: ["24h", "7d", "30d"] } },
+        },
+        response: { 200: SummarySchema, 401: ErrorSchema, 403: ErrorSchema },
+      },
+    },
+    async (req, reply) => {
+      const actor = req.user as UserDoc;
+      if (actor.role !== "admin") {
+        return reply.code(403).send({ error: "forbidden" });
+      }
+      const q = req.query as Record<string, unknown>;
+      const range = isSummaryRange(q.range) ? q.range : "7d";
+      return reply.send(await service.summary(range));
+    }
+  );
+}

--- a/apps/api/src/observability/service.ts
+++ b/apps/api/src/observability/service.ts
@@ -1,0 +1,98 @@
+import { randomUUID } from "node:crypto";
+import type {
+  ObsEventRow,
+  ObsEventType,
+  ObsRepo,
+  ObsSummary,
+  RecentTurn,
+  TraceEvent,
+} from "./repo";
+
+export type SummaryRange = "24h" | "7d" | "30d";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const RANGES: Record<SummaryRange, { ms: number; bucket: "hour" | "day" }> = {
+  "24h": { ms: DAY_MS, bucket: "hour" },
+  "7d": { ms: 7 * DAY_MS, bucket: "day" },
+  "30d": { ms: 30 * DAY_MS, bucket: "day" },
+};
+
+export function isSummaryRange(v: unknown): v is SummaryRange {
+  return v === "24h" || v === "7d" || v === "30d";
+}
+
+/**
+ * Input to `ObservabilityService.record`. Only `type` is required; every other field defaults to
+ * null / `{}`. `ts` defaults to now — pass it when the event time differs from write time.
+ */
+export interface RecordObsInput {
+  type: ObsEventType;
+  ts?: Date;
+  agentId?: string | null;
+  conversationId?: string | null;
+  model?: string | null;
+  provider?: string | null;
+  tier?: string | null;
+  tokensIn?: number | null;
+  tokensOut?: number | null;
+  costUsd?: number | null;
+  durationMs?: number | null;
+  status?: string | null;
+  toolName?: string | null;
+  attributes?: Record<string, unknown>;
+}
+
+/**
+ * The single write path for the AI observability event spine. `record` is **best-effort**: it
+ * builds the row and inserts it, but never throws into the caller — a failed observability write
+ * must not break or stall the chat turn that triggered it (callers also fire-and-forget). Mirrors
+ * `ActivityService.record`.
+ */
+export class ObservabilityService {
+  constructor(private readonly repo: ObsRepo) {}
+
+  async record(input: RecordObsInput): Promise<void> {
+    try {
+      const now = new Date();
+      const row: ObsEventRow = {
+        _id: randomUUID(),
+        ts: input.ts ?? now,
+        type: input.type,
+        agentId: input.agentId ?? null,
+        conversationId: input.conversationId ?? null,
+        model: input.model ?? null,
+        provider: input.provider ?? null,
+        tier: input.tier ?? null,
+        tokensIn: input.tokensIn ?? null,
+        tokensOut: input.tokensOut ?? null,
+        costUsd: input.costUsd ?? null,
+        durationMs: input.durationMs ?? null,
+        status: input.status ?? null,
+        toolName: input.toolName ?? null,
+        attributes: input.attributes ?? {},
+        createdAt: now,
+      };
+      await this.repo.insert(row);
+    } catch (err) {
+      console.error(
+        `[observability] record failed: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+
+  /** Pre-aggregated dashboard data over the trailing window. */
+  summary(range: SummaryRange): Promise<ObsSummary> {
+    const { ms, bucket } = RANGES[range];
+    return this.repo.summarize({ since: new Date(Date.now() - ms), bucket });
+  }
+
+  /** Newest-first recent turns (drill-down entry points). */
+  recentTurns(limit = 25): Promise<RecentTurn[]> {
+    return this.repo.recentTurns(Math.min(Math.max(limit, 1), 100));
+  }
+
+  /** A conversation's event timeline (trace drill-down). */
+  trace(conversationId: string): Promise<TraceEvent[]> {
+    return this.repo.traceByConversation(conversationId);
+  }
+}

--- a/apps/api/src/observability/summarize.pg.test.ts
+++ b/apps/api/src/observability/summarize.pg.test.ts
@@ -1,0 +1,127 @@
+import type { PGlite } from "@electric-sql/pglite";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { runPgMigrations } from "../pg-migrate";
+import { makePglite } from "../test/pglite";
+import { PgObsRepo } from "./repo";
+import { ObservabilityService } from "./service";
+
+const DAY = 24 * 60 * 60 * 1000;
+
+describe("ObservabilityService.summary", () => {
+  let db: PGlite;
+  let service: ObservabilityService;
+
+  beforeEach(async () => {
+    db = await makePglite();
+    await runPgMigrations(db);
+    service = new ObservabilityService(new PgObsRepo(db));
+  });
+
+  afterEach(async () => {
+    await db.close();
+  });
+
+  it("aggregates cost/tokens/turns from llm_call rows; turn rows excluded from totals", async () => {
+    const now = new Date();
+    await service.record({
+      type: "llm_call",
+      ts: now,
+      agentId: "support-agent",
+      model: "claude-opus-4-8",
+      tokensIn: 1000,
+      tokensOut: 500,
+      costUsd: 0.06,
+      status: "ok",
+    });
+    await service.record({
+      type: "llm_call",
+      ts: now,
+      agentId: "support-agent",
+      model: "claude-sonnet-4-6",
+      tokensIn: 2000,
+      tokensOut: 1000,
+      costUsd: 0.02,
+      status: "ok",
+    });
+    // A turn row carrying its own rollups — must NOT be double-counted into totals.
+    await service.record({
+      type: "turn",
+      ts: now,
+      agentId: "support-agent",
+      tokensIn: 3000,
+      tokensOut: 1500,
+      status: "ok",
+    });
+    // An unpriced llm_call (null cost) — counted in unpricedCalls, contributes 0 to cost.
+    await service.record({
+      type: "llm_call",
+      ts: now,
+      agentId: "other-agent",
+      model: "mystery",
+      tokensIn: 100,
+      tokensOut: 100,
+      costUsd: null,
+      status: "ok",
+    });
+
+    // A fallback-served llm_call and a failed/ok tool_call for the reliability lens.
+    await service.record({
+      type: "llm_call",
+      ts: now,
+      model: "claude-haiku-4-5",
+      tokensIn: 5,
+      tokensOut: 5,
+      costUsd: 0,
+      durationMs: 1200,
+      status: "fallback",
+    });
+    await service.record({
+      type: "tool_call",
+      ts: now,
+      toolName: "record_create",
+      status: "error",
+    });
+    await service.record({ type: "tool_call", ts: now, toolName: "search", status: "ok" });
+
+    const s = await service.summary("7d");
+    expect(s.totals.costUsd).toBeCloseTo(0.08, 6);
+    expect(s.totals.tokens).toBe(1500 + 3000 + 200 + 10); // llm_call tokens only (+10 fallback step)
+    expect(s.totals.turns).toBe(1);
+    expect(s.totals.unpricedCalls).toBe(1);
+
+    // Reliability lens
+    expect(s.reliability.fallbacks).toBe(1);
+    expect(s.reliability.toolCalls).toBe(2);
+    expect(s.reliability.toolErrors).toBe(1);
+    expect(s.reliability.turns).toBe(1);
+    expect(s.reliability.p95DurationMs).toBeGreaterThan(0);
+
+    // byAgent ordered by cost desc
+    expect(s.byAgent[0]).toEqual({ agentId: "support-agent", costUsd: expect.closeTo(0.08, 6) });
+    // byModel includes calls count
+    const opus = s.byModel.find((m) => m.model === "claude-opus-4-8");
+    expect(opus).toEqual({
+      model: "claude-opus-4-8",
+      costUsd: expect.closeTo(0.06, 6),
+      calls: 1,
+      unpriced: false,
+    });
+  });
+
+  it("excludes rows outside the trailing window", async () => {
+    const old = new Date(Date.now() - 10 * DAY);
+    await service.record({
+      type: "llm_call",
+      ts: old,
+      model: "claude-opus-4-8",
+      tokensIn: 1000,
+      tokensOut: 0,
+      costUsd: 5,
+      status: "ok",
+    });
+    const within = await service.summary("7d"); // 10d-old row excluded
+    expect(within.totals.costUsd).toBe(0);
+    const wide = await service.summary("30d"); // included
+    expect(wide.totals.costUsd).toBe(5);
+  });
+});

--- a/apps/api/src/observability/trace.pg.test.ts
+++ b/apps/api/src/observability/trace.pg.test.ts
@@ -1,0 +1,90 @@
+import type { PGlite } from "@electric-sql/pglite";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { runPgMigrations } from "../pg-migrate";
+import { makePglite } from "../test/pglite";
+import { PgObsRepo } from "./repo";
+import { ObservabilityService } from "./service";
+
+const CONVO = "11111111-1111-1111-1111-111111111111";
+const OTHER = "22222222-2222-2222-2222-222222222222";
+
+describe("observability trace (recentTurns + traceByConversation)", () => {
+  let db: PGlite;
+  let service: ObservabilityService;
+
+  beforeEach(async () => {
+    db = await makePglite();
+    await runPgMigrations(db);
+    service = new ObservabilityService(new PgObsRepo(db));
+  });
+
+  afterEach(async () => {
+    await db.close();
+  });
+
+  it("lists recent turns newest-first with step counts", async () => {
+    await service.record({
+      type: "turn",
+      ts: new Date(Date.now() - 1000),
+      conversationId: OTHER,
+      agentId: "a",
+      status: "ok",
+      attributes: { steps: 1 },
+    });
+    await service.record({
+      type: "turn",
+      conversationId: CONVO,
+      agentId: "support-agent",
+      status: "error",
+      tokensIn: 10,
+      tokensOut: 5,
+      attributes: { steps: 3 },
+    });
+
+    const recent = await service.recentTurns(10);
+    expect(recent).toHaveLength(2);
+    expect(recent[0]).toMatchObject({
+      conversationId: CONVO,
+      agentId: "support-agent",
+      status: "error",
+      steps: 3,
+    });
+  });
+
+  it("returns a conversation's event timeline oldest-first, scoped to that conversation", async () => {
+    const t0 = new Date(Date.now() - 3000);
+    const t1 = new Date(Date.now() - 2000);
+    const t2 = new Date(Date.now() - 1000);
+    await service.record({
+      type: "llm_call",
+      ts: t0,
+      conversationId: CONVO,
+      model: "claude-opus-4-8",
+      tokensIn: 100,
+      tokensOut: 50,
+      costUsd: 0.02,
+      status: "ok",
+    });
+    await service.record({
+      type: "tool_call",
+      ts: t1,
+      conversationId: CONVO,
+      toolName: "search_knowledge",
+      status: "ok",
+    });
+    await service.record({
+      type: "turn",
+      ts: t2,
+      conversationId: CONVO,
+      status: "ok",
+      attributes: { steps: 1 },
+    });
+    // A different conversation's event must not appear.
+    await service.record({ type: "llm_call", conversationId: OTHER, model: "x", status: "ok" });
+
+    const trace = await service.trace(CONVO);
+    expect(trace.map((e) => e.type)).toEqual(["llm_call", "tool_call", "turn"]);
+    expect(trace[0]).toMatchObject({ model: "claude-opus-4-8", costUsd: 0.02, tokensIn: 100 });
+    expect(trace[1]).toMatchObject({ toolName: "search_knowledge" });
+  });
+});

--- a/apps/api/src/observability/traces.test.ts
+++ b/apps/api/src/observability/traces.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from "vitest";
+import { OtlpTracesExporter } from "./traces";
+
+const TARGET = { endpoint: "https://otlp.grafana.net/otlp", instanceId: "123", token: "tok" };
+
+// Deterministic rand so trace/span ids are stable.
+function exporter(fetchImpl?: typeof fetch) {
+  return new OtlpTracesExporter(
+    TARGET,
+    () => 1_700_000_000_000,
+    () => 0.5,
+    fetchImpl ?? (vi.fn() as never)
+  );
+}
+
+describe("OtlpTracesExporter", () => {
+  it("builds one trace per turn: a root turn span with child step spans sharing the trace id", () => {
+    const e = exporter();
+    e.spanStep("conv-1", {
+      name: "claude-opus-4-8",
+      kind: "llm_call",
+      durationMs: 1200,
+      status: "ok",
+      attributes: { "tulipfarm.provider": "anthropic" },
+    });
+    e.spanStep("conv-1", { name: "search", kind: "tool_call", status: "ok", attributes: {} });
+    e.finishTurn("conv-1", {
+      agentId: "support-agent",
+      status: "ok",
+      durationMs: 2000,
+      steps: 1,
+      tokensIn: 100,
+      tokensOut: 50,
+    });
+
+    const payload = e.buildPayload() as {
+      resourceSpans: [
+        {
+          scopeSpans: [{ spans: Array<{ traceId: string; parentSpanId?: string; name: string }> }];
+        },
+      ];
+    };
+    const spans = payload.resourceSpans[0].scopeSpans[0].spans;
+    expect(spans).toHaveLength(3); // turn + 2 children
+    const root = spans.find((s) => s.name === "turn");
+    expect(root?.parentSpanId).toBeUndefined();
+    // All spans share one trace id; children parent to the root.
+    const traceIds = new Set(spans.map((s) => s.traceId));
+    expect(traceIds.size).toBe(1);
+    for (const child of spans.filter((s) => s.name !== "turn")) {
+      expect(child.parentSpanId).toBeDefined();
+    }
+  });
+
+  it("maps only genuine failures to OTLP ERROR — fallback is not an error", () => {
+    const e = exporter();
+    e.spanStep("c", { name: "m1", kind: "llm_call", status: "fallback", attributes: {} });
+    e.spanStep("c", { name: "t1", kind: "tool_call", status: "error", attributes: {} });
+    e.finishTurn("c", { agentId: "a", status: "ok", steps: 2, tokensIn: 0, tokensOut: 0 });
+    const payload = e.buildPayload() as {
+      resourceSpans: [
+        { scopeSpans: [{ spans: Array<{ name: string; status: { code: number } }> }] },
+      ];
+    };
+    const byName = Object.fromEntries(
+      payload.resourceSpans[0].scopeSpans[0].spans.map((s) => [s.name, s.status.code])
+    );
+    expect(byName.turn).toBe(0); // ok → UNSET
+    expect(byName.m1).toBe(0); // fallback → UNSET (not an error)
+    expect(byName.t1).toBe(2); // error → ERROR
+  });
+
+  it("survives non-finite durations without throwing (BigInt guard)", () => {
+    const e = exporter();
+    expect(() =>
+      e.spanStep("c", {
+        name: "m",
+        kind: "llm_call",
+        durationMs: Number.NaN,
+        status: "ok",
+        attributes: {},
+      })
+    ).not.toThrow();
+    expect(() =>
+      e.finishTurn("c", {
+        agentId: "a",
+        status: "ok",
+        durationMs: Number.POSITIVE_INFINITY,
+        steps: 1,
+        tokensIn: 0,
+        tokensOut: 0,
+      })
+    ).not.toThrow();
+  });
+
+  it("scopes accumulated spans per conversation", () => {
+    const e = exporter();
+    e.spanStep("conv-a", { name: "m", kind: "llm_call", status: "ok", attributes: {} });
+    e.spanStep("conv-b", { name: "m", kind: "llm_call", status: "ok", attributes: {} });
+    // Finishing conv-a must only include conv-a's child, not conv-b's.
+    e.finishTurn("conv-a", {
+      agentId: "a",
+      status: "ok",
+      steps: 1,
+      tokensIn: 0,
+      tokensOut: 0,
+    });
+    const payload = e.buildPayload() as {
+      resourceSpans: [{ scopeSpans: [{ spans: unknown[] }] }];
+    };
+    expect(payload.resourceSpans[0].scopeSpans[0].spans).toHaveLength(2); // turn + 1 child
+  });
+
+  it("POSTs OTLP trace JSON with basic auth to /v1/traces, then clears the buffer", async () => {
+    const fetchMock = vi.fn(async () => new Response(null, { status: 200 }));
+    const e = exporter(fetchMock as unknown as typeof fetch);
+    e.finishTurn("c", { agentId: "a", status: "ok", steps: 0, tokensIn: 0, tokensOut: 0 });
+    await e.flush();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe("https://otlp.grafana.net/otlp/v1/traces");
+    expect((init.headers as Record<string, string>).authorization).toBe(
+      `Basic ${Buffer.from("123:tok").toString("base64")}`
+    );
+    // Buffer cleared after a successful flush.
+    expect(e.buildPayload().resourceSpans).toHaveLength(0);
+  });
+});

--- a/apps/api/src/observability/traces.ts
+++ b/apps/api/src/observability/traces.ts
@@ -1,0 +1,198 @@
+import type { OtlpTarget } from "./metrics";
+
+/**
+ * Dependency-free OTLP/HTTP-JSON trace export to Grafana Cloud (Tempo). One trace per chat turn: a
+ * root `turn` span with child `llm_call` / `tool_call` spans, accumulated per conversation between
+ * turn boundaries (single-tenant V1 runs turns sequentially per conversation). Spans are timed from
+ * event arrival minus the step's durationMs. Only started when observability is enabled.
+ */
+
+export interface TracesSink {
+  spanStep(conversationId: string, d: SpanInput): void;
+  finishTurn(conversationId: string, d: TurnSpanInput): void;
+}
+
+export interface SpanInput {
+  name: string;
+  kind: "llm_call" | "tool_call";
+  durationMs?: number;
+  status: string;
+  attributes: Record<string, string | number>;
+}
+
+export interface TurnSpanInput {
+  agentId: string | null;
+  status: string;
+  durationMs?: number;
+  steps: number;
+  tokensIn: number;
+  tokensOut: number;
+}
+
+interface PendingSpan {
+  name: string;
+  startNano: bigint;
+  endNano: bigint;
+  status: string;
+  attributes: Record<string, string | number>;
+}
+
+// Backstops against unbounded growth if a turn never emits TURN_FINISHED (abort/crash): cap spans
+// per conversation and the number of in-flight conversations (oldest evicted first).
+const MAX_SPANS_PER_TURN = 1000;
+const MAX_PENDING_TURNS = 2000;
+
+/** Finite-safe milliseconds → never lets NaN/Infinity reach BigInt() (which would throw). */
+function safeMs(n: number | undefined): number {
+  return Number.isFinite(n) ? Math.max(0, Math.floor(n as number)) : 0;
+}
+
+/** OTLP span status: only genuine failures map to ERROR(2). `ok`/`fallback` are not errors. */
+function statusCode(status: string): number {
+  return status === "error" || status === "timeout" || status === "blocked" ? 2 : 0;
+}
+
+function hex(bytes: number, rand: () => number): string {
+  let s = "";
+  for (let i = 0; i < bytes; i++) {
+    s += Math.floor(rand() * 256)
+      .toString(16)
+      .padStart(2, "0");
+  }
+  return s;
+}
+
+function attrList(attributes: Record<string, string | number>): unknown[] {
+  return Object.entries(attributes).map(([key, v]) => ({
+    key,
+    value: typeof v === "number" ? { doubleValue: v } : { stringValue: v },
+  }));
+}
+
+export class OtlpTracesExporter implements TracesSink {
+  private pending = new Map<string, PendingSpan[]>();
+  private resourceSpans: unknown[] = [];
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private readonly authHeader: string;
+
+  constructor(
+    private readonly target: OtlpTarget,
+    private readonly nowMs: () => number = Date.now,
+    private readonly rand: () => number = Math.random,
+    private readonly fetchImpl: typeof fetch = fetch,
+    private readonly log: (msg: string) => void = (m) => console.warn(m)
+  ) {
+    this.authHeader = `Basic ${Buffer.from(`${target.instanceId}:${target.token}`).toString("base64")}`;
+  }
+
+  spanStep(conversationId: string, d: SpanInput): void {
+    const endNano = BigInt(safeMs(this.nowMs())) * 1_000_000n;
+    const startNano = endNano - BigInt(safeMs(d.durationMs)) * 1_000_000n;
+    const list = this.pending.get(conversationId);
+    if (list) {
+      if (list.length >= MAX_SPANS_PER_TURN) return; // drop excess; the turn span still flushes
+    } else if (this.pending.size >= MAX_PENDING_TURNS) {
+      // Evict the oldest in-flight conversation (insertion order) to bound memory.
+      const oldest = this.pending.keys().next().value;
+      if (oldest !== undefined) this.pending.delete(oldest);
+    }
+    const next = list ?? [];
+    next.push({
+      name: d.name,
+      startNano,
+      endNano,
+      status: d.status,
+      attributes: { "tulipfarm.kind": d.kind, ...d.attributes },
+    });
+    this.pending.set(conversationId, next);
+  }
+
+  finishTurn(conversationId: string, d: TurnSpanInput): void {
+    const children = this.pending.get(conversationId) ?? [];
+    this.pending.delete(conversationId);
+    const endNano = BigInt(safeMs(this.nowMs())) * 1_000_000n;
+    const startNano = endNano - BigInt(safeMs(d.durationMs)) * 1_000_000n;
+
+    const traceId = hex(16, this.rand);
+    const rootSpanId = hex(8, this.rand);
+    const toSpan = (
+      spanId: string,
+      parentId: string | undefined,
+      name: string,
+      start: bigint,
+      end: bigint,
+      status: string,
+      attributes: Record<string, string | number>
+    ) => ({
+      traceId,
+      spanId,
+      parentSpanId: parentId,
+      name,
+      kind: 1,
+      startTimeUnixNano: `${start}`,
+      endTimeUnixNano: `${end}`,
+      attributes: attrList(attributes),
+      status: { code: statusCode(status) },
+    });
+
+    const spans: unknown[] = [
+      toSpan(rootSpanId, undefined, "turn", startNano, endNano, d.status, {
+        "tulipfarm.kind": "turn",
+        "tulipfarm.agent": d.agentId ?? "unknown",
+        "tulipfarm.steps": d.steps,
+        "tulipfarm.tokens_in": d.tokensIn,
+        "tulipfarm.tokens_out": d.tokensOut,
+      }),
+      ...children.map((c) =>
+        toSpan(
+          hex(8, this.rand),
+          rootSpanId,
+          c.name,
+          c.startNano,
+          c.endNano,
+          c.status,
+          c.attributes
+        )
+      ),
+    ];
+
+    this.resourceSpans.push({
+      resource: { attributes: [{ key: "service.name", value: { stringValue: "tulipfarm" } }] },
+      scopeSpans: [{ scope: { name: "tulipfarm.observability" }, spans }],
+    });
+  }
+
+  async flush(): Promise<void> {
+    if (this.resourceSpans.length === 0) return;
+    const batch = this.resourceSpans;
+    this.resourceSpans = [];
+    try {
+      const res = await this.fetchImpl(`${this.target.endpoint.replace(/\/$/, "")}/v1/traces`, {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: this.authHeader },
+        body: JSON.stringify({ resourceSpans: batch }),
+      });
+      if (!res.ok) this.log(`[observability] OTLP traces push failed: ${res.status}`);
+    } catch (err) {
+      this.log(
+        `[observability] OTLP traces error: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+
+  /** Build the OTLP/JSON ExportTraceServiceRequest currently buffered (for tests). */
+  buildPayload(): { resourceSpans: unknown[] } {
+    return { resourceSpans: this.resourceSpans };
+  }
+
+  start(intervalMs = 15_000): void {
+    if (this.timer) return;
+    this.timer = setInterval(() => void this.flush(), intervalMs);
+    this.timer.unref?.();
+  }
+
+  stop(): void {
+    if (this.timer) clearInterval(this.timer);
+    this.timer = null;
+  }
+}

--- a/apps/api/src/pg-migrate.test.ts
+++ b/apps/api/src/pg-migrate.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { runPgMigrations } from "./pg-migrate";
 import { makePglite } from "./test/pglite";
 
-describe("runPgMigrations — 001_init + 002_knowledge + 003_stream_resume + 004_approvals + 005_conversation_title + 006_message_feedback + 007_conversation_starred + 008_hitl + 009_kv_store + 010_wrapped_deks + 011_okf + 012_okf_crosslinks + 013_drop_bundle_domain + 014_drop_okf_type + 015_title_tsv + 016_doc_type + 017_pg_trgm + 018_terminology_rename + 019_chunk_content_hash + 020_knowledge_connectors + 021_activity_log on PGlite", () => {
+describe("runPgMigrations — 001_init + 002_knowledge + 003_stream_resume + 004_approvals + 005_conversation_title + 006_message_feedback + 007_conversation_starred + 008_hitl + 009_kv_store + 010_wrapped_deks + 011_okf + 012_okf_crosslinks + 013_drop_bundle_domain + 014_drop_okf_type + 015_title_tsv + 016_doc_type + 017_pg_trgm + 018_terminology_rename + 019_chunk_content_hash + 020_knowledge_connectors + 021_activity_log + 022_obs_event on PGlite", () => {
   let db: PGlite;
 
   beforeEach(async () => {
@@ -14,10 +14,10 @@ describe("runPgMigrations — 001_init + 002_knowledge + 003_stream_resume + 004
     await db.close();
   });
 
-  it("advances schema_version to the latest (21)", async () => {
+  it("advances schema_version to the latest (22)", async () => {
     await runPgMigrations(db);
     const res = await db.query<{ version: number }>("SELECT version FROM schema_version");
-    expect(res.rows.map((r) => Number(r.version))).toEqual([21]);
+    expect(res.rows.map((r) => Number(r.version))).toEqual([22]);
   });
 
   it("creates the vector and citext extensions", async () => {
@@ -50,6 +50,7 @@ describe("runPgMigrations — 001_init + 002_knowledge + 003_stream_resume + 004
       "kv_store",
       "message_feedback",
       "messages",
+      "obs_event",
       "pending_interactions",
       "rate_limits",
       "schema_version",
@@ -81,11 +82,11 @@ describe("runPgMigrations — 001_init + 002_knowledge + 003_stream_resume + 004
     ]);
   });
 
-  it("is idempotent — a second run does not throw and leaves version at 21", async () => {
+  it("is idempotent — a second run does not throw and leaves version at 22", async () => {
     await runPgMigrations(db);
     await runPgMigrations(db);
     const res = await db.query<{ version: number }>("SELECT version FROM schema_version");
-    expect(res.rows.map((r) => Number(r.version))).toEqual([21]);
+    expect(res.rows.map((r) => Number(r.version))).toEqual([22]);
   });
 
   it("adds knowledge_pages.title_tsv (generated tsvector) + its GIN index (015, renamed by 018)", async () => {

--- a/apps/api/src/pg-migrations/index.ts
+++ b/apps/api/src/pg-migrations/index.ts
@@ -453,6 +453,36 @@ const ACTIVITY_LOG_STATEMENTS: string[] = [
   "CREATE INDEX IF NOT EXISTS activity_log_category_created_idx ON activity_log (category, created_at DESC, id DESC)",
 ];
 
+const OBS_EVENT_STATEMENTS: string[] = [
+  // AI observability event spine. Append-only; one row per llm_call (model step), tool_call, turn
+  // summary, or background job run. Hot query/aggregate fields are promoted to typed columns; the
+  // long tail (token cache breakdown, error codes, job names) rides in `attributes`. cost_usd is
+  // frozen at write time (computed from the model price map) so historical cost survives price
+  // changes; NULL means the served model was unpriced. Pruned on a schedule (retention window).
+  `CREATE TABLE IF NOT EXISTS obs_event (
+    id              uuid PRIMARY KEY,
+    ts              timestamptz NOT NULL,
+    type            text NOT NULL,
+    agent_id        text,
+    conversation_id text,
+    model           text,
+    provider        text,
+    tier            text,
+    tokens_in       integer,
+    tokens_out      integer,
+    cost_usd        numeric,
+    duration_ms     integer,
+    status          text,
+    tool_name       text,
+    attributes      jsonb NOT NULL DEFAULT '{}',
+    created_at      timestamptz NOT NULL
+  )`,
+  "CREATE INDEX IF NOT EXISTS obs_event_ts_idx ON obs_event (ts DESC)",
+  "CREATE INDEX IF NOT EXISTS obs_event_type_ts_idx ON obs_event (type, ts DESC)",
+  "CREATE INDEX IF NOT EXISTS obs_event_agent_ts_idx ON obs_event (agent_id, ts DESC)",
+  "CREATE INDEX IF NOT EXISTS obs_event_model_ts_idx ON obs_event (model, ts DESC)",
+];
+
 // ── Guarded rename helpers (terminology migration v18) ───────────────────────────────────────
 // ALTER ... RENAME is not naturally idempotent, so each helper checks the catalog first. This
 // keeps a partial-failure re-run safe and runs statement-by-statement on PGlite (no plpgsql DO).
@@ -747,6 +777,16 @@ export const PG_MIGRATIONS: PgMigration[] = [
       "activity: activity_log workspace feed (category/action/actor/target/metadata) + keyset indexes",
     up: async (q) => {
       for (const sql of ACTIVITY_LOG_STATEMENTS) {
+        await q.query(sql);
+      }
+    },
+  },
+  {
+    version: 22,
+    description:
+      "observability: obs_event AI event spine (llm_call/tool_call/turn/job) + ts/type/agent/model indexes",
+    up: async (q) => {
+      for (const sql of OBS_EVENT_STATEMENTS) {
         await q.query(sql);
       }
     },

--- a/apps/api/src/soul/llm-config/routes.test.ts
+++ b/apps/api/src/soul/llm-config/routes.test.ts
@@ -12,8 +12,19 @@ import { SESSION_COOKIE } from "../../auth/middleware";
 import { MemorySessionStore } from "../../auth/session-store";
 import { createUser, type UserDoc, type UserRepo } from "../../auth/users";
 import type { PaginatedResult } from "../../pagination";
+import { __resetLlmCatalogCache } from "./routes";
 
 const TEST_CSRF = "a".repeat(64);
+
+/** A stubbed `fetch` returning a LiteLLM catalog (or empty). Resets the module cache so each test's
+ *  stub is used deterministically (no real network, no cross-test catalog leakage). */
+function stubCatalog(catalog: Record<string, unknown>): void {
+  __resetLlmCatalogCache();
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({ ok: true, json: async () => catalog }) as unknown as Response)
+  );
+}
 
 class FakeUserRepo implements UserRepo {
   private users: UserDoc[] = [];
@@ -125,9 +136,14 @@ describe("llm-config routes", () => {
       llmService,
       secretsService,
     });
+    // Default: empty catalog, so PUT's auto-enrich is a no-op (no specs pinned) and no real network
+    // call happens. Tests that exercise enrichment/resolve override with their own catalog.
+    stubCatalog({});
   });
 
   afterEach(async () => {
+    vi.unstubAllGlobals();
+    __resetLlmCatalogCache();
     await app.close();
     for (const dir of temps.splice(0)) await rm(dir, { recursive: true, force: true });
   });
@@ -255,6 +271,92 @@ describe("llm-config routes", () => {
       expect(withSync).not.toHaveBeenCalled();
       expect(init).not.toHaveBeenCalled();
       await expect(access(join(soulPath, "llm.config.yaml"))).rejects.toThrow();
+    });
+  });
+
+  const CATALOG = {
+    "azure_ai/kimi-k2.5": {
+      input_cost_per_token: 0.00000057,
+      output_cost_per_token: 0.0000023,
+      max_input_tokens: 256000,
+      mode: "chat",
+      supports_function_calling: true,
+    },
+  };
+
+  describe("GET /api/v1/llm-config/resolve-spec", () => {
+    it("is admin-only (403 for a member)", async () => {
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/llm-config/resolve-spec?provider=azure&model=kimi-k2.5",
+        cookies: cookies(memberSid),
+      });
+      expect(res.statusCode).toBe(403);
+    });
+
+    it("resolves a model spec from the LiteLLM catalog for an admin", async () => {
+      stubCatalog(CATALOG);
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/llm-config/resolve-spec?provider=azure&model=kimi-k2.5",
+        cookies: cookies(adminSid),
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json() as {
+        spec: { input_cost_per_token: number; litellm_key: string } | null;
+        matchedKey: string | null;
+        candidates: string[];
+      };
+      expect(body.matchedKey).toBe("azure_ai/kimi-k2.5");
+      expect(body.spec?.input_cost_per_token).toBe(0.00000057);
+      expect(body.spec?.litellm_key).toBe("azure_ai/kimi-k2.5");
+    });
+  });
+
+  describe("PUT auto-resolves + pins model specs", () => {
+    it("pins a LiteLLM spec onto a spec-less model on save", async () => {
+      stubCatalog(CATALOG);
+      const res = await app.inject({
+        method: "PUT",
+        url: "/api/v1/llm-config",
+        cookies: cookies(adminSid),
+        headers,
+        payload: {
+          tiers: {
+            quick: { providers: [{ provider: "azure", model: "kimi-k2.5" }] },
+            standard: { providers: [{ provider: "azure", model: "kimi-k2.5" }] },
+            complex: { providers: [{ provider: "azure", model: "kimi-k2.5" }] },
+          },
+        },
+      });
+      expect(res.statusCode).toBe(200);
+      // The written soul file should now carry the pinned spec (auto-resolved from LiteLLM).
+      const written = parseYaml(await readFile(join(soulPath, "llm.config.yaml"), "utf8")) as {
+        tiers: { quick: { providers: Array<{ spec?: { input_cost_per_token: number } }> } };
+      };
+      expect(written.tiers.quick.providers[0].spec?.input_cost_per_token).toBe(0.00000057);
+    });
+
+    it("leaves a model unpriced (no spec) when LiteLLM has no match", async () => {
+      stubCatalog(CATALOG); // catalog has only kimi-k2.5
+      const res = await app.inject({
+        method: "PUT",
+        url: "/api/v1/llm-config",
+        cookies: cookies(adminSid),
+        headers,
+        payload: {
+          tiers: {
+            quick: { providers: [{ provider: "azure", model: "some-unknown-model-xyz" }] },
+            standard: { providers: [{ provider: "azure", model: "some-unknown-model-xyz" }] },
+            complex: { providers: [{ provider: "azure", model: "some-unknown-model-xyz" }] },
+          },
+        },
+      });
+      expect(res.statusCode).toBe(200);
+      const written = parseYaml(await readFile(join(soulPath, "llm.config.yaml"), "utf8")) as {
+        tiers: { quick: { providers: Array<{ spec?: unknown }> } };
+      };
+      expect(written.tiers.quick.providers[0].spec).toBeUndefined();
     });
   });
 });

--- a/apps/api/src/soul/llm-config/routes.ts
+++ b/apps/api/src/soul/llm-config/routes.ts
@@ -1,9 +1,12 @@
 import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import {
+  fetchLiteLlmCatalog,
+  type LiteLlmCatalog,
   type LlmConfig,
   LlmConfigValidationError,
   type LlmService,
+  resolveModelSpec,
   validateLlmConfig,
 } from "@tulipfarm/llm";
 import { LLM_PROVIDERS, type SecretsService } from "@tulipfarm/secrets";
@@ -15,11 +18,65 @@ import type { UserDoc } from "../../auth/users";
 
 type PreHandler = (req: FastifyRequest, reply: FastifyReply) => Promise<void>;
 
+// In-memory LiteLLM catalog cache (the JSON is ~large; refetch at most hourly). Shared across
+// resolve-spec calls so adding several models doesn't re-download each time.
+const CATALOG_TTL_MS = 60 * 60 * 1000;
+let catalogCache: { at: number; catalog: LiteLlmCatalog | null } | null = null;
+
+/** Test-only: clear the module-level catalog cache so each test controls its own stubbed catalog. */
+export function __resetLlmCatalogCache(): void {
+  catalogCache = null;
+}
+
+async function getCatalog(force = false): Promise<LiteLlmCatalog | null> {
+  if (!force && catalogCache && Date.now() - catalogCache.at < CATALOG_TTL_MS) {
+    return catalogCache.catalog;
+  }
+  const catalog = await fetchLiteLlmCatalog();
+  // Cache even a null (failed) result briefly so a flaky network doesn't hammer GitHub per keystroke
+  // (a `force` refresh always re-fetches first, so a transient failure isn't sticky for the UI).
+  if (catalog || !catalogCache) catalogCache = { at: Date.now(), catalog };
+  return catalog;
+}
+
 // Returned by GET when no llm.config.yaml exists yet, so the editor opens with empty tiers instead of
 // erroring. Not itself schema-valid for PUT (tiers need ≥1 provider) — the user fills it in and saves.
 const EMPTY_LLM_CONFIG = {
   tiers: { quick: { providers: [] }, standard: { providers: [] }, complex: { providers: [] } },
 } as const;
+
+const TIER_KEYS = ["quick", "standard", "complex"] as const;
+
+/**
+ * Auto-resolve + pin a LiteLLM spec onto every model that doesn't already have one, so that simply
+ * adding a model and saving is enough for cost tracking (no per-model "Fetch spec" click). Best-effort:
+ * if the catalog is unreachable, the config is saved unchanged; models with no LiteLLM match are left
+ * spec-less (and show as "unpriced"). Existing specs are preserved — use the form's Refresh to update.
+ * `force` re-resolves ALL models against a freshly-fetched catalog.
+ */
+async function enrichSpecs(config: LlmConfig, force: boolean): Promise<LlmConfig> {
+  const all = TIER_KEYS.flatMap((t) => config.tiers[t].providers);
+  if (!force && all.every((p) => p.spec)) return config; // nothing missing → no fetch
+  const catalog = await getCatalog(force);
+  if (!catalog) return config; // can't reach LiteLLM → save as-is
+  const fetchedAt = new Date().toISOString().slice(0, 10);
+  const enrichTier = (tier: { providers: LlmConfig["tiers"]["quick"]["providers"] }) => ({
+    ...tier,
+    providers: tier.providers.map((p) => {
+      if (p.spec && !force) return p;
+      const { spec } = resolveModelSpec(p.provider, p.model, catalog, fetchedAt);
+      return spec ? { ...p, spec } : p;
+    }),
+  });
+  return {
+    ...config,
+    tiers: {
+      quick: enrichTier(config.tiers.quick),
+      standard: enrichTier(config.tiers.standard),
+      complex: enrichTier(config.tiers.complex),
+    },
+  };
+}
 
 /*
  * LLM config editing (UI-V1-003 / LLM-V1-003). Reads and full-replaces soul/llm.config.yaml.
@@ -119,15 +176,64 @@ export function registerLlmConfigRoutes(
     }
   );
 
+  app.get(
+    "/api/v1/llm-config/resolve-spec",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description:
+          "Resolve a model's spec (pricing/context/capabilities) from LiteLLM for a given provider+model, to pin into llm.config. Admin only. `spec` is null when no confident match was found (use `candidates`).",
+        tags: ["soul"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        querystring: {
+          type: "object",
+          required: ["provider", "model"],
+          properties: {
+            provider: { type: "string" },
+            model: { type: "string" },
+            base_url: { type: "string" },
+            refresh: { type: "boolean" },
+          },
+        },
+        response: {
+          200: {
+            type: "object",
+            required: ["spec", "matchedKey", "candidates"],
+            properties: {
+              spec: { type: "object", additionalProperties: true, nullable: true },
+              matchedKey: { type: "string", nullable: true },
+              candidates: { type: "array", items: { type: "string" } },
+            },
+          },
+          401: ErrorSchema,
+          403: ErrorSchema,
+          502: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const actor = req.user as UserDoc;
+      if (actor.role !== "admin") return reply.code(403).send({ error: "forbidden" });
+      const q = req.query as { provider: string; model: string; refresh?: boolean };
+      const catalog = await getCatalog(q.refresh === true);
+      if (!catalog) {
+        return reply.code(502).send({ error: "could not reach the LiteLLM model catalog" });
+      }
+      const fetchedAt = new Date().toISOString().slice(0, 10);
+      return reply.send(resolveModelSpec(q.provider, q.model, catalog, fetchedAt));
+    }
+  );
+
   app.put(
     "/api/v1/llm-config",
     {
       preHandler: requireAuth,
       schema: {
         description:
-          "Replace the LLM config (admin only). Validated before write; the soul is committed and the LlmService reloaded.",
+          "Replace the LLM config (admin only). Each model's spec (pricing/context/capabilities) is auto-resolved from LiteLLM and pinned (best-effort); `?refresh=true` re-resolves all. Validated before write; the soul is committed and the LlmService reloaded.",
         tags: ["soul"],
         security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        querystring: { type: "object", properties: { refresh: { type: "boolean" } } },
         body: { type: "object", additionalProperties: true },
         response: {
           200: { type: "object", additionalProperties: true },
@@ -152,6 +258,11 @@ export function registerLlmConfigRoutes(
         }
         throw err;
       }
+
+      // Auto-pin specs for any model missing one (or all, with ?refresh=true) so cost tracking works
+      // without a per-model click. Best-effort — a LiteLLM outage saves the config unchanged.
+      const { refresh } = req.query as { refresh?: boolean };
+      config = await enrichSpecs(config, refresh === true);
 
       await writeFile(join(gitSync.path, "llm.config.yaml"), stringifyYaml(config), "utf8");
       await gitSync.withSync("soul: update llm config");

--- a/apps/web/app/components/llm-config-form.tsx
+++ b/apps/web/app/components/llm-config-form.tsx
@@ -1,6 +1,12 @@
 import { type FormEvent, useState } from "react";
 import { Button } from "~/components/ui/button";
-import { isProviderConfigured, type LlmConfig, type LlmProviderInfo } from "~/lib/settings";
+import {
+  isProviderConfigured,
+  type LlmConfig,
+  type LlmProviderInfo,
+  type ModelSpec,
+  resolveModelSpec,
+} from "~/lib/settings";
 
 /*
  * Structured editor for soul/llm.config.yaml (UI-V1-003 / LLM-V1-003). Each tier is an ordered list
@@ -16,19 +22,50 @@ type TierName = (typeof TIERS)[number];
 const inputClass =
   "w-full rounded-sm border border-border bg-background px-3 py-2 text-sm outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:opacity-60";
 
-type Row = { provider: string; model: string; uid: number };
+type SpecState = "loading" | "matched" | "unmatched" | "error";
+type Row = {
+  provider: string;
+  model: string;
+  uid: number;
+  spec?: ModelSpec;
+  specState?: SpecState;
+};
 type Tiers = Record<TierName, Row[]>;
 
 let nextUid = 0;
 
 function cloneTiers(config: LlmConfig): Tiers {
-  const rows = (ps: { provider: string; model: string }[]): Row[] =>
-    ps.map((p) => ({ provider: p.provider, model: p.model, uid: nextUid++ }));
+  const rows = (ps: { provider: string; model: string; spec?: ModelSpec }[]): Row[] =>
+    ps.map((p) => ({
+      provider: p.provider,
+      model: p.model,
+      uid: nextUid++,
+      spec: p.spec,
+      specState: p.spec ? ("matched" as const) : undefined,
+    }));
   return {
     quick: rows(config.tiers.quick.providers),
     standard: rows(config.tiers.standard.providers),
     complex: rows(config.tiers.complex.providers),
   };
+}
+
+const perMtok = (n?: number): string => (n != null ? `$${(n * 1_000_000).toFixed(2)}` : "—");
+
+/** One-line spec summary: cost per Mtok · context · capabilities. */
+function specSummary(spec: ModelSpec): string {
+  const cost = `${perMtok(spec.input_cost_per_token)} / ${perMtok(spec.output_cost_per_token)} per Mtok`;
+  const ctx = spec.max_input_tokens ? ` · ${Math.round(spec.max_input_tokens / 1000)}k ctx` : "";
+  const caps = [
+    spec.supports_function_calling && "tools",
+    spec.supports_vision && "vision",
+    spec.supports_prompt_caching && "cache",
+    spec.supports_reasoning && "reasoning",
+  ]
+    .filter(Boolean)
+    .join(", ");
+  const dep = spec.deprecation_date ? ` · deprecates ${spec.deprecation_date}` : "";
+  return `${cost}${ctx}${caps ? ` · ${caps}` : ""}${dep}`;
 }
 
 export type LlmConfigFormProps = {
@@ -62,6 +99,23 @@ export function LlmConfigForm({
     }));
   }
 
+  // Patch by stable uid (not positional index): safe to call after an `await`, when rows may have
+  // been added/removed/reordered. `where` optionally guards the write so a stale async result is
+  // dropped if the row's provider/model changed while the request was in flight.
+  function patchRowByUid(
+    tier: TierName,
+    uid: number,
+    patch: Partial<Row>,
+    where?: (r: Row) => boolean
+  ) {
+    setTiers((prev) => ({
+      ...prev,
+      [tier]: prev[tier].map((r) =>
+        r.uid === uid && (!where || where(r)) ? { ...r, ...patch } : r
+      ),
+    }));
+  }
+
   function addProvider(tier: TierName) {
     setTiers((prev) => ({
       ...prev,
@@ -71,6 +125,31 @@ export function LlmConfigForm({
 
   function removeProvider(tier: TierName, idx: number) {
     setTiers((prev) => ({ ...prev, [tier]: prev[tier].filter((_, i) => i !== idx) }));
+  }
+
+  // Resolve the model's spec (pricing/context/capabilities) from LiteLLM and pin it to the row. The
+  // spec is persisted with the config on Save, so cost tracking works for this model. Keyed by uid +
+  // an equality guard so an in-flight result never lands on a row whose provider/model has changed
+  // (which would pin a wrong price). `refresh` re-fetches the LiteLLM catalog (vs the server cache).
+  async function fetchSpec(tier: TierName, idx: number) {
+    const row = tiers[tier][idx];
+    if (!row.provider || !row.model.trim()) return;
+    const { uid, provider } = row;
+    const model = row.model.trim();
+    const stillTarget = (r: Row) => r.provider === provider && r.model.trim() === model;
+    const wasRefresh = !!row.spec;
+    patchRowByUid(tier, uid, { specState: "loading" });
+    try {
+      const res = await resolveModelSpec(provider, model, wasRefresh);
+      patchRowByUid(
+        tier,
+        uid,
+        { spec: res.spec ?? undefined, specState: res.spec ? "matched" : "unmatched" },
+        stillTarget
+      );
+    } catch {
+      patchRowByUid(tier, uid, { specState: "error" }, stillTarget);
+    }
   }
 
   // Block submit on a row whose provider is known but not fully configured (its secret/config was
@@ -96,7 +175,11 @@ export function LlmConfigForm({
     setLocalError(problem);
     if (problem) return;
     const toEntries = (rows: Row[]) =>
-      rows.map((r) => ({ provider: r.provider.trim(), model: r.model.trim() }));
+      rows.map((r) => ({
+        provider: r.provider.trim(),
+        model: r.model.trim(),
+        ...(r.spec ? { spec: r.spec } : {}),
+      }));
     const config: LlmConfig = {
       tiers: {
         quick: { providers: toEntries(tiers.quick) },
@@ -130,47 +213,97 @@ export function LlmConfigForm({
           {tiers[tier].map((r, idx) => (
             <div
               key={r.uid}
-              className="grid grid-cols-1 items-end gap-2 border-t border-border pt-3 first:border-t-0 first:pt-0 sm:grid-cols-[1fr_1fr_auto]"
+              className="flex flex-col gap-2 border-t border-border pt-3 first:border-t-0 first:pt-0"
             >
-              <label className="flex flex-col gap-1 text-xs text-muted-foreground">
-                provider
-                <select
-                  className={inputClass}
-                  value={r.provider}
-                  onChange={(e) => patchRow(tier, idx, { provider: e.target.value })}
-                  aria-label={`${tier} provider ${idx + 1} provider`}
+              <div className="grid grid-cols-1 items-end gap-2 sm:grid-cols-[1fr_1fr_auto]">
+                <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+                  provider
+                  <select
+                    className={inputClass}
+                    value={r.provider}
+                    // Changing provider invalidates any pinned spec (it was resolved for the old one).
+                    onChange={(e) =>
+                      patchRow(tier, idx, {
+                        provider: e.target.value,
+                        spec: undefined,
+                        specState: undefined,
+                      })
+                    }
+                    aria-label={`${tier} provider ${idx + 1} provider`}
+                  >
+                    {r.provider && !known.has(r.provider) ? (
+                      <option value={r.provider}>{r.provider}</option>
+                    ) : null}
+                    {providers.map((p) => (
+                      <option key={p.id} value={p.id} disabled={!isEnabled(p)}>
+                        {p.label}
+                        {isEnabled(p) ? "" : " — configure first"}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+                  model
+                  <input
+                    className={inputClass}
+                    value={r.model}
+                    // Changing the model invalidates any pinned spec.
+                    onChange={(e) =>
+                      patchRow(tier, idx, {
+                        model: e.target.value,
+                        spec: undefined,
+                        specState: undefined,
+                      })
+                    }
+                    placeholder="claude-sonnet-4-6"
+                    aria-label={`${tier} provider ${idx + 1} model`}
+                  />
+                </label>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="rounded-sm"
+                  disabled={tiers[tier].length <= 1}
+                  onClick={() => removeProvider(tier, idx)}
                 >
-                  {r.provider && !known.has(r.provider) ? (
-                    <option value={r.provider}>{r.provider}</option>
-                  ) : null}
-                  {providers.map((p) => (
-                    <option key={p.id} value={p.id} disabled={!isEnabled(p)}>
-                      {p.label}
-                      {isEnabled(p) ? "" : " — configure first"}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <label className="flex flex-col gap-1 text-xs text-muted-foreground">
-                model
-                <input
-                  className={inputClass}
-                  value={r.model}
-                  onChange={(e) => patchRow(tier, idx, { model: e.target.value })}
-                  placeholder="claude-sonnet-4-6"
-                  aria-label={`${tier} provider ${idx + 1} model`}
-                />
-              </label>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                className="rounded-sm"
-                disabled={tiers[tier].length <= 1}
-                onClick={() => removeProvider(tier, idx)}
-              >
-                Remove
-              </Button>
+                  Remove
+                </Button>
+              </div>
+
+              {/* Spec resolution: pricing/context/capabilities pinned from LiteLLM. */}
+              <div className="flex items-center gap-3 text-xs">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="cursor-pointer rounded-sm"
+                  disabled={!r.provider || !r.model.trim() || r.specState === "loading"}
+                  onClick={() => fetchSpec(tier, idx)}
+                >
+                  {r.specState === "loading"
+                    ? "Resolving…"
+                    : r.spec
+                      ? "Refresh spec"
+                      : "Fetch spec"}
+                </Button>
+                {r.spec ? (
+                  <span className="truncate text-muted-foreground" title={specSummary(r.spec)}>
+                    {specSummary(r.spec)}
+                  </span>
+                ) : r.specState === "unmatched" ? (
+                  <span className="text-muted-foreground">
+                    No LiteLLM match — cost stays unpriced (enter pricing_overrides in config, or it
+                    just won&rsquo;t show cost).
+                  </span>
+                ) : r.specState === "error" ? (
+                  <span className="text-destructive">Couldn&rsquo;t reach the model catalog.</span>
+                ) : (
+                  <span className="text-muted-foreground">
+                    Spec auto-resolves from LiteLLM on Save (or fetch now to preview).
+                  </span>
+                )}
+              </div>
             </div>
           ))}
 

--- a/apps/web/app/components/observability/chart-canvas.tsx
+++ b/apps/web/app/components/observability/chart-canvas.tsx
@@ -1,0 +1,86 @@
+import { Chart, type ChartConfiguration } from "chart.js/auto";
+import { useEffect, useRef } from "react";
+
+/** Resolve a theme CSS variable (oklch) to a concrete color string for canvas drawing. */
+function themeColor(name: string, fallback: string): string {
+  if (typeof window === "undefined") return fallback;
+  const v = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+  return v || fallback;
+}
+
+export type Series = { labels: string[]; values: number[] };
+
+/**
+ * Minimal first-party chart.js canvas (line or bar) for the observability dashboard. Owns the Chart
+ * lifecycle (create on mount/data change, destroy on cleanup) so there are no leaked instances. Flat
+ * styling, ruby for the data series, muted axes — consistent with the design language.
+ */
+export function ChartCanvas({
+  kind,
+  data,
+  formatValue,
+  ariaLabel,
+}: {
+  kind: "line" | "bar";
+  data: Series;
+  formatValue?: (n: number) => string;
+  ariaLabel: string;
+}) {
+  const ref = useRef<HTMLCanvasElement | null>(null);
+  const sig = `${data.labels.join("|")}::${data.values.join(",")}`;
+
+  // Keyed on data *content* (`sig`), not the object identity (a fresh literal every render), so the
+  // chart rebuilds only when the series actually changes — not on every parent re-render.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: data is captured via `sig`.
+  useEffect(() => {
+    const canvas = ref.current;
+    if (!canvas) return;
+    const primary = themeColor("--primary", "oklch(0.55 0.21 18)");
+    const muted = themeColor("--muted-foreground", "#888");
+    const border = themeColor("--border", "#3334");
+    const fmt = formatValue ?? ((n: number) => String(n));
+
+    const config: ChartConfiguration = {
+      type: kind,
+      data: {
+        labels: data.labels,
+        datasets: [
+          {
+            data: data.values,
+            borderColor: primary,
+            backgroundColor: kind === "bar" ? primary : "transparent",
+            borderWidth: kind === "line" ? 2 : 0,
+            pointRadius: 0,
+            tension: 0.3,
+            fill: false,
+            maxBarThickness: 28,
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: { display: false },
+          tooltip: { callbacks: { label: (c) => fmt(c.parsed.y ?? 0) } },
+        },
+        scales: {
+          x: { grid: { display: false }, ticks: { color: muted, font: { size: 10 } } },
+          y: {
+            grid: { color: border },
+            ticks: { color: muted, font: { size: 10 }, callback: (v) => fmt(Number(v)) },
+            beginAtZero: true,
+          },
+        },
+      },
+    };
+    const chart = new Chart(canvas, config);
+    return () => chart.destroy();
+  }, [kind, sig, formatValue]);
+
+  return (
+    <div className="h-56 w-full">
+      <canvas ref={ref} aria-label={ariaLabel} role="img" />
+    </div>
+  );
+}

--- a/apps/web/app/lib/observability.test.ts
+++ b/apps/web/app/lib/observability.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { formatTokens, formatUsd } from "./observability";
+
+describe("formatUsd", () => {
+  it("formats normal amounts to cents", () => {
+    expect(formatUsd(42.18)).toBe("$42.18");
+  });
+  it("shows extra precision for sub-cent spend so it isn't $0.00", () => {
+    expect(formatUsd(0.0004)).toBe("$0.0004");
+  });
+  it("formats zero", () => {
+    expect(formatUsd(0)).toBe("$0.00");
+  });
+});
+
+describe("formatTokens", () => {
+  it("compacts millions and thousands", () => {
+    expect(formatTokens(1_200_000)).toBe("1.2M");
+    expect(formatTokens(4_500)).toBe("4.5k");
+  });
+  it("leaves small counts as-is", () => {
+    expect(formatTokens(320)).toBe("320");
+  });
+});

--- a/apps/web/app/lib/observability.ts
+++ b/apps/web/app/lib/observability.ts
@@ -1,0 +1,101 @@
+import { apiGet } from "./api";
+
+/*
+ * Read-only client for the AI observability dashboard (GET /api/v1/observability/summary).
+ * Admin-only on the API; a non-admin call throws ApiError(403). Mirrors the other lib/ wrappers.
+ */
+
+export type SummaryRange = "24h" | "7d" | "30d";
+
+export type ObsSummary = {
+  totals: { costUsd: number; tokens: number; turns: number; unpricedCalls: number };
+  series: Array<{ bucket: string; costUsd: number; tokens: number }>;
+  byAgent: Array<{ agentId: string; costUsd: number }>;
+  byModel: Array<{ model: string; costUsd: number; calls: number; unpriced: boolean }>;
+  reliability: {
+    turns: number;
+    turnErrors: number;
+    llmCalls: number;
+    llmErrors: number;
+    fallbacks: number;
+    toolCalls: number;
+    toolErrors: number;
+    p95DurationMs: number;
+  };
+};
+
+export async function getObservabilitySummary(range: SummaryRange): Promise<ObsSummary> {
+  return apiGet<ObsSummary>(`/api/v1/observability/summary?range=${range}`);
+}
+
+export type ObsConfigStatus = {
+  enabled: boolean;
+  otlpConfigured: boolean;
+  endpoint: string | null;
+  retentionDays: number;
+  captureContent: boolean;
+  spendAlertUsd: number | null;
+};
+
+export async function getObservabilityConfig(): Promise<ObsConfigStatus> {
+  return apiGet<ObsConfigStatus>("/api/v1/observability/config");
+}
+
+export type RecentTurn = {
+  conversationId: string | null;
+  agentId: string | null;
+  status: string | null;
+  tokensIn: number;
+  tokensOut: number;
+  steps: number;
+  ts: string;
+};
+
+export type TraceEvent = {
+  type: "llm_call" | "tool_call" | "turn" | "job";
+  ts: string;
+  agentId: string | null;
+  model: string | null;
+  provider: string | null;
+  tier: string | null;
+  status: string | null;
+  tokensIn: number | null;
+  tokensOut: number | null;
+  costUsd: number | null;
+  durationMs: number | null;
+  toolName: string | null;
+  attributes: Record<string, unknown>;
+};
+
+export async function getRecentTurns(limit = 25): Promise<RecentTurn[]> {
+  return apiGet<RecentTurn[]>(`/api/v1/observability/recent?limit=${limit}`);
+}
+
+export async function getTrace(conversationId: string): Promise<TraceEvent[]> {
+  return apiGet<TraceEvent[]>(`/api/v1/observability/trace/${encodeURIComponent(conversationId)}`);
+}
+
+/** Percentage string for an error/fallback rate (0 when the denominator is 0). */
+export function rate(numerator: number, denominator: number): string {
+  if (denominator <= 0) return "0%";
+  return `${((numerator / denominator) * 100).toFixed(1)}%`;
+}
+
+const USD = new Intl.NumberFormat(undefined, {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 2,
+});
+
+/** Money for headline cards: cents precision, but sub-cent spend shows more digits so it isn't $0.00. */
+export function formatUsd(n: number): string {
+  if (n > 0 && n < 0.01) return `$${n.toFixed(4)}`;
+  return USD.format(n);
+}
+
+/** Compact token counts: 1.2M / 4.5k / 320. */
+export function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+}

--- a/apps/web/app/lib/settings.ts
+++ b/apps/web/app/lib/settings.ts
@@ -9,13 +9,51 @@ import { apiDelete, apiGet, apiWrite } from "./api";
 
 // --- LLM config (mirrors @tulipfarm/llm LlmConfig; embeddings is read/preserved but not UI-editable) ---
 
+// Pinned model spec (pricing/context/capabilities), resolved from LiteLLM at config time. Mirrors
+// @tulipfarm/llm ModelSpec. Costs are USD per token.
+export type ModelSpec = {
+  litellm_key?: string;
+  input_cost_per_token?: number;
+  output_cost_per_token?: number;
+  cache_read_input_token_cost?: number;
+  cache_creation_input_token_cost?: number;
+  max_input_tokens?: number;
+  max_output_tokens?: number;
+  mode?: string;
+  supports_function_calling?: boolean;
+  supports_vision?: boolean;
+  supports_prompt_caching?: boolean;
+  supports_reasoning?: boolean;
+  deprecation_date?: string | null;
+  fetched_at?: string;
+};
+
 export type ProviderEntry = {
   provider: string;
   model: string;
   api_key_ref?: string;
   base_url?: string;
   resource_name?: string;
+  spec?: ModelSpec;
 };
+
+export type SpecResolution = {
+  spec: ModelSpec | null;
+  matchedKey: string | null;
+  candidates: string[];
+};
+
+/** Resolve a model's spec from LiteLLM (admin) so it can be pinned into the config. `refresh` forces
+ *  a re-fetch of the catalog past the server's cache. */
+export async function resolveModelSpec(
+  provider: string,
+  model: string,
+  refresh = false
+): Promise<SpecResolution> {
+  const q = new URLSearchParams({ provider, model });
+  if (refresh) q.set("refresh", "true");
+  return apiGet<SpecResolution>(`/api/v1/llm-config/resolve-spec?${q.toString()}`);
+}
 
 // Provider registry (served from @tulipfarm/secrets via GET /api/v1/llm-providers). Each provider
 // declares the full set of fields it needs — some secret (API keys), some plain config (resource

--- a/apps/web/app/routes/_app.settings.observability.tsx
+++ b/apps/web/app/routes/_app.settings.observability.tsx
@@ -1,0 +1,457 @@
+import { useLoaderData, useRouteError } from "@remix-run/react";
+import { useRef, useState } from "react";
+import { ChartCanvas } from "~/components/observability/chart-canvas";
+import { ErrorState } from "~/components/states";
+import { Sheet } from "~/components/ui/sheet";
+import { ApiError } from "~/lib/api";
+import {
+  formatTokens,
+  formatUsd,
+  getObservabilityConfig,
+  getObservabilitySummary,
+  getRecentTurns,
+  getTrace,
+  type ObsConfigStatus,
+  type ObsSummary,
+  type RecentTurn,
+  rate,
+  type SummaryRange,
+  type TraceEvent,
+} from "~/lib/observability";
+import { cn } from "~/lib/utils";
+
+const RANGES: { key: SummaryRange; label: string }[] = [
+  { key: "24h", label: "24h" },
+  { key: "7d", label: "7d" },
+  { key: "30d", label: "30d" },
+];
+
+/** Bucket label: hour-of-day for 24h, month/day otherwise. */
+function bucketLabel(iso: string, range: SummaryRange): string {
+  const d = new Date(iso);
+  return range === "24h"
+    ? d.toLocaleTimeString(undefined, { hour: "2-digit" })
+    : d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+export async function clientLoader() {
+  const [initial, config, recent] = await Promise.all([
+    getObservabilitySummary("7d"),
+    getObservabilityConfig(),
+    getRecentTurns(25),
+  ]);
+  return { initial, config, recent };
+}
+
+export default function SettingsObservability() {
+  const { initial, config, recent } = useLoaderData<typeof clientLoader>();
+  const [summary, setSummary] = useState<ObsSummary>(initial);
+  const [range, setRange] = useState<SummaryRange>("7d");
+  const [loading, setLoading] = useState(false);
+  // Generation guard: drop a summary fetch whose response loses the race to a newer range click.
+  const rangeReq = useRef(0);
+
+  async function applyRange(next: SummaryRange): Promise<void> {
+    setRange(next);
+    const id = ++rangeReq.current;
+    setLoading(true);
+    try {
+      const data = await getObservabilitySummary(next);
+      if (id === rangeReq.current) setSummary(data);
+    } finally {
+      if (id === rangeReq.current) setLoading(false);
+    }
+  }
+
+  const { totals, series, byAgent, byModel, reliability } = summary;
+  const maxAgentCost = Math.max(1e-9, ...byAgent.map((a) => a.costUsd));
+
+  return (
+    <div className={cn("flex flex-col gap-6", loading && "opacity-60 transition-opacity")}>
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">
+          What your agents are spending and doing. Cost is computed from token usage at a
+          best-effort price; unpriced models are counted but show no cost.
+        </p>
+        <nav className="flex shrink-0 gap-1">
+          {RANGES.map((r) => (
+            <button
+              key={r.key}
+              type="button"
+              onClick={() => applyRange(r.key)}
+              className={cn(
+                "cursor-pointer rounded-sm border px-2.5 py-1 text-xs transition-colors",
+                r.key === range
+                  ? "border-primary text-foreground"
+                  : "border-border text-muted-foreground hover:text-foreground"
+              )}
+            >
+              {r.label}
+            </button>
+          ))}
+        </nav>
+      </div>
+
+      {/* Headline metric cards */}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <MetricCard label="Spend" value={formatUsd(totals.costUsd)} />
+        <MetricCard label="Tokens" value={formatTokens(totals.tokens)} />
+        <MetricCard label="Turns" value={String(totals.turns)} />
+        <MetricCard
+          label="Unpriced calls"
+          value={String(totals.unpricedCalls)}
+          muted={totals.unpricedCalls === 0}
+        />
+      </div>
+
+      {/* Reliability */}
+      <Panel title="Reliability">
+        <div className="grid grid-cols-2 gap-x-6 gap-y-3 sm:grid-cols-4">
+          <Stat
+            label="Turn errors"
+            value={rate(reliability.turnErrors, reliability.turns)}
+            danger={reliability.turnErrors > 0}
+            sub={`${reliability.turnErrors}/${reliability.turns}`}
+          />
+          <Stat
+            label="Fallbacks"
+            value={rate(reliability.fallbacks, reliability.llmCalls)}
+            danger={reliability.fallbacks > 0}
+            sub={`${reliability.fallbacks}/${reliability.llmCalls}`}
+          />
+          <Stat
+            label="Tool errors"
+            value={rate(reliability.toolErrors, reliability.toolCalls)}
+            danger={reliability.toolErrors > 0}
+            sub={`${reliability.toolErrors}/${reliability.toolCalls}`}
+          />
+          <Stat label="Step latency p95" value={`${reliability.p95DurationMs} ms`} />
+        </div>
+      </Panel>
+
+      {/* Spend over time */}
+      <Panel title="Spend over time">
+        {series.length === 0 ? (
+          <EmptyHint />
+        ) : (
+          <ChartCanvas
+            kind="line"
+            ariaLabel="Spend over time"
+            formatValue={formatUsd}
+            data={{
+              labels: series.map((p) => bucketLabel(p.bucket, range)),
+              values: series.map((p) => p.costUsd),
+            }}
+          />
+        )}
+      </Panel>
+
+      {/* Spend by agent */}
+      <Panel title="Spend by agent">
+        {byAgent.length === 0 ? (
+          <EmptyHint />
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {byAgent.map((a) => (
+              <li key={a.agentId} className="flex items-center gap-3">
+                <span className="w-40 shrink-0 truncate text-sm text-foreground" title={a.agentId}>
+                  {a.agentId}
+                </span>
+                <span className="h-2 flex-1 overflow-hidden rounded-sm bg-muted/40">
+                  <span
+                    className="block h-full bg-primary"
+                    style={{ width: `${Math.max(2, (a.costUsd / maxAgentCost) * 100)}%` }}
+                  />
+                </span>
+                <span className="w-20 shrink-0 text-right text-sm tabular-nums text-muted-foreground">
+                  {formatUsd(a.costUsd)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Panel>
+
+      {/* By model */}
+      <Panel title="By model">
+        {byModel.length === 0 ? (
+          <EmptyHint />
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-border border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
+                <th className="py-1.5 font-normal">Model</th>
+                <th className="py-1.5 text-right font-normal">Calls</th>
+                <th className="py-1.5 text-right font-normal">Cost</th>
+              </tr>
+            </thead>
+            <tbody>
+              {byModel.map((m) => (
+                <tr key={m.model} className="border-border/60 border-b">
+                  <td className="py-1.5 text-foreground">{m.model}</td>
+                  <td className="py-1.5 text-right tabular-nums text-muted-foreground">
+                    {m.calls}
+                  </td>
+                  <td className="py-1.5 text-right tabular-nums text-muted-foreground">
+                    {m.unpriced ? (
+                      <span title="No price found for this model — add a pricing override in observability.config.yaml">
+                        unpriced
+                      </span>
+                    ) : (
+                      formatUsd(m.costUsd)
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </Panel>
+
+      <RecentTurnsPanel recent={recent} />
+
+      <GrafanaExportPanel config={config} />
+    </div>
+  );
+}
+
+function RecentTurnsPanel({ recent }: { recent: RecentTurn[] }) {
+  const [open, setOpen] = useState<RecentTurn | null>(null);
+  const [trace, setTrace] = useState<TraceEvent[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // Generation guard: a slower earlier trace fetch must not overwrite the one the user just opened.
+  const traceReq = useRef(0);
+
+  async function openTrace(turn: RecentTurn): Promise<void> {
+    setOpen(turn);
+    setTrace(null);
+    setError(null);
+    if (!turn.conversationId) return;
+    const id = ++traceReq.current;
+    setLoading(true);
+    try {
+      const events = await getTrace(turn.conversationId);
+      if (id === traceReq.current) setTrace(events);
+    } catch (err) {
+      // A server/network failure must read as an error, not as "no trace events".
+      if (id === traceReq.current) {
+        setError(err instanceof ApiError ? err.message : "Failed to load trace");
+      }
+    } finally {
+      if (id === traceReq.current) setLoading(false);
+    }
+  }
+
+  return (
+    <Panel title="Recent turns">
+      {recent.length === 0 ? (
+        <EmptyHint />
+      ) : (
+        <ul className="flex flex-col">
+          {recent.map((t, i) => (
+            <li key={`${t.conversationId}-${t.ts}-${i}`}>
+              <button
+                type="button"
+                onClick={() => openTrace(t)}
+                disabled={!t.conversationId}
+                className="flex w-full cursor-pointer items-center gap-3 border-border/60 border-b py-2 text-left transition-colors hover:bg-accent/50 disabled:cursor-default"
+              >
+                <span
+                  className={cn(
+                    "inline-block size-2 shrink-0 rounded-full",
+                    t.status === "error" ? "bg-destructive" : "bg-primary"
+                  )}
+                  aria-hidden
+                />
+                <span className="min-w-0 flex-1 truncate text-sm text-foreground">
+                  {t.agentId ?? "agent"}
+                </span>
+                <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+                  {t.steps} steps · {formatTokens(t.tokensIn + t.tokensOut)} tok
+                </span>
+                <span className="w-28 shrink-0 text-right text-xs text-muted-foreground">
+                  {new Date(t.ts).toLocaleString(undefined, {
+                    month: "short",
+                    day: "numeric",
+                    hour: "2-digit",
+                    minute: "2-digit",
+                  })}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <Sheet open={open !== null} onClose={() => setOpen(null)} title="Turn trace">
+        {loading ? (
+          <p className="text-sm text-muted-foreground">Loading trace…</p>
+        ) : error ? (
+          <p className="text-sm text-destructive">{error}</p>
+        ) : trace && trace.length > 0 ? (
+          <ol className="flex flex-col gap-2">
+            {trace.map((e, i) => (
+              <TraceRow key={`${e.type}-${e.ts}-${i}`} e={e} />
+            ))}
+          </ol>
+        ) : (
+          <p className="text-sm text-muted-foreground">No trace events for this conversation.</p>
+        )}
+      </Sheet>
+    </Panel>
+  );
+}
+
+function TraceRow({ e }: { e: TraceEvent }) {
+  const isError = e.status === "error";
+  const label =
+    e.type === "llm_call"
+      ? `${e.model ?? "model"}${e.tier ? ` · ${e.tier}` : ""}`
+      : e.type === "tool_call"
+        ? (e.toolName ?? "tool")
+        : e.type;
+  return (
+    <li className="flex items-start gap-3 border-border/60 border-b pb-2">
+      <span
+        className={cn(
+          "mt-1 inline-block size-2 shrink-0 rounded-full",
+          isError || e.status === "fallback" ? "bg-destructive" : "bg-primary"
+        )}
+        aria-hidden
+      />
+      <span className="min-w-0 flex-1">
+        <span className="flex items-center gap-2">
+          <span className="text-xs uppercase tracking-wide text-muted-foreground">{e.type}</span>
+          <span className="truncate text-sm text-foreground">{label}</span>
+          {e.status && e.status !== "ok" ? (
+            <span className="rounded-sm bg-destructive/10 px-1 text-xs text-destructive">
+              {e.status}
+            </span>
+          ) : null}
+        </span>
+        <span className="mt-0.5 flex flex-wrap gap-x-3 text-xs tabular-nums text-muted-foreground">
+          {e.tokensIn != null ? (
+            <span>
+              {e.tokensIn}↑ / {e.tokensOut ?? 0}↓ tok
+            </span>
+          ) : null}
+          {e.costUsd != null ? <span>{formatUsd(e.costUsd)}</span> : null}
+          {e.durationMs != null ? <span>{e.durationMs} ms</span> : null}
+        </span>
+      </span>
+    </li>
+  );
+}
+
+function GrafanaExportPanel({ config }: { config: ObsConfigStatus }) {
+  const status = config.enabled && config.otlpConfigured ? "On" : "Off";
+  return (
+    <Panel title="Grafana Cloud export">
+      <div className="flex flex-col gap-3 text-sm">
+        <div className="flex items-center gap-2">
+          <span
+            className={cn(
+              "inline-block size-2 rounded-full",
+              status === "On" ? "bg-primary" : "bg-muted-foreground"
+            )}
+            aria-hidden
+          />
+          <span className="text-foreground">
+            OTLP metrics export is <span className="font-bold">{status}</span>
+          </span>
+          {config.otlpConfigured && config.endpoint ? (
+            <span className="truncate text-xs text-muted-foreground">→ {config.endpoint}</span>
+          ) : null}
+        </div>
+        <p className="text-muted-foreground">
+          Push cost, token, error, fallback, and tool metrics to Grafana Cloud (Mimir) for richer
+          dashboards and alerting. Configure <code className="text-foreground">otlp</code> in{" "}
+          <code className="text-foreground">soul/observability.config.yaml</code> with your
+          endpoint, instance id, and token (a secret ref), then restart. Import the ready-made
+          dashboard and alert rules from{" "}
+          <code className="text-foreground">apps/api/src/observability/grafana/</code>.
+        </p>
+        <dl className="grid grid-cols-2 gap-x-6 gap-y-1 text-xs sm:grid-cols-3">
+          <ConfigRow label="Retention" value={`${config.retentionDays} days`} />
+          <ConfigRow label="Content capture" value={config.captureContent ? "On" : "Off"} />
+          <ConfigRow
+            label="Spend alert"
+            value={config.spendAlertUsd != null ? formatUsd(config.spendAlertUsd) : "unset"}
+          />
+        </dl>
+      </div>
+    </Panel>
+  );
+}
+
+function ConfigRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex justify-between gap-2 border-border/60 border-b py-1">
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="tabular-nums text-foreground">{value}</dd>
+    </div>
+  );
+}
+
+function MetricCard({ label, value, muted }: { label: string; value: string; muted?: boolean }) {
+  return (
+    <div className="rounded-sm border border-border px-3 py-3">
+      <p className="text-xs uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p
+        className={cn(
+          "mt-1 text-xl font-bold tabular-nums",
+          muted ? "text-muted-foreground" : "text-foreground"
+        )}
+      >
+        {value}
+      </p>
+    </div>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  sub,
+  danger,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+  danger?: boolean;
+}) {
+  return (
+    <div>
+      <p className="text-xs uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className={cn("mt-1 text-lg font-bold tabular-nums", danger && "text-destructive")}>
+        {value}
+      </p>
+      {sub ? <p className="text-xs tabular-nums text-muted-foreground">{sub}</p> : null}
+    </div>
+  );
+}
+
+function Panel({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="rounded-sm border border-border p-4">
+      <h2 className="mb-3 text-sm font-bold text-foreground">{title}</h2>
+      {children}
+    </section>
+  );
+}
+
+function EmptyHint() {
+  return (
+    <p className="py-6 text-center text-sm text-muted-foreground">
+      No activity in this window yet.
+    </p>
+  );
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+  const status = error instanceof ApiError ? error.status : undefined;
+  const message = error instanceof Error ? error.message : undefined;
+  return <ErrorState section="settings" status={status} message={message} />;
+}

--- a/apps/web/app/routes/_app.settings.tsx
+++ b/apps/web/app/routes/_app.settings.tsx
@@ -6,6 +6,7 @@ export const meta: MetaFunction = () => [{ title: "Settings · tulipfarm" }];
 const tabs = [
   { to: "/settings/secrets", label: "Secrets", end: false },
   { to: "/settings/llm", label: "LLM", end: false },
+  { to: "/settings/observability", label: "Observability", end: false },
   { to: "/settings/soul", label: "Soul", end: false },
   { to: "/settings/activities", label: "Activities", end: false },
   { to: "/settings/memory", label: "Memory", end: false },

--- a/packages/llm/src/config.ts
+++ b/packages/llm/src/config.ts
@@ -39,12 +39,38 @@ export class EmbeddingUnavailableError extends Error {
 /** Warning surfaced to search callers when no embedding provider is available. */
 export const EMBEDDING_UNAVAILABLE_WARNING = "embedding-unavailable";
 
+// Curated model spec, resolved from LiteLLM's model_prices_and_context_window.json at config time and
+// pinned into the soul (deterministic + git-audited). Field names follow LiteLLM's where they map, so
+// the shape is a recognizable standard. Costs are USD per token (LiteLLM's unit). `additionalProperties`
+// stays open so future LiteLLM fields don't fail validation.
+const ModelSpecSchema = Type.Object(
+  {
+    litellm_key: Type.Optional(Type.String()),
+    input_cost_per_token: Type.Optional(Type.Number({ minimum: 0 })),
+    output_cost_per_token: Type.Optional(Type.Number({ minimum: 0 })),
+    cache_read_input_token_cost: Type.Optional(Type.Number({ minimum: 0 })),
+    cache_creation_input_token_cost: Type.Optional(Type.Number({ minimum: 0 })),
+    max_input_tokens: Type.Optional(Type.Integer({ minimum: 1 })),
+    max_output_tokens: Type.Optional(Type.Integer({ minimum: 1 })),
+    mode: Type.Optional(Type.String()),
+    supports_function_calling: Type.Optional(Type.Boolean()),
+    supports_vision: Type.Optional(Type.Boolean()),
+    supports_prompt_caching: Type.Optional(Type.Boolean()),
+    supports_reasoning: Type.Optional(Type.Boolean()),
+    deprecation_date: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+    /** ISO date the spec was resolved/refreshed from LiteLLM. */
+    fetched_at: Type.Optional(Type.String()),
+  },
+  { additionalProperties: true }
+);
+
 const ProviderEntrySchema = Type.Object({
   provider: Type.String(),
   model: Type.String({ minLength: 1, pattern: "^\\S+$" }),
   api_key_ref: Type.Optional(Type.String()),
   base_url: Type.Optional(Type.String()),
   resource_name: Type.Optional(Type.String()),
+  spec: Type.Optional(ModelSpecSchema),
 });
 
 const TierConfigSchema = Type.Object({
@@ -73,6 +99,7 @@ export const LlmConfigSchema = Type.Object({
   embeddings: Type.Optional(EmbeddingsConfigSchema),
 });
 
+export type ModelSpec = Static<typeof ModelSpecSchema>;
 export type ProviderEntry = Static<typeof ProviderEntrySchema>;
 export type TierConfig = Static<typeof TierConfigSchema>;
 export type EmbeddingProviderEntry = Static<typeof EmbeddingProviderEntrySchema>;

--- a/packages/llm/src/index.ts
+++ b/packages/llm/src/index.ts
@@ -2,6 +2,7 @@ export type {
   EmbeddingProviderEntry,
   EmbeddingsConfig,
   LlmConfig,
+  ModelSpec,
   ProviderEntry,
   TierConfig,
 } from "./config";
@@ -17,8 +18,20 @@ export {
 export { createEmbeddingModel } from "./embedding-provider";
 export { type EmbeddingLogger, EmbeddingService } from "./embeddings";
 export { type FallbackLogger, FallbackModel, isHardFailure } from "./fallback";
-export type { SelectRequest, Tier } from "./llm-service";
+export type {
+  ResolvedModel,
+  ResolvedModelEntry,
+  SelectRequest,
+  Tier,
+} from "./llm-service";
 export { LlmService } from "./llm-service";
+export {
+  fetchLiteLlmCatalog,
+  type LiteLlmCatalog,
+  resolveModelSpec,
+  type SpecResolution,
+} from "./model-spec";
+export { type ModelPrice, PRICING, type PriceResult, priceFor } from "./pricing";
 export { createModel } from "./provider";
 export type { Autonomy, ModelSelector, SelectionContext } from "./selection";
 export { resolveTier } from "./selection";

--- a/packages/llm/src/llm-service.test.ts
+++ b/packages/llm/src/llm-service.test.ts
@@ -261,3 +261,56 @@ describe("LlmService.select", () => {
     expect(() => svc.select({ model: "auto" })).toThrow(LlmNotConfiguredError);
   });
 });
+
+describe("LlmService.resolve", () => {
+  // A tier with two providers so chain ordering (config order) is observable.
+  const multiConfig = {
+    tiers: {
+      quick: {
+        providers: [
+          { provider: "azure", model: "gpt-4o-mini", api_key_ref: "key" },
+          { provider: "anthropic", model: "claude-haiku-4-5", api_key_ref: "key" },
+        ],
+      },
+      standard: {
+        providers: [{ provider: "anthropic", model: "claude-sonnet-4-6", api_key_ref: "key" }],
+      },
+      complex: {
+        providers: [{ provider: "anthropic", model: "claude-opus-4-8", api_key_ref: "key" }],
+      },
+    },
+  };
+  const init = async () => {
+    const svc = new LlmService();
+    await svc.init(multiConfig, fakeSecrets);
+    return svc;
+  };
+
+  it("resolves a tier with its ordered provider/model chain + primary id", async () => {
+    const r = (await init()).resolve({ model: "quick" });
+    expect(r.tier).toBe("quick");
+    expect(r.modelId).toBe("gpt-4o-mini");
+    expect(r.chain).toEqual([
+      { provider: "azure", modelId: "gpt-4o-mini" },
+      { provider: "anthropic", modelId: "claude-haiku-4-5" },
+    ]);
+  });
+
+  it("auto selection carries tier metadata", async () => {
+    const r = (await init()).resolve({ model: "auto", autonomy: "supervised" });
+    expect(r.tier).toBe("standard");
+    expect(r.modelId).toBe("claude-sonnet-4-6");
+  });
+
+  it("raw model id resolves to a single-entry chain with provider, no tier", async () => {
+    const r = (await init()).resolve({ model: "claude-opus-4-8" });
+    expect(r.tier).toBeUndefined();
+    expect(r.modelId).toBe("claude-opus-4-8");
+    expect(r.chain).toEqual([{ provider: "anthropic", modelId: "claude-opus-4-8" }]);
+  });
+
+  it("unknown raw model id throws UnknownModelError", async () => {
+    const svc = await init();
+    expect(() => svc.resolve({ model: "no-such-model" })).toThrow(UnknownModelError);
+  });
+});

--- a/packages/llm/src/llm-service.ts
+++ b/packages/llm/src/llm-service.ts
@@ -4,6 +4,7 @@ import {
   LlmConfigValidationError,
   LlmCredentialError,
   LlmNotConfiguredError,
+  type ModelSpec,
   UnknownModelError,
   validateLlmConfig,
 } from "./config";
@@ -22,9 +23,33 @@ export type SelectRequest = SelectionContext & {
   sessionModel?: ModelSelector;
 };
 
+/** One link in a resolved fallback chain: the configured provider + its model id, in config order. */
+export interface ResolvedModelEntry {
+  provider: string;
+  modelId: string;
+  /** Pinned spec from llm.config (pricing/context/capabilities), when resolved for this model. */
+  spec?: ModelSpec;
+}
+
+/**
+ * The outcome of resolving a model for one turn — the `LanguageModel` to run plus the metadata
+ * needed to attribute the call (observability): the primary model id, the tier (if tier/auto
+ * selection was used), and the ordered provider/model `chain`. For a raw model-id selection the
+ * chain holds the single entry. The served model can differ from `modelId` under fallback; callers
+ * reconcile via the chain.
+ */
+export interface ResolvedModel {
+  model: LanguageModel;
+  modelId: string;
+  tier?: Tier;
+  chain: ResolvedModelEntry[];
+}
+
 export class LlmService {
   private models: Map<Tier, LanguageModel> | null = null;
   private byModelId: Map<string, LanguageModel> = new Map();
+  private chainByTier: Map<Tier, ResolvedModelEntry[]> = new Map();
+  private entryByModelId: Map<string, ResolvedModelEntry> = new Map();
 
   async init(
     rawConfig: unknown,
@@ -39,6 +64,8 @@ export class LlmService {
     const config = validateLlmConfig(rawConfig);
     const models = new Map<Tier, LanguageModel>();
     const byModelId = new Map<string, LanguageModel>();
+    const chainByTier = new Map<Tier, ResolvedModelEntry[]>();
+    const entryByModelId = new Map<string, ResolvedModelEntry>();
 
     for (const tier of TIERS) {
       const { providers } = config.tiers[tier];
@@ -49,7 +76,12 @@ export class LlmService {
       const resolved = await Promise.all(
         providers.map(async (entry) => {
           try {
-            return { model: await createModel(entry, secrets), id: entry.model };
+            return {
+              model: await createModel(entry, secrets),
+              id: entry.model,
+              provider: entry.provider,
+              spec: entry.spec,
+            };
           } catch (err) {
             if (err instanceof LlmCredentialError || err instanceof LlmConfigValidationError) {
               console.warn(
@@ -63,10 +95,14 @@ export class LlmService {
       );
 
       const built: Awaited<ReturnType<typeof createModel>>[] = [];
+      const chain: ResolvedModelEntry[] = [];
       for (const r of resolved) {
         if (r === null) continue;
         built.push(r.model);
+        chain.push({ provider: r.provider, modelId: r.id, spec: r.spec });
         if (!byModelId.has(r.id)) byModelId.set(r.id, r.model);
+        if (!entryByModelId.has(r.id))
+          entryByModelId.set(r.id, { provider: r.provider, modelId: r.id, spec: r.spec });
       }
 
       if (built.length === 0) {
@@ -75,6 +111,7 @@ export class LlmService {
       }
 
       models.set(tier, new FallbackModel(built, logger));
+      chainByTier.set(tier, chain);
       console.info(`[llm] tier=${tier} providers=${built.length}`);
     }
 
@@ -85,6 +122,8 @@ export class LlmService {
 
     this.models = models;
     this.byModelId = byModelId;
+    this.chainByTier = chainByTier;
+    this.entryByModelId = entryByModelId;
   }
 
   getModel(tier: Tier): LanguageModel {
@@ -102,15 +141,28 @@ export class LlmService {
   }
 
   /**
-   * Resolve a model for one turn. Precedence: per-turn sessionModel, then the
-   * caller's configured model, else `auto`. A tier name returns that tier's
-   * fallback chain; `auto` runs the rule-based selection; any other string is a
-   * raw provider model id that bypasses tiers (single model, no fallback).
+   * Resolve a model for one turn, with attribution metadata. Precedence: per-turn sessionModel,
+   * then the caller's configured model, else `auto`. A tier name (or `auto`'s rule-based pick)
+   * returns that tier's fallback chain; any other string is a raw provider model id that bypasses
+   * tiers (single model, no fallback). See `ResolvedModel`.
    */
-  select(req: SelectRequest): LanguageModel {
+  resolve(req: SelectRequest): ResolvedModel {
     const selector = req.sessionModel ?? req.model ?? "auto";
-    if (selector === "auto") return this.getModel(resolveTier(req));
-    if (isTier(selector)) return this.getModel(selector);
-    return this.getModelById(selector);
+    if (selector === "auto") return this.resolveTierModel(resolveTier(req));
+    if (isTier(selector)) return this.resolveTierModel(selector);
+    const model = this.getModelById(selector);
+    const entry = this.entryByModelId.get(selector) ?? { provider: "unknown", modelId: selector };
+    return { model, modelId: selector, chain: [entry] };
+  }
+
+  private resolveTierModel(tier: Tier): ResolvedModel {
+    const model = this.getModel(tier);
+    const chain = this.chainByTier.get(tier) ?? [];
+    return { model, modelId: chain[0]?.modelId ?? "", tier, chain };
+  }
+
+  /** Backward-compatible accessor: the resolved `LanguageModel` only (see `resolve` for metadata). */
+  select(req: SelectRequest): LanguageModel {
+    return this.resolve(req).model;
   }
 }

--- a/packages/llm/src/model-spec.test.ts
+++ b/packages/llm/src/model-spec.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from "vitest";
+import { fetchLiteLlmCatalog, type LiteLlmCatalog, resolveModelSpec } from "./model-spec";
+
+const FETCHED = "2026-06-28";
+
+const CATALOG: LiteLlmCatalog = {
+  sample_spec: { input_cost_per_token: 0 },
+  "gpt-4o": {
+    input_cost_per_token: 0.0000025,
+    output_cost_per_token: 0.00001,
+    max_input_tokens: 128000,
+    max_output_tokens: 16384,
+    mode: "chat",
+    supports_function_calling: true,
+    supports_vision: true,
+    supports_prompt_caching: true,
+  },
+  "azure_ai/kimi-k2.5": {
+    input_cost_per_token: 0.00000057,
+    output_cost_per_token: 0.0000023,
+    max_input_tokens: 256000,
+    mode: "chat",
+    supports_function_calling: true,
+  },
+  "xai/grok-4-1-fast": {
+    input_cost_per_token: 0.000002,
+    output_cost_per_token: 0.00001,
+    mode: "chat",
+  },
+  "openrouter/moonshotai/kimi-k2.5": {
+    input_cost_per_token: 0.0000006,
+    output_cost_per_token: 0.0000025,
+  },
+  // A non-chat / cost-less entry: a confident match requires pricing, so this routes to candidates.
+  "text-embedding-3-small": { mode: "embedding", max_input_tokens: 8191 },
+};
+
+describe("resolveModelSpec", () => {
+  it("matches a bare openai model id", () => {
+    const r = resolveModelSpec("openai", "gpt-4o", CATALOG, FETCHED);
+    expect(r.matchedKey).toBe("gpt-4o");
+    expect(r.spec).toMatchObject({
+      litellm_key: "gpt-4o",
+      input_cost_per_token: 0.0000025,
+      output_cost_per_token: 0.00001,
+      max_input_tokens: 128000,
+      supports_vision: true,
+      fetched_at: FETCHED,
+    });
+  });
+
+  it("matches an azure model via the azure_ai/ prefix", () => {
+    const r = resolveModelSpec("azure", "kimi-k2.5", CATALOG, FETCHED);
+    expect(r.matchedKey).toBe("azure_ai/kimi-k2.5");
+    expect(r.spec?.input_cost_per_token).toBe(0.00000057);
+  });
+
+  it("matches an openai-compatible model by suffix when there's a single bare-id match", () => {
+    const r = resolveModelSpec("openai-compatible", "grok-4-1-fast", CATALOG, FETCHED);
+    expect(r.matchedKey).toBe("xai/grok-4-1-fast");
+  });
+
+  it("returns candidates (no confident match) when the bare id is ambiguous", () => {
+    // both `azure_ai/kimi-k2.5` and `openrouter/moonshotai/kimi-k2.5` end in `kimi-k2.5`
+    const r = resolveModelSpec("openai-compatible", "kimi-k2.5", CATALOG, FETCHED);
+    expect(r.spec).toBeNull();
+    expect(r.candidates).toContain("azure_ai/kimi-k2.5");
+    expect(r.candidates).toContain("openrouter/moonshotai/kimi-k2.5");
+  });
+
+  it("returns no match + loose candidates for an unknown model", () => {
+    const r = resolveModelSpec("openai", "totally-made-up-model", CATALOG, FETCHED);
+    expect(r.matchedKey).toBeNull();
+    expect(r.spec).toBeNull();
+  });
+
+  it("does not confidently match a cost-less (non-chat) entry; offers it as a candidate", () => {
+    const r = resolveModelSpec("openai", "text-embedding-3-small", CATALOG, FETCHED);
+    expect(r.spec).toBeNull();
+    expect(r.matchedKey).toBeNull();
+    expect(r.candidates).toContain("text-embedding-3-small");
+  });
+});
+
+describe("fetchLiteLlmCatalog", () => {
+  it("returns the parsed catalog", async () => {
+    const fetchMock = vi.fn(
+      async () => ({ ok: true, json: async () => CATALOG }) as unknown as Response
+    );
+    const cat = await fetchLiteLlmCatalog({ fetchImpl: fetchMock as unknown as typeof fetch });
+    expect(cat?.["gpt-4o"]).toBeDefined();
+  });
+
+  it("returns null on failure (caller degrades to no spec)", async () => {
+    const fetchMock = vi.fn(async () => {
+      throw new Error("offline");
+    });
+    expect(
+      await fetchLiteLlmCatalog({ fetchImpl: fetchMock as unknown as typeof fetch })
+    ).toBeNull();
+  });
+});

--- a/packages/llm/src/model-spec.ts
+++ b/packages/llm/src/model-spec.ts
@@ -1,0 +1,137 @@
+import type { ModelSpec } from "./config";
+
+/**
+ * Config-time model-spec resolution from LiteLLM's community-maintained
+ * `model_prices_and_context_window.json` — the de-facto pricing/capability DB across the LLM tooling
+ * ecosystem. Resolved once when a model is added/refreshed in Settings and pinned into the soul's
+ * llm.config (deterministic + git-audited), rather than fetched per request.
+ */
+
+// Canonical location is the repo ROOT (the `litellm/<file>` path 404s).
+const LITELLM_CATALOG_URL =
+  "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
+
+/** Raw LiteLLM catalog: model key → entry (we read a curated subset of fields). */
+export type LiteLlmCatalog = Record<string, Record<string, unknown>>;
+
+/**
+ * TulipFarm provider → candidate LiteLLM key prefixes (LiteLLM keys look like `azure_ai/kimi-k2.5`,
+ * `xai/grok-4`, `anthropic/claude-...`, or bare `gpt-4o`). `""` means "try the bare model id".
+ * Order = match priority. `openai-compatible` can be anything, so we also fall back to a suffix search.
+ */
+const PROVIDER_PREFIXES: Record<string, string[]> = {
+  anthropic: ["", "anthropic/"],
+  openai: ["", "openai/"],
+  azure: ["azure_ai/", "azure/", ""],
+  "openai-compatible": [""],
+};
+
+/** Fetch the LiteLLM catalog. Best-effort: network/parse failure resolves to `null` (caller degrades). */
+export async function fetchLiteLlmCatalog(opts?: {
+  url?: string;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}): Promise<LiteLlmCatalog | null> {
+  const url = opts?.url ?? LITELLM_CATALOG_URL;
+  const fetchImpl = opts?.fetchImpl ?? fetch;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), opts?.timeoutMs ?? 6000);
+  try {
+    const res = await fetchImpl(url, { signal: controller.signal });
+    if (!res.ok) return null;
+    const data = (await res.json()) as unknown;
+    if (!data || typeof data !== "object") return null;
+    return data as LiteLlmCatalog;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function num(v: unknown): number | undefined {
+  return typeof v === "number" && Number.isFinite(v) ? v : undefined;
+}
+function bool(v: unknown): boolean | undefined {
+  return typeof v === "boolean" ? v : undefined;
+}
+function str(v: unknown): string | undefined {
+  return typeof v === "string" ? v : undefined;
+}
+
+/** Curate a LiteLLM entry into our pinned ModelSpec (chat models only). */
+function curate(key: string, entry: Record<string, unknown>, fetchedAt: string): ModelSpec {
+  return {
+    litellm_key: key,
+    input_cost_per_token: num(entry.input_cost_per_token),
+    output_cost_per_token: num(entry.output_cost_per_token),
+    cache_read_input_token_cost: num(entry.cache_read_input_token_cost),
+    cache_creation_input_token_cost: num(entry.cache_creation_input_token_cost),
+    max_input_tokens: num(entry.max_input_tokens),
+    max_output_tokens: num(entry.max_output_tokens),
+    mode: str(entry.mode),
+    supports_function_calling: bool(entry.supports_function_calling),
+    supports_vision: bool(entry.supports_vision),
+    supports_prompt_caching: bool(entry.supports_prompt_caching),
+    supports_reasoning: bool(entry.supports_reasoning),
+    deprecation_date: str(entry.deprecation_date) ?? null,
+    fetched_at: fetchedAt,
+  };
+}
+
+export interface SpecResolution {
+  /** The curated spec, or null when no confident match was found. */
+  spec: ModelSpec | null;
+  /** The LiteLLM key that matched (null if unmatched). */
+  matchedKey: string | null;
+  /** Other plausible keys (suffix matches) for the admin to pick from when unmatched/ambiguous. */
+  candidates: string[];
+}
+
+/**
+ * Resolve a TulipFarm (provider, model[, base_url]) to a pinned ModelSpec from the LiteLLM catalog.
+ * Tries provider-prefixed + bare keys (exact, then case-insensitive), then a suffix search across the
+ * catalog. Returns the best match plus alternative candidates so the UI can confirm/override.
+ */
+export function resolveModelSpec(
+  provider: string,
+  model: string,
+  catalog: LiteLlmCatalog,
+  fetchedAt: string
+): SpecResolution {
+  const prefixes = PROVIDER_PREFIXES[provider] ?? [""];
+  // Exclude LiteLLM's `sample_spec` documentation placeholder from all matching.
+  const keys = Object.keys(catalog).filter((k) => k !== "sample_spec");
+  const lowerIndex = new Map(keys.map((k) => [k.toLowerCase(), k]));
+
+  // A confident match must carry pricing — a cost-less entry (embedding/image/non-chat model) would
+  // pin a misleading "—/— per Mtok" spec, so we route those to candidates instead.
+  const confident = (key: string): SpecResolution | null => {
+    const spec = curate(key, catalog[key], fetchedAt);
+    if (typeof spec.input_cost_per_token !== "number") return null;
+    return { spec, matchedKey: key, candidates: [] };
+  };
+
+  // 1. Exact / case-insensitive match on each candidate `${prefix}${model}`.
+  for (const prefix of prefixes) {
+    const candidate = `${prefix}${model}`;
+    const hit = catalog[candidate] ? candidate : lowerIndex.get(candidate.toLowerCase());
+    const m = hit && hit !== "sample_spec" ? confident(hit) : null;
+    if (m) return m;
+  }
+
+  // 2. Suffix search: any catalog key whose bare id (after the last `/`) equals the model.
+  const m = model.toLowerCase();
+  const suffixMatches = keys.filter((k) => k.slice(k.lastIndexOf("/") + 1).toLowerCase() === m);
+  if (suffixMatches.length === 1) {
+    const hit = confident(suffixMatches[0]);
+    if (hit) return hit;
+  }
+  if (suffixMatches.length >= 1) {
+    return { spec: null, matchedKey: null, candidates: suffixMatches.slice(0, 10) };
+  }
+
+  // 3. Loose: keys that contain the model as a substring (helps near-misses); offered as candidates.
+  const loose = keys.filter((k) => k.toLowerCase().includes(m)).slice(0, 10);
+  return { spec: null, matchedKey: null, candidates: loose };
+}

--- a/packages/llm/src/pricing.test.ts
+++ b/packages/llm/src/pricing.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { priceFor } from "./pricing";
+
+describe("priceFor", () => {
+  it("prices a known model from input/output token counts", () => {
+    // claude-opus-4-8 = $15/Mtok in, $75/Mtok out
+    const { costUsd } = priceFor("claude-opus-4-8", 1_000_000, 1_000_000);
+    expect(costUsd).toBe(90);
+  });
+
+  it("scales sub-million token counts", () => {
+    // 10k in @ $3/M + 2k out @ $15/M = 0.03 + 0.03 = 0.06
+    const { costUsd } = priceFor("claude-sonnet-4-6", 10_000, 2_000);
+    expect(costUsd).toBeCloseTo(0.06, 6);
+  });
+
+  it("matches a dated provider id to its family prefix", () => {
+    const { costUsd } = priceFor("claude-opus-4-20250901", 1_000_000, 0);
+    expect(costUsd).toBe(15);
+  });
+
+  it("returns null cost for an unknown model (unpriced)", () => {
+    expect(priceFor("some-unlisted-model", 1000, 1000).costUsd).toBeNull();
+  });
+
+  it("returns null cost for a missing model id", () => {
+    expect(priceFor(null, 1000, 1000).costUsd).toBeNull();
+    expect(priceFor(undefined, 1000, 1000).costUsd).toBeNull();
+  });
+
+  it("prefers an explicit override over the built-in map", () => {
+    const { costUsd } = priceFor("claude-opus-4-8", 1_000_000, 0, {
+      "claude-opus-4-8": { in: 1, out: 1 },
+    });
+    expect(costUsd).toBe(1);
+  });
+
+  it("prices a model only present in the extra map, prefix-tolerant", () => {
+    const extra = { "gpt-5.4": { in: 2, out: 8 } };
+    expect(priceFor("gpt-5.4", 1_000_000, 0, extra).costUsd).toBe(2);
+    // dated/suffixed served id still matches the family prefix in the extra map
+    expect(priceFor("gpt-5.4-2026-06-01", 1_000_000, 0, extra).costUsd).toBe(2);
+  });
+});

--- a/packages/llm/src/pricing.ts
+++ b/packages/llm/src/pricing.ts
@@ -1,0 +1,77 @@
+// Best-effort model price map for cost accounting (observability). Prices are USD per **million**
+// tokens, split input/output, and are a starting point only — they drift and are not authoritative.
+// Cost is computed and frozen at write time so historical spend stays stable across price changes;
+// an unknown model resolves to `null` (surfaced as "unpriced" rather than a wrong number). Admins
+// override/extend this map via config. Figures approximate as of 2026-06; verify against billing.
+
+export interface ModelPrice {
+  /** USD per 1M input tokens. */
+  in: number;
+  /** USD per 1M output tokens. */
+  out: number;
+}
+
+// Keyed by canonical model id (or family prefix — see `priceFor`'s prefix fallback, which lets a
+// dated provider id like `claude-opus-4-20250901` match the `claude-opus-4` family entry).
+export const PRICING: Record<string, ModelPrice> = {
+  // Anthropic (TulipFarm tier defaults)
+  "claude-opus-4-8": { in: 15, out: 75 },
+  "claude-opus-4": { in: 15, out: 75 },
+  "claude-sonnet-4-6": { in: 3, out: 15 },
+  "claude-sonnet-4": { in: 3, out: 15 },
+  "claude-haiku-4-5": { in: 0.8, out: 4 },
+  "claude-haiku-4": { in: 0.8, out: 4 },
+  // OpenAI
+  "gpt-4o": { in: 2.5, out: 10 },
+  "gpt-4o-mini": { in: 0.15, out: 0.6 },
+  "gpt-4.1": { in: 2, out: 8 },
+  "gpt-4.1-mini": { in: 0.4, out: 1.6 },
+  o3: { in: 2, out: 8 },
+  "o3-mini": { in: 1.1, out: 4.4 },
+  // Google
+  "gemini-2.5-pro": { in: 1.25, out: 10 },
+  "gemini-2.5-flash": { in: 0.3, out: 2.5 },
+  // xAI
+  "grok-4": { in: 3, out: 15 },
+};
+
+export interface PriceResult {
+  /** Frozen USD cost, or `null` when the model id is not in the price map (unpriced). */
+  costUsd: number | null;
+}
+
+// Resolve a price entry for a model id within a given map: exact match first, then a normalized
+// (lowercased) match, then the longest family-prefix key the id extends (so dated/suffixed provider
+// ids — e.g. `claude-3-5-sonnet-20241022` → `claude-3-5-sonnet` — still price).
+function lookupIn(modelId: string, map: Record<string, ModelPrice>): ModelPrice | undefined {
+  if (map[modelId]) return map[modelId];
+  const id = modelId.toLowerCase();
+  if (map[id]) return map[id];
+  let best: { key: string; price: ModelPrice } | undefined;
+  for (const [key, price] of Object.entries(map)) {
+    const k = key.toLowerCase();
+    if ((id === k || id.startsWith(`${k}-`)) && (!best || key.length > best.key.length)) {
+      best = { key, price };
+    }
+  }
+  return best?.price;
+}
+
+/**
+ * Compute the frozen USD cost of one model call from its token counts. `extra` (external/LiteLLM
+ * prices merged with config overrides) takes precedence over the built-in map; both are matched
+ * prefix-tolerantly. Returns `{ costUsd: null }` when the model is unpriced. Rounded to 6 decimals
+ * to avoid floating-point dust in the numeric column while keeping sub-cent calls meaningful.
+ */
+export function priceFor(
+  modelId: string | null | undefined,
+  tokensIn: number,
+  tokensOut: number,
+  extra?: Record<string, ModelPrice>
+): PriceResult {
+  if (!modelId) return { costUsd: null };
+  const price = (extra && lookupIn(modelId, extra)) ?? lookupIn(modelId, PRICING);
+  if (!price) return { costUsd: null };
+  const raw = (tokensIn / 1_000_000) * price.in + (tokensOut / 1_000_000) * price.out;
+  return { costUsd: Math.round(raw * 1_000_000) / 1_000_000 };
+}

--- a/packages/soul/src/soul-loader.ts
+++ b/packages/soul/src/soul-loader.ts
@@ -47,6 +47,7 @@ export class SoulLoader {
   integrations: Map<string, SoulIntegration> = new Map();
   llmConfig: Record<string, unknown> | null = null;
   guardrailsConfig: Record<string, unknown> | null = null;
+  observabilityConfig: Record<string, unknown> | null = null;
   manifest: Record<string, unknown> | null = null;
 
   constructor(
@@ -63,6 +64,7 @@ export class SoulLoader {
       integrations,
       llmConfig,
       guardrailsConfig,
+      observabilityConfig,
       manifest,
     ] = await Promise.all([
       this.loadAgents(),
@@ -72,6 +74,10 @@ export class SoulLoader {
       this.loadIntegrations(),
       this.loadYamlFile(join(this.soulPath, "llm.config.yaml"), "llm.config.yaml"),
       this.loadYamlFile(join(this.soulPath, "guardrails.yaml"), "guardrails.yaml"),
+      this.loadYamlFile(
+        join(this.soulPath, "observability.config.yaml"),
+        "observability.config.yaml"
+      ),
       this.loadYamlFile(join(this.soulPath, "soul.yaml"), "soul.yaml"),
     ]);
 
@@ -82,6 +88,7 @@ export class SoulLoader {
     this.integrations = integrations;
     this.llmConfig = llmConfig;
     this.guardrailsConfig = guardrailsConfig;
+    this.observabilityConfig = observabilityConfig;
     this.manifest = manifest;
 
     this.logger.info(


### PR DESCRIPTION
…teLLM model-spec pricing

One Postgres obs_event spine (migration v22) fed by fire-and-forget capture on the chat-turn domain-event bus. Settings -> Observability admin tab: cost/tokens/turns, reliability rates + p95 latency, spend-over-time, by-agent/model, and a per-conversation trace drill-down. Served-model attribution survives fallback chains; nightly retention prune.

Opt-in Grafana Cloud export via dependency-free OTLP/JSON push (metrics -> Mimir, traces -> Tempo), gated by soul/observability.config.yaml; ships dashboard.json + starter alert rules. Metadata-only by default with an opt-in content-capture toggle; bounded metric labels only.

Model pricing/context/capabilities resolved from LiteLLM's catalog and pinned per-model into llm.config.yaml (spec block), auto-resolved on save with a per-model refresh. Cost is frozen at write time from the pinned spec, with a built-in price map as fallback; the flat v7 token-usage bug that zeroed all costs is fixed.