### PR TITLE
fix(a2ui): resolve dataModel bindings for DataTable, List, DetailView array props

### DIFF
--- a/apps/api/src/a2ui/catalog.ts
+++ b/apps/api/src/a2ui/catalog.ts
@@ -166,33 +166,40 @@ export const A2UI_CATALOG: Record<A2uiNode["component"], CatalogEntry> = {
 
   List: (node, ctx, id) => {
     const n = node as Of<"List">;
-    const items = n.items
+    const items = (ctx.raw(n.items) ?? []) as Array<{ text: A2uiValue; meta?: A2uiValue }>;
+    const body = items
       .map((it) => {
         const meta = it.meta ? `<span data-slot="meta">${ctx.text(it.meta)}</span>` : "";
         return `<li>${ctx.text(it.text)}${meta}</li>`;
       })
       .join("");
-    return `<tf-list${id}><ul>${items}</ul></tf-list>`;
+    return `<tf-list${id}><ul>${body}</ul></tf-list>`;
   },
 
   DetailView: (node, ctx, id) => {
     const n = node as Of<"DetailView">;
-    const rows = n.rows
+    const rows = (ctx.raw(n.rows) ?? []) as Array<{ label: A2uiValue; value: A2uiValue }>;
+    const body = rows
       .map((r) => `<div><dt>${ctx.text(r.label)}</dt><dd>${ctx.text(r.value)}</dd></div>`)
       .join("");
-    return `<tf-detail-view${id}><dl>${rows}</dl></tf-detail-view>`;
+    return `<tf-detail-view${id}><dl>${body}</dl></tf-detail-view>`;
   },
 
   DataTable: (node, ctx, id) => {
     const n = node as Of<"DataTable">;
-    const head = n.columns
+    const columns = (ctx.raw(n.columns) ?? []) as string[];
+    const rows = (ctx.raw(n.rows) ?? []) as unknown[][];
+    const head = columns
       .map((c) => {
         const sorted = n.sort && n.sort.column === c ? ` aria-sort="${n.sort.direction}"` : "";
         return `<th${sorted}>${esc(c)}</th>`;
       })
       .join("");
-    const body = n.rows
-      .map((row) => `<tr>${row.map((cell) => `<td>${ctx.text(cell)}</td>`).join("")}</tr>`)
+    const body = rows
+      .map((row) => {
+        const cells = (Array.isArray(row) ? row : []) as A2uiValue[];
+        return `<tr>${cells.map((cell) => `<td>${ctx.text(cell)}</td>`).join("")}</tr>`;
+      })
       .join("");
     return `<tf-data-table${id}><table><thead><tr>${head}</tr></thead><tbody>${body}</tbody></table></tf-data-table>`;
   },


### PR DESCRIPTION
### Summary

- Fixes a crash (`n.rows.map is not a function`) when the LLM uses `{ "path": "..." }` dataModel bindings for array props on `DataTable`, `List`, and `DetailView` components in `render_surface`
- Resolves `rows`, `columns`, and `items` through `ctx.raw()` before accessing them — consistent with how `ForceGraph` and chart components already handle their array-shaped props
- Adds `Array.isArray` guard on individual DataTable row entries for robustness

### What was happening

The A2UI catalog's `DataTable`, `DetailView`, and `List` entries accessed their array props directly from the node (`n.rows.map(...)`) without resolving potential `{ path }` bindings. When the LLM passed these as dataModel bindings (common when displaying resource query results like user leaves), the binding object has no `.map()` method — causing the runtime crash.

Other components (`ForceGraph`, `BarChart`, `LineChart`) already correctly resolve through `ctx.raw()`:
```ts
// ForceGraph — was already correct
const nodes = esc(JSON.stringify(ctx.raw(n.nodes) ?? []));
```

### Test plan

- [x] All 14 existing `a2ui/compiler.test.ts` tests pass
- [x] All 11 `a2ui-render.test.ts` + `a2ui-surface.test.ts` tests pass
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Biome lint passes
- [ ] Manual: ask assistant to display resource records as a DataTable (e.g. "show me company user leaves") — should render without crashing

Closes #133

Made with [Cursor](https://cursor.com)