### PR TITLE
docs(architecture): freeze architecture boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,13 +56,20 @@ Single workspace: `pnpm --filter @tulipfarm/api <script>`.
 
 ## Before marking work done
 
-Run all three — CI runs the same and blocks merge:
+For changes that affect code or build inputs, run all three — CI runs the same and blocks merge:
 
 ```bash
 pnpm lint && pnpm typecheck && pnpm test
 ```
 
 Tests use **Vitest** (`*.test.ts` colocated with source). `pnpm test` passes with no tests (`--passWithNoTests`).
+
+### Documentation-only changes
+
+When the diff contains only documentation, do not run `pnpm lint`, `pnpm typecheck`, `pnpm test`,
+or `pnpm build`. Run only targeted documentation checks needed for the changed files, such as link,
+formatting, example, or task-specific contract checks. Explicit task instructions override this
+exception.
 
 ## Lint / format — Biome (read this to avoid churn)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ ENV CI=true
 # `prepare` lifecycle script runs `lefthook install`, which shells out to git.
 RUN apt-get update && apt-get install -y --no-install-recommends python3 make g++ git \
   && rm -rf /var/lib/apt/lists/*
-RUN corepack enable
+# Node 24-slim no longer bundles corepack by default; install it explicitly.
+RUN npm install -g corepack@latest && corepack enable
 COPY . .
 # The root `prepare` lifecycle script runs `lefthook install`, which shells out to
 # git and needs a repo — but `.git` is dockerignored. A throwaway repo (builder stage

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV CI=true
 # `prepare` lifecycle script runs `lefthook install`, which shells out to git.
 RUN apt-get update && apt-get install -y --no-install-recommends python3 make g++ git \
   && rm -rf /var/lib/apt/lists/*
-# Node 24-slim no longer bundles corepack by default; install it explicitly.
+# node:*-slim no longer bundles corepack by default; install it explicitly.
 RUN npm install -g corepack@latest && corepack enable
 COPY . .
 # The root `prepare` lifecycle script runs `lefthook install`, which shells out to

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -38,7 +38,7 @@
     "@electric-sql/pglite": "^0.5.3",
     "@electric-sql/pglite-pgvector": "^0.0.4",
     "@tulipfarm/tsconfig": "workspace:*",
-    "@types/node": "^24.13.2",
+    "@types/node": "^26.1.1",
     "@types/pg": "^8.20.0",
     "@vitest/coverage-v8": "^4.1.9",
     "esbuild": "^0.28.1",

--- a/apps/api/src/hooks/hook-executor.ts
+++ b/apps/api/src/hooks/hook-executor.ts
@@ -48,9 +48,10 @@ export class HookExecutor {
 
     // Wrap raw worker errors as HookError so callers can handle them uniformly.
     // Also record the error so future send() calls reject immediately instead of hanging.
-    this.worker.on("error", (err) => {
-      this.workerError = err;
-      const hookErr = new HookError(`hook worker error: ${err.message}`);
+    this.worker.on("error", (err: unknown) => {
+      const error = err instanceof Error ? err : new Error(String(err));
+      this.workerError = error;
+      const hookErr = new HookError(`hook worker error: ${error.message}`);
       for (const [id, p] of this.pending) {
         p.reject(hookErr);
         this.pending.delete(id);

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -26,7 +26,7 @@
     "@tailwindcss/postcss": "^4.3.1",
     "@tulipfarm/tsconfig": "workspace:*",
     "@types/mdx": "^2.0.14",
-    "@types/node": "^24.13.2",
+    "@types/node": "^26.1.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "postcss": "^8.5.15",

--- a/docs/architecture/boundaries.md
+++ b/docs/architecture/boundaries.md
@@ -1,0 +1,182 @@
+# TulipFarm architecture boundaries
+
+Status: Accepted architecture contract
+Scope: AW-001 architecture guardrails
+Authority: `metadata/terminologies.md`, then the approved architecture SPEC
+
+This document freezes ownership and enforcement boundaries for TulipFarm. Later tasks may
+choose libraries and adapters behind these boundaries, but may not add a second authority path or
+weaken an invariant without a reviewed architecture decision.
+
+## Product boundary
+
+- One deployment represents one business, while every persisted object carries `business_id`.
+- Tulip-owned runtime code is TypeScript in this pnpm monorepo.
+- PostgreSQL is the correctness core. Queues, caches, vector stores, and model providers are
+  replaceable optimizations or adapters.
+- Browser, HTTP, webhook, and internal Integration surfaces are in scope. A public customer CLI,
+  general SDK, native app, and desktop app are out of scope for v1.
+- Chat is the external/wire term; Conversation is the internal/persistence term. The turn route is
+  `/api/v1/chats/:id/turns`.
+- Integration is the canonical third-party term. The architecture uses `packages/integrations` and
+  `apps/integration-worker`; an installed external link is an Integration installation.
+- Hermes is a read-only behavioral reference. TulipFarm neither forks, embeds, imports, nor keeps
+  runtime compatibility with Hermes.
+
+## Trust and process boundary
+
+```text
+Browser / external systems
+          |
+          v
+       apps/api <------> apps/web
+          |
+          +---- authz / policy / Soul / audit commands
+          +---- PostgreSQL transaction + outbox
+          |
+          v
+      apps/worker ----> Run kernel / Agent runtime / Tool Broker
+          |                                |
+          |                                +--> Secret Broker
+          |                                +--> model adapters
+          |                                +--> isolated sandbox service
+          v
+ apps/integration-worker ----> external Integration adapters
+```
+
+`apps/api` authenticates requests and submits commands; it does not execute long-running Agent or
+Tool work. Workers claim durable work and persist every transition before acknowledging it.
+Untrusted scripts and third-party Integration implementations execute outside the control-plane
+process and communicate through authenticated, versioned protocols.
+
+## Accountable owners
+
+Each cross-cutting concern has exactly one accountable package. Collaborators consume its public
+contract; they do not reimplement its decisions.
+
+| Concern | Accountable owner | Public responsibility |
+| --- | --- | --- |
+| Schemas and canonicalization | `packages/schema` | Versioned JSON Schemas, AJV validators, migrations, canonical values |
+| Soul authorship and publication | `packages/soul` | Changesets, Git adapter, validation pipeline, immutable published bundles |
+| Identity and authorization | `packages/authz` | Principals, roles, grants, authority intersection, policy evidence |
+| Audit and lineage | `packages/audit` | Audit events, hash chains, sealing, retention, cryptographic erasure evidence, export, lineage queries |
+| Credentials and secret resolution | `packages/secrets` | Envelope crypto, Secret Broker, leases, rotation, revocation |
+| Durable orchestration | `packages/run-kernel` | Run and StepRun states, attempts, waits, leases, retries, child Runs |
+| Tool effects and approvals | `packages/tool-broker` | Catalog and intent/effect orchestration that consumes authorization decisions, credential leases, audit appends, exact approvals, and reconciliation |
+| Agent and model behavior | `packages/agent-runtime` | Context assembly, model profiles, bounded Tool loop, budgets, delegation |
+| Knowledge authorization | `packages/knowledge` | Source ACL ingestion, retrieval, provenance, invalidation, deletion |
+| Durable Memory | `packages/memory` | Scoped assertions, confirmation, provenance, supersession, expiry |
+| A2UI and forms | `packages/a2ui` | Safe presentation schemas, Artifacts, signed actions, form contracts |
+| Integrations | `packages/integrations` | Adapter contracts, event normalization, delivery, identity mapping, checkpoints |
+| Isolated execution | `packages/sandbox` | Execution request, backend ports, workspace, egress and resource controls |
+| Persistence and infrastructure ports | `packages/storage` | PostgreSQL repositories, transactions, outbox/inbox, blob/vector/cache ports |
+| Telemetry and redaction | `packages/observability` | OTel conventions, health, metrics, correlation, log redaction |
+
+The Tool Broker consumes policy and DLP decisions from `packages/authz`, credential leases from
+`packages/secrets`, and append contracts from `packages/audit`. Its contract prohibits reimplementing
+or broadening those owners' decisions.
+
+Application ownership is composition-only:
+
+| Application | Responsibility |
+| --- | --- |
+| `apps/api` | HTTP/SSE, sessions, request auth, commands, webhooks, approvals, read models |
+| `apps/worker` | Run dispatch, Agent/Tool steps, timers, reconciliation, projections |
+| `apps/integration-worker` | Integration ingress, sync, delivery, rate limits, reconciliation |
+| `apps/web` | Responsive browser product over authorized APIs |
+
+## Release-blocking invariant map
+
+The accountable owner defines the public contract and evidence shape. Required collaborators may
+add stricter checks but cannot bypass or broaden the owner's decision.
+
+| ID | Invariant | Accountable owner | Enforceable boundary and evidence |
+| --- | --- | --- | --- |
+| I-01 | One business; persisted objects carry `business_id` | `packages/storage` | Repository inputs require `business_id`; DB constraints and audit correlation prove scope |
+| I-02 | Every external principal resolves before execution | `packages/authz` | Identity resolution returns a Tulip principal or constrained guest; unresolved input denies |
+| I-03 | Effective authority is an intersection and never amplifies | `packages/authz` | One decision API intersects user, Agent, Run context, resource, destination, and credential scope |
+| I-04 | Skills instruct but never grant Tools | `packages/authz` | Tool exposure and every Tool intent require independent grants; Skill metadata is not authority |
+| I-05 | Every authored write uses one Soul changeset gateway | `packages/soul` | No public Git/file write API; every proposal records validation, policy, approval, and audit IDs |
+| I-06 | Runtime uses an immutable published digest without live Git | `packages/soul` | Bundle activation is content-addressed; Runs pin a digest; publication failure keeps prior active |
+| I-07 | Every Chat turn and automation is a durable Run | `packages/run-kernel` | Public commands persist Run/StepRun plus outbox before dispatch; no in-process-only execution path |
+| I-08 | Step outputs are immutable typed values | `packages/run-kernel` | AJV-valid Artifact references are append-only; later inputs name prior outputs explicitly |
+| I-09 | Every side effect is idempotent and durably recorded | `packages/tool-broker` | Stable effect identity is persisted before dispatch; ambiguous results reconcile instead of retry |
+| I-10 | Secrets remain opaque until authorized Tool dispatch | `packages/secrets` | Secret Broker leases current credentials after authorization; plaintext never enters Soul/prompts |
+| I-11 | Knowledge authorization precedes ranking and return | `packages/knowledge` | ACL filter/live check runs before candidates; stale, revoked, or unverifiable access denies |
+| I-12 | Untrusted content cannot become authority | `packages/authz` | Data/instruction classification and policy deny permission, credential, and approval amplification |
+| I-13 | Approval binds exact intent and policy revision | `packages/tool-broker` | Digest, evidence, approver rules, expiry, and one-use decision revalidate immediately pre-dispatch |
+| I-14 | Published definitions and evidence are immutable versions | `packages/storage` | Versioned/append-only repository APIs reject update/delete of protected rows and digests |
+| I-15 | Audit evidence is append-only, hash-linked, separately sealed, and supports cryptographic erasure | `packages/audit` | Append API links prior hash; verifier and sealed segment detect removal, reorder, or mutation; authorized key destruction erases protected payloads while retaining tombstone and chain-integrity evidence, and legal holds block erasure |
+| I-16 | Optional infrastructure is never required for correctness | `packages/storage` | Provider ports declare capabilities; PostgreSQL fallback remains authoritative under adapter loss |
+
+## Durable failure contract
+
+Every owning boundary must cover these cases in contract or state-machine tests when implemented:
+
+| Case | Required outcome |
+| --- | --- |
+| Empty, malformed, version-mismatched input | Stable typed denial; no durable partial state |
+| Duplicate or replay | Existing logical result; no duplicate Run or effect |
+| Concurrent update or claim | DB uniqueness/CAS/lease chooses one winner; loser safely retries or denies |
+| Crash before dispatch | Persisted work is reclaimable; no external effect occurred |
+| Crash or timeout after possible dispatch | Effect becomes ambiguous/reconciliation-required; never blind retry |
+| Restart or deploy | Worker reconstructs authority and progress only from durable records/bundle digest |
+| Revocation during a Run | Next protected action reauthorizes and denies; in-flight effects reconcile |
+| Optional provider loss | Degrade, wait, or fail explicitly without losing authoritative state |
+
+## Errors, audit, and observability
+
+- Boundary errors use a versioned envelope: stable code, safe message, correlation ID,
+  retryability, and optional field issues. Stack traces and provider payloads stay internal.
+- Structured logs carry request, event, Run, StepRun, effect, Integration, and audit correlation
+  IDs. They never contain secret plaintext, protected Artifact contents, prompts, or raw webhook
+  bodies.
+- Audit evidence records actor/effective principal, action, resource, allow/deny reason, relevant
+  policy and bundle digests, request/result hashes, causation, and safe metadata.
+- Audit evidence is not replaced by logs or traces. Sensitive content is referenced through an
+  authorized Artifact rather than copied into telemetry.
+- Failure to emit optional telemetry cannot alter correctness. Failure to persist required audit
+  evidence follows policy and stops high-risk work when its durability threshold is exceeded.
+
+## V1 reuse and replacement map
+
+Reuse means behavior or a primitive is adapted only after target contract tests pass. It never means
+the current API or trust boundary is preserved.
+
+| Current source | Decision | Target boundary and rationale |
+| --- | --- | --- |
+| Root pnpm workspace and Turbo config | Reuse | Preserve TypeScript monorepo mechanics; add target apps/packages behind frozen rules |
+| `packages/schema/src/routine.ts` | Adapt primitives; replace contract | Keep TypeBox/AJV techniques; replace v1 Routine shape and deferred semantics in `packages/schema` |
+| `packages/soul/src/git-sync.ts` | Adapt | Reuse tested Git mechanics behind the sole `packages/soul` changeset/publication boundary |
+| `packages/soul/src/soul-loader.ts` | Replace boundary | Fail-open loading cannot be publication authority; runtime consumes an active immutable digest |
+| `packages/routine-engine` | Adapt concepts; replace engine | Keep useful outcomes/snapshots; move to durable `packages/run-kernel` with immutable outputs |
+| `apps/api/src/routines/driver.ts` | Adapt patterns | Preserve CAS, persist-first, journal, wake, timeout, and approval ideas in `packages/run-kernel` |
+| `apps/api/src/routines/repo.ts` | Replace | Mutable context/status model becomes Runs, StepRuns, attempts, waits, and effects |
+| `apps/api/src/chat/turn.ts` | Adapt ergonomics; replace execution | Keep streaming, Skills, models, and compaction behavior inside durable Agent steps |
+| `apps/api/src/tools/registry.ts` | Adapt validation; replace authority | Keep AJV/timeouts; all Tool discovery and calls move through `packages/tool-broker` |
+| `apps/api/src/chat/approvals.ts` | Replace | Process-local pending decisions become durable exact-intent approvals |
+| `apps/api/src/approvals/repo.ts` | Adapt persistence seed | Add digest binding, expiry, policy evidence, one-use decisions, and four-eyes enforcement |
+| `apps/api/src/auth/users.ts` | Replace | Two fixed roles become custom roles and scoped grants in `packages/authz` |
+| `packages/secrets/src/crypto.ts` | Reuse after vectors | Preserve AES-256-GCM primitives behind scoped leases, rotation, and revocation tests |
+| `packages/secrets/src/service.ts` | Adapt | Make it the Secret Broker owner; forbid stale resolution and plaintext propagation |
+| `apps/api/src/a2ui/compiler.ts` | Adapt | Preserve escaping/compiler ideas inside safe `packages/a2ui` Artifact contracts |
+| `apps/api/src/a2ui/surface-store.ts` | Replace boundary | Process/local surfaces become immutable authorized Artifacts and signed actions |
+| `apps/api/src/knowledge/retrieval-service.ts` | Replace authorization seam | `packages/knowledge` enforces source ACLs before ranking/candidate exposure |
+| `apps/api/src/ingress/service.ts` | Replace identity path | Integration events resolve the external principal; never borrow a Conversation owner's identity |
+| `apps/api/src/integrations/mcp-client-service.ts` | Replace enablement path | Discovery creates a pinned Soul proposal; it never registers a Tool directly in process |
+| `packages/llm` | Adapt behind owner | Provider normalization informs `packages/agent-runtime`; ModelProfile/policy owns selection |
+| `DESIGN.md` and existing web components | Reuse selectively | Preserve visual language only over authorized APIs and accessibility contracts |
+
+## Hermes adapt/reject record
+
+Hermes paths are evidence only and remain read-only.
+
+| Hermes source | Adapt | Reject or replace |
+| --- | --- | --- |
+| `README.md` | Model neutrality, interruptible conversations, channel continuity, scheduling and delegation ergonomics | Public CLI/desktop product surface and single-principal trust assumptions |
+| `agent/conversation_loop.py` | Bounded iterative Tool loop, streaming, interruption, provider fallback, malformed-call recovery | Mutable Agent/session state, SQLite as Run durability, plugin hooks as authority, monolithic execution |
+| `gateway/run.py` | Normalized channel events, thread continuity, rate/reconnect handling, user-visible delivery behavior | Process-local Agent caches/queues as records, channel identity as Tulip authority, one daemon as durability |
+| `hermes_cli/plugins.py` | Manifest and discovery ergonomics, explicit registration vocabulary | `importlib` execution of user/project packages in the trusted process and direct dynamic Tool registration |
+
+No Hermes module is a TulipFarm dependency. Useful behavior is re-expressed through typed ports,
+durable Runs, narrowed authorization, isolated execution, and TulipFarm-owned tests.

--- a/docs/architecture/decision-index.md
+++ b/docs/architecture/decision-index.md
@@ -1,0 +1,74 @@
+# TulipFarm architecture decision index
+
+Status: Accepted architecture contract
+Scope: AW-001 decision freeze
+
+This index records architecture decisions authorized by the approved SPEC and the binding repository
+terminology. `metadata/terminologies.md` controls names at every layer; where the SPEC uses a retired
+spelling, only the spelling is corrected here and the approved behavior remains unchanged.
+
+Detailed contracts:
+
+- [Boundaries and owners](boundaries.md)
+- [Dependency rules](dependency-rules.md)
+
+## Accepted decisions
+
+| ID | Decision | Rationale and consequence | Accountable owner |
+| --- | --- | --- | --- |
+| ADR-001 | One deployment represents one business; every persisted object carries `business_id` | Keeps current product scope while making isolation explicit and future-safe | `packages/storage` |
+| ADR-002 | TulipFarm remains a TypeScript pnpm monorepo with modular applications and packages | Preserves current tooling while separating API, durable work, Integrations, and UI | Architecture rules |
+| ADR-003 | PostgreSQL is the correctness core | Transactions, constraints, leases, inbox/outbox, and recovery must work without optional infrastructure | `packages/storage` |
+| ADR-004 | Every Chat turn and automation is one durable Run with durable StepRuns | One state, recovery, policy, and audit model replaces special chat/schedule/webhook engines | `packages/run-kernel` |
+| ADR-005 | Step outputs are immutable typed Artifacts referenced by later inputs | Enables replayable lineage, validation, and safe concurrency; forbids mutable global context | `packages/run-kernel` |
+| ADR-006 | Delivery is at least once with stable effect identities and reconciliation | External exactly-once claims are dishonest; ambiguous dispatch is explicit and never blindly retried | `packages/tool-broker` |
+| ADR-007 | Every authored write uses one Soul changeset and publication gateway | UI, API, Agent, import, migration, MCP, and discovery paths cannot bypass validation/policy/audit | `packages/soul` |
+| ADR-008 | Runs pin immutable published bundles by content digest | Runtime does not need live Git and survives deploys; current security revocations still re-evaluate | `packages/soul` |
+| ADR-009 | Effective authority is an intersection and can only narrow | Users, Agents, Run context, resources, destinations, Tools, and credentials never union authority | `packages/authz` |
+| ADR-010 | Skills contain instructions/assets and never grant Tools | Prevents instruction packages from becoming capability or authorization boundaries | `packages/authz` |
+| ADR-011 | Tool calls use one broker with exact approvals and a durable effect ledger | The broker orchestrates validation, approval, dispatch, and recovery while consuming authorization/DLP decisions, credential leases, and audit appends from their owners | `packages/tool-broker` |
+| ADR-012 | Secrets are opaque references resolved immediately before authorized dispatch | Keeps plaintext out of Soul, prompts, logs, audit, and stale caches | `packages/secrets` |
+| ADR-013 | Knowledge ACLs are enforced before candidate ranking or return | Prevents leakage through candidates, snippets, metadata, summaries, embeddings, and timing | `packages/knowledge` |
+| ADR-014 | Audit is append-only, hash-linked, separately sealed, and supports cryptographic erasure | Missing, reordered, or altered evidence remains detectable; authorized key destruction retains tombstones and chain integrity, subject to legal holds | `packages/audit` |
+| ADR-015 | Provider selections remain behind capability-checked ports | PostgreSQL stays required; cache, vector, queue optimization, blob, KMS, model, and sandbox providers remain replaceable | Port owner |
+| ADR-016 | Untrusted code executes outside the control-plane process | Third-party Integration code and Skill scripts cannot share API/worker memory or implicit credentials | `packages/sandbox` |
+| ADR-017 | Hermes is a read-only behavioral reference, never a dependency or compatibility target | Adapt ergonomics while rejecting process-local durability, implicit authority, and in-process extensions | Architecture rules |
+| ADR-018 | Current behavior is replaced beside existing behavior and cut over by capability | No users require DB compatibility; old routes/workers are removed only after target acceptance proves replacements | Application owners |
+| ADR-019 | V1 ships no public customer CLI, general SDK, native app, or desktop app | Focuses security and product support on responsive browser and approved HTTP/Integration surfaces | `apps/api`, `apps/web` |
+| ADR-020 | Applications compose; packages own domain decisions; packages never import applications | Prevents cycles, hidden ownership, and duplicated business rules | Dependency rules |
+
+## Terminology decisions
+
+These spellings supersede conflicting names in the planning SPEC without changing its behavior.
+
+| ID | Accepted spelling | Replaces | Boundary effect |
+| --- | --- | --- | --- |
+| ADR-021 | Integration | Retired third-party synonyms | Domain, code, DB, REST, UI, and docs use Integration vocabulary |
+| ADR-022 | `packages/integrations` | Retired package spelling in SPEC | Owns Integration adapter contracts, normalization, delivery, and mappings |
+| ADR-023 | `apps/integration-worker` | Retired worker spelling in SPEC | Runs Integration ingress, sync, delivery, retries, and reconciliation |
+| ADR-024 | Integration installation and `IntegrationCheckpoint` | Retired SPEC domain/checkpoint names | Preserves provider/app/install hierarchy without retired synonyms |
+| ADR-025 | `/api/v1/chats/:id/turns` | Retired Conversation wire route | Chat stays external/wire; Conversation remains internal/persistence |
+
+## Rejected alternatives
+
+| Alternative | Reason rejected |
+| --- | --- |
+| Fork or embed Hermes, then add business controls | Durability and authorization are kernel properties, not safe overlays |
+| Separate chat, schedule, webhook, and Routine engines | Creates competing recovery, policy, effect, and audit domains |
+| Redis, pg-boss, a vector DB, or external orchestration service as correctness core | Optional/provider-specific infrastructure cannot be required for correctness |
+| Shared mutable Routine context | Breaks typed lineage, replay, concurrency, and deterministic recovery |
+| Exactly-once external effects | Cannot be guaranteed across arbitrary providers and ambiguous network outcomes |
+| Static Tool sets or missing allowlists as authorization | Tool discovery/exposure never substitutes for policy; missing context denies |
+| Retrieve knowledge then redact | Candidate and metadata leakage already occurred before redaction |
+| Dynamic in-process third-party extensions | Grants trusted memory/code/credential access and bypasses isolation review |
+| Direct Soul file/Git mutation | Bypasses schema, semantic checks, policy, approval, publication, and audit |
+| Approval by heuristic or expired/mismatched decision | Approval must bind one exact normalized intent and current policy evidence |
+| Local/SSH/container shell as production isolation | Workspace abstraction is useful but is not a strong security boundary |
+| Compatibility with v1 internals or development DB | Clean contracts are preferred; cutover tests protect behavior instead |
+
+## Change control
+
+A later task may refine implementation details only when it preserves these decisions, the invariant
+map, and the dependency allowlist. Any change that weakens an invariant, adds an authority/write/
+effect path, introduces trusted unreviewed code, or changes an accepted public boundary requires a
+new reviewed ADR and explicit design approval before implementation.

--- a/docs/architecture/dependency-rules.md
+++ b/docs/architecture/dependency-rules.md
@@ -1,0 +1,115 @@
+# TulipFarm architecture dependency rules
+
+Status: Accepted architecture contract
+Scope: AW-001 package and application import boundaries
+
+These rules define compile-time direction. In every arrow below, `consumer -> provider` means the
+consumer may import only the provider's documented public exports. Runtime calls remain subject to
+authentication, authorization, policy, audit, and durable-state boundaries.
+
+## Direction rules
+
+1. Applications compose packages; packages never import from `apps/*`.
+2. Packages import only public package exports, never another package's private source path.
+3. `packages/schema` and `packages/observability` are foundations and import no TulipFarm runtime
+   package.
+4. A package may depend only on the allowlist below. Transitive availability is not permission.
+5. Domain packages do not read another owner's tables. They use `packages/storage` repository and
+   transaction ports.
+6. Cross-process work uses versioned events/commands plus PostgreSQL inbox/outbox records, never an
+   in-memory callback as the authoritative handoff.
+7. Concrete provider SDKs live only in their owning adapter package. Core contracts expose
+   provider-neutral ports and capability checks.
+8. `apps/web` uses versioned HTTP/SSE and shared wire schemas. It never imports server, persistence,
+   secret, provider, or worker code.
+
+## Package import allowlist
+
+An omitted edge is forbidden.
+
+| Consumer | May import from |
+| --- | --- |
+| `packages/schema` | No TulipFarm runtime package |
+| `packages/observability` | No TulipFarm runtime package |
+| `packages/storage` | `packages/schema`, `packages/observability` |
+| `packages/authz` | `packages/schema`, `packages/observability` |
+| `packages/audit` | `packages/schema`, `packages/storage`, `packages/observability` |
+| `packages/soul` | `packages/schema`, `packages/authz`, `packages/audit`, `packages/storage`, `packages/observability` |
+| `packages/secrets` | `packages/schema`, `packages/authz`, `packages/audit`, `packages/storage`, `packages/observability` |
+| `packages/run-kernel` | `packages/schema`, `packages/audit`, `packages/storage`, `packages/observability` |
+| `packages/sandbox` | `packages/schema`, `packages/authz`, `packages/audit`, `packages/storage`, `packages/observability` |
+| `packages/tool-broker` | `packages/schema`, `packages/authz`, `packages/audit`, `packages/secrets`, `packages/sandbox`, `packages/storage`, `packages/observability` |
+| `packages/knowledge` | `packages/schema`, `packages/authz`, `packages/audit`, `packages/storage`, `packages/observability` |
+| `packages/memory` | `packages/schema`, `packages/authz`, `packages/audit`, `packages/storage`, `packages/observability` |
+| `packages/a2ui` | `packages/schema`, `packages/authz`, `packages/audit`, `packages/observability` |
+| `packages/integrations` | `packages/schema`, `packages/authz`, `packages/audit`, `packages/tool-broker`, `packages/storage`, `packages/observability` |
+| `packages/agent-runtime` | `packages/schema`, `packages/authz`, `packages/audit`, `packages/run-kernel`, `packages/tool-broker`, `packages/knowledge`, `packages/memory`, `packages/observability` |
+
+`packages/integrations` may implement the public Tool adapter interface owned by
+`packages/tool-broker`; the broker does not import Integration implementations. `packages/agent-runtime`
+may submit child-Run commands through the public `packages/run-kernel` port; the kernel never imports
+the Agent runtime. Applications register implementations during composition.
+
+## Application import allowlist
+
+| Consumer | May import from |
+| --- | --- |
+| `apps/api` | `schema`, `soul`, `authz`, `audit`, `secrets`, `run-kernel`, `tool-broker`, `knowledge`, `memory`, `a2ui`, `integrations`, `storage`, `observability` |
+| `apps/worker` | `schema`, `authz`, `audit`, `secrets`, `run-kernel`, `tool-broker`, `agent-runtime`, `knowledge`, `memory`, `a2ui`, `integrations`, `sandbox`, `storage`, `observability` |
+| `apps/integration-worker` | `schema`, `authz`, `audit`, `run-kernel`, `tool-broker`, `integrations`, `storage`, `observability` |
+| `apps/web` | `schema`, `a2ui`, and presentation-only packages such as `ui`/`editor` |
+
+Package names in application rows are relative to `packages/`. Existing v1 packages may remain
+during capability cutover, but target code must not create additional legacy dependencies. Each
+legacy edge is removed when its accountable owner passes replacement and cutover tests.
+
+## Required ports and composition seams
+
+| Port or seam | Contract owner | Implemented/composed by |
+| --- | --- | --- |
+| Transaction, repository, inbox/outbox | `packages/storage` | PostgreSQL adapters in `packages/storage`; applications provide pools |
+| Authorization decision | `packages/authz` | Authz implementation; callers provide principal/context and consume evidence |
+| Audit append/seal | `packages/audit` | PostgreSQL plus provider-neutral sealed-blob adapter |
+| Active bundle lookup | `packages/soul` | Soul publication projection and content-addressed blob adapter |
+| Run commands and step executor | `packages/run-kernel` | API submits; workers claim; executor implementations are injected |
+| Tool adapter | `packages/tool-broker` | Native, Integration, MCP/OpenAPI, DB, and sandbox adapters register at composition |
+| Secret/KMS provider | `packages/secrets` | Local envelope/KMS adapters selected through capability-checked config |
+| Model provider | `packages/agent-runtime` | Provider adapters normalized behind ModelProfile selection |
+| Sandbox backend | `packages/sandbox` | Isolated service/microVM adapters; never local fallback in production |
+| Integration adapter | `packages/integrations` | `apps/integration-worker` loads reviewed Tulip-owned adapters in-process; third-party implementations run out of process over the authenticated, versioned Integration protocol |
+| Blob/vector/cache | `packages/storage` | Filesystem/S3-compatible, pgvector, Redis, or other optional adapters |
+
+## Forbidden edges and bypasses
+
+- No package or application writes Soul Git/YAML except through `packages/soul` changesets.
+- No Agent, Routine, Skill, Integration, route, or worker calls a Tool implementation directly.
+- No model or Tool receives secret plaintext except the authorized adapter at dispatch time.
+- No package other than `packages/knowledge` returns knowledge candidates before ACL evaluation.
+- No Chat, schedule, webhook, form, API, Integration event, or delegation executes outside
+  `packages/run-kernel`.
+- No approval, stream, queue, retry counter, or authoritative state exists only in process memory.
+- No application imports another application. Shared behavior moves to its accountable package.
+- No package imports `pg-boss`, Redis, pgvector, or a provider SDK as a correctness contract.
+- No dynamic MCP/OpenAPI/Integration discovery enables a Tool; discovery creates a Soul proposal.
+- No untrusted extension module is imported into the API or worker process.
+- No missing allowlist/policy broadens access. Missing, stale, or unverifiable context denies.
+
+## Data and event ownership
+
+- `packages/storage` owns physical persistence mechanics; domain owners define repository behavior
+  and receive transaction-scoped ports.
+- Publishers persist state plus an outbox event in one PostgreSQL transaction. Consumers record
+  event ID plus consumer identity before acknowledging.
+- Event schemas live in `packages/schema`. Additive changes may share a version; breaking or
+  semantic changes require a new version.
+- Large/private payloads travel as authorized Artifact references. Events, logs, and errors carry
+  hashes and safe metadata, not protected content or secrets.
+- Workers are horizontally replaceable. Losing a process, cache, queue accelerator, or vector
+  adapter cannot lose authoritative state or grant access.
+
+## Enforcement
+
+AW-004 will turn this allowlist into a CI/static-import check. Until then, review treats any omitted
+edge as a blocking architecture violation. Runtime contract tests must separately prove default
+deny, duplicate safety, crash/retry/restart behavior, authority non-amplification, and redaction;
+passing an import check never substitutes for those tests.

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@tulipfarm/tsconfig": "workspace:*",
-    "@types/node": "^24.13.2",
+    "@types/node": "^26.1.1",
     "typescript": "^6.0.3"
   }
 }

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@tulipfarm/tsconfig": "workspace:*",
-    "@types/node": "^24.13.2",
+    "@types/node": "^26.1.1",
     "typescript": "^6.0.3",
     "vitest": "^4.1.9"
   }

--- a/packages/routine-engine/package.json
+++ b/packages/routine-engine/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@tulipfarm/tsconfig": "workspace:*",
-    "@types/node": "^24.13.2",
+    "@types/node": "^26.1.1",
     "typescript": "^6.0.3",
     "vitest": "^4.1.9"
   }

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@tulipfarm/tsconfig": "workspace:*",
-    "@types/node": "^24.13.2",
+    "@types/node": "^26.1.1",
     "typescript": "^6.0.3",
     "vitest": "^4.1.9"
   }

--- a/packages/secrets/package.json
+++ b/packages/secrets/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@tulipfarm/tsconfig": "workspace:*",
-    "@types/node": "^24.13.2",
+    "@types/node": "^26.1.1",
     "typescript": "^6.0.3",
     "vitest": "^4.1.9"
   }

--- a/packages/soul/package.json
+++ b/packages/soul/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@tulipfarm/tsconfig": "workspace:*",
-    "@types/node": "^24.13.2",
+    "@types/node": "^26.1.1",
     "typescript": "^6.0.3",
     "vitest": "^4.1.9"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,13 +13,13 @@ importers:
         version: 2.5.1
       '@commitlint/cli':
         specifier: ^21.1.0
-        version: 21.1.0(@types/node@22.19.20)(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)(typescript@6.0.3)
+        version: 21.1.0(@types/node@26.1.1)(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)(typescript@6.0.3)
       '@commitlint/config-conventional':
         specifier: ^21.1.0
         version: 21.1.0
       '@release-it/conventional-changelog':
         specifier: ^11.0.1
-        version: 11.0.1(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)(release-it@20.2.1(@types/node@22.19.20)(magicast@0.5.3))
+        version: 11.0.1(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)(release-it@20.2.1(@types/node@26.1.1)(magicast@0.5.3))
       lefthook:
         specifier: ^2.1.9
         version: 2.1.9
@@ -28,7 +28,7 @@ importers:
         version: 17.0.8
       release-it:
         specifier: ^20.2.1
-        version: 20.2.1(@types/node@22.19.20)(magicast@0.5.3)
+        version: 20.2.1(@types/node@26.1.1)(magicast@0.5.3)
       turbo:
         specifier: ^2.10.0
         version: 2.10.0
@@ -37,7 +37,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.19.20)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.0(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   apps/api:
     dependencies:
@@ -118,8 +118,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/tsconfig
       '@types/node':
-        specifier: ^24.13.2
-        version: 24.13.2
+        specifier: ^26.1.1
+        version: 26.1.1
       '@types/pg':
         specifier: ^8.20.0
         version: 8.20.0
@@ -137,7 +137,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.0(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   apps/docs:
     dependencies:
@@ -152,7 +152,7 @@ importers:
         version: 16.10.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.21.0(react@19.2.7))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       fumadocs-mdx:
         specifier: 15.0.12
-        version: 15.0.12(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.10.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.21.0(react@19.2.7))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(rolldown@1.1.2)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 15.0.12(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.10.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.21.0(react@19.2.7))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(rolldown@1.1.2)(vite@8.1.0(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       fumadocs-ui:
         specifier: 16.10.5
         version: 16.10.5(@tailwindcss/oxide@4.3.1)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.10.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.21.0(react@19.2.7))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.1)
@@ -182,8 +182,8 @@ importers:
         specifier: ^2.0.14
         version: 2.0.14
       '@types/node':
-        specifier: ^24.13.2
-        version: 24.13.2
+        specifier: ^26.1.1
+        version: 26.1.1
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
@@ -304,13 +304,13 @@ importers:
     devDependencies:
       '@remix-run/dev':
         specifier: ^2.17.5
-        version: 2.17.5(@remix-run/react@2.17.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(@remix-run/serve@2.17.5(typescript@6.0.3))(@types/node@22.19.20)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(typescript@6.0.3)(vite@8.1.0(@types/node@22.19.20)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(yaml@2.9.0)
+        version: 2.17.5(@remix-run/react@2.17.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(@remix-run/serve@2.17.5(typescript@6.0.3))(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(typescript@6.0.3)(vite@8.1.0(@types/node@26.1.1)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(yaml@2.9.0)
       '@remix-run/testing':
         specifier: ^2.17.5
         version: 2.17.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
       '@tailwindcss/vite':
         specifier: ^4.3.1
-        version: 4.3.1(vite@8.1.0(@types/node@22.19.20)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.3.1(vite@8.1.0(@types/node@26.1.1)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -334,7 +334,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: ^6.0.3
-        version: 6.0.3(vite@8.1.0(@types/node@22.19.20)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 6.0.3(vite@8.1.0(@types/node@26.1.1)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
@@ -349,10 +349,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^8.1.0
-        version: 8.1.0(@types/node@22.19.20)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+        version: 8.1.0(@types/node@26.1.1)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.19.20)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.0(@types/node@22.19.20)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.0(@types/node@26.1.1)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/constants:
     devDependencies:
@@ -360,8 +360,8 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig
       '@types/node':
-        specifier: ^24.13.2
-        version: 24.13.2
+        specifier: ^26.1.1
+        version: 26.1.1
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -455,14 +455,14 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig
       '@types/node':
-        specifier: ^24.13.2
-        version: 24.13.2
+        specifier: ^26.1.1
+        version: 26.1.1
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.0(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/routine-engine:
     dependencies:
@@ -474,14 +474,14 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig
       '@types/node':
-        specifier: ^24.13.2
-        version: 24.13.2
+        specifier: ^26.1.1
+        version: 26.1.1
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.0(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/schema:
     dependencies:
@@ -496,14 +496,14 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig
       '@types/node':
-        specifier: ^24.13.2
-        version: 24.13.2
+        specifier: ^26.1.1
+        version: 26.1.1
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.0(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/secrets:
     devDependencies:
@@ -511,14 +511,14 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig
       '@types/node':
-        specifier: ^24.13.2
-        version: 24.13.2
+        specifier: ^26.1.1
+        version: 26.1.1
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.0(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/soul:
     dependencies:
@@ -539,14 +539,14 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig
       '@types/node':
-        specifier: ^24.13.2
-        version: 24.13.2
+        specifier: ^26.1.1
+        version: 26.1.1
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.0(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/tsconfig: {}
 
@@ -3486,11 +3486,11 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
-  '@types/node@22.19.20':
-    resolution: {integrity: sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==}
-
   '@types/node@24.13.2':
     resolution: {integrity: sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==}
+
+  '@types/node@26.1.1':
+    resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -7397,11 +7397,11 @@ packages:
     engines: {node: '>=0.8.0'}
     hasBin: true
 
-  undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
-
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
   undici@6.26.0:
     resolution: {integrity: sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==}
@@ -8220,12 +8220,12 @@ snapshots:
     dependencies:
       css-tree: 3.2.1
 
-  '@commitlint/cli@21.1.0(@types/node@22.19.20)(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)(typescript@6.0.3)':
+  '@commitlint/cli@21.1.0(@types/node@26.1.1)(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)(typescript@6.0.3)':
     dependencies:
       '@commitlint/config-conventional': 21.1.0
       '@commitlint/format': 21.1.0
       '@commitlint/lint': 21.1.0
-      '@commitlint/load': 21.1.0(@types/node@22.19.20)(typescript@6.0.3)
+      '@commitlint/load': 21.1.0(@types/node@26.1.1)(typescript@6.0.3)
       '@commitlint/read': 21.1.0(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)
       '@commitlint/types': 21.1.0
       tinyexec: 1.2.4
@@ -8270,14 +8270,14 @@ snapshots:
       '@commitlint/rules': 21.1.0
       '@commitlint/types': 21.1.0
 
-  '@commitlint/load@21.1.0(@types/node@22.19.20)(typescript@6.0.3)':
+  '@commitlint/load@21.1.0(@types/node@26.1.1)(typescript@6.0.3)':
     dependencies:
       '@commitlint/config-validator': 21.1.0
       '@commitlint/execute-rule': 21.0.1
       '@commitlint/resolve-extends': 21.1.0
       '@commitlint/types': 21.1.0
       cosmiconfig: 9.0.2(typescript@6.0.3)
-      cosmiconfig-typescript-loader: 6.3.0(@types/node@22.19.20)(cosmiconfig@9.0.2(typescript@6.0.3))(typescript@6.0.3)
+      cosmiconfig-typescript-loader: 6.3.0(@types/node@26.1.1)(cosmiconfig@9.0.2(typescript@6.0.3))(typescript@6.0.3)
       es-toolkit: 1.48.1
       is-plain-obj: 4.1.0
       picocolors: 1.1.1
@@ -8897,122 +8897,122 @@ snapshots:
 
   '@inquirer/ansi@2.0.7': {}
 
-  '@inquirer/checkbox@5.2.1(@types/node@22.19.20)':
+  '@inquirer/checkbox@5.2.1(@types/node@26.1.1)':
     dependencies:
       '@inquirer/ansi': 2.0.7
-      '@inquirer/core': 11.2.1(@types/node@22.19.20)
+      '@inquirer/core': 11.2.1(@types/node@26.1.1)
       '@inquirer/figures': 2.0.7
-      '@inquirer/type': 4.0.7(@types/node@22.19.20)
+      '@inquirer/type': 4.0.7(@types/node@26.1.1)
     optionalDependencies:
-      '@types/node': 22.19.20
+      '@types/node': 26.1.1
 
-  '@inquirer/confirm@6.1.1(@types/node@22.19.20)':
+  '@inquirer/confirm@6.1.1(@types/node@26.1.1)':
     dependencies:
-      '@inquirer/core': 11.2.1(@types/node@22.19.20)
-      '@inquirer/type': 4.0.7(@types/node@22.19.20)
+      '@inquirer/core': 11.2.1(@types/node@26.1.1)
+      '@inquirer/type': 4.0.7(@types/node@26.1.1)
     optionalDependencies:
-      '@types/node': 22.19.20
+      '@types/node': 26.1.1
 
-  '@inquirer/core@11.2.1(@types/node@22.19.20)':
+  '@inquirer/core@11.2.1(@types/node@26.1.1)':
     dependencies:
       '@inquirer/ansi': 2.0.7
       '@inquirer/figures': 2.0.7
-      '@inquirer/type': 4.0.7(@types/node@22.19.20)
+      '@inquirer/type': 4.0.7(@types/node@26.1.1)
       cli-width: 4.1.0
       fast-wrap-ansi: 0.2.2
       mute-stream: 3.0.0
       signal-exit: 4.1.0
     optionalDependencies:
-      '@types/node': 22.19.20
+      '@types/node': 26.1.1
 
-  '@inquirer/editor@5.2.2(@types/node@22.19.20)':
+  '@inquirer/editor@5.2.2(@types/node@26.1.1)':
     dependencies:
-      '@inquirer/core': 11.2.1(@types/node@22.19.20)
-      '@inquirer/external-editor': 3.0.3(@types/node@22.19.20)
-      '@inquirer/type': 4.0.7(@types/node@22.19.20)
+      '@inquirer/core': 11.2.1(@types/node@26.1.1)
+      '@inquirer/external-editor': 3.0.3(@types/node@26.1.1)
+      '@inquirer/type': 4.0.7(@types/node@26.1.1)
     optionalDependencies:
-      '@types/node': 22.19.20
+      '@types/node': 26.1.1
 
-  '@inquirer/expand@5.1.1(@types/node@22.19.20)':
+  '@inquirer/expand@5.1.1(@types/node@26.1.1)':
     dependencies:
-      '@inquirer/core': 11.2.1(@types/node@22.19.20)
-      '@inquirer/type': 4.0.7(@types/node@22.19.20)
+      '@inquirer/core': 11.2.1(@types/node@26.1.1)
+      '@inquirer/type': 4.0.7(@types/node@26.1.1)
     optionalDependencies:
-      '@types/node': 22.19.20
+      '@types/node': 26.1.1
 
-  '@inquirer/external-editor@3.0.3(@types/node@22.19.20)':
+  '@inquirer/external-editor@3.0.3(@types/node@26.1.1)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 22.19.20
+      '@types/node': 26.1.1
 
   '@inquirer/figures@2.0.7': {}
 
-  '@inquirer/input@5.1.2(@types/node@22.19.20)':
+  '@inquirer/input@5.1.2(@types/node@26.1.1)':
     dependencies:
-      '@inquirer/core': 11.2.1(@types/node@22.19.20)
-      '@inquirer/type': 4.0.7(@types/node@22.19.20)
+      '@inquirer/core': 11.2.1(@types/node@26.1.1)
+      '@inquirer/type': 4.0.7(@types/node@26.1.1)
     optionalDependencies:
-      '@types/node': 22.19.20
+      '@types/node': 26.1.1
 
-  '@inquirer/number@4.1.1(@types/node@22.19.20)':
+  '@inquirer/number@4.1.1(@types/node@26.1.1)':
     dependencies:
-      '@inquirer/core': 11.2.1(@types/node@22.19.20)
-      '@inquirer/type': 4.0.7(@types/node@22.19.20)
+      '@inquirer/core': 11.2.1(@types/node@26.1.1)
+      '@inquirer/type': 4.0.7(@types/node@26.1.1)
     optionalDependencies:
-      '@types/node': 22.19.20
+      '@types/node': 26.1.1
 
-  '@inquirer/password@5.1.1(@types/node@22.19.20)':
-    dependencies:
-      '@inquirer/ansi': 2.0.7
-      '@inquirer/core': 11.2.1(@types/node@22.19.20)
-      '@inquirer/type': 4.0.7(@types/node@22.19.20)
-    optionalDependencies:
-      '@types/node': 22.19.20
-
-  '@inquirer/prompts@8.4.2(@types/node@22.19.20)':
-    dependencies:
-      '@inquirer/checkbox': 5.2.1(@types/node@22.19.20)
-      '@inquirer/confirm': 6.1.1(@types/node@22.19.20)
-      '@inquirer/editor': 5.2.2(@types/node@22.19.20)
-      '@inquirer/expand': 5.1.1(@types/node@22.19.20)
-      '@inquirer/input': 5.1.2(@types/node@22.19.20)
-      '@inquirer/number': 4.1.1(@types/node@22.19.20)
-      '@inquirer/password': 5.1.1(@types/node@22.19.20)
-      '@inquirer/rawlist': 5.3.1(@types/node@22.19.20)
-      '@inquirer/search': 4.2.1(@types/node@22.19.20)
-      '@inquirer/select': 5.2.1(@types/node@22.19.20)
-    optionalDependencies:
-      '@types/node': 22.19.20
-
-  '@inquirer/rawlist@5.3.1(@types/node@22.19.20)':
-    dependencies:
-      '@inquirer/core': 11.2.1(@types/node@22.19.20)
-      '@inquirer/type': 4.0.7(@types/node@22.19.20)
-    optionalDependencies:
-      '@types/node': 22.19.20
-
-  '@inquirer/search@4.2.1(@types/node@22.19.20)':
-    dependencies:
-      '@inquirer/core': 11.2.1(@types/node@22.19.20)
-      '@inquirer/figures': 2.0.7
-      '@inquirer/type': 4.0.7(@types/node@22.19.20)
-    optionalDependencies:
-      '@types/node': 22.19.20
-
-  '@inquirer/select@5.2.1(@types/node@22.19.20)':
+  '@inquirer/password@5.1.1(@types/node@26.1.1)':
     dependencies:
       '@inquirer/ansi': 2.0.7
-      '@inquirer/core': 11.2.1(@types/node@22.19.20)
-      '@inquirer/figures': 2.0.7
-      '@inquirer/type': 4.0.7(@types/node@22.19.20)
+      '@inquirer/core': 11.2.1(@types/node@26.1.1)
+      '@inquirer/type': 4.0.7(@types/node@26.1.1)
     optionalDependencies:
-      '@types/node': 22.19.20
+      '@types/node': 26.1.1
 
-  '@inquirer/type@4.0.7(@types/node@22.19.20)':
+  '@inquirer/prompts@8.4.2(@types/node@26.1.1)':
+    dependencies:
+      '@inquirer/checkbox': 5.2.1(@types/node@26.1.1)
+      '@inquirer/confirm': 6.1.1(@types/node@26.1.1)
+      '@inquirer/editor': 5.2.2(@types/node@26.1.1)
+      '@inquirer/expand': 5.1.1(@types/node@26.1.1)
+      '@inquirer/input': 5.1.2(@types/node@26.1.1)
+      '@inquirer/number': 4.1.1(@types/node@26.1.1)
+      '@inquirer/password': 5.1.1(@types/node@26.1.1)
+      '@inquirer/rawlist': 5.3.1(@types/node@26.1.1)
+      '@inquirer/search': 4.2.1(@types/node@26.1.1)
+      '@inquirer/select': 5.2.1(@types/node@26.1.1)
     optionalDependencies:
-      '@types/node': 22.19.20
+      '@types/node': 26.1.1
+
+  '@inquirer/rawlist@5.3.1(@types/node@26.1.1)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@26.1.1)
+      '@inquirer/type': 4.0.7(@types/node@26.1.1)
+    optionalDependencies:
+      '@types/node': 26.1.1
+
+  '@inquirer/search@4.2.1(@types/node@26.1.1)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@26.1.1)
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@26.1.1)
+    optionalDependencies:
+      '@types/node': 26.1.1
+
+  '@inquirer/select@5.2.1(@types/node@26.1.1)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 11.2.1(@types/node@26.1.1)
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@26.1.1)
+    optionalDependencies:
+      '@types/node': 26.1.1
+
+  '@inquirer/type@4.0.7(@types/node@26.1.1)':
+    optionalDependencies:
+      '@types/node': 26.1.1
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -9689,7 +9689,7 @@ snapshots:
 
   '@radix-ui/rect@1.1.2': {}
 
-  '@release-it/conventional-changelog@11.0.1(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)(release-it@20.2.1(@types/node@22.19.20)(magicast@0.5.3))':
+  '@release-it/conventional-changelog@11.0.1(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)(release-it@20.2.1(@types/node@26.1.1)(magicast@0.5.3))':
     dependencies:
       '@conventional-changelog/git-client': 2.7.0(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)
       concat-stream: 2.0.0
@@ -9697,13 +9697,13 @@ snapshots:
       conventional-changelog-angular: 8.3.1
       conventional-changelog-conventionalcommits: 9.3.1
       conventional-recommended-bump: 11.2.0
-      release-it: 20.2.1(@types/node@22.19.20)(magicast@0.5.3)
+      release-it: 20.2.1(@types/node@26.1.1)(magicast@0.5.3)
       semver: 7.8.4
     transitivePeerDependencies:
       - conventional-commits-filter
       - conventional-commits-parser
 
-  '@remix-run/dev@2.17.5(@remix-run/react@2.17.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(@remix-run/serve@2.17.5(typescript@6.0.3))(@types/node@22.19.20)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(typescript@6.0.3)(vite@8.1.0(@types/node@22.19.20)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(yaml@2.9.0)':
+  '@remix-run/dev@2.17.5(@remix-run/react@2.17.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(@remix-run/serve@2.17.5(typescript@6.0.3))(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(typescript@6.0.3)(vite@8.1.0(@types/node@26.1.1)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(yaml@2.9.0)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/generator': 7.29.7
@@ -9720,7 +9720,7 @@ snapshots:
       '@remix-run/router': 1.23.3
       '@remix-run/server-runtime': 2.17.5(typescript@6.0.3)
       '@types/mdx': 2.0.14
-      '@vanilla-extract/integration': 6.5.0(@types/node@22.19.20)(lightningcss@1.32.0)
+      '@vanilla-extract/integration': 6.5.0(@types/node@26.1.1)(lightningcss@1.32.0)
       arg: 5.0.2
       cacache: 17.1.4
       chalk: 4.1.2
@@ -9760,12 +9760,12 @@ snapshots:
       tar-fs: 2.1.4
       tsconfig-paths: 4.2.0
       valibot: 1.4.1(typescript@6.0.3)
-      vite-node: 3.2.4(@types/node@22.19.20)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
       ws: 7.5.11
     optionalDependencies:
       '@remix-run/serve': 2.17.5(typescript@6.0.3)
       typescript: 6.0.3
-      vite: 8.1.0(@types/node@22.19.20)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.1.0(@types/node@26.1.1)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -10198,12 +10198,12 @@ snapshots:
       postcss: 8.5.15
       tailwindcss: 4.3.1
 
-  '@tailwindcss/vite@4.3.1(vite@8.1.0(@types/node@22.19.20)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@tailwindcss/vite@4.3.1(vite@8.1.0(@types/node@26.1.1)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.3.1
       '@tailwindcss/oxide': 4.3.1
       tailwindcss: 4.3.1
-      vite: 8.1.0(@types/node@22.19.20)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.1.0(@types/node@26.1.1)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -10549,13 +10549,13 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
-  '@types/node@22.19.20':
-    dependencies:
-      undici-types: 6.21.0
-
   '@types/node@24.13.2':
     dependencies:
       undici-types: 7.18.2
+
+  '@types/node@26.1.1':
+    dependencies:
+      undici-types: 8.3.0
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -10565,7 +10565,7 @@ snapshots:
 
   '@types/pg@8.20.0':
     dependencies:
-      '@types/node': 22.19.20
+      '@types/node': 24.13.2
       pg-protocol: 1.14.0
       pg-types: 2.2.0
 
@@ -10612,7 +10612,7 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
 
-  '@vanilla-extract/integration@6.5.0(@types/node@22.19.20)(lightningcss@1.32.0)':
+  '@vanilla-extract/integration@6.5.0(@types/node@26.1.1)(lightningcss@1.32.0)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7)
@@ -10625,8 +10625,8 @@ snapshots:
       lodash: 4.18.1
       mlly: 1.8.2
       outdent: 0.8.0
-      vite: 5.4.21(@types/node@22.19.20)(lightningcss@1.32.0)
-      vite-node: 1.6.1(@types/node@22.19.20)(lightningcss@1.32.0)
+      vite: 5.4.21(@types/node@26.1.1)(lightningcss@1.32.0)
+      vite-node: 1.6.1(@types/node@26.1.1)(lightningcss@1.32.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -10643,10 +10643,10 @@ snapshots:
 
   '@vercel/oidc@3.2.0': {}
 
-  '@vitejs/plugin-react@6.0.3(vite@8.1.0(@types/node@22.19.20)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@vitejs/plugin-react@6.0.3(vite@8.1.0(@types/node@26.1.1)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.1.0(@types/node@22.19.20)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.1.0(@types/node@26.1.1)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/coverage-v8@4.1.9(vitest@4.1.9)':
     dependencies:
@@ -10660,7 +10660,7 @@ snapshots:
       obug: 2.1.2
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.19.20)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.0(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/expect@4.1.9':
     dependencies:
@@ -10671,21 +10671,21 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.9(vite@8.1.0(@types/node@22.19.20)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.9(vite@8.1.0(@types/node@26.1.1)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.1.0(@types/node@22.19.20)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.1.0(@types/node@26.1.1)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
-  '@vitest/mocker@4.1.9(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.9(vite@8.1.0(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.1.0(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.9':
     dependencies:
@@ -11292,9 +11292,9 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  cosmiconfig-typescript-loader@6.3.0(@types/node@22.19.20)(cosmiconfig@9.0.2(typescript@6.0.3))(typescript@6.0.3):
+  cosmiconfig-typescript-loader@6.3.0(@types/node@26.1.1)(cosmiconfig@9.0.2(typescript@6.0.3))(typescript@6.0.3):
     dependencies:
-      '@types/node': 22.19.20
+      '@types/node': 26.1.1
       cosmiconfig: 9.0.2(typescript@6.0.3)
       jiti: 2.6.1
       typescript: 6.0.3
@@ -12048,7 +12048,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@15.0.12(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.10.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.21.0(react@19.2.7))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(rolldown@1.1.2)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
+  fumadocs-mdx@15.0.12(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.10.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.21.0(react@19.2.7))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(rolldown@1.1.2)(vite@8.1.0(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
@@ -12074,7 +12074,7 @@ snapshots:
       next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       rolldown: 1.1.2
-      vite: 8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.1.0(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -14616,9 +14616,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  release-it@20.2.1(@types/node@22.19.20)(magicast@0.5.3):
+  release-it@20.2.1(@types/node@26.1.1)(magicast@0.5.3):
     dependencies:
-      '@inquirer/prompts': 8.4.2(@types/node@22.19.20)
+      '@inquirer/prompts': 8.4.2(@types/node@26.1.1)
       '@octokit/rest': 22.0.1
       '@phun-ky/typeof': 2.0.3
       async-retry: 1.3.3
@@ -15354,9 +15354,9 @@ snapshots:
   uglify-js@3.19.3:
     optional: true
 
-  undici-types@6.21.0: {}
-
   undici-types@7.18.2: {}
+
+  undici-types@8.3.0: {}
 
   undici@6.26.0: {}
 
@@ -15555,13 +15555,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-node@1.6.1(@types/node@22.19.20)(lightningcss@1.32.0):
+  vite-node@1.6.1(@types/node@26.1.1)(lightningcss@1.32.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       pathe: 1.1.2
       picocolors: 1.1.1
-      vite: 5.4.21(@types/node@22.19.20)(lightningcss@1.32.0)
+      vite: 5.4.21(@types/node@26.1.1)(lightningcss@1.32.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -15573,13 +15573,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@3.2.4(@types/node@22.19.20)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0):
+  vite-node@3.2.4(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.5(@types/node@22.19.20)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -15594,17 +15594,17 @@ snapshots:
       - tsx
       - yaml
 
-  vite@5.4.21(@types/node@22.19.20)(lightningcss@1.32.0):
+  vite@5.4.21(@types/node@26.1.1)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.15
       rollup: 4.61.1
     optionalDependencies:
-      '@types/node': 22.19.20
+      '@types/node': 26.1.1
       fsevents: 2.3.3
       lightningcss: 1.32.0
 
-  vite@7.3.5(@types/node@22.19.20)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0):
+  vite@7.3.5(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -15613,14 +15613,14 @@ snapshots:
       rollup: 4.61.1
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 22.19.20
+      '@types/node': 26.1.1
       fsevents: 2.3.3
       jiti: 2.7.0
       lightningcss: 1.32.0
       tsx: 4.22.4
       yaml: 2.9.0
 
-  vite@8.1.0(@types/node@22.19.20)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0):
+  vite@8.1.0(@types/node@26.1.1)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -15628,14 +15628,14 @@ snapshots:
       rolldown: 1.1.2
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 22.19.20
+      '@types/node': 26.1.1
       esbuild: 0.17.6
       fsevents: 2.3.3
       jiti: 2.7.0
       tsx: 4.22.4
       yaml: 2.9.0
 
-  vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0):
+  vite@8.1.0(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -15643,17 +15643,17 @@ snapshots:
       rolldown: 1.1.2
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 24.13.2
+      '@types/node': 26.1.1
       esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 2.7.0
       tsx: 4.22.4
       yaml: 2.9.0
 
-  vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.19.20)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.0(@types/node@22.19.20)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.0(@types/node@26.1.1)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(vite@8.1.0(@types/node@22.19.20)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.9(vite@8.1.0(@types/node@26.1.1)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.9
       '@vitest/runner': 4.1.9
       '@vitest/snapshot': 4.1.9
@@ -15670,20 +15670,20 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.1.0(@types/node@22.19.20)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.1.0(@types/node@26.1.1)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
-      '@types/node': 22.19.20
+      '@types/node': 26.1.1
       '@vitest/coverage-v8': 4.1.9(vitest@4.1.9)
       jsdom: 29.1.1
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.19.20)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.0(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.9(vite@8.1.0(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.9
       '@vitest/runner': 4.1.9
       '@vitest/snapshot': 4.1.9
@@ -15700,41 +15700,11 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.1.0(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
-      '@types/node': 22.19.20
-      '@vitest/coverage-v8': 4.1.9(vitest@4.1.9)
-      jsdom: 29.1.1
-    transitivePeerDependencies:
-      - msw
-
-  vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
-    dependencies:
-      '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.9
-      '@vitest/runner': 4.1.9
-      '@vitest/snapshot': 4.1.9
-      '@vitest/spy': 4.1.9
-      '@vitest/utils': 4.1.9
-      es-module-lexer: 2.1.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.2
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.2.4
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.1
-      '@types/node': 24.13.2
+      '@types/node': 26.1.1
       '@vitest/coverage-v8': 4.1.9(vitest@4.1.9)
       jsdom: 29.1.1
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

- freeze package ownership, invariant enforcement, dependency direction, and architecture decisions
- record the TulipFarm and Hermes reuse/adapt/reject boundaries
- use canonical Integration and Chat terminology without introducing a product “v2” identity
- document a targeted-check exception for documentation-only diffs in `AGENTS.md`

## Why

AW-001 needs a stable architecture contract before implementation work begins. These documents
assign one accountable owner to each cross-cutting concern, prohibit authority and persistence
bypasses, and define the current-to-target cutover rules.

The architecture files live directly under `docs/architecture/`. They retain the existing
`/api/v1` namespace instead of adding a new product or API version.

## Review

An independent review scored the initial implementation 4.37/5 (PASS). All findings were addressed:

- added cryptographic erasure, tombstone integrity, and legal-hold requirements
- clarified that Tool Broker consumes authorization, secret, and audit contracts rather than
  reimplementing them
- restricted in-process Integration adapters to reviewed Tulip-owned code

## Validation

- targeted AW-001 invariant and terminology contract checks: pass
- no `v2` product labels or `/api/v2` routes under `docs/architecture/`
- staged whitespace check: pass
- full Node 24 repository signals run during AW-001 implementation:
  - lint: pass
  - typecheck: pass
  - tests: 12/12 Turbo tasks; API 166/166 files and 1,722/1,722 assertions
  - build: pass

The final path and prose-only cleanup used targeted documentation checks as required by the updated
repository guidance.
