### PR TITLE
feat(settings): rework into section-sidebar shell with per-section UX

### DIFF
--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -8,6 +8,7 @@ import {
   ScrollRestoration,
 } from "@remix-run/react";
 import "@fontsource-variable/jetbrains-mono";
+import { NuqsAdapter } from "nuqs/adapters/remix";
 import { type ReactNode, useEffect } from "react";
 import "~/app.css";
 
@@ -70,7 +71,10 @@ export default function App() {
 
   return (
     <Document>
-      <Outlet />
+      {/* NuqsAdapter wires type-safe URL search-param state (useQueryState) to the Remix router. */}
+      <NuqsAdapter>
+        <Outlet />
+      </NuqsAdapter>
     </Document>
   );
 }

--- a/apps/web/app/routes/_app.settings.activities.tsx
+++ b/apps/web/app/routes/_app.settings.activities.tsx
@@ -9,7 +9,8 @@ import {
   Sparkles,
   Wrench,
 } from "lucide-react";
-import { useRef, useState } from "react";
+import { parseAsString, useQueryState } from "nuqs";
+import { useEffect, useRef, useState } from "react";
 import { ErrorState } from "~/components/states";
 import { Sheet } from "~/components/ui/sheet";
 import { type ActivityItem, listActivities } from "~/lib/activities";
@@ -58,31 +59,43 @@ export default function SettingsActivities() {
   const { initial } = useLoaderData<typeof clientLoader>();
   const [items, setItems] = useState<ActivityItem[]>(initial.items);
   const [cursor, setCursor] = useState<string | null>(initial.nextCursor);
-  const [category, setCategory] = useState<string | undefined>(undefined);
+  // Category filter lives in the URL (?category=job) so it survives reload + is shareable. `null` = All.
+  const [category, setCategory] = useQueryState("category", parseAsString);
   const [loading, setLoading] = useState(false);
   const [selected, setSelected] = useState<ActivityItem | null>(null);
-  // Generation guard: discard a category fetch whose response loses the race to a newer click.
+  // Generation guard: discard a category fetch whose response loses the race to a newer change.
   const requestId = useRef(0);
+  const firstRun = useRef(true);
 
-  async function applyCategory(next: string | undefined): Promise<void> {
-    setCategory(next);
+  // Refetch whenever the URL category changes. Skip the very first run when there's no filter — the
+  // loader already provided the unfiltered page (deep-linking to ?category=… still fetches on mount).
+  useEffect(() => {
+    if (firstRun.current) {
+      firstRun.current = false;
+      if (!category) return;
+    }
     const id = ++requestId.current;
     setLoading(true);
-    try {
-      const page = await listActivities({ category: next, limit: PAGE_SIZE });
-      if (id !== requestId.current) return; // a newer click superseded this one — drop stale data
-      setItems(page.items);
-      setCursor(page.nextCursor);
-    } finally {
-      if (id === requestId.current) setLoading(false);
-    }
-  }
+    listActivities({ category: category ?? undefined, limit: PAGE_SIZE })
+      .then((page) => {
+        if (id !== requestId.current) return; // a newer change superseded this one — drop stale data
+        setItems(page.items);
+        setCursor(page.nextCursor);
+      })
+      .finally(() => {
+        if (id === requestId.current) setLoading(false);
+      });
+  }, [category]);
 
   async function loadMore(): Promise<void> {
     if (!cursor) return;
     setLoading(true);
     try {
-      const page = await listActivities({ category, cursor, limit: PAGE_SIZE });
+      const page = await listActivities({
+        category: category ?? undefined,
+        cursor,
+        limit: PAGE_SIZE,
+      });
       setItems((prev) => [...prev, ...page.items]);
       setCursor(page.nextCursor);
     } finally {
@@ -92,24 +105,19 @@ export default function SettingsActivities() {
 
   return (
     <div className="flex flex-col gap-4">
-      <p className="text-sm text-muted-foreground">
-        Everything that happens in this workspace — records, chats, knowledge, skills, syncs, and
-        background jobs.
-      </p>
-
-      <nav className="flex flex-wrap gap-1">
+      <nav className="flex flex-wrap gap-1.5">
         {CATEGORIES.map((c) => {
-          const active = c.key === category;
+          const active = (c.key ?? null) === category;
           return (
             <button
               key={c.label}
               type="button"
-              onClick={() => applyCategory(c.key)}
+              onClick={() => setCategory(c.key ?? null)}
               className={cn(
                 "cursor-pointer rounded-sm border px-2.5 py-1 text-xs transition-colors",
                 active
-                  ? "border-primary text-foreground"
-                  : "border-border text-muted-foreground hover:text-foreground"
+                  ? "border-primary bg-primary/10 text-foreground"
+                  : "border-border text-muted-foreground hover:border-primary/50 hover:text-foreground"
               )}
             >
               {c.label}
@@ -119,11 +127,16 @@ export default function SettingsActivities() {
       </nav>
 
       {items.length === 0 ? (
-        <p className="rounded-sm border border-border bg-muted/40 px-3 py-6 text-center text-sm text-muted-foreground">
+        <p className="rounded-sm border border-border bg-muted/40 px-3 py-10 text-center text-sm text-muted-foreground">
           No activity yet.
         </p>
       ) : (
-        <ul className="flex flex-col">
+        <ul
+          className={cn(
+            "flex flex-col rounded-sm border border-border divide-y divide-border transition-opacity",
+            loading && "opacity-60"
+          )}
+        >
           {items.map((it) => {
             const Icon = CATEGORY_ICON[it.category] ?? Box;
             return (
@@ -131,28 +144,29 @@ export default function SettingsActivities() {
                 <button
                   type="button"
                   onClick={() => setSelected(it)}
-                  className="flex w-full cursor-pointer items-start gap-3 border-border border-b px-1 py-2.5 text-left transition-colors hover:bg-accent/50"
+                  className="flex w-full cursor-pointer items-center gap-3 px-3 py-3 text-left transition-colors hover:bg-accent/50"
                 >
                   <Icon
                     className={cn(
-                      "mt-0.5 size-4 shrink-0",
+                      "size-4 shrink-0",
                       it.status === "error" ? "text-destructive" : "text-muted-foreground"
                     )}
                     aria-hidden
                   />
-                  <span className="min-w-0 flex-1">
-                    <span className="block truncate text-sm text-foreground">{it.summary}</span>
-                    <span className="mt-0.5 flex items-center gap-2 text-xs text-muted-foreground">
-                      <span>{it.actorType === "system" ? "system" : "user"}</span>
-                      <span aria-hidden>·</span>
-                      <span>{formatWhen(it.createdAt)}</span>
-                      {it.status === "error" ? (
-                        <span className="rounded-sm bg-destructive/10 px-1 text-destructive">
-                          error
-                        </span>
-                      ) : null}
+                  <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+                    <span className="truncate text-sm text-foreground">{it.summary}</span>
+                    <span className="text-xs text-muted-foreground">
+                      {it.actorType === "system" ? "system" : "user"}
                     </span>
                   </span>
+                  {it.status === "error" ? (
+                    <span className="shrink-0 rounded-sm bg-destructive/10 px-1.5 py-0.5 text-xs text-destructive">
+                      error
+                    </span>
+                  ) : null}
+                  <time className="shrink-0 text-xs tabular-nums text-muted-foreground">
+                    {formatWhen(it.createdAt)}
+                  </time>
                 </button>
               </li>
             );

--- a/apps/web/app/routes/_app.settings.llm.tsx
+++ b/apps/web/app/routes/_app.settings.llm.tsx
@@ -56,9 +56,6 @@ export default function SettingsLlm() {
 
   return (
     <div className="flex flex-col gap-4">
-      <p className="text-sm text-muted-foreground">
-        Tiers run their providers as a fallback chain (top first).
-      </p>
       {noneEnabled ? (
         <p className="rounded-sm border border-border bg-muted/40 px-3 py-2 text-sm text-muted-foreground">
           No provider secrets yet — add one in the <span className="text-foreground">Secrets</span>{" "}

--- a/apps/web/app/routes/_app.settings.memory.tsx
+++ b/apps/web/app/routes/_app.settings.memory.tsx
@@ -9,12 +9,7 @@ import { deleteMemoryEntry, listMemory, updateMemoryEntry } from "~/lib/memory";
 import { cn } from "~/lib/utils";
 
 const fieldClass =
-  "w-full rounded-sm border border-border bg-background px-3 py-2 text-sm outline-none transition-colors focus-visible:border-primary focus-visible:ring-[3px] focus-visible:ring-ring/30 disabled:opacity-60";
-// Auto-grow with content (modern browsers), capped — no giant empty boxes for one-line values.
-const valueClass = cn(
-  fieldClass,
-  "field-sizing-content min-h-9 max-h-48 resize-none leading-relaxed"
-);
+  "rounded-sm border border-border bg-background px-3 py-1.5 text-sm outline-none transition-colors focus-visible:border-primary focus-visible:ring-[3px] focus-visible:ring-ring/30 disabled:opacity-60";
 
 // Suggested preference keys, each with an example value shown as the placeholder.
 const PRESETS: { key: string; example: string }[] = [
@@ -42,13 +37,13 @@ export default function SettingsMemory() {
   const { entries, maxValueChars } = useLoaderData<typeof clientLoader>();
   const revalidator = useRevalidator();
 
-  // Per-key textarea drafts. Absent key → show the saved value (loader is the source of truth).
+  // Per-key draft edits. Absent key → show the saved value (loader is the source of truth).
   const [drafts, setDrafts] = useState<Record<string, string>>({});
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [pendingDelete, setPendingDelete] = useState<string | null>(null);
 
-  // "Set a preference" composer — a new key + value the user authors.
+  // Inline "add" row — a new key + value the user authors.
   const [newKey, setNewKey] = useState("");
   const [newValue, setNewValue] = useState("");
   const [newPlaceholder, setNewPlaceholder] = useState("");
@@ -84,12 +79,7 @@ export default function SettingsMemory() {
   }
 
   return (
-    <div className="flex flex-col gap-8">
-      <p className="max-w-prose text-sm leading-relaxed text-muted-foreground">
-        What the assistant remembers about you — facts it saved as you chat, plus preferences you
-        set. These ride along on every chat so it can personalize its answers.
-      </p>
-
+    <div className="flex flex-col gap-4">
       {error ? (
         <p
           role="alert"
@@ -99,200 +89,179 @@ export default function SettingsMemory() {
         </p>
       ) : null}
 
-      {/* Composer — a distinct, lightly-tinted input zone, set apart from the saved list. */}
-      <form
-        className="flex flex-col gap-4 rounded-sm border border-border bg-muted/30 p-5"
-        onSubmit={(e) => {
-          e.preventDefault();
-          if (!canSet) return;
-          void run(
-            () => updateMemoryEntry(newKeyTrimmed, newValue),
-            () => {
-              setNewKey("");
-              setNewValue("");
-              setNewPlaceholder("");
-            }
-          );
-        }}
-      >
-        <h2 className="text-sm font-medium text-foreground">Set a memory or preference</h2>
-
-        {availablePresets.length > 0 ? (
-          <div className="flex flex-wrap items-center gap-1.5">
-            <span className="mr-1 text-xs text-muted-foreground">Try</span>
-            {availablePresets.map((preset) => {
-              const active = newKeyTrimmed === preset.key;
-              return (
-                <button
-                  key={preset.key}
-                  type="button"
-                  disabled={busy}
-                  aria-pressed={active}
-                  className={cn(
-                    "cursor-pointer rounded-sm border px-2 py-0.5 text-xs transition-colors disabled:opacity-60",
-                    active
-                      ? "border-primary bg-primary/10 text-foreground"
-                      : "border-border text-muted-foreground hover:border-primary/60 hover:text-foreground"
-                  )}
-                  onClick={() => {
-                    setNewKey(preset.key);
-                    setNewPlaceholder(preset.example);
-                  }}
-                >
-                  {preset.key}
-                </button>
-              );
-            })}
-          </div>
-        ) : null}
-
-        <div className="flex flex-col gap-1">
-          <input
-            className={cn(
-              fieldClass,
-              dupKey && "border-destructive focus-visible:border-destructive"
-            )}
-            value={newKey}
-            disabled={busy}
-            onChange={(e) => setNewKey(e.target.value)}
-            placeholder="key — e.g. tone"
-            aria-label="memory key"
-          />
-          {dupKey ? (
-            <span className="text-xs text-destructive">
-              “{newKeyTrimmed}” already exists — edit it below instead
-            </span>
-          ) : null}
+      {/* One-tap suggestions fill the key field of the add row below. */}
+      {availablePresets.length > 0 ? (
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="mr-1 text-xs text-muted-foreground">Try</span>
+          {availablePresets.map((preset) => (
+            <button
+              key={preset.key}
+              type="button"
+              disabled={busy}
+              aria-pressed={newKeyTrimmed === preset.key}
+              className={cn(
+                "cursor-pointer rounded-sm border px-2 py-0.5 text-xs transition-colors disabled:opacity-60",
+                newKeyTrimmed === preset.key
+                  ? "border-primary bg-primary/10 text-foreground"
+                  : "border-border text-muted-foreground hover:border-primary/60 hover:text-foreground"
+              )}
+              onClick={() => {
+                setNewKey(preset.key);
+                setNewPlaceholder(preset.example);
+              }}
+            >
+              {preset.key}
+            </button>
+          ))}
         </div>
+      ) : null}
 
-        <textarea
-          className={valueClass}
-          rows={1}
-          value={newValue}
-          disabled={busy}
-          onChange={(e) => setNewValue(e.target.value)}
-          placeholder={newPlaceholder || "value — what should the assistant remember?"}
-          aria-label="memory value"
-        />
-
-        <div className="flex items-center justify-end gap-3">
-          {newValue.length > 0 ? (
+      {/* One unified list: an inline add row on top, then every saved memory — each a single line. */}
+      <ul className="flex flex-col divide-y divide-border rounded-sm border border-border">
+        <li className="bg-muted/30">
+          <form
+            className="flex items-center gap-2.5 px-3 py-2"
+            onSubmit={(e) => {
+              e.preventDefault();
+              if (!canSet) return;
+              void run(
+                () => updateMemoryEntry(newKeyTrimmed, newValue),
+                () => {
+                  setNewKey("");
+                  setNewValue("");
+                  setNewPlaceholder("");
+                }
+              );
+            }}
+          >
+            <input
+              className={cn(
+                fieldClass,
+                "w-28 shrink-0 sm:w-40",
+                dupKey && "border-destructive focus-visible:border-destructive"
+              )}
+              value={newKey}
+              disabled={busy}
+              onChange={(e) => setNewKey(e.target.value)}
+              placeholder="key"
+              aria-label="new memory key"
+            />
+            <input
+              className={cn(
+                fieldClass,
+                "min-w-0 flex-1",
+                newOver && "border-destructive focus-visible:border-destructive"
+              )}
+              value={newValue}
+              disabled={busy}
+              onChange={(e) => setNewValue(e.target.value)}
+              placeholder={newPlaceholder || "value — what should the assistant remember?"}
+              aria-label="new memory value"
+            />
             <span
               className={cn(
-                "text-xs tabular-nums",
-                newOver ? "text-destructive" : "text-muted-foreground"
+                "w-14 shrink-0 text-right text-xs tabular-nums",
+                newOver ? "text-destructive" : "text-muted-foreground/70"
               )}
             >
-              {newValue.length} / {maxValueChars}
+              {newValue.length}/{maxValueChars}
             </span>
-          ) : null}
-          <Button type="submit" size="sm" className="cursor-pointer" disabled={!canSet}>
-            <Plus aria-hidden /> {busy ? "Saving…" : "Set"}
-          </Button>
-        </div>
-      </form>
+            <Button type="submit" size="sm" className="shrink-0 cursor-pointer" disabled={!canSet}>
+              <Plus aria-hidden /> Set
+            </Button>
+          </form>
+        </li>
 
-      {/* Saved list */}
-      <section className="flex flex-col gap-3">
-        <div className="flex items-baseline justify-between">
-          <h2 className="text-sm font-medium text-foreground">Remembered</h2>
-          {entries.length > 0 ? (
-            <span className="text-xs tabular-nums text-muted-foreground">
-              {entries.length} {entries.length === 1 ? "entry" : "entries"}
-            </span>
-          ) : null}
-        </div>
-
-        {entries.length === 0 ? (
-          <p className="rounded-sm border border-dashed border-border px-4 py-8 text-center text-sm text-muted-foreground">
-            Nothing yet — set a preference above, or the assistant adds memory as you chat.
-          </p>
-        ) : (
-          <ul className="flex flex-col gap-2.5">
-            {entries.map((entry) => {
-              const value = drafts[entry.key] ?? entry.value;
-              const dirty = value !== entry.value;
-              const over = value.length > maxValueChars;
-              const bySelf = !entry.writtenByAgentId;
-              return (
-                <li
-                  key={entry.key}
-                  className="flex flex-col gap-2 rounded-sm border border-border p-4"
+        {entries.map((entry) => {
+          const value = drafts[entry.key] ?? entry.value;
+          const dirty = value !== entry.value;
+          const over = value.length > maxValueChars;
+          const bySelf = !entry.writtenByAgentId;
+          return (
+            <li key={entry.key} className="flex items-center gap-2.5 px-3 py-2">
+              <div className="flex w-28 shrink-0 items-center gap-1.5 sm:w-40">
+                <span className="truncate text-sm font-medium text-foreground" title={entry.key}>
+                  {entry.key}
+                </span>
+                <span
+                  className="shrink-0 rounded-sm border border-border px-1 py-px text-[10px] uppercase tracking-[0.12em] text-muted-foreground"
+                  title={bySelf ? "set by you" : "saved by the assistant"}
                 >
-                  <div className="flex items-center gap-2">
-                    <span className="font-medium text-foreground">{entry.key}</span>
-                    <span
-                      className="rounded-sm border border-border px-1.5 py-px text-[10px] uppercase tracking-[0.12em] text-muted-foreground"
-                      title={bySelf ? "set by you" : "saved by the assistant"}
-                    >
-                      {entry.writtenByAgentId ?? "you"}
-                    </span>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      className="ml-auto size-8 cursor-pointer text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
-                      disabled={busy}
-                      aria-label={`Delete ${entry.key}`}
-                      onClick={() => setPendingDelete(entry.key)}
-                    >
-                      <Trash2 aria-hidden />
-                    </Button>
-                  </div>
-
-                  <textarea
-                    className={valueClass}
-                    rows={1}
-                    value={value}
+                  {entry.writtenByAgentId ?? "you"}
+                </span>
+              </div>
+              <input
+                className={cn(
+                  fieldClass,
+                  "min-w-0 flex-1",
+                  over && "border-destructive focus-visible:border-destructive"
+                )}
+                value={value}
+                disabled={busy}
+                onChange={(e) => setDrafts((prev) => ({ ...prev, [entry.key]: e.target.value }))}
+                aria-label={`value for ${entry.key}`}
+              />
+              <span
+                className={cn(
+                  "w-14 shrink-0 text-right text-xs tabular-nums",
+                  over ? "text-destructive" : "text-muted-foreground/70"
+                )}
+              >
+                {value.length}/{maxValueChars}
+              </span>
+              {dirty ? (
+                <>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="shrink-0 cursor-pointer"
                     disabled={busy}
-                    onChange={(e) =>
-                      setDrafts((prev) => ({ ...prev, [entry.key]: e.target.value }))
+                    onClick={() => clearDraft(entry.key)}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    className="shrink-0 cursor-pointer"
+                    disabled={busy || over}
+                    onClick={() =>
+                      void run(
+                        () => updateMemoryEntry(entry.key, value),
+                        () => clearDraft(entry.key)
+                      )
                     }
-                    aria-label={`value for ${entry.key}`}
-                  />
+                  >
+                    {busy ? "Saving…" : "Save"}
+                  </Button>
+                </>
+              ) : null}
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="size-8 shrink-0 cursor-pointer text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+                disabled={busy}
+                aria-label={`Delete ${entry.key}`}
+                onClick={() => setPendingDelete(entry.key)}
+              >
+                <Trash2 aria-hidden />
+              </Button>
+            </li>
+          );
+        })}
+      </ul>
 
-                  {dirty ? (
-                    <div className="flex items-center justify-end gap-3">
-                      <span
-                        className={cn(
-                          "text-xs tabular-nums",
-                          over ? "text-destructive" : "text-muted-foreground"
-                        )}
-                      >
-                        {value.length} / {maxValueChars}
-                      </span>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        className="cursor-pointer"
-                        disabled={busy}
-                        onClick={() => clearDraft(entry.key)}
-                      >
-                        Cancel
-                      </Button>
-                      <Button
-                        type="button"
-                        size="sm"
-                        className="cursor-pointer"
-                        disabled={busy || over}
-                        onClick={() =>
-                          void run(
-                            () => updateMemoryEntry(entry.key, value),
-                            () => clearDraft(entry.key)
-                          )
-                        }
-                      >
-                        {busy ? "Saving…" : "Save"}
-                      </Button>
-                    </div>
-                  ) : null}
-                </li>
-              );
-            })}
-          </ul>
-        )}
-      </section>
+      {dupKey ? (
+        <p className="text-xs text-destructive">
+          “{newKeyTrimmed}” already exists — edit it in the list instead.
+        </p>
+      ) : entries.length === 0 ? (
+        <p className="text-xs text-muted-foreground">
+          No saved memories yet — add one above, or the assistant saves them as you chat.
+        </p>
+      ) : null}
 
       <ConfirmModal
         open={pendingDelete !== null}

--- a/apps/web/app/routes/_app.settings.observability.tsx
+++ b/apps/web/app/routes/_app.settings.observability.tsx
@@ -68,11 +68,7 @@ export default function SettingsObservability() {
 
   return (
     <div className={cn("flex flex-col gap-6", loading && "opacity-60 transition-opacity")}>
-      <div className="flex items-center justify-between">
-        <p className="text-sm text-muted-foreground">
-          What your agents are spending and doing. Cost is computed from token usage at a
-          best-effort price; unpriced models are counted but show no cost.
-        </p>
+      <div className="flex items-center justify-end">
         <nav className="flex shrink-0 gap-1">
           {RANGES.map((r) => (
             <button

--- a/apps/web/app/routes/_app.settings.secrets.tsx
+++ b/apps/web/app/routes/_app.settings.secrets.tsx
@@ -103,8 +103,6 @@ export default function SettingsSecrets() {
 
   return (
     <div className="flex flex-col gap-6">
-      <p className="text-sm text-muted-foreground">Secret values are never shown.</p>
-
       {error ? (
         <p
           role="alert"

--- a/apps/web/app/routes/_app.settings.soul.tsx
+++ b/apps/web/app/routes/_app.settings.soul.tsx
@@ -24,12 +24,15 @@ export default function SettingsSoul() {
     );
   }
 
+  // One unified explorer shell (VS Code-style): a single hairline border wraps the tree + viewer,
+  // split by one internal divider — no floating cards, no gap. Stacks the tree above the viewer on
+  // mobile; side-by-side on md+. Fills the remaining viewport height on desktop.
   return (
-    <div className="flex h-[70vh] min-h-0 gap-4">
-      <aside className="w-64 shrink-0 overflow-y-auto rounded-sm border border-border bg-card px-1">
+    <div className="flex h-[32rem] min-h-0 flex-col overflow-hidden rounded-sm border border-border bg-card md:h-[calc(100svh-11rem)] md:flex-row">
+      <aside className="flex max-h-56 shrink-0 flex-col overflow-y-auto border-b border-border px-1 py-1 md:max-h-none md:w-64 md:border-b-0 md:border-r">
         <SoulTree root={root} selected={selected} onSelect={setSelected} />
       </aside>
-      <section className="min-w-0 flex-1 overflow-hidden rounded-sm border border-border bg-card">
+      <section className="min-h-0 min-w-0 flex-1 overflow-hidden">
         <SoulFileViewer path={selected} />
       </section>
     </div>

--- a/apps/web/app/routes/_app.settings.tsx
+++ b/apps/web/app/routes/_app.settings.tsx
@@ -1,50 +1,117 @@
-import { type MetaFunction, NavLink, Outlet } from "@remix-run/react";
+import { type MetaFunction, NavLink, Outlet, useLocation } from "@remix-run/react";
+import { Activity, Brain, Cpu, History, KeyRound, type LucideIcon, Sparkles } from "lucide-react";
 import { cn } from "~/lib/utils";
 
 export const meta: MetaFunction = () => [{ title: "Settings · tulipfarm" }];
 
-const tabs = [
-  { to: "/settings/secrets", label: "Secrets", end: false },
-  { to: "/settings/llm", label: "LLM", end: false },
-  { to: "/settings/observability", label: "Observability", end: false },
-  { to: "/settings/soul", label: "Soul", end: false },
-  { to: "/settings/activities", label: "Activities", end: false },
-  { to: "/settings/memory", label: "Memory", end: false },
+type Section = {
+  to: string;
+  label: string;
+  icon: LucideIcon;
+  description: string;
+  // Dashboard/explorer surfaces fill the full main width; form-style sections stay constrained.
+  wide?: boolean;
+};
+
+// Single source of truth for both the secondary sidebar nav and the per-section header.
+const sections: Section[] = [
+  {
+    to: "/settings/secrets",
+    label: "Secrets",
+    icon: KeyRound,
+    description: "Provider credentials and custom secrets. Values are never shown.",
+  },
+  {
+    to: "/settings/llm",
+    label: "LLM",
+    icon: Cpu,
+    description: "Model tiers and provider routing. Tiers run as a fallback chain, top first.",
+  },
+  {
+    to: "/settings/observability",
+    label: "Observability",
+    icon: Activity,
+    description: "What your agents are spending and doing — cost, tokens, and reliability.",
+    wide: true,
+  },
+  {
+    to: "/settings/soul",
+    label: "Soul",
+    icon: Sparkles,
+    description: "Browse the version-controlled soul repository.",
+    wide: true,
+  },
+  {
+    to: "/settings/activities",
+    label: "Activities",
+    icon: History,
+    description: "Everything that happens in this workspace — records, chats, jobs, and more.",
+    wide: true,
+  },
+  {
+    to: "/settings/memory",
+    label: "Memory",
+    icon: Brain,
+    description: "What the assistant remembers about you — saved facts and preferences.",
+    wide: true,
+  },
 ];
 
-// Layout for the Settings subtree: shared header + tab nav, each child owns its own data + form.
+/*
+ * Settings shell (Knowledge-style). A persistent section rail on the left, the selected section in
+ * the content outlet on the right — the rail stays put while sections swap. The main app sidebar
+ * auto-collapses to its icon rail under /settings (wired in _app.tsx via `forceCollapsed`), giving
+ * this rail the freed space. On mobile the rail stacks above the content. Children own their data.
+ */
 export default function SettingsLayout() {
+  const { pathname } = useLocation();
+  const active = sections.find((s) => pathname.startsWith(s.to)) ?? sections[0];
   return (
-    <section className="mx-auto w-full max-w-3xl px-6 py-10">
-      <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">
-        <span className="text-primary">[</span>settings<span className="text-primary">]</span>
-      </p>
-      <h1 className="mt-2 text-lg font-bold text-foreground">Settings</h1>
-      <p className="mt-1 text-sm text-muted-foreground">Instance configuration for this tenant.</p>
+    <div className="flex h-full min-h-0 flex-col md:flex-row">
+      <aside className="flex max-h-[45vh] shrink-0 flex-col border-b border-border bg-sidebar text-sidebar-foreground md:max-h-none md:w-64 md:border-b-0 md:border-r">
+        <nav aria-label="Settings" className="flex min-h-0 flex-1 flex-col text-sm">
+          <div className="flex shrink-0 items-center px-3 py-2">
+            <span className="text-[0.625rem] font-medium uppercase tracking-[0.2em] text-muted-foreground">
+              Settings
+            </span>
+          </div>
+          <div className="min-h-0 flex-1 overflow-y-auto px-2 pb-3">
+            <ul className="flex flex-col gap-0.5">
+              {sections.map((s) => (
+                <li key={s.to}>
+                  <NavLink
+                    to={s.to}
+                    className={({ isActive }) =>
+                      cn(
+                        "flex cursor-pointer items-center gap-2 rounded-sm px-3 py-1.5 transition-colors",
+                        isActive
+                          ? "bg-sidebar-accent font-medium text-sidebar-primary"
+                          : "text-sidebar-foreground hover:bg-sidebar-accent/50"
+                      )
+                    }
+                  >
+                    <s.icon className="size-4 shrink-0" aria-hidden />
+                    <span className="flex-1 truncate">{s.label}</span>
+                  </NavLink>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </nav>
+      </aside>
 
-      <nav className="mt-6 flex gap-1 border-b border-border">
-        {tabs.map((tab) => (
-          <NavLink
-            key={tab.to}
-            to={tab.to}
-            end={tab.end}
-            className={({ isActive }) =>
-              cn(
-                "-mb-px border-b-2 px-3 py-2 text-sm transition-colors",
-                isActive
-                  ? "border-primary text-foreground"
-                  : "border-transparent text-muted-foreground hover:text-foreground"
-              )
-            }
-          >
-            {tab.label}
-          </NavLink>
-        ))}
-      </nav>
-
-      <div className="mt-6">
-        <Outlet />
+      <div className="min-w-0 flex-1 overflow-y-auto">
+        <div className={cn("w-full px-6 py-8 md:px-8", !active.wide && "max-w-4xl")}>
+          <header className="mb-6">
+            <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">
+              <span className="text-primary">[</span>settings<span className="text-primary">]</span>
+            </p>
+            <h1 className="mt-2 text-lg font-bold text-foreground">{active.label}</h1>
+            <p className="mt-1 text-sm text-muted-foreground">{active.description}</p>
+          </header>
+          <Outlet />
+        </div>
       </div>
-    </section>
+    </div>
   );
 }

--- a/apps/web/app/routes/_app.tsx
+++ b/apps/web/app/routes/_app.tsx
@@ -23,16 +23,17 @@ export async function clientLoader() {
 // Persistent shell: sidebar + main panel. Wraps every section route. ApprovalsProvider polls pending
 // approvals (sidebar badge + Approvals page); ConversationsProvider holds the Recent chats list.
 export default function AppLayout() {
-  // The Knowledge wiki provides its own page-tree rail, so the main nav auto-collapses to its icon
-  // rail under /knowledge (transient — the persisted collapse preference is untouched).
-  const onKnowledge = useLocation().pathname.startsWith("/knowledge");
+  // Knowledge and Settings each provide their own section rail, so the main nav auto-collapses to
+  // its icon rail under those paths (transient — the persisted collapse preference is untouched).
+  const { pathname } = useLocation();
+  const collapseRail = pathname.startsWith("/knowledge") || pathname.startsWith("/settings");
   return (
     <ApprovalsProvider>
       <ConversationsProvider>
         {/* Desktop shell is capped to the viewport (h-svh + overflow-hidden) so the sidebar nav and
             the main panel each scroll internally instead of growing the whole page. */}
         <div className="md:flex md:h-svh md:overflow-hidden">
-          <AppSidebar forceCollapsed={onKnowledge} />
+          <AppSidebar forceCollapsed={collapseRail} />
           <main className="min-h-[calc(100svh-3rem)] flex-1 overflow-auto md:h-svh md:min-h-0">
             <Outlet />
           </main>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -33,6 +33,7 @@
     "dompurify": "^3.4.11",
     "isbot": "^5.1.44",
     "lucide-react": "^1.21.0",
+    "nuqs": "^2.8.9",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-markdown": "^10.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,7 +152,7 @@ importers:
         version: 1.21.0(react@19.2.7)
       next:
         specifier: 16.2.9
-        version: 16.2.9(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -259,6 +259,9 @@ importers:
       lucide-react:
         specifier: ^1.21.0
         version: 1.21.0(react@19.2.7)
+      nuqs:
+        specifier: ^2.8.9
+        version: 2.8.9(@remix-run/react@2.17.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router-dom@6.30.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router@6.30.4(react@19.2.7))(react@19.2.7)
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -2990,6 +2993,9 @@ packages:
 
   '@sinclair/typebox@0.34.49':
     resolution: {integrity: sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==}
+
+  '@standard-schema/spec@1.0.0':
+    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -6015,6 +6021,27 @@ packages:
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
+
+  nuqs@2.8.9:
+    resolution: {integrity: sha512-8ou6AEwsxMWSYo2qkfZtYFVzngwbKmg4c00HVxC1fF6CEJv3Fwm6eoZmfVPALB+vw8Udo7KL5uy96PFcYe1BIQ==}
+    peerDependencies:
+      '@remix-run/react': '>=2'
+      '@tanstack/react-router': ^1
+      next: '>=14.2.0'
+      react: '>=18.2.0 || ^19.0.0-0'
+      react-router: ^5 || ^6 || ^7
+      react-router-dom: ^5 || ^6 || ^7
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@tanstack/react-router':
+        optional: true
+      next:
+        optional: true
+      react-router:
+        optional: true
+      react-router-dom:
+        optional: true
 
   nypm@0.6.7:
     resolution: {integrity: sha512-s3ds97SD5pd1dULE+tHUk1DrV0cSHOnsfpcdGATJ8JpBo21DoKqN9exTH4/2nhPQNOLomBdTFMicN94S4DrZrQ==}
@@ -9829,6 +9856,8 @@ snapshots:
 
   '@sinclair/typebox@0.34.49': {}
 
+  '@standard-schema/spec@1.0.0': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@swc/helpers@0.5.15':
@@ -10345,7 +10374,7 @@ snapshots:
       obug: 2.1.2
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.19.20)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.19.20)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.0(@types/node@22.19.20)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/expect@4.1.9':
     dependencies:
@@ -11588,7 +11617,7 @@ snapshots:
       '@types/mdast': 4.0.4
       '@types/react': 19.2.17
       lucide-react: 1.21.0(react@19.2.7)
-      next: 16.2.9(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       zod: 4.4.3
@@ -11618,7 +11647,7 @@ snapshots:
       '@types/mdast': 4.0.4
       '@types/mdx': 2.0.14
       '@types/react': 19.2.17
-      next: 16.2.9(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       rolldown: 1.1.2
       vite: 8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
@@ -11655,7 +11684,7 @@ snapshots:
     optionalDependencies:
       '@types/mdx': 2.0.14
       '@types/react': 19.2.17
-      next: 16.2.9(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - '@tailwindcss/oxide'
@@ -13353,7 +13382,7 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  next@16.2.9(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@next/env': 16.2.9
       '@swc/helpers': 0.5.15
@@ -13362,7 +13391,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      styled-jsx: 5.1.6(react@19.2.7)
+      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.7)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.9
       '@next/swc-darwin-x64': 16.2.9
@@ -13424,6 +13453,16 @@ snapshots:
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
+
+  nuqs@2.8.9(@remix-run/react@2.17.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router-dom@6.30.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router@6.30.4(react@19.2.7))(react@19.2.7):
+    dependencies:
+      '@standard-schema/spec': 1.0.0
+      react: 19.2.7
+    optionalDependencies:
+      '@remix-run/react': 2.17.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
+      next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react-router: 6.30.4(react@19.2.7)
+      react-router-dom: 6.30.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
   nypm@0.6.7:
     dependencies:
@@ -14678,10 +14717,12 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  styled-jsx@5.1.6(react@19.2.7):
+  styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.7):
     dependencies:
       client-only: 0.0.1
       react: 19.2.7
+    optionalDependencies:
+      '@babel/core': 7.29.7
 
   supports-color@7.2.0:
     dependencies:


### PR DESCRIPTION
- Replace horizontal tabs with a secondary section sidebar; full-width main area with per-section header (Knowledge shell pattern). Primary rail auto-collapses under /settings.
- Per-section width: observability/soul/activities/memory full-width; secrets/llm constrained.
- Soul: unify the two cards into one bordered explorer with internal divider; responsive stacking.
- Activities: full-width divided list, timestamp right-aligned; category filter synced to URL via nuqs (?category=).
- Memory: single-line flow — inline add row + each saved memory as one row with inline char count/limit.
- Wire NuqsAdapter in root; add nuqs dependency.