### PR TITLE
feat(settings): rename Azure provider to Azure Foundry + rework LLM m…

### DIFF
--- a/apps/api/src/soul/llm-config/prune.test.ts
+++ b/apps/api/src/soul/llm-config/prune.test.ts
@@ -7,7 +7,7 @@ import { pruneLlmConfig } from "./prune";
 
 const azure: LlmProviderInfo = {
   id: "azure",
-  label: "Azure OpenAI",
+  label: "Azure Foundry",
   fields: [
     { key: "azure-openai-api-key", label: "API key", role: "api_key", kind: "secret" },
     {

--- a/apps/api/src/soul/llm-config/routes.test.ts
+++ b/apps/api/src/soul/llm-config/routes.test.ts
@@ -177,9 +177,11 @@ describe("llm-config routes", () => {
         expect.objectContaining({ key: "anthropic-api-key", role: "api_key", kind: "secret" })
       );
       const azure = providers.find((p: { id: string }) => p.id === "azure");
+      expect(azure.label).toBe("Azure Foundry");
       expect(azure.fields.map((f: { role: string }) => f.role)).toEqual([
         "api_key",
         "resource_name",
+        "base_url",
       ]);
     });
   });
@@ -310,6 +312,36 @@ describe("llm-config routes", () => {
       expect(body.matchedKey).toBe("azure_ai/kimi-k2.5");
       expect(body.spec?.input_cost_per_token).toBe(0.00000057);
       expect(body.spec?.litellm_key).toBe("azure_ai/kimi-k2.5");
+    });
+  });
+
+  describe("GET /api/v1/llm-config/model-options", () => {
+    it("is admin-only (403 for a member)", async () => {
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/llm-config/model-options?provider=openai",
+        cookies: cookies(memberSid),
+      });
+      expect(res.statusCode).toBe(403);
+    });
+
+    it("returns LiteLLM catalog ids (chat only) for a non-azure provider", async () => {
+      stubCatalog({
+        "gpt-4o": { input_cost_per_token: 1, mode: "chat" },
+        "openai/gpt-4o-mini": { input_cost_per_token: 1, mode: "chat" },
+        "text-embedding-3-small": { input_cost_per_token: 1, mode: "embedding" },
+      });
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/llm-config/model-options?provider=openai",
+        cookies: cookies(adminSid),
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json() as { models: string[]; source: string };
+      expect(body.source).toBe("catalog");
+      expect(body.models).toContain("gpt-4o");
+      expect(body.models).toContain("gpt-4o-mini");
+      expect(body.models).not.toContain("text-embedding-3-small"); // embeddings excluded
     });
   });
 

--- a/apps/api/src/soul/llm-config/routes.ts
+++ b/apps/api/src/soul/llm-config/routes.ts
@@ -6,6 +6,7 @@ import {
   type LlmConfig,
   LlmConfigValidationError,
   type LlmService,
+  litellmModelsForProvider,
   resolveModelSpec,
   validateLlmConfig,
 } from "@tulipfarm/llm";
@@ -221,6 +222,52 @@ export function registerLlmConfigRoutes(
       }
       const fetchedAt = new Date().toISOString().slice(0, 10);
       return reply.send(resolveModelSpec(q.provider, q.model, catalog, fetchedAt));
+    }
+  );
+
+  app.get(
+    "/api/v1/llm-config/model-options",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description:
+          "Suggested model ids for a provider (from the LiteLLM catalog), to populate the Settings model picker. Admin only. `source: catalog` lists known ids; `source: unavailable` (+ `reason`) means the catalog couldn't be reached and the UI falls back to free-text entry.",
+        tags: ["soul"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        querystring: {
+          type: "object",
+          required: ["provider"],
+          properties: { provider: { type: "string" } },
+        },
+        response: {
+          200: {
+            type: "object",
+            required: ["models", "source"],
+            properties: {
+              models: { type: "array", items: { type: "string" } },
+              source: { type: "string", enum: ["catalog", "unavailable"] },
+              reason: { type: "string" },
+            },
+          },
+          401: ErrorSchema,
+          403: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const actor = req.user as UserDoc;
+      if (actor.role !== "admin") return reply.code(403).send({ error: "forbidden" });
+      const { provider } = req.query as { provider: string };
+
+      const catalog = await getCatalog();
+      if (!catalog) {
+        return reply.send({
+          models: [],
+          source: "unavailable",
+          reason: "Couldn't reach the model catalog.",
+        });
+      }
+      return reply.send({ models: litellmModelsForProvider(provider, catalog), source: "catalog" });
     }
   );
 

--- a/apps/docs/content/docs/concepts/llm.mdx
+++ b/apps/docs/content/docs/concepts/llm.mdx
@@ -4,7 +4,7 @@ description: How TulipFarm chooses a model and falls back across providers.
 ---
 
 TulipFarm talks to language models through a single adapter (the Vercel AI SDK). It
-ships four provider integrations — **Anthropic**, **OpenAI**, **Azure OpenAI**, and any
+ships four provider integrations — **Anthropic**, **OpenAI**, **Azure Foundry**, and any
 **OpenAI-compatible** endpoint (which covers gateways like OpenRouter, Together, and
 Groq through their compatible APIs). You do not wire a model into each agent. Instead you
 define **tiers**, and the runtime picks a tier per turn.

--- a/apps/web/app/components/llm-config-form.test.tsx
+++ b/apps/web/app/components/llm-config-form.test.tsx
@@ -1,8 +1,19 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { expect, test, vi } from "vitest";
 import { LlmConfigForm } from "~/components/llm-config-form";
-import type { LlmConfig, LlmProviderInfo } from "~/lib/settings";
+import { getModelOptions, type LlmConfig, type LlmProviderInfo } from "~/lib/settings";
+
+// The form lazily fetches model suggestions and auto-resolves specs over the network; stub both so the
+// component renders offline. `getModelOptions` is overridden per-test where its result matters.
+vi.mock("~/lib/settings", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/lib/settings")>();
+  return {
+    ...actual,
+    getModelOptions: vi.fn().mockResolvedValue({ models: [], source: "unavailable" }),
+    resolveModelSpec: vi.fn().mockResolvedValue({ spec: null, matchedKey: null, candidates: [] }),
+  };
+});
 
 const PROVIDERS: LlmProviderInfo[] = [
   {
@@ -17,7 +28,7 @@ const PROVIDERS: LlmProviderInfo[] = [
   },
   {
     id: "azure",
-    label: "Azure OpenAI",
+    label: "Azure Foundry",
     fields: [
       { key: "azure-openai-api-key", label: "API key", role: "api_key", kind: "secret" },
       {
@@ -76,7 +87,7 @@ test("a provider that is not fully configured is disabled in the dropdown", () =
     screen.getAllByRole("option").find((o) => o.textContent === "OpenAI — configure first")
   ).toBeDisabled();
   expect(
-    screen.getAllByRole("option").find((o) => o.textContent === "Azure OpenAI — configure first")
+    screen.getAllByRole("option").find((o) => o.textContent === "Azure Foundry — configure first")
   ).toBeDisabled();
 });
 
@@ -115,7 +126,7 @@ test("blocks save when a row's provider is not fully configured", async () => {
   );
   await userEvent.click(screen.getByRole("button", { name: /^save$/i }));
   expect(onSubmit).not.toHaveBeenCalled();
-  expect(screen.getByRole("alert")).toHaveTextContent(/Azure OpenAI is not fully configured/i);
+  expect(screen.getByRole("alert")).toHaveTextContent(/Azure Foundry is not fully configured/i);
 });
 
 test("blocks save on a fresh empty config (a tier has no providers)", async () => {
@@ -157,4 +168,94 @@ test("adding a provider row is reflected in the submitted config", async () => {
     { provider: "anthropic", model: "claude-haiku-4-5" },
     { provider: "anthropic", model: "claude-3-5-haiku" },
   ]);
+});
+
+const azureInitial: LlmConfig = {
+  tiers: {
+    quick: { providers: [{ provider: "azure", model: "gpt-4o" }] },
+    standard: { providers: [{ provider: "anthropic", model: "claude-sonnet-4-6" }] },
+    complex: { providers: [{ provider: "anthropic", model: "claude-opus-4-8" }] },
+  },
+};
+
+test("the model picker lists catalog suggestions in a datalist (non-azure)", async () => {
+  vi.mocked(getModelOptions).mockResolvedValue({
+    models: ["claude-haiku-4-5", "claude-opus-4-8"],
+    source: "catalog",
+  });
+  render(
+    <LlmConfigForm
+      initial={initial}
+      providers={PROVIDERS}
+      secretKeys={ALL_SECRETS}
+      onSubmit={vi.fn()}
+      submitting={false}
+    />
+  );
+  await userEvent.click(screen.getByLabelText("quick provider 1 model"));
+  await waitFor(() =>
+    expect(
+      document.querySelector('#models-anthropic option[value="claude-opus-4-8"]')
+    ).toBeInTheDocument()
+  );
+});
+
+test("azure has no suggestion list and a custom model name is submitted as-is", async () => {
+  const onSubmit = vi.fn();
+  render(
+    <LlmConfigForm
+      initial={azureInitial}
+      providers={PROVIDERS}
+      secretKeys={ALL_SECRETS}
+      onSubmit={onSubmit}
+      submitting={false}
+    />
+  );
+  const input = screen.getByLabelText("quick provider 1 model");
+  await userEvent.click(input); // azure: must NOT trigger a deployment fetch / datalist
+  expect(getModelOptions).not.toHaveBeenCalledWith("azure");
+  expect(document.querySelector("#models-azure")).toBeNull();
+  await userEvent.clear(input);
+  await userEvent.type(input, "my-custom-deploy");
+  await userEvent.click(screen.getByRole("button", { name: /^save$/i }));
+  const submitted = onSubmit.mock.calls[0][0] as LlmConfig;
+  expect(submitted.tiers.quick.providers[0]).toEqual({
+    provider: "azure",
+    model: "my-custom-deploy",
+  });
+});
+
+test("a pinned spec renders as metadata badges", () => {
+  const withSpec: LlmConfig = {
+    tiers: {
+      quick: {
+        providers: [
+          {
+            provider: "anthropic",
+            model: "claude-haiku-4-5",
+            spec: {
+              input_cost_per_token: 0.0000008,
+              output_cost_per_token: 0.000004,
+              max_input_tokens: 200000,
+              supports_function_calling: true,
+            },
+          },
+        ],
+      },
+      standard: { providers: [{ provider: "anthropic", model: "claude-sonnet-4-6" }] },
+      complex: { providers: [{ provider: "anthropic", model: "claude-opus-4-8" }] },
+    },
+  };
+  render(
+    <LlmConfigForm
+      initial={withSpec}
+      providers={PROVIDERS}
+      secretKeys={ALL_SECRETS}
+      onSubmit={vi.fn()}
+      submitting={false}
+    />
+  );
+  expect(screen.getByText("$0.80 / $4.00 per Mtok")).toBeInTheDocument();
+  expect(screen.getByText("200k ctx")).toBeInTheDocument();
+  expect(screen.getByText("tools")).toBeInTheDocument();
 });

--- a/apps/web/app/components/llm-config-form.tsx
+++ b/apps/web/app/components/llm-config-form.tsx
@@ -1,9 +1,11 @@
 import { type FormEvent, useState } from "react";
 import { Button } from "~/components/ui/button";
 import {
+  getModelOptions,
   isProviderConfigured,
   type LlmConfig,
   type LlmProviderInfo,
+  type ModelOptions,
   type ModelSpec,
   resolveModelSpec,
 } from "~/lib/settings";
@@ -52,21 +54,23 @@ function cloneTiers(config: LlmConfig): Tiers {
 
 const perMtok = (n?: number): string => (n != null ? `$${(n * 1_000_000).toFixed(2)}` : "—");
 
-/** One-line spec summary: cost per Mtok · context · capabilities. */
-function specSummary(spec: ModelSpec): string {
-  const cost = `${perMtok(spec.input_cost_per_token)} / ${perMtok(spec.output_cost_per_token)} per Mtok`;
-  const ctx = spec.max_input_tokens ? ` · ${Math.round(spec.max_input_tokens / 1000)}k ctx` : "";
-  const caps = [
-    spec.supports_function_calling && "tools",
-    spec.supports_vision && "vision",
-    spec.supports_prompt_caching && "cache",
-    spec.supports_reasoning && "reasoning",
-  ]
-    .filter(Boolean)
-    .join(", ");
-  const dep = spec.deprecation_date ? ` · deprecates ${spec.deprecation_date}` : "";
-  return `${cost}${ctx}${caps ? ` · ${caps}` : ""}${dep}`;
+/** Spec → compact metadata pills: cost · context · capabilities · matched key · deprecation. */
+function specBadges(spec: ModelSpec): string[] {
+  const out = [
+    `${perMtok(spec.input_cost_per_token)} / ${perMtok(spec.output_cost_per_token)} per Mtok`,
+  ];
+  if (spec.max_input_tokens) out.push(`${Math.round(spec.max_input_tokens / 1000)}k ctx`);
+  if (spec.supports_function_calling) out.push("tools");
+  if (spec.supports_vision) out.push("vision");
+  if (spec.supports_prompt_caching) out.push("cache");
+  if (spec.supports_reasoning) out.push("reasoning");
+  if (spec.litellm_key) out.push(`↳ ${spec.litellm_key}`);
+  if (spec.deprecation_date) out.push(`deprecates ${spec.deprecation_date}`);
+  return out;
 }
+
+const badgeClass =
+  "rounded-sm border border-border bg-muted/40 px-1.5 py-0.5 text-[11px] text-muted-foreground";
 
 export type LlmConfigFormProps = {
   initial: LlmConfig;
@@ -87,10 +91,43 @@ export function LlmConfigForm({
 }: LlmConfigFormProps) {
   const [tiers, setTiers] = useState<Tiers>(() => cloneTiers(initial));
   const [localError, setLocalError] = useState<string | null>(null);
+  // Per-provider model suggestions for the picker, loaded lazily when a provider is focused/selected.
+  const [modelOptions, setModelOptions] = useState<Record<string, ModelOptions>>({});
+  const [optionsLoading, setOptionsLoading] = useState<Record<string, boolean>>({});
 
   const isEnabled = (p: LlmProviderInfo) => isProviderConfigured(p, secretKeys);
   const known = new Set(providers.map((p) => p.id));
   const firstEnabled = providers.find(isEnabled);
+
+  // Fetch + cache a provider's model suggestions. Azure returns a best-effort LIVE list of the
+  // resource's callable models; other providers come from the LiteLLM catalog. `force` re-fetches
+  // (used by Azure's "Reload deployments"). Failures cache an "unavailable" result so the picker
+  // quietly falls back to free-text entry.
+  async function loadModelOptions(provider: string, force = false) {
+    // Azure deployment names can't be reliably listed — its model field stays free-text (no datalist).
+    if (!provider || provider === "azure" || !known.has(provider)) return;
+    if (!force && (modelOptions[provider] || optionsLoading[provider])) return;
+    setOptionsLoading((p) => ({ ...p, [provider]: true }));
+    try {
+      const opts = await getModelOptions(provider);
+      setModelOptions((p) => ({ ...p, [provider]: opts }));
+    } catch {
+      setModelOptions((p) => ({
+        ...p,
+        [provider]: { models: [], source: "unavailable", reason: "Couldn't load model list." },
+      }));
+    } finally {
+      setOptionsLoading((p) => ({ ...p, [provider]: false }));
+    }
+  }
+
+  // Auto-resolve the spec when a model is committed (on blur), replacing the old manual button. Skips
+  // if the row is empty, already has a spec, or a resolve is in flight.
+  function autoResolve(tier: TierName, idx: number) {
+    const row = tiers[tier][idx];
+    if (!row?.provider || !row.model.trim() || row.spec || row.specState === "loading") return;
+    void fetchSpec(tier, idx);
+  }
 
   function patchRow(tier: TierName, idx: number, patch: Partial<Row>) {
     setTiers((prev) => ({
@@ -222,13 +259,14 @@ export function LlmConfigForm({
                     className={inputClass}
                     value={r.provider}
                     // Changing provider invalidates any pinned spec (it was resolved for the old one).
-                    onChange={(e) =>
+                    onChange={(e) => {
                       patchRow(tier, idx, {
                         provider: e.target.value,
                         spec: undefined,
                         specState: undefined,
-                      })
-                    }
+                      });
+                      void loadModelOptions(e.target.value);
+                    }}
                     aria-label={`${tier} provider ${idx + 1} provider`}
                   >
                     {r.provider && !known.has(r.provider) ? (
@@ -244,9 +282,16 @@ export function LlmConfigForm({
                 </label>
                 <label className="flex flex-col gap-1 text-xs text-muted-foreground">
                   model
+                  {/* Combobox: a native datalist gives a dropdown of suggested models while still
+                      accepting any custom name typed in. Suggestions load lazily per provider. */}
                   <input
                     className={inputClass}
                     value={r.model}
+                    list={
+                      r.provider && r.provider !== "azure" && known.has(r.provider)
+                        ? `models-${r.provider}`
+                        : undefined
+                    }
                     // Changing the model invalidates any pinned spec.
                     onChange={(e) =>
                       patchRow(tier, idx, {
@@ -255,7 +300,9 @@ export function LlmConfigForm({
                         specState: undefined,
                       })
                     }
-                    placeholder="claude-sonnet-4-6"
+                    onFocus={() => void loadModelOptions(r.provider)}
+                    onBlur={() => autoResolve(tier, idx)}
+                    placeholder="pick or type a model name"
                     aria-label={`${tier} provider ${idx + 1} model`}
                   />
                 </label>
@@ -271,38 +318,38 @@ export function LlmConfigForm({
                 </Button>
               </div>
 
-              {/* Spec resolution: pricing/context/capabilities pinned from LiteLLM. */}
-              <div className="flex items-center gap-3 text-xs">
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className="cursor-pointer rounded-sm"
-                  disabled={!r.provider || !r.model.trim() || r.specState === "loading"}
-                  onClick={() => fetchSpec(tier, idx)}
-                >
-                  {r.specState === "loading"
-                    ? "Resolving…"
-                    : r.spec
-                      ? "Refresh spec"
-                      : "Fetch spec"}
-                </Button>
+              {/* Metadata strip: pricing/context/capabilities auto-resolved from LiteLLM, plus the
+                  Azure deployment picker controls. */}
+              <div className="flex flex-wrap items-center gap-2 text-xs">
                 {r.spec ? (
-                  <span className="truncate text-muted-foreground" title={specSummary(r.spec)}>
-                    {specSummary(r.spec)}
-                  </span>
+                  specBadges(r.spec).map((b) => (
+                    <span key={b} className={badgeClass}>
+                      {b}
+                    </span>
+                  ))
+                ) : r.specState === "loading" ? (
+                  <span className="text-muted-foreground">Resolving spec…</span>
                 ) : r.specState === "unmatched" ? (
                   <span className="text-muted-foreground">
-                    No LiteLLM match — cost stays unpriced (enter pricing_overrides in config, or it
-                    just won&rsquo;t show cost).
+                    No LiteLLM match — cost stays unpriced.
                   </span>
                 ) : r.specState === "error" ? (
                   <span className="text-destructive">Couldn&rsquo;t reach the model catalog.</span>
                 ) : (
-                  <span className="text-muted-foreground">
-                    Spec auto-resolves from LiteLLM on Save (or fetch now to preview).
-                  </span>
+                  <span className="text-muted-foreground">Spec auto-resolves on Save.</span>
                 )}
+                {r.spec ? (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="cursor-pointer rounded-sm"
+                    disabled={r.specState === "loading"}
+                    onClick={() => fetchSpec(tier, idx)}
+                  >
+                    {r.specState === "loading" ? "Refreshing…" : "Refresh"}
+                  </Button>
+                ) : null}
               </div>
             </div>
           ))}
@@ -319,6 +366,15 @@ export function LlmConfigForm({
             </Button>
           </div>
         </fieldset>
+      ))}
+
+      {/* Model suggestions for the comboboxes above — one datalist per loaded provider. */}
+      {Object.entries(modelOptions).map(([prov, opts]) => (
+        <datalist key={prov} id={`models-${prov}`}>
+          {opts.models.map((m) => (
+            <option key={m} value={m} />
+          ))}
+        </datalist>
       ))}
 
       <div className="flex justify-end">

--- a/apps/web/app/lib/settings.ts
+++ b/apps/web/app/lib/settings.ts
@@ -55,6 +55,21 @@ export async function resolveModelSpec(
   return apiGet<SpecResolution>(`/api/v1/llm-config/resolve-spec?${q.toString()}`);
 }
 
+// Suggested model ids for a provider (from the LiteLLM catalog), to populate the model picker.
+// `source: "unavailable"` (+ reason) means the catalog was unreachable and the picker degrades to
+// free-text entry. Azure is intentionally not listed here (deployment names can't be reliably
+// discovered) — its model field is free-text.
+export type ModelOptions = {
+  models: string[];
+  source: "catalog" | "unavailable";
+  reason?: string;
+};
+
+export async function getModelOptions(provider: string): Promise<ModelOptions> {
+  const q = new URLSearchParams({ provider });
+  return apiGet<ModelOptions>(`/api/v1/llm-config/model-options?${q.toString()}`);
+}
+
 // Provider registry (served from @tulipfarm/secrets via GET /api/v1/llm-providers). Each provider
 // declares the full set of fields it needs — some secret (API keys), some plain config (resource
 // name, base URL). The Secrets tab renders all of a provider's fields; the LLM form enables a

--- a/apps/web/app/routes/_app.settings.secrets.tsx
+++ b/apps/web/app/routes/_app.settings.secrets.tsx
@@ -40,6 +40,8 @@ export default function SettingsSecrets() {
   const storedKeys = useMemo(() => new Set(secrets.map((s) => s.key)), [secrets]);
 
   const [providerId, setProviderId] = useState(providers[0]?.id ?? CUSTOM);
+  // Id of the configured provider whose inline editor is open (null = all collapsed).
+  const [openId, setOpenId] = useState<string | null>(null);
   const [values, setValues] = useState<Record<string, string>>({});
   const [customKey, setCustomKey] = useState("");
   const [busy, setBusy] = useState(false);
@@ -49,7 +51,16 @@ export default function SettingsSecrets() {
     fn: () => Promise<unknown>;
   } | null>(null);
 
-  const selected = providers.find((p) => p.id === providerId);
+  // A provider with any stored field is managed (edited/deleted) from its own list row; the "Add a
+  // provider" picker below only offers ones with nothing set yet, so you can't re-add an existing one.
+  const unconfiguredProviders = providers.filter(
+    (p) => !p.fields.some((f) => storedKeys.has(f.key))
+  );
+  // Keep the add-form selection valid even if `providerId` went stale (its provider got configured).
+  const addProviderId = unconfiguredProviders.some((p) => p.id === providerId)
+    ? providerId
+    : (unconfiguredProviders[0]?.id ?? CUSTOM);
+  const adding = providers.find((p) => p.id === addProviderId);
 
   // One list row per CONFIGURED provider (any of its fields stored); leftover keys not owned by a
   // provider (custom/bootstrap secrets) list individually.
@@ -62,10 +73,17 @@ export default function SettingsSecrets() {
   const ownedKeys = new Set(providers.flatMap((p) => p.fields.map((f) => f.key)));
   const customSecrets = secrets.filter((s) => !ownedKeys.has(s.key));
 
-  const filled = (key: string) => (values[key] ?? "").trim().length > 0 || storedKeys.has(key);
-  const canSubmit = selected
-    ? selected.fields.filter((f) => !f.optional).every((f) => filled(f.key))
+  const typed = (key: string) => (values[key] ?? "").trim().length > 0;
+  const filled = (key: string) => typed(key) || storedKeys.has(key);
+  // Adding a new provider needs every required field actually typed (nothing is stored yet).
+  const canAdd = adding
+    ? adding.fields.filter((f) => !f.optional).every((f) => typed(f.key))
     : customKey.trim().length > 0 && (values[CUSTOM] ?? "").length > 0;
+  // Editing an existing provider: enabled once a field was changed and required fields are satisfied
+  // (a stored secret counts as satisfied — leaving it blank keeps it).
+  const canSaveEdit = (p: (typeof providers)[number]) =>
+    p.fields.some((f) => typed(f.key)) &&
+    p.fields.filter((f) => !f.optional).every((f) => filled(f.key));
 
   function setVal(key: string, v: string) {
     setValues((prev) => ({ ...prev, [key]: v }));
@@ -84,22 +102,50 @@ export default function SettingsSecrets() {
     }
   }
 
-  function onSubmit(e: FormEvent) {
-    e.preventDefault();
+  // Persist only the fields the user actually typed into (blank = keep current value). Shared by the
+  // inline edit rows and the add form.
+  function saveFields(fields: { key: string }[]) {
     void run(async () => {
-      if (selected) {
-        await Promise.all(
-          selected.fields
-            .filter((f) => (values[f.key] ?? "").trim().length > 0)
-            .map((f) => putSecret(f.key, values[f.key].trim()))
-        );
-      } else {
-        await putSecret(customKey.trim(), values[CUSTOM]);
-      }
+      await Promise.all(
+        fields.filter((f) => typed(f.key)).map((f) => putSecret(f.key, values[f.key].trim()))
+      );
+      setValues({});
+    });
+  }
+
+  function onAddSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (adding) {
+      saveFields(adding.fields);
+      return;
+    }
+    void run(async () => {
+      await putSecret(customKey.trim(), values[CUSTOM]);
       setValues({});
       setCustomKey("");
     });
   }
+
+  // A provider field input + label. `ownerId` namespaces the aria-label so two providers with a same-
+  // role field don't collide. Secret values are never returned by the API, so a stored secret renders
+  // as a blank field with a "leave blank to keep" hint; config values (e.g. resource name) prefill.
+  const renderField = (field: (typeof providers)[number]["fields"][number], ownerId: string) => (
+    <label key={field.key} className="flex flex-col gap-1 text-xs text-muted-foreground">
+      <span>
+        {field.label}
+        {field.optional ? " (optional)" : ""}
+        {field.kind === "secret" && storedKeys.has(field.key) ? " — set, leave blank to keep" : ""}
+      </span>
+      <input
+        className={inputClass}
+        type={field.kind === "secret" ? "password" : "text"}
+        value={values[field.key] ?? (field.kind === "config" ? (config[field.key] ?? "") : "")}
+        onChange={(e) => setVal(field.key, e.target.value)}
+        placeholder={field.placeholder ?? (field.kind === "secret" ? "••••••••" : "")}
+        aria-label={`${ownerId} ${field.role}`}
+      />
+    </label>
+  );
 
   return (
     <div className="flex flex-col gap-6">
@@ -116,13 +162,14 @@ export default function SettingsSecrets() {
         <p className="text-sm text-muted-foreground">No secrets set.</p>
       ) : (
         <ul className="flex flex-col gap-2">
-          {providerGroups.map((g) => (
-            <li key={g.provider.id}>
-              <details className="group rounded-sm border border-border">
-                <summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2 [&::-webkit-details-marker]:hidden">
+          {providerGroups.map((g) => {
+            const open = openId === g.provider.id;
+            return (
+              <li key={g.provider.id} className="rounded-sm border border-border">
+                <div className="flex items-center gap-2 px-3 py-2">
                   <span
                     aria-hidden
-                    className="text-primary transition-transform group-open:rotate-90"
+                    className={`text-primary transition-transform ${open ? "rotate-90" : ""}`}
                   >
                     ▸
                   </span>
@@ -134,48 +181,55 @@ export default function SettingsSecrets() {
                     type="button"
                     variant="ghost"
                     size="sm"
-                    className="ml-auto rounded-sm"
+                    className="ml-auto cursor-pointer rounded-sm"
                     disabled={busy}
-                    onClick={(e) => {
-                      e.preventDefault();
-                      setProviderId(g.provider.id);
+                    onClick={() => {
+                      setOpenId(open ? null : g.provider.id);
                       setValues({});
+                      setError(null);
                     }}
                   >
-                    Edit
+                    {open ? "Close" : "Edit"}
                   </Button>
                   <Button
                     type="button"
                     variant="ghost"
                     size="sm"
-                    className="rounded-sm"
+                    className="cursor-pointer rounded-sm"
                     disabled={busy}
-                    onClick={(e) => {
-                      e.preventDefault();
+                    onClick={() =>
                       setPendingDelete({
                         label: g.provider.label,
                         fn: () => Promise.all(g.keys.map((k) => deleteSecret(k))),
-                      });
-                    }}
+                      })
+                    }
                   >
                     Delete
                   </Button>
-                </summary>
-                <dl className="flex flex-col gap-1 border-t border-border px-3 py-2 text-sm">
-                  {g.provider.fields
-                    .filter((f) => storedKeys.has(f.key))
-                    .map((f) => (
-                      <div key={f.key} className="flex gap-2">
-                        <dt className="text-muted-foreground">{f.label}</dt>
-                        <dd className="text-foreground">
-                          {f.kind === "secret" ? "•••••••• (set)" : (config[f.key] ?? "(set)")}
-                        </dd>
-                      </div>
-                    ))}
-                </dl>
-              </details>
-            </li>
-          ))}
+                </div>
+                {open ? (
+                  <div className="flex flex-col gap-3 border-t border-border px-3 py-3">
+                    <p className="text-xs text-muted-foreground">
+                      Edit any field, then Save. Secret values are never shown — leave a field blank
+                      to keep it.
+                    </p>
+                    {g.provider.fields.map((f) => renderField(f, g.provider.id))}
+                    <div className="flex justify-end">
+                      <Button
+                        type="button"
+                        size="sm"
+                        className="cursor-pointer rounded-sm"
+                        disabled={busy || !canSaveEdit(g.provider)}
+                        onClick={() => saveFields(g.provider.fields)}
+                      >
+                        {busy ? "Saving…" : "Save"}
+                      </Button>
+                    </div>
+                  </div>
+                ) : null}
+              </li>
+            );
+          })}
 
           {customSecrets.map((secret) => (
             <li
@@ -190,7 +244,7 @@ export default function SettingsSecrets() {
                 type="button"
                 variant="ghost"
                 size="sm"
-                className="ml-auto rounded-sm"
+                className="ml-auto cursor-pointer rounded-sm"
                 disabled={busy}
                 onClick={() =>
                   setPendingDelete({
@@ -206,21 +260,24 @@ export default function SettingsSecrets() {
         </ul>
       )}
 
-      <form onSubmit={onSubmit} className="flex flex-col gap-3 rounded-sm border border-border p-4">
-        <p className="text-sm font-medium text-foreground">Configure a provider</p>
+      <form
+        onSubmit={onAddSubmit}
+        className="flex flex-col gap-3 rounded-sm border border-border p-4"
+      >
+        <p className="text-sm font-medium text-foreground">Add a provider</p>
 
         <label className="flex flex-col gap-1 text-xs text-muted-foreground">
           provider
           <select
             className={inputClass}
-            value={providerId}
+            value={addProviderId}
             onChange={(e) => {
               setProviderId(e.target.value);
               setValues({});
             }}
             aria-label="secret provider"
           >
-            {providers.map((p) => (
+            {unconfiguredProviders.map((p) => (
               <option key={p.id} value={p.id}>
                 {p.label}
               </option>
@@ -229,24 +286,8 @@ export default function SettingsSecrets() {
           </select>
         </label>
 
-        {selected ? (
-          selected.fields.map((field) => (
-            <label key={field.key} className="flex flex-col gap-1 text-xs text-muted-foreground">
-              {field.label}
-              {field.optional ? " (optional)" : ""}
-              {storedKeys.has(field.key) ? <span className="text-primary"> · set</span> : ""}
-              <input
-                className={inputClass}
-                type={field.kind === "secret" ? "password" : "text"}
-                value={
-                  values[field.key] ?? (field.kind === "config" ? (config[field.key] ?? "") : "")
-                }
-                onChange={(e) => setVal(field.key, e.target.value)}
-                placeholder={field.placeholder ?? (field.kind === "secret" ? "••••••••" : "")}
-                aria-label={`${selected.id} ${field.role}`}
-              />
-            </label>
-          ))
+        {adding ? (
+          adding.fields.map((field) => renderField(field, adding.id))
         ) : (
           <>
             <label className="flex flex-col gap-1 text-xs text-muted-foreground">
@@ -274,7 +315,12 @@ export default function SettingsSecrets() {
         )}
 
         <div className="flex justify-end">
-          <Button type="submit" size="sm" className="rounded-sm" disabled={busy || !canSubmit}>
+          <Button
+            type="submit"
+            size="sm"
+            className="cursor-pointer rounded-sm"
+            disabled={busy || !canAdd}
+          >
             {busy ? "Saving…" : "Save provider"}
           </Button>
         </div>

--- a/apps/web/app/routes/settings.routes.test.tsx
+++ b/apps/web/app/routes/settings.routes.test.tsx
@@ -38,7 +38,7 @@ const PROVIDERS: LlmProviderInfo[] = [
   },
   {
     id: "azure",
-    label: "Azure OpenAI",
+    label: "Azure Foundry",
     fields: [
       { key: "azure-openai-api-key", label: "API key", role: "api_key", kind: "secret" },
       {
@@ -73,7 +73,7 @@ afterEach(() => {
 
 const meta = { type: "user-provided" as const, createdAt: "x", updatedAt: "y" };
 
-test("groups a provider's stored fields into one collapsible row and shows config values", () => {
+test("groups a provider's stored fields into one collapsible row and shows config values", async () => {
   renderWithData(<SettingsSecrets />, {
     secrets: [
       { key: "azure-openai-api-key", ...meta },
@@ -82,16 +82,18 @@ test("groups a provider's stored fields into one collapsible row and shows confi
     providers: PROVIDERS,
     config: { "azure-openai-resource-name": "my-res" },
   });
-  // "Azure OpenAI" appears in both the row and the configure dropdown — the single grouped row is
-  // proven by one "2 fields" badge + one Delete (not two per-key rows).
-  expect(screen.getAllByText("Azure OpenAI").length).toBeGreaterThanOrEqual(1);
+  // "Azure Foundry" shows as one grouped row (a configured provider is no longer offered in the add
+  // picker) — proven by one "2 fields" badge + one Delete (not two per-key rows).
+  expect(screen.getAllByText("Azure Foundry").length).toBeGreaterThanOrEqual(1);
   expect(screen.getByText("2 fields")).toBeInTheDocument();
-  expect(screen.getByText("my-res")).toBeInTheDocument(); // config value shown back
-  expect(screen.getByText("•••••••• (set)")).toBeInTheDocument(); // secret value masked
   expect(screen.getAllByRole("button", { name: /delete/i })).toHaveLength(1);
+  // Expand to edit: config value (resource name) prefills; the secret stays blank/write-only.
+  await userEvent.click(screen.getByRole("button", { name: /^edit$/i }));
+  expect(screen.getByLabelText("azure resource_name")).toHaveValue("my-res");
+  expect(screen.getByLabelText("azure api_key")).toHaveValue("");
 });
 
-test("editing a provider loads it into the form with config values prefilled", async () => {
+test("editing a provider inline saves only the changed fields", async () => {
   renderWithData(<SettingsSecrets />, {
     secrets: [
       { key: "azure-openai-api-key", ...meta },
@@ -100,9 +102,32 @@ test("editing a provider loads it into the form with config values prefilled", a
     providers: PROVIDERS,
     config: { "azure-openai-resource-name": "my-res" },
   });
-  await userEvent.click(screen.getByRole("button", { name: /edit/i }));
-  expect(screen.getByLabelText("secret provider")).toHaveValue("azure");
-  expect(screen.getByLabelText("azure resource_name")).toHaveValue("my-res");
+  // Edit happens in the row itself (expand it), then change the resource name and Save.
+  await userEvent.click(screen.getByRole("button", { name: /^edit$/i }));
+  const resource = screen.getByLabelText("azure resource_name");
+  await userEvent.clear(resource);
+  await userEvent.type(resource, "new-res");
+  await userEvent.click(screen.getByRole("button", { name: /^save$/i })); // the row's inline Save
+  expect(settings.putSecret).toHaveBeenCalledWith("azure-openai-resource-name", "new-res");
+  // The untouched (blank) API key is left as-is — not re-written.
+  expect(settings.putSecret).not.toHaveBeenCalledWith("azure-openai-api-key", expect.anything());
+});
+
+test("a configured provider is not offered in the add picker (managed via Edit only)", () => {
+  renderWithData(<SettingsSecrets />, {
+    secrets: [
+      { key: "azure-openai-api-key", ...meta },
+      { key: "azure-openai-resource-name", ...meta },
+    ],
+    providers: PROVIDERS,
+    config: {},
+  });
+  const picker = screen.getByLabelText("secret provider");
+  const optionLabels = within(picker)
+    .getAllByRole("option")
+    .map((o) => o.textContent);
+  expect(optionLabels).not.toContain("Azure Foundry"); // already configured → excluded
+  expect(optionLabels).toContain("Anthropic"); // nothing stored → still offered
 });
 
 test("configuring a multi-field provider stores every field under its registry key", async () => {

--- a/packages/llm/src/index.ts
+++ b/packages/llm/src/index.ts
@@ -28,6 +28,7 @@ export { LlmService } from "./llm-service";
 export {
   fetchLiteLlmCatalog,
   type LiteLlmCatalog,
+  litellmModelsForProvider,
   resolveModelSpec,
   type SpecResolution,
 } from "./model-spec";

--- a/packages/llm/src/model-spec.ts
+++ b/packages/llm/src/model-spec.ts
@@ -135,3 +135,28 @@ export function resolveModelSpec(
   const loose = keys.filter((k) => k.toLowerCase().includes(m)).slice(0, 10);
   return { spec: null, matchedKey: null, candidates: loose };
 }
+
+/**
+ * Bare, chat-capable model ids for a provider, derived from the catalog — used to populate the model
+ * picker's suggestions in Settings. Strips the provider prefix (so `anthropic/claude-x` → `claude-x`),
+ * keeps only entries that look like chat models (priced, `mode` chat/unset), dedupes and sorts.
+ */
+export function litellmModelsForProvider(provider: string, catalog: LiteLlmCatalog): string[] {
+  const prefixes = PROVIDER_PREFIXES[provider] ?? [""];
+  const out = new Set<string>();
+  for (const key of Object.keys(catalog)) {
+    if (key === "sample_spec") continue;
+    const entry = catalog[key];
+    if (typeof entry?.input_cost_per_token !== "number") continue; // skip cost-less / non-chat
+    const mode = typeof entry.mode === "string" ? entry.mode : undefined;
+    if (mode && mode !== "chat") continue; // embeddings/image/rerank etc. aren't tier models
+    for (const prefix of prefixes) {
+      if (prefix === "") {
+        if (!key.includes("/")) out.add(key); // bare ids only, for the "" prefix
+      } else if (key.startsWith(prefix)) {
+        out.add(key.slice(prefix.length));
+      }
+    }
+  }
+  return [...out].sort();
+}

--- a/packages/secrets/src/registry.ts
+++ b/packages/secrets/src/registry.ts
@@ -43,8 +43,11 @@ export const LLM_PROVIDERS: readonly LlmProviderInfo[] = [
     fields: [{ key: "openai-api-key", label: "API key", role: "api_key", kind: "secret" }],
   },
   {
+    // id stays "azure" (renaming it breaks existing soul/llm.config.yaml `provider: azure` rows and
+    // the `case "azure"` provider switch); only the display label moves to "Azure Foundry". The two
+    // stored keys keep their `azure-openai-*` names so existing secrets aren't orphaned.
     id: "azure",
-    label: "Azure OpenAI",
+    label: "Azure Foundry",
     fields: [
       { key: "azure-openai-api-key", label: "API key", role: "api_key", kind: "secret" },
       {
@@ -53,6 +56,17 @@ export const LLM_PROVIDERS: readonly LlmProviderInfo[] = [
         role: "resource_name",
         kind: "config",
         placeholder: "my-resource",
+      },
+      {
+        // Optional override for the Azure AI Foundry inference host. When set it flows through as
+        // `base_url` to createAzure (which appends `/v1{path}`); when blank we fall back to the
+        // resource name → https://{name}.openai.azure.com/openai/v1. New key ⇒ no orphan risk.
+        key: "azure-foundry-endpoint",
+        label: "Endpoint",
+        role: "base_url",
+        kind: "config",
+        optional: true,
+        placeholder: "https://my-resource.services.ai.azure.com/openai",
       },
     ],
   },


### PR DESCRIPTION
…odel picker and secrets edit

- Relabel "Azure OpenAI" → "Azure Foundry" (id "azure" and azure-openai-* keys kept to avoid orphaning secrets / breaking soul configs); add optional azure-foundry-endpoint base_url field for the Foundry inference host.
- LLM config form: model field is a datalist combobox (suggestions from the LiteLLM catalog via new GET /llm-config/model-options) with free-text custom entry; spec auto-resolves on blur and renders as metadata badges.
- Azure has no model list (live /openai/v1/models was unreliable) — free-text only.
- Secrets page: configured providers edit inline via an Edit/Close accordion row; the add form only offers providers with nothing stored yet; clearer write-only secret hint replaces the cryptic "set" marker.