### PR TITLE
feat(ports): define provider-neutral infrastructure ports (AW-005)

### DIFF
--- a/packages/observability/AGENTS.md
+++ b/packages/observability/AGENTS.md
@@ -1,7 +1,10 @@
 # Observability — Agent Conventions
 
 `@tulipfarm/observability` — OTel conventions, metrics, health/readiness, correlation and
-redaction helpers. **Scaffold today:** `src/index.ts` is `export {}`. tsconfig extends
+redaction helpers. **Today:** `src/ports/` defines the provider-neutral `TelemetryPort` and the
+typed capability catalog (`CAPABILITY_IDS`, `CAPABILITY_CLASSIFICATIONS`,
+`assertRequiredCapabilities`) that classifies the ten SPEC §22 backends required-vs-optional —
+PostgreSQL is the sole correctness-critical capability. tsconfig extends
 `@tulipfarm/tsconfig/base.json`. See root `AGENTS.md` for commands/lint.
 
 This is a foundation package: it imports no other TulipFarm runtime package (see

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -1,1 +1,1 @@
-export {};
+export * from "./ports";

--- a/packages/observability/src/ports/capability.test.ts
+++ b/packages/observability/src/ports/capability.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertRequiredCapabilities,
+  CAPABILITY_CLASSIFICATIONS,
+  CAPABILITY_IDS,
+  type CapabilityId,
+  type CapabilityProbe,
+  type CapabilityReport,
+  correctnessCriticalCapabilityIds,
+  MissingCapabilityError,
+  requiredCapabilityIds,
+} from "./capability";
+
+function probe(id: CapabilityId, available: boolean): CapabilityProbe {
+  return { id, provider: "test", available };
+}
+
+function reportWith(available: Partial<Record<CapabilityId, boolean>>): CapabilityReport {
+  const probes = Object.fromEntries(
+    CAPABILITY_IDS.map((id) => [id, probe(id, available[id] ?? false)])
+  ) as Record<CapabilityId, CapabilityProbe>;
+  return { probes };
+}
+
+describe("capability catalog", () => {
+  it("enumerates the ten SPEC §22 provider-neutral backends", () => {
+    expect([...CAPABILITY_IDS].sort()).toEqual(
+      [
+        "blob",
+        "cache",
+        "identity",
+        "kms",
+        "model",
+        "postgres",
+        "queue",
+        "sandbox",
+        "telemetry",
+        "vector",
+      ].sort()
+    );
+  });
+
+  it("names PostgreSQL as the sole correctness-critical capability (invariant 16)", () => {
+    expect(correctnessCriticalCapabilityIds()).toEqual(["postgres"]);
+  });
+
+  it("classifies accelerators and model as optional, foundations as required", () => {
+    for (const id of ["cache", "vector", "queue", "telemetry", "model", "sandbox"] as const) {
+      expect(CAPABILITY_CLASSIFICATIONS[id].requirement).toBe("optional");
+    }
+    for (const id of ["postgres", "blob", "kms", "identity"] as const) {
+      expect(CAPABILITY_CLASSIFICATIONS[id].requirement).toBe("required");
+    }
+  });
+
+  it("requiredCapabilityIds excludes every optional accelerator", () => {
+    const required = new Set(requiredCapabilityIds());
+    expect(required.has("postgres")).toBe(true);
+    expect(required.has("cache")).toBe(false);
+    expect(required.has("vector")).toBe(false);
+    expect(required.has("queue")).toBe(false);
+  });
+});
+
+describe("assertRequiredCapabilities", () => {
+  it("passes when required backends are present even if cache/vector/queue are absent", () => {
+    const report = reportWith({
+      postgres: true,
+      blob: true,
+      kms: true,
+      identity: true,
+      cache: false,
+      vector: false,
+      queue: false,
+      telemetry: false,
+      model: false,
+      sandbox: false,
+    });
+    expect(() => assertRequiredCapabilities(report)).not.toThrow();
+  });
+
+  it("throws MissingCapabilityError naming PostgreSQL when the correctness core is absent", () => {
+    const report = reportWith({ blob: true, kms: true, identity: true });
+    expect(() => assertRequiredCapabilities(report)).toThrow(MissingCapabilityError);
+    expect(() => assertRequiredCapabilities(report)).toThrow(/postgres/);
+  });
+});

--- a/packages/observability/src/ports/capability.ts
+++ b/packages/observability/src/ports/capability.ts
@@ -1,0 +1,168 @@
+/**
+ * Provider-neutral infrastructure capability discovery.
+ *
+ * SPEC §22 requires ten operational backends to be provider-neutral ports "with
+ * documented capability checks": PostgreSQL, blob, KMS, identity, model,
+ * telemetry, vector search, cache, queue optimization, and sandbox. This module
+ * makes that discovery explicit and typed and classifies each capability's
+ * criticality so composition can fail closed on a missing required backend while
+ * degrading gracefully without an optional one.
+ *
+ * Architectural invariant 16 (SPEC §5): no optional cache, queue, vector store,
+ * or model provider is required for correctness. PostgreSQL is therefore the sole
+ * correctness-critical capability; every other backend either fails closed
+ * (required-to-serve) or degrades a feature (optional) without corrupting or
+ * losing committed state.
+ *
+ * This catalog enumerates capability *ids* only. The port interfaces live with
+ * their owning packages: transactions/blob/vector/cache/queue in
+ * `@tulipfarm/storage`, KMS in `@tulipfarm/secrets`, sandbox in
+ * `@tulipfarm/sandbox`, telemetry here. The `identity` and `model` ports are
+ * owned by their downstream domain packages; only their capability classification
+ * is fixed here.
+ */
+
+export const CAPABILITY_IDS = [
+  "postgres",
+  "blob",
+  "kms",
+  "identity",
+  "model",
+  "telemetry",
+  "vector",
+  "cache",
+  "queue",
+  "sandbox",
+] as const;
+
+export type CapabilityId = (typeof CAPABILITY_IDS)[number];
+
+/**
+ * - `required`: the deployment must provide a backend for this port before it can
+ *   serve protected work; a missing required capability fails closed.
+ * - `optional`: omitting or losing the backend degrades a feature but never loses
+ *   authoritative state or grants access.
+ */
+export type CapabilityRequirement = "required" | "optional";
+
+export interface CapabilityClassification {
+  readonly id: CapabilityId;
+  readonly requirement: CapabilityRequirement;
+  /**
+   * True only for capabilities whose loss can corrupt or lose committed state.
+   * Invariant 16 fixes this to PostgreSQL alone.
+   */
+  readonly correctnessCritical: boolean;
+  readonly summary: string;
+}
+
+export const CAPABILITY_CLASSIFICATIONS: Readonly<Record<CapabilityId, CapabilityClassification>> =
+  {
+    postgres: {
+      id: "postgres",
+      requirement: "required",
+      correctnessCritical: true,
+      summary: "Transactional correctness core, inbox/outbox, and durable state.",
+    },
+    blob: {
+      id: "blob",
+      requirement: "required",
+      correctnessCritical: false,
+      summary: "Content-addressed large-payload store; filesystem/S3-compatible adapter.",
+    },
+    kms: {
+      id: "kms",
+      requirement: "required",
+      correctnessCritical: false,
+      summary: "Master-key provider wrapping data-encryption keys; fails closed, never plaintext.",
+    },
+    identity: {
+      id: "identity",
+      requirement: "required",
+      correctnessCritical: false,
+      summary: "Principal resolution / authentication backend (local credentials, OIDC).",
+    },
+    model: {
+      id: "model",
+      requirement: "optional",
+      correctnessCritical: false,
+      summary: "LLM provider behind ModelProfile; not required for correctness (invariant 16).",
+    },
+    telemetry: {
+      id: "telemetry",
+      requirement: "optional",
+      correctnessCritical: false,
+      summary: "OpenTelemetry export; loss degrades observability only.",
+    },
+    vector: {
+      id: "vector",
+      requirement: "optional",
+      correctnessCritical: false,
+      summary: "Vector-search accelerator (pgvector); never an ACL or correctness dependency.",
+    },
+    cache: {
+      id: "cache",
+      requirement: "optional",
+      correctnessCritical: false,
+      summary: "Ephemeral cache accelerator (Redis); its loss cannot lose authoritative state.",
+    },
+    queue: {
+      id: "queue",
+      requirement: "optional",
+      correctnessCritical: false,
+      summary: "Optional queue-optimization accelerator; the durable handoff stays in PostgreSQL.",
+    },
+    sandbox: {
+      id: "sandbox",
+      requirement: "optional",
+      correctnessCritical: false,
+      summary: "Isolated execution backend; production use requires strong-isolation attestation.",
+    },
+  };
+
+export function classifyCapability(id: CapabilityId): CapabilityClassification {
+  return CAPABILITY_CLASSIFICATIONS[id];
+}
+
+export function requiredCapabilityIds(): CapabilityId[] {
+  return CAPABILITY_IDS.filter((id) => CAPABILITY_CLASSIFICATIONS[id].requirement === "required");
+}
+
+export function correctnessCriticalCapabilityIds(): CapabilityId[] {
+  return CAPABILITY_IDS.filter((id) => CAPABILITY_CLASSIFICATIONS[id].correctnessCritical);
+}
+
+/** Result of probing one backend. `detail` must be safe, non-sensitive metadata. */
+export interface CapabilityProbe {
+  readonly id: CapabilityId;
+  /** Provider-neutral adapter identifier, e.g. "postgres", "s3", "local-fs". Never a secret. */
+  readonly provider: string;
+  readonly available: boolean;
+  readonly detail?: string;
+}
+
+export interface CapabilityReport {
+  readonly probes: Readonly<Record<CapabilityId, CapabilityProbe>>;
+}
+
+export class MissingCapabilityError extends Error {
+  readonly missing: readonly CapabilityId[];
+
+  constructor(missing: readonly CapabilityId[]) {
+    super(`missing required infrastructure capabilities: ${missing.join(", ")}`);
+    this.name = "MissingCapabilityError";
+    this.missing = missing;
+  }
+}
+
+/**
+ * Fail closed when any `required` capability is unavailable. Absent optional
+ * accelerators (cache, vector, queue, telemetry, model, sandbox) never throw, so
+ * a deployment stays correct after losing them.
+ */
+export function assertRequiredCapabilities(report: CapabilityReport): void {
+  const missing = requiredCapabilityIds().filter((id) => !report.probes[id]?.available);
+  if (missing.length > 0) {
+    throw new MissingCapabilityError(missing);
+  }
+}

--- a/packages/observability/src/ports/index.ts
+++ b/packages/observability/src/ports/index.ts
@@ -1,0 +1,17 @@
+export type {
+  CapabilityClassification,
+  CapabilityId,
+  CapabilityProbe,
+  CapabilityReport,
+  CapabilityRequirement,
+} from "./capability";
+export {
+  assertRequiredCapabilities,
+  CAPABILITY_CLASSIFICATIONS,
+  CAPABILITY_IDS,
+  classifyCapability,
+  correctnessCriticalCapabilityIds,
+  MissingCapabilityError,
+  requiredCapabilityIds,
+} from "./capability";
+export type { Attributes, AttributeValue, LogLevel, Span, TelemetryPort } from "./telemetry";

--- a/packages/observability/src/ports/telemetry.test.ts
+++ b/packages/observability/src/ports/telemetry.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import type { Attributes, Span, TelemetryPort } from "./telemetry";
+
+// A minimal in-memory adapter proves the port is implementable with only safe,
+// provider-neutral metadata — no payloads, no secrets, no provider SDK types.
+function fakeTelemetry(sink: string[]): TelemetryPort {
+  const span = (name: string): Span => ({
+    setAttributes: (a: Attributes) => sink.push(`attr:${name}:${Object.keys(a).join(",")}`),
+    recordError: (code: string) => sink.push(`err:${name}:${code}`),
+    end: () => sink.push(`end:${name}`),
+  });
+  return {
+    startSpan: (name) => span(name),
+    counter: (name, value = 1) => sink.push(`counter:${name}:${value}`),
+    log: (level, message) => sink.push(`log:${level}:${message}`),
+  };
+}
+
+describe("TelemetryPort", () => {
+  it("records spans, counters, and logs through safe metadata only", () => {
+    const sink: string[] = [];
+    const t = fakeTelemetry(sink);
+    const s = t.startSpan("run.dispatch", { runId: "r1" });
+    s.setAttributes({ stateId: "s1" });
+    s.recordError("tool_timeout");
+    s.end();
+    t.counter("runs.dispatched");
+    t.log("info", "dispatched");
+    expect(sink).toEqual([
+      "attr:run.dispatch:stateId",
+      "err:run.dispatch:tool_timeout",
+      "end:run.dispatch",
+      "counter:runs.dispatched:1",
+      "log:info:dispatched",
+    ]);
+  });
+});

--- a/packages/observability/src/ports/telemetry.ts
+++ b/packages/observability/src/ports/telemetry.ts
@@ -1,0 +1,28 @@
+/**
+ * Provider-neutral telemetry port.
+ *
+ * Capability id `telemetry` (optional; see ./capability). Adapters bind to
+ * OpenTelemetry or any exporter without leaking provider types across the
+ * boundary. Attribute values are restricted to primitives so callers cannot dump
+ * payloads or secrets into spans/metrics/logs; errors are recorded by a stable
+ * safe `code`, never a raw error carrying a stack or protected content (SPEC §22:
+ * "redacting contents and Secrets").
+ */
+
+export type AttributeValue = string | number | boolean;
+export type Attributes = Readonly<Record<string, AttributeValue>>;
+
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+export interface Span {
+  setAttributes(attributes: Attributes): void;
+  /** Record a failure by stable safe code — not a raw error object. */
+  recordError(code: string): void;
+  end(): void;
+}
+
+export interface TelemetryPort {
+  startSpan(name: string, attributes?: Attributes): Span;
+  counter(name: string, value?: number, attributes?: Attributes): void;
+  log(level: LogLevel, message: string, attributes?: Attributes): void;
+}

--- a/packages/sandbox/AGENTS.md
+++ b/packages/sandbox/AGENTS.md
@@ -1,8 +1,10 @@
 # Sandbox — Agent Conventions
 
 `@tulipfarm/sandbox` — isolated execution request contract, backend ports, workspace/assets, and
-egress and compute controls. **Scaffold today:** `src/index.ts` is `export {}`. tsconfig extends
-`@tulipfarm/tsconfig/base.json`. See root `AGENTS.md` for commands/lint.
+egress and compute controls. **Today:** `src/ports/` defines the provider-neutral `SandboxPort`,
+`SandboxIsolationAttestation`, and `assertProductionSandbox` gate (rejects local/SSH and any
+non-strong-isolation backend for production). tsconfig extends `@tulipfarm/tsconfig/base.json`.
+See root `AGENTS.md` for commands/lint.
 
 May import: `@tulipfarm/schema`, `@tulipfarm/authz`, `@tulipfarm/audit`, `@tulipfarm/storage`,
 `@tulipfarm/observability`. See

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -1,1 +1,1 @@
-export {};
+export * from "./ports";

--- a/packages/sandbox/src/ports/index.ts
+++ b/packages/sandbox/src/ports/index.ts
@@ -1,0 +1,8 @@
+export type {
+  SandboxExecutionRequest,
+  SandboxExecutionResult,
+  SandboxIsolation,
+  SandboxIsolationAttestation,
+  SandboxPort,
+} from "./sandbox";
+export { assertProductionSandbox, WeakSandboxIsolationError } from "./sandbox";

--- a/packages/sandbox/src/ports/sandbox.test.ts
+++ b/packages/sandbox/src/ports/sandbox.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertProductionSandbox,
+  type SandboxIsolationAttestation,
+  WeakSandboxIsolationError,
+} from "./sandbox";
+
+function attest(
+  partial: Partial<SandboxIsolationAttestation> & Pick<SandboxIsolationAttestation, "isolation">
+): SandboxIsolationAttestation {
+  return {
+    provider: "test",
+    strongIsolation: false,
+    developmentOnly: false,
+    ...partial,
+  };
+}
+
+describe("assertProductionSandbox", () => {
+  it("accepts strongly isolated microVM and remote-managed backends", () => {
+    expect(() =>
+      assertProductionSandbox(attest({ isolation: "microvm", strongIsolation: true }))
+    ).not.toThrow();
+    expect(() =>
+      assertProductionSandbox(attest({ isolation: "remote-managed", strongIsolation: true }))
+    ).not.toThrow();
+  });
+
+  it("rejects local and ssh dev backends outright (Hermes reject list)", () => {
+    for (const isolation of ["local", "ssh"] as const) {
+      expect(() => assertProductionSandbox(attest({ isolation, strongIsolation: true }))).toThrow(
+        WeakSandboxIsolationError
+      );
+    }
+  });
+
+  it("rejects a container backend lacking strong-isolation attestation", () => {
+    expect(() => assertProductionSandbox(attest({ isolation: "container" }))).toThrow(
+      WeakSandboxIsolationError
+    );
+  });
+
+  it("rejects any development-only backend regardless of claimed isolation", () => {
+    expect(() =>
+      assertProductionSandbox(
+        attest({ isolation: "microvm", strongIsolation: true, developmentOnly: true })
+      )
+    ).toThrow(WeakSandboxIsolationError);
+  });
+});

--- a/packages/sandbox/src/ports/sandbox.ts
+++ b/packages/sandbox/src/ports/sandbox.ts
@@ -1,0 +1,73 @@
+/**
+ * Provider-neutral sandbox execution port.
+ *
+ * Capability id `sandbox` (optional — see `@tulipfarm/observability` capability
+ * catalog). Adapts Hermes's workspace/backend ergonomics while rejecting its
+ * local/SSH execution as a production isolation boundary (SPEC §13). Production
+ * execution requires a strong-isolation backend (microVM or managed remote
+ * sandbox); local and SSH backends exist only as clearly marked development
+ * adapters and can never satisfy the production gate. Default sandbox guardrail
+ * denies network, credential access, host mounts, and business mutation; business
+ * effects must still traverse the Tool Broker.
+ */
+
+export type SandboxIsolation = "microvm" | "remote-managed" | "container" | "local" | "ssh";
+
+export interface SandboxIsolationAttestation {
+  readonly isolation: SandboxIsolation;
+  /** True only for hypervisor-strength or managed-service isolation. */
+  readonly strongIsolation: boolean;
+  /** Development-only backends set this; they can never pass the production gate. */
+  readonly developmentOnly: boolean;
+  /** Provider-neutral backend identifier, e.g. "firecracker", "daytona". Never a secret. */
+  readonly provider: string;
+}
+
+export interface SandboxExecutionRequest {
+  readonly requestId: string;
+  readonly command: readonly string[];
+  readonly timeoutMs: number;
+  /** Default-deny egress: only these destinations are reachable. Omitted means none. */
+  readonly allowedEgress?: readonly string[];
+  /** Provider-neutral workspace/asset reference; never secret plaintext. */
+  readonly workspaceRef?: string;
+}
+
+export interface SandboxExecutionResult {
+  readonly requestId: string;
+  readonly exitCode: number;
+  /** Blob/Artifact reference to captured stdout, scanned before publication. */
+  readonly stdoutRef: string;
+  readonly stderrRef: string;
+  readonly timedOut: boolean;
+}
+
+export interface SandboxPort {
+  attestation(): SandboxIsolationAttestation;
+  execute(request: SandboxExecutionRequest): Promise<SandboxExecutionResult>;
+}
+
+export class WeakSandboxIsolationError extends Error {
+  constructor(attestation: SandboxIsolationAttestation) {
+    super(
+      `sandbox backend '${attestation.provider}' (${attestation.isolation}) lacks the ` +
+        "strong-isolation attestation required for production"
+    );
+    this.name = "WeakSandboxIsolationError";
+  }
+}
+
+/**
+ * Fail closed on any backend that is not strongly isolated for production use.
+ * Development-only, non-strong, and local/SSH backends are always rejected.
+ */
+export function assertProductionSandbox(attestation: SandboxIsolationAttestation): void {
+  if (
+    attestation.developmentOnly ||
+    !attestation.strongIsolation ||
+    attestation.isolation === "local" ||
+    attestation.isolation === "ssh"
+  ) {
+    throw new WeakSandboxIsolationError(attestation);
+  }
+}

--- a/packages/secrets/AGENTS.md
+++ b/packages/secrets/AGENTS.md
@@ -16,6 +16,9 @@
 - **`backfillSecretsToDek`** — migrate legacy (pre-envelope) secrets onto the DEK.
 - **`loadEncryptionKeys`** (+ type `EncryptionKeys`) — reads the env KEK(s).
 - **`assertValidSecretKey`** + `InvalidSecretKeyError` — key-name guard.
+- **KMS port** (`src/ports/kms.ts`) — provider-neutral `KmsPort` (`wrap`/`unwrap`/`activeKey`)
+  with opaque `MasterKeyRef` / `WrappedKey`; the master key never crosses the boundary and no
+  provider SDK type leaks. Adapters: local managed keys, cloud KMS, or Vault-compatible services.
 - Types: `SecretDoc`, `SecretEnvelopeFields`, `SecretMeta`, `SecretType`, `WrappedDekRow`, `KekLabel`.
 
 ## Model — envelope encryption (SEC-V1 key recovery)

--- a/packages/secrets/src/index.ts
+++ b/packages/secrets/src/index.ts
@@ -21,6 +21,7 @@ export {
 } from "./key-manager";
 export type { EncryptionKeys } from "./keys";
 export { loadEncryptionKeys } from "./keys";
+export type { KmsPort, MasterKeyRef, WrappedKey } from "./ports";
 export type { LlmProviderId, LlmProviderInfo, ProviderField, ProviderFieldRole } from "./registry";
 export {
   isProviderConfigured,

--- a/packages/secrets/src/ports/index.ts
+++ b/packages/secrets/src/ports/index.ts
@@ -1,0 +1,1 @@
+export type { KmsPort, MasterKeyRef, WrappedKey } from "./kms";

--- a/packages/secrets/src/ports/kms.test.ts
+++ b/packages/secrets/src/ports/kms.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import type { KmsPort, MasterKeyRef, WrappedKey } from "./kms";
+
+// A deterministic in-memory KMS proves the port wraps/unwraps a DEK without ever
+// exposing master-key material or a provider-specific type across the boundary.
+function fakeKms(keyId: string): KmsPort {
+  const ref: MasterKeyRef = { keyId, provider: "local" };
+  return {
+    activeKey: () => ref,
+    wrap: async (dek) => ({ keyId, ciphertext: Buffer.from(dek).toString("base64") }),
+    unwrap: async (wrapped: WrappedKey) =>
+      new Uint8Array(Buffer.from(wrapped.ciphertext, "base64")),
+  };
+}
+
+describe("KmsPort", () => {
+  it("round-trips a data-encryption key through wrap/unwrap", async () => {
+    const kms = fakeKms("kek-1");
+    const dek = new Uint8Array([1, 2, 3, 4]);
+    const wrapped = await kms.wrap(dek);
+    expect(wrapped.keyId).toBe("kek-1");
+    const unwrapped = await kms.unwrap(wrapped);
+    expect([...unwrapped]).toEqual([1, 2, 3, 4]);
+  });
+
+  it("exposes only an opaque master-key reference, never key material", () => {
+    const ref = fakeKms("kek-1").activeKey();
+    expect(ref).toEqual({ keyId: "kek-1", provider: "local" });
+    // The reference is a discriminator for rotation/audit — it carries no bytes.
+    expect(Object.keys(ref).sort()).toEqual(["keyId", "provider"]);
+  });
+});

--- a/packages/secrets/src/ports/kms.ts
+++ b/packages/secrets/src/ports/kms.ts
@@ -1,0 +1,34 @@
+/**
+ * Provider-neutral KMS (master-key) port.
+ *
+ * Capability id `kms` (required-to-serve, fail-closed — see
+ * `@tulipfarm/observability` capability catalog). A master key wraps per-secret
+ * data-encryption keys (SPEC §13). Adapters may be local managed keys, a cloud
+ * KMS, or a Vault-compatible service, but the port never exposes the master key
+ * itself and never returns a provider-specific type across the boundary:
+ * `MasterKeyRef` is an opaque discriminator for rotation/audit and `WrappedKey`
+ * is opaque ciphertext. `unwrap` yields raw DEK bytes only for immediate
+ * in-memory use by the authorized secret broker — that plaintext never reaches a
+ * prompt, log, audit payload, artifact, or error.
+ */
+
+export interface MasterKeyRef {
+  readonly keyId: string;
+  /** Provider-neutral adapter identifier, e.g. "local", "aws-kms", "vault". Never a secret. */
+  readonly provider: string;
+}
+
+export interface WrappedKey {
+  readonly keyId: string;
+  /** Opaque wrapped ciphertext of a data-encryption key (e.g. base64). */
+  readonly ciphertext: string;
+}
+
+export interface KmsPort {
+  /** Wrap plaintext DEK bytes under the active master key; returns opaque material. */
+  wrap(dek: Uint8Array): Promise<WrappedKey>;
+  /** Unwrap DEK bytes for immediate in-memory use by the secret broker only. */
+  unwrap(wrapped: WrappedKey): Promise<Uint8Array>;
+  /** Active master-key reference for rotation and audit; never returns key material. */
+  activeKey(): MasterKeyRef;
+}

--- a/packages/storage/AGENTS.md
+++ b/packages/storage/AGENTS.md
@@ -1,8 +1,10 @@
 # Storage — Agent Conventions
 
 `@tulipfarm/storage` — PostgreSQL repositories, transaction helpers, outbox/inbox, and
-blob/vector/cache provider ports. **Scaffold today:** `src/index.ts` is `export {}`. tsconfig
-extends `@tulipfarm/tsconfig/base.json`. See root `AGENTS.md` for commands/lint.
+blob/vector/cache provider ports. **Today:** `src/ports/` defines the provider-neutral
+`TransactionPort`/`Queryable`, `BlobPort`, `VectorPort`, `CachePort`, and `QueueAcceleratorPort`
+contracts (no `pg`/SDK types leak across the boundary). tsconfig extends
+`@tulipfarm/tsconfig/base.json`. See root `AGENTS.md` for commands/lint.
 
 May import: `@tulipfarm/schema`, `@tulipfarm/observability`. See
 [`docs/architecture/dependency-rules.md`](../../docs/architecture/dependency-rules.md). Domain

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -1,1 +1,1 @@
-export {};
+export * from "./ports";

--- a/packages/storage/src/ports/blob.test.ts
+++ b/packages/storage/src/ports/blob.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import type { BlobPort, BlobRef } from "./blob";
+
+// Deterministic content hash for the test double — a real adapter uses sha256.
+function contentHash(bytes: Uint8Array): string {
+  let h = 2166136261;
+  for (const b of bytes) {
+    h = Math.imul(h ^ b, 16777619) >>> 0;
+  }
+  return h.toString(16);
+}
+
+// A content-addressed in-memory blob store proves the port stays provider-neutral
+// (no S3/filesystem type leaks) and keys payloads by content hash (SPEC §19).
+function fakeBlobStore(): BlobPort {
+  const store = new Map<string, Uint8Array>();
+  return {
+    put: async (bytes: Uint8Array) => {
+      const hash = contentHash(bytes);
+      store.set(hash, bytes);
+      return { key: hash, hash };
+    },
+    get: async (ref: BlobRef) => {
+      const bytes = store.get(ref.hash);
+      if (!bytes) throw new Error(`blob not found: ${ref.hash}`);
+      return bytes;
+    },
+    delete: async (ref: BlobRef) => {
+      store.delete(ref.hash);
+    },
+  };
+}
+
+describe("BlobPort", () => {
+  it("stores and retrieves a content-addressed payload", async () => {
+    const blob = fakeBlobStore();
+    const ref = await blob.put(new Uint8Array([9, 8, 7]));
+    expect(ref.hash).toBe(ref.key);
+    expect([...(await blob.get(ref))]).toEqual([9, 8, 7]);
+  });
+
+  it("deletes by reference", async () => {
+    const blob = fakeBlobStore();
+    const ref = await blob.put(new Uint8Array([1]));
+    await blob.delete(ref);
+    await expect(blob.get(ref)).rejects.toThrow(/not found/);
+  });
+});

--- a/packages/storage/src/ports/blob.ts
+++ b/packages/storage/src/ports/blob.ts
@@ -1,0 +1,22 @@
+/**
+ * Provider-neutral blob store port.
+ *
+ * Capability id `blob` (required-to-serve, not correctness-critical — see
+ * `@tulipfarm/observability` capability catalog). Large immutable payloads are
+ * content-addressed with a hash and provider-neutral references (SPEC §19); a
+ * filesystem or S3-compatible adapter is sufficient initially. Refs carry no
+ * provider type and no secret.
+ */
+
+export interface BlobRef {
+  /** Storage key. Implementations may make this equal to `hash` (content-addressed). */
+  readonly key: string;
+  /** Content hash (e.g. sha256 hex) used for integrity and deduplication. */
+  readonly hash: string;
+}
+
+export interface BlobPort {
+  put(bytes: Uint8Array, contentType?: string): Promise<BlobRef>;
+  get(ref: BlobRef): Promise<Uint8Array>;
+  delete(ref: BlobRef): Promise<void>;
+}

--- a/packages/storage/src/ports/cache.ts
+++ b/packages/storage/src/ports/cache.ts
@@ -1,0 +1,14 @@
+/**
+ * Provider-neutral ephemeral cache port.
+ *
+ * Capability id `cache` (optional accelerator — see `@tulipfarm/observability`
+ * capability catalog). Redis is one adapter. Losing the cache cannot lose
+ * authoritative state or violate a limit (invariant 16); values are advisory
+ * copies of data the correctness core still owns.
+ */
+
+export interface CachePort {
+  get<T>(key: string): Promise<T | undefined>;
+  set<T>(key: string, value: T, ttlMs: number): Promise<void>;
+  delete(key: string): Promise<void>;
+}

--- a/packages/storage/src/ports/index.ts
+++ b/packages/storage/src/ports/index.ts
@@ -1,0 +1,5 @@
+export type { BlobPort, BlobRef } from "./blob";
+export type { CachePort } from "./cache";
+export type { QueueAcceleratorPort, QueueMessage } from "./queue";
+export type { Queryable, QueryResult, TransactionPort } from "./transaction";
+export type { VectorMatch, VectorMetadata, VectorPort } from "./vector";

--- a/packages/storage/src/ports/queue.ts
+++ b/packages/storage/src/ports/queue.ts
@@ -1,0 +1,20 @@
+/**
+ * Provider-neutral queue-optimization port.
+ *
+ * Capability id `queue` (optional accelerator — see `@tulipfarm/observability`
+ * capability catalog). This port only accelerates dispatch; it is never the
+ * authoritative handoff. The durable cross-process contract is the PostgreSQL
+ * transactional outbox/inbox (dependency-rules §6), so losing this accelerator
+ * cannot lose an event or a side effect.
+ */
+
+export interface QueueMessage<T> {
+  readonly id: string;
+  readonly body: T;
+}
+
+export interface QueueAcceleratorPort {
+  enqueue<T>(topic: string, body: T): Promise<void>;
+  reserve<T>(topic: string, max: number): Promise<QueueMessage<T>[]>;
+  ack(id: string): Promise<void>;
+}

--- a/packages/storage/src/ports/transaction.test.ts
+++ b/packages/storage/src/ports/transaction.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import type { Queryable, TransactionPort } from "./transaction";
+
+// A journalled fake proves the transaction port's contract: commit on success,
+// rollback on throw — without importing `pg` or any provider-specific type.
+function fakeTransactionPort(journal: string[]): TransactionPort {
+  const tx: Queryable = {
+    query: async (text: string) => {
+      journal.push(`query:${text}`);
+      return { rows: [] };
+    },
+  };
+  return {
+    withTransaction: async (fn) => {
+      journal.push("BEGIN");
+      try {
+        const result = await fn(tx);
+        journal.push("COMMIT");
+        return result;
+      } catch (error) {
+        journal.push("ROLLBACK");
+        throw error;
+      }
+    },
+  };
+}
+
+describe("TransactionPort", () => {
+  it("commits when the callback resolves", async () => {
+    const journal: string[] = [];
+    const port = fakeTransactionPort(journal);
+    const result = await port.withTransaction(async (tx) => {
+      await tx.query("insert 1");
+      return 42;
+    });
+    expect(result).toBe(42);
+    expect(journal).toEqual(["BEGIN", "query:insert 1", "COMMIT"]);
+  });
+
+  it("rolls back and re-throws when the callback rejects", async () => {
+    const journal: string[] = [];
+    const port = fakeTransactionPort(journal);
+    await expect(
+      port.withTransaction(async (tx) => {
+        await tx.query("insert 1");
+        throw new Error("boom");
+      })
+    ).rejects.toThrow("boom");
+    expect(journal).toEqual(["BEGIN", "query:insert 1", "ROLLBACK"]);
+  });
+});

--- a/packages/storage/src/ports/transaction.ts
+++ b/packages/storage/src/ports/transaction.ts
@@ -1,0 +1,25 @@
+/**
+ * Provider-neutral PostgreSQL transaction port.
+ *
+ * Capability id `postgres` (required; the sole correctness-critical capability —
+ * see `@tulipfarm/observability` capability catalog). The shape is the minimal
+ * query surface shared by the production `pg.Pool` and the test client, so repos
+ * and migrations run identical SQL in both. Domain packages receive a
+ * transaction-scoped `Queryable` and never import `pg` or hold a raw pool.
+ */
+
+export interface QueryResult<Row = Record<string, unknown>> {
+  readonly rows: Row[];
+}
+
+export interface Queryable {
+  query<Row = Record<string, unknown>>(
+    text: string,
+    params?: readonly unknown[]
+  ): Promise<QueryResult<Row>>;
+}
+
+export interface TransactionPort {
+  /** Run `fn` inside one transaction: commit when it resolves, roll back if it throws. */
+  withTransaction<T>(fn: (tx: Queryable) => Promise<T>): Promise<T>;
+}

--- a/packages/storage/src/ports/vector.ts
+++ b/packages/storage/src/ports/vector.ts
@@ -1,0 +1,22 @@
+/**
+ * Provider-neutral vector-search port.
+ *
+ * Capability id `vector` (optional accelerator — see `@tulipfarm/observability`
+ * capability catalog). pgvector is one adapter; correctness and ACLs never depend
+ * on it (invariant 16). Knowledge authorization happens before this port is
+ * queried, so a vector result is never an authorization decision.
+ */
+
+export type VectorMetadata = Readonly<Record<string, string | number | boolean>>;
+
+export interface VectorMatch {
+  readonly id: string;
+  readonly score: number;
+  readonly metadata?: VectorMetadata;
+}
+
+export interface VectorPort {
+  upsert(id: string, embedding: readonly number[], metadata?: VectorMetadata): Promise<void>;
+  query(embedding: readonly number[], k: number): Promise<VectorMatch[]>;
+  delete(id: string): Promise<void>;
+}


### PR DESCRIPTION
## Summary
- Define provider-neutral infrastructure ports (SPEC §22) as pure type interfaces — no provider SDK types leak across boundaries.
- Add a typed capability catalog in `@tulipfarm/observability` classifying the ten backends required-vs-optional; `postgres` is the sole correctness-critical capability (invariant 16).
- Ports: `TelemetryPort` (observability); `TransactionPort`/`Queryable`, `BlobPort`, `VectorPort`, `CachePort`, `QueueAcceleratorPort` (storage); `KmsPort` with opaque master-key refs (secrets); `SandboxPort` + `assertProductionSandbox` strong-isolation gate (sandbox).

## Scope note
Objective lists **model** and **identity** among the ten. The frozen `docs/architecture/dependency-rules.md` ownership table assigns model's port interface to `agent-runtime` (AW-046) and identity has no infra-port owner — authoring those interfaces here would break the dependency contract. They are represented in the capability catalog only; interfaces are deferred to their owners.

## Acceptance criteria
- ✅ Capability discovery explicit + typed, required-vs-optional (`CAPABILITY_IDS`, `CAPABILITY_CLASSIFICATIONS`, `assertRequiredCapabilities`).
- ✅ Sandbox production gate rejects `developmentOnly`/non-strong/`local`/`ssh` (blocks Hermes local/SSH backends in prod).
- ✅ KMS master key never crosses the boundary (opaque `MasterKeyRef`/`WrappedKey`).

## Test plan
- [x] Test-first: RED (import of nonexistent port module) → GREEN (minimal interfaces). In-memory/structural fakes, no provider SDKs.
- [x] Package tests: 72 passed / 12 files (`observability`, `storage`, `secrets`, `sandbox`).
- [x] `pnpm exec biome check .` — no issues.
- [x] `pnpm typecheck` — 27/27.
- [x] `pnpm build` — 5/5.
- [x] `pnpm test` full suite — api#test flaked once on a vitest fork-pool worker crash (resource pressure under concurrent runs); isolated rerun clean: 1699 tests passed, exit 0. Diff touches no `apps/api` files.