### PR TITLE
fix(chat): enforce owner-only access on conversation read routes

### DIFF
--- a/apps/api/src/chat/conversation-routes.ts
+++ b/apps/api/src/chat/conversation-routes.ts
@@ -9,13 +9,27 @@ import { getPlatformAgent, resolveAgent } from "../soul/agents/registry";
 import { buildSoulCatalogue } from "../soul/catalogue";
 import { listAvailableSkills, listEagerSkills } from "../soul/skills/registry";
 import type { ToolRegistry } from "../tools/registry";
-import type { ConversationRepo } from "./conversations";
+import type { ConversationDoc, ConversationRepo } from "./conversations";
 import type { MessageRepo } from "./messages";
 import { MessageSchema } from "./schemas";
 import { assembleAgentSystemPrompt } from "./system-prompt";
 import { availableToolsFor, canGroundKnowledge } from "./turn-helpers";
 
 type PreHandler = (req: FastifyRequest, reply: FastifyReply) => Promise<void>;
+
+/**
+ * Owner-scoped conversation lookup: a foreign conversation is treated identically to a
+ * missing one (404), so a caller can't distinguish "not found" from "not yours".
+ */
+async function findOwnedConversation(
+  repo: ConversationRepo,
+  id: string,
+  userId: string
+): Promise<ConversationDoc | null> {
+  const convo = await repo.findById(id);
+  if (!convo || convo.userId !== userId) return null;
+  return convo;
+}
 
 /** Read/update routes over conversation metadata + messages (no streaming). */
 export interface ConversationRoutesDeps {
@@ -142,9 +156,8 @@ export function registerConversationRoutes(
       const { id } = req.params as { id: string };
       const body = req.body as { title?: string; starred?: boolean };
 
-      // Owner-only mutation (unlike the tenant-open reads): a non-owner — or a missing id — is a 404.
-      const convo = await repo.findById(id);
-      if (!convo || convo.userId !== user._id) {
+      const convo = await findOwnedConversation(repo, id, user._id);
+      if (!convo) {
         return reply.code(404).send({ error: "conversation not found" });
       }
 
@@ -175,7 +188,7 @@ export function registerConversationRoutes(
     {
       preHandler: requireAuth,
       schema: {
-        description: "Fetch a conversation's metadata (tenant-open: any authenticated user).",
+        description: "Fetch a conversation's metadata. Owner-only.",
         tags: ["chat"],
         security: [{ sessionCookie: [] }, { bearerToken: [] }],
         params: {
@@ -204,8 +217,9 @@ export function registerConversationRoutes(
       },
     },
     async (req, reply) => {
+      const user = req.user as UserDoc;
       const { id } = req.params as { id: string };
-      const convo = await repo.findById(id);
+      const convo = await findOwnedConversation(repo, id, user._id);
       if (!convo) {
         return reply.code(404).send({ error: "conversation not found" });
       }
@@ -227,9 +241,7 @@ export function registerConversationRoutes(
     {
       preHandler: requireAuth,
       schema: {
-        description:
-          "List a conversation's messages, oldest→newest, cursor-paginated " +
-          "(tenant-open: any authenticated user).",
+        description: "List a conversation's messages, oldest→newest, cursor-paginated. Owner-only.",
         tags: ["chat"],
         security: [{ sessionCookie: [] }, { bearerToken: [] }],
         params: {
@@ -260,8 +272,9 @@ export function registerConversationRoutes(
       },
     },
     async (req, reply) => {
+      const user = req.user as UserDoc;
       const { id } = req.params as { id: string };
-      const convo = await repo.findById(id);
+      const convo = await findOwnedConversation(repo, id, user._id);
       if (!convo) {
         return reply.code(404).send({ error: "conversation not found" });
       }
@@ -289,8 +302,8 @@ export function registerConversationRoutes(
         preHandler: requireAuth,
         schema: {
           description:
-            "Dev-only: a conversation's reconstructed system prompt + full raw message rows " +
-            "(not registered in production).",
+            "Dev-only: a conversation's reconstructed system prompt + full raw message rows. " +
+            "Owner-only (not registered in production).",
           tags: ["chat"],
           security: [{ sessionCookie: [] }, { bearerToken: [] }],
           params: {
@@ -314,8 +327,9 @@ export function registerConversationRoutes(
         },
       },
       async (req, reply) => {
+        const user = req.user as UserDoc;
         const { id } = req.params as { id: string };
-        const convo = await repo.findById(id);
+        const convo = await findOwnedConversation(repo, id, user._id);
         if (!convo) {
           return reply.code(404).send({ error: "conversation not found" });
         }

--- a/apps/api/src/chat/routes.test.ts
+++ b/apps/api/src/chat/routes.test.ts
@@ -1852,14 +1852,12 @@ describe("chat routes", () => {
       expect(res.statusCode).toBe(404);
     });
 
-    // tenant-open: reads are NOT owner-scoped (distinct from the POST write path).
-    it("200 for a different authenticated user (tenant-open read)", async () => {
+    it("404 for a different authenticated user (owner-only read)", async () => {
       const convoId = randomUUID();
       const now = new Date();
       await repo.create({ _id: convoId, userId, createdAt: now, updatedAt: now });
       const res = await get(`/api/v1/chats/${convoId}`, { session: otherSid });
-      expect(res.statusCode).toBe(200);
-      expect(res.json().id).toBe(convoId);
+      expect(res.statusCode).toBe(404);
     });
   });
 
@@ -1984,15 +1982,13 @@ describe("chat routes", () => {
       expect(body2.messages.map((m: MessageDoc) => m.content)).toEqual(["m2", "m3"]);
     });
 
-    // tenant-open: a different authenticated user can read the messages.
-    it("200 for a different authenticated user (tenant-open read)", async () => {
+    it("404 for a different authenticated user (owner-only read)", async () => {
       const convoId = randomUUID();
       const now = new Date();
       await repo.create({ _id: convoId, userId, createdAt: now, updatedAt: now });
       seedMessages(convoId, 2);
       const res = await get(`/api/v1/chats/${convoId}/messages`, { session: otherSid });
-      expect(res.statusCode).toBe(200);
-      expect(res.json().messages).toHaveLength(2);
+      expect(res.statusCode).toBe(404);
     });
   });
 
@@ -2085,6 +2081,21 @@ describe("chat routes", () => {
         toolName: "search",
         args: { q: "x" },
       });
+    });
+
+    it("404 for a different authenticated user (owner-only read)", async () => {
+      const convoId = randomUUID();
+      const now = new Date();
+      await repo.create({
+        _id: convoId,
+        userId,
+        agentId: "agent-x",
+        createdAt: now,
+        updatedAt: now,
+      });
+      seedAllRoles(convoId);
+      const res = await get(`/api/v1/chats/${convoId}/debug-context`, { session: otherSid });
+      expect(res.statusCode).toBe(404);
     });
 
     it("is not registered when NODE_ENV=production (route absent → 404 even for a seeded convo)", async () => {


### PR DESCRIPTION
## Summary
- `GET /api/v1/chats/:id`, `GET /api/v1/chats/:id/messages`, and the dev-only `GET /api/v1/chats/:id/debug-context` looked up a conversation by id only, without checking `convo.userId` against the authenticated caller — any authenticated user could read another user's chat metadata, full message history, and (outside production) the reconstructed system prompt/working memory via the debug route.
- Added a shared `findOwnedConversation(repo, id, userId)` helper in `apps/api/src/chat/conversation-routes.ts` mirroring the existing owner check on `PUT /api/v1/chats/:id`, and applied it to all three read routes. A foreign conversation now 404s identically to a missing one, so identifiers stay non-enumerable.
- Updated route `description`s to reflect owner-only semantics.

Out of scope: stream resume (`GET /api/v1/chat/streams/:streamId`) and stop (`POST /api/v1/chat/streams/:streamId/stop`) aren't tied to `userId` today at all (keyed only by `streamId`), so they need a separate change to associate stream records with conversation ownership before an equivalent check can be added there — tracked as follow-up per the issue's test recommendations.

## Verification
- `pnpm --filter @tulipfarm/api exec vitest run src/chat/routes.test.ts` — 84 passed, including new/updated non-owner regression tests for all three routes (previously asserted 200/"tenant-open", now assert 404).
- `pnpm --filter @tulipfarm/api exec tsc --noEmit` — clean.
- `pnpm exec biome check --write` on changed files — clean.

Closes #179