### PR TITLE
fix(docs): document the LLM model picker's live suggestions and cost badges

### DIFF
--- a/apps/docs/content/docs/guides/configure-llm-providers.mdx
+++ b/apps/docs/content/docs/guides/configure-llm-providers.mdx
@@ -25,15 +25,28 @@ store.
 Open **Settings → LLM**. You see the three tiers — `quick`, `standard`, and `complex` —
 each an ordered list of provider rows.
 
-For each tier, choose a configured provider and type the model id to use, for example
-`claude-sonnet-4-6`. A provider only becomes selectable once its credentials are saved;
-unconfigured providers are disabled with a "configure first" note.
+For each tier, choose a configured provider, then click into the **model** field. A
+provider only becomes selectable once its credentials are saved; unconfigured providers
+are disabled with a "configure first" note.
+
+The model field is a combobox: focusing it loads a dropdown of suggested model ids for
+that provider, but you can still type any custom id it doesn't list. Suggestions come
+from the LiteLLM catalog, except for **OpenAI-compatible**, which — when its **Base
+URL** is configured — queries the proxy's own `GET /models` endpoint so you pick from
+what it actually has deployed. **Azure Foundry** has no suggestions (deployment names
+can't be discovered); type the deployment name directly, for example `claude-sonnet-4-6`.
 
 <Callout type="info">
 The order of rows in a tier is its fallback chain — the top provider is tried first, and
 the runtime falls through to the next on failure. Add a second provider to a tier with
 **+ Add provider** to give it a backup.
 </Callout>
+
+When you move focus off a filled-in model field, the app resolves its LiteLLM spec and
+shows it as a row of badges — cost per million tokens, context window, and supported
+capabilities (tools, vision, cache, reasoning). If nothing matches, the row shows "No
+LiteLLM match — cost stays unpriced" instead; a **Refresh** button re-fetches a resolved
+spec.
 
 Each tier needs at least one provider with a model. Choose **Save**; the LLM service
 reloads with the new configuration, written to `soul/llm.config.yaml`.


### PR DESCRIPTION
## Summary
- `guides/configure-llm-providers.mdx` told readers to "type the model id" for a tier's model field, as if it were plain free text. The shipped Settings → LLM UI (`apps/web/app/components/llm-config-form.tsx`) is actually a combobox: focusing the field loads per-provider suggested model ids (from the LiteLLM catalog, or — for `openai-compatible` with a configured Base URL — live from the proxy's own `GET /models`, per `apps/api/src/soul/llm-config/routes.ts`), and Azure Foundry gets no suggestions since deployment names aren't discoverable.
- The guide also never mentioned that committing a model auto-resolves and displays its LiteLLM spec (cost/context/capability badges, with a "No LiteLLM match" fallback and a Refresh button) — a reader-visible part of the same step.
- Rewrote the "Assign models to tiers" section to describe this accurately.

## Accuracy evidence
- Combobox + suggestion loading + spec badges verified directly in `apps/web/app/components/llm-config-form.tsx` (datalist per provider, `loadModelOptions`, `specBadges`, "No LiteLLM match — cost stays unpriced.", Refresh button).
- `openai-compatible` live vs. catalog vs. unavailable source logic verified in `apps/api/src/soul/llm-config/routes.ts` (`fetchLiveModelOptions`, shipped in #186).
- Provider id/label ("OpenAI-compatible", "Base URL" field, "Azure Foundry") verified in `packages/secrets/src/registry.ts`.
- "Saved · LLM service reloaded." confirmation string (already documented, left unchanged) verified in `apps/web/app/routes/_app.settings.llm.tsx:65`.

## Reader experience
- A reader configuring an LLM provider previously expected a plain text box and had no idea suggestions, live proxy discovery, or auto-priced badges existed — this is the actual on-screen experience they'll hit immediately after following the guide.
- Single-page IMPROVE edit, no navigation or scope change; stays within the how-to quadrant.

## Verification
```
pnpm --filter @tulipfarm/docs lint       # pass
pnpm --filter @tulipfarm/docs typecheck  # pass
pnpm --filter @tulipfarm/docs build      # pass, static export renders the new copy
git diff --check                         # clean
```
Confirmed rendered output contains the new copy (`out/docs/guides/configure-llm-providers.html`).