### PR TITLE
feat(memory): apply preference-typed memory entries actively

### DIFF
--- a/apps/api/src/context/README.md
+++ b/apps/api/src/context/README.md
@@ -15,6 +15,7 @@ lazily fetched) makes the rendered prefix deterministic and therefore prompt-cac
 <platform-instructions>   omit when skipPlatformPrompt or no text
 <agent-identity>          agentId / domain / tenantId lines
 <agent-personality>       AGENT.md body
+<memory-instructions>     static preamble: apply preference facts (language/tone/tz) — renders only with <memory>
 <memory>                  per-user working memory, ≤ MAX_TOTAL_CHARS (drop whole on overflow)
 <governance-knowledge>    alwaysLoadForAgents docs (reuses knowledge/governance.ts, 4k/16k caps)
 <skills>                  eager skill bodies — `## name` + body per `eager: true` skill, 32k cap, drop-whole

--- a/apps/api/src/context/assemble.test.ts
+++ b/apps/api/src/context/assemble.test.ts
@@ -249,6 +249,23 @@ describe("assembleSystemPrompt — memory", () => {
     );
     expect(overCap).not.toContain("<memory>");
   });
+
+  it("prepends a static <memory-instructions> preamble when entries are present", () => {
+    const out = assembleSystemPrompt(baseCtx({ memory: [mem("preferred_language", "Spanish")] }));
+    expect(out).toContain("<memory-instructions>");
+    expect(out).toMatch(/preferred_language/);
+    expect(out).toMatch(/reply_tone/);
+    // Preamble sits immediately before the entry block.
+    expect(out.indexOf("<memory-instructions>")).toBeLessThan(out.indexOf("<memory>"));
+  });
+
+  it("omits the preamble (no orphan) when memory is empty or dropped over budget", () => {
+    expect(assembleSystemPrompt(baseCtx({ memory: [] }))).not.toContain("<memory-instructions>");
+    const overCap = assembleSystemPrompt(
+      baseCtx({ memory: [mem("m", "x".repeat(MAX_TOTAL_CHARS))] })
+    );
+    expect(overCap).not.toContain("<memory-instructions>");
+  });
 });
 
 describe("assembleSystemPrompt — governance", () => {

--- a/apps/api/src/context/assemble.ts
+++ b/apps/api/src/context/assemble.ts
@@ -113,14 +113,46 @@ function renderAgentPersonality(ctx: AssembleContext): string {
 }
 
 /**
+ * True when the `<memory>` block will render this turn: memory is non-empty and within budget.
+ * Shared by `renderMemoryInstructions` and `renderMemory` so the static preamble never orphans —
+ * it appears exactly when the entry block does.
+ */
+function memoryRenders(ctx: AssembleContext): boolean {
+  if (ctx.memory.length === 0) return false;
+  const total = ctx.memory.reduce((n, e) => n + e.key.length + e.value.length, 0);
+  return total <= MAX_TOTAL_CHARS;
+}
+
+/**
+ * Fixed behavioral framing for the `<memory>` entries — tells the agent to *apply* preference-typed
+ * facts (language, tone, format, timezone), not just know them. Kept as static text in its own
+ * block so it stays byte-stable (prompt-cacheable) even as the entry list below it changes.
+ */
+const MEMORY_INSTRUCTIONS_TEXT = [
+  "The <memory> block below holds durable personal facts and preferences for this user. Apply them",
+  "actively: preference entries shape HOW you respond, not just what you know. In particular, reply",
+  "in the user's preferred_language using that language's native script (e.g. Devanagari for Hindi)",
+  "unless the stored value specifies a romanized or transliterated form; match their reply_tone,",
+  "address them by preferred_name, and render every date and time in their timezone and date_format.",
+  "Honor these every turn without waiting for the user to restate them.",
+].join(" ");
+
+/**
+ * `<memory-instructions>` block. Static preamble (no interpolation → byte-stable) rendered directly
+ * before `<memory>` whenever memory renders. Gated on the same condition as `renderMemory` so an
+ * empty or over-budget memory never leaves an orphan preamble.
+ */
+function renderMemoryInstructions(ctx: AssembleContext): string {
+  return memoryRenders(ctx) ? block("memory-instructions", MEMORY_INSTRUCTIONS_TEXT) : "";
+}
+
+/**
  * `<memory>` block (MEM-V1-003). Each entry is one `- key: value` line in store order. Budget is
  * the store's own metric — total key+value chars; over `MAX_TOTAL_CHARS` the whole block is
  * dropped (never half-rendered). Entries already pass write-time caps, so this is a defensive floor.
  */
 function renderMemory(ctx: AssembleContext): string {
-  if (ctx.memory.length === 0) return "";
-  const total = ctx.memory.reduce((n, e) => n + e.key.length + e.value.length, 0);
-  if (total > MAX_TOTAL_CHARS) return "";
+  if (!memoryRenders(ctx)) return "";
   const body = ctx.memory.map((e) => `- ${e.key}: ${e.value}`).join("\n");
   return block("memory", body);
 }
@@ -324,6 +356,7 @@ export function assembleSystemPrompt(ctx: AssembleContext): string {
     renderAgentIdentity(ctx),
     renderBusinessContext(ctx),
     renderAgentPersonality(ctx),
+    renderMemoryInstructions(ctx),
     renderMemory(ctx),
     // V1: governance is tenant-wide. `domain` is display-only on the agent (AGT-V1-007), so it
     // feeds <agent-identity> but does NOT scope governance — preserving prior behavior.

--- a/apps/api/src/memory/tools.ts
+++ b/apps/api/src/memory/tools.ts
@@ -24,7 +24,11 @@ export interface PlatformTool {
 const MEMORY_GUIDANCE =
   "Store small, stable, personal facts only (e.g. 'prefers terse replies', 'enterprise plan'). " +
   "Anything large, document-like, or tenant/business data belongs in knowledge — use " +
-  "create_knowledge_page instead.";
+  "create_knowledge_page instead. When you learn a durable preference, store it under one of these " +
+  "well-known keys so it is applied on every future turn: preferred_language (reply in that " +
+  "language), reply_tone (e.g. 'formal', 'concise', 'casual'), timezone (IANA name, e.g. " +
+  "'America/New_York' — format all datetimes in it), date_format (e.g. 'DD/MM/YYYY'), " +
+  "preferred_name (address the user by this name).";
 
 // Plain JSON Schema literals, matching the codebase's inline-schema convention (see ChatBodySchema).
 // `value` deliberately carries NO maxLength: an oversized write must reach the service so the tool


### PR DESCRIPTION
Closes #129.

## Problem

The `<memory>` block was injected as a flat `- key: value` dump with no instruction on *how* to use the values. Entries like `preferred_language: Spanish` were known to the model but not honored each turn.

## Changes

- **`context/assemble.ts`** — new static `<memory-instructions>` block rendered directly before `<memory>` whenever memory renders. Fixed text (byte-stable → prompt-cacheable) instructing the agent to *apply* preference facts:
  - reply in `preferred_language` using that language's **native script** (Devanagari for Hindi) unless the stored value is romanized/transliterated,
  - match `reply_tone`, address by `preferred_name`, render datetimes in `timezone`/`date_format`.
  - Shared `memoryRenders()` gate so the preamble never orphans — absent when memory is empty or dropped over budget.
- **`memory/tools.ts`** — expanded `MEMORY_GUIDANCE` with well-known preference key conventions (`preferred_language`, `reply_tone`, `timezone`, `date_format`, `preferred_name`), surfaced in both `update_memory` and `delete_memory` descriptions.
- **`context/assemble.test.ts`** — assert the preamble is present + ordered before `<memory>` when entries exist, and absent (no orphan) when empty or over budget.
- **`context/README.md`** — documented the new block in the fixed-order table.

## Acceptance criteria
- [x] `<memory-instructions>` contains behavioral instruction text when entries are non-empty
- [x] Block is absent entirely when memory is empty (no orphan preamble; also covers over-budget drop)
- [x] `update_memory` / `delete_memory` descriptions surface preference key conventions
- [x] `pnpm lint && pnpm typecheck && pnpm test` pass (54 assemble + 34 memory tests)

## Notes
- Native-script defaulting was added after live testing: `language: hindi` + `tone: funny` produced Hinglish (romanized), not Devanagari. The preamble now defaults to native script unless the value specifies otherwise.
- Item #3 from the issue (proactive preference elicitation) left as a follow-on.