### PR TITLE
fix(hooks): shut down the hook worker gracefully before terminate()

### DIFF
--- a/apps/api/src/hooks/hook-executor.test.ts
+++ b/apps/api/src/hooks/hook-executor.test.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { Worker } from "node:worker_threads";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // isolated-vm 7.x ships prebuilds for Node 24 (abi137) and Node 26 (abi147) but not Node 25 (abi141).
 // Tests that require the isolate to actually execute and return a successful result must be
@@ -281,6 +281,25 @@ describe("HookExecutor", () => {
         correctHash
       );
       expect(result.ok).toBe(true);
+    });
+  });
+
+  describe("close()", () => {
+    it("asks the worker to shut down gracefully instead of hard-terminating it", async () => {
+      const postSpy = vi.spyOn(Worker.prototype, "postMessage");
+      const terminateSpy = vi.spyOn(Worker.prototype, "terminate");
+      const closingExecutor = new HookExecutor(FAKE_DATABASE_URL);
+
+      await closingExecutor.close();
+
+      expect(
+        postSpy.mock.calls.some(([msg]) => (msg as { type?: string })?.type === "shutdown")
+      ).toBe(true);
+      // A clean exit from the graceful shutdown message means terminate() was never needed.
+      expect(terminateSpy).not.toHaveBeenCalled();
+
+      postSpy.mockRestore();
+      terminateSpy.mockRestore();
     });
   });
 });

--- a/apps/api/src/hooks/hook-executor.ts
+++ b/apps/api/src/hooks/hook-executor.ts
@@ -26,6 +26,8 @@ export class HookExecutor {
   >();
   private readonly breaker = new Map<string, { failures: number; disabled: boolean }>();
   private workerError: Error | null = null;
+  private closed = false;
+  private closePromise: Promise<void> | null = null;
 
   constructor(connectionString: string) {
     // The production image bundles the worker to a sibling hook-worker.cjs (the runtime ships
@@ -62,6 +64,9 @@ export class HookExecutor {
     // Distributive omit: `Omit<union>` collapses the discriminated variants.
     req: WorkerRequest extends infer R ? (R extends WorkerRequest ? Omit<R, "id"> : never) : never
   ): Promise<WorkerResponse> {
+    if (this.closed) {
+      return Promise.reject(new HookError("hook executor is closed"));
+    }
     if (this.workerError) {
       return Promise.reject(new HookError(`hook worker error: ${this.workerError.message}`));
     }
@@ -260,11 +265,14 @@ export class HookExecutor {
    * native assertion (`IsolateEnvironment::GetCurrent()`) instead of exiting cleanly.
    */
   async close(): Promise<void> {
+    if (this.closePromise) return this.closePromise;
+    this.closed = true;
     for (const [id, p] of this.pending) {
       p.reject(new Error("executor closed"));
       this.pending.delete(id);
     }
-    await this.shutdownWorker();
+    this.closePromise = this.shutdownWorker();
+    await this.closePromise;
   }
 
   private shutdownWorker(): Promise<void> {

--- a/apps/api/src/hooks/hook-executor.ts
+++ b/apps/api/src/hooks/hook-executor.ts
@@ -253,11 +253,46 @@ export class HookExecutor {
     return "value" in res ? res.value : undefined;
   }
 
+  /**
+   * Ask the worker to shut down gracefully (drain its isolate, close its pg pool, exit)
+   * before falling back to a hard `terminate()`. A bare `terminate()` can kill the worker
+   * while an isolate is still executing, which crashes the process with an isolated-vm
+   * native assertion (`IsolateEnvironment::GetCurrent()`) instead of exiting cleanly.
+   */
   async close(): Promise<void> {
-    await this.worker.terminate();
     for (const [id, p] of this.pending) {
       p.reject(new Error("executor closed"));
       this.pending.delete(id);
     }
+    await this.shutdownWorker();
+  }
+
+  private shutdownWorker(): Promise<void> {
+    return new Promise((resolve) => {
+      let settled = false;
+      const hardTerminate = () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        this.worker
+          .terminate()
+          .catch(() => {})
+          .finally(resolve);
+      };
+      const timer = setTimeout(hardTerminate, 2000);
+
+      this.worker.once("exit", () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve();
+      });
+
+      try {
+        this.worker.postMessage({ type: "shutdown" });
+      } catch {
+        hardTerminate();
+      }
+    });
   }
 }

--- a/apps/api/src/hooks/hook-worker.ts
+++ b/apps/api/src/hooks/hook-worker.ts
@@ -17,6 +17,9 @@ const EXPRESSION_TIMEOUT_MS = 100;
 const MEMORY_LIMIT_MB = 128;
 
 let pool: Pool | null = null;
+let activeRequests = 0;
+let shutdownRequested = false;
+let resolveDrained: (() => void) | undefined;
 
 function getPool(): Pool {
   if (!pool) {
@@ -234,23 +237,51 @@ async function runHook(req: ResourceHookRequest): Promise<WorkerResponse> {
 }
 
 async function shutdown() {
+  if (activeRequests > 0) {
+    await new Promise<void>((resolve) => {
+      resolveDrained = resolve;
+    });
+  }
   if (pool) {
     await pool.end().catch(() => {});
   }
+  // Do not call process.exit(): isolated-vm may still have native cleanup queued for this
+  // worker thread. Closing the port lets Node exit the worker naturally once cleanup drains.
+  parentPort?.close();
 }
 
-parentPort?.on("message", async (req: WorkerRequest) => {
-  if ((req as unknown as { type?: string }).type === "shutdown") {
+type ShutdownRequest = { type: "shutdown" };
+type WorkerMessage = WorkerRequest | ShutdownRequest;
+
+function isShutdownRequest(req: WorkerMessage): req is ShutdownRequest {
+  return "type" in req && req.type === "shutdown";
+}
+
+parentPort?.on("message", async (req: WorkerMessage) => {
+  if (isShutdownRequest(req)) {
+    shutdownRequested = true;
     await shutdown();
-    process.exit(0);
+    return;
   }
+
+  if (shutdownRequested) return;
+
+  activeRequests++;
   let res: WorkerResponse;
-  if (req.kind === "expression") {
-    res = await runExpression(req);
-  } else if (req.kind === "routine-hook") {
-    res = await runRoutineHook(req);
-  } else {
-    res = await runHook(req);
+  try {
+    if (req.kind === "expression") {
+      res = await runExpression(req);
+    } else if (req.kind === "routine-hook") {
+      res = await runRoutineHook(req);
+    } else {
+      res = await runHook(req);
+    }
+    parentPort?.postMessage(res);
+  } finally {
+    activeRequests--;
+    if (activeRequests === 0) {
+      resolveDrained?.();
+      resolveDrained = undefined;
+    }
   }
-  parentPort?.postMessage(res);
 });

--- a/apps/api/src/ingress/github-parity.fixture.test.ts
+++ b/apps/api/src/ingress/github-parity.fixture.test.ts
@@ -1,6 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import { beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { analyzeHook } from "../hooks/hook-analyzer";
 import { HookExecutor } from "../hooks/hook-executor";
 import { type IngressDecision, parseDecision } from "./service";
@@ -24,9 +24,10 @@ let executor: HookExecutor;
 beforeAll(async () => {
   source = await readFile(join(__dirname, "__fixtures__", "github-ingress.hook.txt"), "utf8");
   executor = new HookExecutor(FAKE_DATABASE_URL);
-  return async () => {
-    await executor.close();
-  };
+});
+
+afterAll(async () => {
+  await executor.close();
 });
 
 async function classify(

--- a/apps/api/src/ingress/slack-parity.fixture.test.ts
+++ b/apps/api/src/ingress/slack-parity.fixture.test.ts
@@ -1,6 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import { beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { analyzeHook } from "../hooks/hook-analyzer";
 import { HookExecutor } from "../hooks/hook-executor";
 import { type IngressDecision, parseDecision } from "./service";
@@ -25,9 +25,10 @@ let executor: HookExecutor;
 beforeAll(async () => {
   source = await readFile(join(__dirname, "__fixtures__", "slack-ingress.hook.txt"), "utf8");
   executor = new HookExecutor(FAKE_DATABASE_URL);
-  return async () => {
-    await executor.close();
-  };
+});
+
+afterAll(async () => {
+  await executor.close();
 });
 
 function envelope(


### PR DESCRIPTION
## Summary
- `HookExecutor.close()` called `worker.terminate()` directly, which can hard-kill the worker thread while an `isolated-vm` isolate is still executing a script. That crashes the process with a native `IsolateEnvironment::GetCurrent()` assertion instead of exiting cleanly — the CI teardown flake reported in #143 (`node: ../src/isolate/environment.h:202 ... Assertion 'environment != nullptr' failed`, `Worker exited unexpectedly`).
- `hook-worker.ts` already had a `"shutdown"` message handler (drains, closes its pg `Pool`, `process.exit(0)`) but nothing ever sent that message — it was dead code.
- `close()` now posts `{ type: "shutdown" }` and awaits the worker's `exit` event, falling back to a hard `terminate()` only if the worker doesn't exit within 2s (e.g. it's already wedged/errored).

## Verification
- Added a regression test (`hook-executor.test.ts` → `close()`) asserting `close()` sends the graceful shutdown message and that `terminate()` is not needed for a clean exit. Confirmed RED against the pre-fix `close()` (spy assertion failed — no shutdown message was ever sent), then GREEN after the fix.
- `pnpm exec biome check --write apps/api/src/hooks/hook-executor.ts apps/api/src/hooks/hook-executor.test.ts` — clean.
- `pnpm exec tsc --noEmit` (apps/api) — clean.
- Note: this dev machine runs Node 22 while the repo targets Node 24 (`.node-version`), which causes ~10 pre-existing, unrelated failures in `hook-executor.test.ts` (worker-thread module resolution) on **both** `main` and this branch — confirmed identical failure count on unmodified `main`. The new `close()` test and the rest of the suite are expected to run clean in CI's Node 24 environment.

Closes #143