### PR TITLE
fix(chat): reject duplicate A2UI turns while a chat turn is in flight

### DIFF
--- a/apps/web/app/lib/chat/use-chat-stream.test.ts
+++ b/apps/web/app/lib/chat/use-chat-stream.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 import type { ChatMessage } from "~/lib/chat/types";
-import { a2uiAgentToSend, seedState } from "~/lib/chat/use-chat-stream";
+import { a2uiAgentToSend, isChatBusy, seedState } from "~/lib/chat/use-chat-stream";
 
 describe("a2uiAgentToSend", () => {
   test("maps a choice payload to a user turn using the label", () => {
@@ -48,6 +48,18 @@ describe("a2uiAgentToSend", () => {
     expect(a2uiAgentToSend({ kind: "other", label: "x" })).toBeNull();
     expect(a2uiAgentToSend({ kind: "a2ui-action" })).toBeNull();
     expect(a2uiAgentToSend("nope")).toBeNull();
+  });
+});
+
+describe("isChatBusy", () => {
+  test("is busy while a turn is submitted or streaming", () => {
+    expect(isChatBusy("submitted")).toBe(true);
+    expect(isChatBusy("streaming")).toBe(true);
+  });
+
+  test("is not busy when idle or errored", () => {
+    expect(isChatBusy("idle")).toBe(false);
+    expect(isChatBusy("error")).toBe(false);
   });
 });
 

--- a/apps/web/app/lib/chat/use-chat-stream.ts
+++ b/apps/web/app/lib/chat/use-chat-stream.ts
@@ -18,7 +18,14 @@ import {
 } from "~/lib/chat/reducer";
 import type { ChatStreamMeta } from "~/lib/chat/sse-client";
 import { postChat, sendApprovalDecision, stopChatStream } from "~/lib/chat/sse-client";
-import type { Autonomy, ChatEvent, ChatMessage, ChatState, ModelTier } from "~/lib/chat/types";
+import type {
+  Autonomy,
+  ChatEvent,
+  ChatMessage,
+  ChatState,
+  ChatStatus,
+  ModelTier,
+} from "~/lib/chat/types";
 import { clearFeedback, sendFeedback as postFeedback } from "~/lib/feedback";
 
 export type SendOptions = {
@@ -142,6 +149,12 @@ export function a2uiAgentToSend(payload: unknown): { text: string; opts?: SendOp
     return { text: hasPayload ? `${event} ${JSON.stringify(p.payload)}` : event };
   }
   return null;
+}
+
+// A turn is in flight — used to reject duplicate A2UI postbacks (e.g. a re-clicked, already-
+// answered wizard step) rather than firing another identical user turn.
+export function isChatBusy(status: ChatStatus): boolean {
+  return status === "submitted" || status === "streaming";
 }
 
 function reducer(state: ChatState, action: ChatAction): ChatState {
@@ -308,8 +321,12 @@ export function useChatStream(opts?: UseChatStreamOptions) {
   }, []);
 
   // Bridge postback from an A2UI tf-* control: turn the `agent` payload into a follow-up user turn.
+  // A2UI surfaces have no composer-level disabled state of their own, so a re-clicked/stale prompt
+  // can fire this while the previous turn is still in flight — reject it rather than sending a
+  // duplicate turn.
   const sendA2uiAgent = useCallback(
     (payload: unknown) => {
+      if (isChatBusy(stateRef.current.status)) return;
       const mapped = a2uiAgentToSend(payload);
       if (mapped) void send(mapped.text, mapped.opts);
     },


### PR DESCRIPTION
## Summary
- A2UI wizard prompts (e.g. the "create an agent" step wizard) render as agent-generated HTML in a sandboxed iframe with no client-side "answered" state — re-clicking **Continue** on an already-submitted step re-fires an identical user turn, even while the previous turn is still streaming.
- `sendA2uiAgent` (`apps/web/app/lib/chat/use-chat-stream.ts`) now no-ops while the chat is `submitted`/`streaming`, via a new `isChatBusy(status)` helper — the same busy check the composer already uses (`chat-panel.tsx`) to disable its own send button.
- This is the "minimum defensive fix" called out in the issue. The richer fix (locking/replacing the answered form with a read-only summary, and the related `ApprovalCard` re-click window) is left for a follow-up.

## Verification
- Added `apps/web/app/lib/chat/use-chat-stream.test.ts` coverage for `isChatBusy`: confirmed RED (`isChatBusy is not a function`) before implementing, GREEN after.
- `pnpm --filter @tulipfarm/web exec vitest run app/lib/chat/use-chat-stream.test.ts` — 12 passed
- `pnpm --filter @tulipfarm/web typecheck` — clean
- `pnpm exec biome check apps/web/app/lib/chat/use-chat-stream.ts apps/web/app/lib/chat/use-chat-stream.test.ts` — clean

Closes #162