### PR TITLE
feat(schema): add strict schema registry

### DIFF
--- a/packages/schema/AGENTS.md
+++ b/packages/schema/AGENTS.md
@@ -22,6 +22,13 @@ Implements `specs/VALIDATION.md`. See root `AGENTS.md` for commands/lint.
 - **LLM error classes** — `LlmConfigValidationError`, `LlmCredentialError`,
   `LlmNotConfiguredError`, `UnknownModelError`, `EmbeddingUnavailableError` (thrown by
   `@tulipfarm/llm` runtime).
+- **`SchemaRegistry`** — strict `apiVersion`/`kind` dispatch with explicit unknown-property
+  behavior, fail-closed YAML parsing, deterministic validation issues, and immutable validated
+  documents.
+- **`canonicalize` + `canonicalHash`** — deterministic canonical JSON and lowercase SHA-256 hex
+  over parsed data; rejects values that JSON would silently erase or change.
+- **Schema contract errors** — stable error codes for invalid/unknown/duplicate schemas, validation,
+  YAML parsing, and canonicalization without protected payload values.
 
 ## Boundaries
 

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "@sinclair/typebox": "^0.34.49",
-    "ajv": "^8.20.0"
+    "ajv": "^8.20.0",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@tulipfarm/tsconfig": "workspace:*",

--- a/packages/schema/src/canonicalize.test.ts
+++ b/packages/schema/src/canonicalize.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { canonicalHash, canonicalize } from "./canonicalize";
+import { CanonicalizationError } from "./errors";
+
+describe("canonicalize", () => {
+  it("sorts object keys recursively while preserving array order", () => {
+    expect(
+      canonicalize({
+        z: [{ beta: 2, alpha: 1 }, "last"],
+        a: { enabled: true, nullable: null },
+      })
+    ).toBe('{"a":{"enabled":true,"nullable":null},"z":[{"alpha":1,"beta":2},"last"]}');
+  });
+
+  it("produces the same SHA-256 hash for equivalent parsed data", () => {
+    const first = { kind: "Agent", apiVersion: "tulipfarm.ai/v1", spec: { b: 2, a: 1 } };
+    const second = { spec: { a: 1, b: 2 }, apiVersion: "tulipfarm.ai/v1", kind: "Agent" };
+
+    expect(canonicalHash(first)).toBe(canonicalHash(second));
+    expect(canonicalHash(first)).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("keeps the canonical hash format stable with a known vector", () => {
+    expect(canonicalHash({ b: 2, a: 1 })).toBe(
+      "43258cff783fe7036d8a43033f830adfc60ec037382473548ac742b888292777"
+    );
+  });
+
+  it("does not erase meaningful array ordering", () => {
+    expect(canonicalHash({ values: [1, 2] })).not.toBe(canonicalHash({ values: [2, 1] }));
+  });
+
+  it.each([
+    ["undefined", { value: undefined }],
+    ["non-finite number", { value: Number.NaN }],
+    ["bigint", { value: 1n }],
+    ["non-plain object", { value: new Date("2026-07-22T00:00:00.000Z") }],
+  ])("rejects %s instead of silently changing it", (_label, value) => {
+    expect(() => canonicalize(value)).toThrow(CanonicalizationError);
+  });
+
+  it("rejects cyclic input with a payload-free structured error", () => {
+    const value: Record<string, unknown> = { secret: "do-not-disclose" };
+    value.self = value;
+
+    try {
+      canonicalize(value);
+      throw new Error("expected canonicalization to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(CanonicalizationError);
+      expect(error).toMatchObject({ code: "CANONICALIZATION_FAILED", path: "/self" });
+      expect((error as Error).message).not.toContain("do-not-disclose");
+    }
+  });
+
+  it("rejects array properties that JSON serialization would silently erase", () => {
+    const value = ["visible"];
+    Object.assign(value, { hiddenByJson: "must-not-disappear" });
+
+    expect(() => canonicalize(value)).toThrow(CanonicalizationError);
+  });
+
+  it("rejects array accessors instead of invoking them", () => {
+    const value: string[] = [];
+    Object.defineProperty(value, "0", {
+      enumerable: true,
+      get: () => "stateful",
+    });
+    value.length = 1;
+
+    expect(() => canonicalize(value)).toThrow(CanonicalizationError);
+  });
+});

--- a/packages/schema/src/canonicalize.ts
+++ b/packages/schema/src/canonicalize.ts
@@ -1,0 +1,84 @@
+import { createHash } from "node:crypto";
+import { CanonicalizationError } from "./errors";
+
+export const CANONICAL_HASH_ALGORITHM = "sha256" as const;
+
+function pointerSegment(value: string): string {
+  return value.replaceAll("~", "~0").replaceAll("/", "~1");
+}
+
+function childPath(path: string, segment: string): string {
+  return `${path}/${pointerSegment(segment)}`;
+}
+
+function serialize(value: unknown, path: string, ancestors: Set<object>): string {
+  if (value === null) return "null";
+  if (typeof value === "boolean") return value ? "true" : "false";
+  if (typeof value === "string") return JSON.stringify(value);
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new CanonicalizationError(path);
+    return JSON.stringify(value);
+  }
+  if (typeof value !== "object") throw new CanonicalizationError(path);
+  if (ancestors.has(value)) throw new CanonicalizationError(path);
+
+  ancestors.add(value);
+  try {
+    if (Array.isArray(value)) {
+      const items: string[] = [];
+      for (let index = 0; index < value.length; index += 1) {
+        const indexPath = childPath(path, String(index));
+        const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+        if (!descriptor?.enumerable || !("value" in descriptor)) {
+          throw new CanonicalizationError(indexPath);
+        }
+        items.push(serialize(descriptor.value, indexPath, ancestors));
+      }
+      for (const key of Reflect.ownKeys(value)) {
+        if (key === "length") continue;
+        if (typeof key === "symbol") throw new CanonicalizationError(path);
+        const index = Number(key);
+        if (
+          !Number.isInteger(index) ||
+          index < 0 ||
+          index >= value.length ||
+          String(index) !== key
+        ) {
+          throw new CanonicalizationError(childPath(path, key));
+        }
+      }
+      return `[${items.join(",")}]`;
+    }
+
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw new CanonicalizationError(path);
+    }
+
+    const entries: string[] = [];
+    const keys = Reflect.ownKeys(value);
+    if (keys.some((key) => typeof key === "symbol")) throw new CanonicalizationError(path);
+    for (const key of (keys as string[]).sort()) {
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (!descriptor?.enumerable || !("value" in descriptor)) {
+        throw new CanonicalizationError(childPath(path, key));
+      }
+      entries.push(
+        `${JSON.stringify(key)}:${serialize(descriptor.value, childPath(path, key), ancestors)}`
+      );
+    }
+    return `{${entries.join(",")}}`;
+  } finally {
+    ancestors.delete(value);
+  }
+}
+
+/** Canonical JSON for parsed data. Object keys sort by UTF-16 code unit; arrays retain order. */
+export function canonicalize(value: unknown): string {
+  return serialize(value, "", new Set());
+}
+
+/** Lowercase SHA-256 hex over the UTF-8 bytes of {@link canonicalize}. */
+export function canonicalHash(value: unknown): string {
+  return createHash(CANONICAL_HASH_ALGORITHM).update(canonicalize(value), "utf8").digest("hex");
+}

--- a/packages/schema/src/errors.ts
+++ b/packages/schema/src/errors.ts
@@ -1,0 +1,114 @@
+export type SchemaContractErrorCode =
+  | "CANONICALIZATION_FAILED"
+  | "DUPLICATE_SCHEMA"
+  | "INVALID_DISCRIMINATOR"
+  | "INVALID_SCHEMA"
+  | "SCHEMA_VALIDATION_FAILED"
+  | "UNKNOWN_API_VERSION"
+  | "UNKNOWN_KIND"
+  | "YAML_PARSE_FAILED";
+
+export class SchemaContractError extends Error {
+  readonly code: SchemaContractErrorCode;
+  readonly path: string;
+
+  constructor(code: SchemaContractErrorCode, message: string, path = "") {
+    super(message);
+    this.name = "SchemaContractError";
+    this.code = code;
+    this.path = path;
+  }
+}
+
+export class CanonicalizationError extends SchemaContractError {
+  constructor(path: string) {
+    super("CANONICALIZATION_FAILED", `Value cannot be canonicalized at ${path || "/"}`, path);
+    this.name = "CanonicalizationError";
+  }
+}
+
+export class InvalidDiscriminatorError extends SchemaContractError {
+  constructor(path: "/apiVersion" | "/kind") {
+    super("INVALID_DISCRIMINATOR", `A non-empty string is required at ${path}`, path);
+    this.name = "InvalidDiscriminatorError";
+  }
+}
+
+export class UnknownSchemaError extends SchemaContractError {
+  readonly apiVersion: string;
+  readonly kind?: string;
+
+  constructor(code: "UNKNOWN_API_VERSION" | "UNKNOWN_KIND", apiVersion: string, kind?: string) {
+    const message =
+      code === "UNKNOWN_API_VERSION"
+        ? `No schemas are registered for apiVersion ${apiVersion}`
+        : `No schema is registered for ${apiVersion}/${kind ?? ""}`;
+    super(code, message, code === "UNKNOWN_API_VERSION" ? "/apiVersion" : "/kind");
+    this.name = "UnknownSchemaError";
+    this.apiVersion = apiVersion;
+    this.kind = kind;
+  }
+}
+
+export class DuplicateSchemaError extends SchemaContractError {
+  readonly apiVersion: string;
+  readonly kind: string;
+
+  constructor(apiVersion: string, kind: string) {
+    super("DUPLICATE_SCHEMA", `Schema already registered for ${apiVersion}/${kind}`);
+    this.name = "DuplicateSchemaError";
+    this.apiVersion = apiVersion;
+    this.kind = kind;
+  }
+}
+
+export class InvalidSchemaError extends SchemaContractError {
+  readonly apiVersion: string;
+  readonly kind: string;
+
+  constructor(apiVersion: string, kind: string, path: string) {
+    super("INVALID_SCHEMA", `Invalid schema for ${apiVersion}/${kind} at ${path || "/"}`, path);
+    this.name = "InvalidSchemaError";
+    this.apiVersion = apiVersion;
+    this.kind = kind;
+  }
+}
+
+export interface SchemaValidationIssue {
+  keyword: string;
+  message: string;
+  path: string;
+}
+
+export class SchemaValidationError extends SchemaContractError {
+  readonly apiVersion: string;
+  readonly kind: string;
+  readonly issues: readonly SchemaValidationIssue[];
+
+  constructor(apiVersion: string, kind: string, issues: readonly SchemaValidationIssue[]) {
+    const first = issues[0] ?? {
+      keyword: "validation",
+      message: "schema validation failed",
+      path: "",
+    };
+    super(
+      "SCHEMA_VALIDATION_FAILED",
+      `Schema validation failed for ${apiVersion}/${kind} at ${first.path || "/"}: ${first.message}`,
+      first.path
+    );
+    this.name = "SchemaValidationError";
+    this.apiVersion = apiVersion;
+    this.kind = kind;
+    this.issues = issues;
+  }
+}
+
+export class YamlParseError extends SchemaContractError {
+  readonly reason: string;
+
+  constructor(reason: string) {
+    super("YAML_PARSE_FAILED", `YAML parsing failed: ${reason}`);
+    this.name = "YamlParseError";
+    this.reason = reason;
+  }
+}

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -3,7 +3,19 @@ export { AUTONOMY_VALUES, validateAgentFrontmatter } from "./agent";
 export { ajv } from "./ajv";
 export type { ValidationBoundary } from "./boundaries";
 export { BOUNDARIES } from "./boundaries";
+export { CANONICAL_HASH_ALGORITHM, canonicalHash, canonicalize } from "./canonicalize";
 export { TulipFarmValidationError } from "./error";
+export type { SchemaContractErrorCode, SchemaValidationIssue } from "./errors";
+export {
+  CanonicalizationError,
+  DuplicateSchemaError,
+  InvalidDiscriminatorError,
+  InvalidSchemaError,
+  SchemaContractError,
+  SchemaValidationError,
+  UnknownSchemaError,
+  YamlParseError,
+} from "./errors";
 export type {
   ContentFilterConfig,
   GuardrailsConfig,
@@ -28,6 +40,12 @@ export {
   UnknownModelError,
   validateLlmConfig,
 } from "./llm";
+export type {
+  SchemaRegistration,
+  ValidatedSchemaDocument,
+  VersionedSchemaDocument,
+} from "./registry";
+export { parseYamlDocument, SchemaRegistry } from "./registry";
 export type {
   RoutineAction,
   RoutineDefinition,

--- a/packages/schema/src/registry.test.ts
+++ b/packages/schema/src/registry.test.ts
@@ -1,0 +1,271 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import {
+  DuplicateSchemaError,
+  InvalidSchemaError,
+  SchemaRegistry,
+  SchemaValidationError,
+  UnknownSchemaError,
+  YamlParseError,
+} from "./index";
+
+const apiVersion = "tulipfarm.ai/v1";
+const kind = "TestDefinition";
+
+const TestDefinitionSchema = {
+  $id: "tulipfarm.ai/v1/TestDefinition",
+  type: "object",
+  additionalProperties: false,
+  required: ["apiVersion", "kind", "metadata", "spec"],
+  properties: {
+    apiVersion: { const: apiVersion },
+    kind: { const: kind },
+    metadata: {
+      type: "object",
+      additionalProperties: false,
+      required: ["name"],
+      properties: { name: { type: "string", minLength: 1 } },
+    },
+    spec: {
+      type: "object",
+      additionalProperties: false,
+      required: ["enabled"],
+      properties: { enabled: { type: "boolean" } },
+    },
+  },
+} as const;
+
+function createRegistry(): SchemaRegistry {
+  return new SchemaRegistry([{ apiVersion, kind, schema: TestDefinitionSchema }]);
+}
+
+describe("SchemaRegistry", () => {
+  it("selects a schema by explicit apiVersion/kind and returns safe digest evidence", () => {
+    const result = createRegistry().validate({
+      kind,
+      spec: { enabled: true },
+      apiVersion,
+      metadata: { name: "general-assistant" },
+    });
+
+    expect(result).toMatchObject({ apiVersion, kind });
+    expect(result.canonical).toBe(
+      `{"apiVersion":"${apiVersion}","kind":"${kind}","metadata":{"name":"general-assistant"},"spec":{"enabled":true}}`
+    );
+    expect(result.hash).toMatch(/^[a-f0-9]{64}$/);
+    expect(Object.isFrozen(result.document)).toBe(true);
+    expect(Object.isFrozen(result.document.metadata)).toBe(true);
+  });
+
+  it("normalizes YAML comments and key ordering to the same hash across registry restarts", () => {
+    const first = createRegistry().validateYaml(`
+# formatting is not identity
+kind: ${kind}
+spec:
+  enabled: true
+apiVersion: ${apiVersion}
+metadata: { name: general-assistant }
+`);
+    const restarted = createRegistry().validateYaml(`
+apiVersion: ${apiVersion}
+kind: ${kind}
+metadata:
+  name: general-assistant
+spec: { enabled: true }
+`);
+
+    expect(first.hash).toBe(restarted.hash);
+    expect(first.canonical).toBe(restarted.canonical);
+  });
+
+  it("fails closed for unknown versions and kinds", () => {
+    expect(() =>
+      createRegistry().validate({ apiVersion: "tulipfarm.ai/v2", kind, metadata: {}, spec: {} })
+    ).toThrowError(
+      expect.objectContaining({
+        code: "UNKNOWN_API_VERSION",
+        apiVersion: "tulipfarm.ai/v2",
+      })
+    );
+    expect(() =>
+      createRegistry().validate({ apiVersion, kind: "Unknown", metadata: {}, spec: {} })
+    ).toThrowError(expect.objectContaining({ code: "UNKNOWN_KIND", apiVersion, kind: "Unknown" }));
+  });
+
+  it("rejects missing or non-string discriminators before schema selection", () => {
+    expect(() => createRegistry().validate({ kind, spec: {} })).toThrowError(
+      expect.objectContaining({ code: "INVALID_DISCRIMINATOR", path: "/apiVersion" })
+    );
+    expect(() => createRegistry().validate({ apiVersion, kind: 7, spec: {} })).toThrowError(
+      expect.objectContaining({ code: "INVALID_DISCRIMINATOR", path: "/kind" })
+    );
+  });
+
+  it("rejects unknown root and nested properties", () => {
+    expect(() =>
+      createRegistry().validate({
+        apiVersion,
+        kind,
+        metadata: { name: "agent", ownerToken: "protected" },
+        spec: { enabled: true },
+      })
+    ).toThrow(SchemaValidationError);
+    expect(() =>
+      createRegistry().validate({
+        apiVersion,
+        kind,
+        metadata: { name: "agent" },
+        spec: { enabled: true },
+        typo: true,
+      })
+    ).toThrow(SchemaValidationError);
+  });
+
+  it("reports validation issues without including protected payload values", () => {
+    try {
+      createRegistry().validate({
+        apiVersion,
+        kind,
+        metadata: { name: "do-not-disclose", secret: "soul-secret-value" },
+        spec: { enabled: "yes" },
+      });
+      throw new Error("expected validation to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(SchemaValidationError);
+      expect(error).toMatchObject({ code: "SCHEMA_VALIDATION_FAILED", apiVersion, kind });
+      expect((error as Error).message).not.toContain("do-not-disclose");
+      expect((error as Error).message).not.toContain("soul-secret-value");
+    }
+  });
+
+  it("rejects duplicate registration replay", () => {
+    const registry = createRegistry();
+
+    expect(() => registry.register({ apiVersion, kind, schema: TestDefinitionSchema })).toThrow(
+      DuplicateSchemaError
+    );
+  });
+
+  it("rejects object schemas that do not make unknown-property behavior explicit", () => {
+    expect(
+      () =>
+        new SchemaRegistry([
+          {
+            apiVersion,
+            kind,
+            schema: {
+              type: "object",
+              required: ["apiVersion", "kind"],
+              properties: {
+                apiVersion: { const: apiVersion },
+                kind: { const: kind },
+              },
+            },
+          },
+        ])
+    ).toThrow(InvalidSchemaError);
+  });
+
+  it("requires explicit unknown-property behavior for nullable object schemas", () => {
+    expect(
+      () =>
+        new SchemaRegistry([
+          {
+            apiVersion,
+            kind,
+            schema: {
+              type: "object",
+              additionalProperties: false,
+              required: ["apiVersion", "kind", "spec"],
+              properties: {
+                apiVersion: { const: apiVersion },
+                kind: { const: kind },
+                spec: { type: ["object", "null"] },
+              },
+            },
+          },
+        ])
+    ).toThrow(InvalidSchemaError);
+  });
+
+  it("allows unknown properties only when the registered schema explicitly permits them", () => {
+    const extensibleKind = "ExtensibleDefinition";
+    const registry = new SchemaRegistry([
+      {
+        apiVersion,
+        kind: extensibleKind,
+        schema: {
+          type: "object",
+          additionalProperties: true,
+          required: ["apiVersion", "kind"],
+          properties: {
+            apiVersion: { const: apiVersion },
+            kind: { const: extensibleKind },
+          },
+        },
+      },
+    ]);
+
+    expect(() =>
+      registry.validate({ apiVersion, kind: extensibleKind, extension: { enabled: true } })
+    ).not.toThrow();
+  });
+
+  it("fails closed for duplicate YAML keys, multiple documents, and malformed YAML", () => {
+    const registry = createRegistry();
+    const cases = [
+      `apiVersion: ${apiVersion}\nkind: ${kind}\nkind: Other\n`,
+      `apiVersion: ${apiVersion}\nkind: ${kind}\n---\napiVersion: ${apiVersion}\nkind: ${kind}\n`,
+      `apiVersion: ${apiVersion}\nkind: [unterminated\n`,
+    ];
+
+    for (const source of cases) {
+      expect(() => registry.validateYaml(source)).toThrow(YamlParseError);
+    }
+  });
+
+  it("rejects non-string YAML keys before scalar coercion can collide", () => {
+    const registry = createRegistry();
+    const cases = [
+      `apiVersion: ${apiVersion}\nkind: ${kind}\n1: first\n"1": second\n`,
+      `apiVersion: ${apiVersion}\nkind: ${kind}\ntrue: first\n"true": second\n`,
+      `apiVersion: ${apiVersion}\nkind: ${kind}\n42: standalone\n`,
+    ];
+
+    for (const source of cases) {
+      expect(() => registry.validateYaml(source)).toThrow(YamlParseError);
+    }
+  });
+
+  it("binds validation, the immutable document, and the hash to one canonical snapshot", () => {
+    let descriptorReads = 0;
+    const spec = new Proxy(
+      { enabled: true },
+      {
+        getOwnPropertyDescriptor(target, property) {
+          const descriptor = Reflect.getOwnPropertyDescriptor(target, property);
+          if (!descriptor || property !== "enabled") return descriptor;
+          const value = descriptorReads % 2 === 0;
+          descriptorReads += 1;
+          return { ...descriptor, value };
+        },
+      }
+    );
+
+    const result = createRegistry().validate({
+      apiVersion,
+      kind,
+      metadata: { name: "snapshot" },
+      spec,
+    });
+
+    expect(result.hash).toBe(createHash("sha256").update(result.canonical, "utf8").digest("hex"));
+    expect(result.document).toEqual(JSON.parse(result.canonical));
+  });
+
+  it("does not silently fall back after YAML or schema selection errors", () => {
+    expect(() =>
+      createRegistry().validateYaml(`apiVersion: ${apiVersion}\nkind: Missing\n`)
+    ).toThrow(UnknownSchemaError);
+  });
+});

--- a/packages/schema/src/registry.ts
+++ b/packages/schema/src/registry.ts
@@ -1,0 +1,278 @@
+import { createHash } from "node:crypto";
+import Ajv2020, { type ErrorObject, type ValidateFunction } from "ajv/dist/2020";
+import { parseAllDocuments } from "yaml";
+import { CANONICAL_HASH_ALGORITHM, canonicalize } from "./canonicalize";
+import {
+  DuplicateSchemaError,
+  InvalidDiscriminatorError,
+  InvalidSchemaError,
+  SchemaValidationError,
+  type SchemaValidationIssue,
+  UnknownSchemaError,
+  YamlParseError,
+} from "./errors";
+
+export interface SchemaRegistration {
+  apiVersion: string;
+  kind: string;
+  schema: unknown;
+}
+
+export interface VersionedSchemaDocument extends Record<string, unknown> {
+  apiVersion: string;
+  kind: string;
+}
+
+export interface ValidatedSchemaDocument {
+  apiVersion: string;
+  kind: string;
+  canonical: string;
+  hash: string;
+  document: Readonly<VersionedSchemaDocument>;
+}
+
+type JsonSchema = boolean | Record<string, unknown>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function schemaPath(path: string, segment: string): string {
+  const escaped = segment.replaceAll("~", "~0").replaceAll("/", "~1");
+  return `${path}/${escaped}`;
+}
+
+function childSchemas(value: unknown): Array<[string, unknown]> {
+  if (!isRecord(value)) return [];
+  return Object.entries(value);
+}
+
+function assertExplicitObjectStrictness(
+  schema: unknown,
+  apiVersion: string,
+  kind: string,
+  path = ""
+): void {
+  if (typeof schema === "boolean") return;
+  if (!isRecord(schema)) throw new InvalidSchemaError(apiVersion, kind, path);
+
+  const describesObject =
+    schema.type === "object" ||
+    (Array.isArray(schema.type) && schema.type.includes("object")) ||
+    Object.hasOwn(schema, "properties") ||
+    Object.hasOwn(schema, "patternProperties");
+  if (
+    describesObject &&
+    !Object.hasOwn(schema, "additionalProperties") &&
+    !Object.hasOwn(schema, "unevaluatedProperties")
+  ) {
+    throw new InvalidSchemaError(apiVersion, kind, path);
+  }
+
+  for (const keyword of [
+    "$defs",
+    "definitions",
+    "dependentSchemas",
+    "patternProperties",
+    "properties",
+  ] as const) {
+    for (const [name, child] of childSchemas(schema[keyword])) {
+      assertExplicitObjectStrictness(
+        child,
+        apiVersion,
+        kind,
+        schemaPath(schemaPath(path, keyword), name)
+      );
+    }
+  }
+  for (const keyword of ["allOf", "anyOf", "oneOf", "prefixItems"] as const) {
+    const children = schema[keyword];
+    if (!Array.isArray(children)) continue;
+    children.forEach((child, index) => {
+      assertExplicitObjectStrictness(
+        child,
+        apiVersion,
+        kind,
+        schemaPath(schemaPath(path, keyword), String(index))
+      );
+    });
+  }
+  for (const keyword of [
+    "additionalProperties",
+    "contains",
+    "else",
+    "if",
+    "items",
+    "not",
+    "propertyNames",
+    "then",
+    "unevaluatedProperties",
+  ] as const) {
+    const child = schema[keyword];
+    if (typeof child === "boolean" || isRecord(child)) {
+      assertExplicitObjectStrictness(child, apiVersion, kind, schemaPath(path, keyword));
+    }
+  }
+}
+
+function assertDiscriminatorSchema(
+  schema: unknown,
+  apiVersion: string,
+  kind: string
+): asserts schema is Record<string, unknown> {
+  if (!isRecord(schema)) throw new InvalidSchemaError(apiVersion, kind, "");
+  const required = schema.required;
+  const properties = schema.properties;
+  if (!Array.isArray(required) || !required.includes("apiVersion") || !required.includes("kind")) {
+    throw new InvalidSchemaError(apiVersion, kind, "/required");
+  }
+  if (!isRecord(properties)) throw new InvalidSchemaError(apiVersion, kind, "/properties");
+  const versionSchema = properties.apiVersion;
+  const kindSchema = properties.kind;
+  if (!isRecord(versionSchema) || versionSchema.const !== apiVersion) {
+    throw new InvalidSchemaError(apiVersion, kind, "/properties/apiVersion/const");
+  }
+  if (!isRecord(kindSchema) || kindSchema.const !== kind) {
+    throw new InvalidSchemaError(apiVersion, kind, "/properties/kind/const");
+  }
+}
+
+function validationIssues(errors: ErrorObject[] | null | undefined): SchemaValidationIssue[] {
+  return (errors ?? [])
+    .map((error) => ({
+      keyword: error.keyword,
+      message: error.message ?? "validation failed",
+      path: error.instancePath,
+    }))
+    .sort((left, right) => {
+      const leftKey = `${left.path}\u0000${left.keyword}\u0000${left.message}`;
+      const rightKey = `${right.path}\u0000${right.keyword}\u0000${right.message}`;
+      if (leftKey < rightKey) return -1;
+      if (leftKey > rightKey) return 1;
+      return 0;
+    });
+}
+
+function discriminator(document: unknown): { apiVersion: string; kind: string } {
+  if (!isRecord(document) || typeof document.apiVersion !== "string" || !document.apiVersion) {
+    throw new InvalidDiscriminatorError("/apiVersion");
+  }
+  if (typeof document.kind !== "string" || !document.kind) {
+    throw new InvalidDiscriminatorError("/kind");
+  }
+  return { apiVersion: document.apiVersion, kind: document.kind };
+}
+
+function deepFreeze(value: unknown): void {
+  if (typeof value !== "object" || value === null || Object.isFrozen(value)) return;
+  Object.freeze(value);
+  for (const child of Object.values(value)) deepFreeze(child);
+}
+
+function yamlValueToJson(value: unknown, ancestors = new Set<object>()): unknown {
+  if (value === null || typeof value === "string" || typeof value === "boolean") return value;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new YamlParseError("NON_FINITE_NUMBER");
+    return value;
+  }
+  if (typeof value !== "object") throw new YamlParseError("UNSUPPORTED_VALUE");
+  if (ancestors.has(value)) throw new YamlParseError("ALIAS_CYCLE");
+
+  ancestors.add(value);
+  try {
+    if (Array.isArray(value)) {
+      return value.map((item) => yamlValueToJson(item, ancestors));
+    }
+    if (value instanceof Map) {
+      const result: Record<string, unknown> = Object.create(null);
+      for (const [key, item] of value) {
+        if (typeof key !== "string") throw new YamlParseError("NON_STRING_KEY");
+        if (Object.hasOwn(result, key)) throw new YamlParseError("KEY_COLLISION");
+        result[key] = yamlValueToJson(item, ancestors);
+      }
+      return result;
+    }
+    throw new YamlParseError("UNSUPPORTED_VALUE");
+  } finally {
+    ancestors.delete(value);
+  }
+}
+
+export function parseYamlDocument(source: string): unknown {
+  let documents: ReturnType<typeof parseAllDocuments>;
+  try {
+    documents = parseAllDocuments(source, {
+      merge: false,
+      prettyErrors: false,
+      strict: true,
+      uniqueKeys: true,
+    });
+  } catch {
+    throw new YamlParseError("PARSER_FAILURE");
+  }
+  if (documents.length !== 1) throw new YamlParseError("DOCUMENT_COUNT");
+  const document = documents[0];
+  const problem = document.errors[0] ?? document.warnings[0];
+  if (problem) throw new YamlParseError(problem.code ?? "INVALID_DOCUMENT");
+  try {
+    return yamlValueToJson(document.toJS({ mapAsMap: true, maxAliasCount: 100 }));
+  } catch (error) {
+    if (error instanceof YamlParseError) throw error;
+    throw new YamlParseError("INVALID_DOCUMENT");
+  }
+}
+
+export class SchemaRegistry {
+  private readonly ajv = new Ajv2020({ allErrors: true, strict: true });
+  private readonly validators = new Map<string, Map<string, ValidateFunction>>();
+
+  constructor(registrations: readonly SchemaRegistration[] = []) {
+    for (const registration of registrations) this.register(registration);
+  }
+
+  register({ apiVersion, kind, schema }: SchemaRegistration): void {
+    if (!apiVersion) throw new InvalidSchemaError(apiVersion, kind, "/apiVersion");
+    if (!kind) throw new InvalidSchemaError(apiVersion, kind, "/kind");
+    if (this.validators.get(apiVersion)?.has(kind)) {
+      throw new DuplicateSchemaError(apiVersion, kind);
+    }
+    assertDiscriminatorSchema(schema, apiVersion, kind);
+    assertExplicitObjectStrictness(schema, apiVersion, kind);
+
+    let validator: ValidateFunction;
+    try {
+      validator = this.ajv.compile(schema as JsonSchema);
+    } catch {
+      throw new InvalidSchemaError(apiVersion, kind, "");
+    }
+    const versionSchemas = this.validators.get(apiVersion) ?? new Map<string, ValidateFunction>();
+    versionSchemas.set(kind, validator);
+    this.validators.set(apiVersion, versionSchemas);
+  }
+
+  validate(document: unknown): ValidatedSchemaDocument {
+    const canonical = canonicalize(document);
+    const parsed = JSON.parse(canonical) as VersionedSchemaDocument;
+    const { apiVersion, kind } = discriminator(parsed);
+    const versionSchemas = this.validators.get(apiVersion);
+    if (!versionSchemas) throw new UnknownSchemaError("UNKNOWN_API_VERSION", apiVersion);
+    const validator = versionSchemas.get(kind);
+    if (!validator) throw new UnknownSchemaError("UNKNOWN_KIND", apiVersion, kind);
+    if (!validator(parsed)) {
+      throw new SchemaValidationError(apiVersion, kind, validationIssues(validator.errors));
+    }
+
+    deepFreeze(parsed);
+    return {
+      apiVersion,
+      kind,
+      canonical,
+      hash: createHash(CANONICAL_HASH_ALGORITHM).update(canonical, "utf8").digest("hex"),
+      document: parsed,
+    };
+  }
+
+  validateYaml(source: string): ValidatedSchemaDocument {
+    return this.validate(parseYamlDocument(source));
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -617,6 +617,9 @@ importers:
       ajv:
         specifier: ^8.20.0
         version: 8.20.0
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
     devDependencies:
       '@tulipfarm/tsconfig':
         specifier: workspace:*


### PR DESCRIPTION
## Summary

- add one strict apiVersion/kind AJV registry with deterministic structured errors and explicit unknown-property contracts
- add fail-closed YAML parsing that rejects duplicate, multi-document, malformed, and non-string-key ambiguity
- add canonical JSON plus SHA-256 hashing from one immutable validated snapshot

## Test plan

- [x] packages/schema: 92 tests passed
- [x] package lint and typecheck passed
- [x] root lint, typecheck, and build passed
- [x] frozen pnpm install and git diff check passed
- [x] workspace test run passed 26 tasks; the API task hit Vitest worker startup/timeouts under parallel pressure, and all seven affected files passed serially (63 tests)
- [x] independent review passed at 4.78/5 with no remaining findings