### PR TITLE
feat(context): inject business context from soul.yaml into system prompt

### DIFF
--- a/apps/api/src/chat/routes.test.ts
+++ b/apps/api/src/chat/routes.test.ts
@@ -823,6 +823,48 @@ describe("chat routes", () => {
       );
     });
 
+    // Business context — soul.yaml's businessName/businessDescription surface in the system prompt
+    // (not working_memory), per apps/api/AGENTS.md's "Context & streaming" note.
+    it("renders soul.yaml manifest businessName/businessDescription in <business-context>", async () => {
+      await app.close();
+      const soulLoader = {
+        agents: new Map(),
+        skills: new Map(),
+        manifest: { businessName: "Acme Corp", businessDescription: "Sells widgets." },
+      } as unknown as SoulLoader;
+      app = await buildApp({
+        sessionStore: store,
+        userRepo,
+        tokenRepo,
+        llmService,
+        conversationRepo: repo,
+        messageRepo,
+        streamResumeRepo: streamRepo,
+        streamHub,
+        workingMemoryService: new WorkingMemoryService(workingMemoryRepo),
+        soulLoader,
+      });
+
+      const res = await post({ message: userMsg("hi") });
+      expect(res.statusCode).toBe(200);
+      await waitFor(() => capturedPrompts.length >= 1);
+
+      const prompt = capturedPrompts[0] as Array<{ role: string; content: unknown }>;
+      const system = JSON.stringify(prompt[0]?.content);
+      expect(system).toContain(
+        "<business-context>\\nname: Acme Corp\\ndescription: Sells widgets.\\n</business-context>"
+      );
+    });
+
+    it("omits <business-context> when soul.yaml has no businessName", async () => {
+      const res = await post({ message: userMsg("hi") });
+      expect(res.statusCode).toBe(200);
+      await waitFor(() => capturedPrompts.length >= 1);
+
+      const prompt = capturedPrompts[0] as Array<{ role: string; content: unknown }>;
+      expect(JSON.stringify(prompt[0]?.content)).not.toContain("<business-context>");
+    });
+
     // Composer tags (`/skill`, `#resource`) — per-turn eager injection. A tagged skill's body lands
     // in <skills> even when it is NOT marked eager (works for any agent), and a tagged resource
     // type's schema lands in <eager-resources>. Names are ephemeral — supplied per request, never

--- a/apps/api/src/chat/system-prompt.test.ts
+++ b/apps/api/src/chat/system-prompt.test.ts
@@ -85,4 +85,16 @@ describe("assembleAgentSystemPrompt", () => {
     expect(blockBody(out, "soul-context")).not.toContain("skill-forge");
     expect(out).toContain("skill-forge");
   });
+
+  it("threads business.name/description into the business-context block", () => {
+    const out = assembleAgentSystemPrompt({
+      agent,
+      platformAgent: undefined,
+      business: { name: "Acme Corp", description: "Sells widgets." },
+      ...empty,
+    });
+    expect(blockBody(out, "business-context")).toBe(
+      "\nname: Acme Corp\ndescription: Sells widgets.\n"
+    );
+  });
 });

--- a/apps/api/src/chat/system-prompt.ts
+++ b/apps/api/src/chat/system-prompt.ts
@@ -15,6 +15,7 @@ import type { AvailableSkill } from "../soul/skills/registry";
 export function assembleAgentSystemPrompt(args: {
   agent: SoulAgent;
   platformAgent: PlatformAgent | undefined;
+  business?: AssembleContext["business"];
   memory: AssembleContext["memory"];
   governancePages: AssembleContext["governancePages"];
   availableSkills: AvailableSkill[];
@@ -28,6 +29,7 @@ export function assembleAgentSystemPrompt(args: {
   const {
     agent,
     platformAgent,
+    business,
     memory,
     governancePages,
     availableSkills,
@@ -47,6 +49,7 @@ export function assembleAgentSystemPrompt(args: {
     agentId: agent.name,
     domain: typeof agent.frontmatter.domain === "string" ? agent.frontmatter.domain : null,
     tenantId: "default",
+    business,
     personality: agent.body,
     memory,
     governancePages,

--- a/apps/api/src/chat/turn.ts
+++ b/apps/api/src/chat/turn.ts
@@ -269,9 +269,18 @@ export async function runChatTurn(req: FastifyRequest, reply: FastifyReply, ctx:
     // agent that can actually cite (cite_sources in its scoped toolset). Otherwise a handoff target
     // without cite_sources (e.g. the IA) would receive pinned pages telling it to call a tool it lacks.
     const canCite = canGroundKnowledge(knowledge, tools);
+    const manifest = soulLoader?.manifest;
+    const business = {
+      name: typeof manifest?.businessName === "string" ? manifest.businessName : undefined,
+      description:
+        typeof manifest?.businessDescription === "string"
+          ? manifest.businessDescription
+          : undefined,
+    };
     return assembleAgentSystemPrompt({
       agent: a,
       platformAgent: pa,
+      business,
       memory: memoryList,
       governancePages,
       availableSkills: soulAvailableSkills,

--- a/apps/api/src/context/assemble.test.ts
+++ b/apps/api/src/context/assemble.test.ts
@@ -39,6 +39,7 @@ describe("assembleSystemPrompt — block order", () => {
         platformInstructions: "platform rules",
         agentId: "sales",
         tenantId: "default",
+        business: { name: "Acme Corp" },
         personality: "You are helpful.",
         memory: [mem("plan", "enterprise")],
         governancePages: [govDoc("Policy", "Be compliant.")],
@@ -47,6 +48,7 @@ describe("assembleSystemPrompt — block order", () => {
     const order = [
       "<platform-instructions>",
       "<agent-identity>",
+      "<business-context>",
       "<agent-personality>",
       "<memory>",
       "<governance-knowledge>",
@@ -182,6 +184,33 @@ describe("assembleSystemPrompt — agent-identity", () => {
 
     const empty = assembleSystemPrompt(baseCtx());
     expect(empty).not.toContain("<agent-identity>");
+  });
+});
+
+describe("assembleSystemPrompt — business-context", () => {
+  it("renders name and description when both are set", () => {
+    const out = assembleSystemPrompt(
+      baseCtx({ business: { name: "Acme Corp", description: "Sells widgets." } })
+    );
+    expect(out).toContain("<business-context>");
+    expect(out).toContain("name: Acme Corp");
+    expect(out).toContain("description: Sells widgets.");
+  });
+
+  it("omits the description line when only name is set", () => {
+    const out = assembleSystemPrompt(baseCtx({ business: { name: "Acme Corp" } }));
+    expect(out).toContain("name: Acme Corp");
+    expect(out).not.toContain("description:");
+  });
+
+  it("omits the block entirely when name is absent", () => {
+    const withDescOnly = assembleSystemPrompt(
+      baseCtx({ business: { description: "Sells widgets." } })
+    );
+    expect(withDescOnly).not.toContain("<business-context>");
+
+    const empty = assembleSystemPrompt(baseCtx());
+    expect(empty).not.toContain("<business-context>");
   });
 });
 

--- a/apps/api/src/context/assemble.ts
+++ b/apps/api/src/context/assemble.ts
@@ -21,6 +21,16 @@ export interface AssembleContext {
   domain?: string | null;
   /** Single-tenant V1: "default". */
   tenantId?: string;
+  /**
+   * soul.yaml manifest's business profile — surfaces as `<business-context>`. `name` unset → block
+   * omitted; other fields render as `key: value` lines only when set. Grouped in one object so new
+   * profile fields (industry, website, ...) only touch this shape and the renderer, not every
+   * call site between `soulLoader.manifest` and here.
+   */
+  business?: {
+    name?: string;
+    description?: string;
+  };
   /** The agent's AGENT.md body. */
   personality?: string;
   /** Per-user working memory, store-capped, oldest-written first (MEM-V1-003). */
@@ -86,6 +96,15 @@ function renderAgentIdentity(ctx: AssembleContext): string {
   if (ctx.domain) lines.push(`domain: ${ctx.domain}`);
   if (ctx.tenantId) lines.push(`tenantId: ${ctx.tenantId}`);
   return lines.length > 0 ? block("agent-identity", lines.join("\n")) : "";
+}
+
+function renderBusinessContext(ctx: AssembleContext): string {
+  const name = ctx.business?.name?.trim();
+  if (!name) return "";
+  const lines = [`name: ${name}`];
+  const description = ctx.business?.description?.trim();
+  if (description) lines.push(`description: ${description}`);
+  return block("business-context", lines.join("\n"));
 }
 
 function renderAgentPersonality(ctx: AssembleContext): string {
@@ -292,7 +311,7 @@ function renderKnowledgeGrounding(ctx: AssembleContext): string {
 }
 
 /**
- * Assemble the agent system prompt from the 10 ordered blocks (specs/CONTEXT-ENGINE.md §1). Pure
+ * Assemble the agent system prompt from the 11 ordered blocks (specs/CONTEXT-ENGINE.md §1). Pure
  * and synchronous. Each block renders to a string or "" (when empty or over budget); empty blocks
  * are omitted entirely so the prefix stays byte-stable across turns. `<skills>` renders eager skill
  * bodies and `<available-skills>` the lazy skill L1 index; `<soul-context>` renders the repo
@@ -303,6 +322,7 @@ export function assembleSystemPrompt(ctx: AssembleContext): string {
   const blocks = [
     renderPlatformInstructions(ctx),
     renderAgentIdentity(ctx),
+    renderBusinessContext(ctx),
     renderAgentPersonality(ctx),
     renderMemory(ctx),
     // V1: governance is tenant-wide. `domain` is display-only on the agent (AGT-V1-007), so it


### PR DESCRIPTION
## Summary

- Threads soul.yaml's `businessName`/`businessDescription` (already persisted by the setup wizard via `patchSoulConfig`) into a new nested `AssembleContext.business` field, rendered as a `<business-context>` block in the system prompt.
- Per `apps/api/AGENTS.md`: static business/identity facts belong in the system prompt (`assembleSystemPrompt`), not `memory/` working_memory.
- Block omits entirely when `businessName` is unset (no empty tags); description line omits when `businessDescription` is unset.
- Chain: `soulLoader.manifest` (`chat/turn.ts`) → `assembleAgentSystemPrompt` (`chat/system-prompt.ts`) → `assembleSystemPrompt` (`context/assemble.ts`), matching the existing optional-chaining idiom already used for `agent.frontmatter.domain`.

Closes TulipFarm/tulipfarm#120

## Test plan

- [x] `apps/api/src/context/assemble.test.ts` — renderer unit tests: both fields render, description-only-when-name-set, block omitted when name absent
- [x] `apps/api/src/chat/system-prompt.test.ts` — wrapper threads `business` into the block
- [x] `apps/api/src/chat/routes.test.ts` — end-to-end via `buildApp` + Fastify inject: manifest → rendered `<business-context>` in captured system prompt, and omitted when no `businessName`
- [x] `pnpm lint && pnpm typecheck && pnpm test` all pass (one pre-existing unrelated flaky test isolated and confirmed unrelated: `knowledge/routes.test.ts` PGlite timeout under full-suite load)