### PR TITLE
fix(integrations): seal secret env values into the secrets store

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -34,6 +34,7 @@ import { registerFeedbackRoutes } from "./feedback/routes";
 import type { GuardrailsService } from "./guardrails";
 import type { HookExecutor } from "./hooks/hook-executor";
 import { type IngressRoutesDeps, registerIngressRoutes } from "./ingress/routes";
+import { resolveConnectionEnv } from "./integrations/connection-env";
 import { McpClientService } from "./integrations/mcp-client-service";
 import type { PageRetrievalService } from "./knowledge/retrieval-service";
 import { registerKnowledgeRoutes } from "./knowledge/routes";
@@ -234,7 +235,13 @@ export async function buildApp(opts: AppOptions = {}) {
     const requireAuth = makeRequireAuth(opts.sessionStore, opts.userRepo, opts.tokenRepo);
     // MCP client service: created once, shared between integration routes (connect/disconnect) and
     // the tool registry (dynamic tool registration). Accepts an optional override for testing.
-    const mcpClientSvc = opts.mcpClient ?? new McpClientService(app.log);
+    const secretsSvc = opts.secretsService;
+    const mcpClientSvc =
+      opts.mcpClient ??
+      new McpClientService(
+        app.log,
+        secretsSvc ? (env) => resolveConnectionEnv(env, secretsSvc) : undefined
+      );
     // Setup status: always registered so the web app gets an explicit 200 in all boot modes.
     // In headless boot the wizard step routes below are absent (404), but status is always reachable.
     const soulPath = process.env.SOUL_PATH;
@@ -314,7 +321,8 @@ export async function buildApp(opts: AppOptions = {}) {
           opts.gitSync,
           mcpClientSvc,
           requireAuth,
-          opts.llmService
+          opts.llmService,
+          opts.secretsService
         );
         if (opts.llmService) {
           registerSkillRoutes(

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -39,6 +39,7 @@ import {
   IntegrationConversationsRepo,
   IntegrationEventsRepo,
 } from "./ingress/repo";
+import { resolveSecretRef } from "./integrations/connection-env";
 import { PgKnowledgeChunkRepo } from "./knowledge/chunks-repo";
 import { buildDefaultRegistry } from "./knowledge/connectors/registry";
 import { PgConnectorStateRepo } from "./knowledge/connectors/state-repo";
@@ -336,6 +337,7 @@ async function boot() {
         soulLoader,
         deliveries: ingressDeliveries,
         enqueue: makeIngressEnqueuer(boss),
+        resolveSecret: (value) => resolveSecretRef(value, secretsService),
       },
     });
 

--- a/apps/api/src/ingress/routes.test.ts
+++ b/apps/api/src/ingress/routes.test.ts
@@ -55,7 +55,10 @@ describe("POST /api/v1/hooks/integrations/:name", () => {
   let enqueue: ReturnType<typeof vi.fn>;
   let seen: Set<string>;
 
-  async function build(integrations: SoulIntegration[] = [makeIntegration()]) {
+  async function build(
+    integrations: SoulIntegration[] = [makeIntegration()],
+    resolveSecret?: (value: string) => Promise<string | undefined>
+  ) {
     enqueue = vi.fn(async (_job: IngressJobPayload) => {});
     seen = new Set();
     app = await buildApp({
@@ -70,6 +73,7 @@ describe("POST /api/v1/hooks/integrations/:name", () => {
           },
         } as never,
         enqueue: enqueue as (job: IngressJobPayload) => Promise<void>,
+        resolveSecret,
       },
     });
   }
@@ -221,6 +225,45 @@ describe("POST /api/v1/hooks/integrations/:name", () => {
     expect(unknown.json()).toEqual(undeclared.json());
     expect(undeclared.json()).toEqual(handlerless.json());
     expect(handlerless.json()).toEqual(disconnected.json());
+  });
+
+  it("resolves a secret:// signing secret through the resolver and accepts the delivery", async () => {
+    await app.close();
+    await build(
+      [
+        makeIntegration({
+          connection: {
+            enabled: true,
+            env: {
+              PROVIDER_SIGNING_SECRET: "secret://integration.chatapp.PROVIDER_SIGNING_SECRET",
+            },
+          },
+        }),
+      ],
+      async (value) =>
+        value === "secret://integration.chatapp.PROVIDER_SIGNING_SECRET" ? SECRET : undefined
+    );
+    const res = await inject(EVENT);
+    expect(res.statusCode).toBe(200);
+    expect(enqueue).toHaveBeenCalledTimes(1);
+  });
+
+  it("401s a secret:// signing secret that cannot be resolved", async () => {
+    await app.close();
+    await build(
+      [
+        makeIntegration({
+          connection: {
+            enabled: true,
+            env: { PROVIDER_SIGNING_SECRET: "secret://integration.chatapp.MISSING" },
+          },
+        }),
+      ],
+      async () => undefined
+    );
+    const res = await inject(EVENT);
+    expect(res.statusCode).toBe(401);
+    expect(res.json()).toEqual({ error: "webhook secret not configured" });
   });
 
   it("401s when the signing secret is missing from the connection env", async () => {

--- a/apps/api/src/ingress/routes.ts
+++ b/apps/api/src/ingress/routes.ts
@@ -1,6 +1,7 @@
 import type { SoulLoader } from "@tulipfarm/soul";
 import type { FastifyInstance } from "fastify";
 import { ErrorSchema } from "../auth/schemas";
+import { isSecretRef } from "../integrations/connection-env";
 import type { IngressDeliveriesRepo } from "./repo";
 import { verifyHmacSignature } from "./signature";
 import { dotPath, matchesBody, renderBodyTemplate } from "./template";
@@ -17,6 +18,8 @@ export interface IngressRoutesDeps {
   soulLoader: SoulLoader;
   deliveries: IngressDeliveriesRepo;
   enqueue: (job: IngressJobPayload) => Promise<void>;
+  /** Resolves a `secret://` env value to plaintext; plaintext values need no resolver. */
+  resolveSecret?: (value: string) => Promise<string | undefined>;
 }
 
 /** Constant 404 body: never reveal whether the integration exists / is connected / declares ingress. */
@@ -84,7 +87,10 @@ export async function registerIngressRoutes(
           // hmac security is a manifest bug, not a reason to accept unsigned traffic.
           return reply.code(401).send({ error: "webhook security not configured" });
         }
-        const secret = connection.env?.[security.secret_env];
+        let secret = connection.env?.[security.secret_env];
+        if (secret && isSecretRef(secret)) {
+          secret = deps.resolveSecret ? await deps.resolveSecret(secret) : undefined;
+        }
         if (!secret) return reply.code(401).send({ error: "webhook secret not configured" });
 
         const raw = req.body as Buffer;

--- a/apps/api/src/integrations/connection-env.test.ts
+++ b/apps/api/src/integrations/connection-env.test.ts
@@ -1,0 +1,164 @@
+import type { IntegrationManifest } from "@tulipfarm/soul";
+import { describe, expect, it } from "vitest";
+import {
+  type ConnectionSecretStore,
+  deleteConnectionSecrets,
+  integrationSecretKey,
+  resolveConnectionEnv,
+  resolveSecretRef,
+  sealConnectionEnv,
+} from "./connection-env";
+
+class FakeSecretStore implements ConnectionSecretStore {
+  readonly values = new Map<string, string>();
+
+  async get(key: string): Promise<string> {
+    const value = this.values.get(key);
+    if (value === undefined) throw new Error(`secret unavailable: ${key}`);
+    return value;
+  }
+
+  async set(key: string, plaintext: string): Promise<void> {
+    this.values.set(key, plaintext);
+  }
+
+  async delete(key: string): Promise<void> {
+    this.values.delete(key);
+  }
+
+  async list(): Promise<Array<{ key: string }>> {
+    return [...this.values.keys()].map((key) => ({ key }));
+  }
+}
+
+const manifest: IntegrationManifest = {
+  name: "slack",
+  egress: { type: "mcp", entry: { transport: "stdio", command: "npx", args: [] } },
+  required_env: [
+    { name: "SLACK_BOT_TOKEN", label: "Bot Token", secret: true },
+    { name: "SLACK_SIGNING_SECRET", label: "Signing Secret", secret: true },
+    { name: "SLACK_TEAM_ID", label: "Team ID", secret: false },
+  ],
+};
+
+describe("sealConnectionEnv", () => {
+  it("moves secret-flagged values to the store and replaces them with refs", async () => {
+    const store = new FakeSecretStore();
+    const sealed = await sealConnectionEnv(
+      "slack",
+      manifest,
+      { SLACK_BOT_TOKEN: "xoxb-secret", SLACK_TEAM_ID: "T012AB3CD" },
+      store
+    );
+
+    expect(sealed).toEqual({
+      SLACK_BOT_TOKEN: "secret://integration.slack.SLACK_BOT_TOKEN",
+      SLACK_TEAM_ID: "T012AB3CD",
+    });
+    expect(store.values.get("integration.slack.SLACK_BOT_TOKEN")).toBe("xoxb-secret");
+    expect(store.values.has("integration.slack.SLACK_TEAM_ID")).toBe(false);
+  });
+
+  it("passes already-sealed refs through without re-storing", async () => {
+    const store = new FakeSecretStore();
+    const ref = "secret://integration.slack.SLACK_BOT_TOKEN";
+    const sealed = await sealConnectionEnv("slack", manifest, { SLACK_BOT_TOKEN: ref }, store);
+
+    expect(sealed.SLACK_BOT_TOKEN).toBe(ref);
+    expect(store.values.size).toBe(0);
+  });
+
+  it("treats the OAuth token and client secret env vars as secret even when unlisted", async () => {
+    const store = new FakeSecretStore();
+    const oauthManifest: IntegrationManifest = {
+      ...manifest,
+      required_env: [],
+      oauth: {
+        flows: {},
+        "x-tulipfarm": {
+          client_id_env: "SLACK_CLIENT_ID",
+          client_secret_env: "SLACK_CLIENT_SECRET",
+          token_env: "SLACK_BOT_TOKEN",
+        },
+      },
+    };
+    const sealed = await sealConnectionEnv(
+      "slack",
+      oauthManifest,
+      { SLACK_BOT_TOKEN: "xoxb-oauth", SLACK_CLIENT_SECRET: "shhh", SLACK_CLIENT_ID: "123.456" },
+      store
+    );
+
+    expect(sealed.SLACK_BOT_TOKEN).toBe("secret://integration.slack.SLACK_BOT_TOKEN");
+    expect(sealed.SLACK_CLIENT_SECRET).toBe("secret://integration.slack.SLACK_CLIENT_SECRET");
+    expect(sealed.SLACK_CLIENT_ID).toBe("123.456");
+  });
+
+  it("leaves empty values alone so 'not provided' stays visible in the file", async () => {
+    const store = new FakeSecretStore();
+    const sealed = await sealConnectionEnv("slack", manifest, { SLACK_BOT_TOKEN: "" }, store);
+    expect(sealed.SLACK_BOT_TOKEN).toBe("");
+    expect(store.values.size).toBe(0);
+  });
+});
+
+describe("resolveConnectionEnv", () => {
+  it("resolves refs and passes plaintext through (legacy connection.yaml compat)", async () => {
+    const store = new FakeSecretStore();
+    await store.set("integration.slack.SLACK_BOT_TOKEN", "xoxb-secret");
+
+    const resolved = await resolveConnectionEnv(
+      {
+        SLACK_BOT_TOKEN: "secret://integration.slack.SLACK_BOT_TOKEN",
+        SLACK_TEAM_ID: "T012AB3CD",
+        LEGACY_PLAINTEXT: "still-works",
+      },
+      store
+    );
+
+    expect(resolved).toEqual({
+      SLACK_BOT_TOKEN: "xoxb-secret",
+      SLACK_TEAM_ID: "T012AB3CD",
+      LEGACY_PLAINTEXT: "still-works",
+    });
+  });
+
+  it("throws when a referenced secret is missing", async () => {
+    const store = new FakeSecretStore();
+    await expect(
+      resolveConnectionEnv({ SLACK_BOT_TOKEN: "secret://integration.slack.SLACK_BOT_TOKEN" }, store)
+    ).rejects.toThrow(/secret unavailable/);
+  });
+});
+
+describe("resolveSecretRef", () => {
+  it("resolves a ref, passes plaintext through, and returns undefined when missing", async () => {
+    const store = new FakeSecretStore();
+    await store.set("integration.slack.SLACK_BOT_TOKEN", "xoxb-secret");
+
+    await expect(
+      resolveSecretRef("secret://integration.slack.SLACK_BOT_TOKEN", store)
+    ).resolves.toBe("xoxb-secret");
+    await expect(resolveSecretRef("plain-value", store)).resolves.toBe("plain-value");
+    await expect(resolveSecretRef("secret://integration.slack.MISSING", store)).resolves.toBe(
+      undefined
+    );
+  });
+});
+
+describe("deleteConnectionSecrets", () => {
+  it("removes only the integration's own secrets", async () => {
+    const store = new FakeSecretStore();
+    await store.set(integrationSecretKey("slack", "SLACK_BOT_TOKEN"), "a");
+    await store.set(integrationSecretKey("slack", "SLACK_SIGNING_SECRET"), "b");
+    await store.set(integrationSecretKey("github", "GITHUB_TOKEN"), "c");
+    await store.set("soul-git-credential", "d");
+
+    await deleteConnectionSecrets("slack", store);
+
+    expect([...store.values.keys()].sort()).toEqual([
+      "integration.github.GITHUB_TOKEN",
+      "soul-git-credential",
+    ]);
+  });
+});

--- a/apps/api/src/integrations/connection-env.ts
+++ b/apps/api/src/integrations/connection-env.ts
@@ -1,0 +1,109 @@
+import type { IntegrationManifest } from "@tulipfarm/soul";
+
+/**
+ * Secret env handling for integration connections. connection.yaml lives in the soul git repo
+ * (committed and pushed to the user's upstream), so secret-flagged env values must never be
+ * written there in plaintext. Instead they are stored in the encrypted secrets store and the
+ * file carries an opaque `secret://<key>` reference, resolved back at point-of-use (MCP
+ * transport start, ingress HMAC verification).
+ */
+
+export const SECRET_REF_PREFIX = "secret://";
+
+/** The subset of SecretsService the connection env helpers need (narrow for testability). */
+export interface ConnectionSecretStore {
+  get(key: string): Promise<string>;
+  set(key: string, plaintext: string): Promise<void>;
+  delete(key: string): Promise<void>;
+  list(): Promise<Array<{ key: string }>>;
+}
+
+export function integrationSecretKey(integrationName: string, envName: string): string {
+  return `integration.${integrationName}.${envName}`;
+}
+
+export function isSecretRef(value: string): boolean {
+  return value.startsWith(SECRET_REF_PREFIX);
+}
+
+/** Env var names the manifest declares as secret (required_env `secret: true` + the OAuth token). */
+function secretEnvNames(manifest: IntegrationManifest): Set<string> {
+  const names = new Set<string>();
+  for (const field of manifest.required_env ?? []) {
+    if (field.secret) names.add(field.name);
+  }
+  // The OAuth access token is always a secret, whether or not it is listed in required_env.
+  const tf = manifest.oauth?.["x-tulipfarm"];
+  if (tf) {
+    names.add(tf.token_env);
+    names.add(tf.client_secret_env);
+  }
+  return names;
+}
+
+/**
+ * Replace secret-flagged env values with `secret://` references, persisting each value to the
+ * secrets store. Values that are already references pass through untouched (reconnect flows
+ * resubmit the stored form). Returns a new object safe to write to connection.yaml.
+ */
+export async function sealConnectionEnv(
+  integrationName: string,
+  manifest: IntegrationManifest,
+  env: Record<string, string>,
+  secrets: ConnectionSecretStore
+): Promise<Record<string, string>> {
+  const secretNames = secretEnvNames(manifest);
+  const sealed: Record<string, string> = {};
+  for (const [name, value] of Object.entries(env)) {
+    if (!secretNames.has(name) || isSecretRef(value) || value === "") {
+      sealed[name] = value;
+      continue;
+    }
+    const key = integrationSecretKey(integrationName, name);
+    await secrets.set(key, value);
+    sealed[name] = `${SECRET_REF_PREFIX}${key}`;
+  }
+  return sealed;
+}
+
+/**
+ * Resolve `secret://` references back to plaintext for runtime use. Plain values pass through,
+ * so pre-existing plaintext connection.yaml files keep working. A missing secret throws — the
+ * callers (MCP connect, ingress verify) already treat failures as "not connected".
+ */
+export async function resolveConnectionEnv(
+  env: Record<string, string>,
+  secrets: ConnectionSecretStore
+): Promise<Record<string, string>> {
+  const resolved: Record<string, string> = {};
+  for (const [name, value] of Object.entries(env)) {
+    resolved[name] = isSecretRef(value)
+      ? await secrets.get(value.slice(SECRET_REF_PREFIX.length))
+      : value;
+  }
+  return resolved;
+}
+
+/** Resolve a single `secret://` value; undefined when missing (plaintext passes through). */
+export async function resolveSecretRef(
+  value: string,
+  secrets: ConnectionSecretStore
+): Promise<string | undefined> {
+  if (!isSecretRef(value)) return value;
+  try {
+    return await secrets.get(value.slice(SECRET_REF_PREFIX.length));
+  } catch {
+    return undefined;
+  }
+}
+
+/** Remove every stored secret belonging to an integration (uninstall cleanup). */
+export async function deleteConnectionSecrets(
+  integrationName: string,
+  secrets: ConnectionSecretStore
+): Promise<void> {
+  const prefix = `integration.${integrationName}.`;
+  for (const meta of await secrets.list()) {
+    if (meta.key.startsWith(prefix)) await secrets.delete(meta.key);
+  }
+}

--- a/apps/api/src/integrations/mcp-client-service.ts
+++ b/apps/api/src/integrations/mcp-client-service.ts
@@ -53,7 +53,11 @@ export class McpClientService {
   private readonly connections = new Map<string, ConnectionEntry>();
   private registry: ToolRegistry | null = null;
 
-  constructor(private readonly logger: Logger) {}
+  constructor(
+    private readonly logger: Logger,
+    /** Resolves `secret://` refs in connection env to plaintext; identity when absent. */
+    private readonly resolveEnv?: (env: Record<string, string>) => Promise<Record<string, string>>
+  ) {}
 
   /** Called once after ToolRegistry is built. McpClientService then registers/unregisters tools directly. */
   setRegistry(registry: ToolRegistry): void {
@@ -115,7 +119,9 @@ export class McpClientService {
           `McpClientService.connect called for non-mcp egress type "${manifest.egress.type}"`
         );
       }
-      const transport = buildTransport(manifest.egress.entry, connection.env ?? {});
+      const rawEnv = connection.env ?? {};
+      const env = this.resolveEnv ? await this.resolveEnv(rawEnv) : rawEnv;
+      const transport = buildTransport(manifest.egress.entry, env);
       entry.transport = transport;
 
       // Crash isolation: if the server closes unexpectedly, mark as error

--- a/apps/api/src/soul/integrations/routes.ts
+++ b/apps/api/src/soul/integrations/routes.ts
@@ -10,6 +10,11 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { parse as parseYaml, stringify as toYaml } from "yaml";
 import { ErrorSchema } from "../../auth/schemas";
 import { analyzeHook } from "../../hooks/hook-analyzer";
+import {
+  type ConnectionSecretStore,
+  deleteConnectionSecrets,
+  sealConnectionEnv,
+} from "../../integrations/connection-env";
 import type { McpClientService } from "../../integrations/mcp-client-service";
 import { buildIngressAudit, type IngressAuditReport } from "./ingress-audit";
 import { readIntegrationsLock, sourceType, writeIntegrationsLock } from "./lock";
@@ -286,8 +291,17 @@ export function registerIntegrationRoutes(
   mcpClient: McpClientService,
   requireAuth: PreHandler,
   /** Enables the IngressAudit LLM review of ingress handlers at install; skipped when absent. */
-  llmService?: LlmService
+  llmService?: LlmService,
+  /** When present, secret-flagged env values are sealed into the secrets store instead of
+   * being written to connection.yaml in the soul git repo. */
+  secretsService?: ConnectionSecretStore
 ): void {
+  const sealEnv = async (
+    name: string,
+    manifest: IntegrationManifest,
+    env: Record<string, string>
+  ): Promise<Record<string, string>> =>
+    secretsService ? await sealConnectionEnv(name, manifest, env, secretsService) : env;
   // List all installed integrations with runtime status
   app.get(
     "/api/v1/integrations",
@@ -764,7 +778,10 @@ export function registerIntegrationRoutes(
       const integration = soulLoader.integrations.get(name);
       if (!integration) return reply.code(404).send({ error: `integration not found: ${name}` });
       const body = (req.body as { env?: Record<string, string> } | null) ?? {};
-      const connection = { enabled: true, env: body.env ?? {} };
+      const connection = {
+        enabled: true,
+        env: await sealEnv(name, integration.manifest, body.env ?? {}),
+      };
 
       // Persist connection.yaml before starting (so a restart re-connects)
       const connPath = join(gitSync.path, "integrations", name, "connection.yaml");
@@ -1002,9 +1019,13 @@ export function registerIntegrationRoutes(
         return reply.redirect(`${webBase}/integrations/${name}?error=${msg}`);
       }
 
-      // Merge token into env and write connection.yaml
+      // Merge token into env and write connection.yaml (secrets sealed to the secrets store)
       const mergedEnv = { ...env, [tf.token_env]: token };
-      const connection = { enabled: true, env: mergedEnv };
+      const integrationForSeal = soulLoader.integrations.get(name);
+      const sealedEnv = integrationForSeal
+        ? await sealEnv(name, integrationForSeal.manifest, mergedEnv)
+        : mergedEnv;
+      const connection = { enabled: true, env: sealedEnv };
       const connPath = join(gitSync.path, "integrations", name, "connection.yaml");
       try {
         await writeFile(connPath, toYaml(connection), "utf8");
@@ -1050,6 +1071,7 @@ export function registerIntegrationRoutes(
 
       await mcpClient.disconnect(name);
       await rm(join(gitSync.path, "integrations", name), { recursive: true, force: true });
+      if (secretsService) await deleteConnectionSecrets(name, secretsService);
 
       const lock = await readIntegrationsLock(gitSync.path);
       delete lock.integrations[name];


### PR DESCRIPTION
## Problem

`connection.yaml` lives in the soul git repo — committed and pushed to the user's upstream — but the connect and OAuth-callback routes wrote every env value into it in **plaintext**, including fields the manifest flags `secret: true` (bot tokens, signing secrets, OAuth access tokens). Found live: the slack bot token sitting in plaintext in a dev soul repo.

## Fix

- **Seal on write** (`connect` route + OAuth callback): values for `required_env` fields with `secret: true` — plus the OAuth `token_env` / `client_secret_env`, always — are encrypted into the secrets store under `integration.<name>.<ENV>`; `connection.yaml` carries an opaque `secret://<key>` reference instead.
- **Resolve at point-of-use**: `McpClientService` resolves the connection env before building the stdio/HTTP transport; the ingress webhook route resolves the HMAC signing secret (TTL-cached by `SecretsService`, so the hot path stays cheap).
- **Cleanup on uninstall**: `DELETE /integrations/:name` removes the integration's stored secrets.
- **Back-compat**: plaintext values in existing `connection.yaml` files pass through resolution untouched — nothing breaks on upgrade; reconnecting an integration seals them.

New module: `apps/api/src/integrations/connection-env.ts` (seal / resolve / delete helpers behind a narrow `ConnectionSecretStore` interface).

## Tests

- `connection-env.test.ts`: seal (flagged-only, ref pass-through, OAuth fields, empty values), resolve (refs + legacy plaintext + missing), single-ref resolve, prefix-scoped delete.
- `ingress/routes.test.ts`: signed delivery accepted with a `secret://` signing secret; unresolvable ref → 401.
- Full gates: `pnpm lint` / `pnpm typecheck` / `pnpm test` all green (1669 api tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdYmPpdq9n3QE21m7S5HCv