### PR TITLE
feat(web): show real app version in sidebar footer

### DIFF
--- a/apps/web/app/components/app-sidebar.tsx
+++ b/apps/web/app/components/app-sidebar.tsx
@@ -350,7 +350,7 @@ export function AppSidebar({ forceCollapsed = false }: { forceCollapsed?: boolea
         >
           {rail ? null : (
             <span className="flex-1 truncate text-xs text-muted-foreground">
-              v1 · local instance
+              v{__APP_VERSION__} · local instance
             </span>
           )}
           <SignOutButton rail={rail} />

--- a/apps/web/app/globals.d.ts
+++ b/apps/web/app/globals.d.ts
@@ -2,6 +2,9 @@
 
 declare module "@fontsource-variable/jetbrains-mono";
 
+// Injected by vite `define` from the monorepo root package.json version.
+declare const __APP_VERSION__: string;
+
 interface ImportMetaEnv {
   // API base for the resource client (defaults to http://localhost:4010 when unset).
   readonly VITE_API_URL?: string;

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -47,7 +47,14 @@ function cspHashPlugin(): Plugin {
   };
 }
 
+// The monorepo root package.json holds the released version; apps/web stays at 0.0.0.
+const appVersion = JSON.parse(readFileSync(new URL("../../package.json", import.meta.url), "utf8"))
+  .version as string;
+
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(appVersion),
+  },
   plugins: [
     // ignoredRouteFiles keeps colocated *.test.tsx out of the route table (and the client
     // bundle) — otherwise Remix routes them and the browser tries to import vitest.

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,9 +1,16 @@
+import { readFileSync } from "node:fs";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vitest/config";
+
+const appVersion = JSON.parse(readFileSync(new URL("../../package.json", import.meta.url), "utf8"))
+  .version as string;
 
 // NOTE: deliberately does NOT load the Remix Vite plugin — it injects a server build that
 // breaks component tests. Use @vitejs/plugin-react and re-declare the ~ alias here.
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(appVersion),
+  },
   plugins: [react()],
   resolve: {
     alias: {


### PR DESCRIPTION
## What

The sidebar footer was hardcoded to `v1 · local instance`. It now renders the actual application version: `v0.3.0-integrations.1 · local instance`.

## How

- `vite.config.ts` reads the monorepo root `package.json` and injects its `version` as a `__APP_VERSION__` global via Vite `define`. The root package.json is the version source — `apps/web` stays at `0.0.0` and is never bumped.
- `vitest.config.ts` mirrors the same `define` so component tests can resolve the global (it deliberately does not load the Remix Vite plugin, so it needs its own copy).
- `app/globals.d.ts` declares `__APP_VERSION__`.
- `app-sidebar.tsx` renders `v{__APP_VERSION__}` instead of the literal.

Build-time injection rather than a runtime API call keeps the footer dependency-free and avoids a fetch on every page load.

## Verification

- `pnpm typecheck` — clean
- `biome check` — clean
- `vitest run app/components/app-sidebar.test.tsx` — 11/11 pass