### PR TITLE
feat(routines): v1 routine engine — parser, state machine, scheduler, approvals, SSE, forge, UI

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -21,6 +21,7 @@
     "@scalar/fastify-api-reference": "^1.62.0",
     "@sinclair/typebox": "^0.34.49",
     "@tulipfarm/llm": "workspace:*",
+    "@tulipfarm/routine-engine": "workspace:*",
     "@tulipfarm/secrets": "workspace:*",
     "@tulipfarm/soul": "workspace:*",
     "@tulipfarm/validation": "workspace:*",

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -14,6 +14,7 @@ import Fastify from "fastify";
 import type { A2uiSurfaceStore } from "./a2ui/surface-store";
 import { registerActivityRoutes } from "./activity/routes";
 import type { ActivityService } from "./activity/service";
+import type { ApprovalsRepo } from "./approvals/repo";
 import { registerApprovalRoutes } from "./approvals/routes";
 import type { TokenRepo } from "./auth/api-tokens";
 import { csrfHook } from "./auth/csrf";
@@ -47,6 +48,8 @@ import { registerOnboardingRoutes } from "./onboarding/routes";
 import type { RateLimiter } from "./rate-limit";
 import type { CounterStore, ResourceRepoFactory } from "./resources/repo";
 import { registerResourceRoutes } from "./resources/routes";
+import type { RoutineRoutesDeps } from "./routines/routes";
+import { registerRoutineRoutes } from "./routines/routes";
 import { registerSecretsRoutes } from "./secrets/routes";
 import { registerSetupRoutes, registerSetupStatusRoute } from "./setup/routes";
 import { isHeadlessBoot } from "./setup/service";
@@ -92,6 +95,10 @@ export interface AppOptions {
   activityService?: ActivityService;
   observabilityService?: ObservabilityService;
   observabilityConfig?: ObservabilityConfig;
+  /** Routine engine surface (v0.11): registry + runs repo + trigger service + enqueuers. */
+  routines?: RoutineRoutesDeps;
+  /** DB approvals store — enables routine_state approvals on the approvals routes. */
+  approvalsRepo?: ApprovalsRepo;
 }
 
 export async function buildApp(opts: AppOptions = {}) {
@@ -359,10 +366,26 @@ export async function buildApp(opts: AppOptions = {}) {
         opts.pendingInteractionRepo,
         opts.a2uiSurfaceStore
       );
-      registerApprovalRoutes(app, approvalRegistry, requireAuth);
+      registerApprovalRoutes(
+        app,
+        approvalRegistry,
+        requireAuth,
+        opts.approvalsRepo && opts.routines
+          ? {
+              approvalsRepo: opts.approvalsRepo,
+              enqueueWake: (job) => {
+                if (!opts.routines) return Promise.resolve();
+                return opts.routines.enqueuers.enqueueWake(job);
+              },
+            }
+          : undefined
+      );
     }
     if (opts.feedbackRepo) {
       registerFeedbackRoutes(app, opts.feedbackRepo, requireAuth);
+    }
+    if (opts.routines) {
+      registerRoutineRoutes(app, opts.routines, requireAuth);
     }
     // The retrieval spine is optional — only the page-search branch needs it (index.ts wires it in
     // prod). Knowledge routes register whenever the service is present; page mode degrades to chunk

--- a/apps/api/src/approvals/repo.ts
+++ b/apps/api/src/approvals/repo.ts
@@ -61,4 +61,25 @@ export class ApprovalsRepo {
     );
     return rows.length > 0 ? rowToApproval(rows[0]) : null;
   }
+
+  /** Pending rows (optionally by kind), oldest first — the routine_state approvals list. */
+  async listPending(kind?: ApprovalKind): Promise<ApprovalRow[]> {
+    const { rows } = await this.db.query(
+      `SELECT id, kind, status, payload, expires_at, created_at, resolved_at
+       FROM approvals WHERE status = 'pending' ${kind ? "AND kind = $1" : ""}
+       ORDER BY created_at`,
+      kind ? [kind] : []
+    );
+    return rows.map(rowToApproval);
+  }
+
+  /** Pending rows past their expiry — settled to `timeout` by the routine sweep. */
+  async listExpiredPending(kind: ApprovalKind, now: Date): Promise<ApprovalRow[]> {
+    const { rows } = await this.db.query(
+      `SELECT id, kind, status, payload, expires_at, created_at, resolved_at
+       FROM approvals WHERE status = 'pending' AND kind = $1 AND expires_at <= $2`,
+      [kind, now]
+    );
+    return rows.map(rowToApproval);
+  }
 }

--- a/apps/api/src/approvals/routes.test.ts
+++ b/apps/api/src/approvals/routes.test.ts
@@ -1,0 +1,186 @@
+import { randomUUID } from "node:crypto";
+import type { PGlite } from "@electric-sql/pglite";
+import type { FastifyInstance } from "fastify";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildApp } from "../app";
+import type { TokenDoc, TokenRepo } from "../auth/api-tokens";
+import { CSRF_COOKIE, CSRF_HEADER } from "../auth/csrf";
+import { SESSION_COOKIE } from "../auth/routes";
+import { MemorySessionStore } from "../auth/session-store";
+import { createUser, type UserDoc, type UserRepo } from "../auth/users";
+import type { PaginatedResult } from "../pagination";
+import { runPgMigrations } from "../pg-migrate";
+import { makePglite } from "../test/pglite";
+import { ApprovalsRepo } from "./repo";
+
+const TEST_CSRF = "a".repeat(64);
+
+class FakeUserRepo implements UserRepo {
+  private users: UserDoc[] = [];
+  async findByEmail(email: string): Promise<UserDoc | null> {
+    return this.users.find((u) => u.email === email.trim().toLowerCase()) ?? null;
+  }
+  async findById(id: string): Promise<UserDoc | null> {
+    return this.users.find((u) => u._id === id) ?? null;
+  }
+  async count(): Promise<number> {
+    return this.users.length;
+  }
+  async insert(user: UserDoc): Promise<void> {
+    this.users.push(user);
+  }
+}
+
+class FakeTokenRepo implements TokenRepo {
+  async create(): Promise<void> {}
+  async findByHash(): Promise<TokenDoc | null> {
+    return null;
+  }
+  async findByUserId(): Promise<TokenDoc[]> {
+    return [];
+  }
+  async findAll(): Promise<TokenDoc[]> {
+    return [];
+  }
+  async findById(): Promise<TokenDoc | null> {
+    return null;
+  }
+  async deleteById(): Promise<void> {}
+  async findAllPaginated(): Promise<PaginatedResult<TokenDoc>> {
+    return { items: [], nextCursor: null };
+  }
+  async findByUserIdPaginated(): Promise<PaginatedResult<TokenDoc>> {
+    return { items: [], nextCursor: null };
+  }
+}
+
+/**
+ * routine_state approvals require the routes to be registered with routineDeps, which
+ * app.ts only wires when BOTH approvalsRepo and routines options are present. The chat
+ * deps (llmService/conversationRepo/messageRepo) gate route registration — fake the
+ * minimum surface.
+ */
+describe("approval routes — routine_state kind", () => {
+  let app: FastifyInstance;
+  let db: PGlite;
+  let sid: string;
+  let approvals: ApprovalsRepo;
+  let wakes: Array<Record<string, unknown>>;
+
+  beforeEach(async () => {
+    db = await makePglite();
+    await runPgMigrations(db);
+    approvals = new ApprovalsRepo(db);
+    wakes = [];
+
+    const store = new MemorySessionStore();
+    const userRepo = new FakeUserRepo();
+    const user = await createUser(userRepo, "user@example.com", "pass", "member");
+    sid = await store.create(user._id);
+
+    app = await buildApp({
+      sessionStore: store,
+      userRepo,
+      tokenRepo: new FakeTokenRepo(),
+      approvalsRepo: approvals,
+      // minimal chat deps so the approvals routes register
+      llmService: { getModel: vi.fn() } as never,
+      conversationRepo: {} as never,
+      messageRepo: {} as never,
+      routines: {
+        registry: { list: () => [], getEntry: () => undefined, get: () => undefined } as never,
+        runs: {} as never,
+        triggerService: {} as never,
+        enqueuers: {
+          enqueueRun: async () => {},
+          enqueueWake: async (job: Record<string, unknown>) => {
+            wakes.push(job);
+          },
+        } as never,
+        getSecret: async () => "",
+      },
+    });
+  });
+
+  afterEach(async () => {
+    await app.close();
+    await db.close();
+  });
+
+  const authed = () => ({ [SESSION_COOKIE]: sid, [CSRF_COOKIE]: TEST_CSRF });
+  const csrf = { [CSRF_HEADER]: TEST_CSRF };
+
+  async function insertRoutineApproval(runId = randomUUID()) {
+    const id = randomUUID();
+    await approvals.insert({
+      id,
+      kind: "routine_state",
+      payload: {
+        routineSlug: "expense-report",
+        runId,
+        stateName: "Gate",
+        channels: ["ui"],
+        summary: { amount: 900 },
+      },
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    return { id, runId };
+  }
+
+  it("lists pending routine_state approvals with kind discrimination", async () => {
+    const { id } = await insertRoutineApproval();
+    const res = await app.inject({ method: "GET", url: "/api/v1/approvals", cookies: authed() });
+    expect(res.statusCode).toBe(200);
+    const { items } = res.json() as { items: Array<Record<string, unknown>> };
+    const item = items.find((i) => i.approvalId === id);
+    expect(item).toMatchObject({
+      kind: "routine_state",
+      routineSlug: "expense-report",
+      stateName: "Gate",
+      summary: { amount: 900 },
+    });
+  });
+
+  it("decide approves a routine_state approval and wakes the run", async () => {
+    const { id, runId } = await insertRoutineApproval();
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/approvals/${id}/decide`,
+      cookies: authed(),
+      headers: csrf,
+      payload: { decision: "approve" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect((await approvals.findById(id))?.status).toBe("approved");
+    expect(wakes).toEqual([
+      expect.objectContaining({ runId, reason: "approval", decision: "approved" }),
+    ]);
+  });
+
+  it("decide denies and wakes with denied", async () => {
+    const { id, runId } = await insertRoutineApproval();
+    await app.inject({
+      method: "POST",
+      url: `/api/v1/approvals/${id}/decide`,
+      cookies: authed(),
+      headers: csrf,
+      payload: { decision: "deny" },
+    });
+    expect((await approvals.findById(id))?.status).toBe("denied");
+    expect(wakes[0]).toMatchObject({ runId, decision: "denied" });
+  });
+
+  it("404s on already-settled approvals", async () => {
+    const { id } = await insertRoutineApproval();
+    await approvals.settle(id, "approved");
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/approvals/${id}/decide`,
+      cookies: authed(),
+      headers: csrf,
+      payload: { decision: "approve" },
+    });
+    expect(res.statusCode).toBe(404);
+    expect(wakes).toHaveLength(0);
+  });
+});

--- a/apps/api/src/approvals/routes.ts
+++ b/apps/api/src/approvals/routes.ts
@@ -1,17 +1,32 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { ErrorSchema } from "../auth/schemas";
 import type { ApprovalRegistry } from "../chat/approvals";
+import type { ApprovalsRepo } from "./repo";
 
 type PreHandler = (req: FastifyRequest, reply: FastifyReply) => Promise<void>;
 
+/** Routine-approval extension: DB-backed routine_state rows + run resumption (v0.11). */
+export interface RoutineApprovalDeps {
+  approvalsRepo: ApprovalsRepo;
+  enqueueWake: (job: {
+    runId: string;
+    reason: "approval";
+    token: string;
+    decision: "approved" | "denied";
+  }) => Promise<void>;
+}
+
 /**
- * Standalone approval routes (AGT-V1-002). Shared by tool-call approvals (current)
- * and future routine human_approval states (v0.11).
+ * Standalone approval routes (AGT-V1-002). Serves BOTH approval kinds behind one
+ * discriminated list/decide surface: `tool_call` (in-memory registry, ephemeral,
+ * resumes a suspended chat stream) and `routine_state` (DB rows, durable, resumes a
+ * suspended routine run via a routine-wake job).
  */
 export function registerApprovalRoutes(
   app: FastifyInstance,
   approvalRegistry: ApprovalRegistry,
-  requireAuth: PreHandler
+  requireAuth: PreHandler,
+  routineDeps?: RoutineApprovalDeps
 ): void {
   app.get(
     "/api/v1/approvals",
@@ -19,8 +34,9 @@ export function registerApprovalRoutes(
       preHandler: requireAuth,
       schema: {
         description:
-          "List all in-flight (pending) tool-execution approvals. Single-trust V1: not scoped " +
-          "per-user. Ephemeral — the set empties on API restart. Poll to drive the Approvals view + badge.",
+          "List all pending approvals, both kinds: tool_call (ephemeral, in-memory — empties on " +
+          "restart) and routine_state (durable rows for routine human_approval states). " +
+          "Discriminate on `kind`.",
         tags: ["approvals"],
         security: [{ sessionCookie: [] }, { bearerToken: [] }],
         response: {
@@ -34,12 +50,19 @@ export function registerApprovalRoutes(
                 items: {
                   type: "object",
                   additionalProperties: false,
-                  required: ["approvalId", "toolCallId", "toolName", "expiresAt", "createdAt"],
+                  required: ["approvalId", "kind", "expiresAt", "createdAt"],
                   properties: {
                     approvalId: { type: "string" },
+                    kind: { type: "string", enum: ["tool_call", "routine_state"] },
+                    // tool_call fields
                     toolCallId: { type: "string" },
                     toolName: { type: "string" },
                     args: {},
+                    // routine_state fields
+                    routineSlug: { type: "string" },
+                    runId: { type: "string" },
+                    stateName: { type: "string" },
+                    summary: {},
                     expiresAt: { type: "string" },
                     createdAt: { type: "string" },
                   },
@@ -52,7 +75,33 @@ export function registerApprovalRoutes(
       },
     },
     async (_req, reply) => {
-      return reply.send({ items: approvalRegistry.listPending() });
+      const toolCalls = approvalRegistry
+        .listPending()
+        .map((item) => ({ kind: "tool_call" as const, ...item }));
+
+      let routineItems: Array<Record<string, unknown>> = [];
+      if (routineDeps) {
+        const rows = await routineDeps.approvalsRepo.listPending("routine_state");
+        routineItems = rows.map((row) => {
+          const payload = (row.payload ?? {}) as {
+            routineSlug?: string;
+            runId?: string;
+            stateName?: string;
+            summary?: unknown;
+          };
+          return {
+            kind: "routine_state" as const,
+            approvalId: row.id,
+            routineSlug: payload.routineSlug,
+            runId: payload.runId,
+            stateName: payload.stateName,
+            summary: payload.summary,
+            expiresAt: row.expiresAt.toISOString(),
+            createdAt: row.createdAt.toISOString(),
+          };
+        });
+      }
+      return reply.send({ items: [...toolCalls, ...routineItems] });
     }
   );
 
@@ -62,8 +111,9 @@ export function registerApprovalRoutes(
       preHandler: requireAuth,
       schema: {
         description:
-          "Approve or deny a pending tool-execution approval. Resumes the suspended chat stream " +
-          "with the tool result (approve) or an error result the model sees (deny).",
+          "Approve or deny a pending approval. tool_call: resumes the suspended chat stream with " +
+          "the tool result (approve) or an error the model sees (deny). routine_state: settles the " +
+          "row and wakes the suspended routine run with the decision.",
         tags: ["approvals"],
         security: [{ sessionCookie: [] }, { bearerToken: [] }],
         params: {
@@ -92,14 +142,29 @@ export function registerApprovalRoutes(
     async (req, reply) => {
       const { approvalId } = req.params as { approvalId: string };
       const { decision } = req.body as { decision: "approve" | "deny" };
-      const resolved = approvalRegistry.decide(
-        approvalId,
-        decision === "approve" ? "approved" : "denied"
-      );
-      if (!resolved) {
-        return reply.code(404).send({ error: "approval not found or already resolved" });
+      const settled = decision === "approve" ? "approved" : "denied";
+
+      // Tool-call approvals first (in-memory authoritative), then DB routine_state rows.
+      const resolved = approvalRegistry.decide(approvalId, settled);
+      if (resolved) return reply.send({ status: decision });
+
+      if (routineDeps) {
+        const row = await routineDeps.approvalsRepo.findById(approvalId);
+        if (row && row.kind === "routine_state" && row.status === "pending") {
+          const payload = (row.payload ?? {}) as { runId?: string };
+          if (payload.runId) {
+            await routineDeps.approvalsRepo.settle(approvalId, settled);
+            await routineDeps.enqueueWake({
+              runId: payload.runId,
+              reason: "approval",
+              token: `approval:${approvalId}`,
+              decision: settled,
+            });
+            return reply.send({ status: decision });
+          }
+        }
       }
-      return reply.send({ status: decision });
+      return reply.code(404).send({ error: "approval not found or already resolved" });
     }
   );
 }

--- a/apps/api/src/chat/stream-emitter.ts
+++ b/apps/api/src/chat/stream-emitter.ts
@@ -20,8 +20,13 @@ interface StreamEmitterDeps {
  * `seq <= lastSeq`, so a reordered live publish silently loses an event. An append failure is logged
  * and does not break the chain (the event is still fanned out; reconnect just won't replay it).
  */
-export function makeStreamEmitter(streamId: string, deps: StreamEmitterDeps): StreamEmitter {
-  let seq = 0;
+export function makeStreamEmitter(
+  streamId: string,
+  deps: StreamEmitterDeps,
+  /** Resume seq allocation after this value (routine runs re-enter across suspensions). */
+  initialSeq = 0
+): StreamEmitter {
+  let seq = initialSeq;
   let tail: Promise<void> = Promise.resolve();
 
   const emit = (eventType: string, data: unknown): Promise<void> => {

--- a/apps/api/src/hooks/hook-executor.ts
+++ b/apps/api/src/hooks/hook-executor.ts
@@ -51,7 +51,10 @@ export class HookExecutor {
     });
   }
 
-  private send(req: Omit<WorkerRequest, "id">): Promise<WorkerResponse> {
+  private send(
+    // Distributive omit: `Omit<union>` collapses the discriminated variants.
+    req: WorkerRequest extends infer R ? (R extends WorkerRequest ? Omit<R, "id"> : never) : never
+  ): Promise<WorkerResponse> {
     if (this.workerError) {
       return Promise.reject(new HookError(`hook worker error: ${this.workerError.message}`));
     }
@@ -59,7 +62,7 @@ export class HookExecutor {
     return new Promise((resolve, reject) => {
       this.pending.set(id, { resolve, reject });
       try {
-        this.worker.postMessage({ ...req, id } satisfies WorkerRequest);
+        this.worker.postMessage({ ...req, id } as WorkerRequest);
       } catch (err) {
         this.pending.delete(id);
         reject(err instanceof Error ? err : new Error(String(err)));
@@ -134,7 +137,7 @@ export class HookExecutor {
       );
     }
     this.recordSuccess(resourceType);
-    return res.record;
+    return "record" in res ? res.record : record;
   }
 
   async runAfterHook(
@@ -158,6 +161,89 @@ export class HookExecutor {
     } else {
       this.recordSuccess(resourceType);
     }
+  }
+
+  /**
+   * Evaluate a routine data-flow expression in the sandbox (100ms, no host/fs/net).
+   * Throws HookError on evaluation failure/timeout. `breakerKey` should identify the
+   * routine (e.g. `routine:{slug}`) so a hot-looping expression trips its own breaker.
+   */
+  async runExpression(
+    code: string,
+    scope: Record<string, unknown>,
+    breakerKey: string
+  ): Promise<unknown> {
+    try {
+      analyzeHook(code);
+    } catch (err) {
+      if (err instanceof HookAnalysisError) throw new HookError(err.message);
+      throw err;
+    }
+    const cb = this.breaker.get(breakerKey);
+    if (cb?.disabled) throw new HookError("expression disabled by circuit breaker");
+
+    let res: WorkerResponse;
+    try {
+      res = await this.send({ kind: "expression", code, scope });
+    } catch (err) {
+      this.recordFailure(breakerKey);
+      throw err instanceof HookError
+        ? err
+        : new HookError(`hook worker error: ${(err as Error).message}`);
+    }
+    if (!res.ok) {
+      this.recordFailure(breakerKey);
+      throw new HookError(
+        res.timedOut ? "expression timed out" : `expression error: ${res.error}`,
+        res.timedOut
+      );
+    }
+    this.recordSuccess(breakerKey);
+    return "value" in res ? res.value : undefined;
+  }
+
+  /**
+   * Run a named function from a routine's hooks.ts (2s budget). Same static-analysis +
+   * hash-integrity + circuit-breaker guards as resource hooks.
+   */
+  async runRoutineHook(
+    hookSource: string,
+    fnName: string,
+    invocation: Record<string, unknown>,
+    args: unknown,
+    breakerKey: string,
+    opts: { expectedHash?: string; optional?: boolean } = {}
+  ): Promise<unknown> {
+    if (process.env.HOOKS_DISABLED === "true") return undefined;
+
+    const guardErr = this.checkGuards(hookSource, breakerKey, opts.expectedHash);
+    if (guardErr) throw guardErr;
+
+    let res: WorkerResponse;
+    try {
+      res = await this.send({
+        kind: "routine-hook",
+        hookSource,
+        fnName,
+        invocation,
+        args,
+        optional: opts.optional,
+      });
+    } catch (err) {
+      this.recordFailure(breakerKey);
+      throw err instanceof HookError
+        ? err
+        : new HookError(`hook worker error: ${(err as Error).message}`);
+    }
+    if (!res.ok) {
+      this.recordFailure(breakerKey);
+      throw new HookError(
+        res.timedOut ? "routine hook timed out" : `routine hook error: ${res.error}`,
+        res.timedOut
+      );
+    }
+    this.recordSuccess(breakerKey);
+    return "value" in res ? res.value : undefined;
   }
 
   async close(): Promise<void> {

--- a/apps/api/src/hooks/hook-worker.ts
+++ b/apps/api/src/hooks/hook-worker.ts
@@ -3,9 +3,17 @@ import { parentPort, workerData } from "node:worker_threads";
 import ivm from "isolated-vm";
 import { Pool } from "pg";
 import { rowToResourceDoc, tableName } from "../resources/schema";
-import type { WorkerRequest, WorkerResponse } from "./types.js";
+import type {
+  ExpressionRequest,
+  ResourceHookRequest,
+  RoutineHookRequest,
+  WorkerRequest,
+  WorkerResponse,
+} from "./types.js";
 
 const HOOK_TIMEOUT_MS = 2000;
+/** Routine data-flow expressions get a much tighter budget (ROUT-V1-007). */
+const EXPRESSION_TIMEOUT_MS = 100;
 const MEMORY_LIMIT_MB = 128;
 
 let pool: Pool | null = null;
@@ -26,7 +34,109 @@ function docToRecord(doc: Record<string, unknown>): Record<string, unknown> {
   return out;
 }
 
-async function runHook(req: WorkerRequest): Promise<WorkerResponse> {
+/** Deterministic-time / seeded-random preamble shared by every sandbox variant. */
+function determinismPreamble(now: number): string {
+  const seed = (now ^ 0xdeadbeef) >>> 0;
+  return `
+  Date.now = () => ${now};
+  let __rng__ = ${seed};
+  Math.random = function() {
+    __rng__ ^= __rng__ << 13;
+    __rng__ ^= __rng__ >>> 17;
+    __rng__ ^= __rng__ << 5;
+    return (__rng__ >>> 0) / 4294967296;
+  };`;
+}
+
+const IDENTIFIER_RE = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+/**
+ * Evaluate a routine data-flow expression: scope keys become locals, the expression's
+ * value is copied back out. No host callbacks are installed — the isolate has no
+ * host/fs/net reach at all.
+ */
+async function runExpression(req: ExpressionRequest): Promise<WorkerResponse> {
+  const { id, code, scope } = req;
+  const isolate = new ivm.Isolate({ memoryLimit: MEMORY_LIMIT_MB });
+  try {
+    const context = await isolate.createContext();
+    const keys = Object.keys(scope).filter((k) => IDENTIFIER_RE.test(k));
+    const values = keys.map((k) => JSON.stringify(scope[k] ?? null));
+    const script = await isolate.compileScript(`
+(() => {
+  ${determinismPreamble(Date.now())}
+  return ((${keys.join(", ")}) => (${code}))(${values.join(", ")});
+})()
+`);
+    const value = await script.run(context, { timeout: EXPRESSION_TIMEOUT_MS, copy: true });
+    return { id, ok: true, value: value ?? null };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { id, ok: false, error: msg, timedOut: msg.includes("execution timed out") };
+  } finally {
+    try {
+      isolate.dispose();
+    } catch {
+      // dispose is best-effort
+    }
+  }
+}
+
+/**
+ * Call one function from a routine's hooks.ts object literal
+ * (`({ beforeHook(ctx){}, myFn(ctx, args){} })`). Gets hash/uuid helpers on ctx like
+ * resource hooks, but no patch/resource access — hooks compute, they don't write.
+ */
+async function runRoutineHook(req: RoutineHookRequest): Promise<WorkerResponse> {
+  const { id, hookSource, fnName, invocation, args, optional } = req;
+  const isolate = new ivm.Isolate({ memoryLimit: MEMORY_LIMIT_MB });
+  try {
+    const context = await isolate.createContext();
+    const jail = context.global;
+    await jail.set(
+      "__hash__",
+      new ivm.Callback((str: string) => createHash("sha256").update(str).digest("hex"), {
+        sync: true,
+      })
+    );
+    await jail.set("__uuid__", new ivm.Callback(() => randomUUID(), { sync: true }));
+
+    const script = await isolate.compileScript(`
+(async () => {
+  ${determinismPreamble(Date.now())}
+  const ctx = Object.freeze({
+    ...(${JSON.stringify(invocation)}),
+    hash: __hash__,
+    uuid: __uuid__,
+  });
+  const __hookDef__ = (${hookSource});
+  const __fn__ = __hookDef__[${JSON.stringify(fnName)}];
+  if (typeof __fn__ !== 'function') {
+    if (${optional === true}) return null;
+    throw new Error('hooks.ts does not define function "' + ${JSON.stringify(fnName)} + '"');
+  }
+  return await __fn__(ctx, ${JSON.stringify(args ?? null)});
+})()
+`);
+    const value = await script.run(context, {
+      timeout: HOOK_TIMEOUT_MS,
+      promise: true,
+      copy: true,
+    });
+    return { id, ok: true, value: value ?? null };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { id, ok: false, error: msg, timedOut: msg.includes("execution timed out") };
+  } finally {
+    try {
+      isolate.dispose();
+    } catch {
+      // dispose is best-effort
+    }
+  }
+}
+
+async function runHook(req: ResourceHookRequest): Promise<WorkerResponse> {
   const { id, hookType, hookSource, record } = req;
   const patchData: Record<string, unknown> = {};
 
@@ -134,6 +244,13 @@ parentPort?.on("message", async (req: WorkerRequest) => {
     await shutdown();
     process.exit(0);
   }
-  const res = await runHook(req);
+  let res: WorkerResponse;
+  if (req.kind === "expression") {
+    res = await runExpression(req);
+  } else if (req.kind === "routine-hook") {
+    res = await runRoutineHook(req);
+  } else {
+    res = await runHook(req);
+  }
   parentPort?.postMessage(res);
 });

--- a/apps/api/src/hooks/routine-sandbox.test.ts
+++ b/apps/api/src/hooks/routine-sandbox.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { HookError, HookExecutor } from "./hook-executor.js";
+
+// Same Node-25 caveat as hook-executor.test.ts: isolated-vm has no abi141 prebuild, so
+// value-returning assertions are skipped there while error-path tests still run.
+const nodeMajor = parseInt(process.version.slice(1).split(".")[0], 10);
+const skipNoIsovm = nodeMajor === 25;
+
+const FAKE_DATABASE_URL = "postgresql://localhost:5432/test";
+
+describe("routine sandbox variants", () => {
+  let executor: HookExecutor;
+
+  beforeEach(() => {
+    executor = new HookExecutor(FAKE_DATABASE_URL);
+  });
+
+  afterEach(async () => {
+    await executor.close();
+  });
+
+  describe("runExpression (#147)", () => {
+    it.skipIf(skipNoIsovm)("evaluates a JS expression against the scope", async () => {
+      const value = await executor.runExpression(
+        "context.amount * 2",
+        { context: { amount: 21 } },
+        "routine:test"
+      );
+      expect(value).toBe(42);
+    });
+
+    it.skipIf(skipNoIsovm)("returns structured values (objects/arrays)", async () => {
+      const value = await executor.runExpression(
+        "({ big: context.items.filter(i => i > 1) })",
+        { context: { items: [1, 2, 3] } },
+        "routine:test"
+      );
+      expect(value).toEqual({ big: [2, 3] });
+    });
+
+    it("kills a hot loop at ~100ms, flagged timedOut", { timeout: 10_000 }, async () => {
+      const start = Date.now();
+      try {
+        await executor.runExpression("(() => { while (true) {} })()", {}, "routine:spin");
+        expect.fail("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(HookError);
+        // Well under the 2s resource-hook budget — proves the 100ms limit applies.
+        expect(Date.now() - start).toBeLessThan(1_500);
+      }
+    });
+
+    it("has no host/fs/net access (static analysis rejects escape attempts)", async () => {
+      for (const code of ["process.exit(0)", "require('fs')", "fetch('http://x')"]) {
+        await expect(executor.runExpression(code, {}, "routine:esc")).rejects.toThrow(HookError);
+      }
+    });
+
+    it.skipIf(skipNoIsovm)("cannot reach ambient globals inside the isolate", async () => {
+      // globalThis exists but has no host powers; typeof checks prove absence.
+      const value = await executor.runExpression(
+        "[typeof globalThis.require, typeof globalThis.module]",
+        {},
+        "routine:amb"
+      );
+      expect(value).toEqual(["undefined", "undefined"]);
+    });
+  });
+
+  describe("runRoutineHook (hooks.ts contract)", () => {
+    const HOOKS = `({
+      beforeHook(ctx) { return "ran"; },
+      computeTotal(ctx, args) { return args.base + ctx.context.bonus; },
+    })`;
+
+    it.skipIf(skipNoIsovm)("dispatches a named step function with ctx and args", async () => {
+      const value = await executor.runRoutineHook(
+        HOOKS,
+        "computeTotal",
+        { runId: "r1", slug: "s", context: { bonus: 5 }, trigger: { type: "manual" } },
+        { base: 10 },
+        "routine:test"
+      );
+      expect(value).toBe(15);
+    });
+
+    it.skipIf(skipNoIsovm)("optional lifecycle hooks are a no-op when missing", async () => {
+      const value = await executor.runRoutineHook(
+        HOOKS,
+        "afterHook",
+        { runId: "r1", slug: "s", context: {}, trigger: { type: "manual" } },
+        undefined,
+        "routine:test",
+        { optional: true }
+      );
+      expect(value).toBeNull();
+    });
+
+    it.skipIf(skipNoIsovm)("a missing non-optional function is an error", async () => {
+      await expect(
+        executor.runRoutineHook(
+          HOOKS,
+          "missingFn",
+          { runId: "r1", slug: "s", context: {}, trigger: { type: "manual" } },
+          undefined,
+          "routine:test"
+        )
+      ).rejects.toThrow(/does not define function/);
+    });
+
+    it("enforces hash integrity when expectedHash is given", async () => {
+      await expect(
+        executor.runRoutineHook(
+          HOOKS,
+          "computeTotal",
+          { runId: "r1", slug: "s", context: {}, trigger: { type: "manual" } },
+          {},
+          "routine:test",
+          { expectedHash: "not-the-hash" }
+        )
+      ).rejects.toThrow(/hash mismatch/);
+    });
+
+    it("rejects banned patterns before entering the isolate", async () => {
+      await expect(
+        executor.runRoutineHook(
+          "({ beforeHook(ctx) { process.exit(1); } })",
+          "beforeHook",
+          { runId: "r1", slug: "s", context: {}, trigger: { type: "manual" } },
+          undefined,
+          "routine:test"
+        )
+      ).rejects.toThrow(/banned pattern/);
+    });
+  });
+});

--- a/apps/api/src/hooks/types.ts
+++ b/apps/api/src/hooks/types.ts
@@ -1,13 +1,44 @@
 export type HookType = "before" | "after";
 
-export interface WorkerRequest {
+/** Resource before/after hook (original shape — `kind` absent for compatibility). */
+export interface ResourceHookRequest {
   id: number;
+  kind?: "resource-hook";
   hookType: HookType;
   hookSource: string;
   resourceType: string;
   record: Record<string, unknown>;
 }
 
+/**
+ * Routine data-flow expression (ROUT-V1-007): a bare JS expression evaluated against
+ * `scope`'s keys as locals. 100ms budget, no host callbacks at all.
+ */
+export interface ExpressionRequest {
+  id: number;
+  kind: "expression";
+  code: string;
+  scope: Record<string, unknown>;
+}
+
+/**
+ * Routine hooks.ts function call: `hookSource` is the object-literal expression
+ * (`({ beforeHook(ctx){}, myFn(ctx, args){} })`); `fnName` selects the function.
+ */
+export interface RoutineHookRequest {
+  id: number;
+  kind: "routine-hook";
+  hookSource: string;
+  fnName: string;
+  invocation: Record<string, unknown>;
+  args?: unknown;
+  /** Lifecycle hooks (beforeX / afterX) are optional: a missing fn is a no-op, not an error. */
+  optional?: boolean;
+}
+
+export type WorkerRequest = ResourceHookRequest | ExpressionRequest | RoutineHookRequest;
+
 export type WorkerResponse =
   | { id: number; ok: true; record: Record<string, unknown> }
+  | { id: number; ok: true; value: unknown }
   | { id: number; ok: false; error: string; timedOut?: boolean };

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -15,9 +15,11 @@ import { subscribeActivityLogging } from "./activity/events";
 import { PgActivityRepo } from "./activity/repo";
 import { ActivityService } from "./activity/service";
 import { buildApp } from "./app";
+import { ApprovalsRepo } from "./approvals/repo";
 import { PgTokenRepo } from "./auth/api-tokens";
 import { DEFAULT_SESSION_TTL_SECONDS, PgSessionStore } from "./auth/session-store";
 import { PgUserRepo } from "./auth/users";
+import { ApprovalRegistry } from "./chat/approvals";
 import { PgConversationRepo } from "./chat/conversations";
 import { PgMessageRepo } from "./chat/messages";
 import { PgPendingInteractionRepo } from "./chat/pending-interactions";
@@ -58,6 +60,14 @@ import { runPgMigrations } from "./pg-migrate";
 import { PgRateLimiter } from "./rate-limit";
 import { reconcileResourceTables, registerResourceReconcile } from "./resources/reconcile";
 import { PgCounterStore, PgResourceRepoFactory } from "./resources/repo";
+import { makeActionExecutor } from "./routines/action-executor";
+import { makeApprovalRequester } from "./routines/approval-channels";
+import { RoutineRunDriver } from "./routines/driver";
+import { makeRoutineEnqueuers, registerRoutineJobs } from "./routines/jobs";
+import { RoutineRegistry, registerRoutineRegistryReload } from "./routines/registry";
+import { RoutineRunsRepo } from "./routines/repo";
+import { reconcileRoutineSchedules, registerRoutineCronWorker } from "./routines/schedules";
+import { RoutineTriggerService, subscribeRoutineEventTriggers } from "./routines/trigger-service";
 import { bootstrapFromEnv } from "./setup/bootstrap";
 import { readSoulConfig, SOUL_GIT_CREDENTIAL_KEY } from "./setup/soul-config";
 import { PLATFORM_AGENTS } from "./soul/agents/platform-agents";
@@ -174,6 +184,32 @@ async function boot() {
       indexQueueStats: makeIndexQueueStats(boss, pool),
     });
 
+    // Routine engine (v0.11): validated registry over soul routines + runs repo + the
+    // trigger funnel. Built before the tool registry so trigger_routine can enqueue,
+    // and before buildApp so the routes get the surface. Uses a console-backed logger
+    // until Fastify's exists; hot paths re-log through app.log via the reload hooks.
+    const bootLog = {
+      error: (obj: unknown, msg?: string) => console.error(msg ?? "", obj),
+      warn: (obj: unknown, msg?: string) => console.warn(msg ?? "", obj),
+    };
+    const routineRegistry = new RoutineRegistry(soulLoader, bootLog);
+    routineRegistry.refresh();
+    const routineRuns = new RoutineRunsRepo(pool);
+    const approvalsRepo = new ApprovalsRepo(pool);
+    const approvalRegistry = new ApprovalRegistry(approvalsRepo);
+    const routineEnqueuers = makeRoutineEnqueuers(boss);
+    const routineEvalFilter = hookExecutor
+      ? (code: string, scope: Record<string, unknown>) =>
+          hookExecutor.runExpression(code, scope, "routine:event-filter")
+      : undefined;
+    const routineTriggerService = new RoutineTriggerService({
+      registry: routineRegistry,
+      runs: routineRuns,
+      enqueuers: routineEnqueuers,
+      evalFilter: routineEvalFilter,
+      log: bootLog,
+    });
+
     // Full chat tool registry: memory + knowledge (platform) plus every forge family
     // (resource records/types, agents, skills, platform tools). Without this, a chat turn only
     // sees memory+knowledge and no agent can create/curate soul artifacts. Per-agent allowlists
@@ -198,7 +234,43 @@ async function boot() {
         gitSync,
         builtinSkills: BUILTIN_SKILLS,
         platformAgentNames: new Set(PLATFORM_AGENTS.map((a) => a.name)),
+        triggerRoutine: (slug, inputs) =>
+          routineTriggerService.trigger(slug, { type: "agent", payload: inputs ?? {} }),
+        onRoutinesChanged: async () => {
+          await soulLoader.reload();
+          routineRegistry.refresh();
+          await reconcileRoutineSchedules(boss, routineRegistry, bootLog);
+        },
       },
+    });
+
+    // Driver + action executor close over the tool registry (tool: and agent: actions).
+    const routineDriver = new RoutineRunDriver({
+      runs: routineRuns,
+      registry: routineRegistry,
+      hub: streamHub,
+      sandbox: hookExecutor ?? {
+        runExpression: async () => {
+          throw new Error("routine expressions unavailable: HOOKS_DISABLED=true");
+        },
+        runRoutineHook: async () => {
+          throw new Error("routine hooks unavailable: HOOKS_DISABLED=true");
+        },
+      },
+      actionExecutor: makeActionExecutor({
+        llmService,
+        registry: toolRegistry,
+        soulLoader,
+        log: bootLog,
+      }),
+      requestApproval: makeApprovalRequester({
+        approvals: approvalsRepo,
+        toolRegistry,
+        publicUrl: process.env.PUBLIC_URL,
+        log: bootLog,
+      }),
+      enqueueWake: (args) => routineEnqueuers.enqueueWake(args),
+      log: bootLog,
     });
 
     const app = await buildApp({
@@ -231,6 +303,16 @@ async function boot() {
       activityService,
       observabilityService,
       observabilityConfig: obsConfig,
+      routines: {
+        registry: routineRegistry,
+        runs: routineRuns,
+        triggerService: routineTriggerService,
+        enqueuers: routineEnqueuers,
+        getSecret: (key) => secretsService.get(key),
+        hub: streamHub,
+      },
+      approvalsRepo,
+      approvalRegistry,
     });
 
     // Init after buildApp so fallback events log through Fastify's Pino logger.
@@ -260,6 +342,26 @@ async function boot() {
       activity: activityService,
       soulLoader,
     });
+    // Routine engine queues + cron worker + event triggers (v0.11). Schedules are
+    // reconciled at boot and again after every soul.synced registry refresh (D4).
+    await registerRoutineJobs(boss, {
+      driver: routineDriver,
+      runs: routineRuns,
+      approvals: approvalsRepo,
+      log: app.log,
+    });
+    await registerRoutineCronWorker(boss, routineTriggerService, app.log);
+    await reconcileRoutineSchedules(boss, routineRegistry, app.log);
+    registerRoutineRegistryReload(gitSync, soulLoader, routineRegistry, app.log, () =>
+      reconcileRoutineSchedules(boss, routineRegistry, app.log)
+    );
+    subscribeRoutineEventTriggers(
+      domainEventEmitter,
+      routineTriggerService,
+      routineRegistry,
+      routineEvalFilter,
+      app.log
+    );
     await registerStreamGc(boss, streamResumeRepo, activityService);
     await registerObsPrune(boss, new PgObsRepo(pool), activityService, {
       obs: observabilityService,

--- a/apps/api/src/knowledge/migration.pg.test.ts
+++ b/apps/api/src/knowledge/migration.pg.test.ts
@@ -47,9 +47,9 @@ describe("002_knowledge migration on PGlite", () => {
     await db.close();
   });
 
-  it("bumps schema_version to the latest (22)", async () => {
+  it("bumps schema_version to the latest (23)", async () => {
     const { rows } = await db.query("SELECT version FROM schema_version WHERE id = true");
-    expect(Number((rows[0] as { version: number }).version)).toBe(22);
+    expect(Number((rows[0] as { version: number }).version)).toBe(23);
   });
 
   it("adds knowledge_chunks.content_hash (019)", async () => {

--- a/apps/api/src/knowledge/routes.test.ts
+++ b/apps/api/src/knowledge/routes.test.ts
@@ -243,7 +243,11 @@ describe("knowledge routes", () => {
     expect(got.json<{ indexingStatus: string }>().indexingStatus).toBe("pending");
   });
 
-  it("reports indexingStatus=lexical-only when no embedding provider is available", async () => {
+  // Boots a SECOND PGlite + full migration run inside the test body — well over the 5s
+  // default when the suite runs fully parallel, so give it explicit headroom.
+  it("reports indexingStatus=lexical-only when no embedding provider is available", {
+    timeout: 30_000,
+  }, async () => {
     const db2 = await makePglite();
     await runPgMigrations(db2);
     const app2 = await buildKnowledgeApp(db2, false);

--- a/apps/api/src/pg-migrate.test.ts
+++ b/apps/api/src/pg-migrate.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { runPgMigrations } from "./pg-migrate";
 import { makePglite } from "./test/pglite";
 
-describe("runPgMigrations — 001_init + 002_knowledge + 003_stream_resume + 004_approvals + 005_conversation_title + 006_message_feedback + 007_conversation_starred + 008_hitl + 009_kv_store + 010_wrapped_deks + 011_okf + 012_okf_crosslinks + 013_drop_bundle_domain + 014_drop_okf_type + 015_title_tsv + 016_doc_type + 017_pg_trgm + 018_terminology_rename + 019_chunk_content_hash + 020_knowledge_connectors + 021_activity_log + 022_obs_event on PGlite", () => {
+describe("runPgMigrations — 001_init + 002_knowledge + 003_stream_resume + 004_approvals + 005_conversation_title + 006_message_feedback + 007_conversation_starred + 008_hitl + 009_kv_store + 010_wrapped_deks + 011_okf + 012_okf_crosslinks + 013_drop_bundle_domain + 014_drop_okf_type + 015_title_tsv + 016_doc_type + 017_pg_trgm + 018_terminology_rename + 019_chunk_content_hash + 020_knowledge_connectors + 021_activity_log + 022_obs_event + 023_routines on PGlite", () => {
   let db: PGlite;
 
   beforeEach(async () => {
@@ -14,10 +14,10 @@ describe("runPgMigrations — 001_init + 002_knowledge + 003_stream_resume + 004
     await db.close();
   });
 
-  it("advances schema_version to the latest (22)", async () => {
+  it("advances schema_version to the latest (23)", async () => {
     await runPgMigrations(db);
     const res = await db.query<{ version: number }>("SELECT version FROM schema_version");
-    expect(res.rows.map((r) => Number(r.version))).toEqual([22]);
+    expect(res.rows.map((r) => Number(r.version))).toEqual([23]);
   });
 
   it("creates the vector and citext extensions", async () => {
@@ -53,6 +53,8 @@ describe("runPgMigrations — 001_init + 002_knowledge + 003_stream_resume + 004
       "obs_event",
       "pending_interactions",
       "rate_limits",
+      "routine_run_events",
+      "routine_runs",
       "schema_version",
       "secrets",
       "sessions",
@@ -82,11 +84,11 @@ describe("runPgMigrations — 001_init + 002_knowledge + 003_stream_resume + 004
     ]);
   });
 
-  it("is idempotent — a second run does not throw and leaves version at 22", async () => {
+  it("is idempotent — a second run does not throw and leaves version at 23", async () => {
     await runPgMigrations(db);
     await runPgMigrations(db);
     const res = await db.query<{ version: number }>("SELECT version FROM schema_version");
-    expect(res.rows.map((r) => Number(r.version))).toEqual([22]);
+    expect(res.rows.map((r) => Number(r.version))).toEqual([23]);
   });
 
   it("adds knowledge_pages.title_tsv (generated tsvector) + its GIN index (015, renamed by 018)", async () => {

--- a/apps/api/src/pg-migrations/index.ts
+++ b/apps/api/src/pg-migrations/index.ts
@@ -483,6 +483,46 @@ const OBS_EVENT_STATEMENTS: string[] = [
   "CREATE INDEX IF NOT EXISTS obs_event_model_ts_idx ON obs_event (model, ts DESC)",
 ];
 
+const ROUTINE_RUNS_STATEMENTS: string[] = [
+  // One row per routine run. definition_snapshot pins the routine.yaml at run creation
+  // (ROUT-V1-007) so in-flight runs survive definition edits. wake_at/state_deadline are
+  // sweep bookkeeping: the routine-sweep cron re-enqueues overdue wakes and times out
+  // stuck states across restarts. attempt_counts is per-state retry counters.
+  `CREATE TABLE IF NOT EXISTS routine_runs (
+    id                  uuid PRIMARY KEY,
+    routine_slug        text NOT NULL,
+    definition_snapshot jsonb NOT NULL,
+    definition_hash     text NOT NULL,
+    status              text NOT NULL,
+    current_state       text,
+    context             jsonb NOT NULL DEFAULT '{}',
+    trigger             jsonb NOT NULL,
+    attempt_counts      jsonb NOT NULL DEFAULT '{}',
+    wake_at             timestamptz,
+    state_deadline      timestamptz,
+    approval_id         uuid,
+    output              jsonb,
+    error               jsonb,
+    created_at          timestamptz NOT NULL DEFAULT now(),
+    updated_at          timestamptz NOT NULL DEFAULT now(),
+    finished_at         timestamptz
+  )`,
+  "CREATE INDEX IF NOT EXISTS routine_runs_slug_idx ON routine_runs (routine_slug, created_at DESC)",
+  "CREATE INDEX IF NOT EXISTS routine_runs_wake_idx ON routine_runs (wake_at) WHERE wake_at IS NOT NULL",
+  "CREATE INDEX IF NOT EXISTS routine_runs_deadline_idx ON routine_runs (state_deadline) WHERE state_deadline IS NOT NULL",
+  // Durable run journal — run history for the UI AND the SSE replay buffer (a
+  // StreamResumeRepo implementation reads/writes it), so replay works for runs of any
+  // age (stream_resume's 1h GC never applies).
+  `CREATE TABLE IF NOT EXISTS routine_run_events (
+    run_id     uuid NOT NULL,
+    seq        integer NOT NULL,
+    type       text NOT NULL,
+    payload    jsonb NOT NULL DEFAULT '{}',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (run_id, seq)
+  )`,
+];
+
 // ── Guarded rename helpers (terminology migration v18) ───────────────────────────────────────
 // ALTER ... RENAME is not naturally idempotent, so each helper checks the catalog first. This
 // keeps a partial-failure re-run safe and runs statement-by-statement on PGlite (no plpgsql DO).
@@ -787,6 +827,16 @@ export const PG_MIGRATIONS: PgMigration[] = [
       "observability: obs_event AI event spine (llm_call/tool_call/turn/job) + ts/type/agent/model indexes",
     up: async (q) => {
       for (const sql of OBS_EVENT_STATEMENTS) {
+        await q.query(sql);
+      }
+    },
+  },
+  {
+    version: 23,
+    description:
+      "routines: routine_runs (definition_snapshot pin, status machine, wake/deadline bookkeeping) + routine_run_events journal (doubles as SSE replay buffer)",
+    up: async (q) => {
+      for (const sql of ROUTINE_RUNS_STATEMENTS) {
         await q.query(sql);
       }
     },

--- a/apps/api/src/platform/tools.test.ts
+++ b/apps/api/src/platform/tools.test.ts
@@ -525,24 +525,43 @@ describe("delegateToAgentTool", () => {
 // ── trigger_routine ───────────────────────────────────────────────────────────
 
 describe("triggerRoutineTool", () => {
-  it("returns stub receipt for a known routine", async () => {
-    const ctx = makeCtx({}, {}, undefined, { "daily-digest": makeRoutine("daily-digest") });
+  const withTrigger = (ctx: PlatformToolContext): PlatformToolContext => ({
+    ...ctx,
+    triggerRoutine: async (slug) => {
+      if (slug === "ghost") {
+        const err = new Error(`routine "${slug}" not found`);
+        err.name = "RoutineTriggerError";
+        throw err;
+      }
+      return { runId: "run-123" };
+    },
+  });
+
+  it("returns the real runId for a known routine", async () => {
+    const ctx = withTrigger(
+      makeCtx({}, {}, undefined, { "daily-digest": makeRoutine("daily-digest") })
+    );
     const res = await triggerRoutineTool.handler({ name: "daily-digest" }, ctx);
     expect(res).toEqual({
       success: true,
-      data: { routineId: "daily-digest", status: "triggered", runId: null, inputs: null },
+      data: { routineId: "daily-digest", status: "triggered", runId: "run-123", inputs: null },
     });
   });
 
   it("passes inputs through", async () => {
-    const ctx = makeCtx({}, {}, undefined, { notify: makeRoutine("notify") });
+    const ctx = withTrigger(makeCtx({}, {}, undefined, { notify: makeRoutine("notify") }));
     const res = await triggerRoutineTool.handler({ name: "notify", inputs: { userId: "u1" } }, ctx);
     expect(res).toMatchObject({ success: true, data: { inputs: { userId: "u1" } } });
   });
 
   it("returns not_found for unknown routine", async () => {
-    const res = await triggerRoutineTool.handler({ name: "ghost" }, makeCtx());
+    const res = await triggerRoutineTool.handler({ name: "ghost" }, withTrigger(makeCtx()));
     expect(res).toMatchObject({ success: false, error: { code: "not_found" } });
+  });
+
+  it("returns internal_error when the routine engine is unavailable", async () => {
+    const res = await triggerRoutineTool.handler({ name: "x" }, makeCtx());
+    expect(res).toMatchObject({ success: false, error: { code: "internal_error" } });
   });
 
   it("returns validation_error for missing name", async () => {
@@ -772,7 +791,7 @@ describe("completeStateTool", () => {
 // ── Registry ──────────────────────────────────────────────────────────────────
 
 describe("PLATFORM_TOOLS registry", () => {
-  it("exports exactly 20 platform tools in order", () => {
+  it("exports exactly 21 platform tools in order", () => {
     const names = PLATFORM_TOOLS.map((t) => t.name);
     expect(names).toEqual([
       "load_skill",
@@ -787,6 +806,7 @@ describe("PLATFORM_TOOLS registry", () => {
       "transfer_to_agent",
       "delegate_to_agent",
       "trigger_routine",
+      "routine_forge",
       "routine_picker",
       "begin_soul_batch",
       "end_soul_batch",

--- a/apps/api/src/platform/tools.ts
+++ b/apps/api/src/platform/tools.ts
@@ -1,7 +1,8 @@
-import { readFile } from "node:fs/promises";
-import { isAbsolute, relative, resolve, sep } from "node:path";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
 import type { GitSyncService, SoulAgent, SoulRoutine, SoulSkill } from "@tulipfarm/soul";
-import { ajv } from "@tulipfarm/validation";
+import { ajv, TulipFarmValidationError, validateRoutineDefinition } from "@tulipfarm/validation";
+import { stringify as stringifyYaml } from "yaml";
 import { A2UI_COMPONENTS_REF, A2UI_SPEC_SCHEMA } from "../a2ui/spec";
 import { err, ok, type ToolCallResult } from "./tool-result";
 
@@ -14,6 +15,10 @@ export interface PlatformToolContext {
   soulPath?: string;
   gitSync?: GitSyncService;
   routineContext?: { routineId: string; runId: string };
+  /** Starts a routine run (agent trigger, v0.11). Errors are thrown with a `.code`-like name. */
+  triggerRoutine?: (slug: string, inputs?: Record<string, unknown>) => Promise<{ runId: string }>;
+  /** Post-write hook after routine_forge: registry revalidate + cron schedule reconcile. */
+  onRoutinesChanged?: () => Promise<void>;
   /**
    * Inbuilt forge skills (resource-forge / skill-forge / agent-forge / onboarding) bundled with the
    * app, not present in the soul. `load_skill` falls back to these by name so the Information
@@ -511,16 +516,102 @@ const validateTriggerRoutine = ajv.compile(TRIGGER_ROUTINE_SCHEMA);
 export const triggerRoutineTool: PlatformTool = {
   name: "trigger_routine",
   description:
-    "Trigger a routine by name. V1 validates the routine exists and records intent, returning a stub receipt. Full async execution is available after Routines v0.11.",
+    "Trigger a routine by name with optional inputs (validated against the routine's x-inputs schema). Returns the run id; watch progress via the routine run APIs.",
   mutating: true,
   inputSchema: TRIGGER_ROUTINE_SCHEMA,
   handler: async (args, ctx) => {
     if (!validateTriggerRoutine(args))
       return err("validation_error", firstError(validateTriggerRoutine.errors));
     const { name, inputs } = args as { name: string; inputs?: Record<string, unknown> };
-    const routine = ctx.soulLoader?.routines?.get(name);
-    if (!routine) return err("not_found", `Routine "${name}" not found in soul.`);
-    return ok({ routineId: name, status: "triggered", runId: null, inputs: inputs ?? null });
+    if (!ctx.triggerRoutine) {
+      return err("internal_error", "Routine engine is not available.");
+    }
+    try {
+      const { runId } = await ctx.triggerRoutine(name, inputs);
+      return ok({ routineId: name, status: "triggered", runId, inputs: inputs ?? null });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      if (e instanceof Error && e.name === "RoutineTriggerError" && message.includes("not found")) {
+        return err("not_found", message);
+      }
+      return err("validation_error", message);
+    }
+  },
+};
+
+// ── routine_forge ─────────────────────────────────────────────────────────────
+
+const ROUTINE_NAME_RE = /^[a-z][a-z0-9-]*$/;
+
+const ROUTINE_FORGE_SCHEMA: Record<string, unknown> = {
+  type: "object",
+  additionalProperties: false,
+  required: ["name", "definition"],
+  properties: {
+    name: {
+      type: "string",
+      minLength: 1,
+      description: "Routine slug (directory under soul/routines/): lowercase, digits, hyphens.",
+    },
+    definition: {
+      type: "object",
+      description:
+        "The routine.yaml document (CNCF Serverless Workflow 0.8 subset + x- extensions). " +
+        "Validated against the V1 meta-schema; deferred constructs are rejected.",
+    },
+    hooks: {
+      type: "string",
+      description:
+        "Optional hooks.ts source: an object-literal expression like " +
+        "({ beforeHook(ctx){}, afterMyState(ctx){}, myStepFn(ctx, args){} }). No import/export.",
+    },
+  },
+};
+const validateRoutineForge = ajv.compile(ROUTINE_FORGE_SCHEMA);
+
+export const routineForgeTool: PlatformTool = {
+  name: "routine_forge",
+  description:
+    "Create or update a routine in the soul repo: validates the definition against the V1 meta-schema (deferred constructs rejected), writes soul/routines/{name}/routine.yaml (+ optional hooks.ts), and commits via withSync. No approval step (ROUT-V1-002).",
+  mutating: true,
+  inputSchema: ROUTINE_FORGE_SCHEMA,
+  handler: async (args, ctx) => {
+    if (!validateRoutineForge(args))
+      return err("validation_error", firstError(validateRoutineForge.errors));
+    const { name, definition, hooks } = args as {
+      name: string;
+      definition: Record<string, unknown>;
+      hooks?: string;
+    };
+    if (!ROUTINE_NAME_RE.test(name)) return err("validation_error", "invalid routine name");
+    if (!ctx.gitSync) return err("internal_error", "Soul git sync is not available.");
+
+    try {
+      validateRoutineDefinition(definition);
+    } catch (e) {
+      if (e instanceof TulipFarmValidationError) {
+        return err("validation_error", `${e.path || "/"}: ${e.message}`);
+      }
+      return err("internal_error", e instanceof Error ? e.message : String(e));
+    }
+
+    try {
+      const dir = join(ctx.gitSync.path, "routines", name);
+      await mkdir(dir, { recursive: true });
+      await writeFile(join(dir, "routine.yaml"), stringifyYaml(definition), "utf8");
+      if (hooks) await writeFile(join(dir, "hooks.ts"), hooks, "utf8");
+      await ctx.gitSync.withSync(`soul: forge routine ${name}`);
+    } catch (e) {
+      return err("internal_error", e instanceof Error ? e.message : String(e));
+    }
+
+    // withSync does not emit soul.synced — revalidate + reconcile schedules explicitly.
+    try {
+      await ctx.onRoutinesChanged?.();
+    } catch (e) {
+      return err("internal_error", e instanceof Error ? e.message : String(e));
+    }
+    return ok({ name, committed: true, hasHooks: Boolean(hooks) });
   },
 };
 
@@ -808,6 +899,7 @@ export const PLATFORM_TOOLS: PlatformTool[] = [
   transferToAgentTool,
   delegateToAgentTool,
   triggerRoutineTool,
+  routineForgeTool,
   routinePickerTool,
   beginSoulBatchTool,
   endSoulBatchTool,

--- a/apps/api/src/routines/action-executor.ts
+++ b/apps/api/src/routines/action-executor.ts
@@ -1,0 +1,47 @@
+import type { ResolvedFunction, RunSnapshot } from "@tulipfarm/routine-engine";
+import type { ToolRegistry } from "../tools/registry";
+import type { ActionExecutor } from "./driver";
+import { type HeadlessTurnDeps, ROUTINE_ACTOR, runHeadlessTurn } from "./headless-turn";
+
+/**
+ * Bridges the engine's `operation` actions onto the platform (D7): `tool:` targets run
+ * through the central ToolRegistry (self-validating handlers, system actor);
+ * `agent:` targets spawn a headless agent turn. `hook:` never reaches here — the
+ * interpreter dispatches those through the sandbox port.
+ *
+ * Throws on failure so the interpreter can route retries/onErrors.
+ */
+export function makeActionExecutor(deps: HeadlessTurnDeps): ActionExecutor {
+  return async (fn: ResolvedFunction, args: Record<string, unknown>, run: RunSnapshot) => {
+    if (fn.kind === "agent") {
+      return runHeadlessTurn(deps, {
+        agentId: fn.target,
+        task: typeof args.task === "string" ? args.task : JSON.stringify(args),
+        routineContext: { routineId: run.slug, runId: run.runId },
+        context: run.context,
+      });
+    }
+
+    if (fn.kind === "tool") {
+      const tool = findTool(deps.registry, fn.target);
+      if (!tool) throw new Error(`tool "${fn.target}" is not registered`);
+      const result = await tool.execute(args, {
+        userId: ROUTINE_ACTOR,
+        autonomy: "full",
+        routineContext: { routineId: run.slug, runId: run.runId },
+      });
+      if (!result.success) {
+        const error = new Error(result.error.message);
+        error.name = result.error.code;
+        throw error;
+      }
+      return result.data;
+    }
+
+    throw new Error(`unsupported action kind "${fn.kind}"`);
+  };
+}
+
+function findTool(registry: ToolRegistry, name: string) {
+  return registry.getAll().find((t) => t.name === name);
+}

--- a/apps/api/src/routines/approval-channels.test.ts
+++ b/apps/api/src/routines/approval-channels.test.ts
@@ -1,0 +1,137 @@
+import { randomUUID } from "node:crypto";
+import type { PGlite } from "@electric-sql/pglite";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApprovalsRepo } from "../approvals/repo";
+import { runPgMigrations } from "../pg-migrate";
+import { makePglite } from "../test/pglite";
+import type { ToolRegistry } from "../tools/registry";
+import type { ToolDef } from "../tools/types";
+import { makeApprovalRequester } from "./approval-channels";
+import type { RoutineRunRow } from "./repo";
+
+function makeRun(): RoutineRunRow {
+  return {
+    id: randomUUID(),
+    routineSlug: "expense-report",
+  } as RoutineRunRow;
+}
+
+function makeToolRegistry(tools: ToolDef[]): ToolRegistry {
+  return { getAll: () => tools } as unknown as ToolRegistry;
+}
+
+describe("makeApprovalRequester (AC-V1-003)", () => {
+  let db: PGlite;
+  let approvals: ApprovalsRepo;
+  const log = { warn: vi.fn() };
+
+  beforeEach(async () => {
+    db = await makePglite();
+    await runPgMigrations(db);
+    approvals = new ApprovalsRepo(db);
+    log.warn.mockClear();
+  });
+
+  afterEach(async () => {
+    await db.close();
+  });
+
+  it("inserts a pending routine_state row for the ui channel", async () => {
+    const requester = makeApprovalRequester({ approvals, log });
+    const run = makeRun();
+    const approvalId = await requester(run, {
+      stateName: "Gate",
+      channels: ["ui"],
+      summary: { amount: 900 },
+    });
+
+    const row = await approvals.findById(approvalId);
+    expect(row?.kind).toBe("routine_state");
+    expect(row?.status).toBe("pending");
+    expect(row?.payload).toMatchObject({
+      routineSlug: "expense-report",
+      runId: run.id,
+      stateName: "Gate",
+      summary: { amount: 900 },
+    });
+  });
+
+  it("delivers to slack via an installed integration send tool", async () => {
+    const execute = vi.fn(async () => ({ success: true as const, data: { ok: true } }));
+    const slackTool = {
+      name: "slack_send_message",
+      tier: "integration",
+      mutating: true,
+      description: "",
+      inputSchema: {},
+      execute,
+    } as unknown as ToolDef;
+    const requester = makeApprovalRequester({
+      approvals,
+      toolRegistry: makeToolRegistry([slackTool]),
+      publicUrl: "https://tulip.example",
+      log,
+    });
+
+    await requester(makeRun(), { stateName: "Gate", channels: ["ui", "slack"], summary: {} });
+    expect(execute).toHaveBeenCalledOnce();
+    const [args] = execute.mock.calls[0] as unknown as [Record<string, unknown>];
+    expect(String(args.text)).toContain("expense-report");
+    expect(String(args.text)).toContain("https://tulip.example/approvals");
+  });
+
+  it("falls back to ui with a warning when slack is absent (spec-legal)", async () => {
+    const requester = makeApprovalRequester({
+      approvals,
+      toolRegistry: makeToolRegistry([]),
+      log,
+    });
+    const approvalId = await requester(makeRun(), {
+      stateName: "Gate",
+      channels: ["slack"],
+      summary: {},
+    });
+    expect((await approvals.findById(approvalId))?.status).toBe("pending");
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining("no Slack send tool")
+    );
+  });
+
+  it("email/sms declarations fall back to ui with a warning (AC-V1-003)", async () => {
+    const requester = makeApprovalRequester({ approvals, log });
+    const approvalId = await requester(makeRun(), {
+      stateName: "Gate",
+      channels: ["email", "sms"],
+      summary: {},
+    });
+    expect((await approvals.findById(approvalId))?.status).toBe("pending");
+    const warnings = log.warn.mock.calls.map((c) => String(c[1]));
+    expect(warnings.some((w) => w.includes('"email" unavailable'))).toBe(true);
+    expect(warnings.some((w) => w.includes('"sms" unavailable'))).toBe(true);
+  });
+
+  it("a failing slack delivery never blocks the approval", async () => {
+    const slackTool = {
+      name: "slack_post",
+      tier: "integration",
+      mutating: true,
+      description: "",
+      inputSchema: {},
+      execute: vi.fn(async () => {
+        throw new Error("slack down");
+      }),
+    } as unknown as ToolDef;
+    const requester = makeApprovalRequester({
+      approvals,
+      toolRegistry: makeToolRegistry([slackTool]),
+      log,
+    });
+    const approvalId = await requester(makeRun(), {
+      stateName: "Gate",
+      channels: ["slack"],
+      summary: {},
+    });
+    expect((await approvals.findById(approvalId))?.status).toBe("pending");
+  });
+});

--- a/apps/api/src/routines/approval-channels.ts
+++ b/apps/api/src/routines/approval-channels.ts
@@ -1,0 +1,108 @@
+import { randomUUID } from "node:crypto";
+import type { ApprovalsRepo } from "../approvals/repo";
+import type { ToolRegistry } from "../tools/registry";
+import type { ApprovalRequester } from "./driver";
+import { ROUTINE_ACTOR } from "./headless-turn";
+
+/** Routine approvals wait for humans — give them days, not the tool-call 5 minutes. */
+export const ROUTINE_APPROVAL_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+type ChannelLogger = {
+  warn: (obj: unknown, msg?: string) => void;
+};
+
+export interface ApprovalChannelDeps {
+  approvals: ApprovalsRepo;
+  /** Used to find an installed Slack send tool (integration tier). */
+  toolRegistry?: ToolRegistry;
+  /** Base URL for the decide link included in channel messages. */
+  publicUrl?: string;
+  log: ChannelLogger;
+}
+
+/** Payload stored on a `routine_state` approval row (read by the approvals list/UI). */
+export interface RoutineApprovalPayload {
+  routineSlug: string;
+  runId: string;
+  stateName: string;
+  channels: string[];
+  summary: Record<string, unknown>;
+}
+
+/**
+ * ApprovalRequester for human_approval states (ROUT-V1-006, AC-V1-003): inserts the
+ * `routine_state` approvals row (`ui` channel — always available), then best-effort
+ * delivers to declared extra channels. Slack "present" ⇔ an installed integration
+ * exposes an integration-tier send-message tool whose name mentions slack + send
+ * (review C2 contract). `email`/`sms` are schema-accepted but unimplemented — warn and
+ * fall back to ui. Channel delivery failures never block the approval itself.
+ */
+export function makeApprovalRequester(deps: ApprovalChannelDeps): ApprovalRequester {
+  return async (run, request) => {
+    const approvalId = randomUUID();
+    const payload: RoutineApprovalPayload = {
+      routineSlug: run.routineSlug,
+      runId: run.id,
+      stateName: request.stateName,
+      channels: request.channels,
+      summary: request.summary,
+    };
+    await deps.approvals.insert({
+      id: approvalId,
+      kind: "routine_state",
+      payload,
+      expiresAt: new Date(Date.now() + ROUTINE_APPROVAL_TTL_MS),
+    });
+
+    for (const channel of request.channels) {
+      if (channel === "ui") continue; // the DB row IS the ui channel
+      if (channel === "slack") {
+        await deliverSlack(deps, approvalId, payload);
+      } else {
+        deps.log.warn(
+          { channel, approvalId },
+          `approval channel "${channel}" unavailable in V1, falling back to ui`
+        );
+      }
+    }
+    return approvalId;
+  };
+}
+
+async function deliverSlack(
+  deps: ApprovalChannelDeps,
+  approvalId: string,
+  payload: RoutineApprovalPayload
+): Promise<void> {
+  const sendTool = deps.toolRegistry
+    ?.getAll()
+    .find(
+      (t) => t.tier === "integration" && /slack/i.test(t.name) && /send|post|message/i.test(t.name)
+    );
+  if (!sendTool) {
+    deps.log.warn(
+      { approvalId },
+      "slack approval channel requested but no Slack send tool is installed; falling back to ui"
+    );
+    return;
+  }
+  const decideUrl = deps.publicUrl
+    ? `${deps.publicUrl.replace(/\/$/, "")}/approvals`
+    : "/approvals";
+  const text = [
+    `Approval needed: routine "${payload.routineSlug}" is waiting at state "${payload.stateName}".`,
+    `Run: ${payload.runId}`,
+    `Decide: ${decideUrl} (approval ${approvalId})`,
+  ].join("\n");
+  try {
+    const result = await sendTool.execute({ text }, { userId: ROUTINE_ACTOR, autonomy: "full" });
+    if (!result.success) {
+      deps.log.warn(
+        { approvalId, error: result.error },
+        "slack approval delivery failed; ui channel remains"
+      );
+    }
+  } catch (err) {
+    deps.log.warn({ approvalId, err }, "slack approval delivery threw; ui channel remains");
+  }
+}

--- a/apps/api/src/routines/driver.test.ts
+++ b/apps/api/src/routines/driver.test.ts
@@ -1,0 +1,360 @@
+import { randomUUID } from "node:crypto";
+import type { PGlite } from "@electric-sql/pglite";
+import type { RoutineDefinition } from "@tulipfarm/validation";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { StreamHub } from "../chat/stream-hub";
+import { runPgMigrations } from "../pg-migrate";
+import { makePglite } from "../test/pglite";
+import { type ActionExecutor, RoutineRunDriver, type RoutineSandbox } from "./driver";
+import type { RoutineRegistry } from "./registry";
+import { RoutineRunsRepo } from "./repo";
+
+function makeSandbox(hookResults: Record<string, unknown> = {}): RoutineSandbox {
+  return {
+    // Real-JS stand-in for the isolated-vm expression adapter.
+    runExpression: vi.fn(async (code: string, scope: Record<string, unknown>) => {
+      const fn = new Function(...Object.keys(scope), `return (${code});`);
+      return fn(...Object.values(scope));
+    }),
+    runRoutineHook: vi.fn(async (_src, fnName) => hookResults[fnName] ?? null),
+  };
+}
+
+function makeRegistry(hookSource?: string): RoutineRegistry {
+  return {
+    get: vi.fn(() => ({
+      slug: "test",
+      definition: {} as RoutineDefinition,
+      hookSource,
+      hookHash: hookSource ? "hash" : undefined,
+    })),
+  } as unknown as RoutineRegistry;
+}
+
+const LOG = { error: vi.fn(), warn: vi.fn() };
+
+describe("RoutineRunDriver (PGlite)", () => {
+  let db: PGlite;
+  let runs: RoutineRunsRepo;
+
+  beforeEach(async () => {
+    db = await makePglite();
+    await runPgMigrations(db);
+    runs = new RoutineRunsRepo(db);
+    LOG.error.mockClear();
+    LOG.warn.mockClear();
+  });
+
+  afterEach(async () => {
+    await db.close();
+  });
+
+  function makeDriver(overrides: {
+    actionExecutor?: ActionExecutor;
+    sandbox?: RoutineSandbox;
+    registry?: RoutineRegistry;
+    enqueueWake?: ReturnType<typeof vi.fn>;
+    requestApproval?: ReturnType<typeof vi.fn>;
+  }) {
+    const enqueueWake = overrides.enqueueWake ?? vi.fn(async () => {});
+    const driver = new RoutineRunDriver({
+      runs,
+      registry: overrides.registry ?? makeRegistry(),
+      hub: new StreamHub(),
+      sandbox: overrides.sandbox ?? makeSandbox(),
+      actionExecutor: overrides.actionExecutor ?? vi.fn(async () => ({ ok: true })),
+      requestApproval: overrides.requestApproval as never,
+      enqueueWake: enqueueWake as never,
+      log: LOG,
+    });
+    return { driver, enqueueWake };
+  }
+
+  async function createRun(def: RoutineDefinition, context: Record<string, unknown> = {}) {
+    const id = randomUUID();
+    await runs.create({
+      id,
+      routineSlug: "test",
+      definitionSnapshot: def,
+      definitionHash: "h",
+      currentState: def.start,
+      context,
+      trigger: { type: "manual" },
+    });
+    return id;
+  }
+
+  const MULTI_STATE = {
+    id: "multi",
+    version: "1.0",
+    start: "Seed",
+    functions: [{ name: "doWork", operation: "tool:resource_create" }],
+    "x-triggers": [{ type: "manual" }],
+    states: [
+      { name: "Seed", type: "inject", data: { amount: 700 }, transition: "Gate" },
+      {
+        name: "Gate",
+        type: "switch",
+        dataConditions: [{ condition: "context.amount > 500", transition: "Work" }],
+        defaultCondition: { end: true },
+      },
+      {
+        name: "Work",
+        type: "operation",
+        actions: [{ functionRef: { refName: "doWork" } }],
+        end: true,
+      },
+    ],
+  } as unknown as RoutineDefinition;
+
+  it("drives a multi-state run to completion, journaling every event", async () => {
+    const actionExecutor = vi.fn(async () => ({ created: true }));
+    const { driver } = makeDriver({ actionExecutor });
+    const id = await createRun(MULTI_STATE);
+
+    await driver.drive(id);
+
+    const run = await runs.findById(id);
+    expect(run?.status).toBe("succeeded");
+    expect(run?.output).toMatchObject({ amount: 700 });
+    expect(run?.finishedAt).not.toBeNull();
+    expect(actionExecutor).toHaveBeenCalledOnce();
+
+    const events = await runs.listEvents(id);
+    const types = events.map((e) => e.type);
+    expect(types[0]).toBe("run.started");
+    expect(types).toContain("state.entered");
+    expect(types[types.length - 1]).toBe("finish");
+    // seqs strictly ascending from 1
+    expect(events.map((e) => e.seq)).toEqual(events.map((_, i) => i + 1));
+  });
+
+  it("suspends on sleep, persists wake bookkeeping, and completes after wake", async () => {
+    const def = {
+      ...MULTI_STATE,
+      id: "sleepy",
+      start: "Nap",
+      states: [
+        { name: "Nap", type: "sleep", duration: "PT1S", transition: "Done" },
+        { name: "Done", type: "inject", data: { woke: true }, end: true },
+      ],
+    } as unknown as RoutineDefinition;
+    const { driver, enqueueWake } = makeDriver({});
+    const id = await createRun(def);
+
+    await driver.drive(id);
+    let run = await runs.findById(id);
+    expect(run?.status).toBe("sleeping");
+    expect(run?.currentState).toBe("Done");
+    expect(run?.wakeAt).not.toBeNull();
+    expect(enqueueWake).toHaveBeenCalledWith(
+      expect.objectContaining({ runId: id, reason: "sleep" })
+    );
+
+    // wake delivery (crash-restart equivalent: fresh drive call)
+    await driver.drive(id);
+    run = await runs.findById(id);
+    expect(run?.status).toBe("succeeded");
+    expect(run?.output).toMatchObject({ woke: true });
+
+    // journal seqs never restarted (review B1): strictly ascending across the suspension
+    const seqs = (await runs.listEvents(id)).map((e) => e.seq);
+    expect(seqs).toEqual([...seqs].sort((a, b) => a - b));
+    expect(new Set(seqs).size).toBe(seqs.length);
+  });
+
+  it("is idempotent under duplicate deliveries (CAS loses quietly)", async () => {
+    const actionExecutor = vi.fn(async () => ({ ok: true }));
+    const { driver } = makeDriver({ actionExecutor });
+    const id = await createRun(MULTI_STATE);
+
+    await Promise.all([driver.drive(id), driver.drive(id)]);
+
+    const run = await runs.findById(id);
+    expect(run?.status).toBe("succeeded");
+    // The Work action ran exactly once despite two deliveries.
+    expect(actionExecutor).toHaveBeenCalledTimes(1);
+  });
+
+  it("schedules a delayed wake on retry outcomes and resumes to success", async () => {
+    const def = {
+      ...MULTI_STATE,
+      id: "flaky",
+      start: "Work",
+      retries: [{ name: "std", maxAttempts: 3, delay: "PT1S" }],
+      states: [
+        {
+          name: "Work",
+          type: "operation",
+          actions: [{ functionRef: { refName: "doWork" }, retryRef: "std" }],
+          end: true,
+        },
+      ],
+    } as unknown as RoutineDefinition;
+    let calls = 0;
+    const actionExecutor = vi.fn(async () => {
+      calls += 1;
+      if (calls === 1) throw new Error("flaky");
+      return { ok: true };
+    });
+    const { driver, enqueueWake } = makeDriver({ actionExecutor });
+    const id = await createRun(def);
+
+    await driver.drive(id);
+    let run = await runs.findById(id);
+    expect(run?.status).toBe("sleeping");
+    expect(run?.attemptCounts).toEqual({ Work: 1 });
+    expect(enqueueWake).toHaveBeenCalledWith(expect.objectContaining({ reason: "retry" }));
+
+    await driver.drive(id);
+    run = await runs.findById(id);
+    expect(run?.status).toBe("succeeded");
+    expect(calls).toBe(2);
+  });
+
+  it("fails the run with the engine error when an action keeps failing", async () => {
+    const def = {
+      ...MULTI_STATE,
+      id: "doomed",
+      start: "Work",
+      states: [
+        {
+          name: "Work",
+          type: "operation",
+          actions: [{ functionRef: { refName: "doWork" } }],
+          end: true,
+        },
+      ],
+    } as unknown as RoutineDefinition;
+    const { driver } = makeDriver({
+      actionExecutor: vi.fn(async () => {
+        throw new Error("nope");
+      }),
+    });
+    const id = await createRun(def);
+
+    await driver.drive(id);
+    const run = await runs.findById(id);
+    expect(run?.status).toBe("failed");
+    expect(run?.error).toMatchObject({ name: "action_failed", message: "nope" });
+    const events = await runs.listEvents(id);
+    expect(events[events.length - 1].type).toBe("error");
+  });
+
+  it("pauses on human_approval, records the approval id, resumes on approval", async () => {
+    const def = {
+      ...MULTI_STATE,
+      id: "gated",
+      start: "Gate",
+      states: [
+        {
+          name: "Gate",
+          type: "operation",
+          "x-autonomy-level": "human_approval",
+          "x-approval-channel": ["ui"],
+          actions: [{ functionRef: { refName: "doWork" } }],
+          end: true,
+        },
+      ],
+    } as unknown as RoutineDefinition;
+    const approvalId = randomUUID();
+    const requestApproval = vi.fn(async () => approvalId);
+    const actionExecutor = vi.fn(async () => ({ ok: true }));
+    const { driver } = makeDriver({ requestApproval, actionExecutor });
+    const id = await createRun(def);
+
+    await driver.drive(id);
+    let run = await runs.findById(id);
+    expect(run?.status).toBe("waiting_approval");
+    expect(run?.approvalId).toBe(approvalId);
+    expect(actionExecutor).not.toHaveBeenCalled();
+
+    await driver.drive(id, { approvalOutcome: "approved" });
+    run = await runs.findById(id);
+    expect(run?.status).toBe("succeeded");
+    expect(actionExecutor).toHaveBeenCalledOnce();
+  });
+
+  it("runs lifecycle + step hooks through the sandbox", async () => {
+    const hookSource =
+      "({ beforeHook(ctx){}, beforeReport(ctx){}, computeTotal(ctx,a){ return 9 } })";
+    const def = {
+      ...MULTI_STATE,
+      id: "hooked",
+      start: "Report",
+      functions: [{ name: "computeTotal", operation: "hook:computeTotal" }],
+      states: [
+        {
+          name: "Report",
+          type: "operation",
+          actions: [
+            {
+              functionRef: { refName: "computeTotal" },
+              actionDataFilter: { toStateData: "context.total" },
+            },
+          ],
+          end: true,
+        },
+      ],
+    } as unknown as RoutineDefinition;
+    const sandbox = makeSandbox({ computeTotal: 9 });
+    const { driver } = makeDriver({ sandbox, registry: makeRegistry(hookSource) });
+    const id = await createRun(def);
+
+    await driver.drive(id);
+    const run = await runs.findById(id);
+    expect(run?.status).toBe("succeeded");
+    expect(run?.output).toMatchObject({ total: 9 });
+
+    const hookCalls = (sandbox.runRoutineHook as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c) => c[1]
+    );
+    expect(hookCalls).toEqual(["beforeHook", "beforeReport", "computeTotal"]);
+  });
+
+  it("persists state_deadline before a timed state and clears it on transition", async () => {
+    const def = {
+      ...MULTI_STATE,
+      id: "timed",
+      start: "Slow",
+      states: [
+        {
+          name: "Slow",
+          type: "operation",
+          timeouts: { stateExecTimeout: "PT30S" },
+          actions: [{ functionRef: { refName: "doWork" } }],
+          transition: "Done",
+        },
+        { name: "Done", type: "inject", data: {}, end: true },
+      ],
+    } as unknown as RoutineDefinition;
+    const deadlines: Array<Date | null> = [];
+    const actionExecutor = vi.fn(async () => {
+      const row = await runs.findById(id);
+      deadlines.push(row?.stateDeadline ?? null);
+      return { ok: true };
+    });
+    const { driver } = makeDriver({ actionExecutor });
+    const id = await createRun(def);
+
+    await driver.drive(id);
+    // deadline was set while the timed state's action ran…
+    expect(deadlines[0]).toBeInstanceOf(Date);
+    // …and cleared once the run completed.
+    const run = await runs.findById(id);
+    expect(run?.status).toBe("succeeded");
+    expect(run?.stateDeadline).toBeNull();
+  });
+
+  it("does nothing for terminal or unknown runs", async () => {
+    const { driver } = makeDriver({});
+    await driver.drive(randomUUID()); // unknown
+    expect(LOG.warn).toHaveBeenCalled();
+
+    const id = await createRun(MULTI_STATE);
+    await runs.transition(id, { status: "pending" }, { status: "cancelled", finished: true });
+    await driver.drive(id);
+    const run = await runs.findById(id);
+    expect(run?.status).toBe("cancelled");
+  });
+});

--- a/apps/api/src/routines/driver.ts
+++ b/apps/api/src/routines/driver.ts
@@ -1,0 +1,359 @@
+import {
+  type EnginePorts,
+  executeState,
+  LIFECYCLE_HOOKS,
+  parseIsoDuration,
+  type ResolvedFunction,
+  type RunEvent,
+  type RunSnapshot,
+} from "@tulipfarm/routine-engine";
+import { makeStreamEmitter } from "../chat/stream-emitter";
+import type { StreamHub } from "../chat/stream-hub";
+import type { RoutineRegistry } from "./registry";
+import type { RoutineRunRow, RoutineRunsRepo, RunStatus } from "./repo";
+import { RunJournalStreamRepo, runStreamId } from "./stream-adapter";
+
+type DriverLogger = {
+  error: (obj: unknown, msg?: string) => void;
+  warn: (obj: unknown, msg?: string) => void;
+  info?: (obj: unknown, msg?: string) => void;
+};
+
+/** Sandbox surface the driver needs (implemented by HookExecutor). */
+export interface RoutineSandbox {
+  runExpression(code: string, scope: Record<string, unknown>, breakerKey: string): Promise<unknown>;
+  runRoutineHook(
+    hookSource: string,
+    fnName: string,
+    invocation: Record<string, unknown>,
+    args: unknown,
+    breakerKey: string,
+    opts?: { expectedHash?: string; optional?: boolean }
+  ): Promise<unknown>;
+}
+
+/** Executes a tool/agent action for an operation state (Phase 4 provides the real one). */
+export type ActionExecutor = (
+  fn: ResolvedFunction,
+  args: Record<string, unknown>,
+  run: RunSnapshot
+) => Promise<unknown>;
+
+/** Creates the approval row + delivers channels; returns the approval id (Phase 6). */
+export type ApprovalRequester = (
+  run: RoutineRunRow,
+  request: { stateName: string; channels: string[]; summary: Record<string, unknown> }
+) => Promise<string>;
+
+export interface DriverDeps {
+  runs: RoutineRunsRepo;
+  registry: RoutineRegistry;
+  hub: StreamHub;
+  sandbox: RoutineSandbox;
+  actionExecutor: ActionExecutor;
+  requestApproval?: ApprovalRequester;
+  /** Enqueue a routine-wake delivery at `startAfter`. */
+  enqueueWake: (args: {
+    runId: string;
+    reason: "sleep" | "retry" | "approval";
+    token: string;
+    startAfter?: Date;
+  }) => Promise<void>;
+  log: DriverLogger;
+}
+
+export interface DriveOptions {
+  /** Approval decision when resuming a waiting_approval run. */
+  approvalOutcome?: "approved" | "denied";
+}
+
+const TERMINAL: RunStatus[] = ["succeeded", "failed", "cancelled"];
+
+function hookMentions(hookSource: string, fnName: string): boolean {
+  return new RegExp(`\\b${fnName}\\s*[(:]`).test(hookSource);
+}
+
+/**
+ * The run driver: loads a run, loops `executeState`, persists after every outcome
+ * (persist-first, enqueue-second — the sweep heals the gap), and exits the loop on any
+ * suspension. Safe under at-least-once delivery: every transition is CAS-guarded, so a
+ * duplicate delivery loses the CAS and returns quietly.
+ */
+export class RoutineRunDriver {
+  constructor(private readonly deps: DriverDeps) {}
+
+  async drive(runId: string, opts: DriveOptions = {}): Promise<void> {
+    const { runs, hub, log } = this.deps;
+    const row = await runs.findById(runId);
+    if (!row) {
+      log.warn({ runId }, "routine-run job for unknown run");
+      return;
+    }
+    if (TERMINAL.includes(row.status)) return;
+
+    // Claim: pending (fresh) / sleeping (wake) / waiting_approval (decision) → running.
+    const claimed = await runs.transition(
+      runId,
+      { status: row.status },
+      { status: "running", wakeAt: null }
+    );
+    if (!claimed) return; // another delivery got here first
+
+    const streamId = runStreamId(runId);
+    hub.register(streamId);
+    const journalRepo = new RunJournalStreamRepo(runs);
+    const lastSeq = (await runs.nextSeq(runId)) - 1;
+    const emitter = makeStreamEmitter(
+      streamId,
+      { repo: journalRepo, hub, log: { error: (obj, msg) => log.error(obj, msg) } },
+      lastSeq
+    );
+
+    const routine = this.deps.registry.get(row.routineSlug);
+    const hookSource = routine?.hookSource;
+    const hookHash = routine?.hookHash;
+    const breakerKey = `routine:${row.routineSlug}`;
+    const sandbox = this.deps.sandbox;
+
+    let approvalOutcome = opts.approvalOutcome;
+    // sleep-completion: currentState null means "the run finished sleeping into its end".
+    if (row.currentState === null) {
+      await this.finish(runId, emitter, { status: "succeeded", output: row.context });
+      return;
+    }
+
+    let snapshot: RunSnapshot = {
+      runId,
+      slug: row.routineSlug,
+      definition: row.definitionSnapshot,
+      currentState: row.currentState,
+      context: row.context,
+      trigger: {
+        type: row.trigger.type as RunSnapshot["trigger"]["type"],
+        payload: row.trigger.payload,
+      },
+      attemptCounts: row.attemptCounts,
+      approvalOutcome,
+    };
+
+    const ports: EnginePorts = {
+      evalExpression: (expr, scope) => sandbox.runExpression(expr, scope, breakerKey),
+      runHook: (fnName, invocation, args) => {
+        if (!hookSource) throw new Error(`routine "${row?.routineSlug}" has no hooks.ts`);
+        const optional = /^(before|after)/.test(fnName);
+        return sandbox.runRoutineHook(
+          hookSource,
+          fnName,
+          invocation as unknown as Record<string, unknown>,
+          args,
+          breakerKey,
+          { expectedHash: hookHash, optional }
+        );
+      },
+      hasHook: (fnName) => Boolean(hookSource && hookMentions(hookSource, fnName)),
+      runAction: (fn, args, run) => this.deps.actionExecutor(fn, args, run),
+      emit: (event: RunEvent) => emitter.emit(event.type, event.data),
+      now: () => new Date(),
+      log: { warn: (msg) => log.warn({ runId }, msg) },
+    };
+
+    const isFirstState = snapshot.currentState === snapshot.definition.start && lastSeq === 0;
+    if (isFirstState) {
+      await emitter.emit("run.started", { slug: row.routineSlug, trigger: row.trigger.type });
+      if (hookSource && hookMentions(hookSource, LIFECYCLE_HOOKS.beforeRun)) {
+        try {
+          await ports.runHook(LIFECYCLE_HOOKS.beforeRun, {
+            runId,
+            slug: row.routineSlug,
+            context: snapshot.context,
+            trigger: snapshot.trigger,
+          });
+        } catch (err) {
+          log.warn({ runId, err }, "beforeHook failed; continuing run");
+        }
+      }
+    }
+
+    // The state loop. Every iteration: execute exactly one state, persist, continue or exit.
+    for (;;) {
+      const stateName = snapshot.currentState;
+
+      // Persist the per-state deadline before executing so the sweep can time the state
+      // out across a crash/restart (the in-process race lives in the engine).
+      const stateDef = snapshot.definition.states.find((s) => s.name === stateName);
+      const timeoutIso = stateDef?.timeouts?.stateExecTimeout;
+      if (timeoutIso) {
+        await runs.transition(
+          runId,
+          { status: "running", currentState: stateName },
+          { stateDeadline: new Date(Date.now() + parseIsoDuration(timeoutIso)) }
+        );
+      }
+
+      const outcome = await executeState(snapshot, ports);
+      await runs.touch(runId); // heartbeat for the sweep
+
+      switch (outcome.type) {
+        case "continue": {
+          const ok = await runs.transition(
+            runId,
+            { status: "running", currentState: stateName },
+            { currentState: outcome.nextState, context: outcome.context, stateDeadline: null }
+          );
+          if (!ok) return; // raced: cancelled or duplicate delivery advanced it
+          snapshot = {
+            ...snapshot,
+            currentState: outcome.nextState,
+            context: outcome.context,
+          };
+          approvalOutcome = undefined;
+          snapshot.approvalOutcome = undefined;
+          continue;
+        }
+        case "complete": {
+          await this.runAfterHook(ports, hookSource, snapshot);
+          await this.finish(runId, emitter, {
+            status: "succeeded",
+            output: outcome.output,
+            expectState: stateName,
+          });
+          return;
+        }
+        case "fail": {
+          await this.runAfterHook(ports, hookSource, snapshot);
+          await this.finish(runId, emitter, {
+            status: "failed",
+            error: outcome.error as unknown as Record<string, unknown>,
+            expectState: stateName,
+          });
+          return;
+        }
+        case "sleep": {
+          const token = `sleep:${stateName}:${outcome.until.getTime()}`;
+          const ok = await runs.transition(
+            runId,
+            { status: "running", currentState: stateName },
+            {
+              status: "sleeping",
+              currentState: outcome.nextState,
+              context: outcome.context,
+              wakeAt: outcome.until,
+              stateDeadline: null,
+            }
+          );
+          if (!ok) return;
+          await emitter.emit("run.sleeping", {
+            state: stateName,
+            until: outcome.until.toISOString(),
+          });
+          await emitter.emit("finish", {
+            reason: "suspended",
+            wakeAt: outcome.until.toISOString(),
+          });
+          hub.finish(streamId);
+          await this.deps.enqueueWake({ runId, reason: "sleep", token, startAfter: outcome.until });
+          return;
+        }
+        case "retry": {
+          const wakeAt = new Date(Date.now() + outcome.delayMs);
+          const token = `retry:${stateName}:${outcome.attempt}`;
+          const attemptCounts = { ...snapshot.attemptCounts, [stateName]: outcome.attempt };
+          const ok = await runs.transition(
+            runId,
+            { status: "running", currentState: stateName },
+            { status: "sleeping", attemptCounts, wakeAt, stateDeadline: null }
+          );
+          if (!ok) return;
+          await emitter.emit("state.retrying", {
+            state: stateName,
+            attempt: outcome.attempt,
+            delayMs: outcome.delayMs,
+            error: outcome.error,
+          });
+          await emitter.emit("finish", { reason: "suspended", wakeAt: wakeAt.toISOString() });
+          hub.finish(streamId);
+          await this.deps.enqueueWake({ runId, reason: "retry", token, startAfter: wakeAt });
+          return;
+        }
+        case "wait_approval": {
+          if (!this.deps.requestApproval || !row) {
+            await this.finish(runId, emitter, {
+              status: "failed",
+              error: { name: "approvals_unavailable", message: "approvals are not configured" },
+              expectState: stateName,
+            });
+            return;
+          }
+          const approvalId = await this.deps.requestApproval(row, outcome.request);
+          const ok = await runs.transition(
+            runId,
+            { status: "running", currentState: stateName },
+            { status: "waiting_approval", approvalId }
+          );
+          if (!ok) return;
+          await emitter.emit("run.waiting_approval", {
+            state: stateName,
+            approvalId,
+            channels: outcome.request.channels,
+          });
+          await emitter.emit("finish", { reason: "suspended" });
+          hub.finish(streamId);
+          return;
+        }
+      }
+    }
+  }
+
+  private async runAfterHook(
+    ports: EnginePorts,
+    hookSource: string | undefined,
+    snapshot: RunSnapshot
+  ): Promise<void> {
+    if (!hookSource || !hookMentions(hookSource, LIFECYCLE_HOOKS.afterRun)) return;
+    try {
+      await ports.runHook(LIFECYCLE_HOOKS.afterRun, {
+        runId: snapshot.runId,
+        slug: snapshot.slug,
+        context: snapshot.context,
+        trigger: snapshot.trigger,
+      });
+    } catch (err) {
+      this.deps.log.warn({ runId: snapshot.runId, err }, "afterHook failed");
+    }
+  }
+
+  private async finish(
+    runId: string,
+    emitter: { emit(type: string, data: unknown): Promise<void> },
+    result: {
+      status: "succeeded" | "failed";
+      output?: Record<string, unknown>;
+      error?: Record<string, unknown>;
+      expectState?: string | null;
+    }
+  ): Promise<void> {
+    const { runs, hub } = this.deps;
+    const ok = await runs.transition(
+      runId,
+      {
+        status: "running",
+        ...(result.expectState !== undefined ? { currentState: result.expectState } : {}),
+      },
+      {
+        status: result.status,
+        output: result.output ?? null,
+        error: result.error ?? null,
+        wakeAt: null,
+        stateDeadline: null,
+        finished: true,
+      }
+    );
+    if (!ok) return;
+    if (result.status === "succeeded") {
+      await emitter.emit("finish", { reason: "completed", output: result.output ?? {} });
+    } else {
+      await emitter.emit("error", { error: result.error ?? {} });
+    }
+    hub.finish(runStreamId(runId));
+  }
+}

--- a/apps/api/src/routines/e2e.test.ts
+++ b/apps/api/src/routines/e2e.test.ts
@@ -1,0 +1,175 @@
+import { EventEmitter } from "node:events";
+import type { PGlite } from "@electric-sql/pglite";
+import type { SoulLoader, SoulRoutine } from "@tulipfarm/soul";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { StreamHub } from "../chat/stream-hub";
+import { DOMAIN_EVENTS } from "../domain-events";
+import { runPgMigrations } from "../pg-migrate";
+import { makePglite } from "../test/pglite";
+import { RoutineRunDriver, type RoutineSandbox } from "./driver";
+import type { RoutineRunJob, RoutineWakeJob } from "./jobs";
+import { RoutineRegistry } from "./registry";
+import { RoutineRunsRepo } from "./repo";
+import { RoutineTriggerService, subscribeRoutineEventTriggers } from "./trigger-service";
+
+/**
+ * AC-V1-001: a routine using ALL FIVE V1 state types (operation/switch/foreach/sleep/
+ * inject) and declaring ALL FIVE V1 trigger types (event/manual/cron/webhook/agent)
+ * runs end-to-end. This wires the real trigger service → runs repo → driver → engine
+ * with an in-memory queue standing in for pg-boss (same at-least-once contract).
+ */
+const FULL_ROUTINE: Record<string, unknown> = {
+  id: "full-surface",
+  version: "1.0",
+  name: "Full V1 Surface",
+  start: "Seed",
+  "x-triggers": [
+    { type: "manual" },
+    { type: "cron", schedule: "0 9 * * *" },
+    { type: "webhook", secret_ref: "hook-secret" },
+    { type: "event", event: "resource.created" },
+    { type: "agent" },
+  ],
+  functions: [{ name: "record", operation: "tool:resource_create" }],
+  retries: [{ name: "std", maxAttempts: 2, delay: "PT1S" }],
+  states: [
+    {
+      name: "Seed",
+      type: "inject",
+      data: { items: [1, 2], threshold: 1 },
+      transition: "Gate",
+    },
+    {
+      name: "Gate",
+      type: "switch",
+      dataConditions: [
+        { condition: "context.items.length > context.threshold", transition: "Work" },
+      ],
+      defaultCondition: { end: true },
+    },
+    {
+      name: "Work",
+      type: "foreach",
+      inputCollection: "context.items",
+      iterationParam: "item",
+      actions: [
+        // biome-ignore lint/suspicious/noTemplateCurlyInString: routine expression DSL
+        { functionRef: { refName: "record", arguments: { n: "${ item }" } }, retryRef: "std" },
+      ],
+      transition: "Cooldown",
+    },
+    { name: "Cooldown", type: "sleep", duration: "PT1S", transition: "Done" },
+    { name: "Done", type: "inject", data: { finished: true }, end: true },
+  ],
+};
+
+function realJsSandbox(): RoutineSandbox {
+  return {
+    runExpression: async (code, scope) => {
+      const fn = new Function(...Object.keys(scope), `return (${code});`);
+      return fn(...Object.values(scope));
+    },
+    runRoutineHook: async () => null,
+  };
+}
+
+describe("AC-V1-001 end-to-end (all 5 states + all 5 triggers)", () => {
+  let db: PGlite;
+  let runs: RoutineRunsRepo;
+  let registry: RoutineRegistry;
+  let service: RoutineTriggerService;
+  let driver: RoutineRunDriver;
+  let queue: Array<{ runId: string; opts?: { approvalOutcome?: "approved" | "denied" } }>;
+
+  beforeEach(async () => {
+    db = await makePglite();
+    await runPgMigrations(db);
+    runs = new RoutineRunsRepo(db);
+
+    const map = new Map<string, SoulRoutine>([
+      ["full-surface", { name: "full-surface", config: FULL_ROUTINE, hasHooks: false }],
+    ]);
+    const loader = { routines: map, reload: vi.fn() } as unknown as SoulLoader;
+    const log = { error: vi.fn(), warn: vi.fn() };
+    registry = new RoutineRegistry(loader, log);
+    registry.refresh();
+
+    queue = [];
+    const enqueuers = {
+      enqueueRun: async (job: RoutineRunJob) => {
+        queue.push({ runId: job.runId });
+      },
+      enqueueWake: async (job: RoutineWakeJob & { startAfter?: Date }) => {
+        queue.push({
+          runId: job.runId,
+          opts: job.reason === "approval" ? { approvalOutcome: job.decision } : undefined,
+        });
+      },
+    };
+    service = new RoutineTriggerService({ registry, runs, enqueuers, log });
+    driver = new RoutineRunDriver({
+      runs,
+      registry,
+      hub: new StreamHub(),
+      sandbox: realJsSandbox(),
+      actionExecutor: vi.fn(async (_fn, args) => ({ recorded: args })),
+      enqueueWake: enqueuers.enqueueWake,
+      log,
+    });
+  });
+
+  afterEach(async () => {
+    await db.close();
+  });
+
+  /** Drain the in-memory queue like the pg-boss workers would (ignoring startAfter). */
+  async function drain(): Promise<void> {
+    for (let i = 0; i < 20 && queue.length > 0; i++) {
+      const job = queue.shift();
+      if (job) await driver.drive(job.runId, job.opts);
+    }
+  }
+
+  it("runs the full-surface routine end-to-end from a manual trigger", async () => {
+    const { runId } = await service.trigger("full-surface", { type: "manual", payload: {} });
+    await drain();
+
+    const run = await runs.findById(runId);
+    expect(run?.status).toBe("succeeded");
+    expect(run?.output).toMatchObject({ finished: true });
+
+    const events = await runs.listEvents(runId);
+    const states = events
+      .filter((e) => e.type === "state.entered")
+      .map((e) => (e.payload as { state: string }).state);
+    expect(states).toEqual(["Seed", "Gate", "Work", "Cooldown", "Done"]);
+    expect(events.filter((e) => e.type === "action.completed")).toHaveLength(2); // foreach x2
+    expect(events.some((e) => e.type === "run.sleeping")).toBe(true);
+    expect(events[events.length - 1].type).toBe("finish");
+  });
+
+  it("every declared trigger type starts a run", async () => {
+    for (const type of ["manual", "cron", "webhook", "agent"] as const) {
+      const { runId } = await service.trigger("full-surface", { type, payload: {} });
+      expect((await runs.findById(runId))?.trigger.type).toBe(type);
+    }
+
+    // event trigger via the domain bus
+    const bus = new EventEmitter();
+    subscribeRoutineEventTriggers(bus, service, registry, undefined, {
+      error: vi.fn(),
+      warn: vi.fn(),
+    });
+    const before = queue.length;
+    bus.emit(DOMAIN_EVENTS.RESOURCE_CREATED, { resourceType: "ticket" });
+    await vi.waitFor(() => expect(queue.length).toBeGreaterThan(before));
+
+    await drain();
+    const all = await runs.listBySlug("full-surface", 50);
+    expect(all).toHaveLength(5);
+    expect(new Set(all.map((r) => r.trigger.type))).toEqual(
+      new Set(["manual", "cron", "webhook", "agent", "event"])
+    );
+    expect(all.every((r) => r.status === "succeeded")).toBe(true);
+  });
+});

--- a/apps/api/src/routines/forge-tool.test.ts
+++ b/apps/api/src/routines/forge-tool.test.ts
@@ -1,0 +1,101 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { GitSyncService } from "@tulipfarm/soul";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { parse as parseYaml } from "yaml";
+import { routineForgeTool } from "../platform/tools";
+
+const VALID_DEFINITION: Record<string, unknown> = {
+  id: "daily-report",
+  version: "1.0",
+  start: "Report",
+  "x-triggers": [{ type: "cron", schedule: "0 9 * * *" }],
+  functions: [{ name: "send", operation: "tool:resource_search" }],
+  states: [
+    {
+      name: "Report",
+      type: "operation",
+      actions: [{ functionRef: { refName: "send" } }],
+      end: true,
+    },
+  ],
+};
+
+describe("routine_forge (AC-V1-004)", () => {
+  let soulPath: string;
+  let gitSync: GitSyncService;
+  let withSync: ReturnType<typeof vi.fn>;
+  let onRoutinesChanged: (() => Promise<void>) & ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    soulPath = mkdtempSync(join(tmpdir(), "forge-"));
+    withSync = vi.fn(async () => {});
+    gitSync = { path: soulPath, withSync } as unknown as GitSyncService;
+    onRoutinesChanged = vi.fn(async () => {}) as typeof onRoutinesChanged;
+  });
+
+  afterEach(() => {
+    rmSync(soulPath, { recursive: true, force: true });
+  });
+
+  it("writes routine.yaml + hooks.ts, commits via withSync, no approval step", async () => {
+    const result = await routineForgeTool.handler(
+      {
+        name: "daily-report",
+        definition: VALID_DEFINITION,
+        hooks: "({ beforeHook(ctx) { return ctx; } })",
+      },
+      { gitSync, onRoutinesChanged }
+    );
+    expect(result).toMatchObject({
+      success: true,
+      data: { name: "daily-report", committed: true, hasHooks: true },
+    });
+
+    const yaml = parseYaml(
+      readFileSync(join(soulPath, "routines", "daily-report", "routine.yaml"), "utf8")
+    );
+    expect(yaml).toMatchObject({ id: "daily-report", start: "Report" });
+    expect(readFileSync(join(soulPath, "routines", "daily-report", "hooks.ts"), "utf8")).toContain(
+      "beforeHook"
+    );
+    expect(withSync).toHaveBeenCalledWith("soul: forge routine daily-report");
+    expect(onRoutinesChanged).toHaveBeenCalledOnce();
+  });
+
+  it("rejects deferred constructs BEFORE writing anything", async () => {
+    const result = await routineForgeTool.handler(
+      {
+        name: "bad",
+        definition: {
+          ...VALID_DEFINITION,
+          id: "bad",
+          "x-triggers": [{ type: "datetime", at: "2027-01-01" }],
+        },
+      },
+      { gitSync, onRoutinesChanged }
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.message).toContain("deferred in V1");
+    }
+    expect(withSync).not.toHaveBeenCalled();
+    expect(() => readFileSync(join(soulPath, "routines", "bad", "routine.yaml"))).toThrow();
+  });
+
+  it("rejects invalid slugs and schema violations", async () => {
+    const badSlug = await routineForgeTool.handler(
+      { name: "Bad Slug!", definition: VALID_DEFINITION },
+      { gitSync }
+    );
+    expect(badSlug.success).toBe(false);
+
+    const badSchema = await routineForgeTool.handler(
+      { name: "ok-name", definition: { id: "x", bogus: true } },
+      { gitSync }
+    );
+    expect(badSchema.success).toBe(false);
+    expect(withSync).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routines/headless-turn.ts
+++ b/apps/api/src/routines/headless-turn.ts
@@ -1,0 +1,96 @@
+import type { SoulLoader } from "@tulipfarm/soul";
+import { generateText, type ToolSet } from "ai";
+import type { ToolRegistry } from "../tools/registry";
+import type { RequestContext } from "../tools/types";
+
+/** Max model steps for a routine-spawned agent turn (tool loop bound). */
+const MAX_HEADLESS_STEPS = 8;
+
+/** System actor recorded for routine-spawned turns (no human user in the loop). */
+export const ROUTINE_ACTOR = "system:routine";
+
+type HeadlessLogger = {
+  warn: (obj: unknown, msg?: string) => void;
+};
+
+export interface HeadlessTurnDeps {
+  /** Structural: only getModel is needed (LlmService satisfies this). */
+  llmService: { getModel(tier: "quick" | "standard" | "complex"): unknown };
+  registry: ToolRegistry;
+  soulLoader?: Pick<SoulLoader, "agents">;
+  log: HeadlessLogger;
+}
+
+export interface HeadlessTurnInput {
+  agentId: string;
+  task: string;
+  routineContext: { routineId: string; runId: string };
+  context: Record<string, unknown>;
+}
+
+/**
+ * Routine `agent:` action (review B3): a headless agent turn — generateText tool loop,
+ * no Fastify req/reply, no conversation row, no SSE. The agent's AGENT.md body is the
+ * system prompt; `routineContext` rides the RequestContext so `call_skill` /
+ * `complete_state` become live. Tool approvals are not gated here — the routine-level
+ * human_approval state is the V1 gate for routine-initiated actions.
+ *
+ * Returns the output passed to `complete_state`, or the final text when the agent
+ * never called it.
+ */
+export async function runHeadlessTurn(
+  deps: HeadlessTurnDeps,
+  input: HeadlessTurnInput
+): Promise<unknown> {
+  const agent = deps.soulLoader?.agents.get(input.agentId);
+  if (!agent) {
+    throw new Error(`agent "${input.agentId}" not found in soul`);
+  }
+
+  const ctx: RequestContext = {
+    userId: ROUTINE_ACTOR,
+    agentId: input.agentId,
+    autonomy: "full",
+    routineContext: input.routineContext,
+  };
+  const tools = deps.registry.buildToolSet(ctx) as ToolSet;
+
+  const system = [
+    agent.body,
+    "",
+    "You are executing one state of an automated routine. Complete the task using your tools,",
+    "then call the complete_state tool exactly once with the state's output data.",
+  ].join("\n");
+
+  const result = await generateText({
+    // biome-ignore lint/suspicious/noExplicitAny: LanguageModel type lives in @tulipfarm/llm; deps are structural here
+    model: deps.llmService.getModel("standard") as any,
+    system,
+    prompt: `Task: ${input.task}\n\nRoutine context data:\n${JSON.stringify(input.context, null, 2)}`,
+    tools,
+    stopWhen: ({ steps }) => {
+      if (steps.length >= MAX_HEADLESS_STEPS) return true;
+      // Stop as soon as complete_state ran — its result is the state output.
+      return steps.some((s) => s.toolResults?.some((r) => r.toolName === "complete_state"));
+    },
+  });
+
+  for (const step of result.steps) {
+    for (const toolResult of step.toolResults ?? []) {
+      if (toolResult.toolName === "complete_state") {
+        const output = toolResult.output as
+          | { success: true; data: { output?: unknown } }
+          | { success: false };
+        if (output && "success" in output && output.success) {
+          return output.data.output ?? null;
+        }
+      }
+    }
+  }
+
+  deps.log.warn(
+    { runId: input.routineContext.runId, agentId: input.agentId },
+    "headless turn finished without complete_state; using final text"
+  );
+  return result.text;
+}

--- a/apps/api/src/routines/jobs.ts
+++ b/apps/api/src/routines/jobs.ts
@@ -1,0 +1,155 @@
+import type { PgBoss } from "pg-boss";
+import type { ApprovalsRepo } from "../approvals/repo";
+import type { RoutineRunDriver } from "./driver";
+import type { RoutineRunsRepo } from "./repo";
+
+export const ROUTINE_RUN_QUEUE = "routine-run";
+export const ROUTINE_WAKE_QUEUE = "routine-wake";
+export const ROUTINE_SWEEP_QUEUE = "routine-sweep";
+/** Sweep cadence: heal missed wakes / expired deadlines every 5 minutes. */
+export const ROUTINE_SWEEP_CRON = "*/5 * * * *";
+/** A running run with no heartbeat for this long is presumed crashed mid-state. */
+export const STALE_HEARTBEAT_MS = 2 * 60 * 1000;
+
+export interface RoutineRunJob {
+  runId: string;
+  slug: string;
+  trigger: { type: string; payload?: unknown };
+}
+
+export interface RoutineWakeJob {
+  runId: string;
+  reason: "sleep" | "retry" | "approval";
+  token: string;
+  decision?: "approved" | "denied";
+}
+
+type JobsLogger = {
+  error: (obj: unknown, msg?: string) => void;
+  warn: (obj: unknown, msg?: string) => void;
+};
+
+export interface RoutineJobsDeps {
+  driver: RoutineRunDriver;
+  runs: RoutineRunsRepo;
+  /** Enables approval expiry in the sweep (routine_state rows past expires_at → timeout). */
+  approvals?: ApprovalsRepo;
+  log: JobsLogger;
+}
+
+/** Producer helpers — threaded into routes/tools so they can enqueue without pg-boss types. */
+export interface RoutineEnqueuers {
+  enqueueRun(job: RoutineRunJob): Promise<void>;
+  enqueueWake(job: RoutineWakeJob & { startAfter?: Date }): Promise<void>;
+}
+
+export function makeRoutineEnqueuers(boss: PgBoss): RoutineEnqueuers {
+  return {
+    async enqueueRun(job) {
+      await boss.send(ROUTINE_RUN_QUEUE, job as unknown as object, {
+        singletonKey: `run:${job.runId}`,
+      });
+    },
+    async enqueueWake(job) {
+      const { startAfter, ...data } = job;
+      await boss.send(ROUTINE_WAKE_QUEUE, data as unknown as object, {
+        singletonKey: `wake:${job.runId}:${job.token}`,
+        ...(startAfter ? { startAfter } : {}),
+      });
+    },
+  };
+}
+
+/**
+ * Registers the routine engine's pg-boss queues (D4): `routine-run` (fresh runs),
+ * `routine-wake` (sleep/retry/approval resumptions, delayed jobs) and the
+ * `routine-sweep` cron that heals the persist-first/enqueue-second crash window by
+ * re-enqueueing any run whose `wake_at` passed without a wake firing.
+ */
+export async function registerRoutineJobs(boss: PgBoss, deps: RoutineJobsDeps): Promise<void> {
+  const { driver, runs, log } = deps;
+  const enqueuers = makeRoutineEnqueuers(boss);
+
+  await boss.createQueue(ROUTINE_RUN_QUEUE);
+  await boss.createQueue(ROUTINE_WAKE_QUEUE);
+  await boss.createQueue(ROUTINE_SWEEP_QUEUE);
+
+  await boss.work(ROUTINE_RUN_QUEUE, async (jobs) => {
+    for (const job of jobs) {
+      const data = job.data as unknown as RoutineRunJob;
+      try {
+        await driver.drive(data.runId);
+      } catch (err) {
+        log.error({ err, runId: data.runId }, "routine run failed unexpectedly");
+        throw err;
+      }
+    }
+  });
+
+  await boss.work(ROUTINE_WAKE_QUEUE, async (jobs) => {
+    for (const job of jobs) {
+      const data = job.data as unknown as RoutineWakeJob;
+      try {
+        await driver.drive(data.runId, {
+          approvalOutcome: data.reason === "approval" ? data.decision : undefined,
+        });
+      } catch (err) {
+        log.error({ err, runId: data.runId }, "routine wake failed unexpectedly");
+        throw err;
+      }
+    }
+  });
+
+  await boss.work(ROUTINE_SWEEP_QUEUE, async () => {
+    const now = new Date();
+    const overdue = await runs.listOverdueWakes(now);
+    for (const run of overdue) {
+      await enqueuers.enqueueWake({
+        runId: run.id,
+        reason: "sleep",
+        token: `sweep:${run.wakeAt?.getTime() ?? now.getTime()}`,
+      });
+    }
+    // Cross-restart state timeouts: a `running` run whose state_deadline passed AND
+    // whose heartbeat is stale lost its process mid-state. Re-enter via drive() — the
+    // state re-executes and the engine's in-process timeout/onErrors routing applies.
+    const staleCutoff = new Date(now.getTime() - STALE_HEARTBEAT_MS);
+    const expired = (await runs.listExpiredDeadlines(now)).filter(
+      (run) => run.updatedAt < staleCutoff
+    );
+    for (const run of expired) {
+      await enqueuers.enqueueWake({
+        runId: run.id,
+        reason: "sleep",
+        token: `deadline:${run.stateDeadline?.getTime() ?? now.getTime()}`,
+      });
+    }
+    // Expired routine approvals: settle as timeout and wake the run with a denial so
+    // the state routes through its onErrors (or fails) instead of waiting forever.
+    if (deps.approvals) {
+      const expiredApprovals = await deps.approvals.listExpiredPending("routine_state", now);
+      for (const row of expiredApprovals) {
+        await deps.approvals.settle(row.id, "timeout");
+        const payload = (row.payload ?? {}) as { runId?: string };
+        if (payload.runId) {
+          await enqueuers.enqueueWake({
+            runId: payload.runId,
+            reason: "approval",
+            token: `approval-timeout:${row.id}`,
+            decision: "denied",
+          });
+        }
+      }
+      if (expiredApprovals.length > 0) {
+        log.warn({ count: expiredApprovals.length }, "routine sweep timed out expired approvals");
+      }
+    }
+    if (overdue.length + expired.length > 0) {
+      log.warn(
+        { overdue: overdue.length, expiredDeadlines: expired.length },
+        "routine sweep re-enqueued stuck runs"
+      );
+    }
+  });
+  await boss.schedule(ROUTINE_SWEEP_QUEUE, ROUTINE_SWEEP_CRON);
+}

--- a/apps/api/src/routines/registry.test.ts
+++ b/apps/api/src/routines/registry.test.ts
@@ -1,0 +1,113 @@
+import { EventEmitter } from "node:events";
+import type { SoulLoader, SoulRoutine } from "@tulipfarm/soul";
+import { describe, expect, it, vi } from "vitest";
+import { RoutineRegistry, registerRoutineRegistryReload } from "./registry";
+
+const VALID_CONFIG: Record<string, unknown> = {
+  id: "daily-report",
+  version: "1.0",
+  start: "Report",
+  "x-triggers": [{ type: "cron", schedule: "0 9 * * *" }],
+  functions: [{ name: "sendReport", operation: "tool:resource_search" }],
+  states: [
+    {
+      name: "Report",
+      type: "operation",
+      actions: [{ functionRef: { refName: "sendReport" } }],
+      end: true,
+    },
+  ],
+};
+
+function makeLoader(routines: Record<string, Partial<SoulRoutine>>): SoulLoader {
+  const map = new Map<string, SoulRoutine>();
+  for (const [name, r] of Object.entries(routines)) {
+    map.set(name, { name, config: {}, hasHooks: false, ...r });
+  }
+  return { routines: map, reload: vi.fn().mockResolvedValue(undefined) } as unknown as SoulLoader;
+}
+
+function makeLog() {
+  return { error: vi.fn(), warn: vi.fn() };
+}
+
+describe("RoutineRegistry", () => {
+  it("validates routines on refresh and exposes valid ones", () => {
+    const loader = makeLoader({
+      "daily-report": { config: VALID_CONFIG, hookSource: "({ beforeHook(ctx){} })" },
+    });
+    const registry = new RoutineRegistry(loader, makeLog());
+    registry.refresh();
+
+    const routine = registry.get("daily-report");
+    expect(routine?.definition.id).toBe("daily-report");
+    expect(routine?.hookSource).toBe("({ beforeHook(ctx){} })");
+    expect(registry.valid()).toHaveLength(1);
+  });
+
+  it("keeps invalid routines as error entries without crashing", () => {
+    const loader = makeLoader({
+      good: { config: VALID_CONFIG },
+      bad: { config: { id: "bad", bogus: true } },
+      deferred: {
+        config: {
+          ...VALID_CONFIG,
+          id: "deferred",
+          "x-triggers": [{ type: "datetime", at: "2027-01-01" }],
+        },
+      },
+    });
+    const registry = new RoutineRegistry(loader, makeLog());
+    registry.refresh();
+
+    expect(registry.get("good")).toBeDefined();
+    expect(registry.get("bad")).toBeUndefined();
+    const badEntry = registry.getEntry("bad");
+    expect(badEntry?.ok).toBe(false);
+    const deferredEntry = registry.getEntry("deferred");
+    expect(deferredEntry?.ok).toBe(false);
+    if (deferredEntry && !deferredEntry.ok) {
+      expect(deferredEntry.loadError).toContain("deferred in V1");
+    }
+    expect(registry.list()).toHaveLength(3);
+    expect(registry.valid()).toHaveLength(1);
+  });
+
+  it("drops entries for routines removed from the soul", () => {
+    const loader = makeLoader({ "daily-report": { config: VALID_CONFIG } });
+    const registry = new RoutineRegistry(loader, makeLog());
+    registry.refresh();
+    expect(registry.get("daily-report")).toBeDefined();
+
+    (loader.routines as Map<string, SoulRoutine>).delete("daily-report");
+    registry.refresh();
+    expect(registry.get("daily-report")).toBeUndefined();
+    expect(registry.list()).toHaveLength(0);
+  });
+});
+
+describe("registerRoutineRegistryReload", () => {
+  it("reloads the soul and refreshes the registry on soul.synced", async () => {
+    const loader = makeLoader({});
+    const registry = new RoutineRegistry(loader, makeLog());
+    const refresh = vi.spyOn(registry, "refresh");
+    const gitSync = new EventEmitter();
+    registerRoutineRegistryReload(gitSync, loader, registry, makeLog());
+
+    gitSync.emit("soul.synced");
+    await vi.waitFor(() => expect(refresh).toHaveBeenCalledOnce());
+    expect(loader.reload).toHaveBeenCalledOnce();
+  });
+
+  it("logs and survives a reload failure", async () => {
+    const loader = makeLoader({});
+    (loader.reload as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("boom"));
+    const registry = new RoutineRegistry(loader, makeLog());
+    const log = makeLog();
+    const gitSync = new EventEmitter();
+    registerRoutineRegistryReload(gitSync, loader, registry, log);
+
+    gitSync.emit("soul.synced");
+    await vi.waitFor(() => expect(log.error).toHaveBeenCalledOnce());
+  });
+});

--- a/apps/api/src/routines/registry.ts
+++ b/apps/api/src/routines/registry.ts
@@ -1,0 +1,122 @@
+import type { EventEmitter } from "node:events";
+import type { SoulLoader, SoulRoutine } from "@tulipfarm/soul";
+import {
+  type RoutineDefinition,
+  TulipFarmValidationError,
+  validateRoutineDefinition,
+} from "@tulipfarm/validation";
+
+/** Pino-style logger surface (object-first), matching guardrails/reload.ts. */
+type RegistryLogger = {
+  error: (obj: unknown, msg?: string) => void;
+  warn: (obj: unknown, msg?: string) => void;
+};
+
+export interface LoadedRoutine {
+  slug: string;
+  definition: RoutineDefinition;
+  hookSource?: string;
+  hookHash?: string;
+}
+
+export interface InvalidRoutine {
+  slug: string;
+  loadError: string;
+}
+
+export type RegistryEntry = ({ ok: true } & LoadedRoutine) | ({ ok: false } & InvalidRoutine);
+
+/**
+ * Validated view over `SoulLoader.routines` (ROUT-V1-001). The loader stays lenient —
+ * it parses YAML and never validates — so this registry is the single place a
+ * routine.yaml is checked against the V1 meta-schema (deferred-construct rejection
+ * included, AC-V1-002). Invalid routines are kept as error entries: they surface in
+ * `GET /api/v1/routines` instead of crashing boot or vanishing silently.
+ */
+export class RoutineRegistry {
+  private entries = new Map<string, RegistryEntry>();
+
+  constructor(
+    private readonly soulLoader: SoulLoader,
+    private readonly log: RegistryLogger
+  ) {}
+
+  /** Re-validate every loaded routine. Call after `soulLoader.load()`/`reload()`. */
+  refresh(): void {
+    const next = new Map<string, RegistryEntry>();
+    for (const [slug, routine] of this.soulLoader.routines) {
+      next.set(slug, this.validateOne(slug, routine));
+    }
+    this.entries = next;
+  }
+
+  private validateOne(slug: string, routine: SoulRoutine): RegistryEntry {
+    try {
+      const definition = validateRoutineDefinition(routine.config);
+      return {
+        ok: true,
+        slug,
+        definition,
+        hookSource: routine.hookSource,
+        hookHash: routine.hookHash,
+      };
+    } catch (err) {
+      const loadError =
+        err instanceof TulipFarmValidationError
+          ? `${err.path || "/"}: ${err.message}`
+          : err instanceof Error
+            ? err.message
+            : String(err);
+      this.log.warn({ slug, loadError }, "routine failed validation");
+      return { ok: false, slug, loadError };
+    }
+  }
+
+  /** All entries (valid + invalid), for listings. */
+  list(): RegistryEntry[] {
+    return [...this.entries.values()];
+  }
+
+  /** A valid routine by slug, or undefined (missing or invalid). */
+  get(slug: string): LoadedRoutine | undefined {
+    const entry = this.entries.get(slug);
+    return entry?.ok ? entry : undefined;
+  }
+
+  /** Entry by slug including invalid ones. */
+  getEntry(slug: string): RegistryEntry | undefined {
+    return this.entries.get(slug);
+  }
+
+  /** Valid routines only. */
+  valid(): LoadedRoutine[] {
+    return this.list().filter((e): e is { ok: true } & LoadedRoutine => e.ok);
+  }
+}
+
+/**
+ * Revalidate routines on every `soul.synced` event (mirrors `registerGuardrailsReload`).
+ * The soul reload itself is owned by the other listeners/periodic sync; this listener
+ * only refreshes the validated view, so ordering with them is not load-bearing — the
+ * 5-minute `registerSoulSync` reload converges any race.
+ */
+export function registerRoutineRegistryReload(
+  gitSync: EventEmitter,
+  soulLoader: SoulLoader,
+  registry: RoutineRegistry,
+  log: RegistryLogger,
+  /** Runs after a successful refresh — e.g. cron schedule reconciliation (D4). */
+  onRefreshed?: () => Promise<void>
+): void {
+  gitSync.on("soul.synced", () => {
+    void (async () => {
+      try {
+        await soulLoader.reload();
+        registry.refresh();
+        await onRefreshed?.();
+      } catch (err) {
+        log.error({ err }, "routine registry reload failed");
+      }
+    })();
+  });
+}

--- a/apps/api/src/routines/repo.pg.test.ts
+++ b/apps/api/src/routines/repo.pg.test.ts
@@ -1,0 +1,149 @@
+import { randomUUID } from "node:crypto";
+import type { PGlite } from "@electric-sql/pglite";
+import type { RoutineDefinition } from "@tulipfarm/validation";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { runPgMigrations } from "../pg-migrate";
+import { makePglite } from "../test/pglite";
+import { RoutineRunsRepo } from "./repo";
+
+const DEF = {
+  id: "r",
+  version: "1.0",
+  start: "Start",
+  "x-triggers": [{ type: "manual" }],
+  states: [{ name: "Start", type: "inject", data: {}, end: true }],
+} as unknown as RoutineDefinition;
+
+describe("RoutineRunsRepo (PGlite)", () => {
+  let db: PGlite;
+  let repo: RoutineRunsRepo;
+
+  beforeEach(async () => {
+    db = await makePglite();
+    await runPgMigrations(db);
+    repo = new RoutineRunsRepo(db);
+  });
+
+  afterEach(async () => {
+    await db.close();
+  });
+
+  async function createRun(id = randomUUID()) {
+    await repo.create({
+      id,
+      routineSlug: "daily-report",
+      definitionSnapshot: DEF,
+      definitionHash: "abc123",
+      currentState: "Start",
+      context: { seeded: true },
+      trigger: { type: "manual", payload: { a: 1 } },
+    });
+    return id;
+  }
+
+  it("creates a pending run with a pinned definition snapshot", async () => {
+    const id = await createRun();
+    const run = await repo.findById(id);
+    expect(run?.status).toBe("pending");
+    expect(run?.currentState).toBe("Start");
+    expect(run?.definitionSnapshot.id).toBe("r");
+    expect(run?.definitionHash).toBe("abc123");
+    expect(run?.context).toEqual({ seeded: true });
+    expect(run?.trigger).toEqual({ type: "manual", payload: { a: 1 } });
+  });
+
+  it("keeps the snapshot when listing by slug", async () => {
+    await createRun();
+    await createRun();
+    const runs = await repo.listBySlug("daily-report");
+    expect(runs).toHaveLength(2);
+    expect(runs[0].definitionSnapshot.states).toHaveLength(1);
+  });
+
+  it("CAS transition succeeds only when status+state match", async () => {
+    const id = await createRun();
+
+    const ok = await repo.transition(
+      id,
+      { status: "pending" },
+      { status: "running", currentState: "Start" }
+    );
+    expect(ok).toBe(true);
+
+    // stale expectation: still thinks it's pending
+    const stale = await repo.transition(id, { status: "pending" }, { status: "running" });
+    expect(stale).toBe(false);
+
+    // state guard
+    const wrongState = await repo.transition(
+      id,
+      { status: "running", currentState: "Other" },
+      { currentState: "Next" }
+    );
+    expect(wrongState).toBe(false);
+
+    const rightState = await repo.transition(
+      id,
+      { status: "running", currentState: "Start" },
+      { currentState: "Next", context: { moved: true } }
+    );
+    expect(rightState).toBe(true);
+    const run = await repo.findById(id);
+    expect(run?.currentState).toBe("Next");
+    expect(run?.context).toEqual({ moved: true });
+  });
+
+  it("supports wake/deadline bookkeeping and overdue listing", async () => {
+    const id = await createRun();
+    const past = new Date(Date.now() - 60_000);
+    await repo.transition(id, { status: "pending" }, { status: "sleeping", wakeAt: past });
+
+    const overdue = await repo.listOverdueWakes(new Date());
+    expect(overdue.map((r) => r.id)).toContain(id);
+
+    await repo.transition(id, { status: "sleeping" }, { status: "running", wakeAt: null });
+    expect(await repo.listOverdueWakes(new Date())).toHaveLength(0);
+  });
+
+  it("lists expired state deadlines only for running runs", async () => {
+    const id = await createRun();
+    const past = new Date(Date.now() - 1_000);
+    await repo.transition(id, { status: "pending" }, { status: "running", stateDeadline: past });
+    expect((await repo.listExpiredDeadlines(new Date())).map((r) => r.id)).toContain(id);
+
+    await repo.transition(id, { status: "running" }, { status: "succeeded", finished: true });
+    expect(await repo.listExpiredDeadlines(new Date())).toHaveLength(0);
+  });
+
+  it("journal: appendEvent is idempotent on (run_id, seq) and listEvents replays in order", async () => {
+    const id = await createRun();
+    const at = new Date();
+    await repo.appendEvent({ runId: id, seq: 1, type: "run.started", payload: {}, createdAt: at });
+    await repo.appendEvent({
+      runId: id,
+      seq: 2,
+      type: "state.entered",
+      payload: { state: "Start" },
+      createdAt: at,
+    });
+    // duplicate delivery
+    await repo.appendEvent({
+      runId: id,
+      seq: 2,
+      type: "state.entered",
+      payload: {},
+      createdAt: at,
+    });
+
+    const events = await repo.listEvents(id);
+    expect(events.map((e) => [e.seq, e.type])).toEqual([
+      [1, "run.started"],
+      [2, "state.entered"],
+    ]);
+    expect(await repo.nextSeq(id)).toBe(3);
+
+    const tail = await repo.listEvents(id, 1);
+    expect(tail).toHaveLength(1);
+    expect(tail[0].seq).toBe(2);
+  });
+});

--- a/apps/api/src/routines/repo.ts
+++ b/apps/api/src/routines/repo.ts
@@ -1,0 +1,242 @@
+import type { RoutineDefinition } from "@tulipfarm/validation";
+import type { Queryable } from "../db";
+
+export type RunStatus =
+  | "pending"
+  | "running"
+  | "sleeping"
+  | "waiting_approval"
+  | "succeeded"
+  | "failed"
+  | "cancelled";
+
+export interface RoutineRunRow {
+  id: string;
+  routineSlug: string;
+  definitionSnapshot: RoutineDefinition;
+  definitionHash: string;
+  status: RunStatus;
+  currentState: string | null;
+  context: Record<string, unknown>;
+  trigger: { type: string; payload?: unknown };
+  attemptCounts: Record<string, number>;
+  wakeAt: Date | null;
+  stateDeadline: Date | null;
+  approvalId: string | null;
+  output: Record<string, unknown> | null;
+  error: Record<string, unknown> | null;
+  createdAt: Date;
+  updatedAt: Date;
+  finishedAt: Date | null;
+}
+
+const COLS = `id, routine_slug, definition_snapshot, definition_hash, status, current_state,
+  context, trigger, attempt_counts, wake_at, state_deadline, approval_id, output, error,
+  created_at, updated_at, finished_at`;
+
+function rowToRun(row: Record<string, unknown>): RoutineRunRow {
+  return {
+    id: row.id as string,
+    routineSlug: row.routine_slug as string,
+    definitionSnapshot: row.definition_snapshot as RoutineDefinition,
+    definitionHash: row.definition_hash as string,
+    status: row.status as RunStatus,
+    currentState: (row.current_state as string | null) ?? null,
+    context: (row.context as Record<string, unknown>) ?? {},
+    trigger: row.trigger as { type: string; payload?: unknown },
+    attemptCounts: (row.attempt_counts as Record<string, number>) ?? {},
+    wakeAt: (row.wake_at as Date | null) ?? null,
+    stateDeadline: (row.state_deadline as Date | null) ?? null,
+    approvalId: (row.approval_id as string | null) ?? null,
+    output: (row.output as Record<string, unknown> | null) ?? null,
+    error: (row.error as Record<string, unknown> | null) ?? null,
+    createdAt: row.created_at as Date,
+    updatedAt: row.updated_at as Date,
+    finishedAt: (row.finished_at as Date | null) ?? null,
+  };
+}
+
+export interface RunJournalEvent {
+  runId: string;
+  seq: number;
+  type: string;
+  payload: unknown;
+  createdAt: Date;
+}
+
+/**
+ * Persistence for routine runs + their journal. Transitions are CAS-guarded on
+ * `(status, current_state)` so at-least-once pg-boss deliveries and the sweep can race
+ * safely: the losing writer's UPDATE matches zero rows and it backs off.
+ */
+export class RoutineRunsRepo {
+  constructor(private readonly db: Queryable) {}
+
+  async create(run: {
+    id: string;
+    routineSlug: string;
+    definitionSnapshot: RoutineDefinition;
+    definitionHash: string;
+    currentState: string;
+    context: Record<string, unknown>;
+    trigger: { type: string; payload?: unknown };
+  }): Promise<void> {
+    await this.db.query(
+      `INSERT INTO routine_runs
+         (id, routine_slug, definition_snapshot, definition_hash, status, current_state, context, trigger)
+       VALUES ($1, $2, $3::jsonb, $4, 'pending', $5, $6::jsonb, $7::jsonb)`,
+      [
+        run.id,
+        run.routineSlug,
+        JSON.stringify(run.definitionSnapshot),
+        run.definitionHash,
+        run.currentState,
+        JSON.stringify(run.context),
+        JSON.stringify(run.trigger),
+      ]
+    );
+  }
+
+  async findById(id: string): Promise<RoutineRunRow | null> {
+    const { rows } = await this.db.query(`SELECT ${COLS} FROM routine_runs WHERE id = $1`, [id]);
+    return rows[0] ? rowToRun(rows[0]) : null;
+  }
+
+  async listBySlug(slug: string, limit = 50): Promise<RoutineRunRow[]> {
+    const { rows } = await this.db.query(
+      `SELECT ${COLS} FROM routine_runs WHERE routine_slug = $1 ORDER BY created_at DESC LIMIT $2`,
+      [slug, limit]
+    );
+    return rows.map(rowToRun);
+  }
+
+  /**
+   * CAS transition: applies `patch` only when the row still matches
+   * (`expectedStatus`, `expectedState`). Returns false when the guard misses
+   * (another delivery already advanced the run).
+   */
+  async transition(
+    id: string,
+    expected: { status: RunStatus; currentState?: string | null },
+    patch: {
+      status?: RunStatus;
+      currentState?: string | null;
+      context?: Record<string, unknown>;
+      attemptCounts?: Record<string, number>;
+      wakeAt?: Date | null;
+      stateDeadline?: Date | null;
+      approvalId?: string | null;
+      output?: Record<string, unknown> | null;
+      error?: Record<string, unknown> | null;
+      finished?: boolean;
+    }
+  ): Promise<boolean> {
+    const sets: string[] = ["updated_at = now()"];
+    const params: unknown[] = [id, expected.status];
+    let p = params.length;
+
+    const add = (sql: string, value: unknown) => {
+      params.push(value);
+      p += 1;
+      sets.push(`${sql} = $${p}`);
+    };
+
+    if (patch.status !== undefined) add("status", patch.status);
+    if (patch.currentState !== undefined) add("current_state", patch.currentState);
+    if (patch.context !== undefined) {
+      params.push(JSON.stringify(patch.context));
+      p += 1;
+      sets.push(`context = $${p}::jsonb`);
+    }
+    if (patch.attemptCounts !== undefined) {
+      params.push(JSON.stringify(patch.attemptCounts));
+      p += 1;
+      sets.push(`attempt_counts = $${p}::jsonb`);
+    }
+    if (patch.wakeAt !== undefined) add("wake_at", patch.wakeAt);
+    if (patch.stateDeadline !== undefined) add("state_deadline", patch.stateDeadline);
+    if (patch.approvalId !== undefined) add("approval_id", patch.approvalId);
+    if (patch.output !== undefined) {
+      params.push(patch.output === null ? null : JSON.stringify(patch.output));
+      p += 1;
+      sets.push(`output = $${p}::jsonb`);
+    }
+    if (patch.error !== undefined) {
+      params.push(patch.error === null ? null : JSON.stringify(patch.error));
+      p += 1;
+      sets.push(`error = $${p}::jsonb`);
+    }
+    if (patch.finished) sets.push("finished_at = now()");
+
+    let guard = "status = $2";
+    if (expected.currentState !== undefined) {
+      params.push(expected.currentState);
+      p += 1;
+      guard += ` AND current_state IS NOT DISTINCT FROM $${p}`;
+    }
+
+    const { rows } = await this.db.query(
+      `UPDATE routine_runs SET ${sets.join(", ")} WHERE id = $1 AND ${guard} RETURNING id`,
+      params
+    );
+    return rows.length > 0;
+  }
+
+  /** Heartbeat for the sweep's stale-run detection. */
+  async touch(id: string): Promise<void> {
+    await this.db.query("UPDATE routine_runs SET updated_at = now() WHERE id = $1", [id]);
+  }
+
+  /** Runs whose wake time passed but no wake job fired (crash window healing). */
+  async listOverdueWakes(now: Date): Promise<RoutineRunRow[]> {
+    const { rows } = await this.db.query(
+      `SELECT ${COLS} FROM routine_runs
+       WHERE wake_at IS NOT NULL AND wake_at <= $1 AND status IN ('sleeping', 'running')`,
+      [now]
+    );
+    return rows.map(rowToRun);
+  }
+
+  /** Runs whose per-state deadline passed while still running. */
+  async listExpiredDeadlines(now: Date): Promise<RoutineRunRow[]> {
+    const { rows } = await this.db.query(
+      `SELECT ${COLS} FROM routine_runs
+       WHERE state_deadline IS NOT NULL AND state_deadline <= $1 AND status = 'running'`,
+      [now]
+    );
+    return rows.map(rowToRun);
+  }
+
+  /** Next journal seq for a run (1-based). */
+  async nextSeq(runId: string): Promise<number> {
+    const { rows } = await this.db.query(
+      "SELECT COALESCE(MAX(seq), 0) AS max FROM routine_run_events WHERE run_id = $1",
+      [runId]
+    );
+    return Number(rows[0]?.max ?? 0) + 1;
+  }
+
+  async appendEvent(event: RunJournalEvent): Promise<void> {
+    await this.db.query(
+      `INSERT INTO routine_run_events (run_id, seq, type, payload, created_at)
+       VALUES ($1, $2, $3, $4::jsonb, $5)
+       ON CONFLICT (run_id, seq) DO NOTHING`,
+      [event.runId, event.seq, event.type, JSON.stringify(event.payload), event.createdAt]
+    );
+  }
+
+  async listEvents(runId: string, afterSeq = 0): Promise<RunJournalEvent[]> {
+    const { rows } = await this.db.query(
+      `SELECT run_id, seq, type, payload, created_at FROM routine_run_events
+       WHERE run_id = $1 AND seq > $2 ORDER BY seq`,
+      [runId, afterSeq]
+    );
+    return rows.map((r) => ({
+      runId: r.run_id as string,
+      seq: Number(r.seq),
+      type: r.type as string,
+      payload: r.payload,
+      createdAt: r.created_at as Date,
+    }));
+  }
+}

--- a/apps/api/src/routines/routes.test.ts
+++ b/apps/api/src/routines/routes.test.ts
@@ -1,0 +1,460 @@
+import type { PGlite } from "@electric-sql/pglite";
+import type { SoulLoader, SoulRoutine } from "@tulipfarm/soul";
+import type { FastifyInstance } from "fastify";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildApp } from "../app";
+import type { TokenDoc, TokenRepo } from "../auth/api-tokens";
+import { CSRF_COOKIE, CSRF_HEADER } from "../auth/csrf";
+import { SESSION_COOKIE } from "../auth/routes";
+import { MemorySessionStore } from "../auth/session-store";
+import { createUser, type UserDoc, type UserRepo } from "../auth/users";
+import { StreamHub } from "../chat/stream-hub";
+import type { PaginatedResult } from "../pagination";
+import { runPgMigrations } from "../pg-migrate";
+import { makePglite } from "../test/pglite";
+import type { RoutineRunJob, RoutineWakeJob } from "./jobs";
+import { RoutineRegistry } from "./registry";
+import { RoutineRunsRepo } from "./repo";
+import { WEBHOOK_SECRET_HEADER } from "./routes";
+import { RoutineTriggerService } from "./trigger-service";
+
+const TEST_CSRF = "a".repeat(64);
+
+class FakeUserRepo implements UserRepo {
+  private users: UserDoc[] = [];
+  async findByEmail(email: string): Promise<UserDoc | null> {
+    return this.users.find((u) => u.email === email.trim().toLowerCase()) ?? null;
+  }
+  async findById(id: string): Promise<UserDoc | null> {
+    return this.users.find((u) => u._id === id) ?? null;
+  }
+  async count(): Promise<number> {
+    return this.users.length;
+  }
+  async insert(user: UserDoc): Promise<void> {
+    this.users.push(user);
+  }
+}
+
+class FakeTokenRepo implements TokenRepo {
+  async create(): Promise<void> {}
+  async findByHash(): Promise<TokenDoc | null> {
+    return null;
+  }
+  async findByUserId(): Promise<TokenDoc[]> {
+    return [];
+  }
+  async findAll(): Promise<TokenDoc[]> {
+    return [];
+  }
+  async findById(): Promise<TokenDoc | null> {
+    return null;
+  }
+  async deleteById(): Promise<void> {}
+  async findAllPaginated(): Promise<PaginatedResult<TokenDoc>> {
+    return { items: [], nextCursor: null };
+  }
+  async findByUserIdPaginated(): Promise<PaginatedResult<TokenDoc>> {
+    return { items: [], nextCursor: null };
+  }
+}
+
+const ROUTINE_CONFIG: Record<string, unknown> = {
+  id: "expense-report",
+  version: "1.0",
+  name: "Expense Report",
+  start: "Record",
+  "x-triggers": [
+    { type: "manual" },
+    { type: "webhook", secret_ref: "expense-hook-secret" },
+    { type: "agent" },
+  ],
+  "x-inputs": {
+    type: "object",
+    additionalProperties: false,
+    required: ["amount"],
+    properties: { amount: { type: "number" }, memo: { type: "string" } },
+  },
+  functions: [{ name: "record", operation: "tool:resource_create" }],
+  states: [
+    {
+      name: "Record",
+      type: "operation",
+      actions: [{ functionRef: { refName: "record" } }],
+      end: true,
+    },
+  ],
+};
+
+function makeSoulLoader(routines: Record<string, Record<string, unknown>>): SoulLoader {
+  const map = new Map<string, SoulRoutine>();
+  for (const [name, config] of Object.entries(routines)) {
+    map.set(name, { name, config, hasHooks: false });
+  }
+  return { routines: map, reload: vi.fn() } as unknown as SoulLoader;
+}
+
+describe("routine routes", () => {
+  let app: FastifyInstance;
+  let db: PGlite;
+  let sid: string;
+  let runs: RoutineRunsRepo;
+  let registry: RoutineRegistry;
+  let enqueuedRuns: RoutineRunJob[];
+
+  beforeEach(async () => {
+    db = await makePglite();
+    await runPgMigrations(db);
+    const store = new MemorySessionStore();
+    const userRepo = new FakeUserRepo();
+    const user = await createUser(userRepo, "user@example.com", "pass", "member");
+    sid = await store.create(user._id);
+
+    const log = { error: vi.fn(), warn: vi.fn() };
+    registry = new RoutineRegistry(
+      makeSoulLoader({ "expense-report": ROUTINE_CONFIG, broken: { id: "broken" } }),
+      log
+    );
+    registry.refresh();
+    runs = new RoutineRunsRepo(db);
+    enqueuedRuns = [];
+    const enqueuers = {
+      enqueueRun: async (job: RoutineRunJob) => {
+        enqueuedRuns.push(job);
+      },
+      enqueueWake: async (_job: RoutineWakeJob & { startAfter?: Date }) => {},
+    };
+    const triggerService = new RoutineTriggerService({ registry, runs, enqueuers, log });
+
+    app = await buildApp({
+      sessionStore: store,
+      userRepo,
+      tokenRepo: new FakeTokenRepo(),
+      routines: {
+        registry,
+        runs,
+        triggerService,
+        enqueuers,
+        getSecret: async (key: string) => {
+          if (key === "expense-hook-secret") return "s3cret";
+          throw new Error("secret not found");
+        },
+        hub: new StreamHub(),
+      },
+    });
+  });
+
+  afterEach(async () => {
+    await app.close();
+    await db.close();
+  });
+
+  const authed = () => ({ [SESSION_COOKIE]: sid, [CSRF_COOKIE]: TEST_CSRF });
+  const csrf = { [CSRF_HEADER]: TEST_CSRF };
+
+  it("GET /routines lists valid and invalid entries", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/v1/routines", cookies: authed() });
+    expect(res.statusCode).toBe(200);
+    const { items } = res.json() as { items: Array<Record<string, unknown>> };
+    const valid = items.find((i) => i.slug === "expense-report");
+    expect(valid).toMatchObject({ valid: true, name: "Expense Report" });
+    expect(valid?.triggers).toHaveLength(3);
+    const broken = items.find((i) => i.slug === "broken");
+    expect(broken?.valid).toBe(false);
+    expect(broken?.loadError).toBeTruthy();
+  });
+
+  it("401 without auth on the listing", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/v1/routines" });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("POST manual run validates inputs against x-inputs and enqueues", async () => {
+    const bad = await app.inject({
+      method: "POST",
+      url: "/api/v1/routines/expense-report/runs",
+      cookies: authed(),
+      headers: csrf,
+      payload: { inputs: { memo: "no amount" } },
+    });
+    expect(bad.statusCode).toBe(400);
+    expect(enqueuedRuns).toHaveLength(0);
+
+    const good = await app.inject({
+      method: "POST",
+      url: "/api/v1/routines/expense-report/runs",
+      cookies: authed(),
+      headers: csrf,
+      payload: { inputs: { amount: 42 } },
+    });
+    expect(good.statusCode).toBe(202);
+    const { runId } = good.json() as { runId: string };
+    expect(enqueuedRuns).toHaveLength(1);
+
+    const run = await runs.findById(runId);
+    expect(run?.status).toBe("pending");
+    expect(run?.definitionSnapshot.id).toBe("expense-report");
+    expect(run?.context).toEqual({ amount: 42 });
+    expect(run?.trigger.type).toBe("manual");
+  });
+
+  it("404 on manual run for unknown routine; 422 for invalid routine", async () => {
+    const missing = await app.inject({
+      method: "POST",
+      url: "/api/v1/routines/nope/runs",
+      cookies: authed(),
+      headers: csrf,
+      payload: {},
+    });
+    expect(missing.statusCode).toBe(404);
+
+    const invalid = await app.inject({
+      method: "POST",
+      url: "/api/v1/routines/broken/runs",
+      cookies: authed(),
+      headers: csrf,
+      payload: {},
+    });
+    expect(invalid.statusCode).toBe(422);
+  });
+
+  it("GET run history and run detail with journal", async () => {
+    const created = await app.inject({
+      method: "POST",
+      url: "/api/v1/routines/expense-report/runs",
+      cookies: authed(),
+      headers: csrf,
+      payload: { inputs: { amount: 10 } },
+    });
+    const { runId } = created.json() as { runId: string };
+    await runs.appendEvent({
+      runId,
+      seq: 1,
+      type: "run.started",
+      payload: {},
+      createdAt: new Date(),
+    });
+
+    const list = await app.inject({
+      method: "GET",
+      url: "/api/v1/routines/expense-report/runs",
+      cookies: authed(),
+    });
+    expect(list.statusCode).toBe(200);
+    expect((list.json() as { items: unknown[] }).items).toHaveLength(1);
+
+    const detail = await app.inject({
+      method: "GET",
+      url: `/api/v1/routines/expense-report/runs/${runId}`,
+      cookies: authed(),
+    });
+    expect(detail.statusCode).toBe(200);
+    const body = detail.json() as { run: Record<string, unknown>; events: unknown[] };
+    expect(body.run.status).toBe("pending");
+    expect(body.events).toHaveLength(1);
+
+    const wrongSlug = await app.inject({
+      method: "GET",
+      url: `/api/v1/routines/broken/runs/${runId}`,
+      cookies: authed(),
+    });
+    expect(wrongSlug.statusCode).toBe(404);
+  });
+
+  it("cancel endpoint cancels a pending run and 409s on terminal runs", async () => {
+    const created = await app.inject({
+      method: "POST",
+      url: "/api/v1/routines/expense-report/runs",
+      cookies: authed(),
+      headers: csrf,
+      payload: { inputs: { amount: 10 } },
+    });
+    const { runId } = created.json() as { runId: string };
+
+    const cancel = await app.inject({
+      method: "POST",
+      url: `/api/v1/routines/expense-report/runs/${runId}/cancel`,
+      cookies: authed(),
+      headers: csrf,
+    });
+    expect(cancel.statusCode).toBe(200);
+    expect((await runs.findById(runId))?.status).toBe("cancelled");
+
+    const again = await app.inject({
+      method: "POST",
+      url: `/api/v1/routines/expense-report/runs/${runId}/cancel`,
+      cookies: authed(),
+      headers: csrf,
+    });
+    expect(again.statusCode).toBe(409);
+  });
+
+  describe("run SSE stream (D7)", () => {
+    it("replays journaled events over SSE and closes on the terminal event", async () => {
+      const created = await app.inject({
+        method: "POST",
+        url: "/api/v1/routines/expense-report/runs",
+        cookies: authed(),
+        headers: csrf,
+        payload: { inputs: { amount: 10 } },
+      });
+      const { runId } = created.json() as { runId: string };
+      const at = new Date();
+      await runs.appendEvent({ runId, seq: 1, type: "run.started", payload: {}, createdAt: at });
+      await runs.appendEvent({
+        runId,
+        seq: 2,
+        type: "finish",
+        payload: { reason: "completed" },
+        createdAt: at,
+      });
+
+      const res = await app.inject({
+        method: "GET",
+        url: `/api/v1/routines/expense-report/runs/${runId}/events`,
+        cookies: authed(),
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.headers["content-type"]).toContain("text/event-stream");
+      expect(res.body).toContain("event: run.started");
+      expect(res.body).toContain("event: finish");
+      expect(res.body).toContain("id: 2");
+    });
+
+    it("resumes from Last-Event-ID, skipping already-seen events", async () => {
+      const created = await app.inject({
+        method: "POST",
+        url: "/api/v1/routines/expense-report/runs",
+        cookies: authed(),
+        headers: csrf,
+        payload: { inputs: { amount: 10 } },
+      });
+      const { runId } = created.json() as { runId: string };
+      const at = new Date();
+      await runs.appendEvent({ runId, seq: 1, type: "run.started", payload: {}, createdAt: at });
+      await runs.appendEvent({ runId, seq: 2, type: "state.entered", payload: {}, createdAt: at });
+      await runs.appendEvent({ runId, seq: 3, type: "finish", payload: {}, createdAt: at });
+
+      const res = await app.inject({
+        method: "GET",
+        url: `/api/v1/routines/expense-report/runs/${runId}/events`,
+        cookies: authed(),
+        headers: { "last-event-id": "2" },
+      });
+      expect(res.body).not.toContain("event: run.started");
+      expect(res.body).toContain("event: finish");
+    });
+
+    it("404s for an unknown run", async () => {
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/routines/expense-report/runs/00000000-0000-0000-0000-000000000000/events",
+        cookies: authed(),
+      });
+      expect(res.statusCode).toBe(404);
+    });
+  });
+
+  describe("webhook seam (D6)", () => {
+    it("rejects without or with a wrong secret header", async () => {
+      const missing = await app.inject({
+        method: "POST",
+        url: "/api/v1/hooks/routines/expense-report",
+        payload: { amount: 5 },
+      });
+      expect(missing.statusCode).toBe(401);
+
+      const wrong = await app.inject({
+        method: "POST",
+        url: "/api/v1/hooks/routines/expense-report",
+        headers: { [WEBHOOK_SECRET_HEADER]: "nope" },
+        payload: { amount: 5 },
+      });
+      expect(wrong.statusCode).toBe(401);
+      expect(enqueuedRuns).toHaveLength(0);
+    });
+
+    it("accepts with the right secret, no session/CSRF involved", async () => {
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/v1/hooks/routines/expense-report",
+        headers: { [WEBHOOK_SECRET_HEADER]: "s3cret" },
+        payload: { amount: 7 },
+      });
+      expect(res.statusCode).toBe(202);
+      expect(enqueuedRuns).toHaveLength(1);
+      const run = await runs.findById((res.json() as { runId: string }).runId);
+      expect(run?.trigger.type).toBe("webhook");
+      expect(run?.context).toEqual({ amount: 7 });
+    });
+
+    it("validates webhook payloads against x-inputs too (D8)", async () => {
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/v1/hooks/routines/expense-report",
+        headers: { [WEBHOOK_SECRET_HEADER]: "s3cret" },
+        payload: { memo: "missing amount" },
+      });
+      expect(res.statusCode).toBe(400);
+    });
+
+    it("404s when the routine has no webhook trigger", async () => {
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/v1/hooks/routines/broken",
+        headers: { [WEBHOOK_SECRET_HEADER]: "s3cret" },
+        payload: {},
+      });
+      expect(res.statusCode).toBe(404);
+    });
+
+    it("rejects when the secret is unresolvable (never open)", async () => {
+      const soul = makeSoulLoader({
+        orphan: {
+          ...ROUTINE_CONFIG,
+          id: "orphan",
+          "x-triggers": [{ type: "webhook", secret_ref: "missing-secret" }],
+        },
+      });
+      const log = { error: vi.fn(), warn: vi.fn() };
+      const orphanRegistry = new RoutineRegistry(soul, log);
+      orphanRegistry.refresh();
+      const orphanRuns = new RoutineRunsRepo(db);
+      const enqueuers = {
+        enqueueRun: async () => {},
+        enqueueWake: async () => {},
+      };
+      const orphanApp = await buildApp({
+        sessionStore: new MemorySessionStore(),
+        userRepo: new FakeUserRepo(),
+        tokenRepo: new FakeTokenRepo(),
+        routines: {
+          registry: orphanRegistry,
+          runs: orphanRuns,
+          triggerService: new RoutineTriggerService({
+            registry: orphanRegistry,
+            runs: orphanRuns,
+            enqueuers,
+            log,
+          }),
+          enqueuers,
+          getSecret: async () => {
+            throw new Error("secret not found");
+          },
+        },
+      });
+      try {
+        const res = await orphanApp.inject({
+          method: "POST",
+          url: "/api/v1/hooks/routines/orphan",
+          headers: { [WEBHOOK_SECRET_HEADER]: "anything" },
+          payload: { amount: 1 },
+        });
+        expect(res.statusCode).toBe(401);
+        expect((res.json() as { error: string }).error).toContain("not configured");
+      } finally {
+        await orphanApp.close();
+      }
+    });
+  });
+});

--- a/apps/api/src/routines/routes.ts
+++ b/apps/api/src/routines/routes.ts
@@ -1,0 +1,489 @@
+import { timingSafeEqual } from "node:crypto";
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { ErrorSchema } from "../auth/schemas";
+import { attachToStream } from "../chat/producer";
+import { writeSseHeaders } from "../chat/sse";
+import type { StreamHub } from "../chat/stream-hub";
+import { corsPassthrough, parseLastEventId } from "../chat/turn-helpers";
+import type { RoutineEnqueuers } from "./jobs";
+import type { RoutineRegistry } from "./registry";
+import type { RoutineRunsRepo } from "./repo";
+import { RunJournalStreamRepo, runStreamId } from "./stream-adapter";
+import { RoutineTriggerError, type RoutineTriggerService } from "./trigger-service";
+
+type PreHandler = (req: FastifyRequest, reply: FastifyReply) => Promise<void>;
+
+export const WEBHOOK_SECRET_HEADER = "x-tulipfarm-webhook-secret";
+
+export interface RoutineRoutesDeps {
+  registry: RoutineRegistry;
+  runs: RoutineRunsRepo;
+  triggerService: RoutineTriggerService;
+  enqueuers: RoutineEnqueuers;
+  /** Resolves a webhook trigger's secret_ref. */
+  getSecret: (key: string) => Promise<string>;
+  /** Live fan-out for run SSE (the driver publishes into the same hub). */
+  hub?: StreamHub;
+}
+
+const RUN_SUMMARY_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["id", "routineSlug", "status", "createdAt"],
+  properties: {
+    id: { type: "string" },
+    routineSlug: { type: "string" },
+    status: { type: "string" },
+    currentState: { type: "string", nullable: true },
+    trigger: {},
+    output: {},
+    error: {},
+    createdAt: { type: "string" },
+    updatedAt: { type: "string" },
+    finishedAt: { type: "string", nullable: true },
+  },
+} as const;
+
+function triggerErrorReply(reply: FastifyReply, err: unknown): FastifyReply | null {
+  if (!(err instanceof RoutineTriggerError)) return null;
+  const status =
+    err.code === "not_found" ? 404 : err.code === "invalid_inputs" ? 400 : (422 as const);
+  return reply.code(status).send({ error: err.message });
+}
+
+function constantTimeEquals(a: string, b: string): boolean {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  return ab.length === bb.length && timingSafeEqual(ab, bb);
+}
+
+/**
+ * Routine API (v0.11): listing, run history/detail, manual trigger, cancel, and the V1
+ * webhook seam. The webhook route is deliberately outside session auth + CSRF (external
+ * callers; CSRF only fires with a session cookie anyway) and is gated by a
+ * constant-time shared-secret header check against the trigger's `secret_ref` (D6).
+ */
+export function registerRoutineRoutes(
+  app: FastifyInstance,
+  deps: RoutineRoutesDeps,
+  requireAuth: PreHandler
+): void {
+  const { registry, runs, triggerService } = deps;
+
+  app.get(
+    "/api/v1/routines",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description:
+          "List all routines from the soul: valid ones with their triggers and manual-input " +
+          "schema, invalid ones with their validation error (they never crash boot).",
+        tags: ["routines"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        response: {
+          200: {
+            type: "object",
+            additionalProperties: false,
+            required: ["items"],
+            properties: {
+              items: {
+                type: "array",
+                items: {
+                  type: "object",
+                  additionalProperties: false,
+                  required: ["slug", "valid"],
+                  properties: {
+                    slug: { type: "string" },
+                    valid: { type: "boolean" },
+                    name: { type: "string", nullable: true },
+                    description: { type: "string", nullable: true },
+                    triggers: { type: "array", items: {} },
+                    inputs: {},
+                    hasHooks: { type: "boolean" },
+                    loadError: { type: "string", nullable: true },
+                  },
+                },
+              },
+            },
+          },
+          401: ErrorSchema,
+        },
+      },
+    },
+    async (_req, reply) => {
+      const items = registry.list().map((entry) =>
+        entry.ok
+          ? {
+              slug: entry.slug,
+              valid: true,
+              name: entry.definition.name ?? entry.definition.id,
+              description: entry.definition.description ?? null,
+              triggers: entry.definition["x-triggers"],
+              inputs: entry.definition["x-inputs"] ?? null,
+              hasHooks: Boolean(entry.hookSource),
+              loadError: null,
+            }
+          : { slug: entry.slug, valid: false, loadError: entry.loadError }
+      );
+      return reply.send({ items });
+    }
+  );
+
+  app.get(
+    "/api/v1/routines/:slug/runs",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description: "Run history for a routine, newest first.",
+        tags: ["routines"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        params: {
+          type: "object",
+          required: ["slug"],
+          properties: { slug: { type: "string", minLength: 1 } },
+        },
+        querystring: {
+          type: "object",
+          additionalProperties: false,
+          properties: { limit: { type: "integer", minimum: 1, maximum: 200 } },
+        },
+        response: {
+          200: {
+            type: "object",
+            additionalProperties: false,
+            required: ["items"],
+            properties: { items: { type: "array", items: RUN_SUMMARY_SCHEMA } },
+          },
+          401: ErrorSchema,
+          404: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const { slug } = req.params as { slug: string };
+      const { limit } = req.query as { limit?: number };
+      if (!registry.getEntry(slug)) return reply.code(404).send({ error: "routine not found" });
+      const items = (await runs.listBySlug(slug, limit ?? 50)).map(toRunSummary);
+      return reply.send({ items });
+    }
+  );
+
+  app.get(
+    "/api/v1/routines/:slug/runs/:runId",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description:
+          "Run detail: current status, pinned definition hash, data context, and the full " +
+          "journal (durable event history — also the SSE replay source).",
+        tags: ["routines"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        params: {
+          type: "object",
+          required: ["slug", "runId"],
+          properties: {
+            slug: { type: "string", minLength: 1 },
+            runId: { type: "string", minLength: 1 },
+          },
+        },
+        response: {
+          200: {
+            type: "object",
+            additionalProperties: false,
+            required: ["run", "events"],
+            properties: {
+              run: {
+                ...RUN_SUMMARY_SCHEMA,
+                properties: {
+                  ...RUN_SUMMARY_SCHEMA.properties,
+                  context: {},
+                  definitionHash: { type: "string" },
+                  attemptCounts: {},
+                  approvalId: { type: "string", nullable: true },
+                },
+              },
+              events: {
+                type: "array",
+                items: {
+                  type: "object",
+                  additionalProperties: false,
+                  required: ["seq", "type"],
+                  properties: {
+                    seq: { type: "integer" },
+                    type: { type: "string" },
+                    payload: {},
+                    createdAt: { type: "string" },
+                  },
+                },
+              },
+            },
+          },
+          401: ErrorSchema,
+          404: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const { slug, runId } = req.params as { slug: string; runId: string };
+      const run = await runs.findById(runId);
+      if (!run || run.routineSlug !== slug) {
+        return reply.code(404).send({ error: "run not found" });
+      }
+      const events = await runs.listEvents(runId);
+      return reply.send({
+        run: {
+          ...toRunSummary(run),
+          context: run.context,
+          definitionHash: run.definitionHash,
+          attemptCounts: run.attemptCounts,
+          approvalId: run.approvalId,
+        },
+        events: events.map((e) => ({
+          seq: e.seq,
+          type: e.type,
+          payload: e.payload,
+          createdAt: e.createdAt.toISOString(),
+        })),
+      });
+    }
+  );
+
+  app.post(
+    "/api/v1/routines/:slug/runs",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description:
+          "Manually trigger a routine. The body is validated against the routine's x-inputs " +
+          "JSON Schema (the same gate webhook and agent triggers pass through).",
+        tags: ["routines"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        params: {
+          type: "object",
+          required: ["slug"],
+          properties: { slug: { type: "string", minLength: 1 } },
+        },
+        body: {
+          type: "object",
+          additionalProperties: false,
+          properties: { inputs: { type: "object" } },
+        },
+        response: {
+          202: {
+            type: "object",
+            additionalProperties: false,
+            required: ["runId"],
+            properties: { runId: { type: "string" } },
+          },
+          400: ErrorSchema,
+          401: ErrorSchema,
+          404: ErrorSchema,
+          422: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const { slug } = req.params as { slug: string };
+      const { inputs } = (req.body ?? {}) as { inputs?: Record<string, unknown> };
+      try {
+        const { runId } = await triggerService.trigger(slug, {
+          type: "manual",
+          payload: inputs ?? {},
+        });
+        return reply.code(202).send({ runId });
+      } catch (err) {
+        const handled = triggerErrorReply(reply, err);
+        if (handled) return handled;
+        throw err;
+      }
+    }
+  );
+
+  app.post(
+    "/api/v1/routines/:slug/runs/:runId/cancel",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description:
+          "Cancel a run. Pending/sleeping/waiting runs cancel immediately; a running run is " +
+          "cancelled at its next state boundary (the driver's CAS transition misses).",
+        tags: ["routines"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        params: {
+          type: "object",
+          required: ["slug", "runId"],
+          properties: {
+            slug: { type: "string", minLength: 1 },
+            runId: { type: "string", minLength: 1 },
+          },
+        },
+        response: {
+          200: {
+            type: "object",
+            additionalProperties: false,
+            required: ["status"],
+            properties: { status: { type: "string" } },
+          },
+          401: ErrorSchema,
+          404: ErrorSchema,
+          409: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const { slug, runId } = req.params as { slug: string; runId: string };
+      const run = await runs.findById(runId);
+      if (!run || run.routineSlug !== slug) {
+        return reply.code(404).send({ error: "run not found" });
+      }
+      if (["succeeded", "failed", "cancelled"].includes(run.status)) {
+        return reply.code(409).send({ error: `run already ${run.status}` });
+      }
+      const ok = await runs.transition(
+        runId,
+        { status: run.status },
+        { status: "cancelled", wakeAt: null, stateDeadline: null, finished: true }
+      );
+      if (!ok) return reply.code(409).send({ error: "run state changed; retry" });
+      return reply.send({ status: "cancelled" });
+    }
+  );
+
+  if (deps.hub) {
+    const hub = deps.hub;
+    const journalRepo = new RunJournalStreamRepo(runs);
+    app.get(
+      "/api/v1/routines/:slug/runs/:runId/events",
+      {
+        preHandler: requireAuth,
+        schema: {
+          description:
+            "Live SSE stream of a run's events (state transitions, outputs). Replays from the " +
+            "durable journal via `Last-Event-ID` (or ?lastEventId=) — works for runs of any age. " +
+            'Suspended runs close with a finish event `{reason: "suspended"}`; reconnect on wake.',
+          tags: ["routines"],
+          security: [{ sessionCookie: [] }, { bearerToken: [] }],
+          params: {
+            type: "object",
+            required: ["slug", "runId"],
+            properties: {
+              slug: { type: "string", minLength: 1 },
+              runId: { type: "string", minLength: 1 },
+            },
+          },
+          querystring: {
+            type: "object",
+            properties: { lastEventId: { type: "integer", minimum: 0 } },
+          },
+          response: { 401: ErrorSchema, 404: ErrorSchema },
+        },
+      },
+      async (req, reply) => {
+        const { slug, runId } = req.params as { slug: string; runId: string };
+        const run = await runs.findById(runId);
+        if (!run || run.routineSlug !== slug) {
+          return reply.code(404).send({ error: "run not found" });
+        }
+        const afterSeq = parseLastEventId(
+          req.headers["last-event-id"],
+          (req.query as { lastEventId?: number }).lastEventId
+        );
+        writeSseHeaders(reply.raw, corsPassthrough(reply));
+        reply.hijack();
+        await attachToStream(reply.raw, runStreamId(runId), afterSeq, {
+          repo: journalRepo,
+          hub,
+        });
+      }
+    );
+  }
+
+  // ── Webhook seam (D6) — NO session auth, NO CSRF (no session cookie involved) ──
+  app.post(
+    "/api/v1/hooks/routines/:slug",
+    {
+      schema: {
+        description:
+          "Inbound webhook trigger for a routine (V1 seam; full integration ingress is v0.12). " +
+          `Auth: constant-time match of the "${WEBHOOK_SECRET_HEADER}" header against the ` +
+          "routine's webhook trigger secret_ref. Rejects when no secret is configured — never open.",
+        tags: ["routines"],
+        params: {
+          type: "object",
+          required: ["slug"],
+          properties: { slug: { type: "string", minLength: 1 } },
+        },
+        response: {
+          202: {
+            type: "object",
+            additionalProperties: false,
+            required: ["runId"],
+            properties: { runId: { type: "string" } },
+          },
+          400: ErrorSchema,
+          401: ErrorSchema,
+          404: ErrorSchema,
+          422: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const { slug } = req.params as { slug: string };
+      const routine = registry.get(slug);
+      const webhookTrigger = routine?.definition["x-triggers"].find((t) => t.type === "webhook");
+      if (!routine || !webhookTrigger || webhookTrigger.type !== "webhook") {
+        return reply.code(404).send({ error: "routine or webhook trigger not found" });
+      }
+
+      let secret: string;
+      try {
+        secret = await deps.getSecret(webhookTrigger.secret_ref);
+      } catch {
+        return reply.code(401).send({ error: "webhook secret not configured" });
+      }
+      const presented = req.headers[WEBHOOK_SECRET_HEADER];
+      const presentedValue = Array.isArray(presented) ? presented[0] : presented;
+      if (!presentedValue || !constantTimeEquals(presentedValue, secret)) {
+        return reply.code(401).send({ error: "invalid webhook secret" });
+      }
+
+      try {
+        const { runId } = await triggerService.trigger(slug, {
+          type: "webhook",
+          payload: req.body ?? {},
+        });
+        return reply.code(202).send({ runId });
+      } catch (err) {
+        const handled = triggerErrorReply(reply, err);
+        if (handled) return handled;
+        throw err;
+      }
+    }
+  );
+}
+
+function toRunSummary(run: {
+  id: string;
+  routineSlug: string;
+  status: string;
+  currentState: string | null;
+  trigger: unknown;
+  output: unknown;
+  error: unknown;
+  createdAt: Date;
+  updatedAt: Date;
+  finishedAt: Date | null;
+}) {
+  return {
+    id: run.id,
+    routineSlug: run.routineSlug,
+    status: run.status,
+    currentState: run.currentState,
+    trigger: run.trigger,
+    output: run.output,
+    error: run.error,
+    createdAt: run.createdAt.toISOString(),
+    updatedAt: run.updatedAt.toISOString(),
+    finishedAt: run.finishedAt ? run.finishedAt.toISOString() : null,
+  };
+}

--- a/apps/api/src/routines/schedules.test.ts
+++ b/apps/api/src/routines/schedules.test.ts
@@ -1,0 +1,103 @@
+import type { SoulLoader, SoulRoutine } from "@tulipfarm/soul";
+import type { PgBoss } from "pg-boss";
+import { describe, expect, it, vi } from "vitest";
+import { RoutineRegistry } from "./registry";
+import { ROUTINE_CRON_QUEUE, reconcileRoutineSchedules } from "./schedules";
+
+function makeRegistry(routines: Record<string, Record<string, unknown>>): RoutineRegistry {
+  const map = new Map<string, SoulRoutine>();
+  for (const [name, config] of Object.entries(routines)) {
+    map.set(name, { name, config, hasHooks: false });
+  }
+  const loader = { routines: map, reload: vi.fn() } as unknown as SoulLoader;
+  const registry = new RoutineRegistry(loader, { error: vi.fn(), warn: vi.fn() });
+  registry.refresh();
+  return registry;
+}
+
+function cronRoutine(id: string, schedule: string, timezone?: string): Record<string, unknown> {
+  return {
+    id,
+    version: "1.0",
+    start: "S",
+    "x-triggers": [{ type: "cron", schedule, ...(timezone ? { timezone } : {}) }],
+    states: [{ name: "S", type: "inject", data: {}, end: true }],
+  };
+}
+
+function makeBoss(existing: Array<{ key: string; cron: string; timezone: string }>) {
+  return {
+    getSchedules: vi.fn(async () => existing.map((s) => ({ ...s, name: ROUTINE_CRON_QUEUE }))),
+    schedule: vi.fn(async () => {}),
+    unschedule: vi.fn(async () => {}),
+  } as unknown as PgBoss;
+}
+
+const LOG = { error: vi.fn(), warn: vi.fn() };
+
+describe("reconcileRoutineSchedules", () => {
+  it("schedules new cron triggers with keyed schedules and tz", async () => {
+    const registry = makeRegistry({
+      "daily-report": cronRoutine("daily-report", "0 9 * * *", "Europe/Berlin"),
+    });
+    const boss = makeBoss([]);
+
+    await reconcileRoutineSchedules(boss, registry, LOG);
+
+    expect(boss.schedule).toHaveBeenCalledWith(
+      ROUTINE_CRON_QUEUE,
+      "0 9 * * *",
+      { slug: "daily-report", triggerIndex: 0 },
+      { key: "daily-report.0", tz: "Europe/Berlin" }
+    );
+    expect(boss.unschedule).not.toHaveBeenCalled();
+  });
+
+  it("leaves unchanged schedules alone and updates changed crons", async () => {
+    const registry = makeRegistry({
+      same: cronRoutine("same", "0 9 * * *"),
+      changed: cronRoutine("changed", "30 6 * * 1"),
+    });
+    const boss = makeBoss([
+      { key: "same.0", cron: "0 9 * * *", timezone: "UTC" },
+      { key: "changed.0", cron: "0 0 * * *", timezone: "UTC" },
+    ]);
+
+    await reconcileRoutineSchedules(boss, registry, LOG);
+
+    expect(boss.schedule).toHaveBeenCalledTimes(1);
+    expect(boss.schedule).toHaveBeenCalledWith(
+      ROUTINE_CRON_QUEUE,
+      "30 6 * * 1",
+      { slug: "changed", triggerIndex: 0 },
+      { key: "changed.0", tz: "UTC" }
+    );
+  });
+
+  it("unschedules keys whose routine disappeared (deletion dedup)", async () => {
+    const registry = makeRegistry({});
+    const boss = makeBoss([{ key: "gone.0", cron: "0 9 * * *", timezone: "UTC" }]);
+
+    await reconcileRoutineSchedules(boss, registry, LOG);
+
+    expect(boss.unschedule).toHaveBeenCalledWith(ROUTINE_CRON_QUEUE, "gone.0");
+    expect(boss.schedule).not.toHaveBeenCalled();
+  });
+
+  it("ignores invalid routines and non-cron triggers", async () => {
+    const registry = makeRegistry({
+      manualOnly: {
+        id: "manualOnly",
+        version: "1.0",
+        start: "S",
+        "x-triggers": [{ type: "manual" }],
+        states: [{ name: "S", type: "inject", data: {}, end: true }],
+      },
+      broken: { id: "broken" },
+    });
+    const boss = makeBoss([]);
+
+    await reconcileRoutineSchedules(boss, registry, LOG);
+    expect(boss.schedule).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routines/schedules.ts
+++ b/apps/api/src/routines/schedules.ts
@@ -1,0 +1,91 @@
+import type { PgBoss } from "pg-boss";
+import type { RoutineRegistry } from "./registry";
+import type { RoutineTriggerService } from "./trigger-service";
+
+export const ROUTINE_CRON_QUEUE = "routine-cron";
+
+type SchedulesLogger = {
+  error: (obj: unknown, msg?: string) => void;
+  warn: (obj: unknown, msg?: string) => void;
+};
+
+interface CronJobData {
+  slug: string;
+  triggerIndex: number;
+}
+
+/**
+ * One static `routine-cron` queue + keyed schedules (review fix B4): every cron trigger
+ * of every valid routine is a pg-boss schedule on the same queue with
+ * key `{slug}.{index}`. The single worker (registered once at boot) turns a firing into
+ * `trigger(slug, { type: "cron" })`. No dynamic per-slug queues — they would have no
+ * workers after reload.
+ */
+export async function registerRoutineCronWorker(
+  boss: PgBoss,
+  service: RoutineTriggerService,
+  log: SchedulesLogger
+): Promise<void> {
+  await boss.createQueue(ROUTINE_CRON_QUEUE);
+  await boss.work(ROUTINE_CRON_QUEUE, async (jobs) => {
+    for (const job of jobs) {
+      const data = job.data as unknown as CronJobData;
+      try {
+        await service.trigger(data.slug, { type: "cron" });
+      } catch (err) {
+        // Routine deleted/invalid between unschedule and firing — log, don't retry.
+        log.warn({ err, slug: data.slug }, "cron-triggered routine failed to start");
+      }
+    }
+  });
+}
+
+/**
+ * Diffs desired cron schedules (from the registry's valid routines) against pg-boss's
+ * keyed schedules on `routine-cron`: schedules new/changed ones (tz from
+ * `x-trigger.timezone`, default UTC) and unschedules keys whose routine or trigger
+ * disappeared (handles routine deletion). Runs at boot and on every `soul.synced`.
+ */
+export async function reconcileRoutineSchedules(
+  boss: PgBoss,
+  registry: RoutineRegistry,
+  log: SchedulesLogger
+): Promise<void> {
+  const desired = new Map<string, { cron: string; tz: string; data: CronJobData }>();
+  for (const routine of registry.valid()) {
+    routine.definition["x-triggers"].forEach((trigger, i) => {
+      if (trigger.type !== "cron") return;
+      desired.set(`${routine.slug}.${i}`, {
+        cron: trigger.schedule,
+        tz: trigger.timezone ?? "UTC",
+        data: { slug: routine.slug, triggerIndex: i },
+      });
+    });
+  }
+
+  const existing = await boss.getSchedules(ROUTINE_CRON_QUEUE);
+  const existingByKey = new Map(existing.map((s) => [s.key, s]));
+
+  for (const [key, want] of desired) {
+    const have = existingByKey.get(key);
+    if (have && have.cron === want.cron && (have.timezone ?? "UTC") === want.tz) continue;
+    try {
+      await boss.schedule(ROUTINE_CRON_QUEUE, want.cron, want.data as unknown as object, {
+        key,
+        tz: want.tz,
+      });
+    } catch (err) {
+      log.error({ err, key, cron: want.cron }, "failed to schedule routine cron");
+    }
+  }
+
+  for (const s of existing) {
+    if (!desired.has(s.key)) {
+      try {
+        await boss.unschedule(ROUTINE_CRON_QUEUE, s.key);
+      } catch (err) {
+        log.error({ err, key: s.key }, "failed to unschedule routine cron");
+      }
+    }
+  }
+}

--- a/apps/api/src/routines/stream-adapter.ts
+++ b/apps/api/src/routines/stream-adapter.ts
@@ -1,0 +1,47 @@
+import type { StreamEvent } from "../chat/stream-hub";
+import type { StreamResumeRepo } from "../chat/stream-resume";
+import type { RoutineRunsRepo } from "./repo";
+
+/** streamId for a run's SSE stream. Namespaced so it can never collide with chat ids. */
+export function runStreamId(runId: string): string {
+  return `routine-run:${runId}`;
+}
+
+function runIdOf(streamId: string): string {
+  return streamId.replace(/^routine-run:/, "");
+}
+
+/**
+ * StreamResumeRepo over `routine_run_events`: the journal IS the SSE replay buffer
+ * (review fix B1/B2). One write path — no stream_resume rows, no 1h GC, Last-Event-ID
+ * replay works for runs of any age, and emitter seq seeding falls out of `nextSeq`.
+ * `deleteOlderThan` is a no-op: run history is a product feature, never GC'd here.
+ */
+export class RunJournalStreamRepo implements StreamResumeRepo {
+  constructor(private readonly runs: RoutineRunsRepo) {}
+
+  async append(row: {
+    streamId: string;
+    seq: number;
+    eventType: string;
+    data: unknown;
+    createdAt: Date;
+  }): Promise<void> {
+    await this.runs.appendEvent({
+      runId: runIdOf(row.streamId),
+      seq: row.seq,
+      type: row.eventType,
+      payload: row.data,
+      createdAt: row.createdAt,
+    });
+  }
+
+  async listAfter(streamId: string, afterSeq: number): Promise<StreamEvent[]> {
+    const events = await this.runs.listEvents(runIdOf(streamId), afterSeq);
+    return events.map((e) => ({ seq: e.seq, eventType: e.type, data: e.payload }));
+  }
+
+  async deleteOlderThan(_cutoff: Date): Promise<number> {
+    return 0;
+  }
+}

--- a/apps/api/src/routines/trigger-service.test.ts
+++ b/apps/api/src/routines/trigger-service.test.ts
@@ -1,0 +1,141 @@
+import { EventEmitter } from "node:events";
+import type { PGlite } from "@electric-sql/pglite";
+import type { SoulLoader, SoulRoutine } from "@tulipfarm/soul";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DOMAIN_EVENTS } from "../domain-events";
+import { runPgMigrations } from "../pg-migrate";
+import { makePglite } from "../test/pglite";
+import type { RoutineRunJob } from "./jobs";
+import { RoutineRegistry } from "./registry";
+import { RoutineRunsRepo } from "./repo";
+import {
+  RoutineTriggerError,
+  RoutineTriggerService,
+  subscribeRoutineEventTriggers,
+} from "./trigger-service";
+
+function makeRegistry(routines: Record<string, Record<string, unknown>>): RoutineRegistry {
+  const map = new Map<string, SoulRoutine>();
+  for (const [name, config] of Object.entries(routines)) {
+    map.set(name, { name, config, hasHooks: false });
+  }
+  const loader = { routines: map, reload: vi.fn() } as unknown as SoulLoader;
+  const registry = new RoutineRegistry(loader, { error: vi.fn(), warn: vi.fn() });
+  registry.refresh();
+  return registry;
+}
+
+const EVENT_ROUTINE: Record<string, unknown> = {
+  id: "on-ticket",
+  version: "1.0",
+  start: "S",
+  "x-triggers": [
+    {
+      type: "event",
+      event: "resource.created",
+      filter: "trigger.payload.resourceType === 'ticket'",
+    },
+    { type: "manual" },
+  ],
+  functions: [{ name: "noop", operation: "tool:resource_search" }],
+  states: [
+    { name: "S", type: "operation", actions: [{ functionRef: { refName: "noop" } }], end: true },
+  ],
+};
+
+const LOG = { error: vi.fn(), warn: vi.fn() };
+
+describe("RoutineTriggerService", () => {
+  let db: PGlite;
+  let runs: RoutineRunsRepo;
+  let enqueued: RoutineRunJob[];
+
+  beforeEach(async () => {
+    db = await makePglite();
+    await runPgMigrations(db);
+    runs = new RoutineRunsRepo(db);
+    enqueued = [];
+  });
+
+  afterEach(async () => {
+    await db.close();
+  });
+
+  function makeService(
+    registry: RoutineRegistry,
+    evalFilter?: (c: string, s: Record<string, unknown>) => Promise<unknown>
+  ) {
+    return new RoutineTriggerService({
+      registry,
+      runs,
+      enqueuers: {
+        enqueueRun: async (job) => {
+          enqueued.push(job);
+        },
+        enqueueWake: async () => {},
+      },
+      evalFilter,
+      log: LOG,
+    });
+  }
+
+  it("rejects undeclared trigger types", async () => {
+    const service = makeService(makeRegistry({ "on-ticket": EVENT_ROUTINE }));
+    await expect(service.trigger("on-ticket", { type: "cron" })).rejects.toThrow(
+      RoutineTriggerError
+    );
+    await expect(service.trigger("on-ticket", { type: "cron" })).rejects.toThrow(
+      /does not declare/
+    );
+  });
+
+  it("creates the run with pinned snapshot + hash and enqueues routine-run", async () => {
+    const service = makeService(makeRegistry({ "on-ticket": EVENT_ROUTINE }));
+    const { runId } = await service.trigger("on-ticket", {
+      type: "manual",
+      payload: { a: 1 },
+    });
+    expect(enqueued).toHaveLength(1);
+    expect(enqueued[0]).toMatchObject({ runId, slug: "on-ticket" });
+    const run = await runs.findById(runId);
+    expect(run?.definitionSnapshot.id).toBe("on-ticket");
+    expect(run?.definitionHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(run?.currentState).toBe("S");
+  });
+
+  describe("event triggers via the domain bus", () => {
+    it("starts matching routines, honoring the filter expression", async () => {
+      const registry = makeRegistry({ "on-ticket": EVENT_ROUTINE });
+      const evalFilter = vi.fn(async (code: string, scope: Record<string, unknown>) => {
+        const fn = new Function(...Object.keys(scope), `return (${code});`);
+        return fn(...Object.values(scope));
+      });
+      const service = makeService(registry, evalFilter);
+      const bus = new EventEmitter();
+      subscribeRoutineEventTriggers(bus, service, registry, evalFilter, LOG);
+
+      bus.emit(DOMAIN_EVENTS.RESOURCE_CREATED, { resourceType: "invoice", resourceId: "1" });
+      await vi.waitFor(() => expect(evalFilter).toHaveBeenCalled());
+      expect(enqueued).toHaveLength(0); // filter rejected
+
+      bus.emit(DOMAIN_EVENTS.RESOURCE_CREATED, { resourceType: "ticket", resourceId: "2" });
+      await vi.waitFor(() => expect(enqueued).toHaveLength(1));
+      const run = await runs.findById(enqueued[0].runId);
+      expect(run?.trigger).toMatchObject({
+        type: "event",
+        payload: { resourceType: "ticket" },
+      });
+    });
+
+    it("ignores events no routine subscribes to", async () => {
+      const registry = makeRegistry({ "on-ticket": EVENT_ROUTINE });
+      const service = makeService(registry);
+      const bus = new EventEmitter();
+      subscribeRoutineEventTriggers(bus, service, registry, undefined, LOG);
+
+      bus.emit(DOMAIN_EVENTS.CONVERSATION_CREATED, { conversationId: "c1" });
+      await new Promise((r) => setTimeout(r, 20));
+      expect(enqueued).toHaveLength(0);
+    });
+  });
+});

--- a/apps/api/src/routines/trigger-service.ts
+++ b/apps/api/src/routines/trigger-service.ts
@@ -1,0 +1,154 @@
+import { createHash, randomUUID } from "node:crypto";
+import type { EventEmitter } from "node:events";
+import { ajv } from "@tulipfarm/validation";
+import { DOMAIN_EVENTS } from "../domain-events";
+import type { RoutineEnqueuers } from "./jobs";
+import type { LoadedRoutine, RoutineRegistry } from "./registry";
+import type { RoutineRunsRepo } from "./repo";
+
+export type TriggerType = "event" | "manual" | "cron" | "webhook" | "agent";
+
+export class RoutineTriggerError extends Error {
+  constructor(
+    readonly code: "not_found" | "trigger_not_declared" | "invalid_inputs" | "routine_invalid",
+    message: string
+  ) {
+    super(message);
+    this.name = "RoutineTriggerError";
+  }
+}
+
+type TriggerLogger = {
+  error: (obj: unknown, msg?: string) => void;
+  warn: (obj: unknown, msg?: string) => void;
+};
+
+export interface TriggerServiceDeps {
+  registry: RoutineRegistry;
+  runs: RoutineRunsRepo;
+  enqueuers: RoutineEnqueuers;
+  /** Evaluates an event trigger's `filter` expression (isolated-vm). */
+  evalFilter?: (code: string, scope: Record<string, unknown>) => Promise<unknown>;
+  log: TriggerLogger;
+}
+
+/**
+ * Single funnel for all five trigger types (D6/D8): validates the routine exists and
+ * declares the trigger, AJV-validates the payload against `x-inputs` (manual, webhook
+ * and agent alike — not per-route), creates the run row with the pinned
+ * definitionSnapshot, and enqueues `routine-run`. This is also the seam v0.12
+ * integration ingress plugs into (`emit_event` → domain event → event trigger).
+ */
+export class RoutineTriggerService {
+  constructor(private readonly deps: TriggerServiceDeps) {}
+
+  async trigger(
+    slug: string,
+    trigger: { type: TriggerType; payload?: unknown }
+  ): Promise<{ runId: string }> {
+    const { registry, runs, enqueuers } = this.deps;
+    const entry = registry.getEntry(slug);
+    if (!entry) throw new RoutineTriggerError("not_found", `routine "${slug}" not found`);
+    if (!entry.ok) {
+      throw new RoutineTriggerError(
+        "routine_invalid",
+        `routine "${slug}" failed validation: ${entry.loadError}`
+      );
+    }
+    const declared = entry.definition["x-triggers"].some((t) => t.type === trigger.type);
+    if (!declared) {
+      throw new RoutineTriggerError(
+        "trigger_not_declared",
+        `routine "${slug}" does not declare a "${trigger.type}" trigger`
+      );
+    }
+
+    this.validateInputs(entry, trigger);
+
+    const runId = randomUUID();
+    const definitionHash = createHash("sha256")
+      .update(JSON.stringify(entry.definition))
+      .digest("hex");
+    await runs.create({
+      id: runId,
+      routineSlug: slug,
+      definitionSnapshot: entry.definition,
+      definitionHash,
+      currentState: entry.definition.start,
+      context: this.initialContext(trigger),
+      trigger: { type: trigger.type, payload: trigger.payload },
+    });
+    await enqueuers.enqueueRun({
+      runId,
+      slug,
+      trigger: { type: trigger.type, payload: trigger.payload },
+    });
+    return { runId };
+  }
+
+  /** Trigger payloads that are plain objects seed the run's data-flow context. */
+  private initialContext(trigger: { payload?: unknown }): Record<string, unknown> {
+    const p = trigger.payload;
+    return typeof p === "object" && p !== null && !Array.isArray(p)
+      ? (p as Record<string, unknown>)
+      : {};
+  }
+
+  private validateInputs(
+    routine: LoadedRoutine,
+    trigger: { type: TriggerType; payload?: unknown }
+  ) {
+    // x-inputs gates caller-supplied payloads; cron/event payloads are system-shaped.
+    if (trigger.type !== "manual" && trigger.type !== "webhook" && trigger.type !== "agent") return;
+    const schema = routine.definition["x-inputs"];
+    if (!schema) return;
+    const validate = ajv.compile(schema);
+    if (!validate(trigger.payload ?? {})) {
+      const e = validate.errors?.[0];
+      throw new RoutineTriggerError(
+        "invalid_inputs",
+        `inputs${e?.instancePath ?? ""} ${e?.message ?? "are invalid"}`
+      );
+    }
+  }
+}
+
+/**
+ * Subscribes routine `event` triggers to the in-process domain-event bus. For every
+ * emitted event, every valid routine declaring a matching event trigger is started
+ * (optionally gated by the trigger's isolated-vm `filter` expression). In-process only
+ * in V1 (single instance); LISTEN/NOTIFY is the flagged multi-instance upgrade.
+ */
+export function subscribeRoutineEventTriggers(
+  events: EventEmitter,
+  service: RoutineTriggerService,
+  registry: RoutineRegistry,
+  evalFilter: ((code: string, scope: Record<string, unknown>) => Promise<unknown>) | undefined,
+  log: TriggerLogger
+): void {
+  for (const eventName of Object.values(DOMAIN_EVENTS)) {
+    events.on(eventName, (payload: unknown) => {
+      void (async () => {
+        for (const routine of registry.valid()) {
+          for (const trigger of routine.definition["x-triggers"]) {
+            if (trigger.type !== "event" || trigger.event !== eventName) continue;
+            try {
+              if (trigger.filter && evalFilter) {
+                const pass = await evalFilter(trigger.filter, {
+                  trigger: { type: "event", event: eventName, payload },
+                });
+                if (!pass) continue;
+              }
+              await service.trigger(routine.slug, { type: "event", payload });
+            } catch (err) {
+              log.error(
+                { err, slug: routine.slug, event: eventName },
+                "event-triggered routine failed to start"
+              );
+            }
+          }
+        }
+      })();
+    });
+  }
+}

--- a/apps/api/src/soul/integrations/lock.ts
+++ b/apps/api/src/soul/integrations/lock.ts
@@ -43,5 +43,7 @@ export function hashContent(content: string): string {
 }
 
 export function sourceType(source: string): "github" | "git" {
-  return /github\.com|^[\w.-]+\/[\w.-]+$/.test(source) ? "github" : "git";
+  // Strip an optional "#<ref>" suffix so "owner/repo#branch" still classifies as github.
+  const base = source.split("#", 1)[0];
+  return /github\.com|^[\w.-]+\/[\w.-]+$/.test(base) ? "github" : "git";
 }

--- a/apps/api/src/soul/integrations/routes.ts
+++ b/apps/api/src/soul/integrations/routes.ts
@@ -77,22 +77,40 @@ function asString(v: unknown): string | undefined {
   return typeof v === "string" && v.length > 0 ? v : undefined;
 }
 
-// Only GitHub slugs or http(s)/file URLs allowed — same SSRF rule as skills.
-function isAllowedSource(source: string): boolean {
-  return /^[\w.-]+\/[\w.-]+$/.test(source) || /^(https?|file):\/\//.test(source);
+// A source may carry an optional "#<ref>" suffix (branch or tag name — not a commit SHA) so
+// pre-merge branches can be scanned and tested: "owner/repo#my-branch". No "#" ⇒ default branch.
+function splitSourceRef(source: string): { base: string; ref?: string } {
+  const idx = source.indexOf("#");
+  return idx === -1 ? { base: source } : { base: source.slice(0, idx), ref: source.slice(idx + 1) };
 }
 
-function normalizeGitUrl(source: string): string {
-  if (/^[\w.-]+\/[\w.-]+$/.test(source)) return `https://github.com/${source}.git`;
-  return source;
+// Leading dash forbidden so a ref can never be mistaken for a git flag.
+const REF_RE = /^[\w][\w./-]*$/;
+
+// Only GitHub slugs or http(s)/file URLs allowed (optional "#<ref>") — same SSRF rule as skills.
+function isAllowedSource(source: string): boolean {
+  const { base, ref } = splitSourceRef(source);
+  if (ref !== undefined && !REF_RE.test(ref)) return false;
+  return /^[\w.-]+\/[\w.-]+$/.test(base) || /^(https?|file):\/\//.test(base);
+}
+
+function normalizeGitUrl(base: string): string {
+  if (/^[\w.-]+\/[\w.-]+$/.test(base)) return `https://github.com/${base}.git`;
+  return base;
 }
 
 async function cloneToTemp(source: string): Promise<{ dir: string; ref: string }> {
+  const { base, ref } = splitSourceRef(source);
   const dir = await mkdtemp(join(tmpdir(), "integration-scan-"));
-  await execFileP("git", ["clone", "--depth", "1", normalizeGitUrl(source), dir], {
-    timeout: CLONE_TIMEOUT_MS,
-    env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
-  });
+  // --branch accepts branch or tag names (not commit SHAs) and still works with --depth 1.
+  await execFileP(
+    "git",
+    ["clone", "--depth", "1", ...(ref ? ["--branch", ref] : []), normalizeGitUrl(base), dir],
+    {
+      timeout: CLONE_TIMEOUT_MS,
+      env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
+    }
+  );
   const { stdout } = await execFileP("git", ["rev-parse", "HEAD"], { cwd: dir });
   return { dir, ref: stdout.trim() };
 }
@@ -411,7 +429,7 @@ export function registerIntegrationRoutes(
       preHandler: requireAuth,
       schema: {
         description:
-          "Clone a git repo and discover installable MCP integration manifest.json files.",
+          "Clone a git repo (source accepts an optional #branch suffix) and discover installable MCP integration manifests.",
         tags: ["integrations"],
         security: [{ sessionCookie: [] }, { bearerToken: [] }],
         body: {
@@ -451,7 +469,8 @@ export function registerIntegrationRoutes(
       const { source } = req.body as { source: string };
       if (!isAllowedSource(source)) {
         return reply.code(400).send({
-          error: "source must be a github owner/repo slug or an http(s)/file URL",
+          error:
+            "source must be a github owner/repo slug or an http(s)/file URL, with an optional #branch suffix",
         });
       }
       let dir: string | undefined;

--- a/apps/api/src/soul/skills/routes.test.ts
+++ b/apps/api/src/soul/skills/routes.test.ts
@@ -287,6 +287,60 @@ describe("skills routes", () => {
       expect(res.json().error).toMatch(/owner\/repo|http/);
     });
 
+    it("rejects a source with an unsafe #ref suffix before cloning", async () => {
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/v1/skills/scan",
+        cookies: auth(),
+        headers,
+        payload: { source: "owner/repo#--upload-pack=evil" },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toMatch(/owner\/repo|http/);
+    });
+
+    it("scans a non-default branch when the source carries a #ref suffix", async () => {
+      const remote = await makeRemoteRepo();
+      temps.push(remote);
+      // Add a second skill on a feature branch only.
+      const git = (args: string[]) => execFileP("git", args, { cwd: remote });
+      await git(["checkout", "-q", "-b", "feat/branch-skill"]);
+      const branchSkillDir = join(remote, "skills", "branch-skill");
+      await mkdir(branchSkillDir, { recursive: true });
+      await writeFile(
+        join(branchSkillDir, "SKILL.md"),
+        "---\nname: branch-skill\ndescription: Only on the branch.\n---\nBranch only.",
+        "utf8"
+      );
+      await git(["add", "-A"]);
+      await git(["commit", "-q", "-m", "add branch skill"]);
+      await git(["checkout", "-q", "-"]);
+
+      const scan = (source: string) =>
+        app.inject({
+          method: "POST",
+          url: "/api/v1/skills/scan",
+          cookies: auth(),
+          headers,
+          payload: { source },
+        });
+
+      // Default branch: only the original skill.
+      const main = await scan(`file://${remote}`);
+      expect(main.statusCode).toBe(200);
+      expect(main.json().skills.map((s: { name: string }) => s.name)).toEqual(["demo-skill"]);
+
+      // #branch: both skills discovered.
+      const branch = await scan(`file://${remote}#feat/branch-skill`);
+      expect(branch.statusCode).toBe(200);
+      expect(
+        branch
+          .json()
+          .skills.map((s: { name: string }) => s.name)
+          .sort()
+      ).toEqual(["branch-skill", "demo-skill"]);
+    });
+
     it("flags an installed skill and an available update against the lock", async () => {
       const remote = await makeRemoteRepo();
       temps.push(remote);

--- a/apps/api/src/soul/skills/routes.ts
+++ b/apps/api/src/soul/skills/routes.ts
@@ -77,22 +77,36 @@ function parseFrontmatter(content: string): { frontmatter: Record<string, unknow
   return { frontmatter, body: match[2].trim() };
 }
 
-// Only allow sources we are willing to hand to `git clone`: a bare "owner/repo" slug, or an
-// http(s)/file URL. ssh:// and scp-style (git@host:path) sources are rejected to avoid the operator's
-// clone reaching internal hosts (SSRF). Single-trust V1; a tighter allowlist is a post-V1 hardening.
-function isAllowedSource(source: string): boolean {
-  return /^[\w.-]+\/[\w.-]+$/.test(source) || /^(https?|file):\/\//.test(source);
+// A source may carry an optional "#<ref>" suffix (branch or tag name — not a commit SHA) so
+// pre-merge branches can be scanned and tested: "owner/repo#my-branch". No "#" ⇒ default branch.
+function splitSourceRef(source: string): { base: string; ref?: string } {
+  const idx = source.indexOf("#");
+  return idx === -1 ? { base: source } : { base: source.slice(0, idx), ref: source.slice(idx + 1) };
 }
 
-// Normalize an allowed source into something `git clone` accepts. A bare "owner/repo" becomes a
-// GitHub https URL; an http(s)/file URL is used as-is.
-function normalizeGitUrl(source: string): string {
-  if (/^[\w.-]+\/[\w.-]+$/.test(source)) return `https://github.com/${source}.git`;
-  return source;
+// Leading dash forbidden so a ref can never be mistaken for a git flag.
+const REF_RE = /^[\w][\w./-]*$/;
+
+// Only allow sources we are willing to hand to `git clone`: a bare "owner/repo" slug, or an
+// http(s)/file URL, each with an optional "#<ref>" suffix. ssh:// and scp-style (git@host:path)
+// sources are rejected to avoid the operator's clone reaching internal hosts (SSRF). Single-trust
+// V1; a tighter allowlist is a post-V1 hardening.
+function isAllowedSource(source: string): boolean {
+  const { base, ref } = splitSourceRef(source);
+  if (ref !== undefined && !REF_RE.test(ref)) return false;
+  return /^[\w.-]+\/[\w.-]+$/.test(base) || /^(https?|file):\/\//.test(base);
+}
+
+// Normalize an allowed source (ref already split off) into something `git clone` accepts. A bare
+// "owner/repo" becomes a GitHub https URL; an http(s)/file URL is used as-is.
+function normalizeGitUrl(base: string): string {
+  if (/^[\w.-]+\/[\w.-]+$/.test(base)) return `https://github.com/${base}.git`;
+  return base;
 }
 
 function sourceType(source: string): "github" | "git" {
-  return /github\.com|^[\w.-]+\/[\w.-]+$/.test(source) ? "github" : "git";
+  const { base } = splitSourceRef(source);
+  return /github\.com|^[\w.-]+\/[\w.-]+$/.test(base) ? "github" : "git";
 }
 
 /**
@@ -129,11 +143,17 @@ export async function discoverSkills(root: string): Promise<DiscoveredSkill[]> {
 }
 
 async function cloneToTemp(source: string): Promise<{ dir: string; ref: string }> {
+  const { base, ref } = splitSourceRef(source);
   const dir = await mkdtemp(join(tmpdir(), "skill-scan-"));
-  await execFileP("git", ["clone", "--depth", "1", normalizeGitUrl(source), dir], {
-    timeout: CLONE_TIMEOUT_MS,
-    env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
-  });
+  // --branch accepts branch or tag names (not commit SHAs) and still works with --depth 1.
+  await execFileP(
+    "git",
+    ["clone", "--depth", "1", ...(ref ? ["--branch", ref] : []), normalizeGitUrl(base), dir],
+    {
+      timeout: CLONE_TIMEOUT_MS,
+      env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
+    }
+  );
   const { stdout } = await execFileP("git", ["rev-parse", "HEAD"], { cwd: dir });
   return { dir, ref: stdout.trim() };
 }
@@ -464,7 +484,8 @@ export function registerSkillRoutes(
     {
       preHandler: requireAuth,
       schema: {
-        description: "Clone a git repo and discover installable SKILL.md files.",
+        description:
+          "Clone a git repo (source accepts an optional #branch suffix) and discover installable SKILL.md files.",
         tags: ["skills"],
         security: [{ sessionCookie: [] }, { bearerToken: [] }],
         body: {
@@ -502,9 +523,10 @@ export function registerSkillRoutes(
     async (req, reply) => {
       const { source } = req.body as { source: string };
       if (!isAllowedSource(source)) {
-        return reply
-          .code(400)
-          .send({ error: "source must be a github owner/repo slug or an http(s)/file URL" });
+        return reply.code(400).send({
+          error:
+            "source must be a github owner/repo slug or an http(s)/file URL, with an optional #branch suffix",
+        });
       }
       let dir: string | undefined;
       try {

--- a/apps/api/src/tools/setup.ts
+++ b/apps/api/src/tools/setup.ts
@@ -143,7 +143,13 @@ export function buildToolRegistry(services: {
         mutating: t.mutating,
         description: t.description,
         inputSchema: t.inputSchema,
-        execute: (args, _ctx) => t.handler(args, ctx),
+        // routineContext is per-call (routine-spawned headless turns), not a service —
+        // merge it from the RequestContext so call_skill/complete_state see their run.
+        execute: (args, reqCtx) =>
+          t.handler(
+            args,
+            reqCtx.routineContext ? { ...ctx, routineContext: reqCtx.routineContext } : ctx
+          ),
       });
     }
   }

--- a/apps/api/src/tools/types.ts
+++ b/apps/api/src/tools/types.ts
@@ -42,6 +42,11 @@ export interface RequestContext {
    * before acting. A mutable holder so the flip is visible to later tool calls in the same turn.
    */
   contextRead?: { value: boolean };
+  /**
+   * Set only on routine-spawned headless agent turns (v0.11). Threaded into the platform
+   * tool context per-call so `call_skill` / `complete_state` see the run they belong to.
+   */
+  routineContext?: { routineId: string; runId: string };
 }
 
 /** Canonical tool shape for the ToolRegistry (TOOL-V1). */

--- a/apps/docs/AGENTS.md
+++ b/apps/docs/AGENTS.md
@@ -63,10 +63,10 @@ Documentation that lies is worse than none. Before writing any factual claim:
   `packages/llm/src`, env vars at their `process.env` read sites, ports in app configs.
   Copy names exactly (`tulip_` token prefix, not `tf_`; four provider integrations, not
   "55+").
-- **Never document an unshipped feature.** Routines and Integrations are empty-state
-  placeholders in the app (`apps/web/app/routes/_app.{routines,integrations}.tsx`) — their
-  guides are honest "not yet available" stubs, not invented how-tos. If a feature isn't in
-  the code, it isn't in the docs.
+- **Never document an unshipped feature.** When a section is still an empty-state
+  placeholder in the app, its guide is an honest "not yet available" stub, not an invented
+  how-to (Routines lived as such a stub until v0.11 shipped). If a feature isn't in the
+  code, it isn't in the docs.
 
 ## Structure (Diátaxis)
 

--- a/apps/docs/content/docs/concepts/meta.json
+++ b/apps/docs/content/docs/concepts/meta.json
@@ -8,6 +8,7 @@
     "resources",
     "agents",
     "skills",
+    "routines",
     "integrations",
     "knowledge",
     "llm",

--- a/apps/docs/content/docs/concepts/routines.mdx
+++ b/apps/docs/content/docs/concepts/routines.mdx
@@ -1,0 +1,119 @@
+---
+title: Routines
+description: Durable, repeatable automations that run without you — and pause for you when it matters.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+A **routine** is a repeatable automation: a named sequence of steps that runs on a
+trigger instead of being improvised in chat each time. Where an agent decides what to do
+in the moment, a routine does the same thing every time — record the expense, check the
+amount, ask for approval over the limit, file the record.
+
+You build a routine the way you build everything else in TulipFarm — by
+[describing it to the assistant](/docs/concepts/building). The assistant writes a
+`routine.yaml` under `soul/routines/{name}/` and commits it; the definition is the
+*result* of the chat, not something you edit. The
+[Routines guide](/docs/guides/routines) walks through creating and running one.
+
+## Five ways a run starts
+
+A routine declares its triggers, and only declared triggers can start it:
+
+| Trigger | Starts a run when… |
+| --- | --- |
+| `manual` | You press **run now** in the Routines section (or ask the assistant to). Inputs come from a form generated from the routine's input schema. |
+| `cron` | A schedule fires — `0 9 * * 1` for every Monday at 09:00, in the routine's timezone (UTC unless it says otherwise). |
+| `webhook` | An external system POSTs to the routine's webhook URL with its shared secret. |
+| `event` | Something happens inside TulipFarm — a record is created or updated, a chat starts or completes. An optional filter expression narrows which events count. |
+| `agent` | An agent decides mid-chat that the routine should run, via its `trigger_routine` tool. |
+
+Every path funnels through the same gate: the trigger must be declared, and the payload
+is validated against the routine's input schema before a run exists.
+
+## Five kinds of step
+
+A routine's body is a chain of **states**, each one of five types:
+
+- **operation** — do something: call a platform tool, or hand a task to an agent
+  ("summarize this and file it") that reports back when done.
+- **switch** — branch on the data: `context.amount > 500` goes one way, everything
+  else goes another.
+- **foreach** — repeat the same actions for each item in a list (bounded at 1,000
+  items per run).
+- **sleep** — wait: ten minutes, a day, a week. The run costs nothing while it sleeps.
+- **inject** — set data into the run's context for later states to use.
+
+Data flows between states through small JavaScript expressions. Every expression runs in
+a locked-down sandbox — 100 milliseconds, no filesystem, no network, no host access — so
+a generated routine cannot reach anything the platform did not hand it.
+
+## Runs are durable
+
+Starting a routine creates a **run**, and a run is built to survive:
+
+- The run pins a **snapshot of the definition** at start. Editing the routine mid-flight
+  never corrupts runs already in progress — they finish on the version they started with.
+- A sleeping or waiting run holds no process. It is a row in the database with a wake-up
+  call scheduled; restart the server and the run resumes where it left off.
+- Failures follow the routine's own error policy: **retries** with backoff, then
+  **onErrors** routing to a recovery state, then — only if nothing matches — a failed
+  run with the error preserved.
+- Each state can carry its own **timeout**; a stuck step fails into the same error
+  routing instead of hanging the run.
+
+Every run keeps a permanent journal of what happened — state entered, action completed,
+retry scheduled, run finished — and the Routines section streams that journal live while
+a run executes. Reconnecting picks up exactly where the stream left off, however old the
+run is.
+
+## Pausing for a human
+
+A state marked as requiring **human approval** stops the run before executing and files
+a request in the app's **Approvals** section — the same place gated
+[agent](/docs/concepts/agents) tool calls appear. The run shows `waiting approval` until someone decides; approve and it
+continues, deny and the denial routes through the routine's error handling like any
+other failure.
+
+Approval requests always appear in the app. If a Slack integration is connected, the
+request is also posted there. Channels the platform cannot deliver yet (email, SMS) fall
+back to the in-app request with a logged warning — a routine never silently loses its
+gate.
+
+<Callout type="info">
+Routine approvals wait seven days. An undecided request times out, counts as a denial,
+and the run routes through its error handling rather than waiting forever.
+</Callout>
+
+## Hooks: custom logic, still sandboxed
+
+A routine can ship a `hooks.ts` next to its `routine.yaml` for logic that is awkward to
+express in steps — computing a total, normalizing a payload. This is what the assistant
+writes underneath (you never author it by hand):
+
+```ts title="soul/routines/expense-report/hooks.ts"
+({
+  beforeHook(ctx) {
+    // runs once when the run starts
+  },
+  afterCheckAmount(ctx) {
+    // runs after the CheckAmount state completes
+  },
+  computeTotal(ctx, args) {
+    // callable as a step action
+    return args.base + ctx.context.surcharge;
+  },
+})
+```
+
+Hooks run in the same sandbox family as the expressions — isolated, time-boxed, hash-
+verified against the committed source — with `before`/`after` functions for the whole
+run or any state, plus named functions a step can call directly.
+
+## Deferred in V1
+
+Some workflow constructs are recognized but deliberately rejected rather than silently
+ignored: parallel fan-out states, event-correlation states, sub-routine calls, and the
+`datetime` and `integration` trigger types. A definition using one fails validation with
+a "deferred in V1" error, so a routine never half-works. They arrive in later releases
+as real routines demand them.

--- a/apps/docs/content/docs/guides/routines.mdx
+++ b/apps/docs/content/docs/guides/routines.mdx
@@ -1,20 +1,97 @@
 ---
-title: Routines
-description: Durable, repeatable automations — planned, not yet available.
+title: Build and run a routine
+description: Describe an automation to the assistant, run it, watch it, and approve it when it pauses.
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-A **routine** is a named, repeatable automation — a sequence of steps an agent can run on
-demand instead of improvising each time. The runtime can already trigger routines, but
-there is no way to author one from the app yet.
+This guide builds a [routine](/docs/concepts/routines) by describing it to the
+assistant, then runs it and follows the run. It assumes a running instance with a model
+configured. For what routines are and how they execute, see the
+[concept page](/docs/concepts/routines).
 
-<Callout type="warn">
-Routines are not yet available to create. The **Routines** section appears in the app, but
-it is empty until the feature ships — "No routines yet. Durable automations appear here
-once defined."
+## Ask the assistant
+
+Open **Chat** and describe the automation — what starts it, what it does, and where a
+human should stay in the loop:
+
+```prompt
+Create a routine that files each expense report as a record, and asks for my
+approval first whenever the amount is over 500. I want to trigger it manually
+and also every Monday at 9am.
+```
+
+The assistant designs the routine — triggers, steps, the approval gate — and writes it
+to the soul with its routine forge. There is no review step: the routine is committed,
+validated, and live immediately. It appears in the **Routines** section, and its Monday
+schedule is registered the moment it lands.
+
+If the definition uses something the platform defers in V1 (parallel branches,
+sub-routines), the forge rejects it with a "deferred in V1" error instead of writing a
+routine that half-works.
+
+## Run it now
+
+Two ways to start a run by hand:
+
+- In chat:
+
+  ```prompt
+  Run the expense report routine for a 220 dollar team lunch.
+  ```
+
+- In **Routines**, open the routine and use the **manual trigger** form. The form's
+  fields come from the routine's own input schema — required inputs are marked, and a
+  payload that doesn't match is rejected before a run starts.
+
+Either way you get a run and land on its page.
+
+## Watch the run
+
+The run page streams progress live: each state as it is entered, each action as it
+completes, retries as they are scheduled. The status badge tells you where the run is —
+`running`, `sleeping` (waiting out a timer, costing nothing), `waiting approval`,
+`succeeded`, `failed`, or `cancelled`.
+
+Closing the page loses nothing. The run's history is permanent — reopen it tomorrow and
+the full event journal is there, and a live run picks the stream back up where you left
+it.
+
+## Approve a paused run
+
+When a run hits a human-approval state it stops, shows `waiting approval`, and files a
+request in **Approvals** alongside gated agent tool calls. The request names the routine
+and the paused state, links back to the run, and carries the run's data so you can judge
+it in place.
+
+**Approve** and the run continues from exactly where it paused. **Deny** and the denial
+flows through the routine's own error handling — a recovery step if the routine defines
+one, a failed run if not.
+
+<Callout type="info">
+An undecided routine approval times out after seven days and counts as a denial. Runs
+never wait forever.
 </Callout>
 
-When routines land, you will build them the same way you build everything else in
-TulipFarm — by [describing what you want to the assistant](/docs/concepts/building), not by
-editing files. This page will become the walkthrough then.
+## Cancel a run
+
+On the run page, **cancel run** stops a pending, sleeping, or waiting run immediately. A
+run that is mid-step finishes that step, then stops at the boundary. Finished runs
+cannot be cancelled — there is nothing left to stop.
+
+## Trigger it from outside
+
+A routine with a webhook trigger gets a URL an external system can call. The caller
+authenticates with the routine's shared secret in a header — this is the one step in
+this guide that happens outside TulipFarm, in whatever system is doing the calling:
+
+```bash
+curl -X POST https://your-instance.example/api/v1/hooks/routines/expense-report \
+  -H "Content-Type: application/json" \
+  -H "x-tulipfarm-webhook-secret: <the routine's secret>" \
+  -d '{"amount": 42, "memo": "webhook test"}'
+```
+
+The response is the new run's id. The payload passes through the same input validation
+as the manual form, and a missing or wrong secret is rejected — a webhook routine whose
+secret is not configured refuses every call rather than running open.

--- a/apps/web/app/components/routines/run-status-badge.tsx
+++ b/apps/web/app/components/routines/run-status-badge.tsx
@@ -1,0 +1,25 @@
+import type { RunStatus } from "~/lib/routines";
+import { cn } from "~/lib/utils";
+
+const STATUS_STYLES: Record<RunStatus, string> = {
+  pending: "bg-muted text-muted-foreground",
+  running: "bg-primary/10 text-primary",
+  sleeping: "bg-muted text-muted-foreground",
+  waiting_approval: "bg-amber-500/10 text-amber-600 dark:text-amber-400",
+  succeeded: "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
+  failed: "bg-destructive/10 text-destructive",
+  cancelled: "bg-muted text-muted-foreground line-through",
+};
+
+export function RunStatusBadge({ status }: { status: RunStatus }) {
+  return (
+    <span
+      className={cn(
+        "rounded-sm px-1.5 py-0.5 text-xs uppercase tracking-[0.15em]",
+        STATUS_STYLES[status] ?? "bg-muted text-muted-foreground"
+      )}
+    >
+      {status.replace("_", " ")}
+    </span>
+  );
+}

--- a/apps/web/app/lib/approvals.ts
+++ b/apps/web/app/lib/approvals.ts
@@ -12,9 +12,16 @@ export { sendApprovalDecision } from "./chat/sse-client";
 
 export type PendingApproval = {
   approvalId: string;
-  toolCallId: string;
-  toolName: string;
-  args: unknown;
+  kind?: "tool_call" | "routine_state";
+  // tool_call fields
+  toolCallId?: string;
+  toolName?: string;
+  args?: unknown;
+  // routine_state fields (routine human_approval states, v0.11)
+  routineSlug?: string;
+  runId?: string;
+  stateName?: string;
+  summary?: unknown;
   expiresAt: string;
   createdAt: string;
 };

--- a/apps/web/app/lib/integrations.ts
+++ b/apps/web/app/lib/integrations.ts
@@ -39,7 +39,7 @@ export type OAuthConfig = {
 export type IntegrationDetail = IntegrationSummary & {
   manifest: {
     required_env?: RequiredEnvVar[];
-    entry: Record<string, unknown>;
+    egress?: { type?: string; entry?: Record<string, unknown> };
     setup_guide_path?: string;
     oauth?: OAuthConfig;
   };

--- a/apps/web/app/lib/routines.ts
+++ b/apps/web/app/lib/routines.ts
@@ -1,0 +1,116 @@
+import { API_BASE, apiGet, apiWrite } from "./api";
+
+/*
+ * Client for the routines API (v0.11). Mirrors lib/agents.ts conventions (cookie-first
+ * auth, ApiError on non-2xx). Live run progress streams from the run SSE endpoint —
+ * `runEventsUrl` builds the EventSource URL (cookies ride along via withCredentials).
+ */
+
+export type RoutineTrigger =
+  | { type: "manual" }
+  | { type: "cron"; schedule: string; timezone?: string }
+  | { type: "webhook"; secret_ref: string }
+  | { type: "event"; event: string; filter?: string }
+  | { type: "agent" };
+
+export type RoutineSummary = {
+  slug: string;
+  valid: boolean;
+  name?: string | null;
+  description?: string | null;
+  triggers?: RoutineTrigger[];
+  inputs?: RoutineInputsSchema | null;
+  hasHooks?: boolean;
+  loadError?: string | null;
+};
+
+/** The x-inputs JSON Schema subset the manual-trigger form renders. */
+export type RoutineInputsSchema = {
+  type?: string;
+  required?: string[];
+  properties?: Record<
+    string,
+    { type?: string; description?: string; enum?: Array<string | number> }
+  >;
+};
+
+export type RunStatus =
+  | "pending"
+  | "running"
+  | "sleeping"
+  | "waiting_approval"
+  | "succeeded"
+  | "failed"
+  | "cancelled";
+
+export type RunSummary = {
+  id: string;
+  routineSlug: string;
+  status: RunStatus;
+  currentState?: string | null;
+  trigger?: { type: string };
+  output?: unknown;
+  error?: { name?: string; message?: string } | null;
+  createdAt: string;
+  updatedAt: string;
+  finishedAt?: string | null;
+};
+
+export type RunEvent = {
+  seq: number;
+  type: string;
+  payload?: unknown;
+  createdAt?: string;
+};
+
+export type RunDetail = {
+  run: RunSummary & {
+    context?: Record<string, unknown>;
+    definitionHash?: string;
+    attemptCounts?: Record<string, number>;
+    approvalId?: string | null;
+  };
+  events: RunEvent[];
+};
+
+export async function listRoutines(): Promise<RoutineSummary[]> {
+  const body = await apiGet<{ items: RoutineSummary[] }>("/api/v1/routines");
+  return body.items;
+}
+
+export async function listRuns(slug: string, limit = 50): Promise<RunSummary[]> {
+  const body = await apiGet<{ items: RunSummary[] }>(
+    `/api/v1/routines/${encodeURIComponent(slug)}/runs?limit=${limit}`
+  );
+  return body.items;
+}
+
+export async function getRun(slug: string, runId: string): Promise<RunDetail> {
+  return apiGet<RunDetail>(
+    `/api/v1/routines/${encodeURIComponent(slug)}/runs/${encodeURIComponent(runId)}`
+  );
+}
+
+export async function triggerRun(
+  slug: string,
+  inputs: Record<string, unknown>
+): Promise<{ runId: string }> {
+  return apiWrite<{ runId: string }>("POST", `/api/v1/routines/${encodeURIComponent(slug)}/runs`, {
+    inputs,
+  });
+}
+
+export async function cancelRun(slug: string, runId: string): Promise<void> {
+  await apiWrite(
+    "POST",
+    `/api/v1/routines/${encodeURIComponent(slug)}/runs/${encodeURIComponent(runId)}/cancel`,
+    {}
+  );
+}
+
+export function runEventsUrl(slug: string, runId: string, lastEventId?: number): string {
+  const base = `${API_BASE}/api/v1/routines/${encodeURIComponent(slug)}/runs/${encodeURIComponent(
+    runId
+  )}/events`;
+  return lastEventId ? `${base}?lastEventId=${lastEventId}` : base;
+}

--- a/apps/web/app/routes/_app.approvals.tsx
+++ b/apps/web/app/routes/_app.approvals.tsx
@@ -1,4 +1,4 @@
-import type { MetaFunction } from "@remix-run/react";
+import { Link, type MetaFunction } from "@remix-run/react";
 import { useRef } from "react";
 import { ApprovalCard } from "~/components/chat/approval-card";
 import { EmptyState } from "~/components/empty-state";
@@ -27,6 +27,38 @@ function ApprovalRow({
   item: PendingApproval;
   onDecide: (approvalId: string, decision: "approve" | "deny") => void;
 }) {
+  // routine_state approvals (routine human_approval states, v0.11): show which routine/
+  // state is paused + a link to the suspended run; the summary is the run's data context.
+  if (item.kind === "routine_state") {
+    const full = describeArgs(item.summary);
+    const short = full.length > 160 ? `${full.slice(0, 160)}…` : full;
+    return (
+      <li className="flex flex-col gap-1.5 px-3 py-3">
+        <ApprovalCard
+          toolName={`routine ${item.routineSlug ?? "?"} · ${item.stateName ?? "?"}`}
+          approval={{ approvalId: item.approvalId, status: "pending", expiresAt: item.expiresAt }}
+          onDecide={(decision) => onDecide(item.approvalId, decision)}
+        />
+        <p className="flex items-center gap-2 truncate font-mono text-xs text-muted-foreground">
+          <span className="rounded-sm bg-muted px-1.5 py-0.5 uppercase tracking-[0.15em]">
+            routine
+          </span>
+          {item.routineSlug && item.runId ? (
+            <Link
+              to={`/routines/${encodeURIComponent(item.routineSlug)}/runs/${item.runId}`}
+              className="text-primary hover:underline"
+            >
+              view run
+            </Link>
+          ) : null}
+          <span className="min-w-0 truncate" title={full}>
+            {short}
+          </span>
+        </p>
+      </li>
+    );
+  }
+
   const full = describeArgs(item.args);
   const short = full.length > 160 ? `${full.slice(0, 160)}…` : full;
   return (
@@ -34,7 +66,7 @@ function ApprovalRow({
     // (chat rehydration-by-id is deferred in V1).
     <li className="flex flex-col gap-1.5 px-3 py-3" data-tool-call-id={item.toolCallId}>
       <ApprovalCard
-        toolName={item.toolName}
+        toolName={item.toolName ?? "tool"}
         approval={{ approvalId: item.approvalId, status: "pending", expiresAt: item.expiresAt }}
         onDecide={(decision) => onDecide(item.approvalId, decision)}
       />

--- a/apps/web/app/routes/_app.integrations.$name.tsx
+++ b/apps/web/app/routes/_app.integrations.$name.tsx
@@ -230,7 +230,7 @@ export default function IntegrationDetailPage() {
   }
 
   const isConnected = integration.status === "connected";
-  const entry = integration.manifest.entry as Record<string, unknown>;
+  const entry = integration.manifest.egress?.entry ?? {};
 
   return (
     <ResourcePanel

--- a/apps/web/app/routes/_app.integrations.marketplace.tsx
+++ b/apps/web/app/routes/_app.integrations.marketplace.tsx
@@ -161,7 +161,7 @@ export default function IntegrationsMarketplace() {
       <form onSubmit={handleScan} className="flex gap-2">
         <input
           className={inputClass}
-          placeholder="owner/repo or https://..."
+          placeholder="owner/repo[#branch] or https://..."
           value={scanUrl}
           onChange={(e) => setScanUrl(e.target.value)}
         />

--- a/apps/web/app/routes/_app.routines.$slug.runs.$runId.tsx
+++ b/apps/web/app/routes/_app.routines.$slug.runs.$runId.tsx
@@ -1,0 +1,176 @@
+import { useLoaderData, useRevalidator, useRouteError } from "@remix-run/react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { ResourcePanel } from "~/components/resource-panel";
+import { RunStatusBadge } from "~/components/routines/run-status-badge";
+import { ErrorState } from "~/components/states";
+import { Button } from "~/components/ui/button";
+import { ApiError } from "~/lib/api";
+import { cancelRun, getRun, type RunEvent, runEventsUrl } from "~/lib/routines";
+
+export async function clientLoader({ params }: { params: { slug: string; runId: string } }) {
+  const detail = await getRun(params.slug, params.runId);
+  return { slug: params.slug, runId: params.runId, detail };
+}
+
+const TERMINAL = new Set(["succeeded", "failed", "cancelled"]);
+
+/**
+ * Live progress: EventSource against the run SSE endpoint, resuming from the last
+ * journaled seq. A `finish` with reason "suspended" means the run is sleeping/waiting —
+ * the stream closes; we revalidate to pick up the new status and reconnect on the next
+ * revalidation if the run woke up.
+ */
+function useRunEvents(
+  slug: string,
+  runId: string,
+  initial: RunEvent[],
+  active: boolean,
+  onStreamEnd: () => void
+) {
+  const [events, setEvents] = useState<RunEvent[]>(initial);
+  const lastSeq = useRef(initial.length > 0 ? initial[initial.length - 1].seq : 0);
+
+  useEffect(() => {
+    setEvents(initial);
+    lastSeq.current = initial.length > 0 ? initial[initial.length - 1].seq : 0;
+  }, [initial]);
+
+  useEffect(() => {
+    if (!active) return;
+    const source = new EventSource(runEventsUrl(slug, runId, lastSeq.current), {
+      withCredentials: true,
+    });
+    const onAny = (e: MessageEvent) => {
+      const seq = Number(e.lastEventId);
+      if (Number.isNaN(seq) || seq <= lastSeq.current) return;
+      lastSeq.current = seq;
+      let payload: unknown = e.data;
+      try {
+        payload = JSON.parse(e.data);
+      } catch {
+        // keep raw string
+      }
+      setEvents((prev) => [...prev, { seq, type: e.type, payload }]);
+      if (e.type === "finish" || e.type === "error") {
+        source.close();
+        onStreamEnd();
+      }
+    };
+    for (const type of [
+      "run.started",
+      "state.entered",
+      "action.completed",
+      "state.completed",
+      "state.retrying",
+      "run.sleeping",
+      "run.waiting_approval",
+      "finish",
+      "error",
+    ]) {
+      source.addEventListener(type, onAny);
+    }
+    source.onerror = () => {
+      source.close();
+      onStreamEnd();
+    };
+    return () => source.close();
+  }, [slug, runId, active, onStreamEnd]);
+
+  return events;
+}
+
+function describePayload(payload: unknown): string {
+  if (payload == null) return "";
+  try {
+    const text = JSON.stringify(payload);
+    return text.length > 200 ? `${text.slice(0, 200)}…` : text;
+  } catch {
+    return String(payload);
+  }
+}
+
+export default function RunDetail() {
+  const { slug, runId, detail } = useLoaderData<typeof clientLoader>();
+  const revalidator = useRevalidator();
+  const run = detail.run;
+  const isLive = !TERMINAL.has(run.status);
+  const revalidate = useMemo(() => () => revalidator.revalidate(), [revalidator.revalidate]);
+  const events = useRunEvents(slug, runId, detail.events, isLive, revalidate);
+  const [cancelError, setCancelError] = useState<string | null>(null);
+
+  const handleCancel = async () => {
+    setCancelError(null);
+    try {
+      await cancelRun(slug, runId);
+      revalidator.revalidate();
+    } catch (err) {
+      setCancelError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  return (
+    <ResourcePanel
+      crumbs={[
+        { label: "routines", to: "/routines" },
+        { label: slug, to: `/routines/${encodeURIComponent(slug)}` },
+        { label: runId.slice(0, 8) },
+      ]}
+    >
+      <div className="flex items-center gap-3">
+        <RunStatusBadge status={run.status} />
+        <span className="font-mono text-xs text-muted-foreground">{runId}</span>
+        {run.currentState ? (
+          <span className="text-xs text-muted-foreground">at {run.currentState}</span>
+        ) : null}
+        <span className="ml-auto flex items-center gap-2">
+          {isLive ? (
+            <Button size="sm" variant="ghost" onClick={handleCancel}>
+              cancel run
+            </Button>
+          ) : null}
+          <Button size="sm" variant="ghost" onClick={() => revalidator.revalidate()}>
+            refresh
+          </Button>
+        </span>
+      </div>
+      {cancelError ? <p className="text-destructive text-xs">{cancelError}</p> : null}
+      {run.error ? (
+        <p className="rounded-sm border border-destructive/30 bg-destructive/5 px-3 py-2 text-destructive text-xs">
+          {run.error.name}: {run.error.message}
+        </p>
+      ) : null}
+
+      <p className="text-xs uppercase tracking-[0.15em] text-muted-foreground">events</p>
+      <ol className="flex flex-col divide-y divide-border rounded-sm border border-border font-mono text-xs">
+        {events.map((event) => (
+          <li key={event.seq} className="flex items-baseline gap-2.5 px-3 py-1.5">
+            <span className="w-8 shrink-0 text-right text-muted-foreground">{event.seq}</span>
+            <span className="shrink-0 font-medium text-foreground">{event.type}</span>
+            <span className="min-w-0 flex-1 truncate text-muted-foreground">
+              {describePayload(event.payload)}
+            </span>
+          </li>
+        ))}
+        {events.length === 0 ? (
+          <li className="px-3 py-2 text-muted-foreground">no events yet</li>
+        ) : null}
+      </ol>
+
+      {run.output != null ? (
+        <>
+          <p className="text-xs uppercase tracking-[0.15em] text-muted-foreground">output</p>
+          <pre className="overflow-x-auto rounded-sm border border-border px-3 py-2 font-mono text-xs">
+            {JSON.stringify(run.output, null, 2)}
+          </pre>
+        </>
+      ) : null}
+    </ResourcePanel>
+  );
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+  const status = error instanceof ApiError ? error.status : undefined;
+  const message = error instanceof Error ? error.message : undefined;
+  return <ErrorState section="routines" status={status} message={message} />;
+}

--- a/apps/web/app/routes/_app.routines.$slug.tsx
+++ b/apps/web/app/routes/_app.routines.$slug.tsx
@@ -1,0 +1,198 @@
+import { Link, useLoaderData, useNavigate, useRevalidator, useRouteError } from "@remix-run/react";
+import { useState } from "react";
+import { ResourcePanel } from "~/components/resource-panel";
+import { RunStatusBadge } from "~/components/routines/run-status-badge";
+import { ErrorState } from "~/components/states";
+import { Button } from "~/components/ui/button";
+import { ApiError } from "~/lib/api";
+import {
+  listRoutines,
+  listRuns,
+  type RoutineInputsSchema,
+  type RoutineSummary,
+  triggerRun,
+} from "~/lib/routines";
+
+export async function clientLoader({ params }: { params: { slug: string } }) {
+  const slug = params.slug;
+  const [routines, runs] = await Promise.all([listRoutines(), listRuns(slug)]);
+  const routine = routines.find((r) => r.slug === slug);
+  if (!routine) throw new ApiError(404, "routine not found");
+  return { routine, runs };
+}
+
+/**
+ * Manual-trigger form derived from the routine's x-inputs JSON Schema (ROUT-V1-007):
+ * string → text, number/integer → number, boolean → checkbox, enum → select.
+ * Validation stays server-authoritative — the API's 400 message renders below.
+ */
+function TriggerForm({
+  routine,
+  onTriggered,
+}: {
+  routine: RoutineSummary;
+  onTriggered: (runId: string) => void;
+}) {
+  const schema: RoutineInputsSchema = routine.inputs ?? {};
+  const properties = schema.properties ?? {};
+  const required = new Set(schema.required ?? []);
+  const [values, setValues] = useState<Record<string, unknown>>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    try {
+      const { runId } = await triggerRun(routine.slug, values);
+      onTriggered(runId);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const setValue = (key: string, value: unknown) =>
+    setValues((prev) => ({ ...prev, [key]: value }));
+
+  return (
+    <form onSubmit={submit} className="flex flex-col gap-3 rounded-sm border border-border p-3">
+      <p className="text-xs uppercase tracking-[0.15em] text-muted-foreground">manual trigger</p>
+      {Object.entries(properties).map(([key, prop]) => {
+        const label = (
+          <span className="text-xs text-muted-foreground">
+            {key}
+            {required.has(key) ? <span className="text-primary"> *</span> : null}
+          </span>
+        );
+        if (prop.enum) {
+          return (
+            <label key={key} className="flex flex-col gap-1">
+              {label}
+              <select
+                className="rounded-sm border border-border bg-background px-2 py-1.5 text-sm"
+                value={String(values[key] ?? "")}
+                onChange={(e) => setValue(key, e.target.value)}
+              >
+                <option value="">—</option>
+                {prop.enum.map((opt) => (
+                  <option key={String(opt)} value={String(opt)}>
+                    {String(opt)}
+                  </option>
+                ))}
+              </select>
+            </label>
+          );
+        }
+        if (prop.type === "boolean") {
+          return (
+            <label key={key} className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={Boolean(values[key])}
+                onChange={(e) => setValue(key, e.target.checked)}
+              />
+              {label}
+            </label>
+          );
+        }
+        const isNumber = prop.type === "number" || prop.type === "integer";
+        return (
+          <label key={key} className="flex flex-col gap-1">
+            {label}
+            <input
+              type={isNumber ? "number" : "text"}
+              className="rounded-sm border border-border bg-background px-2 py-1.5 text-sm"
+              placeholder={prop.description}
+              value={String(values[key] ?? "")}
+              onChange={(e) => setValue(key, isNumber ? Number(e.target.value) : e.target.value)}
+            />
+          </label>
+        );
+      })}
+      {error ? <p className="text-destructive text-xs">{error}</p> : null}
+      <Button type="submit" size="sm" disabled={submitting} className="self-start">
+        {submitting ? "starting…" : "run now"}
+      </Button>
+    </form>
+  );
+}
+
+export default function RoutineDetail() {
+  const { routine, runs } = useLoaderData<typeof clientLoader>();
+  const navigate = useNavigate();
+  const revalidator = useRevalidator();
+  const canTriggerManually = (routine.triggers ?? []).some((t) => t.type === "manual");
+
+  return (
+    <ResourcePanel crumbs={[{ label: "routines", to: "/routines" }, { label: routine.slug }]}>
+      <div className="flex flex-col gap-1">
+        <h1 className="font-medium text-foreground">{routine.name ?? routine.slug}</h1>
+        {routine.description ? (
+          <p className="text-muted-foreground text-sm">{routine.description}</p>
+        ) : null}
+        <p className="text-xs text-muted-foreground">
+          triggers: {(routine.triggers ?? []).map((t) => t.type).join(", ") || "none"}
+          {routine.hasHooks ? " · hooks.ts" : ""}
+        </p>
+      </div>
+
+      {canTriggerManually ? (
+        <TriggerForm
+          routine={routine}
+          onTriggered={(runId) =>
+            navigate(`/routines/${encodeURIComponent(routine.slug)}/runs/${runId}`)
+          }
+        />
+      ) : (
+        <p className="text-xs text-muted-foreground">
+          This routine has no manual trigger — it starts from{" "}
+          {(routine.triggers ?? []).map((t) => t.type).join("/")}.
+        </p>
+      )}
+
+      <div className="flex items-center justify-between">
+        <p className="text-xs uppercase tracking-[0.15em] text-muted-foreground">run history</p>
+        <Button size="sm" variant="ghost" onClick={() => revalidator.revalidate()}>
+          refresh
+        </Button>
+      </div>
+      {runs.length === 0 ? (
+        <p className="text-xs text-muted-foreground">No runs yet.</p>
+      ) : (
+        <ul className="flex flex-col divide-y divide-border rounded-sm border border-border">
+          {runs.map((run) => (
+            <li key={run.id}>
+              <Link
+                to={`/routines/${encodeURIComponent(routine.slug)}/runs/${run.id}`}
+                className="flex items-center gap-2.5 px-3 py-2 transition-colors hover:bg-accent"
+              >
+                <RunStatusBadge status={run.status} />
+                <span className="font-mono text-xs text-muted-foreground">
+                  {run.id.slice(0, 8)}
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  {run.trigger?.type ?? "?"} · {new Date(run.createdAt).toLocaleString()}
+                </span>
+                {run.currentState ? (
+                  <span className="ml-auto text-xs text-muted-foreground">
+                    at {run.currentState}
+                  </span>
+                ) : null}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </ResourcePanel>
+  );
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+  const status = error instanceof ApiError ? error.status : undefined;
+  const message = error instanceof Error ? error.message : undefined;
+  return <ErrorState section="routines" status={status} message={message} />;
+}

--- a/apps/web/app/routes/_app.routines._index.tsx
+++ b/apps/web/app/routes/_app.routines._index.tsx
@@ -1,0 +1,92 @@
+import { Link, useLoaderData, useRouteError } from "@remix-run/react";
+import { EmptyState } from "~/components/empty-state";
+import { ResourcePanel } from "~/components/resource-panel";
+import { ErrorState } from "~/components/states";
+import { ApiError } from "~/lib/api";
+import { listRoutines, type RoutineTrigger } from "~/lib/routines";
+
+export async function clientLoader() {
+  const routines = await listRoutines();
+  return { routines };
+}
+
+function triggerLabel(trigger: RoutineTrigger): string {
+  switch (trigger.type) {
+    case "cron":
+      return `cron ${trigger.schedule}`;
+    case "event":
+      return `on ${trigger.event}`;
+    default:
+      return trigger.type;
+  }
+}
+
+export default function RoutinesIndex() {
+  const { routines } = useLoaderData<typeof clientLoader>();
+
+  if (routines.length === 0) {
+    return (
+      <EmptyState
+        section="routines"
+        title="Routines"
+        hint="No routines yet. Ask the assistant to forge one, or add soul/routines/<slug>/routine.yaml."
+      />
+    );
+  }
+
+  return (
+    <ResourcePanel crumbs={[{ label: "routines" }]}>
+      <p className="text-xs text-muted-foreground">
+        {routines.length} {routines.length === 1 ? "routine" : "routines"}
+      </p>
+      <ul className="flex flex-col divide-y divide-border rounded-sm border border-border">
+        {routines.map((routine) => (
+          <li key={routine.slug}>
+            {routine.valid ? (
+              <Link
+                to={`/routines/${encodeURIComponent(routine.slug)}`}
+                className="group flex items-center gap-2.5 px-3 py-2 transition-colors hover:bg-accent"
+              >
+                <span className="font-medium text-foreground">{routine.name ?? routine.slug}</span>
+                {routine.description ? (
+                  <span className="min-w-0 flex-1 truncate text-muted-foreground">
+                    {routine.description}
+                  </span>
+                ) : (
+                  <span className="flex-1" />
+                )}
+                <span className="ml-auto flex shrink-0 items-center gap-1.5 text-xs text-muted-foreground">
+                  {(routine.triggers ?? []).map((t, i) => (
+                    <span
+                      key={`${t.type}-${i.toString()}`}
+                      className="rounded-sm bg-muted px-1.5 py-0.5 uppercase tracking-[0.15em]"
+                    >
+                      {triggerLabel(t)}
+                    </span>
+                  ))}
+                </span>
+              </Link>
+            ) : (
+              <div className="flex items-center gap-2.5 px-3 py-2">
+                <span className="font-medium text-foreground">{routine.slug}</span>
+                <span
+                  className="min-w-0 flex-1 truncate text-destructive text-xs"
+                  title={routine.loadError ?? undefined}
+                >
+                  invalid: {routine.loadError}
+                </span>
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
+    </ResourcePanel>
+  );
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+  const status = error instanceof ApiError ? error.status : undefined;
+  const message = error instanceof Error ? error.message : undefined;
+  return <ErrorState section="routines" status={status} message={message} />;
+}

--- a/apps/web/app/routes/_app.routines.tsx
+++ b/apps/web/app/routes/_app.routines.tsx
@@ -1,14 +1,7 @@
-import type { MetaFunction } from "@remix-run/react";
-import { EmptyState } from "~/components/empty-state";
+import { type MetaFunction, Outlet } from "@remix-run/react";
 
 export const meta: MetaFunction = () => [{ title: "Routines · tulipfarm" }];
 
-export default function RoutinesPage() {
-  return (
-    <EmptyState
-      section="routines"
-      title="Routines"
-      hint="No routines yet. Durable automations appear here once defined."
-    />
-  );
+export default function RoutinesLayout() {
+  return <Outlet />;
 }

--- a/apps/web/app/routes/_app.skills.marketplace.tsx
+++ b/apps/web/app/routes/_app.skills.marketplace.tsx
@@ -287,7 +287,7 @@ export default function SkillsMarketplace() {
               <input
                 id="source"
                 className={inputClass}
-                placeholder="https://github.com/owner/repo  or  owner/repo"
+                placeholder="owner/repo[#branch]  or  https://github.com/owner/repo"
                 value={source}
                 onChange={(e) => setSource(e.target.value)}
                 disabled={busy !== null}

--- a/packages/routine-engine/package.json
+++ b/packages/routine-engine/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@tulipfarm/routine-engine",
+  "version": "0.0.0",
+  "private": true,
+  "main": "src/index.ts",
+  "scripts": {
+    "lint": "biome check --no-errors-on-unmatched .",
+    "test": "vitest run --passWithNoTests",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@tulipfarm/validation": "workspace:*"
+  },
+  "devDependencies": {
+    "@tulipfarm/tsconfig": "workspace:*",
+    "@types/node": "^24.13.2",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.9"
+  }
+}

--- a/packages/routine-engine/src/duration.test.ts
+++ b/packages/routine-engine/src/duration.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { parseIsoDuration } from "./duration";
+
+describe("parseIsoDuration", () => {
+  it("parses time components", () => {
+    expect(parseIsoDuration("PT1S")).toBe(1_000);
+    expect(parseIsoDuration("PT10M")).toBe(600_000);
+    expect(parseIsoDuration("PT2H")).toBe(7_200_000);
+    expect(parseIsoDuration("PT1H30M15S")).toBe(5_415_000);
+  });
+
+  it("parses date components", () => {
+    expect(parseIsoDuration("P1D")).toBe(86_400_000);
+    expect(parseIsoDuration("P1W")).toBe(604_800_000);
+    expect(parseIsoDuration("P1DT12H")).toBe(129_600_000);
+  });
+
+  it("throws on malformed durations", () => {
+    for (const bad of ["", "P", "PT", "10m", "PT5X", "5 minutes"]) {
+      expect(() => parseIsoDuration(bad)).toThrow(/invalid ISO-8601/);
+    }
+  });
+});

--- a/packages/routine-engine/src/duration.ts
+++ b/packages/routine-engine/src/duration.ts
@@ -1,0 +1,23 @@
+const ISO_RE =
+  /^P(?!$)(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?(?:T(?=\d)(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/;
+
+/**
+ * ISO-8601 duration → milliseconds. Years/months use calendar-free approximations
+ * (365/30 days) — routine sleeps and timeouts are expected in the seconds-to-days range.
+ * Throws on malformed input (the meta-schema should have caught it already).
+ */
+export function parseIsoDuration(iso: string): number {
+  const m = ISO_RE.exec(iso);
+  if (!m) throw new Error(`invalid ISO-8601 duration: ${iso}`);
+  const [, years, months, weeks, days, hours, minutes, seconds] = m;
+  const n = (v: string | undefined) => (v ? Number(v) : 0);
+  return (
+    n(years) * 365 * 86_400_000 +
+    n(months) * 30 * 86_400_000 +
+    n(weeks) * 7 * 86_400_000 +
+    n(days) * 86_400_000 +
+    n(hours) * 3_600_000 +
+    n(minutes) * 60_000 +
+    n(seconds) * 1_000
+  );
+}

--- a/packages/routine-engine/src/index.ts
+++ b/packages/routine-engine/src/index.ts
@@ -1,0 +1,12 @@
+export { parseIsoDuration } from "./duration";
+export { executeState, FOREACH_CAP } from "./interpreter";
+export type { EnginePorts, HookInvocation, ResolvedFunction } from "./ports";
+export type {
+  ApprovalRequest,
+  RunError,
+  RunEvent,
+  RunSnapshot,
+  RunTrigger,
+  StepOutcome,
+} from "./types";
+export { LIFECYCLE_HOOKS, stateHookNames } from "./types";

--- a/packages/routine-engine/src/interpreter.test.ts
+++ b/packages/routine-engine/src/interpreter.test.ts
@@ -1,0 +1,553 @@
+import type { RoutineDefinition } from "@tulipfarm/validation";
+import { describe, expect, it, vi } from "vitest";
+import { executeState } from "./interpreter";
+import type { EnginePorts, ResolvedFunction } from "./ports";
+import type { RunEvent, RunSnapshot } from "./types";
+
+/**
+ * Pure-port fakes: evalExpression runs real JS via Function (the production adapter is
+ * isolated-vm; semantics here only need to match "JS expression over a scope object").
+ */
+function makePorts(overrides: Partial<EnginePorts> = {}) {
+  const events: RunEvent[] = [];
+  const actions: Array<{ fn: ResolvedFunction; args: Record<string, unknown> }> = [];
+  const ports: EnginePorts & { events: RunEvent[]; actions: typeof actions } = {
+    events,
+    actions,
+    evalExpression: vi.fn(async (expr: string, scope: Record<string, unknown>) => {
+      const fn = new Function(...Object.keys(scope), `return (${expr});`);
+      return fn(...Object.values(scope));
+    }),
+    runHook: vi.fn(async () => undefined),
+    hasHook: vi.fn(() => false),
+    runAction: vi.fn(async (fn, args) => {
+      actions.push({ fn, args });
+      return { ok: true, echo: args };
+    }),
+    emit: vi.fn(async (event: RunEvent) => {
+      events.push(event);
+    }),
+    now: () => new Date("2026-07-06T12:00:00Z"),
+    log: { warn: vi.fn() },
+    ...overrides,
+  };
+  return ports;
+}
+
+function makeDef(partial: Partial<RoutineDefinition>): RoutineDefinition {
+  return {
+    id: "test-routine",
+    version: "1.0",
+    start: "Start",
+    "x-triggers": [{ type: "manual" }],
+    functions: [{ name: "doWork", operation: "tool:resource_create" }],
+    states: [],
+    ...partial,
+  } as RoutineDefinition;
+}
+
+function makeRun(def: RoutineDefinition, overrides: Partial<RunSnapshot> = {}): RunSnapshot {
+  return {
+    runId: "run-1",
+    slug: "test-routine",
+    definition: def,
+    currentState: def.start,
+    context: {},
+    trigger: { type: "manual", payload: { amount: 700 } },
+    attemptCounts: {},
+    ...overrides,
+  };
+}
+
+describe("inject state", () => {
+  it("merges data into context and transitions", async () => {
+    const def = makeDef({
+      states: [
+        { name: "Start", type: "inject", data: { greeting: "hi" }, transition: "Next" },
+        { name: "Next", type: "inject", data: {}, end: true },
+      ],
+    });
+    const outcome = await executeState(makeRun(def, { context: { keep: 1 } }), makePorts());
+    expect(outcome).toEqual({
+      type: "continue",
+      nextState: "Next",
+      context: { keep: 1, greeting: "hi" },
+    });
+  });
+
+  it("completes with output when end is true", async () => {
+    const def = makeDef({
+      states: [{ name: "Start", type: "inject", data: { done: true }, end: true }],
+    });
+    const outcome = await executeState(makeRun(def), makePorts());
+    expect(outcome).toEqual({ type: "complete", output: { done: true } });
+  });
+});
+
+describe("switch state", () => {
+  const def = makeDef({
+    states: [
+      {
+        name: "Start",
+        type: "switch",
+        dataConditions: [{ condition: "context.amount > 500", transition: "Big" }],
+        defaultCondition: { transition: "Small" },
+      },
+      { name: "Big", type: "inject", data: {}, end: true },
+      { name: "Small", type: "inject", data: {}, end: true },
+    ],
+  });
+
+  it("takes the first truthy condition", async () => {
+    const outcome = await executeState(makeRun(def, { context: { amount: 700 } }), makePorts());
+    expect(outcome).toMatchObject({ type: "continue", nextState: "Big" });
+  });
+
+  it("falls back to defaultCondition", async () => {
+    const outcome = await executeState(makeRun(def, { context: { amount: 10 } }), makePorts());
+    expect(outcome).toMatchObject({ type: "continue", nextState: "Small" });
+  });
+
+  it("does not mutate the shared definition when branching", async () => {
+    await executeState(makeRun(def, { context: { amount: 700 } }), makePorts());
+    const switchState = def.states[0];
+    expect(switchState.transition).toBeUndefined();
+    expect(switchState.end).toBeUndefined();
+  });
+
+  it("fails with no_matching_condition when nothing matches and no default", async () => {
+    const noDefault = makeDef({
+      states: [
+        {
+          name: "Start",
+          type: "switch",
+          dataConditions: [{ condition: "false", transition: "Start" }],
+        },
+      ],
+    });
+    const outcome = await executeState(makeRun(noDefault), makePorts());
+    expect(outcome).toMatchObject({ type: "fail", error: { name: "no_matching_condition" } });
+  });
+});
+
+describe("operation state", () => {
+  // biome-ignore lint/suspicious/noTemplateCurlyInString: ${...} is the routine expression DSL, not a JS template
+  it("runs actions with ${...} argument expressions and applies actionDataFilter", async () => {
+    const def = makeDef({
+      states: [
+        {
+          name: "Start",
+          type: "operation",
+          actions: [
+            {
+              functionRef: {
+                refName: "doWork",
+                // biome-ignore lint/suspicious/noTemplateCurlyInString: routine expression DSL
+                arguments: { amount: "${ context.amount * 2 }", label: "literal" },
+              },
+              actionDataFilter: { results: "result.echo.amount", toStateData: "context.doubled" },
+            },
+          ],
+          end: true,
+        },
+      ],
+    });
+    const ports = makePorts();
+    const outcome = await executeState(makeRun(def, { context: { amount: 21 } }), ports);
+    expect(ports.actions[0]).toMatchObject({
+      fn: { kind: "tool", target: "resource_create" },
+      args: { amount: 42, label: "literal" },
+    });
+    expect(outcome).toMatchObject({ type: "complete", output: { amount: 21, doubled: 42 } });
+  });
+
+  it("routes an action failure to fail when no retry/onErrors", async () => {
+    const def = makeDef({
+      states: [
+        {
+          name: "Start",
+          type: "operation",
+          actions: [{ functionRef: { refName: "doWork" } }],
+          end: true,
+        },
+      ],
+    });
+    const ports = makePorts({
+      runAction: vi.fn(async () => {
+        throw new Error("boom");
+      }),
+    });
+    const outcome = await executeState(makeRun(def), ports);
+    expect(outcome).toMatchObject({
+      type: "fail",
+      error: { name: "action_failed", message: "boom", state: "Start" },
+    });
+  });
+});
+
+describe("foreach state", () => {
+  it("iterates sequentially exposing iterationParam", async () => {
+    const def = makeDef({
+      states: [
+        {
+          name: "Start",
+          type: "foreach",
+          inputCollection: "context.items",
+          iterationParam: "row",
+          // biome-ignore lint/suspicious/noTemplateCurlyInString: routine expression DSL
+          actions: [{ functionRef: { refName: "doWork", arguments: { id: "${ row.id }" } } }],
+          end: true,
+        },
+      ],
+    });
+    const ports = makePorts();
+    await executeState(makeRun(def, { context: { items: [{ id: 1 }, { id: 2 }] } }), ports);
+    expect(ports.actions.map((a) => a.args)).toEqual([{ id: 1 }, { id: 2 }]);
+  });
+
+  it("fails when the collection exceeds the cap", async () => {
+    const def = makeDef({
+      states: [
+        {
+          name: "Start",
+          type: "foreach",
+          inputCollection: "context.items",
+          actions: [{ functionRef: { refName: "doWork" } }],
+          end: true,
+        },
+      ],
+    });
+    const items = Array.from({ length: 1001 }, (_, i) => i);
+    const outcome = await executeState(makeRun(def, { context: { items } }), makePorts());
+    expect(outcome).toMatchObject({ type: "fail", error: { name: "foreach_cap_exceeded" } });
+  });
+
+  it("fails when inputCollection is not an array", async () => {
+    const def = makeDef({
+      states: [
+        {
+          name: "Start",
+          type: "foreach",
+          inputCollection: "context.items",
+          actions: [{ functionRef: { refName: "doWork" } }],
+          end: true,
+        },
+      ],
+    });
+    const outcome = await executeState(makeRun(def, { context: { items: 42 } }), makePorts());
+    expect(outcome).toMatchObject({ type: "fail", error: { name: "bad_collection" } });
+  });
+});
+
+describe("sleep state", () => {
+  it("suspends until now + duration and resumes at transition", async () => {
+    const def = makeDef({
+      states: [
+        { name: "Start", type: "sleep", duration: "PT10M", transition: "Next" },
+        { name: "Next", type: "inject", data: {}, end: true },
+      ],
+    });
+    const outcome = await executeState(makeRun(def), makePorts());
+    expect(outcome).toMatchObject({
+      type: "sleep",
+      until: new Date("2026-07-06T12:10:00Z"),
+      nextState: "Next",
+    });
+  });
+
+  it("signals run completion after wake when end is true", async () => {
+    const def = makeDef({
+      states: [{ name: "Start", type: "sleep", duration: "PT1S", end: true }],
+    });
+    const outcome = await executeState(makeRun(def), makePorts());
+    expect(outcome).toMatchObject({ type: "sleep", nextState: null });
+  });
+});
+
+describe("retries and onErrors", () => {
+  const failingPorts = () =>
+    makePorts({
+      runAction: vi.fn(async () => {
+        throw new Error("flaky");
+      }),
+    });
+
+  const def = makeDef({
+    retries: [{ name: "std", maxAttempts: 3, delay: "PT2S", multiplier: 2 }],
+    states: [
+      {
+        name: "Start",
+        type: "operation",
+        actions: [{ functionRef: { refName: "doWork" }, retryRef: "std" }],
+        onErrors: [{ errorRef: "*", transition: "Recover" }],
+        end: true,
+      },
+      { name: "Recover", type: "inject", data: { recovered: true }, end: true },
+    ],
+  });
+
+  it("returns retry with exponential backoff while attempts remain", async () => {
+    const first = await executeState(makeRun(def), failingPorts());
+    expect(first).toMatchObject({ type: "retry", attempt: 1, delayMs: 2000 });
+
+    const second = await executeState(
+      makeRun(def, { attemptCounts: { Start: 1 } }),
+      failingPorts()
+    );
+    expect(second).toMatchObject({ type: "retry", attempt: 2, delayMs: 4000 });
+  });
+
+  it("routes through onErrors after retries are exhausted", async () => {
+    const outcome = await executeState(
+      makeRun(def, { attemptCounts: { Start: 2 } }),
+      failingPorts()
+    );
+    expect(outcome).toMatchObject({ type: "continue", nextState: "Recover" });
+  });
+
+  it("matches onErrors by errorRef name", async () => {
+    const named = makeDef({
+      states: [
+        {
+          name: "Start",
+          type: "operation",
+          actions: [{ functionRef: { refName: "doWork" } }],
+          onErrors: [
+            { errorRef: "timeout", transition: "Recover" },
+            { errorRef: "other_error", end: true },
+          ],
+          end: true,
+        },
+        { name: "Recover", type: "inject", data: {}, end: true },
+      ],
+    });
+    const timeoutPorts = makePorts({
+      runAction: vi.fn(async () => {
+        const err = new Error("too slow");
+        err.name = "timeout";
+        throw err;
+      }),
+    });
+    const outcome = await executeState(makeRun(named), timeoutPorts);
+    expect(outcome).toMatchObject({ type: "continue", nextState: "Recover" });
+  });
+
+  it("onErrors end:true completes the run with the error attached", async () => {
+    const named = makeDef({
+      states: [
+        {
+          name: "Start",
+          type: "operation",
+          actions: [{ functionRef: { refName: "doWork" } }],
+          onErrors: [{ errorRef: "*", end: true }],
+          end: true,
+        },
+      ],
+    });
+    const outcome = await executeState(makeRun(named), failingPorts());
+    expect(outcome).toMatchObject({
+      type: "complete",
+      output: { error: { name: "action_failed" } },
+    });
+  });
+});
+
+describe("per-state timeouts (ROUT-V1-007)", () => {
+  const slowPorts = () =>
+    makePorts({
+      runAction: vi.fn(
+        () => new Promise((resolve) => setTimeout(() => resolve({ ok: true }), 5_000))
+      ),
+    });
+
+  it("times out a slow state and routes through onErrors", async () => {
+    const def = makeDef({
+      states: [
+        {
+          name: "Start",
+          type: "operation",
+          timeouts: { stateExecTimeout: "PT1S" },
+          actions: [{ functionRef: { refName: "doWork" } }],
+          onErrors: [{ errorRef: "timeout", transition: "Recover" }],
+          end: true,
+        },
+        { name: "Recover", type: "inject", data: { recovered: true }, end: true },
+      ],
+    });
+    const started = Date.now();
+    const outcome = await executeState(makeRun(def), slowPorts());
+    expect(Date.now() - started).toBeLessThan(3_000);
+    expect(outcome).toMatchObject({ type: "continue", nextState: "Recover" });
+  });
+
+  it("fails with a timeout error when no onErrors matches", async () => {
+    const def = makeDef({
+      states: [
+        {
+          name: "Start",
+          type: "operation",
+          timeouts: { stateExecTimeout: "PT1S" },
+          actions: [{ functionRef: { refName: "doWork" } }],
+          end: true,
+        },
+      ],
+    });
+    const outcome = await executeState(makeRun(def), slowPorts());
+    expect(outcome).toMatchObject({ type: "fail", error: { name: "timeout" } });
+  });
+
+  it("does not time out a fast state", async () => {
+    const def = makeDef({
+      states: [
+        {
+          name: "Start",
+          type: "operation",
+          timeouts: { stateExecTimeout: "PT10S" },
+          actions: [{ functionRef: { refName: "doWork" } }],
+          end: true,
+        },
+      ],
+    });
+    const outcome = await executeState(makeRun(def), makePorts());
+    expect(outcome).toMatchObject({ type: "complete" });
+  });
+});
+
+describe("human_approval gate", () => {
+  const def = makeDef({
+    states: [
+      {
+        name: "Start",
+        type: "operation",
+        "x-autonomy-level": "human_approval",
+        "x-approval-channel": ["ui", "slack"],
+        actions: [{ functionRef: { refName: "doWork" } }],
+        end: true,
+      },
+    ],
+  });
+
+  it("pauses with wait_approval before executing", async () => {
+    const ports = makePorts();
+    const outcome = await executeState(makeRun(def, { context: { amount: 9 } }), ports);
+    expect(outcome).toEqual({
+      type: "wait_approval",
+      request: { stateName: "Start", channels: ["ui", "slack"], summary: { amount: 9 } },
+    });
+    expect(ports.runAction).not.toHaveBeenCalled();
+  });
+
+  it("executes normally once approved", async () => {
+    const ports = makePorts();
+    const outcome = await executeState(makeRun(def, { approvalOutcome: "approved" }), ports);
+    expect(outcome).toMatchObject({ type: "complete" });
+    expect(ports.runAction).toHaveBeenCalledOnce();
+  });
+
+  it("routes denial as approval_denied error", async () => {
+    const outcome = await executeState(makeRun(def, { approvalOutcome: "denied" }), makePorts());
+    expect(outcome).toMatchObject({ type: "fail", error: { name: "approval_denied" } });
+  });
+});
+
+describe("hooks lifecycle", () => {
+  it("runs before<State>/after<State> hooks and hook: actions", async () => {
+    const def = makeDef({
+      functions: [{ name: "computeTotal", operation: "hook:computeTotal" }],
+      states: [
+        {
+          name: "Report",
+          type: "operation",
+          actions: [
+            {
+              functionRef: { refName: "computeTotal", arguments: { base: 10 } },
+              actionDataFilter: { toStateData: "context.total" },
+            },
+          ],
+          end: true,
+        },
+      ],
+      start: "Report",
+    });
+    const runHook = vi.fn(async (fnName: string) => (fnName === "computeTotal" ? 55 : undefined));
+    const hasHook = vi.fn((name: string) => ["beforeReport", "afterReport"].includes(name));
+    const ports = makePorts({ runHook, hasHook });
+
+    const outcome = await executeState(makeRun(def, { currentState: "Report" }), ports);
+    expect(outcome).toMatchObject({ type: "complete", output: { total: 55 } });
+    const calls = runHook.mock.calls.map((c) => c[0]);
+    expect(calls).toEqual(["beforeReport", "computeTotal", "afterReport"]);
+  });
+});
+
+describe("state data filters and events", () => {
+  it("applies input/output stateDataFilter and emits lifecycle events", async () => {
+    const def = makeDef({
+      states: [
+        {
+          name: "Start",
+          type: "inject",
+          data: { added: 1 },
+          stateDataFilter: {
+            input: "({ narrowed: context.wide })",
+            output: "({ final: context.added + context.narrowed })",
+          },
+          end: true,
+        },
+      ],
+    });
+    const ports = makePorts();
+    const outcome = await executeState(makeRun(def, { context: { wide: 41 } }), ports);
+    expect(outcome).toEqual({ type: "complete", output: { final: 42 } });
+    expect(ports.events.map((e) => e.type)).toEqual(["state.entered", "state.completed"]);
+  });
+});
+
+describe("full multi-state run", () => {
+  it("walks a routine across all five state types to completion", async () => {
+    const def = makeDef({
+      start: "Seed",
+      functions: [{ name: "doWork", operation: "tool:resource_create" }],
+      states: [
+        { name: "Seed", type: "inject", data: { items: [1, 2], amount: 700 }, transition: "Gate" },
+        {
+          name: "Gate",
+          type: "switch",
+          dataConditions: [{ condition: "context.amount > 500", transition: "Work" }],
+          defaultCondition: { end: true },
+        },
+        {
+          name: "Work",
+          type: "foreach",
+          inputCollection: "context.items",
+          actions: [{ functionRef: { refName: "doWork" } }],
+          transition: "Cooldown",
+        },
+        { name: "Cooldown", type: "sleep", duration: "PT1S", transition: "Done" },
+        { name: "Done", type: "inject", data: { finished: true }, end: true },
+      ],
+    });
+    const ports = makePorts();
+    let run = makeRun(def, { currentState: "Seed" });
+    const visited: string[] = [];
+
+    for (let i = 0; i < 10; i++) {
+      visited.push(run.currentState);
+      const outcome = await executeState(run, ports);
+      if (outcome.type === "continue") {
+        run = { ...run, currentState: outcome.nextState, context: outcome.context };
+      } else if (outcome.type === "sleep") {
+        expect(outcome.nextState).toBe("Done");
+        run = { ...run, currentState: outcome.nextState ?? "", context: outcome.context };
+      } else if (outcome.type === "complete") {
+        expect(outcome.output).toMatchObject({ finished: true });
+        expect(visited).toEqual(["Seed", "Gate", "Work", "Cooldown", "Done"]);
+        expect(ports.runAction).toHaveBeenCalledTimes(2);
+        return;
+      } else {
+        throw new Error(`unexpected outcome ${outcome.type}`);
+      }
+    }
+    throw new Error("routine did not complete");
+  });
+});

--- a/packages/routine-engine/src/interpreter.ts
+++ b/packages/routine-engine/src/interpreter.ts
@@ -1,0 +1,409 @@
+import type {
+  RoutineAction,
+  RoutineDefinition,
+  RoutineOnError,
+  RoutineState,
+} from "@tulipfarm/validation";
+import { parseIsoDuration } from "./duration";
+import type { EnginePorts, HookInvocation, ResolvedFunction } from "./ports";
+import { type RunError, type RunSnapshot, type StepOutcome, stateHookNames } from "./types";
+
+/** Max items a foreach state may iterate (V1 bound; `parallel` is deferred anyway). */
+export const FOREACH_CAP = 1000;
+
+const EXPR_RE = /^\$\{([\s\S]+)\}$/;
+
+class StateFailure extends Error {
+  constructor(
+    readonly runError: RunError,
+    /** Retry policy of the failing action, when declared. */
+    readonly retryRef?: string
+  ) {
+    super(runError.message);
+  }
+}
+
+function findState(def: RoutineDefinition, name: string): RoutineState {
+  const state = def.states.find((s) => s.name === name);
+  if (!state) throw new Error(`state "${name}" not found in definition`);
+  return state;
+}
+
+function resolveFunction(def: RoutineDefinition, refName: string): ResolvedFunction {
+  const fn = (def.functions ?? []).find((f) => f.name === refName);
+  if (!fn) throw new Error(`function "${refName}" not found in definition`);
+  const [kind, ...rest] = fn.operation.split(":");
+  return { kind: kind as ResolvedFunction["kind"], target: rest.join(":") };
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/** Set a dot-path (e.g. "lastId" or "report.total") inside the context object. */
+function setPath(target: Record<string, unknown>, path: string, value: unknown): void {
+  const parts = path.replace(/^context\./, "").split(".");
+  let node = target;
+  for (const part of parts.slice(0, -1)) {
+    const next = node[part];
+    if (isRecord(next)) {
+      node = next;
+    } else {
+      const created: Record<string, unknown> = {};
+      node[part] = created;
+      node = created;
+    }
+  }
+  node[parts[parts.length - 1] ?? path] = value;
+}
+
+/**
+ * Executes exactly one state of a run and reports what should happen next. Pure with
+ * respect to I/O — every side effect goes through `ports`. The caller persists the
+ * outcome before acting on it (crash safety), so this function may be re-invoked for
+ * the same state after a crash.
+ */
+export async function executeState(run: RunSnapshot, ports: EnginePorts): Promise<StepOutcome> {
+  const def = run.definition;
+  let state: RoutineState;
+  try {
+    state = findState(def, run.currentState);
+  } catch (err) {
+    return fail({ name: "bad_definition", message: String(err), state: run.currentState });
+  }
+
+  // human_approval gate (ROUT-V1-003): pause before executing, resume on decision.
+  if (state["x-autonomy-level"] === "human_approval") {
+    if (run.approvalOutcome === undefined) {
+      return {
+        type: "wait_approval",
+        request: {
+          stateName: state.name,
+          channels: state["x-approval-channel"] ?? ["ui"],
+          summary: run.context,
+        },
+      };
+    }
+    if (run.approvalOutcome === "denied") {
+      return routeError(
+        run,
+        state,
+        { name: "approval_denied", message: `state "${state.name}" was denied`, state: state.name },
+        undefined
+      );
+    }
+  }
+
+  await ports.emit({ type: "state.entered", data: { state: state.name, stateType: state.type } });
+
+  const hooks = stateHookNames(state.name);
+  const invocation: HookInvocation = {
+    runId: run.runId,
+    slug: run.slug,
+    stateName: state.name,
+    context: run.context,
+    trigger: run.trigger,
+  };
+
+  try {
+    if (ports.hasHook(hooks.before)) await ports.runHook(hooks.before, invocation);
+
+    let context = { ...run.context };
+    if (state.stateDataFilter?.input) {
+      const filtered = await evalExpr(ports, state.stateDataFilter.input, scopeOf(run, context));
+      if (isRecord(filtered)) context = filtered;
+    }
+
+    const body = await withStateTimeout(run, state, context, ports);
+    if (body && "type" in body) return body; // sleep suspends here
+    const branch = body?.branch;
+
+    if (state.stateDataFilter?.output) {
+      const filtered = await evalExpr(ports, state.stateDataFilter.output, scopeOf(run, context));
+      if (isRecord(filtered)) context = filtered;
+    }
+
+    if (ports.hasHook(hooks.after)) {
+      await ports.runHook(hooks.after, { ...invocation, context });
+    }
+
+    await ports.emit({ type: "state.completed", data: { state: state.name } });
+
+    const end = branch ? branch.end : state.end;
+    const transition = branch ? branch.transition : state.transition;
+    if (end) return { type: "complete", output: context };
+    if (transition) return { type: "continue", nextState: transition, context };
+    return fail({
+      name: "bad_definition",
+      message: `state "${state.name}" has neither transition nor end`,
+      state: state.name,
+    });
+  } catch (err) {
+    const failure =
+      err instanceof StateFailure
+        ? err
+        : new StateFailure({
+            name: errorName(err),
+            message: err instanceof Error ? err.message : String(err),
+            state: state.name,
+          });
+    return routeError(run, state, failure.runError, failure.retryRef);
+  }
+}
+
+/**
+ * Per-state timeout (ROUT-V1-007): races the state body against
+ * `timeouts.stateExecTimeout`. A timeout becomes a `timeout` StateFailure routed through
+ * the normal retry/onErrors machinery. The caller's CAS-guarded persistence makes the
+ * race safe: whichever outcome persists first wins, the loser's transition misses.
+ */
+async function withStateTimeout(
+  run: RunSnapshot,
+  state: RoutineState,
+  context: Record<string, unknown>,
+  ports: EnginePorts
+): Promise<StepOutcome | BranchResult | undefined> {
+  const iso = state.timeouts?.stateExecTimeout;
+  if (!iso) return runStateBody(run, state, context, ports);
+
+  const ms = parseIsoDuration(iso);
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(
+        new StateFailure({
+          name: "timeout",
+          message: `state "${state.name}" exceeded stateExecTimeout ${iso}`,
+          state: state.name,
+        })
+      );
+    }, ms);
+  });
+  try {
+    return await Promise.race([runStateBody(run, state, context, ports), timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/** The switch branch chosen for this execution (overrides the state's transition/end). */
+interface BranchResult {
+  branch: { transition?: string; end?: boolean };
+}
+
+/**
+ * Executes the state's body against `context` (mutating it). Returns a StepOutcome when
+ * the state suspends (sleep), a BranchResult for switch, undefined otherwise — the
+ * shared completion path in `executeState` takes over.
+ */
+async function runStateBody(
+  run: RunSnapshot,
+  state: RoutineState,
+  context: Record<string, unknown>,
+  ports: EnginePorts
+): Promise<StepOutcome | BranchResult | undefined> {
+  switch (state.type) {
+    case "inject": {
+      Object.assign(context, state.data);
+      return undefined;
+    }
+    case "sleep": {
+      const until = new Date(ports.now().getTime() + parseIsoDuration(state.duration));
+      return {
+        type: "sleep",
+        until,
+        nextState: state.end ? null : (state.transition ?? null),
+        context: { ...run.context },
+      };
+    }
+    case "switch": {
+      for (const cond of state.dataConditions) {
+        const value = await evalExpr(ports, cond.condition, scopeOf(run, context));
+        if (value) return { branch: { transition: cond.transition, end: cond.end } };
+      }
+      if (state.defaultCondition) {
+        return {
+          branch: {
+            transition: state.defaultCondition.transition,
+            end: state.defaultCondition.end,
+          },
+        };
+      }
+      throw new StateFailure({
+        name: "no_matching_condition",
+        message: `switch "${state.name}" matched no condition and has no default`,
+        state: state.name,
+      });
+    }
+    case "operation": {
+      for (const action of state.actions) {
+        await runOneAction(run, state.name, action, context, {}, ports);
+      }
+      return undefined;
+    }
+    case "foreach": {
+      const collection = await evalExpr(ports, state.inputCollection, scopeOf(run, context));
+      if (!Array.isArray(collection)) {
+        throw new StateFailure({
+          name: "bad_collection",
+          message: `foreach "${state.name}" inputCollection did not yield an array`,
+          state: state.name,
+        });
+      }
+      if (collection.length > FOREACH_CAP) {
+        throw new StateFailure({
+          name: "foreach_cap_exceeded",
+          message: `foreach "${state.name}" got ${collection.length} items (cap ${FOREACH_CAP})`,
+          state: state.name,
+        });
+      }
+      const param = state.iterationParam ?? "item";
+      for (const item of collection) {
+        for (const action of state.actions) {
+          await runOneAction(run, state.name, action, context, { [param]: item }, ports);
+        }
+      }
+      return undefined;
+    }
+  }
+}
+
+/**
+ * Runs a single action: resolves the function, evaluates `${...}` argument expressions,
+ * dispatches through ports (tool/agent via runAction, hook via runHook), then applies
+ * actionDataFilter. Throws StateFailure carrying retryRef on failure.
+ */
+async function runOneAction(
+  run: RunSnapshot,
+  stateName: string,
+  action: RoutineAction,
+  context: Record<string, unknown>,
+  extraScope: Record<string, unknown>,
+  ports: EnginePorts
+): Promise<void> {
+  const scope = { ...scopeOf(run, context), ...extraScope };
+  let result: unknown;
+  try {
+    const fn = resolveFunction(run.definition, action.functionRef.refName);
+    const args = await evalArguments(ports, action.functionRef.arguments ?? {}, scope);
+    result =
+      fn.kind === "hook"
+        ? await ports.runHook(
+            fn.target,
+            {
+              runId: run.runId,
+              slug: run.slug,
+              stateName,
+              context,
+              trigger: run.trigger,
+            },
+            args
+          )
+        : await ports.runAction(fn, args, run);
+  } catch (err) {
+    throw new StateFailure(
+      {
+        name: errorName(err),
+        message: err instanceof Error ? err.message : String(err),
+        state: stateName,
+      },
+      action.retryRef
+    );
+  }
+
+  await ports.emit({
+    type: "action.completed",
+    data: { state: stateName, action: action.name ?? action.functionRef.refName },
+  });
+
+  const filter = action.actionDataFilter;
+  if (filter?.toStateData) {
+    const value = filter.results
+      ? await evalExpr(ports, filter.results, { ...scope, result })
+      : result;
+    setPath(context, filter.toStateData, value);
+  }
+}
+
+/**
+ * Retry + onErrors routing (ROUT-V1-007). Retry policy (via the failing action's
+ * retryRef) wins while attempts remain; then onErrors (`errorRef` match or "*") routes
+ * to a recovery state or a clean end; otherwise the run fails.
+ */
+function routeError(
+  run: RunSnapshot,
+  state: RoutineState,
+  error: RunError,
+  retryRef: string | undefined
+): StepOutcome {
+  if (retryRef) {
+    const policy = (run.definition.retries ?? []).find((r) => r.name === retryRef);
+    if (policy) {
+      const attempt = (run.attemptCounts[state.name] ?? 0) + 1;
+      if (attempt < policy.maxAttempts) {
+        const base = policy.delay ? parseIsoDuration(policy.delay) : 1_000;
+        const delayMs = Math.round(base * (policy.multiplier ?? 1) ** (attempt - 1));
+        return { type: "retry", delayMs, attempt, error };
+      }
+    }
+  }
+
+  const route = matchOnError(state.onErrors, error);
+  if (route) {
+    if (route.transition) {
+      return { type: "continue", nextState: route.transition, context: { ...run.context } };
+    }
+    if (route.end) return { type: "complete", output: { ...run.context, error } };
+  }
+  return { type: "fail", error };
+}
+
+function matchOnError(
+  onErrors: RoutineOnError[] | undefined,
+  error: RunError
+): RoutineOnError | undefined {
+  return (onErrors ?? []).find((o) => o.errorRef === error.name || o.errorRef === "*");
+}
+
+function scopeOf(run: RunSnapshot, context: Record<string, unknown>): Record<string, unknown> {
+  return { context, trigger: { type: run.trigger.type, payload: run.trigger.payload } };
+}
+
+async function evalExpr(
+  ports: EnginePorts,
+  expr: string,
+  scope: Record<string, unknown>
+): Promise<unknown> {
+  return ports.evalExpression(expr, scope);
+}
+
+/** Deep-walks literal arguments; string values shaped "${ <js> }" are evaluated. */
+async function evalArguments(
+  ports: EnginePorts,
+  args: Record<string, unknown>,
+  scope: Record<string, unknown>
+): Promise<Record<string, unknown>> {
+  const walk = async (value: unknown): Promise<unknown> => {
+    if (typeof value === "string") {
+      const m = EXPR_RE.exec(value);
+      return m ? ports.evalExpression(m[1].trim(), scope) : value;
+    }
+    if (Array.isArray(value)) return Promise.all(value.map(walk));
+    if (isRecord(value)) {
+      const out: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(value)) out[k] = await walk(v);
+      return out;
+    }
+    return value;
+  };
+  return (await walk(args)) as Record<string, unknown>;
+}
+
+function errorName(err: unknown): string {
+  if (err instanceof Error && err.name !== "Error") return err.name;
+  return "action_failed";
+}
+
+function fail(error: RunError): StepOutcome {
+  return { type: "fail", error };
+}

--- a/packages/routine-engine/src/ports.ts
+++ b/packages/routine-engine/src/ports.ts
@@ -1,0 +1,40 @@
+import type { RunEvent, RunSnapshot } from "./types";
+
+/** Hook invocation context passed to hooks.ts functions (mirrors resource hooks). */
+export interface HookInvocation {
+  runId: string;
+  slug: string;
+  stateName?: string;
+  context: Record<string, unknown>;
+  trigger: { type: string; payload?: unknown };
+}
+
+/** Resolved `functions[]` entry: `tool:x` | `agent:x` | `hook:x`. */
+export interface ResolvedFunction {
+  kind: "tool" | "agent" | "hook";
+  target: string;
+}
+
+/**
+ * Everything the interpreter needs from the outside world. All adapters (isolated-vm,
+ * ToolRegistry, agent turns, journal/SSE) live in apps/api — this package never imports
+ * Fastify or pg-boss.
+ */
+export interface EnginePorts {
+  /** Evaluate a JS expression in the sandbox (100ms, no host/fs/net). */
+  evalExpression(expr: string, scope: Record<string, unknown>): Promise<unknown>;
+  /** Run a hooks.ts function (2s sandbox). Only called when the routine has hooks. */
+  runHook(fnName: string, invocation: HookInvocation, args?: unknown): Promise<unknown>;
+  /** Whether the routine's hooks.ts defines `fnName`. False when there is no hooks.ts. */
+  hasHook(fnName: string): boolean;
+  /** Execute a tool or agent action. Throws on failure (interpreter maps to retry/onErrors). */
+  runAction(
+    fn: ResolvedFunction,
+    args: Record<string, unknown>,
+    run: RunSnapshot
+  ): Promise<unknown>;
+  /** Journal + fan out a run event. */
+  emit(event: RunEvent): Promise<void>;
+  now(): Date;
+  log: { warn(msg: string): void };
+}

--- a/packages/routine-engine/src/types.ts
+++ b/packages/routine-engine/src/types.ts
@@ -1,0 +1,97 @@
+import type { RoutineDefinition } from "@tulipfarm/validation";
+
+/** Trigger that started a run. `payload` is the trigger-specific input. */
+export interface RunTrigger {
+  type: "event" | "manual" | "cron" | "webhook" | "agent";
+  payload?: unknown;
+}
+
+/**
+ * The interpreter's view of a run: everything needed to execute the *next* state.
+ * Persistence (rows, journal seq, wake bookkeeping) is the caller's concern — the
+ * engine only reads/produces these fields.
+ */
+export interface RunSnapshot {
+  runId: string;
+  slug: string;
+  /** definitionSnapshot — pinned at run creation (ROUT-V1-007). */
+  definition: RoutineDefinition;
+  /** Name of the state to execute next. */
+  currentState: string;
+  /** Data-flow context, threaded state to state. */
+  context: Record<string, unknown>;
+  trigger: RunTrigger;
+  /** Per-state retry attempt counts, keyed by state name. */
+  attemptCounts: Record<string, number>;
+  /**
+   * Approval decision for `currentState`, when resuming a human_approval gate.
+   * Absent ⇒ the gate has not been requested/decided yet.
+   */
+  approvalOutcome?: "approved" | "denied";
+}
+
+export interface RunError {
+  /** Stable error name used for onErrors matching (e.g. "action_failed", "timeout"). */
+  name: string;
+  message: string;
+  /** State the error surfaced in. */
+  state: string;
+}
+
+/** Approval request produced by a human_approval state (ROUT-V1-003/006). */
+export interface ApprovalRequest {
+  stateName: string;
+  /** Declared channels, unfiltered — channel fallback (email/sms → ui) is the caller's job. */
+  channels: string[];
+  /** Context snapshot for the approver UI/message. */
+  summary: Record<string, unknown>;
+}
+
+/** Outcome of executing one state. The driver persists, then acts on it. */
+export type StepOutcome =
+  | { type: "continue"; nextState: string; context: Record<string, unknown> }
+  | { type: "complete"; output: Record<string, unknown> }
+  | { type: "fail"; error: RunError }
+  | {
+      type: "sleep";
+      until: Date;
+      /** State to resume at after waking; null ⇒ the run completes on wake. */
+      nextState: string | null;
+      context: Record<string, unknown>;
+    }
+  | { type: "wait_approval"; request: ApprovalRequest }
+  | {
+      type: "retry";
+      /** Delay before re-executing the same state. */
+      delayMs: number;
+      attempt: number;
+      error: RunError;
+    };
+
+/**
+ * Engine-emitted run events. The driver journals these (durable history) and fans them
+ * out over SSE. Terminal event types are exactly "finish" / "error" so the existing
+ * StreamHub close semantics apply unchanged.
+ */
+export interface RunEvent {
+  type:
+    | "run.started"
+    | "state.entered"
+    | "action.completed"
+    | "state.completed"
+    | "state.retrying"
+    | "run.sleeping"
+    | "run.waiting_approval"
+    | "finish"
+    | "error";
+  data: Record<string, unknown>;
+}
+
+/** Whole-routine lifecycle hook names (hooks.ts contract). */
+export const LIFECYCLE_HOOKS = { beforeRun: "beforeHook", afterRun: "afterHook" } as const;
+
+/** Per-state lifecycle hook names: before<StateName> / after<StateName>. */
+export function stateHookNames(stateName: string): { before: string; after: string } {
+  const cap = stateName.charAt(0).toUpperCase() + stateName.slice(1);
+  return { before: `before${cap}`, after: `after${cap}` };
+}

--- a/packages/routine-engine/tsconfig.json
+++ b/packages/routine-engine/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@tulipfarm/tsconfig/base.json",
+  "compilerOptions": {
+    "moduleResolution": "bundler",
+    "module": "ESNext",
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/packages/soul/src/soul-loader.test.ts
+++ b/packages/soul/src/soul-loader.test.ts
@@ -218,6 +218,22 @@ describe("SoulLoader", () => {
       });
       expect(loader.routines.get("daily-report")?.hasHooks).toBe(true);
     });
+
+    it("reads hookSource and computes hookHash when hooks.ts exists", async () => {
+      const hookSource = "({ beforeHook(ctx) { return ctx; } })";
+      await write(join(TMP, "routines", "hooked", "routine.yaml"), "name: hooked\n");
+      await write(join(TMP, "routines", "hooked", "hooks.ts"), hookSource);
+      await write(join(TMP, "routines", "bare", "routine.yaml"), "name: bare\n");
+      const loader = new SoulLoader(TMP, makeLogger());
+      await loader.load();
+      const hooked = loader.routines.get("hooked");
+      expect(hooked?.hookSource).toBe(hookSource);
+      expect(hooked?.hookHash).toMatch(/^[0-9a-f]{64}$/);
+      const bare = loader.routines.get("bare");
+      expect(bare?.hasHooks).toBe(false);
+      expect(bare?.hookSource).toBeUndefined();
+      expect(bare?.hookHash).toBeUndefined();
+    });
   });
 
   describe("integrations", () => {

--- a/packages/soul/src/soul-loader.ts
+++ b/packages/soul/src/soul-loader.ts
@@ -179,8 +179,13 @@ export class SoulLoader {
       try {
         const content = await readFile(configPath, "utf8");
         const config = (parseYaml(content) ?? {}) as Record<string, unknown>;
-        const hasHooks = await fileExists(join(this.soulPath, "routines", name, "hooks.ts"));
-        map.set(name, { name, config, hasHooks });
+        const hooksPath = join(this.soulPath, "routines", name, "hooks.ts");
+        const hasHooks = await fileExists(hooksPath);
+        const hookSource = hasHooks ? await readFile(hooksPath, "utf8") : undefined;
+        const hookHash = hookSource
+          ? createHash("sha256").update(hookSource).digest("hex")
+          : undefined;
+        map.set(name, { name, config, hasHooks, hookSource, hookHash });
       } catch (err) {
         this.logger.warn(
           `Soul: skipping routine "${name}" — ${err instanceof Error ? err.message : String(err)}`

--- a/packages/soul/src/types.ts
+++ b/packages/soul/src/types.ts
@@ -23,6 +23,8 @@ export interface SoulRoutine {
   name: string;
   config: Record<string, unknown>;
   hasHooks: boolean;
+  hookSource?: string;
+  hookHash?: string;
 }
 
 export type McpEntry =

--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -11,6 +11,24 @@ export type {
   ToolBlocklistConfig,
 } from "./guardrails";
 export { validateGuardrailsConfig } from "./guardrails";
+export type {
+  RoutineAction,
+  RoutineDefinition,
+  RoutineOnError,
+  RoutineRetryPolicy,
+  RoutineState,
+  RoutineTrigger,
+} from "./routine";
+export {
+  DEFERRED_STATE_TYPES,
+  DEFERRED_TRIGGER_TYPES,
+  ROUTINE_APPROVAL_CHANNELS,
+  ROUTINE_EVENT_NAMES,
+  ROUTINE_STATE_TYPES,
+  ROUTINE_TRIGGER_TYPES,
+  RoutineDefinitionSchema,
+  validateRoutineDefinition,
+} from "./routine";
 export type { CounterFn } from "./transforms";
 export {
   applyTransforms,

--- a/packages/validation/src/routine.test.ts
+++ b/packages/validation/src/routine.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+import { TulipFarmValidationError } from "./error";
+import { type RoutineDefinition, validateRoutineDefinition } from "./routine";
+
+function baseRoutine(): Record<string, unknown> {
+  return {
+    id: "reimbursement-approval",
+    version: "1.0",
+    name: "Reimbursement Approval",
+    start: "CheckAmount",
+    "x-triggers": [{ type: "manual" }],
+    functions: [
+      { name: "createRecord", operation: "tool:resource_create" },
+      { name: "notify", operation: "agent:general-assistant" },
+      { name: "computeTotal", operation: "hook:computeTotal" },
+    ],
+    retries: [{ name: "default", maxAttempts: 3, delay: "PT5S", multiplier: 2 }],
+    states: [
+      {
+        name: "CheckAmount",
+        type: "switch",
+        dataConditions: [{ condition: "context.amount > 500", transition: "NeedsApproval" }],
+        defaultCondition: { transition: "Record" },
+      },
+      {
+        name: "NeedsApproval",
+        type: "operation",
+        "x-autonomy-level": "human_approval",
+        "x-approval-channel": ["ui", "slack"],
+        actions: [{ functionRef: { refName: "notify", arguments: { task: "review" } } }],
+        transition: "Record",
+      },
+      {
+        name: "Wait",
+        type: "sleep",
+        duration: "PT10M",
+        transition: "Record",
+      },
+      {
+        name: "Seed",
+        type: "inject",
+        data: { approved: true },
+        transition: "Record",
+      },
+      {
+        name: "Record",
+        type: "foreach",
+        inputCollection: "context.items",
+        iterationParam: "item",
+        actions: [
+          {
+            functionRef: { refName: "createRecord" },
+            retryRef: "default",
+            actionDataFilter: { results: "result.id", toStateData: "context.lastId" },
+          },
+        ],
+        end: true,
+      },
+    ],
+  };
+}
+
+describe("validateRoutineDefinition", () => {
+  it("accepts a valid routine using all five V1 state types", () => {
+    const def: RoutineDefinition = validateRoutineDefinition(baseRoutine());
+    expect(def.id).toBe("reimbursement-approval");
+    expect(def.states).toHaveLength(5);
+  });
+
+  it("accepts all five V1 trigger types", () => {
+    const routine = baseRoutine();
+    routine["x-triggers"] = [
+      { type: "manual" },
+      { type: "cron", schedule: "0 9 * * 1", timezone: "UTC" },
+      { type: "webhook", secret_ref: "my-hook-secret" },
+      { type: "event", event: "resource.created", filter: "trigger.payload.resourceType === 'x'" },
+      { type: "agent" },
+    ];
+    expect(() => validateRoutineDefinition(routine)).not.toThrow();
+  });
+
+  it("rejects a parallel state with a deferred-in-V1 error and JSON pointer", () => {
+    const routine = baseRoutine();
+    (routine.states as unknown[]).push({ name: "Fan", type: "parallel", branches: [] });
+    expect(() => validateRoutineDefinition(routine)).toThrowError(/deferred in V1/);
+    try {
+      validateRoutineDefinition(routine);
+    } catch (err) {
+      expect(err).toBeInstanceOf(TulipFarmValidationError);
+      expect((err as TulipFarmValidationError).path).toBe("/states/5/type");
+    }
+  });
+
+  it("rejects an event state as deferred", () => {
+    const routine = baseRoutine();
+    (routine.states as unknown[]).push({ name: "Park", type: "event", onEvents: [] });
+    expect(() => validateRoutineDefinition(routine)).toThrowError(/deferred in V1/);
+  });
+
+  it("rejects subFlowRef (sub-routine) as deferred", () => {
+    const routine = baseRoutine();
+    const states = routine.states as Array<Record<string, unknown>>;
+    const needsApproval = states[1];
+    (needsApproval.actions as unknown[]).push({ subFlowRef: "other-routine" });
+    expect(() => validateRoutineDefinition(routine)).toThrowError(/deferred in V1/);
+  });
+
+  it("rejects datetime and integration triggers as deferred", () => {
+    for (const type of ["datetime", "integration"]) {
+      const routine = baseRoutine();
+      routine["x-triggers"] = [{ type }];
+      expect(() => validateRoutineDefinition(routine)).toThrowError(/deferred in V1/);
+    }
+  });
+
+  it("rejects an unknown event name on an event trigger", () => {
+    const routine = baseRoutine();
+    routine["x-triggers"] = [{ type: "event", event: "nonexistent.event" }];
+    expect(() => validateRoutineDefinition(routine)).toThrow(TulipFarmValidationError);
+  });
+
+  it("rejects a webhook trigger without secret_ref", () => {
+    const routine = baseRoutine();
+    routine["x-triggers"] = [{ type: "webhook" }];
+    expect(() => validateRoutineDefinition(routine)).toThrow(TulipFarmValidationError);
+  });
+
+  it("rejects a start state that does not exist", () => {
+    const routine = baseRoutine();
+    routine.start = "Nope";
+    expect(() => validateRoutineDefinition(routine)).toThrowError(/start state "Nope" not found/);
+  });
+
+  it("rejects a dangling transition target", () => {
+    const routine = baseRoutine();
+    const states = routine.states as Array<Record<string, unknown>>;
+    states[2].transition = "Ghost";
+    expect(() => validateRoutineDefinition(routine)).toThrowError(/"Ghost" not found/);
+  });
+
+  it("rejects an action referencing an unknown function", () => {
+    const routine = baseRoutine();
+    const states = routine.states as Array<Record<string, unknown>>;
+    (states[1].actions as Array<Record<string, unknown>>)[0] = {
+      functionRef: { refName: "missingFn" },
+    };
+    expect(() => validateRoutineDefinition(routine)).toThrowError(/"missingFn" not found/);
+  });
+
+  it("rejects an unknown retryRef", () => {
+    const routine = baseRoutine();
+    const states = routine.states as Array<Record<string, unknown>>;
+    const action = (states[4].actions as Array<Record<string, unknown>>)[0];
+    action.retryRef = "aggressive";
+    expect(() => validateRoutineDefinition(routine)).toThrowError(/"aggressive" not found/);
+  });
+
+  it("rejects human_approval on a non-operation state", () => {
+    const routine = baseRoutine();
+    const states = routine.states as Array<Record<string, unknown>>;
+    states[2]["x-autonomy-level"] = "human_approval";
+    expect(() => validateRoutineDefinition(routine)).toThrowError(/only valid on operation/);
+  });
+
+  it("rejects a bad function operation format", () => {
+    const routine = baseRoutine();
+    (routine.functions as unknown[]).push({ name: "bad", operation: "shell:rm -rf" });
+    expect(() => validateRoutineDefinition(routine)).toThrow(TulipFarmValidationError);
+  });
+
+  it("rejects malformed ISO durations", () => {
+    const routine = baseRoutine();
+    const states = routine.states as Array<Record<string, unknown>>;
+    states[2].duration = "10 minutes";
+    expect(() => validateRoutineDefinition(routine)).toThrow(TulipFarmValidationError);
+  });
+
+  it("rejects unknown top-level keys", () => {
+    const routine = baseRoutine();
+    routine.bogus = true;
+    expect(() => validateRoutineDefinition(routine)).toThrow(TulipFarmValidationError);
+  });
+
+  it("accepts email/sms approval channels at schema level (runtime falls back to ui)", () => {
+    const routine = baseRoutine();
+    const states = routine.states as Array<Record<string, unknown>>;
+    states[1]["x-approval-channel"] = ["email", "sms"];
+    expect(() => validateRoutineDefinition(routine)).not.toThrow();
+  });
+});

--- a/packages/validation/src/routine.ts
+++ b/packages/validation/src/routine.ts
@@ -1,0 +1,399 @@
+import { type Static, Type } from "@sinclair/typebox";
+import { ajv } from "./ajv";
+import { TulipFarmValidationError } from "./error";
+
+/**
+ * routine.yaml meta-schema (ROUT-V1-004/005, AC-V1-002). CNCF Serverless Workflow 0.8
+ * subset + `x-` extensions. Deferred constructs (`parallel`/`event` states, `subFlowRef`,
+ * `datetime`/`integration` triggers) are detected in a pre-pass and rejected with an
+ * explicit "deferred in V1" error before AJV runs, so authors see the real reason instead
+ * of a union-mismatch message.
+ *
+ * Expressions (switch conditions, foreach inputCollection, data filters, `${...}` argument
+ * values) are opaque JS strings here — evaluated at runtime in isolated-vm (100ms).
+ *
+ * hooks.ts contract (documented, not schema-enforced): an object-literal expression
+ * `({ beforeHook(ctx){}, afterHook(ctx){}, before<StateName>(ctx){}, after<StateName>(ctx){},
+ * <fnName>(ctx, args){} })` — step-callable fns are referenced by functions with
+ * `operation: "hook:<fnName>"`.
+ */
+
+export const ROUTINE_STATE_TYPES = ["operation", "switch", "foreach", "sleep", "inject"] as const;
+export const ROUTINE_TRIGGER_TYPES = ["event", "manual", "cron", "webhook", "agent"] as const;
+export const ROUTINE_APPROVAL_CHANNELS = ["ui", "slack", "email", "sms"] as const;
+/** Deferred to post-V1 (ROUT-V1-004/005). */
+export const DEFERRED_STATE_TYPES = ["parallel", "event"] as const;
+export const DEFERRED_TRIGGER_TYPES = ["datetime", "integration"] as const;
+
+/**
+ * Domain-event names a routine `event` trigger may subscribe to. Mirrors
+ * `DOMAIN_EVENTS` in apps/api/src/domain-events.ts (kept as a literal list here —
+ * validation cannot depend on the api app).
+ */
+export const ROUTINE_EVENT_NAMES = [
+  "resource.created",
+  "resource.updated",
+  "conversation.created",
+  "conversation.completed",
+] as const;
+
+const ISO_DURATION = "^P(?!$)(\\d+Y)?(\\d+M)?(\\d+W)?(\\d+D)?(T(?=\\d)(\\d+H)?(\\d+M)?(\\d+S)?)?$";
+
+const EventName = Type.Unsafe<(typeof ROUTINE_EVENT_NAMES)[number]>({
+  type: "string",
+  enum: [...ROUTINE_EVENT_NAMES],
+});
+
+const ApprovalChannel = Type.Unsafe<(typeof ROUTINE_APPROVAL_CHANNELS)[number]>({
+  type: "string",
+  enum: [...ROUTINE_APPROVAL_CHANNELS],
+});
+
+// ── Triggers (x-triggers) ─────────────────────────────────────────────────────
+
+const EventTrigger = Type.Object(
+  {
+    type: Type.Literal("event"),
+    event: EventName,
+    /** Optional JS filter over `{ trigger }`; run must only start when it returns truthy. */
+    filter: Type.Optional(Type.String({ minLength: 1 })),
+  },
+  { additionalProperties: false }
+);
+
+const ManualTrigger = Type.Object(
+  { type: Type.Literal("manual") },
+  { additionalProperties: false }
+);
+
+const CronTrigger = Type.Object(
+  {
+    type: Type.Literal("cron"),
+    schedule: Type.String({ minLength: 1 }),
+    timezone: Type.Optional(Type.String({ minLength: 1 })),
+  },
+  { additionalProperties: false }
+);
+
+const WebhookTrigger = Type.Object(
+  {
+    type: Type.Literal("webhook"),
+    /** Secret name resolved via SecretsService; requests without the matching header are rejected. */
+    secret_ref: Type.String({ minLength: 1 }),
+  },
+  { additionalProperties: false }
+);
+
+const AgentTrigger = Type.Object({ type: Type.Literal("agent") }, { additionalProperties: false });
+
+const Trigger = Type.Union([
+  EventTrigger,
+  ManualTrigger,
+  CronTrigger,
+  WebhookTrigger,
+  AgentTrigger,
+]);
+
+// ── Functions ─────────────────────────────────────────────────────────────────
+
+const FunctionDef = Type.Object(
+  {
+    name: Type.String({ minLength: 1 }),
+    /** `tool:<toolName>` | `agent:<agentName>` | `hook:<hooksFnName>` */
+    operation: Type.String({ pattern: "^(tool|agent|hook):\\S+$" }),
+  },
+  { additionalProperties: false }
+);
+
+// ── Errors / retries ──────────────────────────────────────────────────────────
+
+const OnError = Type.Object(
+  {
+    /** Error name to match, or "*" for any. */
+    errorRef: Type.String({ minLength: 1 }),
+    transition: Type.Optional(Type.String({ minLength: 1 })),
+    end: Type.Optional(Type.Boolean()),
+  },
+  { additionalProperties: false }
+);
+
+const RetryPolicy = Type.Object(
+  {
+    name: Type.String({ minLength: 1 }),
+    maxAttempts: Type.Integer({ minimum: 1, maximum: 100 }),
+    /** ISO-8601 duration, e.g. PT5S. */
+    delay: Type.Optional(Type.String({ pattern: ISO_DURATION })),
+    multiplier: Type.Optional(Type.Number({ minimum: 1 })),
+  },
+  { additionalProperties: false }
+);
+
+// ── States ────────────────────────────────────────────────────────────────────
+
+const StateDataFilter = Type.Object(
+  {
+    input: Type.Optional(Type.String({ minLength: 1 })),
+    output: Type.Optional(Type.String({ minLength: 1 })),
+  },
+  { additionalProperties: false }
+);
+
+const ActionDataFilter = Type.Object(
+  {
+    results: Type.Optional(Type.String({ minLength: 1 })),
+    toStateData: Type.Optional(Type.String({ minLength: 1 })),
+  },
+  { additionalProperties: false }
+);
+
+const Action = Type.Object(
+  {
+    name: Type.Optional(Type.String({ minLength: 1 })),
+    functionRef: Type.Object(
+      {
+        refName: Type.String({ minLength: 1 }),
+        /** Literal args; string values of the form "${ <js> }" are evaluated at runtime. */
+        arguments: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+      },
+      { additionalProperties: false }
+    ),
+    retryRef: Type.Optional(Type.String({ minLength: 1 })),
+    actionDataFilter: Type.Optional(ActionDataFilter),
+  },
+  { additionalProperties: false }
+);
+
+const Timeouts = Type.Object(
+  { stateExecTimeout: Type.Optional(Type.String({ pattern: ISO_DURATION })) },
+  { additionalProperties: false }
+);
+
+/** Fields shared by every V1 state. */
+const stateBase = {
+  name: Type.String({ minLength: 1, pattern: "^[A-Za-z][A-Za-z0-9]*$" }),
+  transition: Type.Optional(Type.String({ minLength: 1 })),
+  end: Type.Optional(Type.Boolean()),
+  onErrors: Type.Optional(Type.Array(OnError, { minItems: 1 })),
+  timeouts: Type.Optional(Timeouts),
+  stateDataFilter: Type.Optional(StateDataFilter),
+  "x-autonomy-level": Type.Optional(Type.Literal("human_approval")),
+  "x-approval-channel": Type.Optional(Type.Array(ApprovalChannel, { minItems: 1 })),
+};
+
+const OperationState = Type.Object(
+  { ...stateBase, type: Type.Literal("operation"), actions: Type.Array(Action, { minItems: 1 }) },
+  { additionalProperties: false }
+);
+
+const SwitchCondition = Type.Object(
+  {
+    condition: Type.String({ minLength: 1 }),
+    transition: Type.Optional(Type.String({ minLength: 1 })),
+    end: Type.Optional(Type.Boolean()),
+  },
+  { additionalProperties: false }
+);
+
+const DefaultCondition = Type.Object(
+  {
+    transition: Type.Optional(Type.String({ minLength: 1 })),
+    end: Type.Optional(Type.Boolean()),
+  },
+  { additionalProperties: false }
+);
+
+const SwitchState = Type.Object(
+  {
+    ...stateBase,
+    type: Type.Literal("switch"),
+    dataConditions: Type.Array(SwitchCondition, { minItems: 1 }),
+    defaultCondition: Type.Optional(DefaultCondition),
+  },
+  { additionalProperties: false }
+);
+
+const ForeachState = Type.Object(
+  {
+    ...stateBase,
+    type: Type.Literal("foreach"),
+    /** JS expression yielding an array (cap 1,000 items, enforced at runtime). */
+    inputCollection: Type.String({ minLength: 1 }),
+    iterationParam: Type.Optional(Type.String({ minLength: 1 })),
+    actions: Type.Array(Action, { minItems: 1 }),
+  },
+  { additionalProperties: false }
+);
+
+const SleepState = Type.Object(
+  { ...stateBase, type: Type.Literal("sleep"), duration: Type.String({ pattern: ISO_DURATION }) },
+  { additionalProperties: false }
+);
+
+const InjectState = Type.Object(
+  { ...stateBase, type: Type.Literal("inject"), data: Type.Record(Type.String(), Type.Unknown()) },
+  { additionalProperties: false }
+);
+
+const State = Type.Union([OperationState, SwitchState, ForeachState, SleepState, InjectState]);
+
+// ── Root ──────────────────────────────────────────────────────────────────────
+
+export const RoutineDefinitionSchema = Type.Object(
+  {
+    id: Type.String({ minLength: 1 }),
+    version: Type.String({ minLength: 1 }),
+    name: Type.Optional(Type.String({ minLength: 1 })),
+    description: Type.Optional(Type.String()),
+    specVersion: Type.Optional(Type.Literal("0.8")),
+    start: Type.String({ minLength: 1 }),
+    states: Type.Array(State, { minItems: 1 }),
+    functions: Type.Optional(Type.Array(FunctionDef)),
+    retries: Type.Optional(Type.Array(RetryPolicy)),
+    "x-triggers": Type.Array(Trigger, { minItems: 1 }),
+    /** JSON Schema for the manual-trigger form; also validates webhook/agent payloads. */
+    "x-inputs": Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+  },
+  { additionalProperties: false }
+);
+
+export type RoutineDefinition = Static<typeof RoutineDefinitionSchema>;
+export type RoutineState = Static<typeof State>;
+export type RoutineTrigger = Static<typeof Trigger>;
+export type RoutineAction = Static<typeof Action>;
+export type RoutineRetryPolicy = Static<typeof RetryPolicy>;
+export type RoutineOnError = Static<typeof OnError>;
+
+const check = ajv.compile(RoutineDefinitionSchema);
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/**
+ * Pre-pass: find deferred CNCF SW constructs and throw a "deferred in V1" error with a
+ * JSON pointer, before AJV turns them into opaque union-mismatch messages (AC-V1-002).
+ */
+function rejectDeferredConstructs(data: unknown): void {
+  if (!isRecord(data)) return;
+
+  const states = Array.isArray(data.states) ? data.states : [];
+  for (const [i, state] of states.entries()) {
+    if (!isRecord(state)) continue;
+    if ((DEFERRED_STATE_TYPES as readonly string[]).includes(String(state.type))) {
+      throw new TulipFarmValidationError(
+        "soul",
+        `/states/${i}/type`,
+        `state type "${String(state.type)}" is deferred in V1`
+      );
+    }
+    const actionLists = [state.actions].filter(Array.isArray);
+    for (const actions of actionLists) {
+      for (const [j, action] of actions.entries()) {
+        if (isRecord(action) && "subFlowRef" in action) {
+          throw new TulipFarmValidationError(
+            "soul",
+            `/states/${i}/actions/${j}/subFlowRef`,
+            "sub-routine invocation (subFlowRef) is deferred in V1"
+          );
+        }
+      }
+    }
+  }
+
+  const triggers = Array.isArray(data["x-triggers"]) ? data["x-triggers"] : [];
+  for (const [i, trigger] of triggers.entries()) {
+    if (!isRecord(trigger)) continue;
+    if ((DEFERRED_TRIGGER_TYPES as readonly string[]).includes(String(trigger.type))) {
+      throw new TulipFarmValidationError(
+        "soul",
+        `/x-triggers/${i}/type`,
+        `trigger type "${String(trigger.type)}" is deferred in V1`
+      );
+    }
+  }
+}
+
+/**
+ * Structural checks AJV cannot express: start/transition targets exist, retryRef /
+ * functionRef names resolve, human_approval only on operation/foreach states.
+ */
+function checkReferences(def: RoutineDefinition): void {
+  const stateNames = new Set(def.states.map((s) => s.name));
+  if (!stateNames.has(def.start)) {
+    throw new TulipFarmValidationError("soul", "/start", `start state "${def.start}" not found`);
+  }
+
+  const fnNames = new Set((def.functions ?? []).map((f) => f.name));
+  const retryNames = new Set((def.retries ?? []).map((r) => r.name));
+
+  const checkTransition = (target: string | undefined, path: string) => {
+    if (target !== undefined && !stateNames.has(target)) {
+      throw new TulipFarmValidationError("soul", path, `transition target "${target}" not found`);
+    }
+  };
+
+  for (const [i, state] of def.states.entries()) {
+    checkTransition(state.transition, `/states/${i}/transition`);
+    for (const [j, onError] of (state.onErrors ?? []).entries()) {
+      checkTransition(onError.transition, `/states/${i}/onErrors/${j}/transition`);
+    }
+    if (state.type === "switch") {
+      for (const [j, cond] of state.dataConditions.entries()) {
+        checkTransition(cond.transition, `/states/${i}/dataConditions/${j}/transition`);
+      }
+      checkTransition(
+        state.defaultCondition?.transition,
+        `/states/${i}/defaultCondition/transition`
+      );
+    }
+    if (state.type === "operation" || state.type === "foreach") {
+      for (const [j, action] of state.actions.entries()) {
+        if (!fnNames.has(action.functionRef.refName)) {
+          throw new TulipFarmValidationError(
+            "soul",
+            `/states/${i}/actions/${j}/functionRef/refName`,
+            `function "${action.functionRef.refName}" not found`
+          );
+        }
+        if (action.retryRef !== undefined && !retryNames.has(action.retryRef)) {
+          throw new TulipFarmValidationError(
+            "soul",
+            `/states/${i}/actions/${j}/retryRef`,
+            `retry policy "${action.retryRef}" not found`
+          );
+        }
+      }
+    }
+    if (
+      state["x-autonomy-level"] === "human_approval" &&
+      state.type !== "operation" &&
+      state.type !== "foreach"
+    ) {
+      throw new TulipFarmValidationError(
+        "soul",
+        `/states/${i}/x-autonomy-level`,
+        "human_approval is only valid on operation/foreach states"
+      );
+    }
+  }
+}
+
+/**
+ * Validate a routine.yaml document against the V1 meta-schema. Returns the typed
+ * definition on success; throws `TulipFarmValidationError` (boundary `"soul"`) — with a
+ * "deferred in V1" message for post-V1 constructs — on failure.
+ */
+export function validateRoutineDefinition(data: unknown): RoutineDefinition {
+  rejectDeferredConstructs(data);
+  if (!check(data)) {
+    const e = check.errors?.[0];
+    throw new TulipFarmValidationError(
+      "soul",
+      e?.instancePath ?? "",
+      e?.message ?? "invalid routine definition"
+    );
+  }
+  const def = data as RoutineDefinition;
+  checkReferences(def);
+  return def;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       '@tulipfarm/llm':
         specifier: workspace:*
         version: link:../../packages/llm
+      '@tulipfarm/routine-engine':
+        specifier: workspace:*
+        version: link:../../packages/routine-engine
       '@tulipfarm/secrets':
         specifier: workspace:*
         version: link:../../packages/secrets
@@ -441,6 +444,25 @@ importers:
       ai:
         specifier: ^7.0.2
         version: 7.0.2(zod@4.4.3)
+    devDependencies:
+      '@tulipfarm/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@types/node':
+        specifier: ^24.13.2
+        version: 24.13.2
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+
+  packages/routine-engine:
+    dependencies:
+      '@tulipfarm/validation':
+        specifier: workspace:*
+        version: link:../validation
     devDependencies:
       '@tulipfarm/tsconfig':
         specifier: workspace:*
@@ -11554,7 +11576,7 @@ snapshots:
 
   eval@0.1.8:
     dependencies:
-      '@types/node': 22.19.20
+      '@types/node': 24.13.2
       require-like: 0.1.2
 
   event-target-shim@5.0.1: {}


### PR DESCRIPTION
Implements milestone **v0.11 — Routines** (#144, #145, #146, #147, #148, #149, #150, #151) per `specs/ROUTINES.md` (ROUT-V1-001…007). Stacked on `feat/integration-v2` — routines are the consumer that makes integration ingress meaningful (webhook lands → ingress emits event → routine reacts).

## What's in

### Definition + validation (#144)
- `packages/validation/src/routine.ts`: CNCF Serverless Workflow 0.8 subset + `x-` extensions, TypeBox/AJV.
- **AC-V1-002**: deferred constructs (`parallel`/`event` states, `subFlowRef`, `datetime`/`integration` triggers) rejected at load with explicit `deferred in V1` errors + JSON pointers, plus reference checks (start/transition targets, functionRef/retryRef resolution).
- Soul loader now reads routine `hooks.ts` source + SHA-256 hash; `apps/api/src/routines/registry.ts` is the validated view (invalid routines surface as error entries, never crash boot).

### Engine (#145, #147, #148)
- New workspace `@tulipfarm/routine-engine`: pure ports/adapters interpreter (no Fastify/pg-boss imports). `executeState(run, def, ports) → StepOutcome` (`continue | complete | fail | sleep | wait_approval | retry`).
- All 5 V1 states (`operation`/`switch`/`foreach` seq cap 1000/`sleep`/`inject`), retries with exponential backoff, `onErrors` routing, per-state `stateExecTimeout` race.
- hooks.ts contract: object-literal expression `({ beforeHook(ctx){}, after<StateName>(ctx){}, myFn(ctx, args){} })` — lifecycle hooks + step-callable fns via `hook:` function refs.
- Data-flow expressions run in isolated-vm (**100ms, zero host callbacks**); hooks get the 2s budget. Both are new `hook-worker` variants reusing the analyzer/hash/circuit-breaker guards. No JSONata anywhere.

### Persistence + scheduler (#145, #146)
- Migration v23: `routine_runs` (pinned `definition_snapshot` for in-flight migration safety, CAS-guarded status machine, wake/deadline bookkeeping) + `routine_run_events` journal.
- **The journal doubles as the SSE replay buffer** (a `StreamResumeRepo` over `routine_run_events`) — replay works for runs of any age, seq survives suspensions, one write path.
- pg-boss topology: `routine-run`, `routine-wake` (delayed jobs, singleton-keyed), one static `routine-cron` queue with **keyed schedules** diff-reconciled at boot / `soul.synced` / after forge, and a `routine-sweep` cron healing missed wakes, expired state deadlines, and expired approvals.
- All 5 triggers: manual (x-inputs-validated), cron (tz-aware), webhook (`POST /api/v1/hooks/routines/:slug`, constant-time shared-secret header, rejects when unconfigured — the v0.12 ingress seam), event (domain-event bus + optional sandboxed filter), agent (`trigger_routine` tool now returns a real runId).
- Headless agent actions: `runHeadlessTurn` (generateText tool loop, no HTTP context) with `routineContext` threaded per-call so `call_skill`/`complete_state` go live.

### human_approval (#149)
- Gated states pause in `waiting_approval` on the shared `approvals` store (`kind: routine_state`); list/decide routes now serve both kinds behind one discriminated schema; deciding wakes the run with the decision.
- **AC-V1-003**: `ui` always; `slack` via an installed integration send tool when present; `email`/`sms` fall back to `ui` with a warning. 7-day expiry settled to timeout by the sweep.

### SSE + forge (#150)
- `GET /api/v1/routines/:slug/runs/:runId/events` with `Last-Event-ID` resume; suspensions close with `finish {reason: suspended}`.
- **AC-V1-004**: `routine_forge` platform tool validates (deferred constructs rejected pre-write), writes `routine.yaml` (+ optional hooks.ts), commits via `GitSyncService.withSync()` with **no approval step**, then revalidates + reconciles schedules.

### Web UI (#151)
- `/routines` list (invalid routines shown with their error), detail with x-inputs-derived manual-trigger form, run page with live EventSource progress + cancel, approvals page renders `routine_state` approvals with a run link.

## Verification
- `pnpm lint && pnpm typecheck && pnpm test` all green: **2,284 tests** (~160 new), including an AC-V1-001 e2e fixture exercising all 5 states + all 5 triggers, crash-resume mid-sleep, duplicate-delivery idempotency, real isolated-vm timeout/escape tests, and webhook auth rejection paths.
- Also: fixed a pre-existing flaky knowledge test and raised the api vitest default timeouts (PGlite-per-file suites under full parallel load).

## Deferred (per spec)
- `parallel`/`event` states, sub-routines, `datetime`/`integration` triggers (ROUT-V1-004/005 — rejected at load).
- Real Slack delivery needs the v0.12 Slack adapter; HMAC webhook verification (`verification_protocol`) arrives with full ingress.

## Updates (2026-07-07)
- **Merged latest `main` back in** (no conflicts): business-context prompt injection (#131), a2ui binding fixes (#134), soul.yaml#llm consolidation (#124), git-sync robustness (#121).
- **docs(routines)**: new concepts page + expanded guide.
- **fix(integrations)**: detail page crashed on manifest v2 (`egress.entry` vs v1 `entry`) — found in manual testing after the integrations repo moved to manifest v2.
- **feat(marketplace)**: scan sources (skills + integrations, incl. `MARKETPLACE_SOURCE`/`INTEGRATIONS_MARKETPLACE_SOURCE`) accept an optional `#<branch-or-tag>` suffix so non-main marketplace branches can be tested; safe-ref validation prevents git-flag injection. Covered by new vitest cases and verified live.
