### PR TITLE
fix(schema): register draft-06/07 meta-schemas for MCP tool schemas

### DIFF
--- a/packages/schema/src/ajv.test.ts
+++ b/packages/schema/src/ajv.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { ajv } from "./ajv";
+
+describe("shared ajv instance", () => {
+  it("compiles a draft-07 tool inputSchema without throwing", () => {
+    const draft07Schema = {
+      $schema: "http://json-schema.org/draft-07/schema#",
+      type: "object",
+      properties: { owner: { type: "string" }, repo: { type: "string" } },
+      required: ["owner", "repo"],
+    };
+    expect(() => ajv.compile(draft07Schema)).not.toThrow();
+  });
+
+  it("compiles a draft-06 tool inputSchema without throwing", () => {
+    const draft06Schema = {
+      $schema: "http://json-schema.org/draft-06/schema#",
+      type: "object",
+      properties: { query: { type: "string" } },
+    };
+    expect(() => ajv.compile(draft06Schema)).not.toThrow();
+  });
+
+  it("still validates data against a compiled draft-07 schema", () => {
+    const validateFn = ajv.compile({
+      $schema: "http://json-schema.org/draft-07/schema#",
+      type: "object",
+      properties: { count: { type: "number" } },
+      required: ["count"],
+    });
+    expect(validateFn({ count: 3 })).toBe(true);
+    expect(validateFn({ count: "nope" })).toBe(false);
+  });
+
+  it("compiles a 2020-12 schema (default draft) without regression", () => {
+    const draft2020Schema = {
+      $schema: "https://json-schema.org/draft/2020-12/schema",
+      type: "object",
+      properties: { id: { type: "string" } },
+    };
+    expect(() => ajv.compile(draft2020Schema)).not.toThrow();
+  });
+});

--- a/packages/schema/src/ajv.ts
+++ b/packages/schema/src/ajv.ts
@@ -1,4 +1,13 @@
 import Ajv2020 from "ajv/dist/2020";
+import draft06MetaSchema from "ajv/dist/refs/json-schema-draft-06.json";
+import draft07MetaSchema from "ajv/dist/refs/json-schema-draft-07.json";
 
 // strict:false: silently ignore x-* and other unknown keywords
 export const ajv = new Ajv2020({ allErrors: true, strict: false });
+
+// Ajv2020 only bundles the 2019-09 + 2020-12 meta-schemas. External MCP servers (e.g. GitHub's)
+// commonly emit tool inputSchemas that declare `$schema: draft-07` (or draft-06); registering the
+// older meta-schemas lets ajv.compile() resolve those refs instead of throwing
+// `no schema with key or ref "http://json-schema.org/draft-07/schema#"`.
+ajv.addMetaSchema(draft06MetaSchema);
+ajv.addMetaSchema(draft07MetaSchema);


### PR DESCRIPTION
## Summary
Connecting external MCP integrations (e.g. GitHub) failed with `MCP server failed to start: no schema with key or ref "http://json-schema.org/draft-07/schema#"`. This was **not** a credentials problem — the MCP server connected and `listTools()` succeeded; the failure was when `ToolRegistry.register()` AJV-compiled each tool's `inputSchema`.

The shared `ajv` instance is an `Ajv2020` (draft 2020-12) that only bundles the 2019-09 + 2020-12 meta-schemas. GitHub's MCP server (and many others) emit tool schemas declaring `$schema: http://json-schema.org/draft-07/schema#`, which `Ajv2020` couldn't resolve — so `ajv.compile()` threw and the error surfaced as a `502` on `/connect`.

This registers the draft-06 + draft-07 meta-schemas on the shared instance so those schemas compile, while our own 2020-12 configs keep working unchanged.

- Register `json-schema-draft-06` + `json-schema-draft-07` meta-schemas on the shared `Ajv2020` in `packages/schema/src/ajv.ts`
- Add a regression test (`packages/schema/src/ajv.test.ts`) covering draft-07/06 compilation, data validation against a compiled draft-07 schema, and a 2020-12 no-regression check

Closes #163

## Test plan
- [x] `pnpm --filter @tulipfarm/schema test` (67 passed, incl. 4 new)
- [x] `pnpm exec biome check` on changed files
- [x] `pnpm --filter @tulipfarm/schema typecheck`
- [ ] Manual: connect the GitHub integration via the Integrations UI and confirm tools register (no `502 MCP server failed to start`)

Made with [Cursor](https://cursor.com)