### PR TITLE
feat(routines): add Routine and Run visualization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,18 @@ If a rule genuinely must be broken, add a scoped suppression on the line — nev
 - Migrations: `apps/api/src/migrations/` run on boot — add new ones there.
 - Env: copy `.env.local.example` → `.env.local`; never commit secrets.
 
+### Product testing must use product surfaces
+
+- For manual, acceptance, or end-to-end testing of Soul-backed behavior, create and update Soul
+  artifacts exclusively through the agentic Chat or the supported UI.
+- Never prepare a test by directly creating or editing YAML, Markdown, or configuration files in
+  the runtime `soul/` repository. This includes shell redirects, patches, scripts, and copied
+  fixtures for Resources, Routines, Agents, Skills, or Integrations.
+- Exercise the same Chat/UI path a user would take. If that path cannot create the required test
+  state, treat it as a product gap instead of bypassing it with a direct Soul filesystem write.
+- Isolated automated unit/integration fixtures outside the runtime `soul/` repository remain
+  allowed; this rule governs product-flow setup against the real Soul repository.
+
 ## API route schemas (OpenAPI)
 
 Every Fastify route **must** have a `schema` option. The spec at `/api/v1/openapi.json` is auto-generated from these schemas — no schema means the endpoint is invisible in docs.

--- a/apps/api/src/routines/definition-hash.test.ts
+++ b/apps/api/src/routines/definition-hash.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { definitionHash } from "./definition-hash";
+
+describe("definitionHash", () => {
+  it("ignores object key insertion order recursively", () => {
+    const first = {
+      id: "ordered",
+      metadata: { labels: { team: "ops", priority: 1 }, enabled: true },
+      states: [{ name: "Done", type: "inject", data: { b: 2, a: 1 }, end: true }],
+    };
+    const reordered = {
+      states: [{ end: true, data: { a: 1, b: 2 }, type: "inject", name: "Done" }],
+      metadata: { enabled: true, labels: { priority: 1, team: "ops" } },
+      id: "ordered",
+    };
+
+    expect(definitionHash(first)).toBe(definitionHash(reordered));
+    expect(definitionHash(first)).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("preserves semantic array order", () => {
+    const first = {
+      id: "ordered",
+      states: [
+        { name: "First", type: "inject", data: {}, transition: "Second" },
+        { name: "Second", type: "inject", data: {}, end: true },
+      ],
+    };
+    const reversed = { ...first, states: [...first.states].reverse() };
+
+    expect(definitionHash(first)).not.toBe(definitionHash(reversed));
+  });
+});

--- a/apps/api/src/routines/definition-hash.ts
+++ b/apps/api/src/routines/definition-hash.ts
@@ -1,0 +1,20 @@
+import { createHash } from "node:crypto";
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value === null || typeof value !== "object") return value;
+
+  const object = value as Record<string, unknown>;
+  return Object.fromEntries(
+    Object.keys(object)
+      .sort()
+      .map((key) => [key, canonicalize(object[key])])
+  );
+}
+
+/** Hashes JSON-compatible Routine definitions independent of object insertion order. */
+export function definitionHash(definition: unknown): string {
+  return createHash("sha256")
+    .update(JSON.stringify(canonicalize(definition)))
+    .digest("hex");
+}

--- a/apps/api/src/routines/driver.test.ts
+++ b/apps/api/src/routines/driver.test.ts
@@ -8,6 +8,7 @@ import { makePglite } from "../test/pglite";
 import { type ActionExecutor, RoutineRunDriver, type RoutineSandbox } from "./driver";
 import type { RoutineRegistry } from "./registry";
 import { RoutineRunsRepo } from "./repo";
+import { RunJournalStreamRepo, runStreamId } from "./stream-adapter";
 
 function makeSandbox(hookResults: Record<string, unknown> = {}): RoutineSandbox {
   return {
@@ -56,13 +57,14 @@ describe("RoutineRunDriver (PGlite)", () => {
     enqueueWake?: ReturnType<typeof vi.fn>;
     requestApproval?: ReturnType<typeof vi.fn>;
     recordRun?: ReturnType<typeof vi.fn>;
+    hub?: StreamHub;
   }) {
     const enqueueWake = overrides.enqueueWake ?? vi.fn(async () => {});
     const recordRun = overrides.recordRun ?? vi.fn();
     const driver = new RoutineRunDriver({
       runs,
       registry: overrides.registry ?? makeRegistry(),
-      hub: new StreamHub(),
+      hub: overrides.hub ?? new StreamHub(),
       sandbox: overrides.sandbox ?? makeSandbox(),
       actionExecutor: overrides.actionExecutor ?? vi.fn(async () => ({ ok: true })),
       requestApproval: overrides.requestApproval as never,
@@ -125,9 +127,27 @@ describe("RoutineRunDriver (PGlite)", () => {
 
     const events = await runs.listEvents(id);
     const types = events.map((e) => e.type);
-    expect(types[0]).toBe("run.started");
-    expect(types).toContain("state.entered");
-    expect(types[types.length - 1]).toBe("finish");
+    expect(types).toEqual([
+      "run.started",
+      "state.entered",
+      "state.completed",
+      "state.transitioned",
+      "state.entered",
+      "state.completed",
+      "state.transitioned",
+      "state.entered",
+      "action.completed",
+      "state.completed",
+      "state.transitioned",
+      "finish",
+    ]);
+    expect(
+      events.filter((event) => event.type === "state.transitioned").map((e) => e.payload)
+    ).toEqual([
+      { source: "Seed", target: "Gate", route: { kind: "transition" } },
+      { source: "Gate", target: "Work", route: { kind: "condition", index: 0 } },
+      { source: "Work", end: true, route: { kind: "end" } },
+    ]);
     // seqs strictly ascending from 1
     expect(events.map((e) => e.seq)).toEqual(events.map((_, i) => i + 1));
   });
@@ -153,6 +173,14 @@ describe("RoutineRunDriver (PGlite)", () => {
     expect(enqueueWake).toHaveBeenCalledWith(
       expect.objectContaining({ runId: id, reason: "sleep" })
     );
+    expect((await runs.listEvents(id)).map((event) => event.type)).toEqual([
+      "run.started",
+      "state.entered",
+      "state.completed",
+      "state.transitioned",
+      "run.sleeping",
+      "finish",
+    ]);
 
     // wake delivery (crash-restart equivalent: fresh drive call)
     await driver.drive(id);
@@ -164,6 +192,42 @@ describe("RoutineRunDriver (PGlite)", () => {
     const seqs = (await runs.listEvents(id)).map((e) => e.seq);
     expect(seqs).toEqual([...seqs].sort((a, b) => a - b));
     expect(new Set(seqs).size).toBe(seqs.length);
+  });
+
+  it("keeps Sleep End history when cancellation wins during suspension", async () => {
+    const def = {
+      ...MULTI_STATE,
+      start: "Nap",
+      states: [{ name: "Nap", type: "sleep", duration: "PT1S", end: true }],
+    } as unknown as RoutineDefinition;
+    const { driver } = makeDriver({});
+    const id = await createRun(def);
+
+    await driver.drive(id);
+    expect(await runs.findById(id)).toMatchObject({ status: "sleeping", currentState: null });
+    expect(
+      (await runs.listEvents(id)).find((event) => event.type === "state.transitioned")?.payload
+    ).toEqual({ source: "Nap", end: true, route: { kind: "end" } });
+    await runs.transition(id, { status: "sleeping" }, { status: "cancelled", finished: true });
+    await driver.drive(id);
+    expect(await runs.findById(id)).toMatchObject({ status: "cancelled" });
+  });
+
+  it("retains replayable committed events when live fan-out fails", async () => {
+    const hub = new StreamHub();
+    vi.spyOn(hub, "publish").mockImplementation(() => {
+      throw new Error("subscriber failed");
+    });
+    const { driver } = makeDriver({ hub });
+    const id = await createRun(MULTI_STATE);
+
+    await driver.drive(id);
+
+    const journal = await runs.listEvents(id);
+    const replay = await new RunJournalStreamRepo(runs).listAfter(runStreamId(id), 0);
+    expect(LOG.error).toHaveBeenCalled();
+    expect(replay.map((event) => event.seq)).toEqual(journal.map((event) => event.seq));
+    expect(replay.at(-1)?.eventType).toBe("finish");
   });
 
   it("is idempotent under duplicate deliveries (CAS loses quietly)", async () => {
@@ -208,6 +272,10 @@ describe("RoutineRunDriver (PGlite)", () => {
     expect(run?.status).toBe("sleeping");
     expect(run?.attemptCounts).toEqual({ Work: 1 });
     expect(enqueueWake).toHaveBeenCalledWith(expect.objectContaining({ reason: "retry" }));
+    expect((await runs.listEvents(id)).slice(-2).map((event) => event.type)).toEqual([
+      "state.retrying",
+      "finish",
+    ]);
 
     await driver.drive(id);
     run = await runs.findById(id);
@@ -264,18 +332,66 @@ describe("RoutineRunDriver (PGlite)", () => {
     const requestApproval = vi.fn(async () => approvalId);
     const actionExecutor = vi.fn(async () => ({ ok: true }));
     const { driver } = makeDriver({ requestApproval, actionExecutor });
-    const id = await createRun(def);
+    const id = await createRun(def, { amount: 9 });
 
     await driver.drive(id);
     let run = await runs.findById(id);
     expect(run?.status).toBe("waiting_approval");
     expect(run?.approvalId).toBe(approvalId);
     expect(actionExecutor).not.toHaveBeenCalled();
+    expect((await runs.listEvents(id)).slice(-2).map((event) => event.payload)).toEqual([
+      {
+        state: "Gate",
+        approvalId,
+        channels: ["ui"],
+        pendingInput: { amount: 9 },
+      },
+      { reason: "suspended" },
+    ]);
 
     await driver.drive(id, { approvalOutcome: "approved" });
     run = await runs.findById(id);
     expect(run?.status).toBe("succeeded");
     expect(actionExecutor).toHaveBeenCalledOnce();
+  });
+
+  it("journals handled error route identity before continuing", async () => {
+    const def = {
+      ...MULTI_STATE,
+      start: "Work",
+      states: [
+        {
+          name: "Work",
+          type: "operation",
+          actions: [{ functionRef: { refName: "doWork" } }],
+          onErrors: [{ errorRef: "*", transition: "Recover" }],
+        },
+        { name: "Recover", type: "inject", data: { recovered: true }, end: true },
+      ],
+    } as unknown as RoutineDefinition;
+    const { driver } = makeDriver({
+      actionExecutor: vi.fn(async () => {
+        throw new Error("boom");
+      }),
+    });
+    const id = await createRun(def);
+
+    await driver.drive(id);
+
+    const transition = (await runs.listEvents(id)).find(
+      (event) =>
+        event.type === "state.transitioned" &&
+        (event.payload as { source?: string }).source === "Work"
+    );
+    expect(transition?.payload).toMatchObject({
+      source: "Work",
+      target: "Recover",
+      route: {
+        kind: "error",
+        index: 0,
+        error: { name: "action_failed", message: "boom", state: "Work" },
+      },
+    });
   });
 
   it("runs lifecycle + step hooks through the sandbox", async () => {

--- a/apps/api/src/routines/driver.ts
+++ b/apps/api/src/routines/driver.ts
@@ -6,12 +6,20 @@ import {
   type ResolvedFunction,
   type RunEvent,
   type RunSnapshot,
+  type SelectedRoute,
+  type StateExecutionData,
 } from "@tulipfarm/routine-engine";
-import { makeStreamEmitter } from "../chat/stream-emitter";
 import type { StreamHub } from "../chat/stream-hub";
 import type { RoutineRegistry } from "./registry";
-import type { RoutineRunRow, RoutineRunsRepo, RunStatus } from "./repo";
-import { RunJournalStreamRepo, runStreamId } from "./stream-adapter";
+import type {
+  PendingRunEvent,
+  RoutineRunRow,
+  RoutineRunsRepo,
+  RunStatus,
+  RunTransitionGuard,
+  RunTransitionPatch,
+} from "./repo";
+import { makeRunJournalEmitter, publishRunEvents, runStreamId } from "./stream-adapter";
 
 type DriverLogger = {
   error: (obj: unknown, msg?: string) => void;
@@ -83,6 +91,27 @@ function hookMentions(hookSource: string, fnName: string): boolean {
   return new RegExp(`\\b${fnName}\\s*[(:]`).test(hookSource);
 }
 
+function stateCompleted(data: StateExecutionData): PendingRunEvent {
+  return { type: "state.completed", payload: { state: data.state, output: data.output ?? {} } };
+}
+
+function stateTransitioned(source: string, selected: SelectedRoute): PendingRunEvent {
+  const payload: Record<string, unknown> = { source };
+  if ("target" in selected && selected.target) payload.target = selected.target;
+  if ("end" in selected && selected.end) payload.end = true;
+  switch (selected.kind) {
+    case "condition":
+      payload.route = { kind: selected.kind, index: selected.index };
+      break;
+    case "error":
+      payload.route = { kind: selected.kind, index: selected.index, error: selected.error };
+      break;
+    default:
+      payload.route = { kind: selected.kind };
+  }
+  return { type: "state.transitioned", payload };
+}
+
 /**
  * The run driver: loads a run, loops `executeState`, persists after every outcome
  * (persist-first, enqueue-second — the sweep heals the gap), and exits the loop on any
@@ -102,7 +131,7 @@ export class RoutineRunDriver {
     if (TERMINAL.includes(row.status)) return;
 
     // Claim: pending (fresh) / sleeping (wake) / waiting_approval (decision) → running.
-    const claimed = await runs.transition(
+    const claimed = await this.transition(
       runId,
       { status: row.status },
       { status: "running", wakeAt: null }
@@ -111,13 +140,7 @@ export class RoutineRunDriver {
 
     const streamId = runStreamId(runId);
     hub.register(streamId);
-    const journalRepo = new RunJournalStreamRepo(runs);
-    const lastSeq = (await runs.nextSeq(runId)) - 1;
-    const emitter = makeStreamEmitter(
-      streamId,
-      { repo: journalRepo, hub, log: { error: (obj, msg) => log.error(obj, msg) } },
-      lastSeq
-    );
+    const emitter = makeRunJournalEmitter(runId, { runs, hub, log });
 
     const routine = this.deps.registry.get(row.routineSlug);
     const hookSource = routine?.hookSource;
@@ -125,10 +148,9 @@ export class RoutineRunDriver {
     const breakerKey = `routine:${row.routineSlug}`;
     const sandbox = this.deps.sandbox;
 
-    let approvalOutcome = opts.approvalOutcome;
     // sleep-completion: currentState null means "the run finished sleeping into its end".
     if (row.currentState === null) {
-      await this.finish(runId, row.routineSlug, emitter, {
+      await this.finish(runId, row.routineSlug, {
         status: "succeeded",
         output: row.context,
       });
@@ -146,7 +168,7 @@ export class RoutineRunDriver {
         payload: row.trigger.payload,
       },
       attemptCounts: row.attemptCounts,
-      approvalOutcome,
+      approvalOutcome: opts.approvalOutcome,
     };
 
     const ports: EnginePorts = {
@@ -170,9 +192,15 @@ export class RoutineRunDriver {
       log: { warn: (msg) => log.warn({ runId }, msg) },
     };
 
-    const isFirstState = snapshot.currentState === snapshot.definition.start && lastSeq === 0;
+    const isFirstState =
+      snapshot.currentState === snapshot.definition.start &&
+      (await runs.listEvents(runId)).length === 0;
     if (isFirstState) {
-      await emitter.emit("run.started", { slug: row.routineSlug, trigger: row.trigger.type });
+      await emitter.emit("run.started", {
+        slug: row.routineSlug,
+        trigger: row.trigger.type,
+        triggerIndex: row.trigger.triggerIndex,
+      });
       if (hookSource && hookMentions(hookSource, LIFECYCLE_HOOKS.beforeRun)) {
         try {
           await ports.runHook(LIFECYCLE_HOOKS.beforeRun, {
@@ -195,12 +223,14 @@ export class RoutineRunDriver {
       // out across a crash/restart (the in-process race lives in the engine).
       const stateDef = snapshot.definition.states.find((s) => s.name === stateName);
       const timeoutIso = stateDef?.timeouts?.stateExecTimeout;
-      if (timeoutIso) {
-        await runs.transition(
+      const approvalGate = stateDef?.["x-autonomy-level"] === "human_approval";
+      if (timeoutIso && (!approvalGate || snapshot.approvalOutcome === "approved")) {
+        const deadlineSet = await this.transition(
           runId,
           { status: "running", currentState: stateName },
           { stateDeadline: new Date(Date.now() + parseIsoDuration(timeoutIso)) }
         );
+        if (!deadlineSet) return;
       }
 
       const outcome = await executeState(snapshot, ports);
@@ -208,10 +238,15 @@ export class RoutineRunDriver {
 
       switch (outcome.type) {
         case "continue": {
-          const ok = await runs.transition(
+          const events = [
+            ...(outcome.route.kind === "error" ? [] : [stateCompleted(outcome.stateData)]),
+            stateTransitioned(stateName, outcome.route),
+          ];
+          const ok = await this.transition(
             runId,
             { status: "running", currentState: stateName },
-            { currentState: outcome.nextState, context: outcome.context, stateDeadline: null }
+            { currentState: outcome.nextState, context: outcome.context, stateDeadline: null },
+            events
           );
           if (!ok) return; // raced: cancelled or duplicate delivery advanced it
           snapshot = {
@@ -219,22 +254,30 @@ export class RoutineRunDriver {
             currentState: outcome.nextState,
             context: outcome.context,
           };
-          approvalOutcome = undefined;
           snapshot.approvalOutcome = undefined;
           continue;
         }
         case "complete": {
           await this.runAfterHook(ports, hookSource, snapshot);
-          await this.finish(runId, row.routineSlug, emitter, {
-            status: "succeeded",
-            output: outcome.output,
-            expectState: stateName,
-          });
+          const events = [
+            ...(outcome.route.kind === "error" ? [] : [stateCompleted(outcome.stateData)]),
+            stateTransitioned(stateName, outcome.route),
+          ];
+          await this.finish(
+            runId,
+            row.routineSlug,
+            {
+              status: "succeeded",
+              output: outcome.output,
+              expectState: stateName,
+            },
+            events
+          );
           return;
         }
         case "fail": {
           await this.runAfterHook(ports, hookSource, snapshot);
-          await this.finish(runId, row.routineSlug, emitter, {
+          await this.finish(runId, row.routineSlug, {
             status: "failed",
             error: outcome.error as unknown as Record<string, unknown>,
             expectState: stateName,
@@ -243,7 +286,7 @@ export class RoutineRunDriver {
         }
         case "sleep": {
           const token = `sleep:${stateName}:${outcome.until.getTime()}`;
-          const ok = await runs.transition(
+          const ok = await this.transition(
             runId,
             { status: "running", currentState: stateName },
             {
@@ -252,17 +295,21 @@ export class RoutineRunDriver {
               context: outcome.context,
               wakeAt: outcome.until,
               stateDeadline: null,
-            }
+            },
+            [
+              stateCompleted(outcome.stateData),
+              stateTransitioned(stateName, outcome.route),
+              {
+                type: "run.sleeping",
+                payload: { state: stateName, wakeAt: outcome.until.toISOString() },
+              },
+              {
+                type: "finish",
+                payload: { reason: "suspended", wakeAt: outcome.until.toISOString() },
+              },
+            ]
           );
           if (!ok) return;
-          await emitter.emit("run.sleeping", {
-            state: stateName,
-            until: outcome.until.toISOString(),
-          });
-          await emitter.emit("finish", {
-            reason: "suspended",
-            wakeAt: outcome.until.toISOString(),
-          });
           hub.finish(streamId);
           await this.deps.enqueueWake({ runId, reason: "sleep", token, startAfter: outcome.until });
           return;
@@ -271,26 +318,31 @@ export class RoutineRunDriver {
           const wakeAt = new Date(Date.now() + outcome.delayMs);
           const token = `retry:${stateName}:${outcome.attempt}`;
           const attemptCounts = { ...snapshot.attemptCounts, [stateName]: outcome.attempt };
-          const ok = await runs.transition(
+          const ok = await this.transition(
             runId,
             { status: "running", currentState: stateName },
-            { status: "sleeping", attemptCounts, wakeAt, stateDeadline: null }
+            { status: "sleeping", attemptCounts, wakeAt, stateDeadline: null },
+            [
+              {
+                type: "state.retrying",
+                payload: {
+                  state: stateName,
+                  attempt: outcome.attempt,
+                  delayMs: outcome.delayMs,
+                  error: outcome.error,
+                },
+              },
+              { type: "finish", payload: { reason: "suspended", wakeAt: wakeAt.toISOString() } },
+            ]
           );
           if (!ok) return;
-          await emitter.emit("state.retrying", {
-            state: stateName,
-            attempt: outcome.attempt,
-            delayMs: outcome.delayMs,
-            error: outcome.error,
-          });
-          await emitter.emit("finish", { reason: "suspended", wakeAt: wakeAt.toISOString() });
           hub.finish(streamId);
           await this.deps.enqueueWake({ runId, reason: "retry", token, startAfter: wakeAt });
           return;
         }
         case "wait_approval": {
-          if (!this.deps.requestApproval || !row) {
-            await this.finish(runId, row.routineSlug, emitter, {
+          if (!this.deps.requestApproval) {
+            await this.finish(runId, row.routineSlug, {
               status: "failed",
               error: { name: "approvals_unavailable", message: "approvals are not configured" },
               expectState: stateName,
@@ -298,18 +350,24 @@ export class RoutineRunDriver {
             return;
           }
           const approvalId = await this.deps.requestApproval(row, outcome.request);
-          const ok = await runs.transition(
+          const ok = await this.transition(
             runId,
             { status: "running", currentState: stateName },
-            { status: "waiting_approval", approvalId }
+            { status: "waiting_approval", approvalId, stateDeadline: null },
+            [
+              {
+                type: "run.waiting_approval",
+                payload: {
+                  state: stateName,
+                  approvalId,
+                  channels: outcome.request.channels,
+                  pendingInput: outcome.request.summary,
+                },
+              },
+              { type: "finish", payload: { reason: "suspended" } },
+            ]
           );
           if (!ok) return;
-          await emitter.emit("run.waiting_approval", {
-            state: stateName,
-            approvalId,
-            channels: outcome.request.channels,
-          });
-          await emitter.emit("finish", { reason: "suspended" });
           hub.finish(streamId);
           return;
         }
@@ -338,16 +396,20 @@ export class RoutineRunDriver {
   private async finish(
     runId: string,
     slug: string,
-    emitter: { emit(type: string, data: unknown): Promise<void> },
     result: {
       status: "succeeded" | "failed";
       output?: Record<string, unknown>;
       error?: Record<string, unknown>;
       expectState?: string | null;
-    }
+    },
+    leadingEvents: PendingRunEvent[] = []
   ): Promise<void> {
-    const { runs, hub } = this.deps;
-    const ok = await runs.transition(
+    const { hub } = this.deps;
+    const terminalEvent: PendingRunEvent =
+      result.status === "succeeded"
+        ? { type: "finish", payload: { reason: "completed", output: result.output ?? {} } }
+        : { type: "error", payload: { error: result.error ?? {} } };
+    const ok = await this.transition(
       runId,
       {
         status: "running",
@@ -360,15 +422,22 @@ export class RoutineRunDriver {
         wakeAt: null,
         stateDeadline: null,
         finished: true,
-      }
+      },
+      [...leadingEvents, terminalEvent]
     );
     if (!ok) return;
     this.deps.recordRun?.({ slug, runId, status: result.status, error: result.error });
-    if (result.status === "succeeded") {
-      await emitter.emit("finish", { reason: "completed", output: result.output ?? {} });
-    } else {
-      await emitter.emit("error", { error: result.error ?? {} });
-    }
     hub.finish(runStreamId(runId));
+  }
+
+  private async transition(
+    runId: string,
+    expected: RunTransitionGuard,
+    patch: RunTransitionPatch,
+    events: PendingRunEvent[] = []
+  ): Promise<boolean> {
+    const result = await this.deps.runs.transitionWithEvents(runId, expected, patch, events);
+    publishRunEvents(runId, result.events, this.deps.hub, this.deps.log);
+    return result.transitioned;
   }
 }

--- a/apps/api/src/routines/jobs.ts
+++ b/apps/api/src/routines/jobs.ts
@@ -14,7 +14,7 @@ export const STALE_HEARTBEAT_MS = 2 * 60 * 1000;
 export interface RoutineRunJob {
   runId: string;
   slug: string;
-  trigger: { type: string; payload?: unknown };
+  trigger: { type: string; payload?: unknown; triggerIndex?: number };
 }
 
 export interface RoutineWakeJob {

--- a/apps/api/src/routines/repo.pg.test.ts
+++ b/apps/api/src/routines/repo.pg.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import type { PGlite } from "@electric-sql/pglite";
 import type { RoutineDefinition } from "@tulipfarm/schema";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Queryable } from "../db";
 import { runPgMigrations } from "../pg-migrate";
 import { makePglite } from "../test/pglite";
 import { RoutineRunsRepo } from "./repo";
@@ -13,6 +14,48 @@ const DEF = {
   "x-triggers": [{ type: "manual" }],
   states: [{ name: "Start", type: "inject", data: {}, end: true }],
 } as unknown as RoutineDefinition;
+
+type PendingRunEvent = { type: string; payload: Record<string, unknown> };
+type TransitionResult = {
+  transitioned: boolean;
+  events: Array<{ runId: string; seq: number; type: string; payload: unknown; createdAt: Date }>;
+};
+type AtomicRoutineRunsRepo = RoutineRunsRepo & {
+  appendEvents(runId: string, events: PendingRunEvent[]): Promise<TransitionResult["events"]>;
+  transitionWithEvents(
+    id: string,
+    expected: { status: "pending" | "running"; currentState?: string | null },
+    patch: { status?: "running" | "succeeded"; currentState?: string | null },
+    events: PendingRunEvent[]
+  ): Promise<TransitionResult>;
+};
+
+function atomic(repo: RoutineRunsRepo): AtomicRoutineRunsRepo {
+  return repo as AtomicRoutineRunsRepo;
+}
+
+function collisionError(): Error & { code: string } {
+  return Object.assign(new Error("duplicate key value violates unique constraint"), {
+    code: "23505",
+  });
+}
+
+class CollisionQueryable implements Queryable {
+  attempts = 0;
+
+  constructor(
+    private readonly delegate: Queryable,
+    private readonly collisions: number
+  ) {}
+
+  async query(text: string, params?: unknown[]): Promise<{ rows: Record<string, unknown>[] }> {
+    if (/routine_run_events/i.test(text) && /insert/i.test(text)) {
+      this.attempts += 1;
+      if (this.attempts <= this.collisions) throw collisionError();
+    }
+    return this.delegate.query(text, params);
+  }
+}
 
 describe("RoutineRunsRepo (PGlite)", () => {
   let db: PGlite;
@@ -145,5 +188,161 @@ describe("RoutineRunsRepo (PGlite)", () => {
     const tail = await repo.listEvents(id, 1);
     expect(tail).toHaveLength(1);
     expect(tail[0].seq).toBe(2);
+  });
+
+  it("allocates an ordered append batch in adjacent journal sequence numbers", async () => {
+    const id = await createRun();
+
+    const committed = await atomic(repo).appendEvents(id, [
+      { type: "state.completed", payload: { state: "Start" } },
+      { type: "state.transitioned", payload: { source: "Start", end: true } },
+      { type: "finish", payload: { reason: "completed" } },
+    ]);
+
+    expect(committed.map((event) => [event.seq, event.type])).toEqual([
+      [1, "state.completed"],
+      [2, "state.transitioned"],
+      [3, "finish"],
+    ]);
+    expect((await repo.listEvents(id)).map((event) => event.payload)).toEqual([
+      { state: "Start" },
+      { source: "Start", end: true },
+      { reason: "completed" },
+    ]);
+  });
+
+  it("commits a CAS transition and its ordered events together", async () => {
+    const id = await createRun();
+
+    const result = await atomic(repo).transitionWithEvents(
+      id,
+      { status: "pending", currentState: "Start" },
+      { status: "running", currentState: null },
+      [
+        { type: "state.completed", payload: { state: "Start" } },
+        { type: "state.transitioned", payload: { source: "Start", end: true } },
+      ]
+    );
+
+    expect(result.transitioned).toBe(true);
+    expect(result.events.map((event) => event.type)).toEqual([
+      "state.completed",
+      "state.transitioned",
+    ]);
+    expect(await repo.findById(id)).toMatchObject({ status: "running", currentState: null });
+    expect((await repo.listEvents(id)).map((event) => event.seq)).toEqual([1, 2]);
+  });
+
+  it("changes neither row nor journal when transition CAS loses", async () => {
+    const id = await createRun();
+
+    const result = await atomic(repo).transitionWithEvents(
+      id,
+      { status: "running", currentState: "Start" },
+      { status: "succeeded", currentState: null },
+      [{ type: "finish", payload: { reason: "completed" } }]
+    );
+
+    expect(result).toEqual({ transitioned: false, events: [] });
+    expect(await repo.findById(id)).toMatchObject({ status: "pending", currentState: "Start" });
+    expect(await repo.listEvents(id)).toEqual([]);
+  });
+
+  it("retries a 23505 collision with fresh allocation and preserves input order", async () => {
+    const id = await createRun();
+    const collisionDb = new CollisionQueryable(db, 2);
+    const collisionRepo = atomic(new RoutineRunsRepo(collisionDb));
+
+    const events = await collisionRepo.appendEvents(id, [
+      { type: "state.completed", payload: { state: "Start" } },
+      { type: "state.transitioned", payload: { source: "Start", end: true } },
+    ]);
+
+    expect(collisionDb.attempts).toBe(3);
+    expect(events.map((event) => [event.seq, event.type])).toEqual([
+      [1, "state.completed"],
+      [2, "state.transitioned"],
+    ]);
+  });
+
+  it("surfaces the eighth consecutive 23505 instead of dropping the batch", async () => {
+    const id = await createRun();
+    const collisionDb = new CollisionQueryable(db, 8);
+    const collisionRepo = atomic(new RoutineRunsRepo(collisionDb));
+
+    await expect(
+      collisionRepo.appendEvents(id, [{ type: "state.entered", payload: { state: "Start" } }])
+    ).rejects.toMatchObject({ code: "23505" });
+    expect(collisionDb.attempts).toBe(8);
+    expect(await repo.listEvents(id)).toEqual([]);
+  });
+
+  it("keeps concurrent append writers unique and gap-free", async () => {
+    const id = await createRun();
+
+    await Promise.all([
+      atomic(repo).appendEvents(id, [
+        { type: "state.entered", payload: { writer: "append", order: 1 } },
+        { type: "state.completed", payload: { writer: "append", order: 2 } },
+      ]),
+      atomic(repo).appendEvents(id, [
+        { type: "state.retrying", payload: { writer: "retry", order: 1 } },
+        { type: "finish", payload: { writer: "retry", order: 2 } },
+      ]),
+    ]);
+
+    const events = await repo.listEvents(id);
+    expect(events.map((event) => event.seq)).toEqual([1, 2, 3, 4]);
+    for (const writer of ["append", "retry"]) {
+      const writerEvents = events.filter(
+        (event) => (event.payload as { writer?: string }).writer === writer
+      );
+      expect(writerEvents.map((event) => (event.payload as { order: number }).order)).toEqual([
+        1, 2,
+      ]);
+    }
+  });
+
+  it("coordinates concurrent append and transition writers", async () => {
+    const id = await createRun();
+    const [appended, transitioned] = await Promise.all([
+      atomic(repo).appendEvents(id, [{ type: "state.entered", payload: { state: "Start" } }]),
+      atomic(repo).transitionWithEvents(
+        id,
+        { status: "pending", currentState: "Start" },
+        { status: "running", currentState: "Next" },
+        [{ type: "state.transitioned", payload: { source: "Start", target: "Next" } }]
+      ),
+    ]);
+
+    expect(appended).toHaveLength(1);
+    expect(transitioned.transitioned).toBe(true);
+    expect((await repo.listEvents(id)).map((event) => event.seq)).toEqual([1, 2]);
+  });
+
+  it("persists events only for the winner of competing transition batches", async () => {
+    const id = await createRun();
+
+    const results = await Promise.all([
+      atomic(repo).transitionWithEvents(
+        id,
+        { status: "pending", currentState: "Start" },
+        { status: "running", currentState: "A" },
+        [{ type: "state.transitioned", payload: { source: "Start", target: "A" } }]
+      ),
+      atomic(repo).transitionWithEvents(
+        id,
+        { status: "pending", currentState: "Start" },
+        { status: "running", currentState: "B" },
+        [{ type: "state.transitioned", payload: { source: "Start", target: "B" } }]
+      ),
+    ]);
+
+    expect(results.filter((result) => result.transitioned)).toHaveLength(1);
+    expect(results.filter((result) => !result.transitioned)).toHaveLength(1);
+    const run = await repo.findById(id);
+    const events = await repo.listEvents(id);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.payload).toMatchObject({ target: run?.currentState });
   });
 });

--- a/apps/api/src/routines/repo.ts
+++ b/apps/api/src/routines/repo.ts
@@ -18,7 +18,7 @@ export interface RoutineRunRow {
   status: RunStatus;
   currentState: string | null;
   context: Record<string, unknown>;
-  trigger: { type: string; payload?: unknown };
+  trigger: { type: string; payload?: unknown; triggerIndex?: number };
   attemptCounts: Record<string, number>;
   wakeAt: Date | null;
   stateDeadline: Date | null;
@@ -43,7 +43,7 @@ function rowToRun(row: Record<string, unknown>): RoutineRunRow {
     status: row.status as RunStatus,
     currentState: (row.current_state as string | null) ?? null,
     context: (row.context as Record<string, unknown>) ?? {},
-    trigger: row.trigger as { type: string; payload?: unknown },
+    trigger: row.trigger as { type: string; payload?: unknown; triggerIndex?: number },
     attemptCounts: (row.attempt_counts as Record<string, number>) ?? {},
     wakeAt: (row.wake_at as Date | null) ?? null,
     stateDeadline: (row.state_deadline as Date | null) ?? null,
@@ -64,6 +64,63 @@ export interface RunJournalEvent {
   createdAt: Date;
 }
 
+export interface PendingRunEvent {
+  type: string;
+  payload: Record<string, unknown>;
+}
+
+export interface RunTransitionGuard {
+  status: RunStatus;
+  currentState?: string | null;
+}
+
+export type RunTransitionPatch = Partial<
+  Pick<
+    RoutineRunRow,
+    | "status"
+    | "currentState"
+    | "context"
+    | "attemptCounts"
+    | "wakeAt"
+    | "stateDeadline"
+    | "approvalId"
+    | "output"
+    | "error"
+  >
+> & {
+  finished?: boolean;
+};
+
+export interface RunTransitionResult {
+  transitioned: boolean;
+  events: RunJournalEvent[];
+}
+
+const MAX_JOURNAL_WRITE_ATTEMPTS = 8;
+
+function isUniqueViolation(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === "23505";
+}
+
+function eventValues(events: PendingRunEvent[], params: unknown[]): string {
+  return events
+    .map((event, index) => {
+      params.push(event.type, JSON.stringify(event.payload));
+      return `(${index + 1}, $${params.length - 1}, $${params.length}::jsonb)`;
+    })
+    .join(", ");
+}
+
+function rowToEvent(row: Record<string, unknown>): RunJournalEvent {
+  return {
+    runId: row.run_id as string,
+    seq: Number(row.seq),
+    type: row.type as string,
+    payload: row.payload,
+    createdAt: row.created_at as Date,
+  };
+}
+
 /**
  * Persistence for routine runs + their journal. Transitions are CAS-guarded on
  * `(status, current_state)` so at-least-once pg-boss deliveries and the sweep can race
@@ -79,7 +136,7 @@ export class RoutineRunsRepo {
     definitionHash: string;
     currentState: string;
     context: Record<string, unknown>;
-    trigger: { type: string; payload?: unknown };
+    trigger: { type: string; payload?: unknown; triggerIndex?: number };
   }): Promise<void> {
     await this.db.query(
       `INSERT INTO routine_runs
@@ -117,19 +174,8 @@ export class RoutineRunsRepo {
    */
   async transition(
     id: string,
-    expected: { status: RunStatus; currentState?: string | null },
-    patch: {
-      status?: RunStatus;
-      currentState?: string | null;
-      context?: Record<string, unknown>;
-      attemptCounts?: Record<string, number>;
-      wakeAt?: Date | null;
-      stateDeadline?: Date | null;
-      approvalId?: string | null;
-      output?: Record<string, unknown> | null;
-      error?: Record<string, unknown> | null;
-      finished?: boolean;
-    }
+    expected: RunTransitionGuard,
+    patch: RunTransitionPatch
   ): Promise<boolean> {
     const sets: string[] = ["updated_at = now()"];
     const params: unknown[] = [id, expected.status];
@@ -182,6 +228,103 @@ export class RoutineRunsRepo {
     return rows.length > 0;
   }
 
+  async appendEvents(runId: string, events: PendingRunEvent[]): Promise<RunJournalEvent[]> {
+    if (events.length === 0) return [];
+
+    return this.retryJournalWrite(async () => {
+      const params: unknown[] = [runId];
+      const values = eventValues(events, params);
+      const { rows } = await this.db.query(
+        `WITH pending (ordinal, type, payload) AS (VALUES ${values}),
+         allocation AS (
+           SELECT COALESCE(MAX(seq), 0) AS max_seq
+           FROM routine_run_events
+           WHERE run_id = $1
+         ),
+         inserted AS (
+           INSERT INTO routine_run_events (run_id, seq, type, payload, created_at)
+           SELECT $1, allocation.max_seq + pending.ordinal, pending.type, pending.payload, now()
+           FROM pending CROSS JOIN allocation
+           ORDER BY pending.ordinal
+           RETURNING run_id, seq, type, payload, created_at
+         )
+         SELECT run_id, seq, type, payload, created_at FROM inserted ORDER BY seq`,
+        params
+      );
+      return rows.map(rowToEvent);
+    });
+  }
+
+  async transitionWithEvents(
+    id: string,
+    expected: RunTransitionGuard,
+    patch: RunTransitionPatch,
+    events: PendingRunEvent[]
+  ): Promise<RunTransitionResult> {
+    return this.retryJournalWrite(async () => {
+      const params: unknown[] = [
+        id,
+        expected.status,
+        JSON.stringify(patch),
+        expected.currentState !== undefined,
+        expected.currentState,
+      ];
+      const pending =
+        events.length > 0
+          ? `VALUES ${eventValues(events, params)}`
+          : "SELECT 0::integer, ''::text, '{}'::jsonb WHERE false";
+      const { rows } = await this.db.query(
+        `WITH transitioned AS (
+           UPDATE routine_runs SET
+             status = CASE WHEN $3::jsonb ? 'status' THEN $3::jsonb->>'status' ELSE status END,
+             current_state = CASE WHEN $3::jsonb ? 'currentState'
+               THEN $3::jsonb->>'currentState' ELSE current_state END,
+             context = CASE WHEN $3::jsonb ? 'context' THEN $3::jsonb->'context' ELSE context END,
+             attempt_counts = CASE WHEN $3::jsonb ? 'attemptCounts'
+               THEN $3::jsonb->'attemptCounts' ELSE attempt_counts END,
+             wake_at = CASE WHEN $3::jsonb ? 'wakeAt'
+               THEN ($3::jsonb->>'wakeAt')::timestamptz ELSE wake_at END,
+             state_deadline = CASE WHEN $3::jsonb ? 'stateDeadline'
+               THEN ($3::jsonb->>'stateDeadline')::timestamptz ELSE state_deadline END,
+             approval_id = CASE WHEN $3::jsonb ? 'approvalId'
+               THEN ($3::jsonb->>'approvalId')::uuid ELSE approval_id END,
+             output = CASE WHEN $3::jsonb ? 'output' THEN $3::jsonb->'output' ELSE output END,
+             error = CASE WHEN $3::jsonb ? 'error' THEN $3::jsonb->'error' ELSE error END,
+             finished_at = CASE WHEN COALESCE(($3::jsonb->>'finished')::boolean, false)
+               THEN now() ELSE finished_at END,
+             updated_at = now()
+           WHERE id = $1 AND status = $2
+             AND (NOT $4::boolean OR current_state IS NOT DISTINCT FROM $5)
+           RETURNING id
+         ),
+         pending (ordinal, type, payload) AS (${pending}),
+         allocation AS (
+           SELECT COALESCE(MAX(seq), 0) AS max_seq
+           FROM routine_run_events
+           WHERE run_id = $1
+         ),
+         inserted AS (
+           INSERT INTO routine_run_events (run_id, seq, type, payload, created_at)
+           SELECT transitioned.id, allocation.max_seq + pending.ordinal,
+             pending.type, pending.payload, now()
+           FROM transitioned CROSS JOIN pending CROSS JOIN allocation
+           ORDER BY pending.ordinal
+           RETURNING run_id, seq, type, payload, created_at
+         )
+         SELECT EXISTS(SELECT 1 FROM transitioned) AS transitioned,
+           inserted.run_id, inserted.seq, inserted.type, inserted.payload, inserted.created_at
+         FROM (SELECT 1) AS singleton
+         LEFT JOIN inserted ON true
+         ORDER BY inserted.seq`,
+        params
+      );
+      return {
+        transitioned: rows[0]?.transitioned === true,
+        events: rows.filter((row) => row.seq !== null).map(rowToEvent),
+      };
+    });
+  }
+
   /** Heartbeat for the sweep's stale-run detection. */
   async touch(id: string): Promise<void> {
     await this.db.query("UPDATE routine_runs SET updated_at = now() WHERE id = $1", [id]);
@@ -231,12 +374,17 @@ export class RoutineRunsRepo {
        WHERE run_id = $1 AND seq > $2 ORDER BY seq`,
       [runId, afterSeq]
     );
-    return rows.map((r) => ({
-      runId: r.run_id as string,
-      seq: Number(r.seq),
-      type: r.type as string,
-      payload: r.payload,
-      createdAt: r.created_at as Date,
-    }));
+    return rows.map(rowToEvent);
+  }
+
+  private async retryJournalWrite<T>(write: () => Promise<T>): Promise<T> {
+    for (let attempt = 1; attempt <= MAX_JOURNAL_WRITE_ATTEMPTS; attempt += 1) {
+      try {
+        return await write();
+      } catch (error) {
+        if (!isUniqueViolation(error) || attempt === MAX_JOURNAL_WRITE_ATTEMPTS) throw error;
+      }
+    }
+    throw new Error("Unreachable journal retry state");
   }
 }

--- a/apps/api/src/routines/routes.test.ts
+++ b/apps/api/src/routines/routes.test.ts
@@ -12,6 +12,7 @@ import { StreamHub } from "../chat/stream-hub";
 import type { PaginatedResult } from "../pagination";
 import { runPgMigrations } from "../pg-migrate";
 import { makePglite } from "../test/pglite";
+import { definitionHash } from "./definition-hash";
 import type { RoutineRunJob, RoutineWakeJob } from "./jobs";
 import { RoutineRegistry } from "./registry";
 import { RoutineRunsRepo } from "./repo";
@@ -100,6 +101,7 @@ describe("routine routes", () => {
   let sid: string;
   let runs: RoutineRunsRepo;
   let registry: RoutineRegistry;
+  let soulLoader: SoulLoader;
   let enqueuedRuns: RoutineRunJob[];
 
   beforeEach(async () => {
@@ -111,10 +113,8 @@ describe("routine routes", () => {
     sid = await store.create(user._id);
 
     const log = { error: vi.fn(), warn: vi.fn() };
-    registry = new RoutineRegistry(
-      makeSoulLoader({ "expense-report": ROUTINE_CONFIG, broken: { id: "broken" } }),
-      log
-    );
+    soulLoader = makeSoulLoader({ "expense-report": ROUTINE_CONFIG, broken: { id: "broken" } });
+    registry = new RoutineRegistry(soulLoader, log);
     registry.refresh();
     runs = new RoutineRunsRepo(db);
     enqueuedRuns = [];
@@ -169,6 +169,68 @@ describe("routine routes", () => {
     expect(res.statusCode).toBe(401);
   });
 
+  describe("GET /routines/:slug detail", () => {
+    it("returns the full valid definition, canonical hash, and Hook presence", async () => {
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/routines/expense-report",
+        cookies: authed(),
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toMatchObject({
+        slug: "expense-report",
+        valid: true,
+        definition: ROUTINE_CONFIG,
+        hasHooks: false,
+      });
+      expect((res.json() as { hash: string }).hash).toBe(definitionHash(ROUTINE_CONFIG));
+      expect(res.json()).not.toHaveProperty("hookSource");
+    });
+
+    it("returns an invalid registry entry as a diagnostic instead of crashing", async () => {
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/routines/broken",
+        cookies: authed(),
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({
+        slug: "broken",
+        valid: false,
+        loadError: expect.any(String),
+      });
+    });
+
+    it("returns 404 for a missing Routine and 401 without auth", async () => {
+      const missing = await app.inject({
+        method: "GET",
+        url: "/api/v1/routines/missing",
+        cookies: authed(),
+      });
+      expect(missing.statusCode).toBe(404);
+
+      const unauthorized = await app.inject({
+        method: "GET",
+        url: "/api/v1/routines/expense-report",
+      });
+      expect(unauthorized.statusCode).toBe(401);
+    });
+
+    it("documents every detail response in OpenAPI", async () => {
+      const res = await app.inject({ method: "GET", url: "/api/v1/openapi.json" });
+      const spec = res.json() as {
+        paths: Record<string, { get?: { responses?: Record<string, unknown> } }>;
+      };
+      expect(Object.keys(spec.paths["/api/v1/routines/{slug}"].get?.responses ?? {})).toEqual([
+        "200",
+        "401",
+        "404",
+      ]);
+    });
+  });
+
   it("POST manual run validates inputs against x-inputs and enqueues", async () => {
     const bad = await app.inject({
       method: "POST",
@@ -195,7 +257,7 @@ describe("routine routes", () => {
     expect(run?.status).toBe("pending");
     expect(run?.definitionSnapshot.id).toBe("expense-report");
     expect(run?.context).toEqual({ amount: 42 });
-    expect(run?.trigger.type).toBe("manual");
+    expect(run?.trigger).toMatchObject({ type: "manual", triggerIndex: 0 });
   });
 
   it("404 on manual run for unknown routine; 422 for invalid routine", async () => {
@@ -251,6 +313,8 @@ describe("routine routes", () => {
     expect(detail.statusCode).toBe(200);
     const body = detail.json() as { run: Record<string, unknown>; events: unknown[] };
     expect(body.run.status).toBe("pending");
+    expect(body.run.definitionSnapshot).toEqual(ROUTINE_CONFIG);
+    expect(body.run.trigger).toMatchObject({ type: "manual", triggerIndex: 0 });
     expect(body.events).toHaveLength(1);
 
     const wrongSlug = await app.inject({
@@ -259,6 +323,30 @@ describe("routine routes", () => {
       cookies: authed(),
     });
     expect(wrongSlug.statusCode).toBe(404);
+  });
+
+  it("GET run detail keeps using its pinned definition after the live Routine disappears", async () => {
+    const created = await app.inject({
+      method: "POST",
+      url: "/api/v1/routines/expense-report/runs",
+      cookies: authed(),
+      headers: csrf,
+      payload: { inputs: { amount: 10 } },
+    });
+    const { runId } = created.json() as { runId: string };
+
+    soulLoader.routines.delete("expense-report");
+    registry.refresh();
+
+    const detail = await app.inject({
+      method: "GET",
+      url: `/api/v1/routines/expense-report/runs/${runId}`,
+      cookies: authed(),
+    });
+    expect(detail.statusCode).toBe(200);
+    expect(
+      (detail.json() as { run: { definitionSnapshot: unknown } }).run.definitionSnapshot
+    ).toEqual(ROUTINE_CONFIG);
   });
 
   it("cancel endpoint cancels a pending run and 409s on terminal runs", async () => {
@@ -290,6 +378,26 @@ describe("routine routes", () => {
   });
 
   describe("run SSE stream (D7)", () => {
+    it("documents enriched Run detail and state.transitioned SSE contracts", async () => {
+      const res = await app.inject({ method: "GET", url: "/api/v1/openapi.json" });
+      const paths = (res.json() as { paths: Record<string, unknown> }).paths;
+      for (const path of [
+        "/api/v1/routines/{slug}/runs/{runId}",
+        "/api/v1/routines/{slug}/runs/{runId}/events",
+      ]) {
+        const operation = (paths[path] as { get: Record<string, unknown> }).get;
+        expect(operation.security).toEqual([{ sessionCookie: [] }, { bearerToken: [] }]);
+        expect(Object.keys(operation.responses as Record<string, unknown>)).toEqual([
+          "200",
+          "401",
+          "404",
+        ]);
+      }
+      expect(JSON.stringify(paths["/api/v1/routines/{slug}/runs/{runId}/events"])).toContain(
+        "state.transitioned"
+      );
+    });
+
     it("replays journaled events over SSE and closes on the terminal event", async () => {
       const created = await app.inject({
         method: "POST",
@@ -304,6 +412,13 @@ describe("routine routes", () => {
       await runs.appendEvent({
         runId,
         seq: 2,
+        type: "state.transitioned",
+        payload: { source: "Record", end: true, route: { kind: "end" } },
+        createdAt: at,
+      });
+      await runs.appendEvent({
+        runId,
+        seq: 3,
         type: "finish",
         payload: { reason: "completed" },
         createdAt: at,
@@ -317,8 +432,9 @@ describe("routine routes", () => {
       expect(res.statusCode).toBe(200);
       expect(res.headers["content-type"]).toContain("text/event-stream");
       expect(res.body).toContain("event: run.started");
+      expect(res.body).toContain("event: state.transitioned");
       expect(res.body).toContain("event: finish");
-      expect(res.body).toContain("id: 2");
+      expect(res.body).toContain("id: 3");
     });
 
     it("resumes from Last-Event-ID, skipping already-seen events", async () => {
@@ -384,7 +500,7 @@ describe("routine routes", () => {
       expect(res.statusCode).toBe(202);
       expect(enqueuedRuns).toHaveLength(1);
       const run = await runs.findById((res.json() as { runId: string }).runId);
-      expect(run?.trigger.type).toBe("webhook");
+      expect(run?.trigger).toMatchObject({ type: "webhook", triggerIndex: 1 });
       expect(run?.context).toEqual({ amount: 7 });
     });
 

--- a/apps/api/src/routines/routes.ts
+++ b/apps/api/src/routines/routes.ts
@@ -5,6 +5,7 @@ import { attachToStream } from "../chat/producer";
 import { writeSseHeaders } from "../chat/sse";
 import type { StreamHub } from "../chat/stream-hub";
 import { corsPassthrough, parseLastEventId } from "../chat/turn-helpers";
+import { definitionHash } from "./definition-hash";
 import type { RoutineEnqueuers } from "./jobs";
 import type { RoutineRegistry } from "./registry";
 import type { RoutineRunsRepo } from "./repo";
@@ -35,7 +36,16 @@ const RUN_SUMMARY_SCHEMA = {
     routineSlug: { type: "string" },
     status: { type: "string" },
     currentState: { type: "string", nullable: true },
-    trigger: {},
+    trigger: {
+      type: "object",
+      additionalProperties: false,
+      required: ["type"],
+      properties: {
+        type: { type: "string", enum: ["event", "manual", "cron", "webhook", "agent"] },
+        payload: {},
+        triggerIndex: { type: "integer", minimum: 0 },
+      },
+    },
     output: {},
     error: {},
     createdAt: { type: "string" },
@@ -44,11 +54,43 @@ const RUN_SUMMARY_SCHEMA = {
   },
 } as const;
 
+const ROUTINE_DETAIL_SCHEMA = {
+  oneOf: [
+    {
+      type: "object",
+      additionalProperties: false,
+      required: ["slug", "valid", "definition", "hash", "hasHooks"],
+      properties: {
+        slug: { type: "string" },
+        valid: { const: true },
+        definition: {},
+        hash: { type: "string", pattern: "^[0-9a-f]{64}$" },
+        hasHooks: { type: "boolean" },
+      },
+    },
+    {
+      type: "object",
+      additionalProperties: false,
+      required: ["slug", "valid", "loadError"],
+      properties: {
+        slug: { type: "string" },
+        valid: { const: false },
+        loadError: { type: "string" },
+      },
+    },
+  ],
+} as const;
+
+const TRIGGER_ERROR_STATUS = {
+  not_found: 404,
+  invalid_inputs: 400,
+  trigger_not_declared: 422,
+  routine_invalid: 422,
+} as const;
+
 function triggerErrorReply(reply: FastifyReply, err: unknown): FastifyReply | null {
   if (!(err instanceof RoutineTriggerError)) return null;
-  const status =
-    err.code === "not_found" ? 404 : err.code === "invalid_inputs" ? 400 : (422 as const);
-  return reply.code(status).send({ error: err.message });
+  return reply.code(TRIGGER_ERROR_STATUS[err.code]).send({ error: err.message });
 }
 
 function constantTimeEquals(a: string, b: string): boolean {
@@ -130,6 +172,45 @@ export function registerRoutineRoutes(
   );
 
   app.get(
+    "/api/v1/routines/:slug",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description:
+          "Full Routine detail for read-only visualization. Valid Routines include their live " +
+          "definition and canonical hash; invalid Routines include only validation diagnostics.",
+        tags: ["routines"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        params: {
+          type: "object",
+          required: ["slug"],
+          properties: { slug: { type: "string", minLength: 1 } },
+        },
+        response: {
+          200: ROUTINE_DETAIL_SCHEMA,
+          401: ErrorSchema,
+          404: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const { slug } = req.params as { slug: string };
+      const entry = registry.getEntry(slug);
+      if (!entry) return reply.code(404).send({ error: "routine not found" });
+      if (!entry.ok) {
+        return reply.send({ slug: entry.slug, valid: false, loadError: entry.loadError });
+      }
+      return reply.send({
+        slug: entry.slug,
+        valid: true,
+        definition: entry.definition,
+        hash: definitionHash(entry.definition),
+        hasHooks: Boolean(entry.hookSource),
+      });
+    }
+  );
+
+  app.get(
     "/api/v1/routines/:slug/runs",
     {
       preHandler: requireAuth,
@@ -194,10 +275,20 @@ export function registerRoutineRoutes(
             properties: {
               run: {
                 ...RUN_SUMMARY_SCHEMA,
+                required: [
+                  ...RUN_SUMMARY_SCHEMA.required,
+                  "trigger",
+                  "context",
+                  "definitionHash",
+                  "definitionSnapshot",
+                  "attemptCounts",
+                  "approvalId",
+                ],
                 properties: {
                   ...RUN_SUMMARY_SCHEMA.properties,
                   context: {},
                   definitionHash: { type: "string" },
+                  definitionSnapshot: {},
                   attemptCounts: {},
                   approvalId: { type: "string", nullable: true },
                 },
@@ -235,6 +326,7 @@ export function registerRoutineRoutes(
           ...toRunSummary(run),
           context: run.context,
           definitionHash: run.definitionHash,
+          definitionSnapshot: run.definitionSnapshot,
           attemptCounts: run.attemptCounts,
           approvalId: run.approvalId,
         },
@@ -360,7 +452,8 @@ export function registerRoutineRoutes(
           description:
             "Live SSE stream of a run's events (state transitions, outputs). Replays from the " +
             "durable journal via `Last-Event-ID` (or ?lastEventId=) — works for runs of any age. " +
-            'Suspended runs close with a finish event `{reason: "suspended"}`; reconnect on wake.',
+            "Each selected route is emitted as `state.transitioned`, including ordered " +
+            'condition/error identity. Suspended runs close with `{reason: "suspended"}`.',
           tags: ["routines"],
           security: [{ sessionCookie: [] }, { bearerToken: [] }],
           params: {
@@ -375,7 +468,15 @@ export function registerRoutineRoutes(
             type: "object",
             properties: { lastEventId: { type: "integer", minimum: 0 } },
           },
-          response: { 401: ErrorSchema, 404: ErrorSchema },
+          response: {
+            200: {
+              type: "string",
+              description:
+                "Server-sent Run journal events, including state.transitioned route identity.",
+            },
+            401: ErrorSchema,
+            404: ErrorSchema,
+          },
         },
       },
       async (req, reply) => {
@@ -430,7 +531,9 @@ export function registerRoutineRoutes(
     async (req, reply) => {
       const { slug } = req.params as { slug: string };
       const routine = registry.get(slug);
-      const webhookTrigger = routine?.definition["x-triggers"].find((t) => t.type === "webhook");
+      const webhookTriggerIndex =
+        routine?.definition["x-triggers"].findIndex((trigger) => trigger.type === "webhook") ?? -1;
+      const webhookTrigger = routine?.definition["x-triggers"][webhookTriggerIndex];
       if (!routine || !webhookTrigger || webhookTrigger.type !== "webhook") {
         return reply.code(404).send({ error: "routine or webhook trigger not found" });
       }
@@ -451,6 +554,7 @@ export function registerRoutineRoutes(
         const { runId } = await triggerService.trigger(slug, {
           type: "webhook",
           payload: req.body ?? {},
+          triggerIndex: webhookTriggerIndex,
         });
         return reply.code(202).send({ runId });
       } catch (err) {

--- a/apps/api/src/routines/schedules.test.ts
+++ b/apps/api/src/routines/schedules.test.ts
@@ -2,7 +2,12 @@ import type { SoulLoader, SoulRoutine } from "@tulipfarm/soul";
 import type { PgBoss } from "pg-boss";
 import { describe, expect, it, vi } from "vitest";
 import { RoutineRegistry } from "./registry";
-import { ROUTINE_CRON_QUEUE, reconcileRoutineSchedules } from "./schedules";
+import {
+  ROUTINE_CRON_QUEUE,
+  reconcileRoutineSchedules,
+  registerRoutineCronWorker,
+} from "./schedules";
+import type { RoutineTriggerService } from "./trigger-service";
 
 function makeRegistry(routines: Record<string, Record<string, unknown>>): RoutineRegistry {
   const map = new Map<string, SoulRoutine>();
@@ -99,5 +104,29 @@ describe("reconcileRoutineSchedules", () => {
 
     await reconcileRoutineSchedules(boss, registry, LOG);
     expect(boss.schedule).not.toHaveBeenCalled();
+  });
+});
+
+describe("registerRoutineCronWorker", () => {
+  it("passes the scheduled Trigger index into the trigger service", async () => {
+    type Worker = (jobs: Array<{ data: unknown }>) => Promise<void>;
+    let worker: Worker | undefined;
+    const boss = {
+      createQueue: vi.fn(async () => {}),
+      work: vi.fn(async (_queue: string, handler: unknown) => {
+        worker = handler as Worker;
+      }),
+    } as unknown as PgBoss;
+    const trigger = vi.fn(async () => ({ runId: "run-1" }));
+    const service = { trigger } as unknown as RoutineTriggerService;
+
+    await registerRoutineCronWorker(boss, service, LOG);
+    if (!worker) throw new Error("routine cron worker was not registered");
+    await worker([{ data: { slug: "daily-report", triggerIndex: 3 } }]);
+
+    expect(trigger).toHaveBeenCalledWith("daily-report", {
+      type: "cron",
+      triggerIndex: 3,
+    });
   });
 });

--- a/apps/api/src/routines/schedules.ts
+++ b/apps/api/src/routines/schedules.ts
@@ -31,7 +31,7 @@ export async function registerRoutineCronWorker(
     for (const job of jobs) {
       const data = job.data as unknown as CronJobData;
       try {
-        await service.trigger(data.slug, { type: "cron" });
+        await service.trigger(data.slug, { type: "cron", triggerIndex: data.triggerIndex });
       } catch (err) {
         // Routine deleted/invalid between unschedule and firing — log, don't retry.
         log.warn({ err, slug: data.slug }, "cron-triggered routine failed to start");

--- a/apps/api/src/routines/stream-adapter.ts
+++ b/apps/api/src/routines/stream-adapter.ts
@@ -1,10 +1,46 @@
-import type { StreamEvent } from "../chat/stream-hub";
+import type { StreamEvent, StreamHub } from "../chat/stream-hub";
 import type { StreamResumeRepo } from "../chat/stream-resume";
-import type { RoutineRunsRepo } from "./repo";
+import type { RoutineRunsRepo, RunJournalEvent } from "./repo";
 
 /** streamId for a run's SSE stream. Namespaced so it can never collide with chat ids. */
 export function runStreamId(runId: string): string {
   return `routine-run:${runId}`;
+}
+
+type RunStreamLogger = { error: (obj: unknown, msg?: string) => void };
+
+/** Fan out rows only after their journal transaction commits. Replay heals any live failure. */
+export function publishRunEvents(
+  runId: string,
+  events: RunJournalEvent[],
+  hub: StreamHub,
+  log: RunStreamLogger
+): void {
+  const streamId = runStreamId(runId);
+  for (const event of events) {
+    try {
+      hub.publish(streamId, { seq: event.seq, eventType: event.type, data: event.payload });
+    } catch (err) {
+      log.error({ err, streamId, seq: event.seq }, "routine journal live publish failed");
+    }
+  }
+}
+
+/** Serialized append-and-publish path for engine events outside a Run-row transition. */
+export function makeRunJournalEmitter(
+  runId: string,
+  deps: { runs: RoutineRunsRepo; hub: StreamHub; log: RunStreamLogger }
+): { emit(type: string, data: Record<string, unknown>): Promise<void> } {
+  let tail = Promise.resolve();
+  const emit = (type: string, data: Record<string, unknown>): Promise<void> => {
+    const write = tail.then(async () => {
+      const events = await deps.runs.appendEvents(runId, [{ type, payload: data }]);
+      publishRunEvents(runId, events, deps.hub, deps.log);
+    });
+    tail = write.catch(() => {});
+    return write;
+  };
+  return { emit };
 }
 
 function runIdOf(streamId: string): string {
@@ -14,8 +50,8 @@ function runIdOf(streamId: string): string {
 /**
  * StreamResumeRepo over `routine_run_events`: the journal IS the SSE replay buffer
  * (review fix B1/B2). One write path — no stream_resume rows, no 1h GC, Last-Event-ID
- * replay works for runs of any age, and emitter seq seeding falls out of `nextSeq`.
- * `deleteOlderThan` is a no-op: run history is a product feature, never GC'd here.
+ * replay works for runs of any age. `deleteOlderThan` is a no-op because Run history
+ * is a product feature, never GC'd here.
  */
 export class RunJournalStreamRepo implements StreamResumeRepo {
   constructor(private readonly runs: RoutineRunsRepo) {}
@@ -27,13 +63,9 @@ export class RunJournalStreamRepo implements StreamResumeRepo {
     data: unknown;
     createdAt: Date;
   }): Promise<void> {
-    await this.runs.appendEvent({
-      runId: runIdOf(row.streamId),
-      seq: row.seq,
-      type: row.eventType,
-      payload: row.data,
-      createdAt: row.createdAt,
-    });
+    await this.runs.appendEvents(runIdOf(row.streamId), [
+      { type: row.eventType, payload: row.data as Record<string, unknown> },
+    ]);
   }
 
   async listAfter(streamId: string, afterSeq: number): Promise<StreamEvent[]> {

--- a/apps/api/src/routines/trigger-service.test.ts
+++ b/apps/api/src/routines/trigger-service.test.ts
@@ -2,9 +2,11 @@ import { EventEmitter } from "node:events";
 import type { PGlite } from "@electric-sql/pglite";
 import type { SoulLoader, SoulRoutine } from "@tulipfarm/soul";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { StreamHub } from "../chat/stream-hub";
 import { DOMAIN_EVENTS } from "../domain-events";
 import { runPgMigrations } from "../pg-migrate";
 import { makePglite } from "../test/pglite";
+import { RoutineRunDriver } from "./driver";
 import type { RoutineRunJob } from "./jobs";
 import { RoutineRegistry } from "./registry";
 import { RoutineRunsRepo } from "./repo";
@@ -43,6 +45,22 @@ const EVENT_ROUTINE: Record<string, unknown> = {
   ],
 };
 
+const ALL_TRIGGER_ROUTINE: Record<string, unknown> = {
+  id: "all-triggers",
+  version: "1.0",
+  start: "Done",
+  "x-triggers": [
+    { type: "manual" },
+    { type: "event", event: "resource.created" },
+    { type: "webhook", secret_ref: "first-webhook" },
+    { type: "cron", schedule: "0 9 * * *" },
+    { type: "agent" },
+    { type: "manual" },
+    { type: "event", event: "resource.created" },
+  ],
+  states: [{ name: "Done", type: "inject", data: {}, end: true }],
+};
+
 const LOG = { error: vi.fn(), warn: vi.fn() };
 
 describe("RoutineTriggerService", () => {
@@ -79,6 +97,21 @@ describe("RoutineTriggerService", () => {
     });
   }
 
+  function makeDriver(registry: RoutineRegistry): RoutineRunDriver {
+    return new RoutineRunDriver({
+      runs,
+      registry,
+      hub: new StreamHub(),
+      sandbox: {
+        runExpression: async () => true,
+        runRoutineHook: async () => null,
+      },
+      actionExecutor: async () => ({}),
+      enqueueWake: async () => {},
+      log: LOG,
+    });
+  }
+
   it("rejects undeclared trigger types", async () => {
     const service = makeService(makeRegistry({ "on-ticket": EVENT_ROUTINE }));
     await expect(service.trigger("on-ticket", { type: "cron" })).rejects.toThrow(
@@ -103,6 +136,69 @@ describe("RoutineTriggerService", () => {
     expect(run?.currentState).toBe("S");
   });
 
+  it("accepts a matching explicit Trigger index and persists it", async () => {
+    const service = makeService(makeRegistry({ "all-triggers": ALL_TRIGGER_ROUTINE }));
+    const { runId } = await service.trigger("all-triggers", {
+      type: "manual",
+      triggerIndex: 5,
+    });
+
+    expect((await runs.findById(runId))?.trigger).toMatchObject({
+      type: "manual",
+      triggerIndex: 5,
+    });
+  });
+
+  it.each([
+    ["negative", -1, "manual"],
+    ["out of bounds", 99, "manual"],
+    ["non-integer", 1.5, "manual"],
+    ["type mismatch", 1, "manual"],
+  ] as const)("rejects a %s explicit Trigger index before creating a Run", async (_case, index, type) => {
+    const service = makeService(makeRegistry({ "all-triggers": ALL_TRIGGER_ROUTINE }));
+
+    await expect(
+      service.trigger("all-triggers", { type, triggerIndex: index })
+    ).rejects.toMatchObject({ code: "trigger_not_declared" });
+    expect(enqueued).toHaveLength(0);
+    expect(await runs.listBySlug("all-triggers")).toHaveLength(0);
+  });
+
+  it("deterministically selects the first matching Trigger when no index is supplied", async () => {
+    const service = makeService(makeRegistry({ "all-triggers": ALL_TRIGGER_ROUTINE }));
+    const { runId } = await service.trigger("all-triggers", { type: "manual" });
+
+    expect((await runs.findById(runId))?.trigger).toMatchObject({
+      type: "manual",
+      triggerIndex: 0,
+    });
+  });
+
+  it.each([
+    ["manual", 0],
+    ["event", 1],
+    ["webhook", 2],
+    ["cron", 3],
+    ["agent", 4],
+  ] as const)("persists %s Trigger identity and journals it in run.started", async (type, index) => {
+    const registry = makeRegistry({ "all-triggers": ALL_TRIGGER_ROUTINE });
+    const service = makeService(registry);
+    const { runId } = await service.trigger("all-triggers", { type });
+
+    expect((await runs.findById(runId))?.trigger).toMatchObject({
+      type,
+      triggerIndex: index,
+    });
+
+    await makeDriver(registry).drive(runId);
+    const started = (await runs.listEvents(runId)).find((event) => event.type === "run.started");
+    expect(started?.payload).toMatchObject({
+      slug: "all-triggers",
+      trigger: type,
+      triggerIndex: index,
+    });
+  });
+
   describe("event triggers via the domain bus", () => {
     it("starts matching routines, honoring the filter expression", async () => {
       const registry = makeRegistry({ "on-ticket": EVENT_ROUTINE });
@@ -123,8 +219,22 @@ describe("RoutineTriggerService", () => {
       const run = await runs.findById(enqueued[0].runId);
       expect(run?.trigger).toMatchObject({
         type: "event",
+        triggerIndex: 0,
         payload: { resourceType: "ticket" },
       });
+    });
+
+    it("threads each matching event Trigger's exact array index", async () => {
+      const registry = makeRegistry({ "all-triggers": ALL_TRIGGER_ROUTINE });
+      const service = makeService(registry);
+      const bus = new EventEmitter();
+      subscribeRoutineEventTriggers(bus, service, registry, undefined, LOG);
+
+      bus.emit(DOMAIN_EVENTS.RESOURCE_CREATED, { resourceType: "ticket" });
+      await vi.waitFor(() => expect(enqueued).toHaveLength(2));
+
+      const startedRuns = await Promise.all(enqueued.map((job) => runs.findById(job.runId)));
+      expect(startedRuns.map((run) => run?.trigger.triggerIndex)).toEqual([1, 6]);
     });
 
     it("starts routines on integration.event with a protocol/event filter (Slack ingress)", async () => {

--- a/apps/api/src/routines/trigger-service.ts
+++ b/apps/api/src/routines/trigger-service.ts
@@ -1,12 +1,25 @@
-import { createHash, randomUUID } from "node:crypto";
+import { randomUUID } from "node:crypto";
 import type { EventEmitter } from "node:events";
 import { ajv } from "@tulipfarm/schema";
 import { DOMAIN_EVENTS } from "../domain-events";
+import { definitionHash } from "./definition-hash";
 import type { RoutineEnqueuers } from "./jobs";
 import type { LoadedRoutine, RoutineRegistry } from "./registry";
 import type { RoutineRunsRepo } from "./repo";
 
 export type TriggerType = "event" | "manual" | "cron" | "webhook" | "agent";
+
+export interface TriggerInvocation {
+  type: TriggerType;
+  payload?: unknown;
+  triggerIndex?: number;
+}
+
+export interface PersistedRunTrigger {
+  type: TriggerType;
+  payload?: unknown;
+  triggerIndex?: number;
+}
 
 export class RoutineTriggerError extends Error {
   constructor(
@@ -42,10 +55,7 @@ export interface TriggerServiceDeps {
 export class RoutineTriggerService {
   constructor(private readonly deps: TriggerServiceDeps) {}
 
-  async trigger(
-    slug: string,
-    trigger: { type: TriggerType; payload?: unknown }
-  ): Promise<{ runId: string }> {
+  async trigger(slug: string, trigger: TriggerInvocation): Promise<{ runId: string }> {
     const { registry, runs, enqueuers } = this.deps;
     const entry = registry.getEntry(slug);
     if (!entry) throw new RoutineTriggerError("not_found", `routine "${slug}" not found`);
@@ -55,8 +65,8 @@ export class RoutineTriggerService {
         `routine "${slug}" failed validation: ${entry.loadError}`
       );
     }
-    const declared = entry.definition["x-triggers"].some((t) => t.type === trigger.type);
-    if (!declared) {
+    const triggerIndex = this.resolveTriggerIndex(entry, trigger);
+    if (triggerIndex === null) {
       throw new RoutineTriggerError(
         "trigger_not_declared",
         `routine "${slug}" does not declare a "${trigger.type}" trigger`
@@ -66,24 +76,41 @@ export class RoutineTriggerService {
     this.validateInputs(entry, trigger);
 
     const runId = randomUUID();
-    const definitionHash = createHash("sha256")
-      .update(JSON.stringify(entry.definition))
-      .digest("hex");
+    const persistedTrigger: PersistedRunTrigger = {
+      type: trigger.type,
+      payload: trigger.payload,
+      triggerIndex,
+    };
     await runs.create({
       id: runId,
       routineSlug: slug,
       definitionSnapshot: entry.definition,
-      definitionHash,
+      definitionHash: definitionHash(entry.definition),
       currentState: entry.definition.start,
       context: this.initialContext(trigger),
-      trigger: { type: trigger.type, payload: trigger.payload },
+      trigger: persistedTrigger,
     });
     await enqueuers.enqueueRun({
       runId,
       slug,
-      trigger: { type: trigger.type, payload: trigger.payload },
+      trigger: persistedTrigger,
     });
     return { runId };
+  }
+
+  private resolveTriggerIndex(
+    routine: LoadedRoutine,
+    invocation: TriggerInvocation
+  ): number | null {
+    const triggers = routine.definition["x-triggers"];
+    if (invocation.triggerIndex === undefined) {
+      const index = triggers.findIndex((trigger) => trigger.type === invocation.type);
+      return index >= 0 ? index : null;
+    }
+
+    const index = invocation.triggerIndex;
+    if (!Number.isInteger(index) || index < 0 || index >= triggers.length) return null;
+    return triggers[index]?.type === invocation.type ? index : null;
   }
 
   /** Trigger payloads that are plain objects seed the run's data-flow context. */
@@ -130,7 +157,7 @@ export function subscribeRoutineEventTriggers(
     events.on(eventName, (payload: unknown) => {
       void (async () => {
         for (const routine of registry.valid()) {
-          for (const trigger of routine.definition["x-triggers"]) {
+          for (const [triggerIndex, trigger] of routine.definition["x-triggers"].entries()) {
             if (trigger.type !== "event" || trigger.event !== eventName) continue;
             try {
               if (trigger.filter && evalFilter) {
@@ -139,7 +166,7 @@ export function subscribeRoutineEventTriggers(
                 });
                 if (!pass) continue;
               }
-              await service.trigger(routine.slug, { type: "event", payload });
+              await service.trigger(routine.slug, { type: "event", payload, triggerIndex });
             } catch (err) {
               log.error(
                 { err, slug: routine.slug, event: eventName },

--- a/apps/web/app/components/routines/routine-canvas.test.tsx
+++ b/apps/web/app/components/routines/routine-canvas.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { RoutineGraph } from "~/lib/routines/graph";
+import type { RunOverlay } from "~/lib/routines/run-overlay";
+import { RoutineCanvas } from "./routine-canvas";
+import { RoutineRunCanvas } from "./routine-run-canvas";
+
+const graph: RoutineGraph = {
+  nodes: [
+    { id: "trigger:0", kind: "trigger", label: "Manual Trigger" },
+    {
+      id: "state:Start",
+      kind: "state",
+      label: "Start",
+      stateType: "operation",
+      actions: [{ name: "Send", function: "send", arguments: ["count"] }],
+    },
+    { id: "end", kind: "end", label: "End" },
+  ],
+  edges: [
+    { id: "start:0", source: "trigger:0", target: "state:Start", kind: "start", label: "Starts" },
+    {
+      id: "condition:Start:0",
+      source: "state:Start",
+      target: "end",
+      kind: "condition",
+      label: "Condition 1",
+    },
+  ],
+};
+
+const overlay: RunOverlay = {
+  lastSeq: 4,
+  nodes: {
+    "trigger:0": { status: "completed", exact: true },
+    "state:Start": {
+      status: "failed",
+      input: { amount: 4 },
+      output: { amount: 8 },
+      error: { name: "bad_input", message: "No" },
+      attempts: 2,
+      startedAt: "2026-07-19T00:00:01.000Z",
+      completedAt: "2026-07-19T00:00:03.000Z",
+    },
+  },
+  edges: {
+    "start:0": { status: "taken", exact: true },
+    "condition:Start:0": { status: "taken", inferred: true, label: "Inferred from legacy Run" },
+  },
+};
+
+describe("RoutineCanvas", () => {
+  it.each(["{Enter}", " "])("exposes graph names and selects with %s", async (key) => {
+    const user = userEvent.setup();
+    render(<RoutineCanvas graph={graph} mode="read" />);
+
+    expect(screen.getByRole("button", { name: /State Start/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Trigger 0, Manual/ })).toBeInTheDocument();
+    expect(screen.getByLabelText(/Condition 1 from Start to End/)).toBeInTheDocument();
+    expect(screen.getByText("Send: send(count)")).toBeInTheDocument();
+    await user.tab();
+    await user.keyboard(key);
+    expect(screen.getByRole("complementary", { name: /details/i })).toBeInTheDocument();
+  });
+
+  it("shows Run data and exposes inferred identity with text, not color alone", async () => {
+    render(<RoutineRunCanvas graph={graph} overlay={overlay} events={[]} />);
+
+    const user = userEvent.setup();
+    const state = screen.getByRole("button", { name: /Start.*failed/i });
+    await user.click(state);
+    expect(screen.getByText(/"amount": 4/)).toBeInTheDocument();
+    expect(screen.getByText(/"amount": 8/)).toBeInTheDocument();
+    expect(screen.getByText(/bad_input.*No/)).toBeInTheDocument();
+    expect(screen.getByText(/2 attempts/)).toBeInTheDocument();
+    expect(screen.getByText(/00:00:01.*00:00:03/)).toBeInTheDocument();
+    const inferredEdge = screen.getByLabelText(/Inferred from legacy Run/);
+    expect(inferredEdge).toBeInTheDocument();
+    expect(inferredEdge).toHaveAttribute("title", "Inferred from legacy Run");
+  });
+
+  it.each([
+    [false, true],
+    [true, false],
+  ])("maps reduced motion %s to animation %s", (reduced, animated) => {
+    vi.spyOn(window, "matchMedia").mockImplementation((query) => ({
+      matches: reduced && query === "(prefers-reduced-motion: reduce)",
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+    render(<RoutineRunCanvas graph={graph} overlay={overlay} events={[]} />);
+    expect(Boolean(document.querySelector("[data-animated='true']"))).toBe(animated);
+  });
+});

--- a/apps/web/app/components/routines/routine-canvas.tsx
+++ b/apps/web/app/components/routines/routine-canvas.tsx
@@ -1,0 +1,196 @@
+import "@xyflow/react/dist/style.css";
+import { type Edge, type Node, ReactFlow } from "@xyflow/react";
+import { Circle, Flag, TriangleAlert, Zap } from "lucide-react";
+import { useMemo, useState } from "react";
+import {
+  layoutRoutineGraph,
+  type RoutineGraph,
+  type RoutineGraphNode,
+  routineNodeDimensions,
+} from "~/lib/routines/graph";
+import type { RunNodeStatus, RunOverlay } from "~/lib/routines/run-overlay";
+
+type Props = { graph: RoutineGraph; mode: "read" | "run"; overlay?: RunOverlay };
+type FlowNode = Node<{ label: React.ReactNode; source: RoutineGraphNode }>;
+const statusText = (status?: RunNodeStatus) => status?.replace("_", " ") ?? "not executed";
+const Icon = ({ status }: { status?: RunNodeStatus }) => {
+  const C = status?.includes("error") || status === "failed" ? TriangleAlert : Circle;
+  return <C aria-hidden="true" className="size-3.5 shrink-0" />;
+};
+
+function NodeIcon({ node, status }: { node: RoutineGraphNode; status?: RunNodeStatus }) {
+  if (node.kind === "trigger") return <Zap aria-hidden="true" className="size-4" />;
+  if (node.kind === "end") return <Flag aria-hidden="true" className="size-4" />;
+  return <Icon status={status} />;
+}
+
+function nodeName(node: RoutineGraphNode, status?: RunNodeStatus, inferred?: boolean): string {
+  const suffix = inferred ? ", Inferred from legacy Run" : "";
+  if (node.kind === "trigger") {
+    const index = node.id.split(":")[1];
+    const type = node.triggerType ?? node.label.replace(/ Trigger$/, "");
+    return `Trigger ${index}, ${type.charAt(0).toUpperCase()}${type.slice(1)}${suffix}`;
+  }
+  if (node.kind === "state")
+    return `State ${node.label}, ${node.stateType}, ${statusText(status)}${suffix}`;
+  return `End${suffix}`;
+}
+
+function edgeName(edge: RoutineGraph["edges"][number], graph: RoutineGraph): string {
+  const label = (id: string) => graph.nodes.find((node) => node.id === id)?.label ?? id;
+  const index = edge.kind === "condition" ? Number(edge.id.split(":").at(-1)) + 1 : undefined;
+  const kind = index ? `Condition ${index}` : edge.label;
+  return `${kind} from ${label(edge.source)} to ${label(edge.target)}`;
+}
+
+const json = (value: unknown) => JSON.stringify(value).replaceAll(":", ": ");
+
+export function RoutineCanvas({ graph, mode, overlay }: Props) {
+  const [selected, setSelected] = useState<string>();
+  const reduced =
+    typeof window !== "undefined" && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  const laidOut = useMemo(() => layoutRoutineGraph(graph), [graph]);
+  const nodes: FlowNode[] = laidOut.nodes.map((node) => {
+    const run = overlay?.nodes[node.id];
+    const { width, height } = routineNodeDimensions(node.kind);
+    const actionSummary = node.actions
+      ?.map((action) => `${action.name}: ${action.function}(${action.arguments.join(", ")})`)
+      .join(" · ");
+    return {
+      id: node.id,
+      position: node.position,
+      ariaRole: "presentation",
+      focusable: false,
+      selectable: true,
+      draggable: false,
+      measured: { width, height },
+      className: `rounded-sm border bg-card text-card-foreground shadow-none hover:bg-accent active:bg-secondary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring ${run?.inferred ? "border-dashed" : "border-border"}`,
+      style: { width, minHeight: height },
+      data: {
+        source: node,
+        label: (
+          <button
+            type="button"
+            aria-label={nodeName(node, run?.status, run?.inferred)}
+            aria-describedby={actionSummary ? `${node.id}-actions` : undefined}
+            title={run?.inferred ? "Inferred from legacy Run" : undefined}
+            onMouseDown={(event) => event.stopPropagation()}
+            onClick={(event) => {
+              event.stopPropagation();
+              setSelected(node.id);
+            }}
+            className="nodrag nopan flex min-h-11 w-full items-center gap-2 px-2 py-2 text-left outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <NodeIcon node={node} status={run?.status} />
+            <span className="min-w-0">
+              <span className="block truncate text-xs font-medium">{node.label}</span>
+              <span className="block font-mono text-[0.625rem] uppercase tracking-[0.12em] text-muted-foreground">
+                {node.kind === "state" ? statusText(run?.status) : node.kind}
+              </span>
+              {actionSummary && (
+                <span
+                  id={`${node.id}-actions`}
+                  className="mt-1 block truncate font-mono text-[0.625rem] text-muted-foreground"
+                >
+                  {actionSummary}
+                </span>
+              )}
+            </span>
+          </button>
+        ),
+      },
+    };
+  });
+  const edges: Edge[] = laidOut.edges.map((edge) => {
+    const run = overlay?.edges[edge.id];
+    const animated = Boolean(run && !reduced);
+    return {
+      ...edge,
+      type: "smoothstep",
+      ariaLabel: `${edgeName(edge, graph)}${run?.inferred ? ", Inferred from legacy Run" : ""}`,
+      focusable: false,
+      animated,
+      label: edge.label,
+      className: run?.inferred ? "[&_path]:stroke-dasharray-[5_4]" : undefined,
+      style: { stroke: run ? "var(--primary)" : "var(--border)", strokeWidth: run ? 2 : 1 },
+    };
+  });
+  const selectedNode = graph.nodes.find((node) => node.id === selected);
+  const data = selectedNode ? overlay?.nodes[selectedNode.id] : undefined;
+  return (
+    <section
+      aria-label={mode === "run" ? "Run canvas" : "Routine canvas"}
+      className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_18rem]"
+    >
+      <div className="h-[26rem] min-w-0 overflow-x-auto rounded-sm border border-border bg-background">
+        <div className="h-full min-w-[44rem]">
+          <ReactFlow
+            nodes={nodes}
+            edges={edges}
+            fitView
+            nodesDraggable={false}
+            nodesConnectable={false}
+            edgesReconnectable={false}
+            deleteKeyCode={null}
+            panOnDrag
+            zoomOnDoubleClick={false}
+            className="[&_.react-flow__handle]:hidden [&_.react-flow__attribution]:hidden"
+            proOptions={{ hideAttribution: true }}
+          />
+          {edges.map((edge) => (
+            <button
+              key={edge.id}
+              type="button"
+              aria-label={edge.ariaLabel}
+              title={
+                edge.ariaLabel?.includes("Inferred from legacy Run")
+                  ? "Inferred from legacy Run"
+                  : undefined
+              }
+              data-animated={edge.animated}
+              onClick={() => setSelected(edge.id)}
+              className="sr-only focus:not-sr-only focus:absolute focus:left-2 focus:top-2 focus:z-10 focus:min-h-11 focus:rounded-sm focus:border focus:border-border focus:bg-card focus:px-3 focus:outline-2 focus:outline-ring"
+            >
+              {edge.ariaLabel}
+            </button>
+          ))}
+        </div>
+      </div>
+      {selected && (
+        <aside
+          aria-label="State details"
+          className="min-h-44 rounded-sm border border-border bg-card p-4 text-xs"
+        >
+          <h3 className="mb-3 font-mono text-[0.625rem] uppercase tracking-[0.16em] text-muted-foreground">
+            State details
+          </h3>
+          <p className="mb-3 font-medium">{selectedNode?.label ?? selected}</p>
+          {data?.input && (
+            <p className="break-all">
+              <span className="text-muted-foreground">Input </span>
+              {json(data.input)}
+            </p>
+          )}
+          {data?.output && (
+            <p className="mt-2 break-all">
+              <span className="text-muted-foreground">Output </span>
+              {json(data.output)}
+            </p>
+          )}
+          {data?.error && <p className="mt-2 break-all text-destructive">{json(data.error)}</p>}
+          {data?.attempts !== undefined && <p className="mt-2">{data.attempts} attempts</p>}
+          {(data?.startedAt || data?.completedAt) && (
+            <p className="mt-2 font-mono text-[0.625rem] text-muted-foreground">
+              {data.startedAt} — {data.completedAt}
+            </p>
+          )}
+          {data?.inferred && (
+            <p className="mt-3 border-t border-dashed border-border pt-3 text-muted-foreground">
+              Inferred from legacy Run
+            </p>
+          )}
+        </aside>
+      )}
+    </section>
+  );
+}

--- a/apps/web/app/components/routines/routine-run-canvas.tsx
+++ b/apps/web/app/components/routines/routine-run-canvas.tsx
@@ -1,0 +1,50 @@
+import { useState } from "react";
+import type { RunEvent } from "~/lib/routines";
+import type { RoutineGraph } from "~/lib/routines/graph";
+import type { RunOverlay } from "~/lib/routines/run-overlay";
+import { RoutineCanvas } from "./routine-canvas";
+
+type Props = { graph: RoutineGraph; overlay: RunOverlay; events: RunEvent[] };
+
+export function RoutineRunCanvas({ graph, overlay, events }: Props) {
+  const [journalOpen, setJournalOpen] = useState(false);
+  return (
+    <div className="space-y-4">
+      <RoutineCanvas graph={graph} mode="run" overlay={overlay} />
+      <div className="rounded-sm border border-border bg-card text-xs">
+        <button
+          type="button"
+          aria-expanded={journalOpen}
+          aria-controls="run-journal"
+          onClick={() => setJournalOpen((open) => !open)}
+          className="min-h-11 cursor-pointer px-4 py-3 font-mono text-[0.625rem] uppercase tracking-[0.16em] text-muted-foreground outline-none hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          Journal
+        </button>
+        <ol
+          id="run-journal"
+          hidden={!journalOpen}
+          className="divide-y divide-border border-t border-border font-mono text-[0.625rem]"
+        >
+          {events.length ? (
+            events.map((event) => (
+              <li key={event.seq} className="grid grid-cols-[auto_1fr] gap-x-3 px-4 py-2">
+                <span className="text-muted-foreground">{event.seq}</span>
+                <span>{event.type}</span>
+                {event.payload !== undefined && (
+                  <pre className="col-start-2 mt-1 overflow-x-auto whitespace-pre-wrap text-muted-foreground">
+                    {typeof event.payload === "string"
+                      ? event.payload
+                      : JSON.stringify(event.payload, null, 2)}
+                  </pre>
+                )}
+              </li>
+            ))
+          ) : (
+            <li className="px-4 py-3 text-muted-foreground">No events yet</li>
+          )}
+        </ol>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/lib/routines.ts
+++ b/apps/web/app/lib/routines.ts
@@ -1,3 +1,4 @@
+import type { RoutineDefinition } from "@tulipfarm/schema";
 import { API_BASE, apiGet, apiWrite } from "./api";
 
 /*
@@ -24,6 +25,16 @@ export type RoutineSummary = {
   loadError?: string | null;
 };
 
+export type RoutineDetail =
+  | {
+      slug: string;
+      valid: true;
+      definition: RoutineDefinition;
+      hash: string;
+      hasHooks: boolean;
+    }
+  | { slug: string; valid: false; loadError: string };
+
 /** The x-inputs JSON Schema subset the manual-trigger form renders. */
 export type RoutineInputsSchema = {
   type?: string;
@@ -48,7 +59,7 @@ export type RunSummary = {
   routineSlug: string;
   status: RunStatus;
   currentState?: string | null;
-  trigger?: { type: string };
+  trigger?: { type: string; triggerIndex?: number };
   output?: unknown;
   error?: { name?: string; message?: string } | null;
   createdAt: string;
@@ -67,6 +78,7 @@ export type RunDetail = {
   run: RunSummary & {
     context?: Record<string, unknown>;
     definitionHash?: string;
+    definitionSnapshot: RoutineDefinition;
     attemptCounts?: Record<string, number>;
     approvalId?: string | null;
   };
@@ -76,6 +88,10 @@ export type RunDetail = {
 export async function listRoutines(): Promise<RoutineSummary[]> {
   const body = await apiGet<{ items: RoutineSummary[] }>("/api/v1/routines");
   return body.items;
+}
+
+export async function getRoutine(slug: string): Promise<RoutineDetail> {
+  return apiGet<RoutineDetail>(`/api/v1/routines/${encodeURIComponent(slug)}`);
 }
 
 export async function listRuns(slug: string, limit = 50): Promise<RunSummary[]> {

--- a/apps/web/app/lib/routines/graph.test.ts
+++ b/apps/web/app/lib/routines/graph.test.ts
@@ -1,0 +1,89 @@
+import type { RoutineDefinition } from "@tulipfarm/schema";
+import { describe, expect, it } from "vitest";
+import { layoutRoutineGraph, projectRoutineGraph } from "./graph";
+
+const definition: RoutineDefinition = {
+  id: "route-fixture",
+  version: "1",
+  start: "Branch",
+  "x-triggers": [{ type: "manual" }, { type: "manual" }],
+  functions: [{ name: "send", operation: "tool:record_create" }],
+  states: [
+    {
+      name: "Branch",
+      type: "switch",
+      dataConditions: [
+        { condition: "context.a", transition: "Worker" },
+        { condition: "context.b", transition: "Worker" },
+      ],
+      defaultCondition: { end: true },
+    },
+    {
+      name: "Worker",
+      type: "operation",
+      actions: [{ name: "Send", functionRef: { refName: "send", arguments: { count: 1 } } }],
+      onErrors: [
+        { errorRef: "timeout", transition: "Done" },
+        { errorRef: "*", end: true },
+      ],
+      transition: "Done",
+    },
+    { name: "Done", type: "inject", data: { ok: true }, end: true },
+  ],
+};
+
+describe("projectRoutineGraph", () => {
+  it("projects every typed route with stable IDs and one synthetic End", () => {
+    const graph = projectRoutineGraph(definition);
+
+    expect(graph.nodes.map(({ id, kind, label }) => ({ id, kind, label }))).toEqual([
+      { id: "trigger:0", kind: "trigger", label: "Manual Trigger" },
+      { id: "trigger:1", kind: "trigger", label: "Manual Trigger" },
+      { id: "state:Branch", kind: "state", label: "Branch" },
+      { id: "state:Worker", kind: "state", label: "Worker" },
+      { id: "state:Done", kind: "state", label: "Done" },
+      { id: "end", kind: "end", label: "End" },
+    ]);
+    expect(
+      graph.edges.map(({ id, source, target, kind }) => ({ id, source, target, kind }))
+    ).toEqual([
+      { id: "start:0", source: "trigger:0", target: "state:Branch", kind: "start" },
+      { id: "start:1", source: "trigger:1", target: "state:Branch", kind: "start" },
+      {
+        id: "condition:Branch:0",
+        source: "state:Branch",
+        target: "state:Worker",
+        kind: "condition",
+      },
+      {
+        id: "condition:Branch:1",
+        source: "state:Branch",
+        target: "state:Worker",
+        kind: "condition",
+      },
+      { id: "default:Branch", source: "state:Branch", target: "end", kind: "default" },
+      { id: "transition:Worker", source: "state:Worker", target: "state:Done", kind: "transition" },
+      { id: "error:Worker:0", source: "state:Worker", target: "state:Done", kind: "error" },
+      { id: "error:Worker:1", source: "state:Worker", target: "end", kind: "error" },
+      { id: "end:Done", source: "state:Done", target: "end", kind: "end" },
+    ]);
+    expect(graph.edges.map((edge) => edge.label).join(" | ")).toBe(
+      "Starts | Starts | context.a | context.b | Default | Next | timeout | * | End"
+    );
+    expect(graph.nodes.find((node) => node.id === "state:Worker")?.actions).toEqual([
+      { name: "Send", function: "send", arguments: ["count"] },
+    ]);
+  });
+
+  it("lays out deterministically without mutating its projection", () => {
+    const graph = projectRoutineGraph(definition);
+    const before = structuredClone(graph);
+    const first = layoutRoutineGraph(graph);
+    const second = layoutRoutineGraph(graph);
+
+    expect(first).toEqual(second);
+    expect(graph).toEqual(before);
+    expect(first.nodes.every((node) => Number.isFinite(node.position.x))).toBe(true);
+    expect(first.nodes.every((node) => Number.isFinite(node.position.y))).toBe(true);
+  });
+});

--- a/apps/web/app/lib/routines/graph.ts
+++ b/apps/web/app/lib/routines/graph.ts
@@ -1,0 +1,175 @@
+import type { EdgeLabel, GraphLabel, NodeLabel } from "@dagrejs/dagre";
+import { Graph, layout } from "@dagrejs/dagre";
+import type { RoutineAction, RoutineDefinition, RoutineState } from "@tulipfarm/schema";
+
+export type RoutineNodeKind = "trigger" | "state" | "end";
+export type RoutineEdgeKind = "start" | "transition" | "end" | "condition" | "default" | "error";
+
+export interface RoutineActionSummary {
+  name: string;
+  function: string;
+  arguments: string[];
+}
+
+export interface RoutineGraphNode {
+  id: string;
+  kind: RoutineNodeKind;
+  label: string;
+  triggerType?: string;
+  stateType?: RoutineState["type"];
+  actions?: RoutineActionSummary[];
+  position?: { x: number; y: number };
+}
+
+export interface RoutineGraphEdge {
+  id: string;
+  source: string;
+  target: string;
+  kind: RoutineEdgeKind;
+  label: string;
+}
+
+export interface RoutineGraph {
+  nodes: RoutineGraphNode[];
+  edges: RoutineGraphEdge[];
+}
+
+export interface LaidOutRoutineGraph extends RoutineGraph {
+  nodes: Array<RoutineGraphNode & { position: { x: number; y: number } }>;
+}
+
+const stateId = (name: string) => `state:${encodeURIComponent(name)}`;
+
+function triggerLabel(type: string): string {
+  return `${type.charAt(0).toUpperCase()}${type.slice(1)} Trigger`;
+}
+
+function summarizeActions(actions: RoutineAction[]): RoutineActionSummary[] {
+  return actions.map((action) => ({
+    name: action.name ?? action.functionRef.refName,
+    function: action.functionRef.refName,
+    arguments: Object.keys(action.functionRef.arguments ?? {}),
+  }));
+}
+
+function stateActions(state: RoutineState): RoutineActionSummary[] {
+  return state.type === "operation" || state.type === "foreach"
+    ? summarizeActions(state.actions)
+    : [];
+}
+
+function destination(transition: string | undefined, end: boolean | undefined): string | null {
+  if (transition) return stateId(transition);
+  return end ? "end" : null;
+}
+
+function stateEdges(state: RoutineState): RoutineGraphEdge[] {
+  const edges: RoutineGraphEdge[] = [];
+  const source = stateId(state.name);
+  const add = (
+    id: string,
+    kind: RoutineEdgeKind,
+    label: string,
+    transition: string | undefined,
+    end: boolean | undefined
+  ) => {
+    const target = destination(transition, end);
+    if (target) edges.push({ id, source, target, kind, label });
+  };
+
+  if (state.type === "switch") {
+    for (const [index, condition] of state.dataConditions.entries()) {
+      add(
+        `condition:${state.name}:${index}`,
+        "condition",
+        condition.condition,
+        condition.transition,
+        condition.end
+      );
+    }
+    if (state.defaultCondition) {
+      add(
+        `default:${state.name}`,
+        "default",
+        "Default",
+        state.defaultCondition.transition,
+        state.defaultCondition.end
+      );
+    }
+  } else {
+    add(
+      state.transition ? `transition:${state.name}` : `end:${state.name}`,
+      state.transition ? "transition" : "end",
+      state.transition ? "Next" : "End",
+      state.transition,
+      state.end
+    );
+  }
+
+  for (const [index, error] of (state.onErrors ?? []).entries()) {
+    add(`error:${state.name}:${index}`, "error", error.errorRef, error.transition, error.end);
+  }
+  return edges;
+}
+
+export function projectRoutineGraph(definition: RoutineDefinition): RoutineGraph {
+  const nodes: RoutineGraphNode[] = definition["x-triggers"].map((trigger, index) => ({
+    id: `trigger:${index}`,
+    kind: "trigger",
+    label: triggerLabel(trigger.type),
+    triggerType: trigger.type,
+  }));
+  nodes.push(
+    ...definition.states.map((state) => ({
+      id: stateId(state.name),
+      kind: "state" as const,
+      label: state.name,
+      stateType: state.type,
+      actions: stateActions(state),
+    })),
+    { id: "end", kind: "end", label: "End" }
+  );
+
+  const edges: RoutineGraphEdge[] = definition["x-triggers"].map((_, index) => ({
+    id: `start:${index}`,
+    source: `trigger:${index}`,
+    target: stateId(definition.start),
+    kind: "start",
+    label: "Starts",
+  }));
+  for (const state of definition.states) edges.push(...stateEdges(state));
+  return { nodes, edges };
+}
+
+export function routineNodeDimensions(kind: RoutineNodeKind): { width: number; height: number } {
+  if (kind === "state") return { width: 220, height: 96 };
+  if (kind === "trigger") return { width: 180, height: 64 };
+  return { width: 120, height: 56 };
+}
+
+export function layoutRoutineGraph(graph: RoutineGraph): LaidOutRoutineGraph {
+  const dagre = new Graph<GraphLabel, NodeLabel, EdgeLabel>({ multigraph: true }).setGraph({
+    rankdir: "LR",
+    nodesep: 48,
+    ranksep: 96,
+  });
+  dagre.setDefaultEdgeLabel(() => ({}));
+  for (const node of graph.nodes) dagre.setNode(node.id, routineNodeDimensions(node.kind));
+  for (const edge of graph.edges) dagre.setEdge(edge.source, edge.target, {}, edge.id);
+  layout(dagre);
+
+  return {
+    nodes: graph.nodes.map((node) => {
+      const placed = dagre.node(node.id);
+      return {
+        ...node,
+        actions: node.actions?.map((action) => ({ ...action, arguments: [...action.arguments] })),
+        position: {
+          x: (placed.x ?? 0) - placed.width / 2,
+          y: (placed.y ?? 0) - placed.height / 2,
+        },
+      };
+    }),
+    edges: graph.edges.map((edge) => ({ ...edge })),
+  };
+}

--- a/apps/web/app/lib/routines/run-overlay.test.ts
+++ b/apps/web/app/lib/routines/run-overlay.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+import type { RoutineGraph } from "./graph";
+import { reduceRunOverlay } from "./run-overlay";
+
+const graph: RoutineGraph = {
+  nodes: [
+    { id: "trigger:0", kind: "trigger", label: "Manual Trigger" },
+    { id: "state:A", kind: "state", label: "A", stateType: "operation", actions: [] },
+    { id: "state:B", kind: "state", label: "B", stateType: "inject", actions: [] },
+    { id: "end", kind: "end", label: "End" },
+  ],
+  edges: [
+    { id: "start:0", source: "trigger:0", target: "state:A", kind: "start", label: "Starts" },
+    { id: "condition:A:0", source: "state:A", target: "state:B", kind: "condition", label: "1" },
+    { id: "condition:A:1", source: "state:A", target: "state:B", kind: "condition", label: "2" },
+    { id: "error:A:0", source: "state:A", target: "state:B", kind: "error", label: "timeout" },
+    { id: "end:B", source: "state:B", target: "end", kind: "end", label: "End" },
+  ],
+};
+
+const event = (seq: number, type: string, payload: Record<string, unknown>, second = seq) => ({
+  seq,
+  type,
+  payload,
+  createdAt: `2026-07-19T00:00:${String(second).padStart(2, "0")}.000Z`,
+});
+
+describe("reduceRunOverlay", () => {
+  it("folds explicit identity, State data, duration, retry, sleep, Approval, and failure", () => {
+    const events = [
+      event(1, "run.started", { triggerIndex: 0 }),
+      event(2, "state.entered", { state: "A", input: { amount: 4 }, attempt: 1 }),
+      event(3, "state.retrying", { state: "A", attempt: 1, error: { name: "timeout" } }),
+      event(4, "state.completed", { state: "A", output: { amount: 8 } }, 7),
+      event(5, "state.transitioned", {
+        source: "A",
+        target: "B",
+        route: { kind: "condition", index: 1 },
+      }),
+      event(6, "run.sleeping", { state: "B", wakeAt: "2026-07-20T00:00:00Z" }),
+      event(7, "run.waiting_approval", { state: "B", approvalId: "approval-1" }),
+      event(8, "error", { state: "B", error: { name: "denied", message: "No" } }),
+      event(8, "error", { state: "B", error: { name: "duplicate" } }),
+    ];
+    const overlay = reduceRunOverlay(graph, events);
+
+    expect(overlay.lastSeq).toBe(8);
+    expect(overlay.nodes["trigger:0"]).toMatchObject({ status: "completed", exact: true });
+    expect(overlay.nodes["state:A"]).toMatchObject({
+      status: "completed",
+      input: { amount: 4 },
+      output: { amount: 8 },
+      attempts: 1,
+      durationMs: 5000,
+    });
+    expect(overlay.nodes["state:B"]).toMatchObject({ status: "failed", error: { name: "denied" } });
+    expect(overlay.edges["start:0"]).toMatchObject({ status: "taken", exact: true });
+    expect(overlay.edges["condition:A:1"]).toMatchObject({ status: "taken", exact: true });
+    expect(overlay.edges["condition:A:0"]).toBeUndefined();
+  });
+
+  it.each([
+    ["state.retrying", "retrying"],
+    ["run.sleeping", "sleeping"],
+    ["run.waiting_approval", "waiting_approval"],
+  ])("represents intermediate %s status", (type, status) => {
+    const overlay = reduceRunOverlay(graph, [event(1, type, { state: "A" })]);
+    expect(overlay.nodes["state:A"]).toMatchObject({ status });
+  });
+
+  it("selects handled-error and explicit terminal routes", () => {
+    const overlay = reduceRunOverlay(graph, [
+      event(1, "state.transitioned", {
+        source: "A",
+        target: "B",
+        route: { kind: "error", index: 0, error: { name: "timeout" } },
+      }),
+      event(2, "state.transitioned", { source: "B", end: true, route: { kind: "end" } }),
+    ]);
+    expect(overlay.edges["error:A:0"]).toMatchObject({ exact: true });
+    expect(overlay.edges["end:B"]).toMatchObject({ exact: true });
+  });
+
+  it("restores a sleeping source to completed when its target State enters", () => {
+    const overlay = reduceRunOverlay(graph, [
+      event(1, "state.entered", { state: "A", input: {} }),
+      event(2, "state.completed", { state: "A", output: {} }),
+      event(3, "state.transitioned", {
+        source: "A",
+        target: "B",
+        route: { kind: "condition", index: 0 },
+      }),
+      event(4, "run.sleeping", { state: "A" }),
+      event(5, "finish", { reason: "suspended" }),
+      event(6, "state.entered", { state: "B", input: {} }),
+    ]);
+    expect(overlay.nodes["state:A"]).toMatchObject({ status: "completed" });
+    expect(overlay.nodes["state:B"]).toMatchObject({ status: "running" });
+  });
+
+  it("restores Sleep End on terminal completion without weakening exact End identity", () => {
+    const overlay = reduceRunOverlay(graph, [
+      event(1, "state.entered", { state: "B", input: {} }),
+      event(2, "state.completed", { state: "B", output: {} }),
+      event(3, "state.transitioned", { source: "B", end: true, route: { kind: "end" } }),
+      event(4, "run.sleeping", { state: "B" }),
+      event(5, "finish", { reason: "suspended" }),
+      event(6, "finish", { reason: "completed" }),
+    ]);
+    expect(overlay.nodes["state:B"]).toMatchObject({ status: "completed" });
+    expect(overlay.nodes.end).toMatchObject({ status: "completed", exact: true });
+  });
+
+  it("ignores contradictory explicit route evidence without inferring another edge", () => {
+    const overlay = reduceRunOverlay(graph, [
+      event(1, "state.entered", { state: "A", input: {} }),
+      event(2, "state.transitioned", {
+        source: "A",
+        target: "B",
+        route: { kind: "condition", index: 99 },
+      }),
+      event(3, "state.entered", { state: "B", input: {} }),
+    ]);
+    expect(overlay.edges).toEqual({});
+  });
+
+  it("marks one or every legacy candidate as inferred without inventing missing evidence", () => {
+    const one = reduceRunOverlay(graph, [
+      event(1, "run.started", { trigger: { type: "manual" } }),
+      event(3, "state.entered", { state: "A", input: {} }),
+      event(4, "state.entered", { state: "B", input: {} }),
+      event(5, "state.completed", { state: "B", output: {} }),
+      event(6, "finish", { reason: "completed" }),
+    ]);
+
+    expect(one.nodes["trigger:0"]).toMatchObject({
+      inferred: true,
+      label: "Inferred from legacy Run",
+    });
+    expect(one.edges["condition:A:0"]).toMatchObject({ inferred: true });
+    expect(one.edges["condition:A:1"]).toMatchObject({ inferred: true });
+    expect(one.edges["end:B"]).toMatchObject({ inferred: true });
+    const ambiguousGraph = structuredClone(graph);
+    ambiguousGraph.nodes.push({ ...graph.nodes[0], id: "trigger:1" });
+    ambiguousGraph.edges.push({ ...graph.edges[0], id: "start:1", source: "trigger:1" });
+    const ambiguous = reduceRunOverlay(ambiguousGraph, [
+      event(1, "run.started", { trigger: { type: "manual" } }),
+    ]);
+    expect(ambiguous.nodes["trigger:0"]).toMatchObject({ inferred: true });
+    expect(ambiguous.nodes["trigger:1"]).toMatchObject({ inferred: true });
+    expect(reduceRunOverlay(graph, [event(2, "unknown", {})]).edges).toEqual({});
+  });
+});

--- a/apps/web/app/lib/routines/run-overlay.ts
+++ b/apps/web/app/lib/routines/run-overlay.ts
@@ -1,0 +1,202 @@
+import type { RunEvent } from "../routines";
+import type { RoutineGraph, RoutineGraphEdge } from "./graph";
+
+export type RunNodeStatus =
+  | "running"
+  | "completed"
+  | "retrying"
+  | "sleeping"
+  | "waiting_approval"
+  | "handled_error"
+  | "failed"
+  | "cancelled";
+
+export interface RunNodeOverlay extends Partial<Record<"exact" | "inferred", boolean>> {
+  status: RunNodeStatus;
+  label?: string;
+  input?: Record<string, unknown>;
+  output?: Record<string, unknown>;
+  error?: Record<string, unknown>;
+  attempts?: number;
+  startedAt?: string;
+  completedAt?: string;
+  durationMs?: number;
+}
+
+export interface RunOverlay {
+  lastSeq: number;
+  nodes: Record<string, RunNodeOverlay>;
+  edges: Record<string, { status: "taken"; exact?: boolean; inferred?: boolean; label?: string }>;
+}
+const INFERRED = { status: "taken", inferred: true, label: "Inferred from legacy Run" } as const;
+const stateId = (state = "") => `state:${encodeURIComponent(state)}`;
+const rec = (value: unknown) =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+const text = (value: unknown) => (typeof value === "string" ? value : undefined);
+const num = (value: unknown) =>
+  typeof value === "number" && Number.isFinite(value) ? value : undefined;
+function routeId(source: string, route: Record<string, unknown>): string | undefined {
+  const index = num(route.index);
+  if (route.kind === "transition") return `transition:${source}`;
+  if (route.kind === "end") return `end:${source}`;
+  if (route.kind === "default") return `default:${source}`;
+  if (route.kind === "condition" && Number.isInteger(index)) return `condition:${source}:${index}`;
+  if (route.kind === "error" && Number.isInteger(index)) return `error:${source}:${index}`;
+}
+
+function transitionTarget(payload: Record<string, unknown>): string | undefined {
+  const target = text(payload.target);
+  if (target) return stateId(target);
+  return payload.end === true ? "end" : undefined;
+}
+
+function inferEdges(overlay: RunOverlay, edges: RoutineGraphEdge[]): void {
+  for (const edge of edges) overlay.edges[edge.id] = INFERRED;
+}
+
+function setState(
+  overlay: RunOverlay,
+  state: string,
+  status: RunNodeStatus,
+  data: Partial<RunNodeOverlay> = {}
+): void {
+  const id = stateId(state);
+  overlay.nodes[id] = { ...overlay.nodes[id], status, exact: true, ...data };
+}
+
+function restoreSleep(overlay: RunOverlay, state?: string): void {
+  if (state && overlay.nodes[stateId(state)]?.status === "sleeping")
+    setState(overlay, state, "completed");
+}
+
+export function reduceRunOverlay(graph: RoutineGraph, events: readonly RunEvent[]): RunOverlay {
+  const overlay: RunOverlay = { lastSeq: 0, nodes: {}, edges: {} };
+  const unique = new Map<number, RunEvent>();
+  for (const event of events) {
+    if (Number.isInteger(event.seq) && event.seq >= 0 && !unique.has(event.seq)) {
+      unique.set(event.seq, event);
+    }
+  }
+
+  let previousEntry: string | undefined;
+  let explicitSinceEntry = false;
+  let completed: string | undefined;
+  for (const event of [...unique.values()].sort((a, b) => a.seq - b.seq)) {
+    overlay.lastSeq = Math.max(overlay.lastSeq, event.seq);
+    const payload = rec(event.payload);
+    if (!payload) continue;
+    const state = text(payload.state);
+    const rawAt = text(event.createdAt);
+    const at = rawAt && Number.isFinite(Date.parse(rawAt)) ? rawAt : undefined;
+
+    if (event.type === "run.started") {
+      const index = num(payload.triggerIndex);
+      const id = Number.isInteger(index) ? `trigger:${index}` : undefined;
+      if (id && graph.nodes.some((node) => node.id === id)) {
+        overlay.nodes[id] = { status: "completed", exact: true };
+        if (graph.edges.some((edge) => edge.id === `start:${index}`)) {
+          overlay.edges[`start:${index}`] = { status: "taken", exact: true };
+        }
+      } else if (payload.triggerIndex === undefined) {
+        const trigger = payload.trigger;
+        const type = text(trigger) ?? text(rec(trigger)?.type);
+        if (!type) continue;
+        for (const node of graph.nodes.filter(
+          (candidate) =>
+            candidate.kind === "trigger" &&
+            (candidate.triggerType ?? candidate.label.replace(/ Trigger$/, "").toLowerCase()) ===
+              type
+        )) {
+          overlay.nodes[node.id] = {
+            status: "completed",
+            inferred: true,
+            label: INFERRED.label,
+          };
+          const edge = graph.edges.find((candidate) => candidate.source === node.id);
+          if (edge) overlay.edges[edge.id] = INFERRED;
+        }
+      }
+    } else if (event.type === "state.entered" && state) {
+      restoreSleep(overlay, previousEntry === state ? undefined : previousEntry);
+      if (previousEntry && !explicitSinceEntry) {
+        inferEdges(
+          overlay,
+          graph.edges.filter(
+            (edge) => edge.source === stateId(previousEntry) && edge.target === stateId(state)
+          )
+        );
+      }
+      setState(overlay, state, "running", {
+        input: rec(payload.input),
+        attempts: num(payload.attempt),
+        startedAt: at,
+      });
+      previousEntry = state;
+      explicitSinceEntry = false;
+      completed = undefined;
+    } else if (event.type === "state.completed" && state) {
+      const prior = overlay.nodes[stateId(state)];
+      const duration = prior?.startedAt && at ? Date.parse(at) - Date.parse(prior.startedAt) : -1;
+      setState(overlay, state, "completed", {
+        output: rec(payload.output),
+        completedAt: at,
+        ...(duration >= 0 ? { durationMs: duration } : {}),
+      });
+      completed = state;
+    } else if (event.type === "state.transitioned") {
+      const source = text(payload.source);
+      if (source && previousEntry === source) explicitSinceEntry = true;
+      const route = rec(payload.route);
+      const target = transitionTarget(payload);
+      if (!source || !route || !target) continue;
+      const edge = graph.edges.find((candidate) => candidate.id === routeId(source, route));
+      if (!edge || edge.target !== target) continue;
+      overlay.edges[edge.id] = { status: "taken", exact: true };
+      if (target === "end") overlay.nodes.end = { status: "completed", exact: true };
+      if (route.kind === "error") {
+        setState(overlay, source, "handled_error", { error: rec(route.error) });
+      }
+    } else {
+      const current = state ?? previousEntry;
+      const cancelled =
+        event.type === "run.cancelled" ||
+        (event.type === "finish" && payload.reason === "cancelled");
+      if (event.type === "finish" && payload.reason === "completed") {
+        restoreSleep(overlay, completed);
+      }
+      if (event.type === "state.retrying" && current) {
+        setState(overlay, current, "retrying", {
+          attempts: num(payload.attempt),
+          error: rec(payload.error),
+        });
+      } else if (event.type === "run.sleeping" && current) {
+        setState(overlay, current, "sleeping");
+      } else if (event.type === "run.waiting_approval" && current) {
+        setState(overlay, current, "waiting_approval", {
+          input: rec(payload.pendingInput),
+        });
+      } else if (event.type === "error" && current) {
+        setState(overlay, current, "failed", { error: rec(payload.error) });
+      } else if (cancelled && current) {
+        setState(overlay, current, "cancelled");
+      } else if (
+        event.type === "finish" &&
+        payload.reason === "completed" &&
+        completed &&
+        !explicitSinceEntry &&
+        !overlay.nodes.end?.exact
+      ) {
+        const candidates = graph.edges.filter(
+          (edge) => edge.source === stateId(completed) && edge.target === "end"
+        );
+        inferEdges(overlay, candidates);
+        if (candidates.length) {
+          overlay.nodes.end = { status: "completed", inferred: true, label: INFERRED.label };
+        }
+      }
+    }
+  }
+  return overlay;
+}

--- a/apps/web/app/routes/_app.routines.$slug.runs.$runId.tsx
+++ b/apps/web/app/routes/_app.routines.$slug.runs.$runId.tsx
@@ -1,11 +1,14 @@
 import { useLoaderData, useRevalidator, useRouteError } from "@remix-run/react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { ResourcePanel } from "~/components/resource-panel";
+import { RoutineRunCanvas } from "~/components/routines/routine-run-canvas";
 import { RunStatusBadge } from "~/components/routines/run-status-badge";
 import { ErrorState } from "~/components/states";
 import { Button } from "~/components/ui/button";
 import { ApiError } from "~/lib/api";
 import { cancelRun, getRun, type RunEvent, runEventsUrl } from "~/lib/routines";
+import { projectRoutineGraph } from "~/lib/routines/graph";
+import { reduceRunOverlay } from "~/lib/routines/run-overlay";
 
 export async function clientLoader({ params }: { params: { slug: string; runId: string } }) {
   const detail = await getRun(params.slug, params.runId);
@@ -61,6 +64,7 @@ function useRunEvents(
       "state.entered",
       "action.completed",
       "state.completed",
+      "state.transitioned",
       "state.retrying",
       "run.sleeping",
       "run.waiting_approval",
@@ -79,16 +83,6 @@ function useRunEvents(
   return events;
 }
 
-function describePayload(payload: unknown): string {
-  if (payload == null) return "";
-  try {
-    const text = JSON.stringify(payload);
-    return text.length > 200 ? `${text.slice(0, 200)}…` : text;
-  } catch {
-    return String(payload);
-  }
-}
-
 export default function RunDetail() {
   const { slug, runId, detail } = useLoaderData<typeof clientLoader>();
   const revalidator = useRevalidator();
@@ -96,6 +90,18 @@ export default function RunDetail() {
   const isLive = !TERMINAL.has(run.status);
   const revalidate = useMemo(() => () => revalidator.revalidate(), [revalidator.revalidate]);
   const events = useRunEvents(slug, runId, detail.events, isLive, revalidate);
+  const graph = useMemo(
+    () => projectRoutineGraph(run.definitionSnapshot),
+    [run.definitionSnapshot]
+  );
+  const overlay = useMemo(() => {
+    const next = reduceRunOverlay(graph, events);
+    if (run.status === "cancelled" && run.currentState) {
+      const id = `state:${encodeURIComponent(run.currentState)}`;
+      next.nodes[id] = { ...next.nodes[id], status: "cancelled", exact: true };
+    }
+    return next;
+  }, [events, graph, run.currentState, run.status]);
   const [cancelError, setCancelError] = useState<string | null>(null);
 
   const handleCancel = async () => {
@@ -140,21 +146,7 @@ export default function RunDetail() {
         </p>
       ) : null}
 
-      <p className="text-xs uppercase tracking-[0.15em] text-muted-foreground">events</p>
-      <ol className="flex flex-col divide-y divide-border rounded-sm border border-border font-mono text-xs">
-        {events.map((event) => (
-          <li key={event.seq} className="flex items-baseline gap-2.5 px-3 py-1.5">
-            <span className="w-8 shrink-0 text-right text-muted-foreground">{event.seq}</span>
-            <span className="shrink-0 font-medium text-foreground">{event.type}</span>
-            <span className="min-w-0 flex-1 truncate text-muted-foreground">
-              {describePayload(event.payload)}
-            </span>
-          </li>
-        ))}
-        {events.length === 0 ? (
-          <li className="px-3 py-2 text-muted-foreground">no events yet</li>
-        ) : null}
-      </ol>
+      <RoutineRunCanvas graph={graph} overlay={overlay} events={events} />
 
       {run.output != null ? (
         <>

--- a/apps/web/app/routes/_app.routines.$slug.tsx
+++ b/apps/web/app/routes/_app.routines.$slug.tsx
@@ -1,23 +1,17 @@
 import { Link, useLoaderData, useNavigate, useRevalidator, useRouteError } from "@remix-run/react";
 import { useState } from "react";
 import { ResourcePanel } from "~/components/resource-panel";
+import { RoutineCanvas } from "~/components/routines/routine-canvas";
 import { RunStatusBadge } from "~/components/routines/run-status-badge";
 import { ErrorState } from "~/components/states";
 import { Button } from "~/components/ui/button";
 import { ApiError } from "~/lib/api";
-import {
-  listRoutines,
-  listRuns,
-  type RoutineInputsSchema,
-  type RoutineSummary,
-  triggerRun,
-} from "~/lib/routines";
+import { getRoutine, listRuns, type RoutineInputsSchema, triggerRun } from "~/lib/routines";
+import { projectRoutineGraph } from "~/lib/routines/graph";
 
 export async function clientLoader({ params }: { params: { slug: string } }) {
   const slug = params.slug;
-  const [routines, runs] = await Promise.all([listRoutines(), listRuns(slug)]);
-  const routine = routines.find((r) => r.slug === slug);
-  if (!routine) throw new ApiError(404, "routine not found");
+  const [routine, runs] = await Promise.all([getRoutine(slug), listRuns(slug)]);
   return { routine, runs };
 }
 
@@ -30,7 +24,7 @@ function TriggerForm({
   routine,
   onTriggered,
 }: {
-  routine: RoutineSummary;
+  routine: { slug: string; inputs?: RoutineInputsSchema | null };
   onTriggered: (runId: string) => void;
 }) {
   const schema: RoutineInputsSchema = routine.inputs ?? {};
@@ -124,24 +118,38 @@ export default function RoutineDetail() {
   const { routine, runs } = useLoaderData<typeof clientLoader>();
   const navigate = useNavigate();
   const revalidator = useRevalidator();
-  const canTriggerManually = (routine.triggers ?? []).some((t) => t.type === "manual");
+
+  if (!routine.valid) {
+    return (
+      <ResourcePanel crumbs={[{ label: "routines", to: "/routines" }, { label: routine.slug }]}>
+        <p className="text-sm text-destructive">{routine.loadError}</p>
+      </ResourcePanel>
+    );
+  }
+
+  const definition = routine.definition;
+  const triggers = definition["x-triggers"];
+  const inputs = definition["x-inputs"] ?? null;
+  const canTriggerManually = triggers.some((trigger) => trigger.type === "manual");
 
   return (
     <ResourcePanel crumbs={[{ label: "routines", to: "/routines" }, { label: routine.slug }]}>
       <div className="flex flex-col gap-1">
-        <h1 className="font-medium text-foreground">{routine.name ?? routine.slug}</h1>
-        {routine.description ? (
-          <p className="text-muted-foreground text-sm">{routine.description}</p>
+        <h1 className="font-medium text-foreground">{definition.name ?? routine.slug}</h1>
+        {definition.description ? (
+          <p className="text-muted-foreground text-sm">{definition.description}</p>
         ) : null}
         <p className="text-xs text-muted-foreground">
-          triggers: {(routine.triggers ?? []).map((t) => t.type).join(", ") || "none"}
+          triggers: {triggers.map((trigger) => trigger.type).join(", ") || "none"}
           {routine.hasHooks ? " · hooks.ts" : ""}
         </p>
       </div>
 
+      <RoutineCanvas graph={projectRoutineGraph(definition)} mode="read" />
+
       {canTriggerManually ? (
         <TriggerForm
-          routine={routine}
+          routine={{ slug: routine.slug, inputs }}
           onTriggered={(runId) =>
             navigate(`/routines/${encodeURIComponent(routine.slug)}/runs/${runId}`)
           }
@@ -149,7 +157,7 @@ export default function RoutineDetail() {
       ) : (
         <p className="text-xs text-muted-foreground">
           This routine has no manual trigger — it starts from{" "}
-          {(routine.triggers ?? []).map((t) => t.type).join("/")}.
+          {triggers.map((trigger) => trigger.type).join("/")}.
         </p>
       )}
 

--- a/apps/web/app/routes/routines.canvas.routes.test.tsx
+++ b/apps/web/app/routes/routines.canvas.routes.test.tsx
@@ -1,0 +1,147 @@
+import * as remix from "@remix-run/react";
+import { createRemixStub } from "@remix-run/testing";
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, expect, test, vi } from "vitest";
+import RoutineDetail from "./_app.routines.$slug";
+import RunDetail from "./_app.routines.$slug.runs.$runId";
+
+vi.mock("@remix-run/react", async () => {
+  const actual = await vi.importActual<typeof import("@remix-run/react")>("@remix-run/react");
+  return { ...actual, useLoaderData: vi.fn() };
+});
+
+const definition = {
+  id: "expense-report",
+  version: "1",
+  start: "Done",
+  "x-triggers": [{ type: "manual" as const }],
+  states: [{ name: "Done", type: "inject" as const, data: {}, end: true }],
+};
+
+const streamListeners = new Map<string, EventListener>();
+class EventSourceStub {
+  addEventListener = (type: string, listener: EventListener) => streamListeners.set(type, listener);
+  close = vi.fn();
+  onerror: (() => void) | null = null;
+}
+
+function renderRoute(Component: React.ComponentType, data: unknown) {
+  vi.mocked(remix.useLoaderData).mockReturnValue(data);
+  const Stub = createRemixStub([{ path: "/", Component }]);
+  render(<Stub initialEntries={["/"]} />);
+}
+
+afterEach(() => {
+  streamListeners.clear();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+test("valid Routine makes its canvas primary while retaining Trigger and Run history", () => {
+  renderRoute(RoutineDetail, {
+    routine: {
+      slug: "expense-report",
+      valid: true,
+      name: "Expense report",
+      definition,
+      triggers: definition["x-triggers"],
+    },
+    runs: [
+      {
+        id: "run-12345678",
+        routineSlug: "expense-report",
+        status: "succeeded",
+        trigger: { type: "manual" },
+        createdAt: "2026-07-19T00:00:00Z",
+        updatedAt: "2026-07-19T00:00:01Z",
+      },
+    ],
+  });
+  expect(screen.getByRole("region", { name: /Routine canvas/ })).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: /run now/i })).toBeInTheDocument();
+  expect(screen.getByText(/run history/i)).toBeInTheDocument();
+});
+
+test("invalid Routine renders its diagnostic without a canvas", () => {
+  renderRoute(RoutineDetail, {
+    routine: { slug: "broken", valid: false, loadError: "missing start State" },
+    runs: [],
+  });
+  expect(screen.getByText("missing start State")).toBeInTheDocument();
+  expect(screen.queryByRole("region", { name: /Routine canvas/ })).toBeNull();
+});
+
+test("Run uses pinned definition, dedupes SSE, and retains its controls", async () => {
+  vi.stubGlobal("EventSource", EventSourceStub);
+  vi.spyOn(window, "matchMedia").mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+  renderRoute(RunDetail, {
+    slug: "expense-report",
+    runId: "run-12345678",
+    detail: {
+      run: {
+        id: "run-12345678",
+        routineSlug: "expense-report",
+        status: "running",
+        definitionSnapshot: definition,
+        trigger: { type: "manual", triggerIndex: 0 },
+        createdAt: "2026-07-19T00:00:00Z",
+        updatedAt: "2026-07-19T00:00:01Z",
+      },
+      events: [],
+    },
+  });
+  expect(screen.getByRole("region", { name: /Run canvas/ })).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: /State Done, inject/ })).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: /End from Done to End/ })).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: /cancel run/i })).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: /refresh/i })).toBeInTheDocument();
+  const journal = screen.getByRole("button", { name: /journal/i });
+  const handler = streamListeners.get("state.transitioned");
+  expect(handler).toBeDefined();
+  const message = new MessageEvent("state.transitioned", {
+    data: JSON.stringify({ source: "Done", route: { kind: "end" }, end: true }),
+    lastEventId: "1",
+  });
+  act(() => {
+    handler?.(message);
+    handler?.(message);
+  });
+  expect(document.querySelector("[data-animated='true']")).toBeInTheDocument();
+  await userEvent.click(journal);
+  expect(screen.getAllByText("state.transitioned")).toHaveLength(1);
+  expect(screen.getByText(/"source": "Done"/)).toBeInTheDocument();
+});
+
+test("persisted cancellation overrides a sleeping journal overlay", () => {
+  renderRoute(RunDetail, {
+    slug: "expense-report",
+    runId: "run-cancelled",
+    detail: {
+      run: {
+        id: "run-cancelled",
+        routineSlug: "expense-report",
+        status: "cancelled",
+        currentState: "Done",
+        definitionSnapshot: definition,
+        trigger: { type: "manual", triggerIndex: 0 },
+        createdAt: "2026-07-19T00:00:00Z",
+        updatedAt: "2026-07-19T00:00:01Z",
+      },
+      events: [
+        { seq: 1, type: "state.entered", payload: { state: "Done" } },
+        { seq: 2, type: "run.sleeping", payload: { state: "Done" } },
+      ],
+    },
+  });
+  expect(screen.getByRole("button", { name: /State Done, inject, cancelled/ })).toBeInTheDocument();
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@dagrejs/dagre": "^3.0.0",
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@radix-ui/react-slot": "^1.3.0",
     "@remix-run/node": "^2.17.5",
@@ -25,6 +26,8 @@
     "@tiptap/starter-kit": "^3.27.1",
     "@tiptap/suggestion": "^3.27.1",
     "@tulipfarm/editor": "workspace:*",
+    "@tulipfarm/schema": "workspace:*",
+    "@xyflow/react": "^12.11.2",
     "chart.js": "^4.5.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/packages/routine-engine/src/index.ts
+++ b/packages/routine-engine/src/index.ts
@@ -7,6 +7,8 @@ export type {
   RunEvent,
   RunSnapshot,
   RunTrigger,
+  SelectedRoute,
+  StateExecutionData,
   StepOutcome,
 } from "./types";
 export { LIFECYCLE_HOOKS, stateHookNames } from "./types";

--- a/packages/routine-engine/src/interpreter.test.ts
+++ b/packages/routine-engine/src/interpreter.test.ts
@@ -1,7 +1,7 @@
 import type { RoutineDefinition } from "@tulipfarm/schema";
 import { describe, expect, it, vi } from "vitest";
 import { executeState } from "./interpreter";
-import type { EnginePorts, ResolvedFunction } from "./ports";
+import type { EnginePorts, HookInvocation, ResolvedFunction } from "./ports";
 import type { RunEvent, RunSnapshot } from "./types";
 
 /**
@@ -72,6 +72,8 @@ describe("inject state", () => {
       type: "continue",
       nextState: "Next",
       context: { keep: 1, greeting: "hi" },
+      route: { kind: "transition", target: "Next" },
+      stateData: { state: "Start", input: { keep: 1 }, output: { keep: 1, greeting: "hi" } },
     });
   });
 
@@ -80,7 +82,12 @@ describe("inject state", () => {
       states: [{ name: "Start", type: "inject", data: { done: true }, end: true }],
     });
     const outcome = await executeState(makeRun(def), makePorts());
-    expect(outcome).toEqual({ type: "complete", output: { done: true } });
+    expect(outcome).toEqual({
+      type: "complete",
+      output: { done: true },
+      route: { kind: "end", end: true },
+      stateData: { state: "Start", input: {}, output: { done: true } },
+    });
   });
 });
 
@@ -100,12 +107,55 @@ describe("switch state", () => {
 
   it("takes the first truthy condition", async () => {
     const outcome = await executeState(makeRun(def, { context: { amount: 700 } }), makePorts());
-    expect(outcome).toMatchObject({ type: "continue", nextState: "Big" });
+    expect(outcome.type).toBe("continue");
+    expect(outcome).toHaveProperty("route", { kind: "condition", index: 0, target: "Big" });
   });
 
   it("falls back to defaultCondition", async () => {
     const outcome = await executeState(makeRun(def, { context: { amount: 10 } }), makePorts());
-    expect(outcome).toMatchObject({ type: "continue", nextState: "Small" });
+    expect(outcome.type).toBe("continue");
+    expect(outcome).toHaveProperty("route", { kind: "default", target: "Small" });
+  });
+
+  it("preserves the ordered condition index when duplicate targets exist", async () => {
+    const duplicateTargets = makeDef({
+      states: [
+        {
+          name: "Start",
+          type: "switch",
+          dataConditions: [
+            { condition: "context.choice === 1", transition: "Same" },
+            { condition: "context.choice === 2", transition: "Same" },
+          ],
+          defaultCondition: { end: true },
+        },
+        { name: "Same", type: "inject", data: {}, end: true },
+      ],
+    });
+    const outcome = await executeState(
+      makeRun(duplicateTargets, { context: { choice: 2 } }),
+      makePorts()
+    );
+    expect(outcome).toMatchObject({ type: "continue", nextState: "Same" });
+    expect(outcome).toHaveProperty("route", { kind: "condition", index: 1, target: "Same" });
+  });
+
+  it.each([
+    [true, { kind: "condition", index: 0, end: true }],
+    [false, { kind: "default", end: true }],
+  ])("preserves switch End route identity", async (finish, route) => {
+    const terminal = makeDef({
+      states: [
+        {
+          name: "Start",
+          type: "switch",
+          dataConditions: [{ condition: "context.finish === true", end: true }],
+          defaultCondition: { end: true },
+        },
+      ],
+    });
+    const outcome = await executeState(makeRun(terminal, { context: { finish } }), makePorts());
+    expect(outcome).toMatchObject({ type: "complete", route });
   });
 
   it("does not mutate the shared definition when branching", async () => {
@@ -177,10 +227,11 @@ describe("operation state", () => {
         throw new Error("boom");
       }),
     });
-    const outcome = await executeState(makeRun(def), ports);
-    expect(outcome).toMatchObject({
+    const outcome = await executeState(makeRun(def, { context: { keep: 1 } }), ports);
+    expect(outcome).toEqual({
       type: "fail",
       error: { name: "action_failed", message: "boom", state: "Start" },
+      stateData: { state: "Start", input: { keep: 1 } },
     });
   });
 });
@@ -252,6 +303,8 @@ describe("sleep state", () => {
       type: "sleep",
       until: new Date("2026-07-06T12:10:00Z"),
       nextState: "Next",
+      route: { kind: "transition", target: "Next" },
+      stateData: { state: "Start", input: {}, output: {} },
     });
   });
 
@@ -260,7 +313,12 @@ describe("sleep state", () => {
       states: [{ name: "Start", type: "sleep", duration: "PT1S", end: true }],
     });
     const outcome = await executeState(makeRun(def), makePorts());
-    expect(outcome).toMatchObject({ type: "sleep", nextState: null });
+    expect(outcome).toMatchObject({
+      type: "sleep",
+      nextState: null,
+      route: { kind: "end", end: true },
+      stateData: { state: "Start", input: {}, output: {} },
+    });
   });
 });
 
@@ -279,7 +337,10 @@ describe("retries and onErrors", () => {
         name: "Start",
         type: "operation",
         actions: [{ functionRef: { refName: "doWork" }, retryRef: "std" }],
-        onErrors: [{ errorRef: "*", transition: "Recover" }],
+        onErrors: [
+          { errorRef: "timeout", end: true },
+          { errorRef: "*", transition: "Recover" },
+        ],
         end: true,
       },
       { name: "Recover", type: "inject", data: { recovered: true }, end: true },
@@ -302,7 +363,17 @@ describe("retries and onErrors", () => {
       makeRun(def, { attemptCounts: { Start: 2 } }),
       failingPorts()
     );
-    expect(outcome).toMatchObject({ type: "continue", nextState: "Recover" });
+    expect(outcome).toMatchObject({
+      type: "continue",
+      nextState: "Recover",
+      route: {
+        kind: "error",
+        index: 1,
+        target: "Recover",
+        error: { name: "action_failed", message: "flaky", state: "Start" },
+      },
+      stateData: { state: "Start", input: {} },
+    });
   });
 
   it("matches onErrors by errorRef name", async () => {
@@ -348,6 +419,12 @@ describe("retries and onErrors", () => {
     expect(outcome).toMatchObject({
       type: "complete",
       output: { error: { name: "action_failed" } },
+      route: {
+        kind: "error",
+        index: 0,
+        end: true,
+        error: { name: "action_failed", state: "Start" },
+      },
     });
   });
 });
@@ -428,12 +505,17 @@ describe("human_approval gate", () => {
   });
 
   it("pauses with wait_approval before executing", async () => {
-    const ports = makePorts();
+    const ports = makePorts({
+      hasHook: vi.fn(() => true),
+    });
     const outcome = await executeState(makeRun(def, { context: { amount: 9 } }), ports);
     expect(outcome).toEqual({
       type: "wait_approval",
       request: { stateName: "Start", channels: ["ui", "slack"], summary: { amount: 9 } },
     });
+    expect(ports.evalExpression).not.toHaveBeenCalled();
+    expect(ports.emit).not.toHaveBeenCalled();
+    expect(ports.runHook).not.toHaveBeenCalled();
     expect(ports.runAction).not.toHaveBeenCalled();
   });
 
@@ -447,6 +529,91 @@ describe("human_approval gate", () => {
   it("routes denial as approval_denied error", async () => {
     const outcome = await executeState(makeRun(def, { approvalOutcome: "denied" }), makePorts());
     expect(outcome).toMatchObject({ type: "fail", error: { name: "approval_denied" } });
+  });
+
+  it("filters, enters, runs Hooks and Action exactly once after approval", async () => {
+    const approved = makeDef({
+      states: [
+        {
+          name: "Start",
+          type: "operation",
+          "x-autonomy-level": "human_approval",
+          actions: [{ functionRef: { refName: "doWork" } }],
+          stateDataFilter: {
+            input: "({ filtered: context.wide })",
+            output: "({ finalized: context.filtered })",
+          },
+          end: true,
+        },
+      ],
+    });
+    const hookInputs: Record<string, unknown>[] = [];
+    const runHook = vi.fn(async (name: string, invocation: HookInvocation) => {
+      hookInputs.push({ ...invocation.context });
+      if (name === "afterStart") invocation.context.afterHook = true;
+    });
+    const ports = makePorts({ runHook, hasHook: vi.fn(() => true) });
+    const outcome = await executeState(
+      makeRun(approved, { context: { wide: 9 }, approvalOutcome: "approved" }),
+      ports
+    );
+
+    expect(outcome).toMatchObject({
+      type: "complete",
+      route: { kind: "end", end: true },
+      stateData: {
+        state: "Start",
+        input: { filtered: 9 },
+        output: { finalized: 9, afterHook: true },
+      },
+    });
+    expect(hookInputs).toEqual([{ filtered: 9 }, { finalized: 9 }]);
+    expect(ports.evalExpression).toHaveBeenCalledTimes(2);
+    expect(ports.emit).toHaveBeenCalledTimes(2);
+    expect(ports.events[0]).toEqual({
+      type: "state.entered",
+      data: { state: "Start", stateType: "operation", input: { filtered: 9 }, attempt: 1 },
+    });
+    expect(ports.runHook).toHaveBeenCalledTimes(2);
+    expect(ports.runAction).toHaveBeenCalledOnce();
+  });
+
+  it("routes denial by onErrors without filters, events, Hooks, or Actions", async () => {
+    const denied = makeDef({
+      states: [
+        {
+          name: "Start",
+          type: "operation",
+          "x-autonomy-level": "human_approval",
+          stateDataFilter: { input: "({ filtered: context.wide })" },
+          actions: [{ functionRef: { refName: "doWork" } }],
+          onErrors: [{ errorRef: "approval_denied", transition: "Denied" }],
+          end: true,
+        },
+        { name: "Denied", type: "inject", data: {}, end: true },
+      ],
+    });
+    const ports = makePorts({ hasHook: vi.fn(() => true) });
+    const outcome = await executeState(
+      makeRun(denied, { context: { wide: 9 }, approvalOutcome: "denied" }),
+      ports
+    );
+
+    expect(outcome).toMatchObject({
+      type: "continue",
+      nextState: "Denied",
+      route: {
+        kind: "error",
+        index: 0,
+        target: "Denied",
+        error: { name: "approval_denied", state: "Start" },
+      },
+      stateData: { state: "Start", input: { wide: 9 } },
+    });
+    expect(ports.evalExpression).not.toHaveBeenCalled();
+    expect(ports.emit).not.toHaveBeenCalled();
+    expect(ports.runHook).not.toHaveBeenCalled();
+    expect(ports.runAction).not.toHaveBeenCalled();
   });
 });
 
@@ -498,8 +665,27 @@ describe("state data filters and events", () => {
     });
     const ports = makePorts();
     const outcome = await executeState(makeRun(def, { context: { wide: 41 } }), ports);
-    expect(outcome).toEqual({ type: "complete", output: { final: 42 } });
-    expect(ports.events.map((e) => e.type)).toEqual(["state.entered", "state.completed"]);
+    expect(outcome).toEqual({
+      type: "complete",
+      output: { final: 42 },
+      route: { kind: "end", end: true },
+      stateData: {
+        state: "Start",
+        input: { narrowed: 41 },
+        output: { final: 42 },
+      },
+    });
+    expect(ports.events).toEqual([
+      {
+        type: "state.entered",
+        data: {
+          state: "Start",
+          stateType: "inject",
+          input: { narrowed: 41 },
+          attempt: 1,
+        },
+      },
+    ]);
   });
 });
 

--- a/packages/routine-engine/src/interpreter.ts
+++ b/packages/routine-engine/src/interpreter.ts
@@ -6,7 +6,14 @@ import type {
 } from "@tulipfarm/schema";
 import { parseIsoDuration } from "./duration";
 import type { EnginePorts, HookInvocation, ResolvedFunction } from "./ports";
-import { type RunError, type RunSnapshot, type StepOutcome, stateHookNames } from "./types";
+import {
+  type RunError,
+  type RunSnapshot,
+  type SelectedRoute,
+  type StateExecutionData,
+  type StepOutcome,
+  stateHookNames,
+} from "./types";
 
 /** Max items a foreach state may iterate (V1 bound; `parallel` is deferred anyway). */
 export const FOREACH_CAP = 1000;
@@ -89,34 +96,46 @@ export async function executeState(run: RunSnapshot, ports: EnginePorts): Promis
         run,
         state,
         { name: "approval_denied", message: `state "${state.name}" was denied`, state: state.name },
-        undefined
+        undefined,
+        stateData(state.name, run.context)
       );
     }
   }
 
-  await ports.emit({ type: "state.entered", data: { state: state.name, stateType: state.type } });
-
   const hooks = stateHookNames(state.name);
-  const invocation: HookInvocation = {
-    runId: run.runId,
-    slug: run.slug,
-    stateName: state.name,
-    context: run.context,
-    trigger: run.trigger,
-  };
+  let context = { ...run.context };
+  let executionData = stateData(state.name, context);
+  let emittingEntry = false;
 
   try {
-    if (ports.hasHook(hooks.before)) await ports.runHook(hooks.before, invocation);
-
-    let context = { ...run.context };
     if (state.stateDataFilter?.input) {
       const filtered = await evalExpr(ports, state.stateDataFilter.input, scopeOf(run, context));
       if (isRecord(filtered)) context = filtered;
     }
+    executionData = stateData(state.name, context);
+
+    emittingEntry = true;
+    await ports.emit({
+      type: "state.entered",
+      data: {
+        state: state.name,
+        stateType: state.type,
+        input: executionData.input,
+        attempt: (run.attemptCounts[state.name] ?? 0) + 1,
+      },
+    });
+    emittingEntry = false;
+
+    const invocation: HookInvocation = {
+      runId: run.runId,
+      slug: run.slug,
+      stateName: state.name,
+      context,
+      trigger: run.trigger,
+    };
+    if (ports.hasHook(hooks.before)) await ports.runHook(hooks.before, invocation);
 
     const body = await withStateTimeout(run, state, context, ports);
-    if (body && "type" in body) return body; // sleep suspends here
-    const branch = body?.branch;
 
     if (state.stateDataFilter?.output) {
       const filtered = await evalExpr(ports, state.stateDataFilter.output, scopeOf(run, context));
@@ -127,27 +146,49 @@ export async function executeState(run: RunSnapshot, ports: EnginePorts): Promis
       await ports.runHook(hooks.after, { ...invocation, context });
     }
 
-    await ports.emit({ type: "state.completed", data: { state: state.name } });
+    executionData.output = snapshot(context);
 
-    const end = branch ? branch.end : state.end;
-    const transition = branch ? branch.transition : state.transition;
-    if (end) return { type: "complete", output: context };
-    if (transition) return { type: "continue", nextState: transition, context };
-    return fail({
+    if (body?.sleep) {
+      return {
+        type: "sleep",
+        ...body.sleep,
+        context,
+        route: body.route,
+        stateData: executionData,
+      };
+    }
+
+    const route = body?.route ?? stateRoute(state.name, state.transition, state.end);
+    if ("end" in route) {
+      return { type: "complete", output: context, route, stateData: executionData };
+    }
+    if (route.target) {
+      return {
+        type: "continue",
+        nextState: route.target,
+        context,
+        route,
+        stateData: executionData,
+      };
+    }
+    throw new StateFailure({
       name: "bad_definition",
       message: `state "${state.name}" has neither transition nor end`,
       state: state.name,
     });
   } catch (err) {
-    const failure =
-      err instanceof StateFailure
-        ? err
-        : new StateFailure({
-            name: errorName(err),
-            message: err instanceof Error ? err.message : String(err),
-            state: state.name,
-          });
-    return routeError(run, state, failure.runError, failure.retryRef);
+    if (emittingEntry) throw err;
+    let failure: StateFailure;
+    if (err instanceof StateFailure) {
+      failure = err;
+    } else {
+      failure = new StateFailure({
+        name: errorName(err),
+        message: err instanceof Error ? err.message : String(err),
+        state: state.name,
+      });
+    }
+    return routeError(run, state, failure.runError, failure.retryRef, executionData);
   }
 }
 
@@ -162,7 +203,7 @@ async function withStateTimeout(
   state: RoutineState,
   context: Record<string, unknown>,
   ports: EnginePorts
-): Promise<StepOutcome | BranchResult | undefined> {
+): Promise<StateBodyResult | undefined> {
   const iso = state.timeouts?.stateExecTimeout;
   if (!iso) return runStateBody(run, state, context, ports);
 
@@ -186,22 +227,22 @@ async function withStateTimeout(
   }
 }
 
-/** The switch branch chosen for this execution (overrides the state's transition/end). */
-interface BranchResult {
-  branch: { transition?: string; end?: boolean };
+/** Route or suspension selected by the State body. */
+interface StateBodyResult {
+  route: SelectedRoute;
+  sleep?: { until: Date; nextState: string | null };
 }
 
 /**
- * Executes the state's body against `context` (mutating it). Returns a StepOutcome when
- * the state suspends (sleep), a BranchResult for switch, undefined otherwise — the
- * shared completion path in `executeState` takes over.
+ * Executes the state's body against `context` (mutating it). Returns the selected route
+ * for Sleep/Switch States; the shared completion path in `executeState` takes over.
  */
 async function runStateBody(
   run: RunSnapshot,
   state: RoutineState,
   context: Record<string, unknown>,
   ports: EnginePorts
-): Promise<StepOutcome | BranchResult | undefined> {
+): Promise<StateBodyResult | undefined> {
   switch (state.type) {
     case "inject": {
       Object.assign(context, state.data);
@@ -210,22 +251,32 @@ async function runStateBody(
     case "sleep": {
       const until = new Date(ports.now().getTime() + parseIsoDuration(state.duration));
       return {
-        type: "sleep",
-        until,
-        nextState: state.end ? null : (state.transition ?? null),
-        context: { ...run.context },
+        route: stateRoute(state.name, state.transition, state.end),
+        sleep: { until, nextState: state.end ? null : (state.transition ?? null) },
       };
     }
     case "switch": {
-      for (const cond of state.dataConditions) {
+      for (const [index, cond] of state.dataConditions.entries()) {
         const value = await evalExpr(ports, cond.condition, scopeOf(run, context));
-        if (value) return { branch: { transition: cond.transition, end: cond.end } };
+        if (value) {
+          return {
+            route: {
+              kind: "condition",
+              index,
+              ...routeDestination(state.name, cond.transition, cond.end),
+            },
+          };
+        }
       }
       if (state.defaultCondition) {
         return {
-          branch: {
-            transition: state.defaultCondition.transition,
-            end: state.defaultCondition.end,
+          route: {
+            kind: "default",
+            ...routeDestination(
+              state.name,
+              state.defaultCondition.transition,
+              state.defaultCondition.end
+            ),
           },
         };
       }
@@ -334,7 +385,8 @@ function routeError(
   run: RunSnapshot,
   state: RoutineState,
   error: RunError,
-  retryRef: string | undefined
+  retryRef: string | undefined,
+  executionData: StateExecutionData
 ): StepOutcome {
   if (retryRef) {
     const policy = (run.definition.retries ?? []).find((r) => r.name === retryRef);
@@ -343,26 +395,86 @@ function routeError(
       if (attempt < policy.maxAttempts) {
         const base = policy.delay ? parseIsoDuration(policy.delay) : 1_000;
         const delayMs = Math.round(base * (policy.multiplier ?? 1) ** (attempt - 1));
-        return { type: "retry", delayMs, attempt, error };
+        return { type: "retry", delayMs, attempt, error, stateData: executionData };
       }
     }
   }
 
-  const route = matchOnError(state.onErrors, error);
-  if (route) {
+  const match = matchOnError(state.onErrors, error);
+  if (match) {
+    const { index, route } = match;
+    const selectedRoute: SelectedRoute = {
+      kind: "error",
+      index,
+      error,
+      ...routeDestination(state.name, route.transition, route.end),
+    };
     if (route.transition) {
-      return { type: "continue", nextState: route.transition, context: { ...run.context } };
+      return {
+        type: "continue",
+        nextState: route.transition,
+        context: { ...run.context },
+        route: selectedRoute,
+        stateData: executionData,
+      };
     }
-    if (route.end) return { type: "complete", output: { ...run.context, error } };
+    if (route.end) {
+      return {
+        type: "complete",
+        output: { ...run.context, error },
+        route: selectedRoute,
+        stateData: executionData,
+      };
+    }
   }
-  return { type: "fail", error };
+  return { type: "fail", error, stateData: executionData };
 }
 
 function matchOnError(
   onErrors: RoutineOnError[] | undefined,
   error: RunError
-): RoutineOnError | undefined {
-  return (onErrors ?? []).find((o) => o.errorRef === error.name || o.errorRef === "*");
+): { index: number; route: RoutineOnError } | undefined {
+  const index = (onErrors ?? []).findIndex(
+    (route) => route.errorRef === error.name || route.errorRef === "*"
+  );
+  const route = onErrors?.[index];
+  return route ? { index, route } : undefined;
+}
+
+function stateRoute(
+  state: string,
+  transition: string | undefined,
+  end: boolean | undefined
+): SelectedRoute {
+  if (transition) return { kind: "transition", target: transition };
+  if (end) return { kind: "end", end: true };
+  throw invalidRoute(state);
+}
+
+function routeDestination(
+  state: string,
+  transition: string | undefined,
+  end: boolean | undefined
+): { target: string } | { end: true } {
+  if (transition) return { target: transition };
+  if (end) return { end: true };
+  throw invalidRoute(state);
+}
+
+function invalidRoute(state: string): StateFailure {
+  return new StateFailure({
+    name: "bad_definition",
+    message: `state "${state}" has neither transition nor end`,
+    state,
+  });
+}
+
+function stateData(state: string, input: Record<string, unknown>): StateExecutionData {
+  return { state, input: snapshot(input) };
+}
+
+function snapshot(value: Record<string, unknown>): Record<string, unknown> {
+  return structuredClone(value);
 }
 
 function scopeOf(run: RunSnapshot, context: Record<string, unknown>): Record<string, unknown> {

--- a/packages/routine-engine/src/types.ts
+++ b/packages/routine-engine/src/types.ts
@@ -47,17 +47,51 @@ export interface ApprovalRequest {
   summary: Record<string, unknown>;
 }
 
+/** Exact outgoing route selected while executing a State. */
+export type SelectedRoute =
+  | { kind: "transition"; target: string }
+  | { kind: "end"; end: true }
+  | { kind: "condition"; index: number; target?: string; end?: true }
+  | { kind: "default"; target?: string; end?: true }
+  | {
+      kind: "error";
+      index: number;
+      target?: string;
+      end?: true;
+      error: RunError;
+    };
+
+/** Effective input and output snapshots for one State execution. */
+export interface StateExecutionData {
+  state: string;
+  input: Record<string, unknown>;
+  output?: Record<string, unknown>;
+}
+
 /** Outcome of executing one state. The driver persists, then acts on it. */
 export type StepOutcome =
-  | { type: "continue"; nextState: string; context: Record<string, unknown> }
-  | { type: "complete"; output: Record<string, unknown> }
-  | { type: "fail"; error: RunError }
+  | {
+      type: "continue";
+      nextState: string;
+      context: Record<string, unknown>;
+      route: SelectedRoute;
+      stateData: StateExecutionData;
+    }
+  | {
+      type: "complete";
+      output: Record<string, unknown>;
+      route: SelectedRoute;
+      stateData: StateExecutionData;
+    }
+  | { type: "fail"; error: RunError; stateData?: StateExecutionData }
   | {
       type: "sleep";
       until: Date;
       /** State to resume at after waking; null ⇒ the run completes on wake. */
       nextState: string | null;
       context: Record<string, unknown>;
+      route: SelectedRoute;
+      stateData: StateExecutionData;
     }
   | { type: "wait_approval"; request: ApprovalRequest }
   | {
@@ -66,6 +100,7 @@ export type StepOutcome =
       delayMs: number;
       attempt: number;
       error: RunError;
+      stateData: StateExecutionData;
     };
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,6 +205,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@dagrejs/dagre':
+        specifier: ^3.0.0
+        version: 3.0.0
       '@fontsource-variable/jetbrains-mono':
         specifier: ^5.2.8
         version: 5.2.8
@@ -244,6 +247,12 @@ importers:
       '@tulipfarm/editor':
         specifier: workspace:*
         version: link:../../packages/editor
+      '@tulipfarm/schema':
+        specifier: workspace:*
+        version: link:../../packages/schema
+      '@xyflow/react':
+        specifier: ^12.11.2
+        version: 12.11.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       chart.js:
         specifier: ^4.5.1
         version: 4.5.1
@@ -965,6 +974,12 @@ packages:
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@dagrejs/dagre@3.0.0':
+    resolution: {integrity: sha512-ZzhnTy1rfuoew9Ez3EIw4L2znPGnYYhfn8vc9c4oB8iw6QAsszbiU0vRhlxWPFnmmNSFAkrYeF1PhM5m4lAN0Q==}
+
+  '@dagrejs/graphlib@4.0.1':
+    resolution: {integrity: sha512-IvcV6FduIIAmLwnH+yun+QtV36SC7mERqa86aClNqmMN09WhmPPYU8ckHrZBozErf+UvHPWOTJYaGYiIcs0DgA==}
 
   '@electric-sql/pglite-pgvector@0.0.4':
     resolution: {integrity: sha512-oHOQlYMzgxmoFWRbKhhoV0UNfoNUdbTHUD/z/nujr8LrUe4HdiSAUY2+Mv+Z033hZO9UWqOuj3Be2KztwK79ow==}
@@ -3420,8 +3435,26 @@ packages:
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
 
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
   '@types/d3-force@3.0.10':
     resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
 
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
@@ -3567,6 +3600,22 @@ packages:
 
   '@workflow/serde@4.1.0':
     resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
+
+  '@xyflow/react@12.11.2':
+    resolution: {integrity: sha512-eLAlDWJfWnQEhJwGMjlWdAXO9eYllKpliUmPQlAmOLxz6mExXuzMVDUKLMquixgkrtmMFFtug3jGKmYYld12cA==}
+    peerDependencies:
+      '@types/react': '>=17'
+      '@types/react-dom': '>=17'
+      react: '>=17'
+      react-dom: '>=17'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@xyflow/system@0.0.79':
+    resolution: {integrity: sha512-czLyOh91NF0hIzbNzwi8I6GlqG23BHh2435OddfI6uiaLH3xdrdygO93gqgH1Bv9mhy8XPFQJOBn1FTq4LvEWA==}
 
   '@zeit/schemas@2.36.0':
     resolution: {integrity: sha512-7kjMwcChYEzMKjeex9ZFXkt1AyNov9R5HZtjBKVsmVpw7pa7ZtlCGvCBC2vnnXctaYN+aRI61HjIqeetZW5ROg==}
@@ -3921,6 +3970,9 @@ packages:
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
+  classcat@5.0.5:
+    resolution: {integrity: sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==}
+
   clean-stack@2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
     engines: {node: '>=6'}
@@ -4147,20 +4199,50 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
   d3-dispatch@3.0.1:
     resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
     engines: {node: '>=12'}
 
   d3-force@3.0.0:
     resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
     engines: {node: '>=12'}
 
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
   d3-quadtree@3.0.1:
     resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
     engines: {node: '>=12'}
 
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
   d3-timer@3.0.1:
     resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
     engines: {node: '>=12'}
 
   data-uri-to-buffer@3.0.1:
@@ -7809,6 +7891,21 @@ packages:
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -8264,6 +8361,12 @@ snapshots:
       css-tree: 3.2.1
 
   '@csstools/css-tokenizer@4.0.0': {}
+
+  '@dagrejs/dagre@3.0.0':
+    dependencies:
+      '@dagrejs/graphlib': 4.0.1
+
+  '@dagrejs/graphlib@4.0.1': {}
 
   '@electric-sql/pglite-pgvector@0.0.4(@electric-sql/pglite@0.5.3)':
     dependencies:
@@ -10391,7 +10494,28 @@ snapshots:
 
   '@types/cookie@0.6.0': {}
 
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
   '@types/d3-force@3.0.10': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
 
   '@types/debug@4.1.13':
     dependencies:
@@ -10590,6 +10714,31 @@ snapshots:
   '@web3-storage/multipart-parser@1.0.0': {}
 
   '@workflow/serde@4.1.0': {}
+
+  '@xyflow/react@12.11.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@xyflow/system': 0.0.79
+      classcat: 5.0.5
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      zustand: 4.5.7(@types/react@19.2.17)(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+    transitivePeerDependencies:
+      - immer
+
+  '@xyflow/system@0.0.79':
+    dependencies:
+      '@types/d3-drag': 3.0.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
 
   '@zeit/schemas@2.36.0': {}
 
@@ -10964,6 +11113,8 @@ snapshots:
     dependencies:
       clsx: 2.1.1
 
+  classcat@5.0.5: {}
+
   clean-stack@2.2.0: {}
 
   cli-boxes@3.0.0: {}
@@ -11180,7 +11331,16 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-color@3.1.0: {}
+
   d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-ease@3.0.1: {}
 
   d3-force@3.0.0:
     dependencies:
@@ -11188,9 +11348,32 @@ snapshots:
       d3-quadtree: 3.0.1
       d3-timer: 3.0.1
 
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
   d3-quadtree@3.0.1: {}
 
+  d3-selection@3.0.0: {}
+
   d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   data-uri-to-buffer@3.0.1: {}
 
@@ -15693,5 +15876,12 @@ snapshots:
       zod: 4.4.3
 
   zod@4.4.3: {}
+
+  zustand@4.5.7(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      use-sync-external-store: 1.6.0(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      react: 19.2.7
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary

- add read-only canvases to Routine detail and Run detail pages
- render pinned Run definitions with durable, exact Trigger and route execution overlays
- add atomic compare-and-swap plus journal persistence and exact Trigger identity
- preserve the existing manual Trigger, history, cancel, refresh, and journal controls
- support accessibility, reduced motion, and honest inference for legacy Runs
- document that manual, acceptance, and E2E product testing must create Soul artifacts through agentic Chat or supported UI

## Scope clarification

This PR provides Routine and Run visualization infrastructure. It does **not** add a Routine builder or creation/editing UI.

The canvases appear on:

- `/routines/:slug`
- `/routines/:slug/runs/:runId`

They do not appear in the Chat pre-forge preview.

## Non-goals

- Routine creation UI
- visual editor or builder
- drafts or activation workflow
- Chat preview canvas
- saved canvas layout

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `git diff --check`

All passed. Existing unrelated warnings remain unchanged.