### PR TITLE
fix: skip env-configured soul backup step; LLM-safe navigate_to pattern

### DIFF
--- a/apps/api/src/platform/frontend-tools.ts
+++ b/apps/api/src/platform/frontend-tools.ts
@@ -64,7 +64,9 @@ const NAVIGATE_TO_SCHEMA: Record<string, unknown> = {
     to: {
       type: "string",
       minLength: 1,
-      pattern: "^/(?!/)",
+      // "/" then not another "/" (blocks protocol-relative //host). Written without regex
+      // lookaround: LLM providers reject tool schemas whose `pattern` uses (?!...)/(?=...).
+      pattern: "^/([^/].*)?$",
       description: 'An internal app path starting with "/", e.g. "/resources/tickets/TICK-1042".',
     },
     reason: {

--- a/apps/api/src/tools/llm-schema-compat.test.ts
+++ b/apps/api/src/tools/llm-schema-compat.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { KNOWLEDGE_TOOLS } from "../knowledge/tools";
+import { KV_TOOLS } from "../kv/tools";
+import { MEMORY_TOOLS } from "../memory/tools";
+import { FRONTEND_TOOLS } from "../platform/frontend-tools";
+import { PLATFORM_TOOLS } from "../platform/tools";
+import { RESOURCE_TOOLS } from "../resources/tools.js";
+import { AGENT_TOOLS } from "../soul/agents/tools.js";
+import { RESOURCE_TYPE_TOOLS } from "../soul/resource-types/tools.js";
+import { SKILL_TOOLS } from "../soul/skills/tools.js";
+
+/*
+ * LLM provider compatibility sweep for tool input schemas. Providers validate the JSON Schema
+ * sent with each tool and reject unsupported regex features in `pattern` — e.g. Anthropic fails
+ * the whole chat turn with "Invalid JSON schema: regex lookaround is not supported" if any tool
+ * pattern uses (?=...), (?!...) or (?<...). Every statically-registered tool schema (the set
+ * buildToolRegistry ships on each turn) must stay lookaround-free.
+ */
+
+const ALL_TOOL_SETS: Array<[string, ReadonlyArray<{ name: string; inputSchema: unknown }>]> = [
+  ["MEMORY_TOOLS", MEMORY_TOOLS],
+  ["KV_TOOLS", KV_TOOLS],
+  ["KNOWLEDGE_TOOLS", KNOWLEDGE_TOOLS],
+  ["RESOURCE_TOOLS", RESOURCE_TOOLS],
+  ["RESOURCE_TYPE_TOOLS", RESOURCE_TYPE_TOOLS],
+  ["AGENT_TOOLS", AGENT_TOOLS],
+  ["SKILL_TOOLS", SKILL_TOOLS],
+  ["PLATFORM_TOOLS", PLATFORM_TOOLS],
+  ["FRONTEND_TOOLS", FRONTEND_TOOLS],
+];
+
+/** Collect every `pattern` keyword value in a JSON-Schema tree. */
+function collectPatterns(node: unknown, path: string, out: Array<[string, string]>): void {
+  if (Array.isArray(node)) {
+    for (const [i, item] of node.entries()) collectPatterns(item, `${path}[${i}]`, out);
+    return;
+  }
+  if (node === null || typeof node !== "object") return;
+  for (const [key, value] of Object.entries(node)) {
+    if (key === "pattern" && typeof value === "string") out.push([`${path}.pattern`, value]);
+    else collectPatterns(value, `${path}.${key}`, out);
+  }
+}
+
+const LOOKAROUND = /\(\?[=!<]/;
+
+describe("tool inputSchema LLM compatibility", () => {
+  it("no registered tool schema uses regex lookaround in a pattern", () => {
+    const offenders: string[] = [];
+    for (const [setName, tools] of ALL_TOOL_SETS) {
+      for (const tool of tools) {
+        const patterns: Array<[string, string]> = [];
+        collectPatterns(tool.inputSchema, `${setName}/${tool.name}`, patterns);
+        for (const [at, pattern] of patterns) {
+          if (LOOKAROUND.test(pattern)) offenders.push(`${at} = ${pattern}`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/apps/web/app/routes/setup.test.tsx
+++ b/apps/web/app/routes/setup.test.tsx
@@ -1,0 +1,114 @@
+import { createRemixStub } from "@remix-run/testing";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, expect, test, vi } from "vitest";
+import * as setupLib from "~/lib/setup";
+import * as soulLib from "~/lib/soul";
+import SetupRoute from "./setup";
+
+/*
+ * Setup wizard flow tests, focused on the conditional Soul backup step: the step is hidden
+ * (3-step wizard, finish after LLM) when the soul git remote is already configured — e.g. seeded
+ * by SOUL_GIT_REMOTE_URL/SOUL_GIT_CREDENTIAL env vars at boot — and shown otherwise. Remote state
+ * comes from getGitConfig() (fetched once, right after the admin step logs the user in).
+ */
+
+vi.mock("~/lib/setup", () => ({
+  getSetupStatus: vi.fn(),
+  setupAdmin: vi.fn(),
+  setupBusiness: vi.fn(),
+  setupGit: vi.fn(),
+  completeSetup: vi.fn(),
+}));
+vi.mock("~/lib/soul", () => ({
+  getGitConfig: vi.fn(),
+  friendlyGitError: (raw: string) => raw,
+}));
+vi.mock("~/lib/settings", () => ({
+  listProviders: vi.fn().mockResolvedValue([]),
+  putLlmConfig: vi.fn(),
+  putSecret: vi.fn(),
+}));
+
+const setupAdmin = vi.mocked(setupLib.setupAdmin);
+const setupBusiness = vi.mocked(setupLib.setupBusiness);
+const completeSetup = vi.mocked(setupLib.completeSetup);
+const getGitConfig = vi.mocked(soulLib.getGitConfig);
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+function gitConfig(remoteConfigured: boolean): soulLib.SoulGitConfig {
+  return {
+    credentialSet: remoteConfigured,
+    status: {
+      remoteConfigured,
+      ahead: 0,
+      behind: 0,
+      headSha: null,
+      lastSyncError: null,
+      lastSyncAt: null,
+    },
+  };
+}
+
+function renderWizard() {
+  const Stub = createRemixStub([{ path: "/", Component: () => <SetupRoute /> }]);
+  render(<Stub initialEntries={["/"]} />);
+}
+
+/** Complete steps 1 (admin) and 2 (business), landing on the LLM step. */
+async function advanceToLlmStep(user: ReturnType<typeof userEvent.setup>) {
+  setupAdmin.mockResolvedValue(undefined as never);
+  setupBusiness.mockResolvedValue(undefined as never);
+
+  await user.type(screen.getByLabelText(/email/i), "admin@example.com");
+  await user.type(screen.getByLabelText(/^password/i), "mypassword");
+  await user.type(screen.getByLabelText(/confirm password/i), "mypassword");
+  await user.click(screen.getByRole("button", { name: "Continue" }));
+
+  await user.type(await screen.findByLabelText(/business name/i), "Oscorp");
+  await user.click(screen.getByRole("button", { name: "Continue" }));
+
+  await screen.findByRole("heading", { name: "LLM setup" });
+}
+
+test("shows all four steps (incl. Soul backup) when no git remote is configured", async () => {
+  const user = userEvent.setup();
+  getGitConfig.mockResolvedValue(gitConfig(false));
+  renderWizard();
+
+  await advanceToLlmStep(user);
+  await user.click(screen.getByRole("button", { name: /Skip for now/ }));
+
+  expect(await screen.findByRole("heading", { name: "Soul backup" })).toBeInTheDocument();
+  expect(completeSetup).not.toHaveBeenCalled();
+});
+
+test("hides the Soul backup step and finishes after LLM when the remote is env-configured", async () => {
+  const user = userEvent.setup();
+  getGitConfig.mockResolvedValue(gitConfig(true));
+  completeSetup.mockResolvedValue(undefined as never);
+  renderWizard();
+
+  await advanceToLlmStep(user);
+  // Indicator no longer offers the Soul backup step.
+  expect(screen.queryByText("Soul backup")).not.toBeInTheDocument();
+
+  await user.click(screen.getByRole("button", { name: /Skip for now/ }));
+  await waitFor(() => expect(completeSetup).toHaveBeenCalledTimes(1));
+  expect(screen.queryByRole("heading", { name: "Soul backup" })).not.toBeInTheDocument();
+});
+
+test("falls back to showing the Soul backup step when the git status probe fails", async () => {
+  const user = userEvent.setup();
+  getGitConfig.mockRejectedValue(new Error("network down"));
+  renderWizard();
+
+  await advanceToLlmStep(user);
+  await user.click(screen.getByRole("button", { name: /Skip for now/ }));
+
+  expect(await screen.findByRole("heading", { name: "Soul backup" })).toBeInTheDocument();
+  expect(completeSetup).not.toHaveBeenCalled();
+});

--- a/apps/web/app/routes/setup.tsx
+++ b/apps/web/app/routes/setup.tsx
@@ -4,7 +4,7 @@ import { Button } from "~/components/ui/button";
 import { ApiError } from "~/lib/api";
 import { type LlmProviderInfo, listProviders, putLlmConfig, putSecret } from "~/lib/settings";
 import { completeSetup, getSetupStatus, setupAdmin, setupBusiness, setupGit } from "~/lib/setup";
-import { friendlyGitError } from "~/lib/soul";
+import { friendlyGitError, getGitConfig } from "~/lib/soul";
 
 export const meta: MetaFunction = () => [{ title: "Setup · tulipfarm" }];
 
@@ -21,10 +21,10 @@ type Step = 0 | 1 | 2 | 3;
 const inputClass =
   "w-full rounded-sm border border-border bg-background px-3 py-2 text-sm outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:opacity-60";
 
-function StepIndicator({ current }: { current: Step }) {
+function StepIndicator({ steps, current }: { steps: readonly string[]; current: Step }) {
   return (
     <div className="flex items-center gap-2 mb-8">
-      {STEPS.map((label, i) => (
+      {steps.map((label, i) => (
         <div key={label} className="flex items-center gap-2">
           <div
             className={[
@@ -43,7 +43,7 @@ function StepIndicator({ current }: { current: Step }) {
           >
             {label}
           </span>
-          {i < STEPS.length - 1 && <div className="h-px w-4 bg-border" />}
+          {i < steps.length - 1 && <div className="h-px w-4 bg-border" />}
         </div>
       ))}
     </div>
@@ -390,6 +390,14 @@ export default function SetupRoute() {
   const [step, setStep] = useState<Step>(0);
   const [finishing, setFinishing] = useState(false);
   const [finishError, setFinishError] = useState<string | null>(null);
+  // Whether a soul git remote is already live (e.g. seeded by SOUL_GIT_REMOTE_URL /
+  // SOUL_GIT_CREDENTIAL at boot). null = unknown (probe pending/not started) — treated as
+  // "not configured" so the wizard never blocks on the probe and defaults to showing the step.
+  const [gitConfigured, setGitConfigured] = useState<boolean | null>(null);
+
+  // Hide the Soul backup step when the remote already exists. Only while we haven't reached it:
+  // if the probe resolves after the user is already on the step, keep the 4-step layout stable.
+  const steps: readonly string[] = gitConfigured === true && step < 3 ? STEPS.slice(0, 3) : STEPS;
 
   async function finish() {
     setFinishing(true);
@@ -404,11 +412,20 @@ export default function SetupRoute() {
   }
 
   const advance = () => {
-    if (step < 3) {
+    if (step < steps.length - 1) {
       setStep((s) => (s + 1) as Step);
     } else {
       void finish();
     }
+  };
+
+  // The admin step's auto-login makes the (authenticated) git-config probe possible: fire it
+  // once, then advance. Probe failure counts as "not configured" — the step stays visible.
+  const advanceFromAdmin = () => {
+    getGitConfig()
+      .then((cfg) => setGitConfigured(cfg.status.remoteConfigured))
+      .catch(() => setGitConfigured(false));
+    advance();
   };
 
   return (
@@ -420,20 +437,18 @@ export default function SetupRoute() {
       <p className="mt-1 text-sm text-muted-foreground">Let's get you set up.</p>
 
       <div className="mt-8">
-        <StepIndicator current={step} />
+        <StepIndicator steps={steps} current={step} />
 
-        <h2 className="mb-4 text-base font-medium">{STEPS[step]}</h2>
+        <h2 className="mb-4 text-base font-medium">{steps[step]}</h2>
 
         {finishError && <ErrorAlert message={finishError} />}
 
-        {step === 0 && <AdminStep onNext={advance} />}
+        {step === 0 && <AdminStep onNext={advanceFromAdmin} />}
         {step === 1 && <BusinessStep onNext={advance} />}
         {step === 2 && <LlmStep onNext={advance} />}
         {step === 3 && <GitStep onNext={advance} />}
 
-        {step === 3 && finishing && (
-          <p className="mt-4 text-sm text-muted-foreground">Finishing setup…</p>
-        )}
+        {finishing && <p className="mt-4 text-sm text-muted-foreground">Finishing setup…</p>}
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary

Two deployment-blocking fixes found on the Azure `tulip-oscorp` instance:

### 1. Setup wizard: hide "Soul backup" when the remote is already env-configured
Deployments that seed `SOUL_GIT_REMOTE_URL`/`SOUL_GIT_CREDENTIAL` have soul backup active from boot (`apps/api/src/index.ts` seeds the live `GitSyncService`), yet wizard step 4 still asked for a remote URL. Now, after the admin step's auto-login, the wizard probes the existing `GET /api/v1/soul/git-config` once: if `status.remoteConfigured` is true it renders a 3-step wizard and finishes after the LLM step. Probe failure or still-pending falls back to the full 4-step wizard. Backend unchanged.

### 2. Chat turns failed: `Invalid JSON schema: regex lookaround is not supported`
The `navigate_to` platform tool's input schema used `pattern: "^/(?!/)"`; Anthropic rejects tool schemas containing regex lookaround, failing every chat turn. Replaced with the equivalent `^/([^/].*)?$` — identical semantics (internal paths only, protocol-relative `//host` still blocked, existing security tests unchanged). Added `apps/api/src/tools/llm-schema-compat.test.ts`, a sweep asserting no registered tool schema uses lookaround, so this provider rejection class can't regress.

## Tests
- New `apps/web/app/routes/setup.test.tsx`: step hidden when `remoteConfigured`, shown when not, shown when the probe fails (TDD, written first).
- New `apps/api/src/tools/llm-schema-compat.test.ts`: lookaround sweep across all registered tool sets.
- Full gates green: `pnpm lint`, `pnpm typecheck`, `pnpm test` (API 1552, web 424).