### PR TITLE
feat(soul): add manual /api/v1/soul/reload endpoint

### DIFF
--- a/apps/api/src/soul/routes.test.ts
+++ b/apps/api/src/soul/routes.test.ts
@@ -131,11 +131,14 @@ class FakeTokenRepo implements TokenRepo {
   }
 }
 
-function makeFakeGitSync(overrides: Partial<{ commit: unknown; push: unknown }> = {}) {
+function makeFakeGitSync(
+  overrides: Partial<{ commit: unknown; push: unknown; emit: unknown }> = {}
+) {
   return {
     path: SOUL_ROOT,
     commit: vi.fn().mockResolvedValue({ sha: "abc1234", filesChanged: 2 }),
     push: vi.fn().mockResolvedValue(true),
+    emit: vi.fn(),
     ...overrides,
   } as unknown as GitSyncService;
 }
@@ -251,6 +254,26 @@ describe("soul routes", () => {
       });
       expect(res.statusCode).toBe(200);
       expect(res.json()).toEqual({ pushed: false });
+    });
+  });
+
+  // ── POST /api/v1/soul/reload ──────────────────────────────────────────────
+
+  describe("POST /api/v1/soul/reload", () => {
+    it("returns 401 without auth", async () => {
+      const res = await app.inject({ method: "POST", url: "/api/v1/soul/reload" });
+      expect(res.statusCode).toBe(401);
+    });
+
+    it("emits soul.synced and returns 204", async () => {
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/v1/soul/reload",
+        cookies: { [SESSION_COOKIE]: sid, [CSRF_COOKIE]: TEST_CSRF },
+        headers: { [CSRF_HEADER]: TEST_CSRF },
+      });
+      expect(res.statusCode).toBe(204);
+      expect(gitSync.emit).toHaveBeenCalledWith("soul.synced");
     });
   });
 

--- a/apps/api/src/soul/routes.ts
+++ b/apps/api/src/soul/routes.ts
@@ -175,6 +175,29 @@ export function registerSoulRoutes(
     }
   );
 
+  app.post(
+    "/api/v1/soul/reload",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description:
+          "Re-emit soul.synced so registries (routines, guardrails, resources, LLM config) " +
+          "reload hand-edited soul files. Dev-friendly path for remote-less souls, where the " +
+          "periodic sync (which normally emits soul.synced) never runs.",
+        tags: ["soul"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        response: {
+          204: { type: "null" },
+          401: ErrorSchema,
+        },
+      },
+    },
+    async (_req, reply) => {
+      gitSync.emit("soul.synced");
+      return reply.code(204).send();
+    }
+  );
+
   if (!secretsService) return;
 
   app.get(


### PR DESCRIPTION
## Summary
- In local dev (no git remote configured), `registerSoulSync` never registers its periodic-sync job, so `GitSyncService`'s `soul.synced` event — which drives routine registry, guardrails, resource-type, and LLM-config reloads — is never emitted. Hand-edited soul files (e.g. routines dropped straight into `soul/routines/`) stay invisible until something else happens to trigger a reload or the API restarts.
- Adds `POST /api/v1/soul/reload`: an authenticated, dev-friendly endpoint that re-emits `soul.synced` on demand so all existing listeners (`registerRoutineRegistryReload`, `registerGuardrailsReload`, `registerResourcesReconcile`, `registerLlmReload`) pick up the change, without touching any existing `withSync` call sites (which already do their own manual reload — emitting from `withSync` itself would double-fire those).
- Route is registered alongside the other soul routes that don't require `secretsService` (`commit`/`push`/`tree`/`file`), so it works with no git remote or secrets configured at all.

## Verification
- Added `apps/api/src/soul/routes.test.ts` coverage: 401 without auth, and 204 + `gitSync.emit` called with `"soul.synced"` on success.
- `pnpm --filter @tulipfarm/api exec vitest run src/soul/routes.test.ts` — 31 passed
- `pnpm --filter @tulipfarm/api typecheck` — clean
- `pnpm exec biome check apps/api/src/soul/routes.ts apps/api/src/soul/routes.test.ts` — clean

Closes #144