### PR TITLE
fix(integrations): rate-limit mutating integration routes, annotate clone safety

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -322,7 +322,8 @@ export async function buildApp(opts: AppOptions = {}) {
           mcpClientSvc,
           requireAuth,
           opts.llmService,
-          opts.secretsService
+          opts.secretsService,
+          opts.rateLimiter
         );
         if (opts.llmService) {
           registerSkillRoutes(

--- a/apps/api/src/soul/integrations/routes.test.ts
+++ b/apps/api/src/soul/integrations/routes.test.ts
@@ -17,6 +17,7 @@ import { MemorySessionStore } from "../../auth/session-store";
 import { createUser, type UserDoc, type UserRepo } from "../../auth/users";
 import type { McpClientService } from "../../integrations/mcp-client-service";
 import type { PaginatedResult } from "../../pagination";
+import type { RateLimiter, RateLimitResult } from "../../rate-limit";
 
 const TEST_CSRF = "a".repeat(64);
 
@@ -157,5 +158,84 @@ describe("POST /api/v1/integrations/:name/connect", () => {
     expect(res.statusCode).toBe(200);
     const connection = mcpConnect.mock.calls[0][2];
     expect(connection.env).toEqual({ TOKEN: "existing-secret", NAME: "bar" });
+  });
+});
+
+describe("rate limiting on integrations write routes", () => {
+  let app: FastifyInstance;
+  let store: MemorySessionStore;
+  let sid: string;
+
+  class DenyingRateLimiter implements RateLimiter {
+    async check(): Promise<RateLimitResult> {
+      return { allowed: false, limit: 30, remaining: 0, resetAt: Date.now() + 60_000 };
+    }
+  }
+
+  const auth = () => ({ [SESSION_COOKIE]: sid, [CSRF_COOKIE]: TEST_CSRF });
+  const headers = { [CSRF_HEADER]: TEST_CSRF };
+
+  beforeEach(async () => {
+    store = new MemorySessionStore();
+    const userRepo = new FakeUserRepo();
+    const tokenRepo = new FakeTokenRepo();
+    const user = await createUser(userRepo, "user@example.com", "pass", "member");
+    sid = await store.create(user._id);
+
+    const soulPath = await mkdtemp(join(tmpdir(), "soul-integrations-"));
+    const gitSync = {
+      path: soulPath,
+      withSync: vi.fn().mockResolvedValue({ sha: "abc1234", filesChanged: 1 }),
+    } as unknown as GitSyncService;
+
+    const soulLoader = {
+      integrations: new Map([
+        ["demo-integration", makeIntegration({ TOKEN: "existing-secret", NAME: "foo" })],
+      ]),
+      reload: vi.fn().mockResolvedValue(undefined),
+    } as unknown as SoulLoader;
+
+    const mcpClient = {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      getStatus: vi.fn().mockReturnValue("connected"),
+      getToolNames: vi.fn().mockReturnValue([]),
+    } as unknown as McpClientService;
+
+    app = await buildApp({
+      sessionStore: store,
+      userRepo,
+      tokenRepo,
+      gitSync,
+      soulLoader,
+      mcpClient,
+      rateLimiter: new DenyingRateLimiter(),
+    });
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it("rejects connect with 429 once the rate limiter denies the request", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/integrations/demo-integration/connect",
+      cookies: auth(),
+      headers,
+      payload: {},
+    });
+    expect(res.statusCode).toBe(429);
+  });
+
+  it("rejects scan with 429 once the rate limiter denies the request", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/integrations/scan",
+      cookies: auth(),
+      headers,
+      payload: { source: "tulipfarm/integrations" },
+    });
+    expect(res.statusCode).toBe(429);
   });
 });

--- a/apps/api/src/soul/integrations/routes.ts
+++ b/apps/api/src/soul/integrations/routes.ts
@@ -16,6 +16,8 @@ import {
   sealConnectionEnv,
 } from "../../integrations/connection-env";
 import type { McpClientService } from "../../integrations/mcp-client-service";
+import type { RateLimiter } from "../../rate-limit";
+import { makeRateLimitHook } from "../../rate-limit";
 import { buildIngressAudit, type IngressAuditReport } from "./ingress-audit";
 import { readIntegrationsLock, sourceType, writeIntegrationsLock } from "./lock";
 
@@ -113,6 +115,9 @@ async function cloneToTemp(source: string): Promise<{ dir: string; ref: string }
   const { base, ref } = splitSourceRef(source);
   const dir = await mkdtemp(join(tmpdir(), "integration-scan-"));
   // --branch accepts branch or tag names (not commit SHAs) and still works with --depth 1.
+  // `base` and `ref` are gated by isAllowedSource/REF_RE before this is ever called, and execFile
+  // passes argv directly to the git binary (no shell), so neither can inject additional flags or
+  // shell metacharacters — not a command-line-injection path.
   await execFileP(
     "git",
     ["clone", "--depth", "1", ...(ref ? ["--branch", ref] : []), normalizeGitUrl(base), dir],
@@ -294,7 +299,8 @@ export function registerIntegrationRoutes(
   llmService?: LlmService,
   /** When present, secret-flagged env values are sealed into the secrets store instead of
    * being written to connection.yaml in the soul git repo. */
-  secretsService?: ConnectionSecretStore
+  secretsService?: ConnectionSecretStore,
+  rateLimiter?: RateLimiter
 ): void {
   const sealEnv = async (
     name: string,
@@ -302,6 +308,14 @@ export function registerIntegrationRoutes(
     env: Record<string, string>
   ): Promise<Record<string, string>> =>
     secretsService ? await sealConnectionEnv(name, manifest, env, secretsService) : env;
+
+  // Marketplace/scan/install/connect/oauth/delete all do fs and/or git work — rate-limit them
+  // to bound abuse of the clone path and repeated soul writes (same policy as resource-types).
+  const rateLimitHook = rateLimiter
+    ? makeRateLimitHook(rateLimiter, (req) => `rl:integrations:${req.ip}`, 30, 60_000)
+    : undefined;
+  const limitedAuth: PreHandler[] = rateLimitHook ? [rateLimitHook, requireAuth] : [requireAuth];
+  const limitedOnly: PreHandler[] = rateLimitHook ? [rateLimitHook] : [];
   // List all installed integrations with runtime status
   app.get(
     "/api/v1/integrations",
@@ -354,7 +368,7 @@ export function registerIntegrationRoutes(
   app.get(
     "/api/v1/integrations/marketplace",
     {
-      preHandler: requireAuth,
+      preHandler: limitedAuth,
       schema: {
         description:
           "Browse the official integrations marketplace (tulipfarm/integrations). Returns a scanId usable with the install endpoint.",
@@ -504,7 +518,7 @@ export function registerIntegrationRoutes(
   app.post(
     "/api/v1/integrations/scan",
     {
-      preHandler: requireAuth,
+      preHandler: limitedAuth,
       schema: {
         description:
           "Clone a git repo (source accepts an optional #branch suffix) and discover installable MCP integration manifests.",
@@ -591,7 +605,7 @@ export function registerIntegrationRoutes(
   app.post(
     "/api/v1/integrations/install",
     {
-      preHandler: requireAuth,
+      preHandler: limitedAuth,
       schema: {
         description: "Install the named integrations from a scan into the soul repo.",
         tags: ["integrations"],
@@ -740,7 +754,7 @@ export function registerIntegrationRoutes(
   app.post(
     "/api/v1/integrations/:name/connect",
     {
-      preHandler: requireAuth,
+      preHandler: limitedAuth,
       schema: {
         description:
           "Connect an installed integration: write connection config and start the MCP server.",
@@ -809,7 +823,7 @@ export function registerIntegrationRoutes(
   app.post(
     "/api/v1/integrations/:name/disconnect",
     {
-      preHandler: requireAuth,
+      preHandler: limitedAuth,
       schema: {
         description: "Disconnect an integration: stop the MCP server and mark as disabled.",
         tags: ["integrations"],
@@ -850,7 +864,7 @@ export function registerIntegrationRoutes(
   app.post(
     "/api/v1/integrations/:name/oauth/start",
     {
-      preHandler: requireAuth,
+      preHandler: limitedAuth,
       schema: {
         description:
           "Begin OAuth authorization flow. Returns an authUrl to open in a new tab. The user's client_id and other env values must be supplied so the redirect can be pre-filled on callback.",
@@ -929,6 +943,7 @@ export function registerIntegrationRoutes(
   app.get(
     "/api/v1/integrations/:name/oauth/callback",
     {
+      preHandler: limitedOnly,
       schema: {
         description:
           "OAuth callback handler. Exchanges the authorization code for an access token, writes connection.yaml, and starts the MCP server. Redirects to the integration detail page.",
@@ -1054,7 +1069,7 @@ export function registerIntegrationRoutes(
   app.delete(
     "/api/v1/integrations/:name",
     {
-      preHandler: requireAuth,
+      preHandler: limitedAuth,
       schema: {
         description: "Remove an integration from the soul repo (disconnects first if connected).",
         tags: ["integrations"],


### PR DESCRIPTION
## Summary
- Adds the same optional `RateLimiter` used by `soul/resource-types/routes.ts` to `registerIntegrationRoutes`, and applies it to the 8 integration routes that do fs/git work: `marketplace`, `scan`, `install`, `:name/connect`, `:name/disconnect`, `:name/oauth/start`, `:name/oauth/callback`, and `DELETE :name`. This resolves the `js/missing-rate-limiting` CodeQL alerts.
- Adds a code comment on `cloneToTemp` documenting why the `git clone` invocation is not a command-injection path (source/ref are regex-gated by `isAllowedSource`/`REF_RE` before this is called, and `execFile` passes argv directly to the git binary with no shell) — for the `js/second-order-command-line-injection` alert.
- Wires the new `rateLimiter` param through in `app.ts`'s `registerIntegrationRoutes` call, reusing the existing `opts.rateLimiter`.

## Verification
- Added a regression test suite (`rate limiting on integrations write routes` in `apps/api/src/soul/integrations/routes.test.ts`) with a `DenyingRateLimiter` fake, confirmed RED (both new tests failed with 200/500 before the fix) then GREEN after wiring the rate-limit hook.
- `pnpm exec vitest run src/soul/integrations/routes.test.ts` (scoped to `apps/api`): 4 passed.
- `pnpm exec biome check` on the 3 changed files: clean.
- `pnpm --filter @tulipfarm/api typecheck`: clean.
- `git diff --check`: clean.
- Did not run the root test/build suite per repo automation policy (Raspberry Pi resource constraints).

Closes #142