### PR TITLE
fix(docker): install ca-certificates in runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,9 @@ RUN pnpm --filter @tulipfarm/api exec esbuild src/index.ts \
 RUN pnpm --filter @tulipfarm/api deploy --prod --legacy /deploy
 
 FROM node:24-slim AS runtime
-# git: soul backup/sync shells out to it.
-RUN apt-get update && apt-get install -y --no-install-recommends git \
+# git: soul backup/sync shells out to it. ca-certificates: git clones soul
+# remotes over https; --no-install-recommends skips it, so name it explicitly.
+RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 ENV NODE_ENV=production \

--- a/scripts/generate-secrets.sh
+++ b/scripts/generate-secrets.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# TulipFarm bootstrap secret generator — any deployment lane (compose, App Service,
+# Cloud Run, k8s, bare host).
+#
+#   ./scripts/generate-secrets.sh              # print to terminal
+#   ./scripts/generate-secrets.sh >> .env      # append to an env file
+#
+# Prints the generatable required secrets (ENCRYPTION_KEY, JWT_SECRET,
+# WEBHOOK_SIGNING_SECRET — 32-byte base64, validated at boot by apps/api/src/env.ts)
+# plus a POSTGRES_PASSWORD, and comments documenting the remaining required
+# variables that depend on your environment. Stdout is pure env-file content;
+# warnings go to stderr.
+set -euo pipefail
+
+die()  { printf '\033[0;31m✗\033[0m %s\n' "$*" >&2; exit 1; }
+need() { command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"; }
+
+gen_secret() { openssl rand -base64 32; }
+# URL-safe (no /+= so it embeds in DATABASE_URL without escaping).
+gen_pw()     { openssl rand -base64 24 | tr -dc 'A-Za-z0-9' | head -c 32; }
+
+need openssl
+
+enc="$(gen_secret)"; jwt="$(gen_secret)"; webhook="$(gen_secret)"; pw="$(gen_pw)"
+
+cat <<EOF
+# TulipFarm bootstrap secrets — generated $(date -u +%Y-%m-%dT%H:%M:%SZ)
+ENCRYPTION_KEY=${enc}
+JWT_SECRET=${jwt}
+WEBHOOK_SIGNING_SECRET=${webhook}
+POSTGRES_PASSWORD=${pw}
+
+# Also required at boot (set for your environment — not generatable):
+# DATABASE_URL=postgresql://tulipfarm:${pw}@<host>:5432/tulipfarm
+# SOUL_PATH=/opt/tulipfarm/soul   # already set in the container image
+EOF
+
+printf '\033[0;33m⚠\033[0m  Keep a copy of ENCRYPTION_KEY somewhere safe — if it is lost, stored secrets are unrecoverable.\n' >&2


### PR DESCRIPTION
## Summary
- **Fix soul git sync over HTTPS in the production image.** The runtime stage installs git with `--no-install-recommends`, which drops its recommended `ca-certificates` package — the container had no CA bundle, so every HTTPS clone/sync failed with `server certificate verification failed. CAfile: none CRLfile: none` and the app fell back to local soul state. `ca-certificates` is now installed explicitly.
- **Add `scripts/generate-secrets.sh`**, a bootstrap secret generator that emits the required boot secrets (`ENCRYPTION_KEY`, `JWT_SECRET`, `WEBHOOK_SIGNING_SECRET`, `POSTGRES_PASSWORD`) as pure env-file output for any deployment lane, with comments for the non-generatable variables.

## Verification
Reproduced and validated the CA fix in a live `node:24-slim` container:
- `apt-get install --no-install-recommends git` (old state) → `git ls-remote https://github.com/...` fails with the exact `CAfile: none` error from production logs.
- `apt-get install --no-install-recommends git ca-certificates` (this PR) → clone/ls-remote succeeds.