### PR TITLE
fix(knowledge): make reindex replacement atomic

### DIFF
--- a/apps/api/src/db.ts
+++ b/apps/api/src/db.ts
@@ -10,6 +10,48 @@ export interface Queryable {
   query(text: string, params?: unknown[]): Promise<{ rows: Record<string, unknown>[] }>;
 }
 
+interface TransactionalQueryable extends Queryable {
+  transaction<T>(callback: (tx: Queryable) => Promise<T>): Promise<T>;
+}
+
+interface ReleasableQueryable extends Queryable {
+  release(): void;
+}
+
+interface ConnectableQueryable extends Queryable {
+  connect(): Promise<ReleasableQueryable>;
+}
+
+function hasTransaction(q: Queryable): q is TransactionalQueryable {
+  return typeof (q as { transaction?: unknown }).transaction === "function";
+}
+
+function hasConnect(q: Queryable): q is ConnectableQueryable {
+  return typeof (q as { connect?: unknown }).connect === "function";
+}
+
+/** Run work on one transaction for both PGlite tests and the production pg Pool. */
+export async function withTransaction<T>(
+  q: Queryable,
+  callback: (tx: Queryable) => Promise<T>
+): Promise<T> {
+  if (hasTransaction(q)) return q.transaction(callback);
+  if (!hasConnect(q)) throw new Error("Queryable does not support transactions");
+
+  const client = await q.connect();
+  try {
+    await client.query("BEGIN");
+    const result = await callback(client);
+    await client.query("COMMIT");
+    return result;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
 export async function connectPg(): Promise<Pool> {
   pool = new Pool({ connectionString: process.env.DATABASE_URL as string });
   // Force a connection now so boot fails loud if Postgres is unreachable.

--- a/apps/api/src/knowledge/chunks-repo.pg.test.ts
+++ b/apps/api/src/knowledge/chunks-repo.pg.test.ts
@@ -1,11 +1,13 @@
 import { createHash, randomUUID } from "node:crypto";
 import type { PGlite } from "@electric-sql/pglite";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Queryable } from "../db";
 import { runPgMigrations } from "../pg-migrate";
 import { makePglite } from "../test/pglite";
 import { PgKnowledgeChunkRepo } from "./chunks-repo";
+import { indexPage } from "./index-service";
 import { PgKnowledgePageRepo } from "./repo";
-import type { ChunkInput, KnowledgePage } from "./types";
+import type { ChunkInput, EmbeddingPort, KnowledgePage } from "./types";
 
 function page(over: Partial<KnowledgePage> = {}): KnowledgePage {
   const now = new Date();
@@ -40,6 +42,46 @@ function chunk(over: Partial<ChunkInput> = {}): ChunkInput {
   };
 }
 
+function unavailableEmbeddings(): EmbeddingPort {
+  return {
+    isAvailable: () => false,
+    embedMany: async () => ({ embeddings: [], dimension: 0 }),
+    getActive: () => null,
+    getDimension: () => null,
+    consumePendingReindex: () => false,
+  };
+}
+
+class FailSecondChunkInsert implements Queryable {
+  private insertCount = 0;
+
+  constructor(private readonly db: PGlite) {}
+
+  query(text: string, params?: unknown[]): Promise<{ rows: Record<string, unknown>[] }> {
+    return this.queryWith(this.db, text, params);
+  }
+
+  transaction<T>(callback: (tx: Queryable) => Promise<T>): Promise<T> {
+    return this.db.transaction((tx) =>
+      callback({
+        query: (text, params) => this.queryWith(tx, text, params),
+      })
+    );
+  }
+
+  private queryWith(
+    q: Queryable,
+    text: string,
+    params?: unknown[]
+  ): Promise<{ rows: Record<string, unknown>[] }> {
+    if (text.includes("INSERT INTO knowledge_chunks")) {
+      this.insertCount += 1;
+      if (this.insertCount === 2) throw new Error("injected chunk insert failure");
+    }
+    return q.query(text, params);
+  }
+}
+
 describe("PgKnowledgeChunkRepo", () => {
   let db: PGlite;
   let chunks: PgKnowledgeChunkRepo;
@@ -68,6 +110,23 @@ describe("PgKnowledgeChunkRepo", () => {
     await chunks.deleteByPage(p._id);
     const after = await db.query("SELECT count(*)::int AS n FROM knowledge_chunks");
     expect((after.rows[0] as { n: number }).n).toBe(0);
+  });
+
+  it("keeps the previous complete index when replacement insertion fails", async () => {
+    const p = page({ content: "x".repeat(1_000), plainText: "x".repeat(1_000) });
+    await pages.insert(p);
+    await chunks.insertMany(p._id, [chunk({ content: "old index" })]);
+
+    const failingChunks = new PgKnowledgeChunkRepo(new FailSecondChunkInsert(db));
+    await expect(indexPage(p, failingChunks, unavailableEmbeddings())).rejects.toThrow(
+      "injected chunk insert failure"
+    );
+
+    const { rows } = await db.query(
+      "SELECT content FROM knowledge_chunks WHERE page_id = $1 ORDER BY chunk_index",
+      [p._id]
+    );
+    expect(rows.map((row) => (row as { content: string }).content)).toEqual(["old index"]);
   });
 
   it("ranks vector search by cosine similarity and filters by dim + active page", async () => {

--- a/apps/api/src/knowledge/chunks-repo.ts
+++ b/apps/api/src/knowledge/chunks-repo.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import type { Queryable } from "../db";
+import { type Queryable, withTransaction } from "../db";
 import type {
   ChunkInput,
   ExistingChunk,
@@ -66,6 +66,8 @@ function rowToHit(row: Record<string, unknown>, score: number): SearchHit {
 export interface KnowledgeChunkRepo {
   deleteByPage(pageId: string): Promise<void>;
   insertMany(pageId: string, chunks: ChunkInput[]): Promise<void>;
+  /** Atomically replace one page's complete chunk generation. */
+  replaceForPage(pageId: string, chunks: ChunkInput[]): Promise<void>;
   /** Existing chunks (ordered by chunk_index) projected for the re-index content-hash diff. */
   listByPageForDiff(pageId: string): Promise<ExistingChunk[]>;
   /** Cosine exact-scan over chunks whose stored dim matches the active model. */
@@ -95,8 +97,21 @@ export class PgKnowledgeChunkRepo implements KnowledgeChunkRepo {
   }
 
   async insertMany(pageId: string, chunks: ChunkInput[]): Promise<void> {
+    await this.insertManyWith(this.q, pageId, chunks);
+  }
+
+  async replaceForPage(pageId: string, chunks: ChunkInput[]): Promise<void> {
+    await withTransaction(this.q, async (tx) => {
+      // Lock the parent so concurrent reindexes for this page cannot interleave generations.
+      await tx.query("SELECT id FROM knowledge_pages WHERE id = $1 FOR UPDATE", [pageId]);
+      await tx.query("DELETE FROM knowledge_chunks WHERE page_id = $1", [pageId]);
+      await this.insertManyWith(tx, pageId, chunks);
+    });
+  }
+
+  private async insertManyWith(q: Queryable, pageId: string, chunks: ChunkInput[]): Promise<void> {
     for (const chunk of chunks) {
-      await this.q.query(
+      await q.query(
         `INSERT INTO knowledge_chunks
            (id, page_id, chunk_index, content, content_hash, embedding, tsv, model, dim, created_at)
          VALUES ($1, $2, $3, $4, $5, $6::vector, to_tsvector('english', $4), $7, $8, now())`,

--- a/apps/api/src/knowledge/index-service.ts
+++ b/apps/api/src/knowledge/index-service.ts
@@ -32,7 +32,7 @@ export async function indexPage(
 ): Promise<IndexResult> {
   const textChunks = chunkText(page.plainText);
   if (textChunks.length === 0) {
-    await chunksRepo.deleteByPage(page._id);
+    await chunksRepo.replaceForPage(page._id, []);
     return { chunkCount: 0, embedded: false };
   }
 
@@ -86,8 +86,7 @@ export async function indexPage(
     model: vectors[i] !== null ? activeModel : null,
     dim: vectors[i] !== null ? dims[i] : null,
   }));
-  await chunksRepo.deleteByPage(page._id);
-  await chunksRepo.insertMany(page._id, inputs);
+  await chunksRepo.replaceForPage(page._id, inputs);
   return { chunkCount: inputs.length, embedded: vectors.some((v) => v !== null) };
 }
 

--- a/apps/api/src/knowledge/migration.pg.test.ts
+++ b/apps/api/src/knowledge/migration.pg.test.ts
@@ -47,9 +47,9 @@ describe("002_knowledge migration on PGlite", () => {
     await db.close();
   });
 
-  it("bumps schema_version to the latest (25)", async () => {
+  it("bumps schema_version to the latest (26)", async () => {
     const { rows } = await db.query("SELECT version FROM schema_version WHERE id = true");
-    expect(Number((rows[0] as { version: number }).version)).toBe(25);
+    expect(Number((rows[0] as { version: number }).version)).toBe(26);
   });
 
   it("adds knowledge_chunks.content_hash (019)", async () => {
@@ -59,6 +59,15 @@ describe("002_knowledge migration on PGlite", () => {
     expect((col.rows as { column_name: string }[]).map((r) => r.column_name)).toEqual([
       "content_hash",
     ]);
+  });
+
+  it("enforces one chunk per page and chunk index (026)", async () => {
+    const { rows } = await db.query(
+      "SELECT indexdef FROM pg_indexes WHERE indexname = 'knowledge_chunks_page_chunk_idx'"
+    );
+    expect((rows[0] as { indexdef: string }).indexdef).toContain(
+      "UNIQUE INDEX knowledge_chunks_page_chunk_idx"
+    );
   });
 
   it("backfills content_hash with md5(content) for pre-existing chunks (019)", async () => {

--- a/apps/api/src/knowledge/migration.pg.test.ts
+++ b/apps/api/src/knowledge/migration.pg.test.ts
@@ -23,15 +23,16 @@ async function seedChunk(
   db: PGlite,
   pageId: string,
   content: string,
-  embedding: string | null
+  embedding: string | null,
+  chunkIndex = 0
 ): Promise<void> {
   await db.query(
     `INSERT INTO knowledge_chunks (id, page_id, chunk_index, content, embedding, tsv, model, dim, created_at)
-     VALUES ($1, $2, 0, $3, ${embedding === null ? "NULL" : "$4::vector"}, to_tsvector('english', $3),
+     VALUES ($1, $2, $3, $4, ${embedding === null ? "NULL" : "$5::vector"}, to_tsvector('english', $4),
              'm', 3, now())`,
     embedding === null
-      ? [randomUUID(), pageId, content]
-      : [randomUUID(), pageId, content, embedding]
+      ? [randomUUID(), pageId, chunkIndex, content]
+      : [randomUUID(), pageId, chunkIndex, content, embedding]
   );
 }
 
@@ -125,7 +126,7 @@ describe("002_knowledge migration on PGlite", () => {
   it("stores a nullable vector + tsvector and ranks by cosine exact-scan", async () => {
     const pageId = await seedPage(db);
     await seedChunk(db, pageId, "alpha", "[1,0,0]");
-    await seedChunk(db, pageId, "beta", "[0.2,0.9,0]");
+    await seedChunk(db, pageId, "beta", "[0.2,0.9,0]", 1);
 
     const { rows } = await db.query(
       `SELECT content, (embedding <=> $1::vector) AS dist

--- a/apps/api/src/pg-migrate.test.ts
+++ b/apps/api/src/pg-migrate.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { runPgMigrations } from "./pg-migrate";
 import { makePglite } from "./test/pglite";
 
-describe("runPgMigrations — 001_init + 002_knowledge + 003_stream_resume + 004_approvals + 005_conversation_title + 006_message_feedback + 007_conversation_starred + 008_hitl + 009_kv_store + 010_wrapped_deks + 011_okf + 012_okf_crosslinks + 013_drop_bundle_domain + 014_drop_okf_type + 015_title_tsv + 016_doc_type + 017_pg_trgm + 018_terminology_rename + 019_chunk_content_hash + 020_knowledge_connectors + 021_activity_log + 022_obs_event + 023_routines + 024_ingress + 025_admin_singleton on PGlite", () => {
+describe("runPgMigrations — through 026_atomic_knowledge_chunks on PGlite", () => {
   let db: PGlite;
 
   beforeEach(async () => {
@@ -14,10 +14,10 @@ describe("runPgMigrations — 001_init + 002_knowledge + 003_stream_resume + 004
     await db.close();
   });
 
-  it("advances schema_version to the latest (25)", async () => {
+  it("advances schema_version to the latest (26)", async () => {
     await runPgMigrations(db);
     const res = await db.query<{ version: number }>("SELECT version FROM schema_version");
-    expect(res.rows.map((r) => Number(r.version))).toEqual([25]);
+    expect(res.rows.map((r) => Number(r.version))).toEqual([26]);
   });
 
   it("creates the vector and citext extensions", async () => {
@@ -87,11 +87,11 @@ describe("runPgMigrations — 001_init + 002_knowledge + 003_stream_resume + 004
     ]);
   });
 
-  it("is idempotent — a second run does not throw and leaves version at 25", async () => {
+  it("is idempotent — a second run does not throw and leaves version at 26", async () => {
     await runPgMigrations(db);
     await runPgMigrations(db);
     const res = await db.query<{ version: number }>("SELECT version FROM schema_version");
-    expect(res.rows.map((r) => Number(r.version))).toEqual([25]);
+    expect(res.rows.map((r) => Number(r.version))).toEqual([26]);
   });
 
   it("adds knowledge_pages.title_tsv (generated tsvector) + its GIN index (015, renamed by 018)", async () => {

--- a/apps/api/src/pg-migrations/index.ts
+++ b/apps/api/src/pg-migrations/index.ts
@@ -907,4 +907,20 @@ export const PG_MIGRATIONS: PgMigration[] = [
       }
     },
   },
+  {
+    version: 26,
+    description: "knowledge: enforce one chunk per page generation index",
+    up: async (q) => {
+      await q.query(
+        `DELETE FROM knowledge_chunks older
+         USING knowledge_chunks newer
+         WHERE older.page_id = newer.page_id
+           AND older.chunk_index = newer.chunk_index
+           AND (older.created_at, older.id) < (newer.created_at, newer.id)`
+      );
+      await q.query(
+        "CREATE UNIQUE INDEX IF NOT EXISTS knowledge_chunks_page_chunk_idx ON knowledge_chunks (page_id, chunk_index)"
+      );
+    },
+  },
 ];


### PR DESCRIPTION
## Summary

- replace each page chunk generation inside one database transaction
- lock the page row to serialize concurrent reindexes and keep old chunks visible until commit
- enforce unique page/chunk indexes and cover rollback with a fault-injection regression test

## Verification

- `git diff --check`
- `pnpm --filter @tulipfarm/api test src/knowledge/chunks-repo.pg.test.ts src/knowledge/index-service.pg.test.ts src/pg-migrate.test.ts src/knowledge/migration.pg.test.ts --reporter=dot`
- `pnpm --filter @tulipfarm/api typecheck`
- `pnpm --filter @tulipfarm/api lint` (passes with one pre-existing warning in `src/ingress/identity.test.ts`)

Closes #177