### PR TITLE
ci: skip unit tests for docs-only and markdown-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,38 @@ permissions:
   contents: read
 
 jobs:
+  # Detect whether a PR touches anything beyond docs. `code` is 'true' when any
+  # changed file is NOT under apps/docs/ and NOT a .md/.mdx file. Dependency-free
+  # (no marketplace actions). Non-PR events (e.g. push to main) always set true.
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - id: filter
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+          code=false
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              apps/docs/*) ;;
+              *.md) ;;
+              *.mdx) ;;
+              *) code=true ;;
+            esac
+          done < <(git diff --name-only "$base" "$head")
+          echo "code=$code" >> "$GITHUB_OUTPUT"
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -189,6 +221,8 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
@@ -231,6 +265,8 @@ jobs:
   coverage:
     name: Coverage (apps/api)
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
@@ -268,7 +304,7 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, build, docs-build, test, coverage]
+    needs: [changes, lint, typecheck, build, docs-build, test, coverage]
     # always() so it still runs when a core job fails.
     if: ${{ always() }}
     permissions:
@@ -296,12 +332,16 @@ jobs:
             const path = require("path");
             const marker = "<!-- tulipfarm-ci-report -->";
 
+            // Fourth tuple field `allowSkip`: when true, a `skipped` result
+            // counts as passing (the Test job is gated off for docs/markdown-only
+            // PRs via the `changes` job). Lint/typecheck/build/docs-build stay
+            // strictly required.
             const coreChecks = [
-              ["Lint", "lint", process.env.LINT_RESULT],
-              ["Typecheck", "typecheck", process.env.TYPECHECK_RESULT],
-              ["Build", "build", process.env.BUILD_RESULT],
-              ["Docs build", "docs-build", process.env.DOCS_BUILD_RESULT],
-              ["Test", "test", process.env.TEST_RESULT],
+              ["Lint", "lint", process.env.LINT_RESULT, false],
+              ["Typecheck", "typecheck", process.env.TYPECHECK_RESULT, false],
+              ["Build", "build", process.env.BUILD_RESULT, false],
+              ["Docs build", "docs-build", process.env.DOCS_BUILD_RESULT, false],
+              ["Test", "test", process.env.TEST_RESULT, true],
             ];
             const icon = (r) =>
               r === "success" ? "✅ pass"
@@ -372,7 +412,9 @@ jobs:
               }
             }
 
-            const failed = coreChecks.filter(([, , r]) => r !== "success");
+            const failed = coreChecks.filter(
+              ([, , r, allowSkip]) => r !== "success" && !(allowSkip && r === "skipped")
+            );
             if (failed.length) {
               core.setFailed(
                 `Required checks not passing: ${failed.map(([l, , r]) => `${l}=${r}`).join(", ")}`


### PR DESCRIPTION
## What & why

Previously, CI ran the Vitest `Test` job and the `Coverage (apps/api)` job on **every** PR, with no path-based gating. Documentation-only and markdown-only changes paid the full cost of the test suite even though they cannot affect test outcomes.

This PR gates those jobs so they are skipped when a PR changes **only** `apps/docs/**` files and/or markdown files (`.md` / `.mdx`).

> Note: this repo has **no e2e tests**, so "unit and e2e tests" reduces to the Vitest `Test` job plus the non-blocking `Coverage (apps/api)` job in `.github/workflows/ci.yml`.

## How

- **New `changes` job** at the top of the jobs list. It computes an output `code = 'true'` when any changed file is NOT under `apps/docs/` and NOT a `.md`/`.mdx` file. It is dependency-free (plain shell `git diff --name-only` against the PR base/head SHAs — no new marketplace actions, per the repo's "no new deps" convention). Non-PR events (e.g. push to `main`) always set `code=true`, so tests always run there.
- **`test` and `coverage`** now `needs: changes` and gate on `if: ${{ needs.changes.outputs.code == 'true' }}`.
- **`ci-success` gate** updated so a `skipped` result for the `Test` check counts as passing (via a per-check `allowSkip` flag), while still failing on `failure`/`cancelled`. Lint, typecheck, build, and docs-build remain strictly required. The gate still runs on `if: ${{ always() }}` so it reports even when tests are skipped. The `changes` job was added to its `needs` for a valid dependency graph but does not itself gate merge.

## Unchanged

- **Lint, typecheck, build, and docs-build still run on every PR** — only the test/coverage jobs are gated.

## Behavior

- Docs/markdown-only PR → `Test`/`Coverage` skipped → `CI Success` green.
- Any code change → `Test` runs and gates as before.
- Push to `main` → `code=true` → tests run.

Slack thread: https://tulipfarm.slack.com/archives/C0ASQJB2AUE/p1784639470026129?thread_ts=1784639300.299749&cid=C0ASQJB2AUE

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AK73JJS848iUSMtYRLknJ5

---
_Generated by [Claude Code](https://claude.ai/code/session_01AK73JJS848iUSMtYRLknJ5)_