### PR TITLE
docs(agents): capture session learnings for soul, api, web

### DIFF
--- a/apps/api/AGENTS.md
+++ b/apps/api/AGENTS.md
@@ -52,6 +52,16 @@ Fake dependencies implement the real interface (class, not `vi.fn()` object) for
 
 Mock `node:fs` / `node:fs/promises` with `vi.mock` at the top of the test file when the route does filesystem I/O.
 
+Always run tests via `pnpm test` (turbo, per-package). A bare root `pnpm exec vitest run` skips
+per-package vitest config (e.g. missing jsdom setup) and gives false failures. Stale CJS files in
+`apps/api/dist/` can also get picked up by vitest when run from repo root — if a failure looks
+unrelated to your change, confirm by scoping the run to the touched package before assuming a
+regression.
+
+`@electric-sql/pglite`'s `vector` export moved packages between versions: pre-0.5 it's
+`@electric-sql/pglite/vector`; 0.5.x+ moved it to `@electric-sql/pglite-pgvector` (same `vector`
+export). Check this import path when bumping pglite.
+
 ## Adding a New Feature
 
 1. Create `src/<feature>/` directory
@@ -103,6 +113,9 @@ knowledge (`knowledge/tools.ts`), kv (`kv/tools.ts` — agent-scoped `kv_get`/`k
 - **Durable SSE** (`chat/`): the chat turn streams via an in-memory `StreamHub` (`stream-hub.ts`)
   while persisting each event to the `stream_resume` table (`stream-resume.ts`). Reconnects replay
   from `Last-Event-ID`; `stream-gc.ts` expires old buffers on pg-boss.
+- Static business/identity facts (e.g. `soul.yaml`'s `businessName`/`businessDescription`) belong
+  in the **system prompt** (`assembleSystemPrompt`), not `memory/` working_memory — don't route
+  them through working_memory just because onboarding captured them at runtime.
 
 ## Guardrails (`src/guardrails/`)
 

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -110,6 +110,10 @@ Vitest with a dedicated `vitest.config.ts` (`@vitejs/plugin-react` + `jsdom`) â€
 load the Remix Vite plugin. Colocate `*.test.tsx`. Components using `<Link>`/`<NavLink>`/`<Outlet>`
 need a router context: wrap with `createRemixStub` from `@remix-run/testing`.
 
+Known pre-existing issue: the `~/` path alias isn't resolved in web's vitest config, which can
+cause widespread unrelated test failures. If web tests fail broadly and don't relate to your
+change, verify against a clean baseline (main) before treating it as a regression you caused.
+
 ## Prod serving (nginx)
 
 `pnpm --filter @tulipfarm/web build` emits `build/client/` (incl. `index.html`). Serve it static

--- a/packages/soul/AGENTS.md
+++ b/packages/soul/AGENTS.md
@@ -48,4 +48,23 @@ Parsing is fault-tolerant: a bad file is logged and skipped, and the loader stay
 ## Tests
 
 Vitest, colocated. Mock `node:fs` / `simple-git`; cover loader degradation and the
-pull/commit/push divergence cases.
+pull/commit/push divergence cases. In route tests that touch soul git config, spy on
+`GitSyncService.prototype.configureRemote`/`getStatus` (don't hit real git), and use
+`soulConfigFs.readFile`/`writeFile` (not raw `node:fs`).
+
+## Git-sync gotchas
+
+- Remote/credential env vars are `SOUL_GIT_REMOTE_URL` / `SOUL_GIT_CREDENTIAL` (soul-scoped,
+  matches `SOUL_PATH`) — not `GIT_REMOTE_URL`/`GIT_CREDENTIALS`. Watch for stale references when
+  touching `.env.local.example`, `specs/SOUL.md`, `specs/INSTALLATION.md`, docs mdx, or secret keys.
+- `GitSyncService` reads its remote from env at boot; a remote set later via Settings → Soul UI
+  persists to `soul.yaml` + a secret — boot must also read that persisted config, or the UI-set
+  remote is silently dropped on restart.
+- `bootSync()` must never throw (a bad/stale remote in `soul.yaml` previously crash-looped the
+  server on boot) — but `configureRemote()` (backs `PUT /soul/git-config`) must keep throwing so
+  the route can 400 on bad credentials. Fix boot-time resilience at the boot call site, not by
+  swallowing errors inside the shared methods.
+- Auth is HTTPS-only: `authUrl()` in `git-sync.ts` injects `SOUL_GIT_CREDENTIAL` (a PAT) as
+  `https://<token>@host/...`. No SSH keygen/agent support — an SSH remote URL will fail.
+- Soul-repo commits are always authored as `BOT_GIT_NAME`/`BOT_GIT_EMAIL` (`tulipfarm-bot`),
+  regardless of whose PAT authenticates the push.


### PR DESCRIPTION
## Summary
- packages/soul/AGENTS.md: git-sync env var rename (SOUL_GIT_REMOTE_URL/SOUL_GIT_CREDENTIAL), boot-persisted-remote-config gotcha, bootSync-must-not-throw vs configureRemote-must-throw split, HTTPS-only auth, bot commit author, test-mock conventions.
- apps/api/AGENTS.md: use `pnpm test` not raw root vitest, stale `dist/` false failures, pglite `vector` export path moved in 0.5.x, business facts belong in system prompt not working_memory.
- apps/web/AGENTS.md: `~/` alias unresolved in vitest config — check baseline before blaming your change on broad web test failures.

Distilled from scanning the last 20 local Claude Code session transcripts for this repo for corrections/gotchas not already captured in docs.

## Test plan
- [x] Docs-only change, no code touched