### PR TITLE
feat(soul): consolidate llm.config.yaml into soul.yaml#llm

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,6 +18,7 @@
     "@fastify/swagger": "^9.7.0",
     "@node-rs/argon2": "^2.0.2",
     "@scalar/fastify-api-reference": "^1.62.0",
+    "@sinclair/typebox": "^0.34.49",
     "@tulipfarm/llm": "workspace:*",
     "@tulipfarm/secrets": "workspace:*",
     "@tulipfarm/soul": "workspace:*",

--- a/apps/api/src/soul/llm-config/cascade.ts
+++ b/apps/api/src/soul/llm-config/cascade.ts
@@ -1,21 +1,19 @@
-import { unlink, writeFile } from "node:fs/promises";
-import { join } from "node:path";
 import type { LlmConfig, LlmService } from "@tulipfarm/llm";
 import type { SecretsService } from "@tulipfarm/secrets";
 import { llmProviderForFieldKey } from "@tulipfarm/secrets";
 import type { GitSyncService, Logger, SoulLoader } from "@tulipfarm/soul";
-import { stringify as stringifyYaml } from "yaml";
 import { pruneLlmConfig } from "./prune";
+import { deleteLlmConfigFromSoulYaml, writeLlmConfigToSoulYaml } from "./soul-yaml-io";
 
 /**
- * Returns an `onSecretDeleted` callback that keeps `llm.config.yaml` in sync when a
+ * Returns an `onSecretDeleted` callback that keeps `soul.yaml#llm` in sync when a
  * provider api_key secret is removed.
  *
  * On delete the callback:
  * 1. Checks whether the deleted key is an api_key field for a known LLM provider.
  * 2. Prunes matching provider entries from the current config.
  * 3. If every tier still has providers → writes the pruned config and re-inits.
- *    If any tier is left empty  → deletes the file entirely (clean unconfigured state).
+ *    If any tier is left empty  → removes the `llm:` key entirely (clean unconfigured state).
  * 4. Commits via gitSync and reloads the soul + LLM service.
  *
  * Errors are re-thrown so the caller can log and suppress them without crashing the
@@ -39,19 +37,13 @@ export function makeLlmCascadeOnSecretDelete(
     const result = pruneLlmConfig(currentConfig, deletedKey, owner);
     if (result.action === "unchanged") return;
 
-    const configPath = join(gitSync.path, "llm.config.yaml");
     const commitMsg = `soul: remove ${owner.id} provider (secret ${deletedKey} deleted)`;
 
     if (result.action === "update") {
-      await writeFile(configPath, stringifyYaml(result.config), "utf8");
+      await writeLlmConfigToSoulYaml(gitSync.path, result.config);
     } else {
-      // "delete" — pruning left a tier empty; remove the file for a clean unconfigured state
-      try {
-        await unlink(configPath);
-      } catch (err) {
-        if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
-        throw err;
-      }
+      // "delete" — pruning left a tier empty; remove the `llm:` key for a clean unconfigured state
+      await deleteLlmConfigFromSoulYaml(gitSync.path);
     }
 
     await gitSync.withSync(commitMsg);

--- a/apps/api/src/soul/llm-config/routes.test.ts
+++ b/apps/api/src/soul/llm-config/routes.test.ts
@@ -99,7 +99,10 @@ describe("llm-config routes", () => {
     // reload re-reads the written file (mirrors SoulLoader), so the PUT response reflects what was saved.
     let current: unknown = validConfig;
     reload = vi.fn(async () => {
-      current = parseYaml(await readFile(join(soulPath, "llm.config.yaml"), "utf8"));
+      const manifest = parseYaml(await readFile(join(soulPath, "soul.yaml"), "utf8")) as {
+        llm?: unknown;
+      };
+      current = manifest.llm;
     });
     const soulLoader = {
       get llmConfig() {
@@ -230,7 +233,7 @@ describe("llm-config routes", () => {
       });
       expect(res.statusCode).toBe(403);
       expect(withSync).not.toHaveBeenCalled();
-      await expect(access(join(soulPath, "llm.config.yaml"))).rejects.toThrow();
+      await expect(access(join(soulPath, "soul.yaml"))).rejects.toThrow();
     });
 
     it("validates, writes, commits, reloads, and re-inits the LlmService", async () => {
@@ -253,8 +256,10 @@ describe("llm-config routes", () => {
       expect(res.statusCode).toBe(200);
       expect(res.json()).toEqual(next);
 
-      const written = parseYaml(await readFile(join(soulPath, "llm.config.yaml"), "utf8"));
-      expect(written).toEqual(next);
+      const manifest = parseYaml(await readFile(join(soulPath, "soul.yaml"), "utf8")) as {
+        llm: unknown;
+      };
+      expect(manifest.llm).toEqual(next);
       expect(withSync).toHaveBeenCalledWith("soul: update llm config");
       expect(reload).toHaveBeenCalledOnce();
       expect(init).toHaveBeenCalledOnce();
@@ -272,7 +277,7 @@ describe("llm-config routes", () => {
       expect(res.statusCode).toBe(422);
       expect(withSync).not.toHaveBeenCalled();
       expect(init).not.toHaveBeenCalled();
-      await expect(access(join(soulPath, "llm.config.yaml"))).rejects.toThrow();
+      await expect(access(join(soulPath, "soul.yaml"))).rejects.toThrow();
     });
   });
 
@@ -363,10 +368,12 @@ describe("llm-config routes", () => {
       });
       expect(res.statusCode).toBe(200);
       // The written soul file should now carry the pinned spec (auto-resolved from LiteLLM).
-      const written = parseYaml(await readFile(join(soulPath, "llm.config.yaml"), "utf8")) as {
-        tiers: { quick: { providers: Array<{ spec?: { input_cost_per_token: number } }> } };
+      const manifest = parseYaml(await readFile(join(soulPath, "soul.yaml"), "utf8")) as {
+        llm: {
+          tiers: { quick: { providers: Array<{ spec?: { input_cost_per_token: number } }> } };
+        };
       };
-      expect(written.tiers.quick.providers[0].spec?.input_cost_per_token).toBe(0.00000057);
+      expect(manifest.llm.tiers.quick.providers[0].spec?.input_cost_per_token).toBe(0.00000057);
     });
 
     it("leaves a model unpriced (no spec) when LiteLLM has no match", async () => {
@@ -385,10 +392,10 @@ describe("llm-config routes", () => {
         },
       });
       expect(res.statusCode).toBe(200);
-      const written = parseYaml(await readFile(join(soulPath, "llm.config.yaml"), "utf8")) as {
-        tiers: { quick: { providers: Array<{ spec?: unknown }> } };
+      const manifest = parseYaml(await readFile(join(soulPath, "soul.yaml"), "utf8")) as {
+        llm: { tiers: { quick: { providers: Array<{ spec?: unknown }> } } };
       };
-      expect(written.tiers.quick.providers[0].spec).toBeUndefined();
+      expect(manifest.llm.tiers.quick.providers[0].spec).toBeUndefined();
     });
   });
 });

--- a/apps/api/src/soul/llm-config/routes.ts
+++ b/apps/api/src/soul/llm-config/routes.ts
@@ -1,5 +1,3 @@
-import { writeFile } from "node:fs/promises";
-import { join } from "node:path";
 import {
   fetchLiteLlmCatalog,
   type LiteLlmCatalog,
@@ -13,9 +11,9 @@ import {
 import { LLM_PROVIDERS, type SecretsService } from "@tulipfarm/secrets";
 import type { GitSyncService, SoulLoader } from "@tulipfarm/soul";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
-import { stringify as stringifyYaml } from "yaml";
 import { ErrorSchema } from "../../auth/schemas";
 import type { UserDoc } from "../../auth/users";
+import { writeLlmConfigToSoulYaml } from "./soul-yaml-io";
 
 type PreHandler = (req: FastifyRequest, reply: FastifyReply) => Promise<void>;
 
@@ -40,8 +38,8 @@ async function getCatalog(force = false): Promise<LiteLlmCatalog | null> {
   return catalog;
 }
 
-// Returned by GET when no llm.config.yaml exists yet, so the editor opens with empty tiers instead of
-// erroring. Not itself schema-valid for PUT (tiers need ≥1 provider) — the user fills it in and saves.
+// Returned by GET when soul.yaml has no `llm:` key yet, so the editor opens with empty tiers instead
+// of erroring. Not itself schema-valid for PUT (tiers need ≥1 provider) — the user fills it in and saves.
 const EMPTY_LLM_CONFIG = {
   tiers: { quick: { providers: [] }, standard: { providers: [] }, complex: { providers: [] } },
 } as const;
@@ -80,7 +78,7 @@ async function enrichSpecs(config: LlmConfig, force: boolean): Promise<LlmConfig
 }
 
 /*
- * LLM config editing (UI-V1-003 / LLM-V1-003). Reads and full-replaces soul/llm.config.yaml.
+ * LLM config editing (UI-V1-003 / LLM-V1-003). Reads and full-replaces soul.yaml's `llm:` key.
  *
  * Write path safety (LLM-V1-003 AC4): the incoming config is validated with `validateLlmConfig`
  * BEFORE it is written, and `LlmService.init` re-validates and rebuilds before mutating its own
@@ -162,7 +160,7 @@ export function registerLlmConfigRoutes(
       preHandler: requireAuth,
       schema: {
         description:
-          "Read the current LLM config. A fresh instance with no llm.config.yaml gets an empty skeleton (three tiers, no providers) so the editor opens ready to configure.",
+          "Read the current LLM config. A fresh instance with no `llm:` key in soul.yaml gets an empty skeleton (three tiers, no providers) so the editor opens ready to configure.",
         tags: ["soul"],
         security: [{ sessionCookie: [] }, { bearerToken: [] }],
         response: {
@@ -311,7 +309,7 @@ export function registerLlmConfigRoutes(
       const { refresh } = req.query as { refresh?: boolean };
       config = await enrichSpecs(config, refresh === true);
 
-      await writeFile(join(gitSync.path, "llm.config.yaml"), stringifyYaml(config), "utf8");
+      await writeLlmConfigToSoulYaml(gitSync.path, config);
       await gitSync.withSync("soul: update llm config");
       await soulLoader.reload();
       await llmService.init(soulLoader.llmConfig, secrets, app.log);

--- a/apps/api/src/soul/llm-config/soul-yaml-io.test.ts
+++ b/apps/api/src/soul/llm-config/soul-yaml-io.test.ts
@@ -1,0 +1,77 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { LlmConfig } from "@tulipfarm/llm";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { parse as parseYaml } from "yaml";
+import { deleteLlmConfigFromSoulYaml, writeLlmConfigToSoulYaml } from "./soul-yaml-io";
+
+let TMP: string;
+
+const validConfig: LlmConfig = {
+  tiers: {
+    quick: { providers: [{ provider: "azure", model: "gpt-4o" }] },
+    standard: { providers: [{ provider: "azure", model: "gpt-4o" }] },
+    complex: { providers: [{ provider: "azure", model: "gpt-4o" }] },
+  },
+};
+
+beforeEach(async () => {
+  TMP = await mkdtemp(join(tmpdir(), "soul-yaml-io-test-"));
+});
+afterEach(() => rm(TMP, { recursive: true, force: true }));
+
+describe("writeLlmConfigToSoulYaml", () => {
+  it("writes a valid llm config under the top-level llm: key", async () => {
+    await writeLlmConfigToSoulYaml(TMP, validConfig);
+    const manifest = parseYaml(await readFile(join(TMP, "soul.yaml"), "utf8"));
+    expect(manifest.llm).toEqual(validConfig);
+  });
+
+  it("preserves other known top-level keys already in soul.yaml", async () => {
+    await writeFile(join(TMP, "soul.yaml"), "businessName: Acme\nsetupComplete: true\n", "utf8");
+    await writeLlmConfigToSoulYaml(TMP, validConfig);
+    const manifest = parseYaml(await readFile(join(TMP, "soul.yaml"), "utf8"));
+    expect(manifest.businessName).toBe("Acme");
+    expect(manifest.setupComplete).toBe(true);
+    expect(manifest.llm).toEqual(validConfig);
+  });
+
+  it("preserves unknown top-level keys (open schema)", async () => {
+    await writeFile(join(TMP, "soul.yaml"), "someFutureKey: hello\n", "utf8");
+    await writeLlmConfigToSoulYaml(TMP, validConfig);
+    const manifest = parseYaml(await readFile(join(TMP, "soul.yaml"), "utf8"));
+    expect(manifest.someFutureKey).toBe("hello");
+  });
+
+  it("rejects a structurally invalid llm config", async () => {
+    await expect(writeLlmConfigToSoulYaml(TMP, { tiers: {} })).rejects.toThrow();
+  });
+
+  it("rejects a soul.yaml whose existing known field has the wrong type", async () => {
+    await writeFile(join(TMP, "soul.yaml"), "setupComplete: not-a-boolean\n", "utf8");
+    await expect(writeLlmConfigToSoulYaml(TMP, validConfig)).rejects.toThrow();
+  });
+});
+
+describe("deleteLlmConfigFromSoulYaml", () => {
+  it("removes the llm: key, preserving other keys", async () => {
+    await writeFile(
+      join(TMP, "soul.yaml"),
+      "businessName: Acme\nllm:\n  tiers:\n    quick:\n      providers:\n        - provider: azure\n          model: gpt-4o\n    standard:\n      providers:\n        - provider: azure\n          model: gpt-4o\n    complex:\n      providers:\n        - provider: azure\n          model: gpt-4o\n",
+      "utf8"
+    );
+    await deleteLlmConfigFromSoulYaml(TMP);
+    const manifest = parseYaml(await readFile(join(TMP, "soul.yaml"), "utf8"));
+    expect(manifest.llm).toBeUndefined();
+    expect(manifest.businessName).toBe("Acme");
+  });
+
+  it("is a no-op when soul.yaml has no llm: key", async () => {
+    await expect(deleteLlmConfigFromSoulYaml(TMP)).resolves.toBeUndefined();
+  });
+
+  it("is a no-op when soul.yaml does not exist", async () => {
+    await expect(deleteLlmConfigFromSoulYaml(join(TMP, "missing"))).resolves.toBeUndefined();
+  });
+});

--- a/apps/api/src/soul/llm-config/soul-yaml-io.ts
+++ b/apps/api/src/soul/llm-config/soul-yaml-io.ts
@@ -1,0 +1,67 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { type Static, Type } from "@sinclair/typebox";
+import { LlmConfigSchema } from "@tulipfarm/llm";
+import { ajv, TulipFarmValidationError } from "@tulipfarm/validation";
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+
+/**
+ * soul.yaml top-level schema, validated at this module's read/write boundary (mirrors how
+ * `validateResourceSchema`/`validateGuardrailsConfig` gate their own soul files). Only the fields
+ * this module and the setup wizard (`setup/soul-config.ts`) know about are typed —
+ * `additionalProperties` stays open so other soul-writing code (agents, routines, future keys)
+ * isn't broken by a key this module doesn't recognize.
+ */
+export const SoulManifestSchema = Type.Object(
+  {
+    soulFormatVersion: Type.Optional(Type.Number()),
+    businessName: Type.Optional(Type.String()),
+    businessDescription: Type.Optional(Type.String()),
+    setupComplete: Type.Optional(Type.Boolean()),
+    gitRemoteUrl: Type.Optional(Type.String()),
+    llm: Type.Optional(LlmConfigSchema),
+  },
+  { additionalProperties: true }
+);
+
+export type SoulManifest = Static<typeof SoulManifestSchema>;
+
+const checkManifest = ajv.compile(SoulManifestSchema);
+
+function validateManifest(data: unknown): SoulManifest {
+  if (!checkManifest(data)) {
+    const e = checkManifest.errors?.[0];
+    throw new TulipFarmValidationError(
+      "soul",
+      e?.instancePath ?? "",
+      e?.message ?? "invalid soul.yaml"
+    );
+  }
+  return data as SoulManifest;
+}
+
+async function readManifest(soulPath: string): Promise<SoulManifest> {
+  try {
+    const content = await readFile(join(soulPath, "soul.yaml"), "utf8");
+    return validateManifest(parseYaml(content) ?? {});
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return {};
+    throw err;
+  }
+}
+
+/** Merges `config` into `soul.yaml` under the top-level `llm:` key, preserving other keys. */
+export async function writeLlmConfigToSoulYaml(soulPath: string, config: unknown): Promise<void> {
+  const manifest = await readManifest(soulPath);
+  const next = validateManifest({ ...manifest, llm: config });
+  await writeFile(join(soulPath, "soul.yaml"), stringifyYaml(next), "utf8");
+}
+
+/** Removes the top-level `llm:` key from `soul.yaml`, preserving other keys. No-op if absent. */
+export async function deleteLlmConfigFromSoulYaml(soulPath: string): Promise<void> {
+  const manifest = await readManifest(soulPath);
+  if (!("llm" in manifest)) return;
+  const { llm: _llm, ...rest } = manifest;
+  const next = validateManifest(rest);
+  await writeFile(join(soulPath, "soul.yaml"), stringifyYaml(next), "utf8");
+}

--- a/apps/web/app/lib/settings.ts
+++ b/apps/web/app/lib/settings.ts
@@ -2,7 +2,7 @@ import { apiDelete, apiGet, apiWrite } from "./api";
 
 /*
  * Client for the Settings section (UI-V1-003). Two independent areas:
- *  - LLM config: read/replace soul/llm.config.yaml tiers (structured, via the LLM config form).
+ *  - LLM config: read/replace soul.yaml's `llm` tiers (structured, via the LLM config form).
  *  - Secrets: list keys (never values) + admin add/update/delete (existing SECRETS backend).
  * Dark mode is handled entirely client-side by ThemeToggle in the sidebar and is not part of this.
  */

--- a/apps/web/app/routes/_app.settings.soul.tsx
+++ b/apps/web/app/routes/_app.settings.soul.tsx
@@ -17,7 +17,8 @@ export async function clientLoader() {
 export default function SettingsSoul() {
   const { root, gitConfig } = useLoaderData<typeof clientLoader>();
   const revalidator = useRevalidator();
-  const [selected, setSelected] = useState<string | null>(null);
+  const hasSoulYaml = root.some((node) => node.path === "soul.yaml");
+  const [selected, setSelected] = useState<string | null>(hasSoulYaml ? "soul.yaml" : null);
 
   return (
     <div className="flex flex-col gap-4">

--- a/packages/llm/src/index.ts
+++ b/packages/llm/src/index.ts
@@ -9,6 +9,7 @@ export type {
 export {
   EMBEDDING_UNAVAILABLE_WARNING,
   EmbeddingUnavailableError,
+  LlmConfigSchema,
   LlmConfigValidationError,
   LlmCredentialError,
   LlmNotConfiguredError,

--- a/packages/secrets/src/registry.ts
+++ b/packages/secrets/src/registry.ts
@@ -3,8 +3,8 @@
  * needs — some secret (API keys), some plain config (Azure resource_name, custom base_url). This is
  * the single source of truth: the Settings UI configures a provider in one place by rendering its
  * fields, every value is stored in the secrets store keyed by the field's `key`, and the LLM layer
- * resolves a provider's credentials/config from the store via this registry (so an llm.config row is
- * just { provider, model }). Lives in @tulipfarm/secrets; consumed by @tulipfarm/llm and the web app
+ * resolves a provider's credentials/config from the store via this registry (so a soul.yaml `llm`
+ * row is just { provider, model }). Lives in @tulipfarm/secrets; consumed by @tulipfarm/llm and the web app
  * (over HTTP). Grows as new providers/integrations are added.
  */
 
@@ -43,7 +43,7 @@ export const LLM_PROVIDERS: readonly LlmProviderInfo[] = [
     fields: [{ key: "openai-api-key", label: "API key", role: "api_key", kind: "secret" }],
   },
   {
-    // id stays "azure" (renaming it breaks existing soul/llm.config.yaml `provider: azure` rows and
+    // id stays "azure" (renaming it breaks existing soul.yaml `llm` `provider: azure` rows and
     // the `case "azure"` provider switch); only the display label moves to "Azure Foundry". The two
     // stored keys keep their `azure-openai-*` names so existing secrets aren't orphaned.
     id: "azure",

--- a/packages/soul/AGENTS.md
+++ b/packages/soul/AGENTS.md
@@ -10,7 +10,8 @@ git remote. Implements `specs/SOUL.md`. See root `AGENTS.md` for commands/lint.
 ## Public API (`src/index.ts`)
 
 - **`SoulLoader`** — reads artifacts from disk into in-memory maps; `load()` / reload. Root YAML
-  configs are exposed as fields: `llmConfig`, `guardrailsConfig`, `manifest`.
+  configs are exposed as fields: `llmConfig` (from `soul.yaml`'s nested `llm:` key),
+  `guardrailsConfig`, `manifest` (the full parsed `soul.yaml`).
 - **`GitSyncService`** — `bootSync`, `pull`, `commit`, `push`, `withSync(message)` (commit +
   best-effort push around a write — used by the API's soul-backed tools), periodic sync.
 - **`runSoulMigrations()`** + type `SoulMigration`.
@@ -24,7 +25,7 @@ skills/<name>/SKILL.md
 resources/<name>/schema.yml       # + optional hooks.ts (SHA256-hashed for integrity)
 routines/<name>/routine.yaml      # + optional hooks.ts
 integrations/<name>/config.yaml
-llm.config.yaml   soul.yaml   guardrails.yaml   # repo-root manifests (optional)
+soul.yaml   guardrails.yaml   # repo-root manifests (optional); soul.yaml's `llm:` key holds LLM config
 ```
 
 Resource schemas are checked with `validateResourceSchema` (`@tulipfarm/validation`) on load.
@@ -32,7 +33,8 @@ Parsing is fault-tolerant: a bad file is logged and skipped, and the loader stay
 
 ## File map
 
-- `soul-loader.ts` — the five `load*` readers + frontmatter parsing + hook-hash tracking.
+- `soul-loader.ts` — the `load*` readers + frontmatter parsing + hook-hash tracking; `llmConfig` is
+  derived from `manifest.llm` after `soul.yaml` loads (not a separate file read).
 - `git-sync.ts` — sync engine. Divergence rule (SOUL-V1-004): upstream wins on genuine
   divergence, but **un-pushed local commits are preserved** (retry push, don't blind-reset).
   Commits use `BOT_GIT_NAME` / `BOT_GIT_EMAIL` from `@tulipfarm/constants`.

--- a/packages/soul/src/soul-loader.test.ts
+++ b/packages/soul/src/soul-loader.test.ts
@@ -236,22 +236,32 @@ describe("SoulLoader", () => {
   });
 
   describe("llmConfig and manifest", () => {
-    it("parses llm.config.yaml and soul.yaml", async () => {
-      await write(join(TMP, "llm.config.yaml"), "provider: anthropic\nmodel: claude-sonnet-4-6\n");
-      await write(join(TMP, "soul.yaml"), "name: my-instance\n");
+    it("parses llm from soul.yaml's nested `llm:` key", async () => {
+      await write(
+        join(TMP, "soul.yaml"),
+        "name: my-instance\nllm:\n  provider: anthropic\n  model: claude-sonnet-4-6\n"
+      );
       const loader = new SoulLoader(TMP, makeLogger());
       await loader.load();
       expect(loader.llmConfig).toMatchObject({ provider: "anthropic" });
       expect(loader.manifest).toMatchObject({ name: "my-instance" });
     });
 
-    it("returns null for missing llm.config.yaml and soul.yaml without warn", async () => {
+    it("returns null for missing soul.yaml without warn", async () => {
       const logger = makeLogger();
       const loader = new SoulLoader(TMP, logger);
       await loader.load();
       expect(loader.llmConfig).toBeNull();
       expect(loader.manifest).toBeNull();
       expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it("returns null llmConfig when soul.yaml has no `llm:` key", async () => {
+      await write(join(TMP, "soul.yaml"), "name: my-instance\n");
+      const loader = new SoulLoader(TMP, makeLogger());
+      await loader.load();
+      expect(loader.llmConfig).toBeNull();
+      expect(loader.manifest).toMatchObject({ name: "my-instance" });
     });
   });
 

--- a/packages/soul/src/soul-loader.ts
+++ b/packages/soul/src/soul-loader.ts
@@ -62,7 +62,6 @@ export class SoulLoader {
       resources,
       routines,
       integrations,
-      llmConfig,
       guardrailsConfig,
       observabilityConfig,
       manifest,
@@ -72,7 +71,6 @@ export class SoulLoader {
       this.loadResources(),
       this.loadRoutines(),
       this.loadIntegrations(),
-      this.loadYamlFile(join(this.soulPath, "llm.config.yaml"), "llm.config.yaml"),
       this.loadYamlFile(join(this.soulPath, "guardrails.yaml"), "guardrails.yaml"),
       this.loadYamlFile(
         join(this.soulPath, "observability.config.yaml"),
@@ -86,7 +84,7 @@ export class SoulLoader {
     this.resources = resources;
     this.routines = routines;
     this.integrations = integrations;
-    this.llmConfig = llmConfig;
+    this.llmConfig = (manifest?.llm as Record<string, unknown> | undefined) ?? null;
     this.guardrailsConfig = guardrailsConfig;
     this.observabilityConfig = observabilityConfig;
     this.manifest = manifest;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       '@scalar/fastify-api-reference':
         specifier: ^1.62.0
         version: 1.62.0
+      '@sinclair/typebox':
+        specifier: ^0.34.49
+        version: 0.34.49
       '@tulipfarm/llm':
         specifier: workspace:*
         version: link:../../packages/llm
@@ -140,13 +143,13 @@ importers:
         version: 3.1.18
       fumadocs-core:
         specifier: 16.10.5
-        version: 16.10.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.21.0(react@19.2.7))(next@16.2.9(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+        version: 16.10.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.21.0(react@19.2.7))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       fumadocs-mdx:
         specifier: 15.0.12
-        version: 15.0.12(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.10.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.21.0(react@19.2.7))(next@16.2.9(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.9(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(rolldown@1.1.2)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 15.0.12(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.10.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.21.0(react@19.2.7))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(rolldown@1.1.2)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       fumadocs-ui:
         specifier: 16.10.5
-        version: 16.10.5(@tailwindcss/oxide@4.3.1)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.10.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.21.0(react@19.2.7))(next@16.2.9(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.9(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.1)
+        version: 16.10.5(@tailwindcss/oxide@4.3.1)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.10.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.21.0(react@19.2.7))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.1)
       lucide-react:
         specifier: ^1.21.0
         version: 1.21.0(react@19.2.7)
@@ -10374,7 +10377,7 @@ snapshots:
       obug: 2.1.2
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.19.20)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.0(@types/node@22.19.20)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.19.20)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/expect@4.1.9':
     dependencies:
@@ -11591,7 +11594,7 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  fumadocs-core@16.10.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.21.0(react@19.2.7))(next@16.2.9(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3):
+  fumadocs-core@16.10.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.21.0(react@19.2.7))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3):
     dependencies:
       '@orama/orama': 3.1.18
       estree-util-value-to-estree: 3.5.0
@@ -11624,14 +11627,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@15.0.12(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.10.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.21.0(react@19.2.7))(next@16.2.9(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.9(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(rolldown@1.1.2)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
+  fumadocs-mdx@15.0.12(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.10.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.21.0(react@19.2.7))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(rolldown@1.1.2)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.28.1
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.10.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.21.0(react@19.2.7))(next@16.2.9(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+      fumadocs-core: 16.10.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.21.0(react@19.2.7))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       js-yaml: 4.2.0
       mdast-util-mdx: 3.0.0
       picocolors: 1.1.1
@@ -11654,7 +11657,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-ui@16.10.5(@tailwindcss/oxide@4.3.1)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.10.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.21.0(react@19.2.7))(next@16.2.9(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.9(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.1):
+  fumadocs-ui@16.10.5(@tailwindcss/oxide@4.3.1)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.10.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.21.0(react@19.2.7))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.1):
     dependencies:
       '@fuma-translate/react': 1.0.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@fumadocs/tailwind': 0.0.5(@tailwindcss/oxide@4.3.1)(tailwindcss@4.3.1)
@@ -11669,7 +11672,7 @@ snapshots:
       '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
       '@radix-ui/react-tabs': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.10.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.21.0(react@19.2.7))(next@16.2.9(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+      fumadocs-core: 16.10.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.21.0(react@19.2.7))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       lucide-react: 1.21.0(react@19.2.7)
       motion: 12.41.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-themes: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -194,7 +194,7 @@ if [ ! -d "$SOUL_DIR/.git" ]; then
   echo "📁 Initializing soul directory at $SOUL_DIR..."
   mkdir -p "$SOUL_DIR"/{resources,routines,agents,skills,integrations}
 
-  # Create stub files. NOTE: no llm.config.yaml stub — an empty/comment-only one fails LLM-config
+  # Create stub files. NOTE: no `llm:` key in soul.yaml — an empty/comment-only one fails LLM-config
   # validation (requires `tiers`). Absent config = LLM features disabled until the UI wizard writes it.
   # soul.yaml is intentionally minimal — setupComplete is set by the setup wizard, not here.
   cat > "$SOUL_DIR/soul.yaml" << 'EOF'


### PR DESCRIPTION
## Summary
- Consolidates `soul/llm.config.yaml` into `soul.yaml` under a top-level `llm:` key (closes #119) — loader (`SoulLoader`), API write path (`routes.ts`), delete-cascade path (`cascade.ts`) all go through a new shared `soul-yaml-io.ts` helper.
- Adds AJV/TypeBox schema validation (`SoulManifestSchema`) directly in `soul-yaml-io.ts`, applied on read/write/delete — mirrors the existing resources/guardrails validation pattern. Schema stays open (`additionalProperties: true`) so it doesn't break the setup wizard's independent, untyped use of `businessName`/`businessDescription`/`setupComplete`/`gitRemoteUrl` on the same file.
- `/settings/soul` explorer now defaults to opening `soul.yaml` instead of showing nothing.
- No migration added for existing repos with a standalone `llm.config.yaml` — explicitly out of scope for this PR.

## Test plan
- [x] `pnpm exec biome check` — clean across all touched workspaces
- [x] `pnpm --filter @tulipfarm/api --filter @tulipfarm/llm typecheck` — clean
- [x] `pnpm --filter @tulipfarm/api test` — 135 files / 1451 tests passed (incl. new `soul-yaml-io.test.ts`)
- [x] `pnpm --filter @tulipfarm/llm --filter @tulipfarm/soul --filter @tulipfarm/secrets --filter @tulipfarm/web test` — all green