### PR TITLE
fix(web): show not-found state for a missing integration

### DIFF
--- a/apps/web/app/routes/_app.integrations.$name.tsx
+++ b/apps/web/app/routes/_app.integrations.$name.tsx
@@ -9,7 +9,7 @@ import {
 import { useEffect, useState } from "react";
 import { MarkdownView } from "~/components/markdown-view";
 import { ResourcePanel } from "~/components/resource-panel";
-import { ErrorState } from "~/components/states";
+import { ErrorState, NotFoundState } from "~/components/states";
 import { Button } from "~/components/ui/button";
 import { Modal } from "~/components/ui/modal";
 import { ApiError } from "~/lib/api";
@@ -475,6 +475,9 @@ export default function IntegrationDetailPage() {
 
 export function ErrorBoundary() {
   const error = useRouteError();
+  if (error instanceof ApiError && error.status === 404) {
+    return <NotFoundState section="integrations" />;
+  }
   const status = error instanceof ApiError ? error.status : undefined;
   const message = error instanceof Error ? error.message : undefined;
   return <ErrorState section="integrations" status={status} message={message} />;

--- a/apps/web/app/routes/integrations.routes.test.tsx
+++ b/apps/web/app/routes/integrations.routes.test.tsx
@@ -1,0 +1,34 @@
+import * as remix from "@remix-run/react";
+import { render, screen } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { expect, test, vi } from "vitest";
+import { ApiError } from "~/lib/api";
+import { ErrorBoundary as DetailErrorBoundary } from "./_app.integrations.$name";
+
+// Route smoke test for the integration detail ErrorBoundary — mock useRouteError and render
+// directly (the states have no <Link>, so no router context is needed).
+
+vi.mock("@remix-run/react", async () => {
+  const actual = await vi.importActual<typeof import("@remix-run/react")>("@remix-run/react");
+  return {
+    ...actual,
+    useRouteError: vi.fn(),
+  };
+});
+
+function renderError(node: ReactElement, error: unknown) {
+  vi.mocked(remix.useRouteError).mockReturnValue(error);
+  render(node);
+}
+
+test("detail ErrorBoundary renders 404 not found for a missing integration", () => {
+  renderError(<DetailErrorBoundary />, new ApiError(404, "not found"));
+  expect(screen.getByText(/404 not found/i)).toBeInTheDocument();
+  expect(screen.queryByText(/could not be reached/i)).not.toBeInTheDocument();
+});
+
+test("detail ErrorBoundary surfaces a non-404 API failure generically", () => {
+  renderError(<DetailErrorBoundary />, new ApiError(500, "boom"));
+  expect(screen.getByText(/error: 500/i)).toBeInTheDocument();
+  expect(screen.getByText(/could not be reached/i)).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- The integration detail page (`/integrations/<name>`) rendered the generic connectivity error copy ("The resource API could not be reached. Check that the API is running on :4010.") for a plain 404, conflating "not found" with a real connectivity failure.
- `_app.integrations.$name.tsx`'s `ErrorBoundary` now distinguishes `ApiError` status 404 (renders `NotFoundState`) from other failures (keeps `ErrorState` with the connectivity copy), matching the existing pattern already used in `_app.resources.$type.$id.tsx`.

## Verification
- Added `apps/web/app/routes/integrations.routes.test.tsx` with a regression test that renders the `ErrorBoundary` with an `ApiError(404, ...)` and asserts the not-found copy renders (and the connectivity copy does not); confirmed RED before the fix, GREEN after.
- `pnpm --filter @tulipfarm/web exec vitest run app/routes/integrations.routes.test.tsx` — 2 passed
- `pnpm --filter @tulipfarm/web typecheck` — clean
- `pnpm --filter @tulipfarm/web exec biome check` on changed files — clean

Closes #141