### PR TITLE
fix(routines): sharpen routine_forge tool description with schema essentials

### DIFF
--- a/apps/api/src/platform/tools.ts
+++ b/apps/api/src/platform/tools.ts
@@ -572,7 +572,20 @@ const validateRoutineForge = ajv.compile(ROUTINE_FORGE_SCHEMA);
 export const routineForgeTool: PlatformTool = {
   name: "routine_forge",
   description:
-    "Create or update a routine in the soul repo: validates the definition against the V1 meta-schema (deferred constructs rejected), writes soul/routines/{name}/routine.yaml (+ optional hooks.ts), and commits via withSync. No approval step (ROUT-V1-002).",
+    "Create or update a ROUTINE (a scheduled/triggered automation) in the soul repo — use this, " +
+    "not skill_create, whenever the user asks to 'create a routine' / 'automate X' / 'every " +
+    "morning do Y' / 'when X happens do Y'. `definition` is a CNCF Serverless Workflow 0.8 subset " +
+    'and MUST include the top-level fields `id` (matches `name`), `version` (e.g. "1.0"), ' +
+    "`start` (the first state's name), `states` (min 1), and `x-triggers` (min 1, e.g. " +
+    "[{ type: 'cron', schedule: '0 9 * * *' }] or [{ type: 'manual' }]) — additional properties " +
+    "are rejected at every level. Minimal example: " +
+    '{ id: "daily-report", version: "1.0", start: "Report", "x-triggers": [{ type: "cron", ' +
+    'schedule: "0 9 * * *" }], functions: [{ name: "send", operation: "tool:resource_search" }], ' +
+    'states: [{ name: "Report", type: "operation", actions: [{ functionRef: { refName: "send" } }], ' +
+    "end: true }] }. Load the routine-forge skill for the full authoring workflow before calling " +
+    "this. Validates the definition against the V1 meta-schema (deferred constructs rejected), " +
+    "writes soul/routines/{name}/routine.yaml (+ optional hooks.ts), and commits via withSync. " +
+    "No approval step (ROUT-V1-002).",
   mutating: true,
   inputSchema: ROUTINE_FORGE_SCHEMA,
   handler: async (args, ctx) => {

--- a/apps/api/src/routines/forge-tool.test.ts
+++ b/apps/api/src/routines/forge-tool.test.ts
@@ -98,4 +98,12 @@ describe("routine_forge (AC-V1-004)", () => {
     expect(badSchema.success).toBe(false);
     expect(withSync).not.toHaveBeenCalled();
   });
+
+  it("describes the required top-level fields so the model doesn't fall through to skill_create", () => {
+    const { description } = routineForgeTool;
+    for (const field of ["id", "version", "start", "states", "x-triggers"]) {
+      expect(description).toContain(field);
+    }
+    expect(description.toLowerCase()).toContain("not skill_create");
+  });
 });


### PR DESCRIPTION
## Summary
- Asking chat to "create a routine" was routing to `skill_create` (writing `soul/skills/...`) instead of `routine_forge`, and even when explicitly told to use `routine_forge` the model couldn't produce a schema-valid definition — the tool's LLM-facing `description` never mentioned the required top-level fields (`id`, `version`, `start`, `states`, `x-triggers`) or gave an example.
- Sharpened `routineForgeTool.description` (`apps/api/src/platform/tools.ts`) to: explicitly say "use this, not skill_create" for routine/automation requests, list the required top-level fields with `additionalProperties: false` called out, and include a minimal valid example definition (mirroring the known-good fixture already used in `forge-tool.test.ts`).
- No schema, routing-code, or tool-registration changes — this is a text-only fix to the tool description the model reads at call time.

## Verification
- Added a regression test (`forge-tool.test.ts` → "describes the required top-level fields...") asserting the description mentions `id`/`version`/`start`/`states`/`x-triggers` and explicitly says not to use `skill_create`. Confirmed RED against the pre-fix description (stashed the `tools.ts` change and reran — failed on missing `version`), then GREEN after restoring the fix.
- `pnpm --filter @tulipfarm/api exec vitest run src/routines/forge-tool.test.ts src/platform/tools.test.ts src/routines/forge-run.e2e.test.ts src/soul/agents/registry.test.ts` — 98 passed.
- `pnpm exec biome check --write apps/api/src/platform/tools.ts apps/api/src/routines/forge-tool.test.ts` — clean.
- `pnpm --filter @tulipfarm/api exec tsc --noEmit` — clean.

Closes #139