### PR TITLE
fix(setup): close the first-admin check-then-insert race with a DB invariant

### DIFF
--- a/apps/api/src/auth/users.pg.test.ts
+++ b/apps/api/src/auth/users.pg.test.ts
@@ -3,7 +3,7 @@ import type { PGlite } from "@electric-sql/pglite";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { runPgMigrations } from "../pg-migrate";
 import { makePglite } from "../test/pglite";
-import { PgUserRepo, type UserDoc } from "./users";
+import { AdminAlreadyExistsError, PgUserRepo, type UserDoc } from "./users";
 
 function makeUser(overrides: Partial<UserDoc> = {}): UserDoc {
   return {
@@ -60,5 +60,16 @@ describe("PgUserRepo", () => {
   it("rejects a duplicate email (unique constraint)", async () => {
     await repo.insert(makeUser({ email: "dup@example.com" }));
     await expect(repo.insert(makeUser({ email: "dup@example.com" }))).rejects.toThrow();
+  });
+
+  it("rejects a second admin insert with AdminAlreadyExistsError (users_single_admin_idx, #172)", async () => {
+    await repo.insert(makeUser({ role: "admin" }));
+    await expect(repo.insert(makeUser({ role: "admin" }))).rejects.toThrow(AdminAlreadyExistsError);
+  });
+
+  it("still allows member inserts after an admin exists", async () => {
+    await repo.insert(makeUser({ role: "admin" }));
+    await expect(repo.insert(makeUser({ role: "member" }))).resolves.toBeUndefined();
+    expect(await repo.count()).toBe(2);
   });
 });

--- a/apps/api/src/auth/users.ts
+++ b/apps/api/src/auth/users.ts
@@ -35,6 +35,18 @@ export interface UserRepo {
 }
 
 /**
+ * Thrown by `insert()` when a second admin row would violate the single-admin database
+ * invariant (`users_single_admin_idx`, migration v25) — the concurrency-safe replacement
+ * for the old check-then-insert `count() === 0` race in setup/routes.ts (#172).
+ */
+export class AdminAlreadyExistsError extends Error {
+  constructor() {
+    super("an admin user already exists");
+    this.name = "AdminAlreadyExistsError";
+  }
+}
+
+/**
  * The narrow lookup surface integration ingress needs to resolve an inbound sender to a
  * TulipFarm user (email match → admin fallback). Kept separate from UserRepo so test fakes
  * that don't care about ingress don't have to implement findFirstAdmin. PgUserRepo satisfies it.
@@ -44,6 +56,17 @@ export interface IngressUserLookup {
   findById(id: string): Promise<UserDoc | null>;
   /** Oldest admin user — the fallback identity for integration ingress turns. */
   findFirstAdmin(): Promise<UserDoc | null>;
+}
+
+function isUniqueViolation(error: unknown, constraint: string): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === "23505" &&
+    "constraint" in error &&
+    error.constraint === constraint
+  );
 }
 
 function rowToUser(row: Record<string, unknown>): UserDoc {
@@ -77,10 +100,17 @@ export class PgUserRepo implements UserRepo {
   }
 
   async insert(user: UserDoc): Promise<void> {
-    await this.q.query(
-      "INSERT INTO users (id, email, password_hash, role, created_at) VALUES ($1, $2, $3, $4, $5)",
-      [user._id, user.email, user.passwordHash, user.role, user.createdAt]
-    );
+    try {
+      await this.q.query(
+        "INSERT INTO users (id, email, password_hash, role, created_at) VALUES ($1, $2, $3, $4, $5)",
+        [user._id, user.email, user.passwordHash, user.role, user.createdAt]
+      );
+    } catch (err) {
+      if (user.role === "admin" && isUniqueViolation(err, "users_single_admin_idx")) {
+        throw new AdminAlreadyExistsError();
+      }
+      throw err;
+    }
   }
 
   async findFirstAdmin(): Promise<UserDoc | null> {

--- a/apps/api/src/knowledge/migration.pg.test.ts
+++ b/apps/api/src/knowledge/migration.pg.test.ts
@@ -47,9 +47,9 @@ describe("002_knowledge migration on PGlite", () => {
     await db.close();
   });
 
-  it("bumps schema_version to the latest (24)", async () => {
+  it("bumps schema_version to the latest (25)", async () => {
     const { rows } = await db.query("SELECT version FROM schema_version WHERE id = true");
-    expect(Number((rows[0] as { version: number }).version)).toBe(24);
+    expect(Number((rows[0] as { version: number }).version)).toBe(25);
   });
 
   it("adds knowledge_chunks.content_hash (019)", async () => {

--- a/apps/api/src/pg-migrate.test.ts
+++ b/apps/api/src/pg-migrate.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { runPgMigrations } from "./pg-migrate";
 import { makePglite } from "./test/pglite";
 
-describe("runPgMigrations — 001_init + 002_knowledge + 003_stream_resume + 004_approvals + 005_conversation_title + 006_message_feedback + 007_conversation_starred + 008_hitl + 009_kv_store + 010_wrapped_deks + 011_okf + 012_okf_crosslinks + 013_drop_bundle_domain + 014_drop_okf_type + 015_title_tsv + 016_doc_type + 017_pg_trgm + 018_terminology_rename + 019_chunk_content_hash + 020_knowledge_connectors + 021_activity_log + 022_obs_event + 023_routines + 024_ingress on PGlite", () => {
+describe("runPgMigrations — 001_init + 002_knowledge + 003_stream_resume + 004_approvals + 005_conversation_title + 006_message_feedback + 007_conversation_starred + 008_hitl + 009_kv_store + 010_wrapped_deks + 011_okf + 012_okf_crosslinks + 013_drop_bundle_domain + 014_drop_okf_type + 015_title_tsv + 016_doc_type + 017_pg_trgm + 018_terminology_rename + 019_chunk_content_hash + 020_knowledge_connectors + 021_activity_log + 022_obs_event + 023_routines + 024_ingress + 025_admin_singleton on PGlite", () => {
   let db: PGlite;
 
   beforeEach(async () => {
@@ -14,10 +14,10 @@ describe("runPgMigrations — 001_init + 002_knowledge + 003_stream_resume + 004
     await db.close();
   });
 
-  it("advances schema_version to the latest (24)", async () => {
+  it("advances schema_version to the latest (25)", async () => {
     await runPgMigrations(db);
     const res = await db.query<{ version: number }>("SELECT version FROM schema_version");
-    expect(res.rows.map((r) => Number(r.version))).toEqual([24]);
+    expect(res.rows.map((r) => Number(r.version))).toEqual([25]);
   });
 
   it("creates the vector and citext extensions", async () => {
@@ -87,11 +87,11 @@ describe("runPgMigrations — 001_init + 002_knowledge + 003_stream_resume + 004
     ]);
   });
 
-  it("is idempotent — a second run does not throw and leaves version at 24", async () => {
+  it("is idempotent — a second run does not throw and leaves version at 25", async () => {
     await runPgMigrations(db);
     await runPgMigrations(db);
     const res = await db.query<{ version: number }>("SELECT version FROM schema_version");
-    expect(res.rows.map((r) => Number(r.version))).toEqual([24]);
+    expect(res.rows.map((r) => Number(r.version))).toEqual([25]);
   });
 
   it("adds knowledge_pages.title_tsv (generated tsvector) + its GIN index (015, renamed by 018)", async () => {

--- a/apps/api/src/pg-migrations/index.ts
+++ b/apps/api/src/pg-migrations/index.ts
@@ -614,6 +614,15 @@ async function renameIndexIfExists(q: Queryable, from: string, to: string): Prom
  * renamed explicitly. The OKF synthetic source_id `okf:<spaceId>:<path>` is unchanged (the UUID
  * value is identical — only the variable name moves), so no data backfill is needed.
  */
+// First-admin claiming (setup/routes.ts POST /api/v1/setup/admin) was check-then-insert:
+// a `count() === 0` guard followed by a separate `insert()`, racy under concurrent requests
+// (each observes zero users before either commits). This partial unique index makes "at
+// most one admin row" a database invariant instead of a process-local check, so a losing
+// concurrent insert fails with a unique violation the route can catch and reject.
+const ADMIN_SINGLETON_STATEMENTS: string[] = [
+  "CREATE UNIQUE INDEX IF NOT EXISTS users_single_admin_idx ON users (role) WHERE role = 'admin'",
+];
+
 const TERMINOLOGY_RENAME_STATEMENTS = async (q: Queryable): Promise<void> => {
   // Retire the legacy collections grouping. Join table first (FK), then the parent.
   await q.query("DROP TABLE IF EXISTS knowledge_documents_collections");
@@ -884,6 +893,16 @@ export const PG_MIGRATIONS: PgMigration[] = [
       "ingress: integration_conversations (external thread↔conversation map), integration_events (webhook-kind records), ingress_deliveries (retry dedup)",
     up: async (q) => {
       for (const sql of INGRESS_STATEMENTS) {
+        await q.query(sql);
+      }
+    },
+  },
+  {
+    version: 25,
+    description:
+      "auth: partial unique index enforcing at most one admin user (closes the first-admin check-then-insert race)",
+    up: async (q) => {
+      for (const sql of ADMIN_SINGLETON_STATEMENTS) {
         await q.query(sql);
       }
     },

--- a/apps/api/src/setup/routes.test.ts
+++ b/apps/api/src/setup/routes.test.ts
@@ -17,7 +17,7 @@ import { buildApp } from "../app";
 import type { TokenDoc, TokenRepo } from "../auth/api-tokens";
 import { CSRF_COOKIE, CSRF_HEADER } from "../auth/csrf";
 import { MemorySessionStore } from "../auth/session-store";
-import type { UserDoc, UserRepo } from "../auth/users";
+import { AdminAlreadyExistsError, type UserDoc, type UserRepo } from "../auth/users";
 import type { PaginatedResult } from "../pagination";
 
 class FakeUserRepo implements UserRepo {
@@ -31,7 +31,12 @@ class FakeUserRepo implements UserRepo {
   async count() {
     return this.users.length;
   }
+  // Mirrors the production `users_single_admin_idx` invariant (PgUserRepo.insert) so tests
+  // can exercise the first-admin race without a real Postgres connection (#172).
   async insert(u: UserDoc) {
+    if (u.role === "admin" && this.users.some((existing) => existing.role === "admin")) {
+      throw new AdminAlreadyExistsError();
+    }
     this.users.push(u);
   }
 }
@@ -170,6 +175,26 @@ describe("setup routes", () => {
       payload: { email: "evil@acme.io", password: "supersecret" },
     });
     expect(again.statusCode).toBe(403);
+  });
+
+  it("concurrent first-admin requests: exactly one wins, the loser gets 403 with no session cookie (#172)", async () => {
+    const [first, second] = await Promise.all([
+      app.inject({
+        method: "POST",
+        url: "/api/v1/setup/admin",
+        payload: { email: "winner@acme.io", password: "supersecret" },
+      }),
+      app.inject({
+        method: "POST",
+        url: "/api/v1/setup/admin",
+        payload: { email: "attacker@acme.io", password: "supersecret" },
+      }),
+    ]);
+    const statuses = [first.statusCode, second.statusCode].sort();
+    expect(statuses).toEqual([201, 403]);
+    const loser = first.statusCode === 403 ? first : second;
+    expect(loser.cookies.some((c) => c.name === "tf_sid")).toBe(false);
+    expect(loser.json()).toEqual({ error: "setup already complete" });
   });
 
   it("business step persists name + description to soul.yaml", async () => {

--- a/apps/api/src/setup/routes.ts
+++ b/apps/api/src/setup/routes.ts
@@ -8,7 +8,7 @@ import { generateCsrfToken, setCsrfCookie } from "../auth/csrf";
 import { SESSION_COOKIE } from "../auth/middleware";
 import { ErrorSchema, PublicUserSchema } from "../auth/schemas";
 import { DEFAULT_SESSION_TTL_SECONDS, type SessionStore } from "../auth/session-store";
-import { createUser, toPublicUser, type UserRepo } from "../auth/users";
+import { AdminAlreadyExistsError, createUser, toPublicUser, type UserRepo } from "../auth/users";
 import { makeRateLimitHook, type RateLimiter } from "../rate-limit";
 import { isHeadlessBoot } from "./service";
 import { patchSoulConfig, readSoulConfig } from "./soul-config";
@@ -169,7 +169,19 @@ export function registerSetupRoutes(app: FastifyInstance, deps: SetupDeps): void
           .code(400)
           .send({ error: "email and a password of at least 8 characters are required" });
       }
-      const user = await createUser(userRepo, email, password, "admin");
+      // requireSetupOpen's count() check is a fast-path only — it cannot prevent two
+      // concurrent requests both observing zero users. The database's single-admin
+      // invariant (users_single_admin_idx) is what actually closes the race: the loser's
+      // insert throws AdminAlreadyExistsError here and gets no session (#172).
+      let user: Awaited<ReturnType<typeof createUser>>;
+      try {
+        user = await createUser(userRepo, email, password, "admin");
+      } catch (err) {
+        if (err instanceof AdminAlreadyExistsError) {
+          return reply.code(403).send({ error: "setup already complete" });
+        }
+        throw err;
+      }
       const sid = await sessionStore.create(user._id);
       setSessionCookies(reply, sid, ttlSeconds);
       return reply.code(201).send({ user: toPublicUser(user) });


### PR DESCRIPTION
## Summary
- `POST /api/v1/setup/admin`'s `requireSetupOpen` guard (`userRepo.count() === 0`) and the admin `insert()` were separate operations with no lock/transaction between them, so two concurrent first-run requests could each observe zero users and both create an administrator (with a valid session).
- Adds a partial unique index `users_single_admin_idx ON users (role) WHERE role = 'admin'` (migration v25) making "at most one admin row" a database invariant instead of a process-local check.
- `PgUserRepo.insert()` now detects the resulting `23505` unique-violation on that index and throws a typed `AdminAlreadyExistsError`; the setup route catches it and returns `403 { error: "setup already complete" }` with no session/CSRF cookie set for the loser.

## Verification
- Added a regression test reproducing the exact race: `apps/api/src/setup/routes.test.ts` fires two concurrent `POST /api/v1/setup/admin` requests via `Promise.all` and asserts exactly one gets `201` (with a session cookie) and the other gets `403` with no `tf_sid` cookie. Confirmed RED (both succeeded) against the pre-fix code, GREEN after.
- Added `apps/api/src/auth/users.pg.test.ts` cases against a real PGlite-migrated schema: a second admin insert rejects with `AdminAlreadyExistsError`, and member inserts still work fine after an admin exists (no regression to normal user creation).
- `pnpm --filter @tulipfarm/api exec vitest run src/auth/users.pg.test.ts src/setup/routes.test.ts` — 20/20 passing.
- `pnpm --filter @tulipfarm/api exec tsc --noEmit` — clean.
- `pnpm exec biome check --write` on touched files — clean.
- Did not run the full monorepo test suite (per automation policy), only the targeted `auth`/`setup` packages affected by this change.

Closes #172
Closes #182