### PR TITLE
ci: skip unit and e2e tests for docs-only and markdown-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,41 @@ permissions:
   contents: read
 
 jobs:
+  # Detect whether a PR touches anything beyond docs/markdown. Drives the
+  # conditional skip of the (unit + e2e) test suite on docs-only / markdown-only PRs.
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      # "true" unless every changed file is under apps/docs or is *.md / *.mdx.
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Detect non-docs / non-markdown changes
+        id: filter
+        env:
+          EVENT: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -uo pipefail
+          # Default to running the suite; only skip when a PR is proven to touch
+          # nothing but apps/docs or markdown (*.md / *.mdx).
+          code=true
+          if [ "$EVENT" = "pull_request" ] && [ -n "${BASE_SHA:-}" ] && [ -n "${HEAD_SHA:-}" ]; then
+            changed=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" 2>/dev/null || true)
+            if [ -n "$changed" ]; then
+              other=$(printf '%s\n' "$changed" | grep -v -E '^apps/docs/' | grep -v -E '\.mdx?$' || true)
+              if [ -z "$other" ]; then
+                code=false
+              fi
+            fi
+          fi
+          echo "Run test suite: $code"
+          echo "code=$code" >> "$GITHUB_OUTPUT"
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -189,6 +224,9 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    # Unit + e2e tests. Skipped on docs-only / markdown-only PRs (see `changes`).
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
@@ -231,6 +269,9 @@ jobs:
   coverage:
     name: Coverage (apps/api)
     runs-on: ubuntu-latest
+    # Mirror the `test` job's skip: no point running coverage on docs-only PRs.
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
@@ -372,7 +413,9 @@ jobs:
               }
             }
 
-            const failed = coreChecks.filter(([, , r]) => r !== "success");
+            // A "skipped" core check counts as passing so docs-only / markdown-only
+            // PRs (which intentionally skip the test suite) still satisfy the gate.
+            const failed = coreChecks.filter(([, , r]) => r !== "success" && r !== "skipped");
             if (failed.length) {
               core.setFailed(
                 `Required checks not passing: ${failed.map(([l, , r]) => `${l}=${r}`).join(", ")}`


### PR DESCRIPTION
## Summary

Skips the unit + e2e test suite for pull requests that only touch documentation or markdown, so docs-only changes are not gated on the full test run.

The change modifies only `.github/workflows/ci.yml`:

- Adds a `changes` job that diffs the PR's base/head SHAs and sets output `code=false` only when every changed file is under `apps/docs/` or matches `*.md` / `*.mdx`; otherwise `code=true`.
- Gates the `test` job (which runs the combined unit + e2e suite via `pnpm test`) and the non-blocking `coverage` job on `needs: changes` + `if: needs.changes.outputs.code == 'true'`, so they are skipped on docs-only / markdown-only PRs.
- Updates the required `ci-success` gate so a "skipped" core check counts as passing — otherwise a skipped test would leave the required check red and block docs-only PRs.

## Behavior

- Lint, typecheck, build, and docs-build still run on every PR.
- Non-PR events (pushes to `main`) always run tests.
- The compose-parity and installer-smoke integration gates are out of scope and unchanged.

Slack thread: https://tulipfarm.slack.com/archives/C0ASQJB2AUE/p1784639300299749

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6N9S4Nn64B4QVUsYX9d1D)_