### PR TITLE
ci(architecture): enforce package dependency allowlist and import cycles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,93 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  # Static architecture guardrail (AW-004): enforce the package/app dependency
+  # allowlist and block forbidden imports and import cycles. Encodes
+  # docs/architecture/dependency-rules.md. Fast and deterministic — always runs.
+  architecture:
+    name: Architecture
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup
+      - name: Enforce dependency and import rules
+        run: |
+          set -o pipefail
+          pnpm architecture:test 2>&1 | tee architecture.log
+          pnpm architecture:check 2>&1 | tee -a architecture.log
+      - name: Job summary
+        if: always()
+        env:
+          STATUS: ${{ job.status }}
+        run: |
+          {
+            echo "## Architecture"
+            if [ "$STATUS" = "success" ]; then
+              echo "✅ **Dependency and import rules passed**"
+            else
+              echo "❌ **Architecture check failed** — last 100 lines:"
+              echo ""
+              echo '<details><summary>Log tail</summary>'
+              echo ""
+              echo '```'
+              tail -n 100 architecture.log 2>/dev/null || echo "(no log captured)"
+              echo '```'
+              echo ""
+              echo '</details>'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: log-architecture
+          path: architecture.log
+          if-no-files-found: ignore
+          retention-days: 7
+
+  # Schema contract fixtures (AW-004 / SPEC §25 layer 1): run the schema package's
+  # fixture and property tests as a focused, always-on signal for the single
+  # contract authority. Independent of the sharded package test job.
+  schema-fixtures:
+    name: Schema fixtures
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup
+      - name: Validate schema fixtures
+        run: |
+          set -o pipefail
+          pnpm --filter @tulipfarm/schema test 2>&1 | tee schema-fixtures.log
+      - name: Job summary
+        if: always()
+        env:
+          STATUS: ${{ job.status }}
+        run: |
+          {
+            echo "## Schema fixtures"
+            if [ "$STATUS" = "success" ]; then
+              echo "✅ **Schema fixtures passed**"
+            else
+              echo "❌ **Schema fixtures failed** — last 100 lines:"
+              echo ""
+              echo '<details><summary>Log tail</summary>'
+              echo ""
+              echo '```'
+              tail -n 100 schema-fixtures.log 2>/dev/null || echo "(no log captured)"
+              echo '```'
+              echo ""
+              echo '</details>'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: log-schema-fixtures
+          path: schema-fixtures.log
+          if-no-files-found: ignore
+          retention-days: 7
+
   docs-build:
     name: Docs build
     runs-on: ubuntu-latest
@@ -468,7 +555,19 @@ jobs:
     name: CI Success
     runs-on: ubuntu-latest
     needs:
-      [changes, lint, typecheck, build, docs-build, test-api, test-packages, test-apps, coverage]
+      [
+        changes,
+        lint,
+        typecheck,
+        build,
+        architecture,
+        schema-fixtures,
+        docs-build,
+        test-api,
+        test-packages,
+        test-apps,
+        coverage,
+      ]
     # always() so it still runs when a core job fails.
     if: ${{ always() }}
     permissions:
@@ -494,6 +593,8 @@ jobs:
           LINT_RESULT: ${{ needs.lint.result }}
           TYPECHECK_RESULT: ${{ needs.typecheck.result }}
           BUILD_RESULT: ${{ needs.build.result }}
+          ARCHITECTURE_RESULT: ${{ needs.architecture.result }}
+          SCHEMA_FIXTURES_RESULT: ${{ needs['schema-fixtures'].result }}
           DOCS_BUILD_RESULT: ${{ needs['docs-build'].result }}
           TEST_API_RESULT: ${{ needs['test-api'].result }}
           TEST_PACKAGES_RESULT: ${{ needs['test-packages'].result }}
@@ -512,6 +613,8 @@ jobs:
               ["Lint", "lint", process.env.LINT_RESULT, false],
               ["Typecheck", "typecheck", process.env.TYPECHECK_RESULT, false],
               ["Build", "build", process.env.BUILD_RESULT, false],
+              ["Architecture", "architecture", process.env.ARCHITECTURE_RESULT, false],
+              ["Schema fixtures", "schema-fixtures", process.env.SCHEMA_FIXTURES_RESULT, false],
               ["Docs build", "docs-build", process.env.DOCS_BUILD_RESULT, false],
               ["Test API (5 shards)", "test-api", process.env.TEST_API_RESULT, true],
               ["Test packages", "test-packages", process.env.TEST_PACKAGES_RESULT, true],

--- a/docs/architecture/dependency-rules.md
+++ b/docs/architecture/dependency-rules.md
@@ -109,7 +109,11 @@ legacy edge is removed when its accountable owner passes replacement and cutover
 
 ## Enforcement
 
-AW-004 will turn this allowlist into a CI/static-import check. Until then, review treats any omitted
-edge as a blocking architecture violation. Runtime contract tests must separately prove default
-deny, duplicate safety, crash/retry/restart behavior, authority non-amplification, and redaction;
-passing an import check never substitutes for those tests.
+This allowlist is enforced as a static-import check in `scripts/architecture-check.ts`
+(`pnpm architecture:check`), which the CI `Architecture` job runs on every PR. The check scans the
+`@tulipfarm/*` import graph and fails on any forbidden edge or import cycle with an actionable
+message. The `legacyExceptions` map in `scripts/lib/architecture-rules.ts` documents the remaining
+v1 edges tolerated during cutover; new legacy edges must not be added there. Review still treats any
+omitted, undocumented edge as a blocking architecture violation. Runtime contract tests must
+separately prove default deny, duplicate safety, crash/retry/restart behavior, authority
+non-amplification, and redaction; passing an import check never substitutes for those tests.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "dev:docs": "turbo dev --filter=@tulipfarm/docs",
     "dev:web": "turbo dev --filter=@tulipfarm/web",
     "reset:dev": "bash scripts/reset-dev.sh",
+    "architecture:check": "node scripts/architecture-check.ts",
+    "architecture:test": "vitest run scripts",
     "lint": "turbo lint",
     "typecheck": "turbo typecheck",
     "test": "turbo test",

--- a/scripts/architecture-check.ts
+++ b/scripts/architecture-check.ts
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+/**
+ * CI/static architecture check. Scans the monorepo's `@tulipfarm/*` import graph
+ * and enforces `docs/architecture/dependency-rules.md`: forbidden imports and
+ * import cycles both fail the build with actionable messages.
+ *
+ * Run: `pnpm architecture:check` (or `node scripts/architecture-check.ts`).
+ */
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  ARCHITECTURE_CONFIG,
+  checkArchitecture,
+  formatViolations,
+} from "./lib/architecture-rules.ts";
+import { scanImports } from "./lib/scan.ts";
+
+export function runArchitectureCheck(root: string): number {
+  const violations = checkArchitecture(scanImports(root), ARCHITECTURE_CONFIG);
+  process.stdout.write(`${formatViolations(violations)}\n`);
+  return violations.length === 0 ? 0 : 1;
+}
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exit(runArchitectureCheck(repoRoot));
+}

--- a/scripts/lib/architecture-rules.test.ts
+++ b/scripts/lib/architecture-rules.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+import {
+  ARCHITECTURE_CONFIG,
+  type ArchitectureConfig,
+  checkArchitecture,
+  formatViolations,
+} from "./architecture-rules.ts";
+
+const config: ArchitectureConfig = {
+  allowlist: {
+    schema: [],
+    observability: [],
+    storage: ["schema", "observability"],
+    soul: ["schema", "storage"],
+  },
+  legacyExceptions: {
+    soul: ["constants"],
+  },
+};
+
+describe("checkArchitecture — forbidden imports", () => {
+  it("allows a governed node importing an allowlisted package", () => {
+    expect(checkArchitecture({ storage: ["schema", "observability"] }, config)).toEqual([]);
+  });
+
+  it("flags a governed node importing a package outside its allowlist", () => {
+    const violations = checkArchitecture({ storage: ["soul"] }, config);
+    expect(violations).toHaveLength(1);
+    const [v] = violations;
+    expect(v.kind).toBe("forbidden-import");
+    expect(v).toMatchObject({ from: "storage", to: "soul" });
+    // Actionable: names the offending edge, the allowlist, and the contract doc.
+    expect(v.message).toContain("@tulipfarm/storage");
+    expect(v.message).toContain("@tulipfarm/soul");
+    expect(v.message).toContain("allowlist");
+    expect(v.message).toContain("docs/architecture/dependency-rules.md");
+  });
+
+  it("tolerates a documented legacy exception", () => {
+    expect(checkArchitecture({ soul: ["schema", "constants"] }, config)).toEqual([]);
+  });
+
+  it("ignores self imports", () => {
+    expect(checkArchitecture({ soul: ["soul", "schema"] }, config)).toEqual([]);
+  });
+
+  it("does not police ungoverned nodes", () => {
+    // `llm` has no allowlist entry -> it is legacy/ungoverned and is not checked.
+    expect(checkArchitecture({ llm: ["schema", "soul", "storage"] }, config)).toEqual([]);
+  });
+
+  it("treats a foundation node (empty allowlist) as importing nothing", () => {
+    const violations = checkArchitecture({ schema: ["storage"] }, config);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toMatchObject({
+      kind: "forbidden-import",
+      from: "schema",
+      to: "storage",
+    });
+  });
+});
+
+describe("checkArchitecture — cycles", () => {
+  it("detects a direct cycle", () => {
+    const violations = checkArchitecture({ a: ["b"], b: ["a"] }, config);
+    const cycles = violations.filter((v) => v.kind === "cycle");
+    expect(cycles).toHaveLength(1);
+    expect(cycles[0].message).toContain("cycle");
+    expect(cycles[0].message).toContain("docs/architecture/dependency-rules.md");
+  });
+
+  it("detects an indirect cycle", () => {
+    const cycles = checkArchitecture({ a: ["b"], b: ["c"], c: ["a"] }, config).filter(
+      (v) => v.kind === "cycle"
+    );
+    expect(cycles).toHaveLength(1);
+    if (cycles[0].kind === "cycle") {
+      expect(new Set(cycles[0].cycle)).toEqual(new Set(["a", "b", "c"]));
+    }
+  });
+
+  it("reports each cycle only once", () => {
+    const cycles = checkArchitecture({ a: ["b"], b: ["a"] }, config).filter(
+      (v) => v.kind === "cycle"
+    );
+    expect(cycles).toHaveLength(1);
+  });
+
+  it("passes a DAG", () => {
+    const cycles = checkArchitecture(
+      { soul: ["schema", "storage"], storage: ["schema"], schema: [] },
+      config
+    ).filter((v) => v.kind === "cycle");
+    expect(cycles).toEqual([]);
+  });
+});
+
+describe("formatViolations", () => {
+  it("renders every violation message", () => {
+    const violations = checkArchitecture({ storage: ["soul"], a: ["b"], b: ["a"] }, config);
+    const text = formatViolations(violations);
+    for (const v of violations) expect(text).toContain(v.message);
+  });
+
+  it("returns a clean-tree message when there are no violations", () => {
+    expect(formatViolations([]).toLowerCase()).toContain("no");
+  });
+});
+
+describe("ARCHITECTURE_CONFIG", () => {
+  it("governs all 15 target packages and 4 apps", () => {
+    const governed = Object.keys(ARCHITECTURE_CONFIG.allowlist);
+    for (const pkg of [
+      "schema",
+      "observability",
+      "storage",
+      "authz",
+      "audit",
+      "soul",
+      "secrets",
+      "run-kernel",
+      "sandbox",
+      "tool-broker",
+      "knowledge",
+      "memory",
+      "a2ui",
+      "integrations",
+      "agent-runtime",
+    ]) {
+      expect(governed).toContain(pkg);
+    }
+    for (const app of ["api", "worker", "integration-worker", "web"]) {
+      expect(governed).toContain(app);
+    }
+  });
+
+  it("keeps foundation packages import-free", () => {
+    expect(ARCHITECTURE_CONFIG.allowlist.schema).toEqual([]);
+    expect(ARCHITECTURE_CONFIG.allowlist.observability).toEqual([]);
+  });
+
+  it("encodes the soul allowlist from the contract", () => {
+    expect(new Set(ARCHITECTURE_CONFIG.allowlist.soul)).toEqual(
+      new Set(["schema", "authz", "audit", "storage", "observability"])
+    );
+  });
+
+  it("documents the current legacy exceptions", () => {
+    expect(ARCHITECTURE_CONFIG.legacyExceptions.soul).toContain("constants");
+    expect(new Set(ARCHITECTURE_CONFIG.legacyExceptions.api)).toEqual(
+      new Set(["llm", "routine-engine"])
+    );
+  });
+
+  it("never lists a package in both its allowlist and its legacy exceptions", () => {
+    for (const [node, allowed] of Object.entries(ARCHITECTURE_CONFIG.allowlist)) {
+      const legacy = ARCHITECTURE_CONFIG.legacyExceptions[node] ?? [];
+      for (const dep of legacy) expect(allowed).not.toContain(dep);
+    }
+  });
+
+  it("passes its own real config against itself with no cycles", () => {
+    // The allowlist edges must themselves form a DAG.
+    const graph: Record<string, string[]> = {};
+    for (const [node, allowed] of Object.entries(ARCHITECTURE_CONFIG.allowlist)) {
+      graph[node] = allowed;
+    }
+    const cycles = checkArchitecture(graph, ARCHITECTURE_CONFIG).filter((v) => v.kind === "cycle");
+    expect(cycles).toEqual([]);
+  });
+});

--- a/scripts/lib/architecture-rules.ts
+++ b/scripts/lib/architecture-rules.ts
@@ -1,0 +1,202 @@
+/**
+ * Package/application dependency rules for TulipFarm.
+ *
+ * This is the executable form of `docs/architecture/dependency-rules.md`. The
+ * allowlist below is transcribed from that contract's tables; an omitted edge is
+ * forbidden. `checkArchitecture` is a pure function over an import graph so it can
+ * be unit-tested with fixtures and reused by the repo scanner in
+ * `scripts/architecture-check.ts`.
+ */
+
+const CONTRACT_DOC = "docs/architecture/dependency-rules.md";
+
+/** Import graph: node short-name (e.g. "soul") -> imported `@tulipfarm/*` short-names. */
+export type ImportGraph = Record<string, string[]>;
+
+export interface ArchitectureConfig {
+  /** Governed node -> the `@tulipfarm/*` short-names it may import. Omitted edge = forbidden. */
+  allowlist: Record<string, string[]>;
+  /** Governed node -> legacy edges tolerated during cutover. Documented, reviewable, not blanket. */
+  legacyExceptions: Record<string, string[]>;
+}
+
+export type Violation =
+  | { kind: "forbidden-import"; from: string; to: string; message: string }
+  | { kind: "cycle"; cycle: string[]; message: string };
+
+const qualify = (shortName: string): string => `@tulipfarm/${shortName}`;
+
+/**
+ * Validate an import graph against the architecture contract.
+ *
+ * Two independent checks:
+ *  1. Forbidden imports — every governed node may only import packages in its
+ *     allowlist (plus documented legacy exceptions and itself). Ungoverned/legacy
+ *     nodes are not policed for outgoing edges.
+ *  2. Cycles — the full import graph (governed and legacy nodes alike) must be
+ *     acyclic. Each distinct cycle is reported once.
+ */
+export function checkArchitecture(graph: ImportGraph, config: ArchitectureConfig): Violation[] {
+  return [...findForbiddenImports(graph, config), ...findCycles(graph)];
+}
+
+function findForbiddenImports(graph: ImportGraph, config: ArchitectureConfig): Violation[] {
+  const violations: Violation[] = [];
+  for (const [from, imports] of Object.entries(graph)) {
+    const allowed = config.allowlist[from];
+    if (allowed === undefined) continue; // ungoverned/legacy node
+    const permitted = new Set([from, ...allowed, ...(config.legacyExceptions[from] ?? [])]);
+    for (const to of imports) {
+      if (permitted.has(to)) continue;
+      const allowedList = allowed.length > 0 ? allowed.map(qualify).join(", ") : "(none)";
+      violations.push({
+        kind: "forbidden-import",
+        from,
+        to,
+        message:
+          `${qualify(from)} imports ${qualify(to)}, which is not in its allowlist. ` +
+          `Allowed: [${allowedList}]. See ${CONTRACT_DOC}.`,
+      });
+    }
+  }
+  return violations;
+}
+
+function findCycles(graph: ImportGraph): Violation[] {
+  const violations: Violation[] = [];
+  const seenCycles = new Set<string>();
+  const visited = new Set<string>();
+  const onStack = new Set<string>();
+  const stack: string[] = [];
+
+  const visit = (node: string): void => {
+    visited.add(node);
+    onStack.add(node);
+    stack.push(node);
+    for (const next of graph[node] ?? []) {
+      if (next === node) continue; // self-edges are handled by the forbidden-import check
+      if (onStack.has(next)) {
+        const cycle = stack.slice(stack.indexOf(next));
+        const key = canonicalCycleKey(cycle);
+        if (!seenCycles.has(key)) {
+          seenCycles.add(key);
+          violations.push({
+            kind: "cycle",
+            cycle,
+            message:
+              `Import cycle detected: ${[...cycle, cycle[0]].map(qualify).join(" -> ")}. ` +
+              `Break the cycle; see ${CONTRACT_DOC}.`,
+          });
+        }
+      } else if (!visited.has(next)) {
+        visit(next);
+      }
+    }
+    onStack.delete(node);
+    stack.pop();
+  };
+
+  for (const node of Object.keys(graph)) {
+    if (!visited.has(node)) visit(node);
+  }
+  return violations;
+}
+
+/** Rotation-invariant key so the same cycle discovered from different entries dedupes. */
+function canonicalCycleKey(cycle: string[]): string {
+  const start = cycle.indexOf([...cycle].sort()[0]);
+  return [...cycle.slice(start), ...cycle.slice(0, start)].join(">");
+}
+
+export function formatViolations(violations: Violation[]): string {
+  if (violations.length === 0) return "Architecture check passed: no forbidden imports or cycles.";
+  const lines = violations.map((v, i) => `  ${i + 1}. ${v.message}`);
+  return `Architecture check found ${violations.length} violation(s):\n${lines.join("\n")}`;
+}
+
+/**
+ * The real contract, transcribed from `docs/architecture/dependency-rules.md`.
+ * Package rows come from the "Package import allowlist" table; app rows from the
+ * "Application import allowlist" table.
+ */
+export const ARCHITECTURE_CONFIG: ArchitectureConfig = {
+  allowlist: {
+    // Foundations — no TulipFarm runtime package.
+    schema: [],
+    observability: [],
+    // Storage/authz sit directly on the foundations.
+    storage: ["schema", "observability"],
+    authz: ["schema", "observability"],
+    audit: ["schema", "storage", "observability"],
+    soul: ["schema", "authz", "audit", "storage", "observability"],
+    secrets: ["schema", "authz", "audit", "storage", "observability"],
+    "run-kernel": ["schema", "audit", "storage", "observability"],
+    sandbox: ["schema", "authz", "audit", "storage", "observability"],
+    "tool-broker": ["schema", "authz", "audit", "secrets", "sandbox", "storage", "observability"],
+    knowledge: ["schema", "authz", "audit", "storage", "observability"],
+    memory: ["schema", "authz", "audit", "storage", "observability"],
+    a2ui: ["schema", "authz", "audit", "observability"],
+    integrations: ["schema", "authz", "audit", "tool-broker", "storage", "observability"],
+    "agent-runtime": [
+      "schema",
+      "authz",
+      "audit",
+      "run-kernel",
+      "tool-broker",
+      "knowledge",
+      "memory",
+      "observability",
+    ],
+    // Applications compose packages; they never import another application.
+    api: [
+      "schema",
+      "soul",
+      "authz",
+      "audit",
+      "secrets",
+      "run-kernel",
+      "tool-broker",
+      "knowledge",
+      "memory",
+      "a2ui",
+      "integrations",
+      "storage",
+      "observability",
+    ],
+    worker: [
+      "schema",
+      "authz",
+      "audit",
+      "secrets",
+      "run-kernel",
+      "tool-broker",
+      "agent-runtime",
+      "knowledge",
+      "memory",
+      "a2ui",
+      "integrations",
+      "sandbox",
+      "storage",
+      "observability",
+    ],
+    "integration-worker": [
+      "schema",
+      "authz",
+      "audit",
+      "run-kernel",
+      "tool-broker",
+      "integrations",
+      "storage",
+      "observability",
+    ],
+    // `apps/web` uses shared wire schemas and presentation-only packages.
+    web: ["schema", "a2ui", "ui", "editor"],
+  },
+  // Legacy v1 edges that still exist during cutover. Each is a target package
+  // importing a not-yet-replaced legacy package; removed when its owner passes
+  // replacement/cutover tests. New legacy edges must NOT be added here.
+  legacyExceptions: {
+    soul: ["constants"],
+    api: ["llm", "routine-engine"],
+  },
+};

--- a/scripts/lib/scan.test.ts
+++ b/scripts/lib/scan.test.ts
@@ -1,0 +1,64 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { ARCHITECTURE_CONFIG, checkArchitecture } from "./architecture-rules.ts";
+import { discoverWorkspaces, scanImports } from "./scan.ts";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+describe("scanImports (real repo)", () => {
+  it("discovers every workspace package and app", () => {
+    const names = discoverWorkspaces(repoRoot).map((w) => w.shortName);
+    expect(names).toContain("schema");
+    expect(names).toContain("soul");
+    expect(names).toContain("api");
+    expect(names).toContain("web");
+  });
+
+  it("captures the known legacy edges", () => {
+    const graph = scanImports(repoRoot);
+    expect(graph.soul).toContain("constants");
+    expect(graph.api).toEqual(expect.arrayContaining(["llm", "routine-engine", "soul"]));
+  });
+
+  it("leaves the current tree free of architecture violations", () => {
+    const violations = checkArchitecture(scanImports(repoRoot), ARCHITECTURE_CONFIG);
+    expect(violations).toEqual([]);
+  });
+});
+
+describe("scanImports (synthetic fixture)", () => {
+  it("extracts only @tulipfarm cross-package edges and skips build dirs", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "arch-scan-"));
+    try {
+      // Register the packages the fixture imports so they are known workspaces.
+      for (const name of ["schema", "authz", "audit", "secrets"]) {
+        const p = path.join(root, "packages", name);
+        mkdirSync(p, { recursive: true });
+        writeFileSync(path.join(p, "package.json"), JSON.stringify({ name: `@tulipfarm/${name}` }));
+      }
+      const pkg = path.join(root, "packages", "demo");
+      mkdirSync(path.join(pkg, "src"), { recursive: true });
+      writeFileSync(path.join(pkg, "package.json"), JSON.stringify({ name: "@tulipfarm/demo" }));
+      writeFileSync(
+        path.join(pkg, "src", "index.ts"),
+        [
+          'import { a } from "@tulipfarm/schema";',
+          'export { b } from "@tulipfarm/authz/deep/path";',
+          'import { c } from "lodash";',
+          'const d = await import("@tulipfarm/audit");',
+        ].join("\n")
+      );
+      // A file under a build output dir must be ignored.
+      mkdirSync(path.join(pkg, "dist"), { recursive: true });
+      writeFileSync(path.join(pkg, "dist", "index.ts"), 'import "@tulipfarm/secrets";');
+
+      const graph = scanImports(root);
+      expect(new Set(graph.demo)).toEqual(new Set(["schema", "authz", "audit"]));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/lib/scan.ts
+++ b/scripts/lib/scan.ts
@@ -1,0 +1,110 @@
+/**
+ * Filesystem scanner that turns the monorepo's TypeScript sources into the
+ * `ImportGraph` consumed by `checkArchitecture`. Only `@tulipfarm/*` imports
+ * between discovered workspaces are recorded; external packages are ignored.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import ts from "typescript";
+import type { ImportGraph } from "./architecture-rules.ts";
+
+const WORKSPACE_ROOTS = ["packages", "apps"] as const;
+const SCOPE_PREFIX = "@tulipfarm/";
+const SOURCE_EXTENSIONS = new Set([".ts", ".tsx", ".mts", ".cts"]);
+const IGNORED_DIRS = new Set([
+  "node_modules",
+  "dist",
+  "build",
+  ".next",
+  "out",
+  "coverage",
+  ".turbo",
+  ".vitest-reports",
+]);
+// `tsconfig` is a build-config package, not a runtime import target.
+const NON_RUNTIME_NODES = new Set(["tsconfig"]);
+
+export interface Workspace {
+  shortName: string;
+  dir: string;
+}
+
+/** Discover `@tulipfarm/*` workspaces under `packages/*` and `apps/*`. */
+export function discoverWorkspaces(root: string): Workspace[] {
+  const workspaces: Workspace[] = [];
+  for (const base of WORKSPACE_ROOTS) {
+    const baseDir = path.join(root, base);
+    let entries: string[];
+    try {
+      entries = readdirSync(baseDir);
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const dir = path.join(baseDir, entry);
+      const manifestPath = path.join(dir, "package.json");
+      let name: unknown;
+      try {
+        name = JSON.parse(readFileSync(manifestPath, "utf8")).name;
+      } catch {
+        continue;
+      }
+      if (typeof name !== "string" || !name.startsWith(SCOPE_PREFIX)) continue;
+      const shortName = name.slice(SCOPE_PREFIX.length);
+      if (NON_RUNTIME_NODES.has(shortName)) continue;
+      workspaces.push({ shortName, dir });
+    }
+  }
+  return workspaces;
+}
+
+/** Build the cross-package import graph for the repository rooted at `root`. */
+export function scanImports(root: string): ImportGraph {
+  const workspaces = discoverWorkspaces(root);
+  const known = new Set(workspaces.map((w) => w.shortName));
+  const graph: ImportGraph = {};
+
+  for (const { shortName, dir } of workspaces) {
+    const edges = new Set<string>();
+    for (const file of sourceFiles(dir)) {
+      for (const target of tulipImports(file)) {
+        if (target === shortName || !known.has(target) || NON_RUNTIME_NODES.has(target)) continue;
+        edges.add(target);
+      }
+    }
+    graph[shortName] = [...edges].sort();
+  }
+  return graph;
+}
+
+function* sourceFiles(dir: string): Generator<string> {
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (IGNORED_DIRS.has(entry.name)) continue;
+      yield* sourceFiles(full);
+    } else if (SOURCE_EXTENSIONS.has(path.extname(entry.name))) {
+      yield full;
+    }
+  }
+}
+
+/** Extract the `@tulipfarm/*` short-names imported by a single source file. */
+function tulipImports(file: string): string[] {
+  const text = readFileSync(file, "utf8");
+  const info = ts.preProcessFile(text, /*readImportFiles*/ true, /*detectJavaScriptImports*/ true);
+  const targets: string[] = [];
+  for (const { fileName } of info.importedFiles) {
+    if (!fileName.startsWith(SCOPE_PREFIX)) continue;
+    // "@tulipfarm/foo" and "@tulipfarm/foo/bar" both map to "foo".
+    targets.push(fileName.slice(SCOPE_PREFIX.length).split("/")[0]);
+  }
+  return targets;
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION
## Summary

- Encodes `docs/architecture/dependency-rules.md` as an executable static import check (AW-004). `scripts/architecture-check.ts` scans the `@tulipfarm/*` import graph across `packages/*` + `apps/*` and fails on any **forbidden edge** or **import cycle** with an actionable message.
- Adds two CI jobs — **Architecture** (`pnpm architecture:test` + `pnpm architecture:check`) and **Schema fixtures** (`@tulipfarm/schema` fixture tests) — both wired into the required `CI Success` gate.
- Current `soul→constants` and `api→{llm,routine-engine}` v1 edges are captured as documented, reviewable `legacyExceptions` (not blanket suppressions); new legacy edges are rejected.

Ref: AW-004 / [starter plan](../one/004.enforce_package_dependency_and_ci_guardrails.md), SPEC §§1–6, 26. Depends on AW-002 (done).

## Design notes

- `scripts/` runs as native Node 26 TypeScript (type-stripping); `scripts/package.json` `type:module` scopes ESM without touching root. No new deps (`typescript` already a root devDep).
- `checkArchitecture(graph, config)` is pure → unit-tested with fixtures; the scanner uses `ts.preProcessFile`.
- `scripts/` is outside Turbo, so it's covered by the Architecture CI job (execution + vitest) and the biome pre-commit hook rather than `turbo lint`/`typecheck`.

## Test plan

- [x] RED observed for both rules and scanner tests before implementation.
- [x] `pnpm architecture:test` — 22/22 (pure-logic + repo-regression + synthetic fixture).
- [x] End-to-end fail-path proven: injected forbidden edge (`storage→soul`) → exit 1 with actionable message; injected `authz↔a2ui` cycle → detected once; tree reverted clean.
- [x] `pnpm architecture:check` exit 0 on current tree.
- [x] `pnpm --filter @tulipfarm/schema test` — 67/67 (schema-fixtures job).
- [x] `pnpm lint` ✅ · `pnpm typecheck` ✅ · `pnpm build` ✅