### PR TITLE
feat(llm-settings): fetch model list from LiteLLM proxy API for openai-compatible providers

### DIFF
--- a/apps/api/src/soul/llm-config/routes.test.ts
+++ b/apps/api/src/soul/llm-config/routes.test.ts
@@ -82,6 +82,7 @@ describe("llm-config routes", () => {
   let withSync: ReturnType<typeof vi.fn>;
   let reload: ReturnType<typeof vi.fn>;
   let init: ReturnType<typeof vi.fn>;
+  let secretsGet: ReturnType<typeof vi.fn>;
   const temps: string[] = [];
 
   beforeEach(async () => {
@@ -119,13 +120,15 @@ describe("llm-config routes", () => {
     } as unknown as GitSyncService;
     init = vi.fn().mockResolvedValue(undefined);
     const llmService = { init, select: vi.fn() } as never;
+    // resource-name (config) is set; everything else (incl. api keys, base URLs) is unavailable by
+    // default — tests that exercise the openai-compatible live-fetch path override this.
+    secretsGet = vi.fn(async (key: string) => {
+      if (key === "azure-openai-resource-name") return "my-res";
+      throw new Error("unset");
+    });
     const secretsService = {
       list: vi.fn().mockResolvedValue([]),
-      // resource-name (config) is set; everything else (incl. api keys) is unavailable.
-      get: vi.fn(async (key: string) => {
-        if (key === "azure-openai-resource-name") return "my-res";
-        throw new Error("unset");
-      }),
+      get: secretsGet,
       set: vi.fn(),
       delete: vi.fn(),
     } as never;
@@ -347,6 +350,67 @@ describe("llm-config routes", () => {
       expect(body.models).toContain("gpt-4o");
       expect(body.models).toContain("gpt-4o-mini");
       expect(body.models).not.toContain("text-embedding-3-small"); // embeddings excluded
+    });
+
+    it("returns live proxy models for openai-compatible when base_url is configured", async () => {
+      secretsGet.mockImplementation(async (key: string) => {
+        if (key === "openai-compatible-base-url") return "http://localhost:11434/v1";
+        if (key === "openai-compatible-api-key") return "sk-test";
+        throw new Error("unset");
+      });
+      const catalogFetch = vi.fn();
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (url: string, init?: RequestInit) => {
+          if (url === "http://localhost:11434/v1/models") {
+            expect((init?.headers as Record<string, string>).Authorization).toBe("Bearer sk-test");
+            return {
+              ok: true,
+              json: async () => ({ data: [{ id: "llama3" }, { id: "mixtral" }] }),
+            };
+          }
+          return catalogFetch();
+        })
+      );
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/llm-config/model-options?provider=openai-compatible",
+        cookies: cookies(adminSid),
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json() as { models: string[]; source: string };
+      expect(body.source).toBe("live");
+      expect(body.models).toEqual(["llama3", "mixtral"]);
+      expect(catalogFetch).not.toHaveBeenCalled();
+    });
+
+    it("falls back to the catalog when the live proxy fetch fails", async () => {
+      secretsGet.mockImplementation(async (key: string) => {
+        if (key === "openai-compatible-base-url") return "http://localhost:11434/v1";
+        throw new Error("unset");
+      });
+      __resetLlmCatalogCache();
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (url: string) => {
+          if (url === "http://localhost:11434/v1/models") {
+            return { ok: false, json: async () => ({}) };
+          }
+          return {
+            ok: true,
+            json: async () => ({ "custom-model": { input_cost_per_token: 1, mode: "chat" } }),
+          };
+        })
+      );
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/llm-config/model-options?provider=openai-compatible",
+        cookies: cookies(adminSid),
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json() as { models: string[]; source: string };
+      expect(body.source).toBe("catalog");
+      expect(body.models).toContain("custom-model");
     });
   });
 

--- a/apps/api/src/soul/llm-config/routes.ts
+++ b/apps/api/src/soul/llm-config/routes.ts
@@ -44,6 +44,55 @@ const EMPTY_LLM_CONFIG = {
 
 const TIER_KEYS = ["quick", "standard", "complex"] as const;
 
+const LIVE_MODELS_TIMEOUT_MS = 5000;
+
+/**
+ * For `openai-compatible` providers pointed at a self-hosted LiteLLM proxy, the static LiteLLM
+ * catalog lists every model that ever existed rather than what the operator actually deployed.
+ * Best-effort: any missing base_url, network error, non-200, or unparseable body returns null so
+ * the caller falls back to the catalog (the field stays usable as free-text entry either way).
+ */
+async function fetchLiveModelOptions(
+  secrets: SecretsService,
+  log: { warn: (obj: unknown, msg?: string) => void }
+): Promise<string[] | null> {
+  let baseUrl: string;
+  try {
+    baseUrl = await secrets.get("openai-compatible-base-url");
+  } catch {
+    return null;
+  }
+  if (!baseUrl) return null;
+
+  let apiKey: string | undefined;
+  try {
+    apiKey = await secrets.get("openai-compatible-api-key");
+  } catch {
+    apiKey = undefined;
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), LIVE_MODELS_TIMEOUT_MS);
+  try {
+    const res = await fetch(`${baseUrl.replace(/\/+$/, "")}/models`, {
+      headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : {},
+      signal: controller.signal,
+    });
+    if (!res.ok) return null;
+    const body = (await res.json()) as { data?: unknown };
+    if (!Array.isArray(body.data)) return null;
+    const ids = body.data
+      .map((m) => (m as { id?: unknown }).id)
+      .filter((id): id is string => typeof id === "string");
+    return ids;
+  } catch (err) {
+    log.warn({ err }, "live model fetch from openai-compatible proxy failed");
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 /**
  * Auto-resolve + pin a LiteLLM spec onto every model that doesn't already have one, so that simply
  * adding a model and saving is enough for cost tracking (no per-model "Fetch spec" click). Best-effort:
@@ -227,7 +276,7 @@ export function registerLlmConfigRoutes(
       preHandler: requireAuth,
       schema: {
         description:
-          "Suggested model ids for a provider (from the LiteLLM catalog), to populate the Settings model picker. Admin only. `source: catalog` lists known ids; `source: unavailable` (+ `reason`) means the catalog couldn't be reached and the UI falls back to free-text entry.",
+          "Suggested model ids for a provider, to populate the Settings model picker. Admin only. For `openai-compatible` with a configured base_url, `source: live` lists the proxy's actually-deployed models (via its `GET /models`); otherwise `source: catalog` lists known LiteLLM ids; `source: unavailable` (+ `reason`) means neither could be reached and the UI falls back to free-text entry.",
         tags: ["soul"],
         security: [{ sessionCookie: [] }, { bearerToken: [] }],
         querystring: {
@@ -241,7 +290,7 @@ export function registerLlmConfigRoutes(
             required: ["models", "source"],
             properties: {
               models: { type: "array", items: { type: "string" } },
-              source: { type: "string", enum: ["catalog", "unavailable"] },
+              source: { type: "string", enum: ["catalog", "live", "unavailable"] },
               reason: { type: "string" },
             },
           },
@@ -254,6 +303,11 @@ export function registerLlmConfigRoutes(
       const actor = req.user as UserDoc;
       if (actor.role !== "admin") return reply.code(403).send({ error: "forbidden" });
       const { provider } = req.query as { provider: string };
+
+      if (provider === "openai-compatible") {
+        const live = await fetchLiveModelOptions(secrets, req.log);
+        if (live) return reply.send({ models: live, source: "live" });
+      }
 
       const catalog = await getCatalog();
       if (!catalog) {

--- a/apps/web/app/lib/settings.ts
+++ b/apps/web/app/lib/settings.ts
@@ -55,13 +55,14 @@ export async function resolveModelSpec(
   return apiGet<SpecResolution>(`/api/v1/llm-config/resolve-spec?${q.toString()}`);
 }
 
-// Suggested model ids for a provider (from the LiteLLM catalog), to populate the model picker.
-// `source: "unavailable"` (+ reason) means the catalog was unreachable and the picker degrades to
-// free-text entry. Azure is intentionally not listed here (deployment names can't be reliably
-// discovered) — its model field is free-text.
+// Suggested model ids for a provider, to populate the model picker. `source: "live"` (openai-compatible
+// only) lists the configured proxy's actually-deployed models; `source: "catalog"` falls back to the
+// LiteLLM catalog; `source: "unavailable"` (+ reason) means neither was reachable and the picker
+// degrades to free-text entry. Azure is intentionally not listed here (deployment names can't be
+// reliably discovered) — its model field is free-text.
 export type ModelOptions = {
   models: string[];
-  source: "catalog" | "unavailable";
+  source: "catalog" | "live" | "unavailable";
   reason?: string;
 };
 


### PR DESCRIPTION
## Summary
- `GET /api/v1/llm-config/model-options` now, for `provider=openai-compatible` with a configured `base_url`, calls the proxy's `GET {base_url}/models` (standard OpenAI-compatible endpoint, 5s timeout, `Authorization: Bearer <key>` when an API key is set) and returns the deployed model ids as `source: "live"`.
- Falls back to the existing static LiteLLM catalog (`source: "catalog"`) when `base_url` is unset, the live fetch fails (network error, non-200, unparseable body), or the provider isn't `openai-compatible` — the model field stays usable as free-text entry either way.
- Added `"live"` to the `source` enum in the route's OpenAPI response schema and in `apps/web/app/lib/settings.ts`'s `ModelOptions` type.

## Verification
- Added a failing regression test first (confirmed RED by reverting the route change), then implemented the fix (confirmed GREEN).
- `pnpm --filter @tulipfarm/api exec vitest run src/soul/llm-config/routes.test.ts` — 16/16 passing, including new cases: live fetch succeeds → `source: "live"`; live fetch fails (non-200) → falls back to catalog.
- `pnpm exec biome check` on changed files — clean.
- `tsc --noEmit` in `apps/api` and `apps/web` — clean.
- Did not run the full monorepo test suite (per automation policy, to keep the local Pi responsive).

Closes #125