### PR TITLE
feat(soul): git-sync robustness, sync status UI, clearer error UX

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,7 @@ DATABASE_URL=postgresql://tulipfarm:CHANGE_ME_POSTGRES@postgres:5432/tulipfarm
 # Bundled datastore credential (installer-generated)
 POSTGRES_PASSWORD=CHANGE_ME_POSTGRES
 
-# --- Bootstrap secrets (installer-generated: openssl rand -base64 32) ---
+# --- Bootstrap env config (installer-generated: openssl rand -base64 32) ---
 ENCRYPTION_KEY=CHANGE_ME_32_BYTE_BASE64
 # Set only during key rotation (SEC-V1-001 dual-key graceful decrypt):
 # ENCRYPTION_KEY_PREVIOUS=
@@ -32,8 +32,8 @@ WEBHOOK_SIGNING_SECRET=CHANGE_ME_BASE64
 # --- Soul ---
 SOUL_PATH=/opt/tulipfarm/soul
 # Optional git remote for soul backup/sync. Activate by setting both; restart to apply.
-# GIT_REMOTE_URL=
-# GIT_CREDENTIALS=
+# SOUL_GIT_REMOTE_URL=
+# SOUL_GIT_CREDENTIAL=
 
 # --- Headless seeding (container platforms: Cloud Run, Fly, App Service) ---
 # Set ALL THREE to skip the web setup wizard and seed on first boot automatically.

--- a/.env.local.example
+++ b/.env.local.example
@@ -11,7 +11,7 @@ DATABASE_URL=postgres://localhost:5432/tulipfarm
 # (A relative/in-repo path is rejected at boot — see GitSyncService.ensureRepo.)
 SOUL_PATH=~/.tulipfarm/soul
 
-# Bootstrap Secrets
+# Bootstrap Env Config
 # Generate with: openssl rand -base64 32
 ENCRYPTION_KEY=<generate: openssl rand -base64 32>
 JWT_SECRET=<generate: openssl rand -base64 32>
@@ -26,8 +26,8 @@ WEBHOOK_SIGNING_SECRET=<generate: openssl rand -base64 32>
 SESSION_TTL_SECONDS=604800
 
 # Optional: Git-backed soul repo (set after first run to enable remote sync)
-# GIT_REMOTE_URL=https://github.com/yourname/soul.git
-# GIT_CREDENTIALS=ghp_xxxx
+# SOUL_GIT_REMOTE_URL=https://github.com/yourname/soul.git
+# SOUL_GIT_CREDENTIAL=ghp_xxxx
 
 # Optional: Key rotation (set only when rotating ENCRYPTION_KEY)
 # ENCRYPTION_KEY_PREVIOUS=<old key during rotation>

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ developer's choice (both options satisfy AC-006).
      service, and creates the `tulipfarm` database.
 
    Either way it initializes the soul directory and generates `.env.local` with
-   bootstrap secrets. For a non-interactive run, preset the choice:
+   bootstrap env config. For a non-interactive run, preset the choice:
    ```bash
    DB_MODE=docker bash scripts/setup-dev.sh   # or DB_MODE=native
    ```
@@ -97,21 +97,23 @@ The `scripts/setup-dev.sh` script automatically:
 - Installs and starts PostgreSQL 17 + pgvector
 - Creates the `tulipfarm` database
 - Initializes the soul git repository at `~/.tulipfarm/soul` with the required directory structure
-- Generates `.env.local` with random bootstrap secrets (`ENCRYPTION_KEY`, `JWT_SECRET`, `WEBHOOK_SIGNING_SECRET`)
+- Generates `.env.local` with random bootstrap env config (`ENCRYPTION_KEY`, `JWT_SECRET`, `WEBHOOK_SIGNING_SECRET`)
 
-**Manual adjustments:** Edit `.env.local` to customize the datastore or add optional variables like `GIT_REMOTE_URL` for syncing soul changes to a remote repository.
+**Manual adjustments:** Edit `.env.local` to customize the datastore or add optional variables like `SOUL_GIT_REMOTE_URL` for syncing soul changes to a remote repository.
 
 ### Soul Repository
 
 The soul lives at `~/.tulipfarm/soul` — a git repository that stores your system configuration (resources, routines, agents, skills, integrations). By default, it is local-only. To enable remote sync:
 
 1. Create a private GitHub repository for your soul
-2. Add the remote and set `GIT_REMOTE_URL` in `.env.local`:
+2. Add the remote and set `SOUL_GIT_REMOTE_URL` in `.env.local`:
    ```bash
    git -C ~/.tulipfarm/soul remote add origin https://github.com/your-org/your-soul.git
    git -C ~/.tulipfarm/soul push -u origin main
    ```
-3. Update `.env.local`: `GIT_REMOTE_URL=https://github.com/your-org/your-soul.git`
+3. Update `.env.local`: `SOUL_GIT_REMOTE_URL=https://github.com/your-org/your-soul.git`
+
+Or configure it from the Settings UI setup wizard, which persists the remote + credential and syncs immediately (no restart needed).
 
 ### Stopping Services
 

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -262,7 +262,7 @@ export async function buildApp(opts: AppOptions = {}) {
       );
     }
     if (opts.gitSync) {
-      registerSoulRoutes(app, opts.gitSync, requireAuth);
+      registerSoulRoutes(app, opts.gitSync, requireAuth, opts.secretsService);
       if (opts.soulLoader) {
         registerResourceTypeRoutes(
           app,

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -59,6 +59,7 @@ import { PgRateLimiter } from "./rate-limit";
 import { reconcileResourceTables, registerResourceReconcile } from "./resources/reconcile";
 import { PgCounterStore, PgResourceRepoFactory } from "./resources/repo";
 import { bootstrapFromEnv } from "./setup/bootstrap";
+import { readSoulConfig, SOUL_GIT_CREDENTIAL_KEY } from "./setup/soul-config";
 import { PLATFORM_AGENTS } from "./soul/agents/platform-agents";
 import { BUILTIN_SKILLS } from "./soul/skills/builtin-skills";
 import { registerSoulSync } from "./soul-sync";
@@ -73,33 +74,8 @@ const port = Number.parseInt(process.env.PORT || "4010", 10);
 
 async function boot() {
   try {
-    const gitSync = new GitSyncService(
-      process.env.SOUL_PATH as string,
-      process.env.GIT_REMOTE_URL,
-      process.env.GIT_CREDENTIALS,
-      console
-    );
-    await gitSync.bootSync();
-
-    await runSoulMigrations(process.env.SOUL_PATH as string, console);
-
-    const soulLoader = new SoulLoader(process.env.SOUL_PATH as string, console);
-    await soulLoader.load();
-
     const pool = await connectPg();
     await runPgMigrations(pool);
-    // Per-type resource tables can't be created lazily (no `db.collection(type)`):
-    // materialise them for every loaded soul type before serving.
-    await reconcileResourceTables(pool, soulLoader, console);
-
-    const ttlSeconds = Number.parseInt(
-      process.env.SESSION_TTL_SECONDS ?? String(DEFAULT_SESSION_TTL_SECONDS),
-      10
-    );
-    const sessionStore = new PgSessionStore(pool, ttlSeconds);
-    const userRepo = new PgUserRepo(pool);
-    const tokenRepo = new PgTokenRepo(pool);
-    const rateLimiter = new PgRateLimiter(pool);
 
     const secretRepo = new PgSecretRepo(pool);
     const dekRepo = new PgDekRepo(pool);
@@ -112,6 +88,46 @@ async function boot() {
     const secretsService = new SecretsService(secretRepo, activeDek, {
       legacyKeys: encryptionKeys,
     });
+
+    const soulPath = process.env.SOUL_PATH as string;
+    // SOUL_GIT_REMOTE_URL/SOUL_GIT_CREDENTIAL only seed the very first boot. Once Settings → Soul
+    // persists a remote (soul.yaml's gitRemoteUrl + the "soul-git-credential" secret), that takes
+    // over — otherwise a restart would forget a remote configured after boot.
+    const persistedSoulConfig = await readSoulConfig(soulPath);
+    const gitRemoteUrl = persistedSoulConfig.gitRemoteUrl ?? process.env.SOUL_GIT_REMOTE_URL;
+    const gitCredential =
+      (await secretsService.get(SOUL_GIT_CREDENTIAL_KEY).catch(() => undefined)) ??
+      process.env.SOUL_GIT_CREDENTIAL;
+
+    const gitSync = new GitSyncService(soulPath, gitRemoteUrl, gitCredential, console);
+    // A stale/invalid remote (revoked PAT, unreachable host) must never crash-loop boot — fall
+    // back to whatever soul state is already on disk and keep serving. `configureRemote` (the
+    // Settings → Soul PUT route) still throws on the same failure so the user sees it there.
+    try {
+      await gitSync.bootSync();
+    } catch (err) {
+      console.error(
+        `Soul: boot sync with remote failed (${err instanceof Error ? err.message : String(err)}) — continuing with local soul state`
+      );
+    }
+
+    await runSoulMigrations(soulPath, console);
+
+    const soulLoader = new SoulLoader(soulPath, console);
+    await soulLoader.load();
+
+    // Per-type resource tables can't be created lazily (no `db.collection(type)`):
+    // materialise them for every loaded soul type before serving.
+    await reconcileResourceTables(pool, soulLoader, console);
+
+    const ttlSeconds = Number.parseInt(
+      process.env.SESSION_TTL_SECONDS ?? String(DEFAULT_SESSION_TTL_SECONDS),
+      10
+    );
+    const sessionStore = new PgSessionStore(pool, ttlSeconds);
+    const userRepo = new PgUserRepo(pool);
+    const tokenRepo = new PgTokenRepo(pool);
+    const rateLimiter = new PgRateLimiter(pool);
 
     const hookExecutor =
       process.env.HOOKS_DISABLED === "true"
@@ -240,7 +256,7 @@ async function boot() {
       log: app.log,
     });
 
-    await registerSoulSync(boss, gitSync, process.env.GIT_REMOTE_URL, {
+    await registerSoulSync(boss, gitSync, gitRemoteUrl, {
       activity: activityService,
       soulLoader,
     });

--- a/apps/api/src/setup/routes.test.ts
+++ b/apps/api/src/setup/routes.test.ts
@@ -213,19 +213,39 @@ describe("setup routes", () => {
     expect(res.statusCode).toBe(400);
   });
 
-  it("git step stores remote URL in soul.yaml", async () => {
+  it("git step stores remote URL in soul.yaml, credential as a secret, and syncs immediately", async () => {
     const cookies = await createAdmin();
+    const configureRemote = vi
+      .spyOn(GitSyncService.prototype, "configureRemote")
+      .mockResolvedValue(undefined);
     const res = await app.inject({
       method: "POST",
       url: "/api/v1/setup/git",
       headers: authHeaders(cookies),
-      payload: { remoteUrl: "https://github.com/acme/soul.git" },
+      payload: { remoteUrl: "https://github.com/acme/soul.git", credentials: "ghp_test" },
     });
     expect(res.statusCode).toBe(204);
+    expect(configureRemote).toHaveBeenCalledWith("https://github.com/acme/soul.git", "ghp_test");
     const cfg = parse(await fs.readFile(path.join(dir, "soul", "soul.yaml"), "utf8")) as {
       gitRemoteUrl?: string;
     };
     expect(cfg.gitRemoteUrl).toBe("https://github.com/acme/soul.git");
+    configureRemote.mockRestore();
+  });
+
+  it("git step surfaces a sync failure (bad remote/credential) as 400", async () => {
+    const cookies = await createAdmin();
+    const configureRemote = vi
+      .spyOn(GitSyncService.prototype, "configureRemote")
+      .mockRejectedValue(new Error("Authentication failed"));
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/setup/git",
+      headers: authHeaders(cookies),
+      payload: { remoteUrl: "https://github.com/acme/soul.git", credentials: "bad_token" },
+    });
+    expect(res.statusCode).toBe(400);
+    configureRemote.mockRestore();
   });
 
   it("business step requires auth", async () => {

--- a/apps/api/src/setup/routes.ts
+++ b/apps/api/src/setup/routes.ts
@@ -271,15 +271,16 @@ export function registerSetupRoutes(app: FastifyInstance, deps: SetupDeps): void
     }
   );
 
-  // Step 4 (optional): configure soul git backup. Stores remote URL in soul.yaml and
-  // credentials as an encrypted secret. Git sync activates on next restart with
-  // GIT_REMOTE_URL + GIT_CREDENTIALS env vars; the stored values are for reference.
+  // Step 4 (optional): configure soul git backup. Stores remote URL in soul.yaml (Soul Config)
+  // and credentials as an encrypted Secret ("soul-git-credential"), then syncs immediately —
+  // clones/pulls the remote into the live GitSyncService instance, no restart required.
   app.post(
     "/api/v1/setup/git",
     {
       preHandler: wizardStep,
       schema: {
-        description: "Configure soul git backup (optional). Persists remote URL + credentials.",
+        description:
+          "Configure soul git backup (optional). Persists remote URL + credentials and syncs immediately.",
         tags: ["setup"],
         security: [{ sessionCookie: [] }],
         body: {
@@ -306,9 +307,14 @@ export function registerSetupRoutes(app: FastifyInstance, deps: SetupDeps): void
 
       await patchSoulConfig(soulPath, { gitRemoteUrl: remoteUrl });
       if (credentials) {
-        await secretsService.set("git-credentials", credentials);
+        await secretsService.set("soul-git-credential", credentials);
       }
-      await gitSync.commit("chore: set git remote config").catch(() => {});
+      try {
+        await gitSync.configureRemote(remoteUrl, credentials || undefined);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return reply.code(400).send({ error: `Failed to sync with remote: ${message}` });
+      }
       return reply.code(204).send();
     }
   );

--- a/apps/api/src/setup/soul-config.ts
+++ b/apps/api/src/setup/soul-config.ts
@@ -2,6 +2,8 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import { parse, stringify } from "yaml";
 
+export const SOUL_GIT_CREDENTIAL_KEY = "soul-git-credential";
+
 export interface SoulConfig {
   businessName?: string;
   businessDescription?: string;

--- a/apps/api/src/soul/routes.test.ts
+++ b/apps/api/src/soul/routes.test.ts
@@ -1,4 +1,6 @@
+import { promises as soulConfigFs } from "node:fs";
 import { readdir, readFile, realpath, stat } from "node:fs/promises";
+import type { SecretMeta, SecretsService } from "@tulipfarm/secrets";
 import type { GitSyncService } from "@tulipfarm/soul";
 import type { FastifyInstance } from "fastify";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -20,6 +22,21 @@ vi.mock("node:fs/promises", async (importOriginal) => {
     readFile: vi.fn(),
     realpath: vi.fn(),
     stat: vi.fn(),
+  };
+});
+
+// soul-config.ts (git-config routes) reads/writes soul.yaml via `node:fs`'s `promises`, a
+// different module specifier than tree.ts's `node:fs/promises` — mock separately.
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    promises: {
+      ...actual.promises,
+      readFile: vi.fn(),
+      mkdir: vi.fn(),
+      writeFile: vi.fn(),
+    },
   };
 });
 
@@ -343,6 +360,225 @@ describe("soul routes", () => {
         cookies: { [SESSION_COOKIE]: sid },
       });
       expect(res.statusCode).toBe(404);
+    });
+  });
+
+  describe("git-config routes", () => {
+    function makeFakeSecretsService(keys: string[] = []) {
+      return {
+        list: vi.fn().mockResolvedValue(keys.map((key) => ({ key }) as SecretMeta)),
+        set: vi.fn().mockResolvedValue(undefined),
+      } as unknown as SecretsService;
+    }
+
+    async function rebuild(gitSyncOverrides: Record<string, unknown>, secretKeys: string[] = []) {
+      gitSync = {
+        ...makeFakeGitSync(),
+        getStatus: vi.fn().mockResolvedValue({
+          remoteConfigured: false,
+          ahead: 0,
+          behind: 0,
+          headSha: null,
+          lastSyncError: null,
+          lastSyncAt: null,
+        }),
+        configureRemote: vi.fn().mockResolvedValue(undefined),
+        syncNow: vi.fn().mockResolvedValue(undefined),
+        ...gitSyncOverrides,
+      } as unknown as GitSyncService;
+      const secretsService = makeFakeSecretsService(secretKeys);
+      await app.close();
+      app = await buildApp({ sessionStore: store, userRepo, tokenRepo, gitSync, secretsService });
+      return secretsService;
+    }
+
+    beforeEach(() => {
+      vi.mocked(soulConfigFs.readFile).mockRejectedValue(
+        Object.assign(new Error("ENOENT"), { code: "ENOENT" })
+      );
+    });
+
+    describe("GET /api/v1/soul/git-config", () => {
+      it("returns 401 without auth", async () => {
+        await rebuild({});
+        const res = await app.inject({ method: "GET", url: "/api/v1/soul/git-config" });
+        expect(res.statusCode).toBe(401);
+      });
+
+      it("reports not-configured with no remote and no credential", async () => {
+        await rebuild({});
+        const res = await app.inject({
+          method: "GET",
+          url: "/api/v1/soul/git-config",
+          cookies: { [SESSION_COOKIE]: sid },
+        });
+        expect(res.statusCode).toBe(200);
+        expect(res.json()).toEqual({
+          credentialSet: false,
+          status: {
+            remoteConfigured: false,
+            ahead: 0,
+            behind: 0,
+            headSha: null,
+            lastSyncError: null,
+            lastSyncAt: null,
+          },
+        });
+      });
+
+      it("reports remote url, credentialSet, and ahead/behind when configured", async () => {
+        vi.mocked(soulConfigFs.readFile).mockResolvedValue(
+          "gitRemoteUrl: https://github.com/acme/soul.git\n"
+        );
+        await rebuild(
+          {
+            getStatus: vi.fn().mockResolvedValue({
+              remoteConfigured: true,
+              remoteUrl: "https://github.com/acme/soul.git",
+              ahead: 1,
+              behind: 2,
+              headSha: "abc1234",
+              lastSyncError: null,
+              lastSyncAt: "2026-07-02T07:00:00.000Z",
+            }),
+          },
+          ["soul-git-credential"]
+        );
+        const res = await app.inject({
+          method: "GET",
+          url: "/api/v1/soul/git-config",
+          cookies: { [SESSION_COOKIE]: sid },
+        });
+        expect(res.statusCode).toBe(200);
+        expect(res.json()).toEqual({
+          remoteUrl: "https://github.com/acme/soul.git",
+          credentialSet: true,
+          status: {
+            remoteConfigured: true,
+            ahead: 1,
+            behind: 2,
+            headSha: "abc1234",
+            lastSyncError: null,
+            lastSyncAt: "2026-07-02T07:00:00.000Z",
+          },
+        });
+      });
+
+      it("reports a lastSyncError when the last sync attempt failed", async () => {
+        await rebuild({
+          getStatus: vi.fn().mockResolvedValue({
+            remoteConfigured: true,
+            remoteUrl: "https://github.com/acme/soul.git",
+            ahead: 0,
+            behind: 0,
+            headSha: "abc1234",
+            lastSyncError: "could not read Username for 'https://github.com'",
+            lastSyncAt: "2026-07-02T07:00:00.000Z",
+          }),
+        });
+        const res = await app.inject({
+          method: "GET",
+          url: "/api/v1/soul/git-config",
+          cookies: { [SESSION_COOKIE]: sid },
+        });
+        expect(res.json().status.lastSyncError).toBe(
+          "could not read Username for 'https://github.com'"
+        );
+      });
+    });
+
+    describe("POST /api/v1/soul/sync", () => {
+      it("returns 401 without auth", async () => {
+        await rebuild({});
+        const res = await app.inject({ method: "POST", url: "/api/v1/soul/sync" });
+        expect(res.statusCode).toBe(401);
+      });
+
+      it("triggers a manual sync and returns 204 on success", async () => {
+        await rebuild({});
+        const res = await app.inject({
+          method: "POST",
+          url: "/api/v1/soul/sync",
+          cookies: { [SESSION_COOKIE]: sid, [CSRF_COOKIE]: TEST_CSRF },
+          headers: { [CSRF_HEADER]: TEST_CSRF },
+        });
+        expect(res.statusCode).toBe(204);
+        expect(gitSync.syncNow).toHaveBeenCalled();
+      });
+
+      it("surfaces a syncNow failure as 400", async () => {
+        await rebuild({
+          syncNow: vi.fn().mockRejectedValue(new Error("could not read Username")),
+        });
+        const res = await app.inject({
+          method: "POST",
+          url: "/api/v1/soul/sync",
+          cookies: { [SESSION_COOKIE]: sid, [CSRF_COOKIE]: TEST_CSRF },
+          headers: { [CSRF_HEADER]: TEST_CSRF },
+        });
+        expect(res.statusCode).toBe(400);
+        expect(res.json().error).toContain("could not read Username");
+      });
+    });
+
+    describe("PUT /api/v1/soul/git-config", () => {
+      it("returns 401 without auth", async () => {
+        await rebuild({});
+        const res = await app.inject({
+          method: "PUT",
+          url: "/api/v1/soul/git-config",
+          payload: { remoteUrl: "https://github.com/acme/soul.git" },
+        });
+        expect(res.statusCode).toBe(401);
+      });
+
+      it("returns 400 when remoteUrl is missing", async () => {
+        await rebuild({});
+        const res = await app.inject({
+          method: "PUT",
+          url: "/api/v1/soul/git-config",
+          cookies: { [SESSION_COOKIE]: sid, [CSRF_COOKIE]: TEST_CSRF },
+          headers: { [CSRF_HEADER]: TEST_CSRF },
+          payload: {},
+        });
+        expect(res.statusCode).toBe(400);
+      });
+
+      it("persists remote url, sets credential secret, and calls configureRemote", async () => {
+        const secretsService = await rebuild({});
+        const res = await app.inject({
+          method: "PUT",
+          url: "/api/v1/soul/git-config",
+          cookies: { [SESSION_COOKIE]: sid, [CSRF_COOKIE]: TEST_CSRF },
+          headers: { [CSRF_HEADER]: TEST_CSRF },
+          payload: { remoteUrl: "https://github.com/acme/soul.git", credential: "ghp_test" },
+        });
+        expect(res.statusCode).toBe(204);
+        expect(vi.mocked(soulConfigFs.writeFile)).toHaveBeenCalledWith(
+          expect.stringContaining("soul.yaml"),
+          expect.stringContaining("https://github.com/acme/soul.git"),
+          "utf8"
+        );
+        expect(secretsService.set).toHaveBeenCalledWith("soul-git-credential", "ghp_test");
+        expect(gitSync.configureRemote).toHaveBeenCalledWith(
+          "https://github.com/acme/soul.git",
+          "ghp_test"
+        );
+      });
+
+      it("surfaces a configureRemote failure as 400", async () => {
+        await rebuild({
+          configureRemote: vi.fn().mockRejectedValue(new Error("Authentication failed")),
+        });
+        const res = await app.inject({
+          method: "PUT",
+          url: "/api/v1/soul/git-config",
+          cookies: { [SESSION_COOKIE]: sid, [CSRF_COOKIE]: TEST_CSRF },
+          headers: { [CSRF_HEADER]: TEST_CSRF },
+          payload: { remoteUrl: "https://github.com/acme/soul.git", credential: "bad_token" },
+        });
+        expect(res.statusCode).toBe(400);
+      });
     });
   });
 

--- a/apps/api/src/soul/routes.ts
+++ b/apps/api/src/soul/routes.ts
@@ -1,6 +1,8 @@
+import type { SecretsService } from "@tulipfarm/secrets";
 import type { GitSyncService } from "@tulipfarm/soul";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { ErrorSchema } from "../auth/schemas";
+import { patchSoulConfig, readSoulConfig, SOUL_GIT_CREDENTIAL_KEY } from "../setup/soul-config";
 import { readSoulFile, resolveSafe, UnsafePathError, walkTree } from "./tree";
 
 type PreHandler = (req: FastifyRequest, reply: FastifyReply) => Promise<void>;
@@ -12,7 +14,8 @@ function isErrnoException(err: unknown): err is NodeJS.ErrnoException {
 export function registerSoulRoutes(
   app: FastifyInstance,
   gitSync: GitSyncService,
-  requireAuth: PreHandler
+  requireAuth: PreHandler,
+  secretsService?: SecretsService
 ): void {
   // Recursive node schema for the soul tree response (self-referencing children).
   app.addSchema({
@@ -169,6 +172,139 @@ export function registerSoulRoutes(
         }
         throw err;
       }
+    }
+  );
+
+  if (!secretsService) return;
+
+  app.get(
+    "/api/v1/soul/git-config",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description: "Read the soul git remote config and live sync status.",
+        tags: ["soul"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        response: {
+          200: {
+            type: "object",
+            properties: {
+              remoteUrl: { type: "string" },
+              credentialSet: { type: "boolean" },
+              status: {
+                type: "object",
+                properties: {
+                  remoteConfigured: { type: "boolean" },
+                  ahead: { type: "number" },
+                  behind: { type: "number" },
+                  headSha: { type: ["string", "null"] },
+                  lastSyncError: { type: ["string", "null"] },
+                  lastSyncAt: { type: ["string", "null"] },
+                },
+                required: [
+                  "remoteConfigured",
+                  "ahead",
+                  "behind",
+                  "headSha",
+                  "lastSyncError",
+                  "lastSyncAt",
+                ],
+              },
+            },
+            required: ["credentialSet", "status"],
+          },
+          401: ErrorSchema,
+        },
+      },
+    },
+    async (_req, reply) => {
+      const [config, secrets, status] = await Promise.all([
+        readSoulConfig(gitSync.path),
+        secretsService.list(),
+        gitSync.getStatus(),
+      ]);
+      return reply.send({
+        remoteUrl: config.gitRemoteUrl,
+        credentialSet: secrets.some((s) => s.key === SOUL_GIT_CREDENTIAL_KEY),
+        status: {
+          remoteConfigured: status.remoteConfigured,
+          ahead: status.ahead,
+          behind: status.behind,
+          headSha: status.headSha,
+          lastSyncError: status.lastSyncError,
+          lastSyncAt: status.lastSyncAt,
+        },
+      });
+    }
+  );
+
+  app.post(
+    "/api/v1/soul/sync",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description: "Manually trigger a sync against the configured soul git remote.",
+        tags: ["soul"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        response: {
+          204: { type: "null" },
+          400: ErrorSchema,
+          401: ErrorSchema,
+        },
+      },
+    },
+    async (_req, reply) => {
+      try {
+        await gitSync.syncNow();
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return reply.code(400).send({ error: `Sync failed: ${message}` });
+      }
+      return reply.code(204).send();
+    }
+  );
+
+  app.put(
+    "/api/v1/soul/git-config",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description:
+          "Configure (or reconfigure) the soul git remote + credential and sync immediately.",
+        tags: ["soul"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        body: {
+          type: "object",
+          required: ["remoteUrl"],
+          properties: {
+            remoteUrl: { type: "string", minLength: 1 },
+            credential: { type: "string" },
+          },
+        },
+        response: {
+          204: { type: "null" },
+          400: ErrorSchema,
+          401: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const body = (req.body ?? {}) as { remoteUrl?: unknown; credential?: unknown };
+      const remoteUrl = typeof body.remoteUrl === "string" ? body.remoteUrl.trim() : "";
+      const credential = typeof body.credential === "string" ? body.credential.trim() : "";
+      if (!remoteUrl) return reply.code(400).send({ error: "remoteUrl is required" });
+
+      await patchSoulConfig(gitSync.path, { gitRemoteUrl: remoteUrl });
+      if (credential) {
+        await secretsService.set(SOUL_GIT_CREDENTIAL_KEY, credential);
+      }
+      try {
+        await gitSync.configureRemote(remoteUrl, credential || undefined);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return reply.code(400).send({ error: `Failed to sync with remote: ${message}` });
+      }
+      return reply.code(204).send();
     }
   );
 }

--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -121,8 +121,8 @@ export default function HomePage() {
             <p className="text-sm leading-6 text-fd-muted-foreground">
               One script installs PostgreSQL 17 + pgvector, plants your soul repository at{" "}
               <code className="text-fd-foreground">~/.tulipfarm/soul</code>, and generates your
-              bootstrap secrets. <code className="text-fd-foreground">pnpm dev</code> boots the API
-              and the web UI; the first account you create is the admin.
+              bootstrap env config. <code className="text-fd-foreground">pnpm dev</code> boots the
+              API and the web UI; the first account you create is the admin.
             </p>
             <Link
               href="/docs/getting-started"

--- a/apps/docs/components/home/boot-sequence.tsx
+++ b/apps/docs/components/home/boot-sequence.tsx
@@ -20,7 +20,7 @@ const LINES: Line[] = [
   { kind: "cmd", text: "bash scripts/setup-dev.sh" },
   { kind: "ok", text: "postgres 17 + pgvector ready" },
   { kind: "ok", text: "soul planted at ~/.tulipfarm/soul" },
-  { kind: "ok", text: "bootstrap secrets generated" },
+  { kind: "ok", text: "bootstrap env config generated" },
   { kind: "cmd", text: "pnpm dev" },
   { kind: "svc", text: "api  http://localhost:4010" },
   { kind: "svc", text: "web  http://localhost:4000" },

--- a/apps/docs/content/docs/concepts/secrets.mdx
+++ b/apps/docs/content/docs/concepts/secrets.mdx
@@ -5,18 +5,20 @@ description: Encrypted storage for the credentials your instance needs.
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-Secrets are the credentials your instance holds — LLM provider API keys, integration
-tokens, and anything else an agent or service needs to authenticate. TulipFarm stores
-them in two layers.
+A **secret** is the encrypted-at-rest storage primitive; a **credential** (an LLM
+provider API key, an integration token, a git access token) is the auth material it
+backs. TulipFarm stores credentials as secrets in two layers.
 
 ## Two layers
 
-- **Bootstrap secrets** are environment variables set before the instance starts:
+- **Bootstrap env config** are environment variables set before the instance starts:
   `ENCRYPTION_KEY`, `JWT_SECRET`, `WEBHOOK_SIGNING_SECRET`, and the database
-  connection. The setup script generates the random ones into `.env.local`.
-- **Application secrets** are everything you add at runtime — provider keys and custom
-  values. These are encrypted with AES-256-GCM and stored in the datastore, never in
-  plaintext and never in the soul.
+  connection. The setup script generates the random ones into `.env.local`. Most of
+  these values aren't credentials at all — `ENCRYPTION_KEY` is the one genuinely
+  secret value in this bucket.
+- **Application secrets** are everything you add at runtime — provider credentials and
+  custom values. These are encrypted with AES-256-GCM and stored in the datastore,
+  never in plaintext and never in the soul.
 
 The `ENCRYPTION_KEY` protects the application secrets — it wraps the data key that actually
 encrypts them. Its length is validated at startup, so a malformed key fails fast rather than

--- a/apps/docs/content/docs/concepts/setup.mdx
+++ b/apps/docs/content/docs/concepts/setup.mdx
@@ -47,8 +47,9 @@ four steps:
    depending on the provider) and writes a default `llm.config.yaml` with all three tiers
    pointing to the chosen provider and model. This step can be skipped and configured later
    in **Settings → LLM Config**.
-4. **Soul backup** — sets a git remote URL and optional credentials so the soul syncs to
-   a private repository. This step can also be skipped.
+4. **Soul backup** — sets a git remote URL and optional credential so the soul syncs to
+   a private repository. The instance clones/pulls the remote immediately on submit — no
+   restart required. This step can also be skipped.
 
 After step 4, the wizard calls `POST /api/v1/setup/complete`, which writes
 `setupComplete: true` to `soul.yaml`. Subsequent wizard-step routes return `403`.

--- a/apps/docs/content/docs/concepts/soul.mdx
+++ b/apps/docs/content/docs/concepts/soul.mdx
@@ -48,10 +48,11 @@ they live in the datastore.
 
 ## How the soul syncs
 
-The soul is loaded into the runtime at startup. If you set `GIT_REMOTE_URL`, the
+The soul is loaded into the runtime at startup. If you set `SOUL_GIT_REMOTE_URL`, the
 instance clones the remote on first boot and pulls from it on a periodic schedule;
 `main` wins when histories genuinely diverge, but local commits that are merely ahead
-and un-pushed are preserved and retried, never discarded.
+and un-pushed are preserved and retried, never discarded. Setting the remote from the
+setup wizard instead syncs immediately — no restart required.
 
 With no remote set, the soul is local-only. Writes still commit locally, and your
 configuration is captured by backups of the soul directory.
@@ -60,6 +61,14 @@ configuration is captured by backups of the soul directory.
 Setting a remote is strongly recommended. It turns your soul into a backed-up,
 portable record of your whole instance.
 </Callout>
+
+## Commit authorship
+
+Soul commits are attributed to `tulipfarm-bot <tulipfarmhq@gmail.com>` by default —
+that's the author on every write regardless of whose credential authenticates the
+push to the remote. Override it with the `BOT_GIT_NAME` and `BOT_GIT_EMAIL`
+environment variables if you want soul history attributed to your own name or
+organization instead.
 
 ## Soul writes are never gated
 

--- a/apps/docs/content/docs/getting-started.mdx
+++ b/apps/docs/content/docs/getting-started.mdx
@@ -47,7 +47,7 @@ The script prompts you to choose how to run PostgreSQL:
   starts the system service.
 
 Either way, the script initializes your soul repository at `~/.tulipfarm/soul` and generates a
-`.env.local` file with random bootstrap secrets (`ENCRYPTION_KEY`, `JWT_SECRET`,
+`.env.local` file with random bootstrap env config (`ENCRYPTION_KEY`, `JWT_SECRET`,
 `WEBHOOK_SIGNING_SECRET`).
 
 For a non-interactive run (CI, scripted environments), set `DB_MODE` before running:

--- a/apps/docs/content/docs/reference/environment-variables.mdx
+++ b/apps/docs/content/docs/reference/environment-variables.mdx
@@ -56,8 +56,10 @@ generates and writes these; they are documented here for reference.
 |---|---|---|
 | `SESSION_TTL_SECONDS` | `604800` | Session cookie lifetime in seconds (7 days). |
 | `VITE_PORT` | `4000` | Port the web UI dev server listens on (local development only). |
-| `GIT_REMOTE_URL` | — | Remote for the soul repository. When set, the instance clones on first boot and syncs on a schedule. |
-| `GIT_CREDENTIALS` | — | Credentials for pushing to `GIT_REMOTE_URL` (e.g. a GitHub personal access token). |
+| `SOUL_GIT_REMOTE_URL` | — | Remote for the soul repository. When set, the instance clones on first boot and syncs on a schedule. Can also be set from the setup wizard, which syncs immediately. |
+| `SOUL_GIT_CREDENTIAL` | — | Credential for pushing to `SOUL_GIT_REMOTE_URL` (e.g. a GitHub personal access token). |
+| `BOT_GIT_NAME` | `tulipfarm-bot` | Git commit author name for soul writes. See [Soul](/docs/concepts/soul#commit-authorship). |
+| `BOT_GIT_EMAIL` | `tulipfarmhq@gmail.com` | Git commit author email for soul writes. See [Soul](/docs/concepts/soul#commit-authorship). |
 | `ENCRYPTION_KEY_PREVIOUS` | — | The prior `ENCRYPTION_KEY` during a key rotation. Decryption tries the current key first, then this one. See [Secrets](/docs/concepts/secrets). |
 | `API_TOKEN_PEPPER` | — | Base64 server secret (32 bytes). When set, API tokens are hashed with `HMAC-SHA256(token, pepper)` instead of plain SHA-256. See [Hashing](/docs/security/hashing). |
 | `HOOKS_DISABLED` | — | Set to `true` to skip resource `hooks.ts` execution entirely. Use to boot an instance whose hooks are failing. |

--- a/apps/web/app/components/soul/soul-git-config.tsx
+++ b/apps/web/app/components/soul/soul-git-config.tsx
@@ -1,0 +1,208 @@
+import { type FormEvent, useState } from "react";
+import { Button } from "~/components/ui/button";
+import { ApiError } from "~/lib/api";
+import { friendlyGitError, putGitConfig, type SoulGitConfig, syncSoul } from "~/lib/soul";
+
+const inputClass =
+  "w-full rounded-sm border border-border bg-background px-3 py-2 text-sm outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:opacity-60";
+
+function errorMessage(err: unknown): string {
+  if (err instanceof ApiError) {
+    if (err.status === 403) return "admin only — only admins can change the git remote";
+    return friendlyGitError(err.message);
+  }
+  return err instanceof Error ? friendlyGitError(err.message) : "request failed";
+}
+
+function statusLabel(status: SoulGitConfig["status"]): { text: string; className: string } {
+  if (!status.remoteConfigured) {
+    return { text: "not connected", className: "text-muted-foreground" };
+  }
+  if (status.lastSyncError) {
+    return { text: "sync failed", className: "text-destructive" };
+  }
+  if (status.ahead === 0 && status.behind === 0) {
+    return { text: "up to date", className: "text-muted-foreground" };
+  }
+  const parts: string[] = [];
+  if (status.ahead > 0) parts.push(`${status.ahead} ahead`);
+  if (status.behind > 0) parts.push(`${status.behind} behind`);
+  return { text: parts.join(", "), className: "text-primary" };
+}
+
+function formatLastSync(iso: string | null): string {
+  if (!iso) return "never synced";
+  return `last synced ${new Date(iso).toLocaleString()}`;
+}
+
+// Add/edit the soul git remote (URL + PAT) and show live sync status, above the read-only
+// tree/viewer on Settings → Soul. The PAT field is write-only (mirrors _app.settings.secrets.tsx):
+// it never redisplays a stored credential, only shows whether one is set.
+export function SoulGitConfigPanel({
+  config,
+  onSaved,
+}: {
+  config: SoulGitConfig;
+  onSaved: () => void;
+}) {
+  const [editing, setEditing] = useState(!config.remoteUrl);
+  const [remoteUrl, setRemoteUrl] = useState(config.remoteUrl ?? "");
+  const [credential, setCredential] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [syncing, setSyncing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    setBusy(true);
+    setError(null);
+    try {
+      await putGitConfig(remoteUrl.trim(), credential.trim() || undefined);
+      setCredential("");
+      setEditing(false);
+      onSaved();
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onSync() {
+    setSyncing(true);
+    setError(null);
+    try {
+      await syncSoul();
+      onSaved();
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setSyncing(false);
+    }
+  }
+
+  const status = statusLabel(config.status);
+
+  return (
+    <div className="rounded-sm border border-border">
+      {error ? (
+        <p
+          role="alert"
+          className="m-3 mb-0 rounded-sm border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+        >
+          {error}
+        </p>
+      ) : null}
+
+      {!editing ? (
+        <>
+          <div className="flex items-center gap-2 px-3 py-2">
+            <span aria-hidden className="text-primary">
+              ▸
+            </span>
+            <span className="font-medium text-foreground">Git remote</span>
+            <span
+              className={`rounded-sm bg-muted px-1.5 py-0.5 text-xs uppercase tracking-[0.15em] ${status.className}`}
+            >
+              {status.text}
+            </span>
+            <div className="ml-auto flex items-center gap-1">
+              {config.remoteUrl ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="cursor-pointer rounded-sm"
+                  disabled={syncing}
+                  onClick={onSync}
+                >
+                  {syncing ? "Syncing…" : "Sync now"}
+                </Button>
+              ) : null}
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="cursor-pointer rounded-sm"
+                onClick={() => setEditing(true)}
+              >
+                Edit
+              </Button>
+            </div>
+          </div>
+          <p className="truncate border-t border-border px-3 py-2 font-mono text-xs text-muted-foreground">
+            {config.remoteUrl ?? "no remote configured"}
+          </p>
+          {config.remoteUrl ? (
+            <p className="truncate border-t border-border px-3 py-2 text-xs text-muted-foreground">
+              {formatLastSync(config.status.lastSyncAt)}
+            </p>
+          ) : null}
+          {config.status.lastSyncError ? (
+            <p
+              role="alert"
+              className="truncate border-t border-border px-3 py-2 text-xs text-destructive"
+            >
+              {friendlyGitError(config.status.lastSyncError)}
+            </p>
+          ) : null}
+        </>
+      ) : (
+        <form onSubmit={onSubmit} className="flex flex-col gap-3 p-3">
+          <p className="text-sm font-medium text-foreground">
+            {config.remoteUrl ? "Edit git remote" : "Connect a git remote"}
+          </p>
+          <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+            remote url
+            <input
+              className={inputClass}
+              value={remoteUrl}
+              onChange={(e) => setRemoteUrl(e.target.value)}
+              placeholder="https://github.com/org/soul.git"
+              aria-label="soul git remote url"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+            personal access token
+            {config.credentialSet ? " — set, leave blank to keep" : " (optional)"}
+            <input
+              className={inputClass}
+              type="password"
+              value={credential}
+              onChange={(e) => setCredential(e.target.value)}
+              placeholder="••••••••"
+              aria-label="soul git credential"
+            />
+          </label>
+          <div className="flex justify-end gap-2">
+            {config.remoteUrl ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="cursor-pointer rounded-sm"
+                disabled={busy}
+                onClick={() => {
+                  setEditing(false);
+                  setRemoteUrl(config.remoteUrl ?? "");
+                  setCredential("");
+                  setError(null);
+                }}
+              >
+                Cancel
+              </Button>
+            ) : null}
+            <Button
+              type="submit"
+              size="sm"
+              className="cursor-pointer rounded-sm"
+              disabled={busy || remoteUrl.trim().length === 0}
+            >
+              {busy ? "Saving…" : "Save"}
+            </Button>
+          </div>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/lib/soul.ts
+++ b/apps/web/app/lib/soul.ts
@@ -1,4 +1,4 @@
-import { apiGet } from "./api";
+import { apiGet, apiSend } from "./api";
 
 /*
  * Read-only client for the Soul Explorer API. The soul repo is a git directory on the API
@@ -30,4 +30,46 @@ export async function getSoulTree(): Promise<SoulTreeNode[]> {
 
 export function getSoulFile(path: string): Promise<SoulFile> {
   return apiGet<SoulFile>(`/api/v1/soul/file?path=${encodeURIComponent(path)}`);
+}
+
+export type SoulGitStatus = {
+  remoteConfigured: boolean;
+  ahead: number;
+  behind: number;
+  headSha: string | null;
+  lastSyncError: string | null;
+  lastSyncAt: string | null;
+};
+
+export type SoulGitConfig = {
+  remoteUrl?: string;
+  credentialSet: boolean;
+  status: SoulGitStatus;
+};
+
+export function getGitConfig(): Promise<SoulGitConfig> {
+  return apiGet<SoulGitConfig>("/api/v1/soul/git-config");
+}
+
+// `credential` (a PAT) is write-only: pass it only when the user typed a new one, since the API
+// never returns the stored value back.
+export function putGitConfig(remoteUrl: string, credential?: string): Promise<void> {
+  return apiSend("PUT", "/api/v1/soul/git-config", { remoteUrl, credential });
+}
+
+export function syncSoul(): Promise<void> {
+  return apiSend("POST", "/api/v1/soul/sync", {});
+}
+
+// Raw git stderr (e.g. "fatal: could not read Username for 'https://github.com': terminal
+// prompts disabled") is unreadable to a non-technical user. Translate the common auth-failure
+// shapes into a clear message with next steps; leave anything else as-is.
+const GIT_AUTH_FAILURE_PATTERN =
+  /could not read username|authentication failed|terminal prompts disabled|support for password authentication was removed|invalid username or password/i;
+
+export function friendlyGitError(raw: string): string {
+  if (GIT_AUTH_FAILURE_PATTERN.test(raw)) {
+    return "Authentication failed — this remote needs a personal access token with repo access. Add one below.";
+  }
+  return raw;
 }

--- a/apps/web/app/routes/_app.settings.secrets.tsx
+++ b/apps/web/app/routes/_app.settings.secrets.tsx
@@ -63,7 +63,7 @@ export default function SettingsSecrets() {
   const adding = providers.find((p) => p.id === addProviderId);
 
   // One list row per CONFIGURED provider (any of its fields stored); leftover keys not owned by a
-  // provider (custom/bootstrap secrets) list individually.
+  // provider (custom/bootstrap env config) list individually.
   const providerGroups = providers
     .map((p) => ({
       provider: p,

--- a/apps/web/app/routes/_app.settings.soul.tsx
+++ b/apps/web/app/routes/_app.settings.soul.tsx
@@ -1,40 +1,45 @@
-import { useLoaderData, useRouteError } from "@remix-run/react";
+import { useLoaderData, useRevalidator, useRouteError } from "@remix-run/react";
 import { useState } from "react";
 import { SoulFileViewer } from "~/components/soul/soul-file-viewer";
+import { SoulGitConfigPanel } from "~/components/soul/soul-git-config";
 import { SoulTree } from "~/components/soul/soul-tree";
 import { ErrorState } from "~/components/states";
 import { ApiError } from "~/lib/api";
-import { getSoulTree } from "~/lib/soul";
+import { getGitConfig, getSoulTree } from "~/lib/soul";
 
-// Read-only Soul Explorer: a VS Code-style file tree of the whole soul repo + Shiki source viewer.
+// Read-only Soul Explorer: a VS Code-style file tree of the whole soul repo + Shiki source viewer,
+// plus a git remote config + sync status panel.
 export async function clientLoader() {
-  const root = await getSoulTree();
-  return { root };
+  const [root, gitConfig] = await Promise.all([getSoulTree(), getGitConfig()]);
+  return { root, gitConfig };
 }
 
 export default function SettingsSoul() {
-  const { root } = useLoaderData<typeof clientLoader>();
+  const { root, gitConfig } = useLoaderData<typeof clientLoader>();
+  const revalidator = useRevalidator();
   const [selected, setSelected] = useState<string | null>(null);
 
-  if (root.length === 0) {
-    return (
-      <p className="rounded-sm border border-border bg-card px-4 py-6 text-sm text-muted-foreground">
-        The soul repo is empty or not initialized.
-      </p>
-    );
-  }
-
-  // One unified explorer shell (VS Code-style): a single hairline border wraps the tree + viewer,
-  // split by one internal divider — no floating cards, no gap. Stacks the tree above the viewer on
-  // mobile; side-by-side on md+. Fills the remaining viewport height on desktop.
   return (
-    <div className="flex h-[32rem] min-h-0 flex-col overflow-hidden rounded-sm border border-border bg-card md:h-[calc(100svh-11rem)] md:flex-row">
-      <aside className="flex max-h-56 shrink-0 flex-col overflow-y-auto border-b border-border px-1 py-1 md:max-h-none md:w-64 md:border-b-0 md:border-r">
-        <SoulTree root={root} selected={selected} onSelect={setSelected} />
-      </aside>
-      <section className="min-h-0 min-w-0 flex-1 overflow-hidden">
-        <SoulFileViewer path={selected} />
-      </section>
+    <div className="flex flex-col gap-4">
+      <SoulGitConfigPanel config={gitConfig} onSaved={() => revalidator.revalidate()} />
+
+      {root.length === 0 ? (
+        <p className="rounded-sm border border-border bg-card px-4 py-6 text-sm text-muted-foreground">
+          The soul repo is empty or not initialized.
+        </p>
+      ) : (
+        // One unified explorer shell (VS Code-style): a single hairline border wraps the tree +
+        // viewer, split by one internal divider — no floating cards, no gap. Stacks the tree above
+        // the viewer on mobile; side-by-side on md+. Fills the remaining viewport height on desktop.
+        <div className="flex h-[32rem] min-h-0 flex-col overflow-hidden rounded-sm border border-border bg-card md:h-[calc(100svh-11rem)] md:flex-row">
+          <aside className="flex max-h-56 shrink-0 flex-col overflow-y-auto border-b border-border px-1 py-1 md:max-h-none md:w-64 md:border-b-0 md:border-r">
+            <SoulTree root={root} selected={selected} onSelect={setSelected} />
+          </aside>
+          <section className="min-h-0 min-w-0 flex-1 overflow-hidden">
+            <SoulFileViewer path={selected} />
+          </section>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/app/routes/setup.tsx
+++ b/apps/web/app/routes/setup.tsx
@@ -4,6 +4,7 @@ import { Button } from "~/components/ui/button";
 import { ApiError } from "~/lib/api";
 import { type LlmProviderInfo, listProviders, putLlmConfig, putSecret } from "~/lib/settings";
 import { completeSetup, getSetupStatus, setupAdmin, setupBusiness, setupGit } from "~/lib/setup";
+import { friendlyGitError } from "~/lib/soul";
 
 export const meta: MetaFunction = () => [{ title: "Setup · tulipfarm" }];
 
@@ -330,7 +331,9 @@ function GitStep({ onNext }: { onNext: () => void }) {
       await setupGit(remoteUrl.trim(), credentials.trim() || undefined);
       onNext();
     } catch (err) {
-      setError(err instanceof ApiError ? err.message : "Failed to save git config.");
+      setError(
+        err instanceof ApiError ? friendlyGitError(err.message) : "Failed to save git config."
+      );
     } finally {
       setBusy(false);
     }

--- a/metadata/terminologies.md
+++ b/metadata/terminologies.md
@@ -52,9 +52,11 @@ Never let these bleed: UI/URL never say "conversation"; domain/DB never say "cha
 | A connected third-party | **Integration** | `Integration` | `/integrations`, `/api/v1/integrations` | "Integrations" | `connection`/`connector` → retired |
 | Auth material for a provider/integration | **Credential** | `Credential` | — | "Credentials" | API key/token/login; *backed by* a Secret |
 | Encrypted at-rest value (storage primitive) | **Secret** | `Secret` | `/settings/secrets` | "Secrets" | the store; ≠ Credential |
+| Boot-time value from `.env`/`process.env` | **Env Config** | — | — | — | restart-required; not all values are secret (e.g. `SOUL_PATH`) — the one genuinely secret value inside it is the KEK (`ENCRYPTION_KEY`), named directly, not by renaming this bucket |
 | An installable agent capability module | **Skill** | `Skill` | `/skills`, `/api/v1/skills` | "Skills" | `plugin`/`capability` → retired as synonyms¹ |
 | Where skills are browsed/installed | **Marketplace** / **Install** | — | `/skills/marketplace`, `/skills/install` | "Marketplace" | |
 | The git-backed config repo | **Soul** | `Soul` | `/api/v1/soul` | "Soul" | holds agents/routines/skills/integrations/resources |
+| Git-tracked YAML settings inside the Soul repo | **Soul Config** | `SoulConfig` | — | — | e.g. `soul.yaml`, `llm.config.yaml`; non-secret, runtime-editable but reload behavior varies (some apply on `soul.synced`, others require restart) |
 | The knowledge wiki feature | **Knowledge** | — | `/knowledge` | "Knowledge" | a wiki |
 | A grouping of pages | **Space** | `Space` | `/knowledge/spaces/:id` | "Space" | retires `bundle`, `collection`² |
 | A knowledge content node | **Page** | `Page` | `/knowledge/pages/:id` | "Page" | retires `concept`, `document`; pages link pages (backlink graph) |

--- a/packages/soul/src/git-sync.test.ts
+++ b/packages/soul/src/git-sync.test.ts
@@ -29,6 +29,8 @@ function makeMockGit(overrides: Record<string, any> = {}) {
       commit: "abc1234",
       summary: { changes: 2, insertions: 0, deletions: 0 },
     }),
+    getRemotes: vi.fn().mockResolvedValue([{ name: "origin", refs: { fetch: "", push: "" } }]),
+    listRemote: vi.fn().mockResolvedValue("abc1234def5678\trefs/heads/main\n"),
     ...overrides,
   };
   git.outputHandler = vi.fn().mockReturnValue(git);
@@ -127,6 +129,27 @@ describe("GitSyncService", () => {
       mockGit.fetch.mockRejectedValue(new Error("timeout"));
       const svc = new GitSyncService(SOUL, REMOTE, undefined, logger);
       await expect(svc.bootSync()).rejects.toThrow("timeout");
+    });
+  });
+
+  describe("bootSync — remote has no main branch yet (freshly created empty repo)", () => {
+    beforeEach(() => {
+      mockExistsSync.mockReturnValue(true);
+      mockGit.listRemote.mockResolvedValue(""); // no refs at all on origin
+    });
+
+    it("pushes local main to initialize the remote instead of fetching", async () => {
+      const svc = new GitSyncService(SOUL, REMOTE, undefined, logger);
+      await svc.bootSync();
+      expect(mockGit.fetch).not.toHaveBeenCalled();
+      expect(mockGit.push).toHaveBeenCalledWith("origin", "main");
+    });
+
+    it("does not push when local has no commits yet", async () => {
+      mockGit.revparse.mockRejectedValue(new Error("no commits"));
+      const svc = new GitSyncService(SOUL, REMOTE, undefined, logger);
+      await svc.bootSync();
+      expect(mockGit.push).not.toHaveBeenCalled();
     });
   });
 
@@ -280,6 +303,75 @@ describe("GitSyncService", () => {
     });
   });
 
+  describe("configureRemote (setup wizard live sync)", () => {
+    beforeEach(() => {
+      mockExistsSync.mockReturnValue(true); // repo dir already exists (booted local-only or already cloned)
+    });
+
+    it("adds origin and syncs when the repo previously had no remote (local-only boot)", async () => {
+      mockGit.getRemotes.mockResolvedValue([]);
+      mockGit.raw.mockResolvedValue("0\t0");
+      const svc = new GitSyncService(SOUL, undefined, undefined, logger);
+      await svc.configureRemote(REMOTE, "ghp_token");
+      expect(mockGit.remote).toHaveBeenCalledWith([
+        "add",
+        "origin",
+        "https://ghp_token@github.com/user/soul.git",
+      ]);
+      expect(mockGit.fetch).toHaveBeenCalledWith("origin", "main");
+    });
+
+    it("repoints an existing origin and re-syncs", async () => {
+      mockGit.getRemotes.mockResolvedValue([{ name: "origin", refs: { fetch: "", push: "" } }]);
+      mockGit.raw.mockResolvedValue("0\t2");
+      const svc = new GitSyncService(SOUL, REMOTE, undefined, logger);
+      await svc.configureRemote("https://github.com/user/other-soul.git", "ghp_new");
+      expect(mockGit.remote).toHaveBeenCalledWith([
+        "set-url",
+        "origin",
+        "https://ghp_new@github.com/user/other-soul.git",
+      ]);
+      expect(mockGit.pull).toHaveBeenCalledWith("origin", "main", ["--ff-only"]);
+    });
+
+    it("propagates a fetch/clone failure (bad URL or bad token)", async () => {
+      mockGit.getRemotes.mockResolvedValue([]);
+      mockGit.fetch.mockRejectedValue(new Error("Authentication failed"));
+      const svc = new GitSyncService(SOUL, undefined, undefined, logger);
+      await expect(svc.configureRemote(REMOTE, "bad_token")).rejects.toThrow(
+        "Authentication failed"
+      );
+    });
+  });
+
+  describe("syncNow (manual sync)", () => {
+    beforeEach(() => {
+      mockExistsSync.mockReturnValue(true);
+    });
+
+    it("throws when no remote is configured", async () => {
+      const svc = new GitSyncService(SOUL, undefined, undefined, logger);
+      await expect(svc.syncNow()).rejects.toThrow("no git remote configured");
+    });
+
+    it("pulls and clears lastSyncError on success", async () => {
+      mockGit.raw.mockResolvedValue("0\t0");
+      const svc = new GitSyncService(SOUL, REMOTE, undefined, logger);
+      await svc.syncNow();
+      const status = await svc.getStatus();
+      expect(status.lastSyncError).toBeNull();
+      expect(status.lastSyncAt).not.toBeNull();
+    });
+
+    it("records lastSyncError and rethrows on failure", async () => {
+      mockGit.fetch.mockRejectedValue(new Error("could not read Username"));
+      const svc = new GitSyncService(SOUL, REMOTE, undefined, logger);
+      await expect(svc.syncNow()).rejects.toThrow("could not read Username");
+      const status = await svc.getStatus();
+      expect(status.lastSyncError).toContain("could not read Username");
+    });
+  });
+
   describe("syncOnce", () => {
     beforeEach(() => {
       mockExistsSync.mockReturnValue(true);
@@ -304,6 +396,102 @@ describe("GitSyncService", () => {
       const svc = new GitSyncService(SOUL, REMOTE, undefined, logger);
       await expect(svc.syncOnce()).resolves.toBeUndefined();
       expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("host unreachable"));
+    });
+  });
+
+  describe("hasRemote", () => {
+    it("is false with no remote configured", () => {
+      const svc = new GitSyncService(SOUL, undefined, undefined, logger);
+      expect(svc.hasRemote()).toBe(false);
+    });
+
+    it("is true once a remote is configured", () => {
+      const svc = new GitSyncService(SOUL, REMOTE, undefined, logger);
+      expect(svc.hasRemote()).toBe(true);
+    });
+  });
+
+  describe("getStatus", () => {
+    it("reports not configured with no repo on disk", async () => {
+      mockExistsSync.mockReturnValue(false);
+      const svc = new GitSyncService(SOUL, undefined, undefined, logger);
+      await expect(svc.getStatus()).resolves.toEqual({
+        remoteConfigured: false,
+        remoteUrl: undefined,
+        ahead: 0,
+        behind: 0,
+        headSha: null,
+        lastSyncError: null,
+        lastSyncAt: null,
+      });
+    });
+
+    it("reports headSha with no remote configured", async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockGit.revparse.mockResolvedValue("abc1234");
+      const svc = new GitSyncService(SOUL, undefined, undefined, logger);
+      const status = await svc.getStatus();
+      expect(status).toEqual({
+        remoteConfigured: false,
+        ahead: 0,
+        behind: 0,
+        headSha: "abc1234",
+        lastSyncError: null,
+        lastSyncAt: null,
+      });
+      expect(mockGit.fetch).not.toHaveBeenCalled();
+    });
+
+    it("reports ahead/behind against origin/main when remote is configured", async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockGit.revparse.mockResolvedValue("abc1234");
+      mockGit.raw.mockResolvedValue("1\t2");
+      const svc = new GitSyncService(SOUL, REMOTE, undefined, logger);
+      const status = await svc.getStatus();
+      expect(mockGit.fetch).toHaveBeenCalledWith("origin", "main");
+      expect(status).toEqual({
+        remoteConfigured: true,
+        remoteUrl: REMOTE,
+        ahead: 1,
+        behind: 2,
+        headSha: "abc1234",
+        lastSyncError: null,
+        lastSyncAt: expect.any(String),
+      });
+    });
+
+    it("degrades to zero ahead/behind on fetch failure but surfaces lastSyncError, never throws", async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockGit.revparse.mockResolvedValue("abc1234");
+      mockGit.fetch.mockRejectedValue(new Error("host unreachable"));
+      const svc = new GitSyncService(SOUL, REMOTE, undefined, logger);
+      await expect(svc.getStatus()).resolves.toEqual({
+        remoteConfigured: true,
+        remoteUrl: REMOTE,
+        ahead: 0,
+        behind: 0,
+        headSha: "abc1234",
+        lastSyncError: "host unreachable",
+        lastSyncAt: expect.any(String),
+      });
+    });
+
+    it("reports zero ahead/behind with no error when remote has no main branch yet", async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockGit.revparse.mockResolvedValue("abc1234");
+      mockGit.listRemote.mockResolvedValue("");
+      const svc = new GitSyncService(SOUL, REMOTE, undefined, logger);
+      const status = await svc.getStatus();
+      expect(mockGit.fetch).not.toHaveBeenCalled();
+      expect(status).toEqual({
+        remoteConfigured: true,
+        remoteUrl: REMOTE,
+        ahead: 0,
+        behind: 0,
+        headSha: "abc1234",
+        lastSyncError: null,
+        lastSyncAt: expect.any(String),
+      });
     });
   });
 });

--- a/packages/soul/src/git-sync.ts
+++ b/packages/soul/src/git-sync.ts
@@ -5,20 +5,40 @@ import { BOT_GIT_EMAIL, BOT_GIT_NAME } from "@tulipfarm/constants";
 import simpleGit from "simple-git";
 import type { Logger } from "./types";
 
+// Never let git block on an interactive username/password prompt (e.g. a bad/missing credential
+// against a private remote) — without this, a clone/fetch over HTTPS can hang indefinitely
+// instead of failing fast, which is what made the setup wizard's "Saving…" spin forever.
+process.env.GIT_TERMINAL_PROMPT ??= "0";
+
+const GIT_TIMEOUT_MS = 30_000;
+
 export class GitSyncService extends EventEmitter {
   constructor(
     private readonly soulPath: string,
-    private readonly remoteUrl: string | undefined,
-    private readonly credentials: string | undefined,
+    private remoteUrl: string | undefined,
+    private credentials: string | undefined,
     private readonly logger: Logger
   ) {
     super();
   }
 
   private ensured = false;
+  private lastSyncError: string | null = null;
+  private lastSyncAt: Date | null = null;
+
+  /** `simpleGit` bound to `soulPath` with a hard timeout, so a hung/blocking git process
+   * (network stall, unexpected credential prompt) fails after `GIT_TIMEOUT_MS` instead of
+   * hanging the request forever. */
+  private gitAt() {
+    return simpleGit(this.soulPath, { timeout: { block: GIT_TIMEOUT_MS } });
+  }
 
   get path(): string {
     return this.soulPath;
+  }
+
+  hasRemote(): boolean {
+    return this.remoteUrl !== undefined && this.remoteUrl !== "";
   }
 
   /**
@@ -34,7 +54,7 @@ export class GitSyncService extends EventEmitter {
     if (!existsSync(join(this.soulPath, ".git"))) {
       let enclosing: string | null = null;
       try {
-        enclosing = (await simpleGit(this.soulPath).revparse(["--show-toplevel"])).trim();
+        enclosing = (await this.gitAt().revparse(["--show-toplevel"])).trim();
       } catch {
         enclosing = null; // not inside any git repo — safe to init a fresh one
       }
@@ -43,11 +63,11 @@ export class GitSyncService extends EventEmitter {
           `Soul: SOUL_PATH "${this.soulPath}" is inside another git repository (${enclosing}). Point SOUL_PATH at a dedicated directory outside the project repo (e.g. ~/.tulipfarm/soul).`
         );
       }
-      await simpleGit(this.soulPath).init();
+      await this.gitAt().init();
       this.logger.info(`Soul: initialized git repo at ${this.soulPath}`);
     }
 
-    const git = simpleGit(this.soulPath);
+    const git = this.gitAt();
     await git.addConfig("user.name", BOT_GIT_NAME);
     await git.addConfig("user.email", BOT_GIT_EMAIL);
     this.ensured = true;
@@ -61,30 +81,185 @@ export class GitSyncService extends EventEmitter {
 
   async bootSync(): Promise<void> {
     if (!this.remoteUrl) {
-      this.logger.info("Soul: no GIT_REMOTE_URL set, running in local-only mode");
+      this.logger.info("Soul: no SOUL_GIT_REMOTE_URL set, running in local-only mode");
       await this.ensureRepo();
       return;
     }
+    await this.syncWithRemote();
+  }
+
+  /** Manual, user-triggered sync (Settings → Soul "Sync now"). Throws on failure — same
+   * contract as `bootSync`/`configureRemote` — so the route can surface the error. */
+  async syncNow(): Promise<void> {
+    if (!this.remoteUrl) {
+      throw new Error("no git remote configured");
+    }
+    await this.syncWithRemote();
+  }
+
+  /** Clone-or-pull against `remoteUrl`, recording the outcome (`lastSyncError`/`lastSyncAt`) for
+   * status display regardless of success or failure. Always rethrows on failure — callers decide
+   * whether that's fatal (`configureRemote`/`syncNow`) or swallowed (boot). */
+  private async syncWithRemote(): Promise<void> {
     const url = this.authUrl();
-    if (!existsSync(join(this.soulPath, ".git"))) {
-      this.logger.info(`Soul: cloning from remote into ${this.soulPath}`);
-      await simpleGit()
-        .outputHandler((_cmd, stdout, stderr) => {
-          stdout.pipe(process.stdout);
-          stderr.pipe(process.stderr);
-        })
-        .clone(url, this.soulPath);
-      this.logger.info("Soul: clone complete");
+    try {
+      if (!existsSync(join(this.soulPath, ".git"))) {
+        this.logger.info(`Soul: cloning from remote into ${this.soulPath}`);
+        await simpleGit({ timeout: { block: GIT_TIMEOUT_MS } })
+          .outputHandler((_cmd, stdout, stderr) => {
+            stdout.pipe(process.stdout);
+            stderr.pipe(process.stderr);
+          })
+          .clone(url, this.soulPath);
+        this.logger.info("Soul: clone complete");
+      } else {
+        this.logger.info("Soul: pulling from origin/main");
+        await this.pull();
+        this.logger.info("Soul: synced from origin/main");
+      }
+      this.lastSyncError = null;
+      this.lastSyncAt = new Date();
+    } catch (err) {
+      this.lastSyncError = err instanceof Error ? err.message : String(err);
+      this.lastSyncAt = new Date();
+      throw err;
+    }
+  }
+
+  /** A brand-new GitHub repo has no branches at all until something is pushed — `main` doesn't
+   * exist on `origin` yet. Fetching/diffing against it would fail with "couldn't find remote ref
+   * main", so callers check this first and push to initialize the branch instead. */
+  private async remoteHasMain(git: ReturnType<typeof this.gitAt>): Promise<boolean> {
+    const heads = await git.listRemote(["--heads", "origin", "main"]);
+    return heads.trim() !== "";
+  }
+
+  /** Point `origin` at `url` — `set-url` if it already exists, else `add` (e.g. a repo that
+   * booted local-only never had an `origin` to point). */
+  private async ensureRemote(url: string): Promise<void> {
+    const git = this.gitAt();
+    const remotes = await git.getRemotes();
+    if (remotes.some((r) => r.name === "origin")) {
+      await git.remote(["set-url", "origin", url]);
     } else {
-      this.logger.info("Soul: pulling from origin/main");
-      await this.pull();
-      this.logger.info("Soul: synced from origin/main");
+      await git.remote(["add", "origin", url]);
+    }
+  }
+
+  /** Live-reconfigure the remote/credentials and sync immediately (SOUL setup wizard) — no
+   * restart required, unlike the boot-time env vars this instance was originally constructed
+   * with. Reuses `bootSync`'s `pull` branch, which now works whether or not `origin` already
+   * existed (see `ensureRemote`). */
+  async configureRemote(remoteUrl: string, credentials?: string): Promise<void> {
+    this.remoteUrl = remoteUrl;
+    this.credentials = credentials;
+    await this.ensureRepo();
+    await this.bootSync();
+  }
+
+  /** Read-only sync status for display (Settings → Soul). Never throws — a fetch failure
+   * (offline, bad credential) degrades ahead/behind to 0, but is recorded as `lastSyncError` so
+   * the UI can show it rather than silently reporting "up to date". */
+  async getStatus(): Promise<{
+    remoteConfigured: boolean;
+    remoteUrl?: string;
+    ahead: number;
+    behind: number;
+    headSha: string | null;
+    lastSyncError: string | null;
+    lastSyncAt: string | null;
+  }> {
+    const remoteConfigured = this.hasRemote();
+    const base = {
+      lastSyncError: this.lastSyncError,
+      lastSyncAt: this.lastSyncAt ? this.lastSyncAt.toISOString() : null,
+    };
+    if (!existsSync(join(this.soulPath, ".git"))) {
+      return {
+        remoteConfigured,
+        remoteUrl: this.remoteUrl,
+        ahead: 0,
+        behind: 0,
+        headSha: null,
+        ...base,
+      };
+    }
+
+    const git = this.gitAt();
+    let headSha: string | null;
+    try {
+      headSha = (await git.revparse(["HEAD"])).trim();
+    } catch {
+      headSha = null; // no commits yet
+    }
+
+    if (!remoteConfigured) {
+      return { remoteConfigured, ahead: 0, behind: 0, headSha, ...base };
+    }
+
+    try {
+      await this.ensureRemote(this.authUrl());
+      if (!(await this.remoteHasMain(git))) {
+        this.lastSyncError = null;
+        this.lastSyncAt = new Date();
+        return {
+          remoteConfigured,
+          remoteUrl: this.remoteUrl,
+          ahead: 0,
+          behind: 0,
+          headSha,
+          lastSyncError: null,
+          lastSyncAt: this.lastSyncAt.toISOString(),
+        };
+      }
+      await git.fetch("origin", "main");
+      const counts = await git.raw(["rev-list", "--left-right", "--count", "HEAD...origin/main"]);
+      const [aheadStr, behindStr] = counts.trim().split(/\s+/);
+      this.lastSyncError = null;
+      this.lastSyncAt = new Date();
+      return {
+        remoteConfigured,
+        remoteUrl: this.remoteUrl,
+        ahead: Number.parseInt(aheadStr, 10),
+        behind: Number.parseInt(behindStr, 10),
+        headSha,
+        lastSyncError: null,
+        lastSyncAt: this.lastSyncAt.toISOString(),
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.warn(`Soul: status fetch failed — ${message}`);
+      this.lastSyncError = message;
+      this.lastSyncAt = new Date();
+      return {
+        remoteConfigured,
+        remoteUrl: this.remoteUrl,
+        ahead: 0,
+        behind: 0,
+        headSha,
+        lastSyncError: message,
+        lastSyncAt: this.lastSyncAt.toISOString(),
+      };
     }
   }
 
   private async pull(): Promise<void> {
-    const git = simpleGit(this.soulPath);
-    await git.remote(["set-url", "origin", this.authUrl()]);
+    const git = this.gitAt();
+    await this.ensureRemote(this.authUrl());
+
+    if (!(await this.remoteHasMain(git))) {
+      const hasCommits = await git
+        .revparse(["HEAD"])
+        .then(() => true)
+        .catch(() => false);
+      if (hasCommits) {
+        this.logger.info("Soul: remote has no main branch yet — pushing to initialize it");
+        await git.push("origin", "main");
+        this.logger.info("Soul: pushed to initialize origin/main");
+      }
+      return;
+    }
+
     await git.fetch("origin", "main");
 
     const counts = await git.raw(["rev-list", "--left-right", "--count", "HEAD...origin/main"]);
@@ -124,7 +299,7 @@ export class GitSyncService extends EventEmitter {
 
   async commit(message: string): Promise<{ sha: string; filesChanged: number }> {
     await this.ensureRepo();
-    const git = simpleGit(this.soulPath);
+    const git = this.gitAt();
     await git.add("-A");
     const result = await git.commit(message);
     return { sha: result.commit, filesChanged: result.summary.changes };
@@ -132,7 +307,7 @@ export class GitSyncService extends EventEmitter {
 
   async push(): Promise<boolean> {
     if (!this.remoteUrl) return false;
-    const git = simpleGit(this.soulPath);
+    const git = this.gitAt();
     await git.remote(["set-url", "origin", this.authUrl()]);
     await git.push("origin", "main");
     return true;
@@ -157,12 +332,15 @@ export class GitSyncService extends EventEmitter {
     if (!this.remoteUrl) return;
     try {
       await this.pull();
+      this.lastSyncError = null;
+      this.lastSyncAt = new Date();
       this.logger.info("Soul: periodic sync complete");
       this.emit("soul.synced");
     } catch (err) {
-      this.logger.error(
-        `Soul: periodic sync failed — ${err instanceof Error ? err.message : String(err)}`
-      );
+      const message = err instanceof Error ? err.message : String(err);
+      this.lastSyncError = message;
+      this.lastSyncAt = new Date();
+      this.logger.error(`Soul: periodic sync failed — ${message}`);
     }
   }
 }


### PR DESCRIPTION
## Summary

- Fix onboarding wizard's Soul backup step hanging forever on "Saving…" — `simple-git` had no terminal-prompt guard or hard timeout, so a bad/missing credential blocked on an interactive prompt instead of failing fast (`GIT_TERMINAL_PROMPT=0` + 30s block timeout on all git calls).
- Fix sync against a freshly-created, still-empty GitHub remote failing with `couldn't find remote ref main` — `pull()`/`getStatus()` now check whether `origin` has a `main` branch yet and push to initialize it instead of unconditionally fetching.
- Fix "Sync now" surfacing a generic `Bad Request` — the empty-body POST tripped Fastify's empty-JSON-body guard before reaching the handler; now sends `{}`.
- Translate raw git auth-failure stderr into an actionable message ("needs a personal access token…") via a shared `friendlyGitError()`, used in both Settings → Soul and the onboarding wizard.
- Add a git remote/PAT config panel + live sync status (ahead/behind, last sync error/time, "Sync now") to Settings → Soul, matching the wizard's write-only PAT UX.
- Rename `GIT_REMOTE_URL`/`GIT_CREDENTIALS` → `SOUL_GIT_REMOTE_URL`/`SOUL_GIT_CREDENTIAL` and clarify "bootstrap env config" vs secret terminology across env examples, README, and docs.

## Test plan

- [x] `pnpm lint` (biome check) clean
- [x] `pnpm typecheck` clean across all workspaces
- [x] `pnpm test` — all packages green (soul 3 files, web 61 files, api 134 files)
- [x] Manually reproduced and verified the fix for the wizard hang, the empty-remote push-to-initialize case, and the Bad Request bug against a real GitHub repo