### PR TITLE
fix(integrations): require admin role for integration lifecycle routes

### DIFF
--- a/apps/api/src/soul/integrations/routes.test.ts
+++ b/apps/api/src/soul/integrations/routes.test.ts
@@ -94,7 +94,7 @@ describe("POST /api/v1/integrations/:name/connect", () => {
     store = new MemorySessionStore();
     const userRepo = new FakeUserRepo();
     const tokenRepo = new FakeTokenRepo();
-    const user = await createUser(userRepo, "user@example.com", "pass", "member");
+    const user = await createUser(userRepo, "user@example.com", "pass", "admin");
     sid = await store.create(user._id);
 
     soulPath = await mkdtemp(join(tmpdir(), "soul-integrations-"));
@@ -158,6 +158,120 @@ describe("POST /api/v1/integrations/:name/connect", () => {
     expect(res.statusCode).toBe(200);
     const connection = mcpConnect.mock.calls[0][2];
     expect(connection.env).toEqual({ TOKEN: "existing-secret", NAME: "bar" });
+  });
+});
+
+describe("integration lifecycle routes are admin only", () => {
+  let app: FastifyInstance;
+  let store: MemorySessionStore;
+  let sid: string;
+
+  const auth = () => ({ [SESSION_COOKIE]: sid, [CSRF_COOKIE]: TEST_CSRF });
+  const headers = { [CSRF_HEADER]: TEST_CSRF };
+
+  beforeEach(async () => {
+    store = new MemorySessionStore();
+    const userRepo = new FakeUserRepo();
+    const tokenRepo = new FakeTokenRepo();
+    const user = await createUser(userRepo, "member@example.com", "pass", "member");
+    sid = await store.create(user._id);
+
+    const soulPath = await mkdtemp(join(tmpdir(), "soul-integrations-"));
+    const gitSync = {
+      path: soulPath,
+      withSync: vi.fn().mockResolvedValue({ sha: "abc1234", filesChanged: 1 }),
+    } as unknown as GitSyncService;
+
+    const soulLoader = {
+      integrations: new Map([
+        ["demo-integration", makeIntegration({ TOKEN: "existing-secret", NAME: "foo" })],
+      ]),
+      reload: vi.fn().mockResolvedValue(undefined),
+    } as unknown as SoulLoader;
+
+    const mcpClient = {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      getStatus: vi.fn().mockReturnValue("connected"),
+      getToolNames: vi.fn().mockReturnValue([]),
+    } as unknown as McpClientService;
+
+    app = await buildApp({
+      sessionStore: store,
+      userRepo,
+      tokenRepo,
+      gitSync,
+      soulLoader,
+      mcpClient,
+    });
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it("rejects scan from a member with 403", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/integrations/scan",
+      cookies: auth(),
+      headers,
+      payload: { source: "tulipfarm/integrations" },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("rejects install from a member with 403", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/integrations/install",
+      cookies: auth(),
+      headers,
+      payload: { scanId: "does-not-matter", names: ["demo-integration"] },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("rejects connect from a member with 403", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/integrations/demo-integration/connect",
+      cookies: auth(),
+      headers,
+      payload: {},
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("rejects disconnect from a member with 403", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/integrations/demo-integration/disconnect",
+      cookies: auth(),
+      headers,
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("rejects oauth start from a member with 403", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/integrations/demo-integration/oauth/start",
+      cookies: auth(),
+      headers,
+      payload: { env: {} },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("rejects delete from a member with 403", async () => {
+    const res = await app.inject({
+      method: "DELETE",
+      url: "/api/v1/integrations/demo-integration",
+      cookies: auth(),
+      headers,
+    });
+    expect(res.statusCode).toBe(403);
   });
 });
 

--- a/apps/api/src/soul/integrations/routes.ts
+++ b/apps/api/src/soul/integrations/routes.ts
@@ -9,6 +9,7 @@ import type { GitSyncService, IntegrationManifest, OAuthConfig, SoulLoader } fro
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { parse as parseYaml, stringify as toYaml } from "yaml";
 import { ErrorSchema } from "../../auth/schemas";
+import type { UserDoc } from "../../auth/users";
 import { analyzeHook } from "../../hooks/hook-analyzer";
 import {
   type ConnectionSecretStore,
@@ -521,7 +522,7 @@ export function registerIntegrationRoutes(
       preHandler: limitedAuth,
       schema: {
         description:
-          "Clone a git repo (source accepts an optional #branch suffix) and discover installable MCP integration manifests.",
+          "Clone a git repo (source accepts an optional #branch suffix) and discover installable MCP integration manifests (admin only).",
         tags: ["integrations"],
         security: [{ sessionCookie: [] }, { bearerToken: [] }],
         body: {
@@ -554,10 +555,14 @@ export function registerIntegrationRoutes(
           },
           400: ErrorSchema,
           401: ErrorSchema,
+          403: ErrorSchema,
         },
       },
     },
     async (req, reply) => {
+      const actor = req.user as UserDoc;
+      if (actor.role !== "admin") return reply.code(403).send({ error: "forbidden" });
+
       const { source } = req.body as { source: string };
       if (!isAllowedSource(source)) {
         return reply.code(400).send({
@@ -607,7 +612,7 @@ export function registerIntegrationRoutes(
     {
       preHandler: limitedAuth,
       schema: {
-        description: "Install the named integrations from a scan into the soul repo.",
+        description: "Install the named integrations from a scan into the soul repo (admin only).",
         tags: ["integrations"],
         security: [{ sessionCookie: [] }, { bearerToken: [] }],
         body: {
@@ -633,6 +638,7 @@ export function registerIntegrationRoutes(
           },
           400: ErrorSchema,
           401: ErrorSchema,
+          403: ErrorSchema,
           404: ErrorSchema,
           422: {
             type: "object",
@@ -646,6 +652,9 @@ export function registerIntegrationRoutes(
       },
     },
     async (req, reply) => {
+      const actor = req.user as UserDoc;
+      if (actor.role !== "admin") return reply.code(403).send({ error: "forbidden" });
+
       const { scanId, names, acceptRisk } = req.body as {
         scanId: string;
         names: string[];
@@ -757,7 +766,7 @@ export function registerIntegrationRoutes(
       preHandler: limitedAuth,
       schema: {
         description:
-          "Connect an installed integration: write connection config and start the MCP server.",
+          "Connect an installed integration: write connection config and start the MCP server (admin only).",
         tags: ["integrations"],
         security: [{ sessionCookie: [] }, { bearerToken: [] }],
         params: { type: "object", required: ["name"], properties: { name: { type: "string" } } },
@@ -779,12 +788,16 @@ export function registerIntegrationRoutes(
           },
           400: ErrorSchema,
           401: ErrorSchema,
+          403: ErrorSchema,
           404: ErrorSchema,
           502: ErrorSchema,
         },
       },
     },
     async (req, reply) => {
+      const actor = req.user as UserDoc;
+      if (actor.role !== "admin") return reply.code(403).send({ error: "forbidden" });
+
       const { name } = req.params as { name: string };
       if (!NAME_RE.test(name) || !soulLoader.integrations.has(name)) {
         return reply.code(404).send({ error: `integration not found: ${name}` });
@@ -825,18 +838,23 @@ export function registerIntegrationRoutes(
     {
       preHandler: limitedAuth,
       schema: {
-        description: "Disconnect an integration: stop the MCP server and mark as disabled.",
+        description:
+          "Disconnect an integration: stop the MCP server and mark as disabled (admin only).",
         tags: ["integrations"],
         security: [{ sessionCookie: [] }, { bearerToken: [] }],
         params: { type: "object", required: ["name"], properties: { name: { type: "string" } } },
         response: {
           200: { type: "object", required: ["status"], properties: { status: { type: "string" } } },
           401: ErrorSchema,
+          403: ErrorSchema,
           404: ErrorSchema,
         },
       },
     },
     async (req, reply) => {
+      const actor = req.user as UserDoc;
+      if (actor.role !== "admin") return reply.code(403).send({ error: "forbidden" });
+
       const { name } = req.params as { name: string };
       if (!NAME_RE.test(name) || !soulLoader.integrations.has(name)) {
         return reply.code(404).send({ error: `integration not found: ${name}` });
@@ -867,7 +885,7 @@ export function registerIntegrationRoutes(
       preHandler: limitedAuth,
       schema: {
         description:
-          "Begin OAuth authorization flow. Returns an authUrl to open in a new tab. The user's client_id and other env values must be supplied so the redirect can be pre-filled on callback.",
+          "Begin OAuth authorization flow (admin only). Returns an authUrl to open in a new tab. The user's client_id and other env values must be supplied so the redirect can be pre-filled on callback.",
         tags: ["integrations"],
         security: [{ sessionCookie: [] }, { bearerToken: [] }],
         params: { type: "object", required: ["name"], properties: { name: { type: "string" } } },
@@ -887,11 +905,15 @@ export function registerIntegrationRoutes(
           },
           400: ErrorSchema,
           401: ErrorSchema,
+          403: ErrorSchema,
           404: ErrorSchema,
         },
       },
     },
     async (req, reply) => {
+      const actor = req.user as UserDoc;
+      if (actor.role !== "admin") return reply.code(403).send({ error: "forbidden" });
+
       const { name } = req.params as { name: string };
       const integration = soulLoader.integrations.get(name);
       if (!integration) return reply.code(404).send({ error: `integration not found: ${name}` });
@@ -1071,18 +1093,23 @@ export function registerIntegrationRoutes(
     {
       preHandler: limitedAuth,
       schema: {
-        description: "Remove an integration from the soul repo (disconnects first if connected).",
+        description:
+          "Remove an integration from the soul repo (disconnects first if connected; admin only).",
         tags: ["integrations"],
         security: [{ sessionCookie: [] }, { bearerToken: [] }],
         params: { type: "object", required: ["name"], properties: { name: { type: "string" } } },
         response: {
           204: { type: "null" },
           401: ErrorSchema,
+          403: ErrorSchema,
           404: ErrorSchema,
         },
       },
     },
     async (req, reply) => {
+      const actor = req.user as UserDoc;
+      if (actor.role !== "admin") return reply.code(403).send({ error: "forbidden" });
+
       const { name } = req.params as { name: string };
       if (!NAME_RE.test(name) || !soulLoader.integrations.has(name)) {
         return reply.code(404).send({ error: `integration not found: ${name}` });


### PR DESCRIPTION
## Summary
- Integration scan, install, connect, disconnect, OAuth-start, and delete routes previously required only generic authentication (`requireAuth`), with no role check.
- A connected MCP integration can run an arbitrary stdio command supplied by the installed manifest (`McpClientService` → `StdioClientTransport`), so any authenticated **member** could scan a repo they control, install it, and connect it to escalate to arbitrary code execution as the API process.
- Gate the six mutating integration lifecycle routes behind `req.user.role === "admin"`, matching the existing admin-only pattern already used elsewhere in the codebase (e.g. `apps/api/src/secrets/routes.ts`, `apps/api/src/soul/llm-config/routes.ts`): a 403 `{ error: "forbidden" }` for non-admins, plus `403: ErrorSchema` added to each route's OpenAPI response schema and "(admin only)" noted in each route description.
- Read-only routes (`GET /api/v1/integrations`, `/marketplace`, `/:name`) and the unauthenticated OAuth callback (state-token protected, not session-based) are left unchanged — this PR scopes to the mutating lifecycle operations called out in the issue's evidence and recommended remediation.

This addresses the core authorization gap in #173 (item 1 of its acceptance criteria: "A member receives 403 from every integration lifecycle endpoint..."). The issue's other acceptance criteria — content-hash-bound admin authorization for stdio manifests, and a minimal/allowlisted environment for the spawned MCP subprocess instead of `process.env` — are larger structural changes not addressed here and would be good follow-up work.

## Verification
- Added a new `describe("integration lifecycle routes are admin only", ...)` block in `apps/api/src/soul/integrations/routes.test.ts` asserting a `member`-role user gets `403` from scan, install, connect, disconnect, oauth/start, and delete.
- Updated the existing connect-flow tests (which previously used a `member` user and asserted `200`) to use an `admin` user, since they test env-merge behavior unrelated to authorization.
- `pnpm exec vitest run src/soul/integrations/routes.test.ts` (scoped to `apps/api`): 10/10 passed.
- `pnpm exec biome check` on the two changed files: clean.
- `pnpm --filter @tulipfarm/api typecheck`: clean.
- `git diff --check`: clean.

Closes #173