### PR TITLE
feat(schema): define Agent, Skill, ToolContract, and ModelProfile schemas (AW-008)

### DIFF
--- a/packages/schema/src/definitions/agent.test.ts
+++ b/packages/schema/src/definitions/agent.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { SchemaValidationError } from "../errors";
+import { SchemaRegistry } from "../registry";
+import { AGENT_DEFINITION } from "./agent";
+import { DEFINITION_API_VERSION } from "./common";
+
+function registry(): SchemaRegistry {
+  return new SchemaRegistry([AGENT_DEFINITION]);
+}
+
+const metadata = {
+  id: "11111111-1111-1111-1111-111111111111",
+  slug: "general-assistant",
+  schemaVersion: 1,
+  authoredVersion: 3,
+  lifecycle: "published",
+};
+
+const full = {
+  apiVersion: DEFINITION_API_VERSION,
+  kind: "Agent",
+  metadata: { ...metadata, displayName: "General Assistant", publishedDigest: "a".repeat(64) },
+  spec: {
+    owner: "user_01",
+    maintainers: ["user_02"],
+    personality: "Helpful and precise.",
+    roles: ["agent-operator"],
+    permissionCeiling: { grants: ["read-tickets"], maxRiskClass: "medium" },
+    modelProfile: "sol-high",
+    skills: ["triage"],
+    allowedTools: ["github.issue.get"],
+    autonomy: "execute_low_risk",
+    limits: { tokens: 100000, costUsd: 1.5, delegationDepth: 2 },
+    guardrails: { data: "pii-guardrail", delegation: "delegation-guardrail" },
+    memoryScopes: ["agent_private", "business"],
+    knowledgeScopes: ["support-space"],
+    trustTier: "business_authored",
+    evaluationSuite: "triage-evals",
+  },
+};
+
+const minimal = {
+  apiVersion: DEFINITION_API_VERSION,
+  kind: "Agent",
+  metadata,
+  spec: {
+    owner: "user_01",
+    modelProfile: "sol-high",
+    autonomy: "answer_only",
+    trustTier: "first_party",
+  },
+};
+
+describe("Agent definition schema", () => {
+  it("registers without violating the strict-object or discriminator contract", () => {
+    expect(() => registry()).not.toThrow();
+  });
+
+  it("validates a fully populated Agent definition", () => {
+    const result = registry().validate(full);
+    expect(result).toMatchObject({ apiVersion: DEFINITION_API_VERSION, kind: "Agent" });
+    expect(result.hash).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("validates a minimal Agent with only required spec fields", () => {
+    expect(() => registry().validate(minimal)).not.toThrow();
+  });
+
+  it("rejects an unknown autonomy ceiling", () => {
+    const doc = { ...minimal, spec: { ...minimal.spec, autonomy: "do_anything" } };
+    expect(() => registry().validate(doc)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects an unknown lifecycle state", () => {
+    const doc = { ...minimal, metadata: { ...metadata, lifecycle: "archived" } };
+    expect(() => registry().validate(doc)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects an unknown trust tier", () => {
+    const doc = { ...minimal, spec: { ...minimal.spec, trustTier: "vendor" } };
+    expect(() => registry().validate(doc)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a missing required spec field", () => {
+    const { modelProfile: _drop, ...spec } = minimal.spec;
+    expect(() => registry().validate({ ...minimal, spec })).toThrow(SchemaValidationError);
+  });
+
+  it("rejects unknown top-level spec properties", () => {
+    const doc = { ...minimal, spec: { ...minimal.spec, superuser: true } };
+    expect(() => registry().validate(doc)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a malformed identifier", () => {
+    const doc = { ...minimal, metadata: { ...metadata, id: "not-a-ulid-or-uuid" } };
+    expect(() => registry().validate(doc)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a non-kebab slug", () => {
+    const doc = { ...minimal, metadata: { ...metadata, slug: "General Assistant" } };
+    expect(() => registry().validate(doc)).toThrow(SchemaValidationError);
+  });
+
+  it("owns the Agent kind at the canonical api version", () => {
+    expect(AGENT_DEFINITION).toMatchObject({ apiVersion: DEFINITION_API_VERSION, kind: "Agent" });
+  });
+});

--- a/packages/schema/src/definitions/agent.ts
+++ b/packages/schema/src/definitions/agent.ts
@@ -1,0 +1,116 @@
+import {
+  AGENT_AUTONOMY_CEILINGS,
+  type AgentAutonomyCeiling,
+  DEFINITION_TRUST_TIERS,
+  type DefinitionEnvelope,
+  type DefinitionTrustTier,
+  definitionRegistration,
+  definitionSchema,
+  MEMORY_SCOPES,
+  type MemoryScope,
+  refListSchema,
+} from "./common";
+
+/**
+ * Agent authored definition (SPEC §7.1). Captures identity, owner/maintainers, assigned roles and
+ * permission ceiling, personality, ModelProfile, Skill/Tool references, autonomy ceiling, limits,
+ * data/delegation Guardrails, Memory/Knowledge scopes, trust tier, and evaluation suite.
+ *
+ * An Agent may reference Tools it is *allowed* to use, but the reference never grants authority:
+ * effective authority is the intersection computed at runtime (SPEC §12). Permission never
+ * broadens through an Agent, Skill, delegation, or team (invariant 3).
+ */
+
+const KIND = "Agent";
+
+/** Deployment/role/Agent-level numeric limits (SPEC §9.1). The narrowest limit wins at runtime. */
+const agentLimitsSchema = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    wallClockMs: { type: "integer", minimum: 0 },
+    activeMs: { type: "integer", minimum: 0 },
+    tokens: { type: "integer", minimum: 0 },
+    costUsd: { type: "number", minimum: 0 },
+    toolCalls: { type: "integer", minimum: 0 },
+    delegationDepth: { type: "integer", minimum: 0 },
+  },
+} as const;
+
+const agentSpecSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["owner", "modelProfile", "autonomy", "trustTier"],
+  properties: {
+    owner: { type: "string", minLength: 1, maxLength: 256 },
+    maintainers: refListSchema,
+    personality: { type: "string", maxLength: 8192 },
+    // Assigned Agent roles and the permission ceiling that bounds effective authority.
+    roles: refListSchema,
+    permissionCeiling: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        grants: refListSchema,
+        maxRiskClass: { type: "string", enum: ["low", "medium", "high"] },
+      },
+    },
+    modelProfile: { type: "string", minLength: 1, maxLength: 256 },
+    skills: refListSchema,
+    // Tools the Agent is *allowed* to request; never a grant of authority.
+    allowedTools: refListSchema,
+    autonomy: { type: "string", enum: [...AGENT_AUTONOMY_CEILINGS] },
+    limits: agentLimitsSchema,
+    guardrails: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        data: { type: "string", minLength: 1, maxLength: 256 },
+        delegation: { type: "string", minLength: 1, maxLength: 256 },
+      },
+    },
+    memoryScopes: {
+      type: "array",
+      uniqueItems: true,
+      items: { type: "string", enum: [...MEMORY_SCOPES] },
+    },
+    knowledgeScopes: refListSchema,
+    trustTier: { type: "string", enum: [...DEFINITION_TRUST_TIERS] },
+    // Evaluation suite gate (SPEC §10); action-capable Agents require it before publication.
+    evaluationSuite: { type: "string", minLength: 1, maxLength: 256 },
+  },
+} as const;
+
+export const AgentDefinitionSchema = definitionSchema(KIND, agentSpecSchema);
+
+export const AGENT_DEFINITION = definitionRegistration(KIND, AgentDefinitionSchema);
+
+export interface AgentSpec {
+  owner: string;
+  maintainers?: string[];
+  personality?: string;
+  roles?: string[];
+  permissionCeiling?: {
+    grants?: string[];
+    maxRiskClass?: "low" | "medium" | "high";
+  };
+  modelProfile: string;
+  skills?: string[];
+  allowedTools?: string[];
+  autonomy: AgentAutonomyCeiling;
+  limits?: {
+    wallClockMs?: number;
+    activeMs?: number;
+    tokens?: number;
+    costUsd?: number;
+    toolCalls?: number;
+    delegationDepth?: number;
+  };
+  guardrails?: { data?: string; delegation?: string };
+  memoryScopes?: MemoryScope[];
+  knowledgeScopes?: string[];
+  trustTier: DefinitionTrustTier;
+  evaluationSuite?: string;
+}
+
+export type AgentDefinition = DefinitionEnvelope<"Agent", AgentSpec>;

--- a/packages/schema/src/definitions/common.ts
+++ b/packages/schema/src/definitions/common.ts
@@ -1,0 +1,168 @@
+import type { SchemaRegistration } from "../registry";
+
+/**
+ * Shared building blocks for the canonical authored-definition schemas (Agent, Skill,
+ * ToolContract, ModelProfile) registered in the AW-007 {@link SchemaRegistry}. Each schema
+ * is a plain JSON Schema (draft 2020-12) that satisfies the registry's strict-object and
+ * discriminator contracts: every object declares explicit unknown-property behaviour, and the
+ * root pins `apiVersion`/`kind` with `const`.
+ */
+
+/** Single canonical API version for authored Soul definitions. */
+export const DEFINITION_API_VERSION = "tulipfarm.ai/v1" as const;
+
+/**
+ * Authored lifecycle (SPEC §7.1). Editing a published definition creates a new version;
+ * rollback activates a prior immutable version rather than rewriting history.
+ */
+export const DEFINITION_LIFECYCLE_STATES = [
+  "draft",
+  "validated",
+  "simulated",
+  "approved",
+  "published",
+  "active",
+  "retired",
+] as const;
+export type DefinitionLifecycle = (typeof DEFINITION_LIFECYCLE_STATES)[number];
+
+/**
+ * Trust tiers shared by Agents and Skills (SPEC §10): first-party reviewed, business-authored,
+ * and third-party/Agent-generated. Changed executable content is scanned and approved per
+ * Guardrail according to tier.
+ */
+export const DEFINITION_TRUST_TIERS = ["first_party", "business_authored", "third_party"] as const;
+export type DefinitionTrustTier = (typeof DEFINITION_TRUST_TIERS)[number];
+
+/**
+ * Autonomy ceilings (SPEC §11.1). None bypasses the Tool Broker; they are Guardrail presets over
+ * the same broker, not alternate execution paths.
+ */
+export const AGENT_AUTONOMY_CEILINGS = [
+  "answer_only",
+  "propose_actions",
+  "execute_low_risk",
+  "execute_policy_authorized",
+] as const;
+export type AgentAutonomyCeiling = (typeof AGENT_AUTONOMY_CEILINGS)[number];
+
+/** Memory scopes an Agent may address (SPEC §14.2). */
+export const MEMORY_SCOPES = [
+  "user_private",
+  "user_agent",
+  "agent_private",
+  "team_role",
+  "business",
+  "run_local",
+] as const;
+export type MemoryScope = (typeof MEMORY_SCOPES)[number];
+
+/** Base risk classification of a Tool effect (SPEC §11.1–§11.2). */
+export const TOOL_RISK_CLASSES = ["low", "medium", "high"] as const;
+export type ToolRiskClass = (typeof TOOL_RISK_CLASSES)[number];
+
+/** How a Tool's stable idempotency key is honoured (SPEC §11.3). */
+export const TOOL_IDEMPOTENCY_STRATEGIES = ["provider", "reconcile", "none"] as const;
+export type ToolIdempotencyStrategy = (typeof TOOL_IDEMPOTENCY_STRATEGIES)[number];
+
+/** Implementation backends a Tool contract can bind to (SPEC §11.1, §15). */
+export const TOOL_ADAPTER_KINDS = [
+  "native",
+  "integration",
+  "mcp",
+  "openapi",
+  "http",
+  "sandbox",
+  "postgres",
+] as const;
+export type ToolAdapterKind = (typeof TOOL_ADAPTER_KINDS)[number];
+
+/** Reasoning/effort level requested from a model (SPEC §17). */
+export const MODEL_REASONING_LEVELS = ["low", "medium", "high", "xhigh", "max"] as const;
+export type ModelReasoningLevel = (typeof MODEL_REASONING_LEVELS)[number];
+
+/** Data-retention posture a ModelProfile requires of its provider (SPEC §17). */
+export const MODEL_DATA_RETENTION = ["none", "zero_retention", "provider_default"] as const;
+export type ModelDataRetention = (typeof MODEL_DATA_RETENTION)[number];
+
+/** ULID (Crockford base32) or canonical UUID. */
+const ID_PATTERN =
+  "^([0-9A-HJKMNP-TV-Z]{26}|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$";
+/** Lowercase kebab-case human slug. */
+const SLUG_PATTERN = "^[a-z][a-z0-9]*(-[a-z0-9]+)*$";
+/** Lowercase hex sha-256 digest. */
+const DIGEST_PATTERN = "^[a-f0-9]{64}$";
+
+/**
+ * Common envelope every authored definition carries (SPEC §7.1): stable identifier, human slug,
+ * schema version, authored version, lifecycle state, and immutable published digest.
+ */
+export const definitionMetadataSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["id", "slug", "schemaVersion", "authoredVersion", "lifecycle"],
+  properties: {
+    id: { type: "string", pattern: ID_PATTERN },
+    slug: { type: "string", pattern: SLUG_PATTERN, maxLength: 128 },
+    displayName: { type: "string", minLength: 1, maxLength: 256 },
+    schemaVersion: { type: "integer", minimum: 1 },
+    authoredVersion: { type: "integer", minimum: 1 },
+    lifecycle: { type: "string", enum: [...DEFINITION_LIFECYCLE_STATES] },
+    publishedDigest: { type: "string", pattern: DIGEST_PATTERN },
+  },
+} as const;
+
+/** A non-empty array of unique reference strings (slugs or IDs of other definitions). */
+export const refListSchema = {
+  type: "array",
+  uniqueItems: true,
+  items: { type: "string", minLength: 1, maxLength: 256 },
+} as const;
+
+/**
+ * Wrap a `spec` schema in the strict discriminated root every authored definition shares.
+ * The root pins `apiVersion`/`kind` and forbids unknown top-level keys.
+ */
+export function definitionSchema(
+  kind: string,
+  spec: Record<string, unknown>
+): Record<string, unknown> {
+  return {
+    $id: `${DEFINITION_API_VERSION}/${kind}`,
+    type: "object",
+    additionalProperties: false,
+    required: ["apiVersion", "kind", "metadata", "spec"],
+    properties: {
+      apiVersion: { const: DEFINITION_API_VERSION },
+      kind: { const: kind },
+      metadata: definitionMetadataSchema,
+      spec,
+    },
+  };
+}
+
+/** Registration payload for the {@link SchemaRegistry}. */
+export function definitionRegistration(
+  kind: string,
+  schema: Record<string, unknown>
+): SchemaRegistration {
+  return { apiVersion: DEFINITION_API_VERSION, kind, schema };
+}
+
+/** Shape shared by every validated authored definition. */
+export interface DefinitionMetadata {
+  id: string;
+  slug: string;
+  displayName?: string;
+  schemaVersion: number;
+  authoredVersion: number;
+  lifecycle: DefinitionLifecycle;
+  publishedDigest?: string;
+}
+
+export interface DefinitionEnvelope<Kind extends string, Spec> {
+  apiVersion: typeof DEFINITION_API_VERSION;
+  kind: Kind;
+  metadata: DefinitionMetadata;
+  spec: Spec;
+}

--- a/packages/schema/src/definitions/index.test.ts
+++ b/packages/schema/src/definitions/index.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { SchemaRegistry } from "../registry";
+import { DEFINITION_API_VERSION, DEFINITION_KINDS, DEFINITION_REGISTRATIONS } from "./index";
+
+describe("Authored definition registry integration", () => {
+  it("registers all four canonical kinds in one registry without collision", () => {
+    expect(() => new SchemaRegistry(DEFINITION_REGISTRATIONS)).not.toThrow();
+  });
+
+  it("exposes exactly the Agent, Skill, ToolContract, and ModelProfile kinds", () => {
+    expect([...DEFINITION_KINDS]).toEqual(["Agent", "Skill", "ToolContract", "ModelProfile"]);
+    expect(DEFINITION_REGISTRATIONS.map((r) => r.kind)).toEqual([...DEFINITION_KINDS]);
+  });
+
+  it("owns every registration at the single canonical api version", () => {
+    for (const registration of DEFINITION_REGISTRATIONS) {
+      expect(registration.apiVersion).toBe(DEFINITION_API_VERSION);
+    }
+  });
+
+  it("produces a deterministic canonical hash across registry restarts", () => {
+    const doc = {
+      apiVersion: DEFINITION_API_VERSION,
+      kind: "ModelProfile",
+      metadata: {
+        id: "44444444-4444-4444-4444-444444444444",
+        slug: "sol-high",
+        schemaVersion: 1,
+        authoredVersion: 1,
+        lifecycle: "published",
+      },
+      spec: {
+        provider: "openai",
+        model: "gpt-5.6-sol",
+        reasoning: "high",
+        supports: { tools: true, structuredOutput: true, contextWindowTokens: 400000 },
+        allowCaching: false,
+      },
+    };
+    const first = new SchemaRegistry(DEFINITION_REGISTRATIONS).validate(doc);
+    const second = new SchemaRegistry(DEFINITION_REGISTRATIONS).validate(doc);
+    expect(first.hash).toBe(second.hash);
+  });
+});

--- a/packages/schema/src/definitions/index.ts
+++ b/packages/schema/src/definitions/index.ts
@@ -1,0 +1,44 @@
+import type { SchemaRegistration } from "../registry";
+import { AGENT_DEFINITION } from "./agent";
+import { MODEL_PROFILE_DEFINITION } from "./model";
+import { SKILL_DEFINITION } from "./skill";
+import { TOOL_CONTRACT_DEFINITION } from "./tool";
+
+export {
+  AGENT_DEFINITION,
+  type AgentDefinition,
+  AgentDefinitionSchema,
+  type AgentSpec,
+} from "./agent";
+export * from "./common";
+export {
+  MODEL_PROFILE_DEFINITION,
+  type ModelProfileDefinition,
+  ModelProfileDefinitionSchema,
+  type ModelProfileSpec,
+} from "./model";
+export {
+  SKILL_DEFINITION,
+  SKILL_FORBIDDEN_GRANT_KEYS,
+  type SkillDefinition,
+  SkillDefinitionSchema,
+  type SkillSpec,
+} from "./skill";
+export {
+  TOOL_CONTRACT_DEFINITION,
+  type ToolContractDefinition,
+  ToolContractDefinitionSchema,
+  type ToolContractSpec,
+} from "./tool";
+
+/** Every canonical authored-definition registration, in a stable order. */
+export const DEFINITION_REGISTRATIONS: readonly SchemaRegistration[] = [
+  AGENT_DEFINITION,
+  SKILL_DEFINITION,
+  TOOL_CONTRACT_DEFINITION,
+  MODEL_PROFILE_DEFINITION,
+];
+
+/** Canonical `kind` discriminators owned by AW-008. */
+export const DEFINITION_KINDS = ["Agent", "Skill", "ToolContract", "ModelProfile"] as const;
+export type DefinitionKind = (typeof DEFINITION_KINDS)[number];

--- a/packages/schema/src/definitions/model.test.ts
+++ b/packages/schema/src/definitions/model.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { SchemaValidationError } from "../errors";
+import { SchemaRegistry } from "../registry";
+import { DEFINITION_API_VERSION } from "./common";
+import { MODEL_PROFILE_DEFINITION } from "./model";
+
+function registry(): SchemaRegistry {
+  return new SchemaRegistry([MODEL_PROFILE_DEFINITION]);
+}
+
+const metadata = {
+  id: "44444444-4444-4444-4444-444444444444",
+  slug: "sol-high",
+  schemaVersion: 1,
+  authoredVersion: 1,
+  lifecycle: "published",
+};
+
+const minimal = {
+  apiVersion: DEFINITION_API_VERSION,
+  kind: "ModelProfile",
+  metadata,
+  spec: {
+    provider: "openai",
+    model: "gpt-5.6-sol",
+    reasoning: "high",
+    supports: { tools: true, structuredOutput: true, contextWindowTokens: 400000 },
+    allowCaching: false,
+  },
+};
+
+const full = {
+  ...minimal,
+  spec: {
+    ...minimal.spec,
+    capabilityClass: "frontier",
+    constraints: {
+      maxCostUsd: 5,
+      maxTokens: 200000,
+      maxLatencyMs: 60000,
+      dataRetention: "zero_retention",
+      allowTraining: false,
+      residency: "eu",
+    },
+    budgets: { maxCostUsd: 2, maxTokens: 100000 },
+    fallbacks: ["sol-xhigh", "fable-high"],
+  },
+};
+
+describe("ModelProfile definition schema", () => {
+  it("registers without violating the strict-object or discriminator contract", () => {
+    expect(() => registry()).not.toThrow();
+  });
+
+  it("validates a fully populated ModelProfile", () => {
+    expect(() => registry().validate(full)).not.toThrow();
+  });
+
+  it("validates a minimal ModelProfile with only required fields", () => {
+    expect(() => registry().validate(minimal)).not.toThrow();
+  });
+
+  it("requires caching intent to be explicit", () => {
+    const { allowCaching: _drop, ...spec } = minimal.spec;
+    expect(() => registry().validate({ ...minimal, spec })).toThrow(SchemaValidationError);
+  });
+
+  it("rejects an unknown reasoning level", () => {
+    const doc = { ...minimal, spec: { ...minimal.spec, reasoning: "ultra" } };
+    expect(() => registry().validate(doc)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects an unknown data-retention posture", () => {
+    const doc = {
+      ...minimal,
+      spec: { ...minimal.spec, constraints: { dataRetention: "keep_forever" } },
+    };
+    expect(() => registry().validate(doc)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a zero context window", () => {
+    const doc = {
+      ...minimal,
+      spec: {
+        ...minimal.spec,
+        supports: { tools: true, structuredOutput: true, contextWindowTokens: 0 },
+      },
+    };
+    expect(() => registry().validate(doc)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a missing support declaration", () => {
+    const { supports: _drop, ...spec } = minimal.spec;
+    expect(() => registry().validate({ ...minimal, spec })).toThrow(SchemaValidationError);
+  });
+});

--- a/packages/schema/src/definitions/model.ts
+++ b/packages/schema/src/definitions/model.ts
@@ -1,0 +1,95 @@
+import {
+  type DefinitionEnvelope,
+  definitionRegistration,
+  definitionSchema,
+  MODEL_DATA_RETENTION,
+  MODEL_REASONING_LEVELS,
+  type ModelDataRetention,
+  type ModelReasoningLevel,
+  refListSchema,
+} from "./common";
+
+/**
+ * ModelProfile authored definition (SPEC §7.1, §17). Provider/model, capability class, reasoning
+ * level, Tool/structured-output/context support, cost/latency/data-retention/training/residency
+ * constraints, fallback order, budgets, and whether caching is permitted. Model output is
+ * untrusted; AJV validation, Guardrail, and Tool authorization remain independent of the model.
+ */
+
+const KIND = "ModelProfile";
+
+const modelSpecSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["provider", "model", "reasoning", "supports", "allowCaching"],
+  properties: {
+    provider: { type: "string", minLength: 1, maxLength: 128 },
+    model: { type: "string", minLength: 1, maxLength: 128 },
+    capabilityClass: { type: "string", minLength: 1, maxLength: 64 },
+    reasoning: { type: "string", enum: [...MODEL_REASONING_LEVELS] },
+    supports: {
+      type: "object",
+      additionalProperties: false,
+      required: ["tools", "structuredOutput", "contextWindowTokens"],
+      properties: {
+        tools: { type: "boolean" },
+        structuredOutput: { type: "boolean" },
+        contextWindowTokens: { type: "integer", minimum: 1 },
+      },
+    },
+    constraints: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        maxCostUsd: { type: "number", minimum: 0 },
+        maxTokens: { type: "integer", minimum: 0 },
+        maxLatencyMs: { type: "integer", minimum: 0 },
+        dataRetention: { type: "string", enum: [...MODEL_DATA_RETENTION] },
+        allowTraining: { type: "boolean" },
+        residency: { type: "string", minLength: 1, maxLength: 64 },
+      },
+    },
+    budgets: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        maxCostUsd: { type: "number", minimum: 0 },
+        maxTokens: { type: "integer", minimum: 0 },
+      },
+    },
+    // Ordered fallback ModelProfile references; fallback occurs only when the replacement meets the
+    // same Tool/structured-output/context/data/residency/budget constraints (SPEC §17).
+    fallbacks: refListSchema,
+    // Sensitive caching is off by default (SPEC §17); authors must state intent explicitly.
+    allowCaching: { type: "boolean" },
+  },
+} as const;
+
+export const ModelProfileDefinitionSchema = definitionSchema(KIND, modelSpecSchema);
+
+export const MODEL_PROFILE_DEFINITION = definitionRegistration(KIND, ModelProfileDefinitionSchema);
+
+export interface ModelProfileSpec {
+  provider: string;
+  model: string;
+  capabilityClass?: string;
+  reasoning: ModelReasoningLevel;
+  supports: {
+    tools: boolean;
+    structuredOutput: boolean;
+    contextWindowTokens: number;
+  };
+  constraints?: {
+    maxCostUsd?: number;
+    maxTokens?: number;
+    maxLatencyMs?: number;
+    dataRetention?: ModelDataRetention;
+    allowTraining?: boolean;
+    residency?: string;
+  };
+  budgets?: { maxCostUsd?: number; maxTokens?: number };
+  fallbacks?: string[];
+  allowCaching: boolean;
+}
+
+export type ModelProfileDefinition = DefinitionEnvelope<"ModelProfile", ModelProfileSpec>;

--- a/packages/schema/src/definitions/skill.test.ts
+++ b/packages/schema/src/definitions/skill.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { SchemaValidationError } from "../errors";
+import { SchemaRegistry } from "../registry";
+import { DEFINITION_API_VERSION } from "./common";
+import { SKILL_DEFINITION, SKILL_FORBIDDEN_GRANT_KEYS, SkillDefinitionSchema } from "./skill";
+
+function skillSpecPropertyNames(): string[] {
+  const root = SkillDefinitionSchema as {
+    properties: { spec: { properties: Record<string, unknown> } };
+  };
+  return Object.keys(root.properties.spec.properties);
+}
+
+function registry(): SchemaRegistry {
+  return new SchemaRegistry([SKILL_DEFINITION]);
+}
+
+const metadata = {
+  id: "22222222-2222-2222-2222-222222222222",
+  slug: "issue-triage",
+  schemaVersion: 1,
+  authoredVersion: 1,
+  lifecycle: "draft",
+};
+
+const minimal = {
+  apiVersion: DEFINITION_API_VERSION,
+  kind: "Skill",
+  metadata,
+  spec: { trustTier: "third_party" },
+};
+
+const full = {
+  apiVersion: DEFINITION_API_VERSION,
+  kind: "Skill",
+  metadata,
+  spec: {
+    references: ["docs/triage.md"],
+    templates: ["reply.hbs"],
+    examples: ["example-1.md"],
+    schemas: ["schemas/input.json"],
+    assets: ["logo.png"],
+    scripts: ["scripts/classify.ts"],
+    dependencies: ["shared-utils"],
+    requiredToolAbilities: ["github.issue.label"],
+    trustTier: "first_party",
+  },
+};
+
+describe("Skill definition schema", () => {
+  it("registers without violating the strict-object or discriminator contract", () => {
+    expect(() => registry()).not.toThrow();
+  });
+
+  it("validates a fully populated Skill definition", () => {
+    expect(() => registry().validate(full)).not.toThrow();
+  });
+
+  it("validates a minimal Skill with only a trust tier", () => {
+    expect(() => registry().validate(minimal)).not.toThrow();
+  });
+
+  it("allows required Tool abilities as a declaration of need", () => {
+    const doc = { ...minimal, spec: { ...minimal.spec, requiredToolAbilities: ["mailer.send"] } };
+    expect(() => registry().validate(doc)).not.toThrow();
+  });
+
+  // Invariant 4: a Skill never contains a permission grant.
+  it.each(SKILL_FORBIDDEN_GRANT_KEYS)("fails closed when a Skill smuggles a %s grant", (key) => {
+    const doc = { ...minimal, spec: { ...minimal.spec, [key]: ["github.issue.delete"] } };
+    expect(() => registry().validate(doc)).toThrow(SchemaValidationError);
+  });
+
+  it("never declares a grant-shaped property in its own spec schema", () => {
+    const specProps = skillSpecPropertyNames();
+    for (const forbidden of SKILL_FORBIDDEN_GRANT_KEYS) {
+      expect(specProps).not.toContain(forbidden);
+    }
+  });
+
+  it("rejects an unknown trust tier", () => {
+    const doc = { ...minimal, spec: { trustTier: "internal" } };
+    expect(() => registry().validate(doc)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a missing trust tier", () => {
+    const doc = { ...minimal, spec: {} };
+    expect(() => registry().validate(doc)).toThrow(SchemaValidationError);
+  });
+});

--- a/packages/schema/src/definitions/skill.ts
+++ b/packages/schema/src/definitions/skill.ts
@@ -1,0 +1,72 @@
+import {
+  DEFINITION_TRUST_TIERS,
+  type DefinitionEnvelope,
+  type DefinitionTrustTier,
+  definitionRegistration,
+  definitionSchema,
+  refListSchema,
+} from "./common";
+
+/**
+ * Skill authored definition (SPEC §7.1, invariant 4). A Skill contains instructions and assets and
+ * *declares* the Tool abilities it needs; it NEVER contains a permission grant, Tool grant, role,
+ * or access grant. Authority comes only from the invoking user/Agent intersection at runtime — a
+ * Skill can never add it (invariant 3). `additionalProperties: false` fails closed on any attempt
+ * to smuggle a grant-shaped field into a Skill.
+ */
+
+const KIND = "Skill";
+
+/** Property names that would turn a Skill into an authority grant. Kept for the guard test. */
+export const SKILL_FORBIDDEN_GRANT_KEYS = [
+  "grants",
+  "grant",
+  "permissions",
+  "permission",
+  "permissionCeiling",
+  "roles",
+  "role",
+  "toolGrants",
+  "grantedTools",
+  "accessGrants",
+  "accessGrant",
+  "credentials",
+] as const;
+
+const skillSpecSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["trustTier"],
+  properties: {
+    references: refListSchema,
+    templates: refListSchema,
+    examples: refListSchema,
+    // Paths to JSON Schema assets bundled with the Skill (SPEC §8.1 skills/<slug>/schemas).
+    schemas: refListSchema,
+    assets: refListSchema,
+    // Sandboxed helper scripts; execution still traverses the sandbox + Tool Broker (SPEC §13).
+    scripts: refListSchema,
+    dependencies: refListSchema,
+    // Tool *abilities the Skill requires* — a declaration of need, never a grant of a Tool.
+    requiredToolAbilities: refListSchema,
+    trustTier: { type: "string", enum: [...DEFINITION_TRUST_TIERS] },
+  },
+} as const;
+
+export const SkillDefinitionSchema = definitionSchema(KIND, skillSpecSchema);
+
+export const SKILL_DEFINITION = definitionRegistration(KIND, SkillDefinitionSchema);
+
+export interface SkillSpec {
+  references?: string[];
+  templates?: string[];
+  examples?: string[];
+  schemas?: string[];
+  assets?: string[];
+  scripts?: string[];
+  dependencies?: string[];
+  requiredToolAbilities?: string[];
+  trustTier: DefinitionTrustTier;
+}
+
+export type SkillDefinition = DefinitionEnvelope<"Skill", SkillSpec>;

--- a/packages/schema/src/definitions/tool.test.ts
+++ b/packages/schema/src/definitions/tool.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { SchemaValidationError } from "../errors";
+import { SchemaRegistry } from "../registry";
+import { DEFINITION_API_VERSION } from "./common";
+import { TOOL_CONTRACT_DEFINITION } from "./tool";
+
+function registry(): SchemaRegistry {
+  return new SchemaRegistry([TOOL_CONTRACT_DEFINITION]);
+}
+
+const metadata = {
+  id: "33333333-3333-3333-3333-333333333333",
+  slug: "github-issue-label",
+  schemaVersion: 1,
+  authoredVersion: 2,
+  lifecycle: "active",
+};
+
+const minimal = {
+  apiVersion: DEFINITION_API_VERSION,
+  kind: "ToolContract",
+  metadata,
+  spec: {
+    toolId: "github.issue.label",
+    toolVersion: "1.0.0",
+    action: "label",
+    inputSchema: { type: "object", properties: { issue: { type: "number" } } },
+    outputSchema: { type: "object" },
+    riskClass: "medium",
+    mutating: true,
+    dryRun: true,
+    idempotency: { strategy: "provider" },
+    adapter: { kind: "integration", ref: "github" },
+  },
+};
+
+const full = {
+  ...minimal,
+  spec: {
+    ...minimal.spec,
+    errorSchema: { type: "object" },
+    requiredActions: ["issues:write"],
+    requiredResources: ["ticket"],
+    dataClasses: ["internal"],
+    allowedDestinations: ["github.com"],
+    timeout: { activeMs: 5000, wallClockMs: 30000 },
+    retry: { maxAttempts: 3, safeToRetry: false },
+    compensation: { operation: "github.issue.unlabel", reconciliation: "github.issue.get" },
+  },
+};
+
+describe("ToolContract definition schema", () => {
+  it("registers without violating the strict-object or discriminator contract", () => {
+    expect(() => registry()).not.toThrow();
+  });
+
+  it("validates a fully populated ToolContract", () => {
+    expect(() => registry().validate(full)).not.toThrow();
+  });
+
+  it("validates a minimal ToolContract with only required fields", () => {
+    expect(() => registry().validate(minimal)).not.toThrow();
+  });
+
+  it("carries an embedded input schema as opaque data", () => {
+    const doc = {
+      ...minimal,
+      spec: {
+        ...minimal.spec,
+        inputSchema: { type: "object", additionalProperties: false, required: ["x"] },
+      },
+    };
+    expect(() => registry().validate(doc)).not.toThrow();
+  });
+
+  it("rejects an unknown risk class", () => {
+    const doc = { ...minimal, spec: { ...minimal.spec, riskClass: "catastrophic" } };
+    expect(() => registry().validate(doc)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a missing idempotency strategy", () => {
+    const doc = { ...minimal, spec: { ...minimal.spec, idempotency: {} } };
+    expect(() => registry().validate(doc)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a partial retry policy", () => {
+    const doc = { ...minimal, spec: { ...minimal.spec, retry: { maxAttempts: 1 } } };
+    expect(() => registry().validate(doc)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects an unknown adapter kind", () => {
+    const doc = { ...minimal, spec: { ...minimal.spec, adapter: { kind: "ssh", ref: "box" } } };
+    expect(() => registry().validate(doc)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a non-boolean mutating classification", () => {
+    const doc = { ...minimal, spec: { ...minimal.spec, mutating: "yes" } };
+    expect(() => registry().validate(doc)).toThrow(SchemaValidationError);
+  });
+});

--- a/packages/schema/src/definitions/tool.ts
+++ b/packages/schema/src/definitions/tool.ts
@@ -1,0 +1,126 @@
+import {
+  type DefinitionEnvelope,
+  definitionRegistration,
+  definitionSchema,
+  refListSchema,
+  TOOL_ADAPTER_KINDS,
+  TOOL_IDEMPOTENCY_STRATEGIES,
+  TOOL_RISK_CLASSES,
+  type ToolAdapterKind,
+  type ToolIdempotencyStrategy,
+  type ToolRiskClass,
+} from "./common";
+
+/**
+ * ToolContract authored definition (SPEC §7.1, §11). Versioned input/output/error schemas, risk
+ * and mutation classification, required actions/resources, data classes, allowed destinations,
+ * idempotency behaviour, timeout/retry rules, dry-run support, compensation/reconciliation
+ * operations, and the implementation adapter. Every Tool call re-enters the Tool Broker; the
+ * contract is data, not an execution bypass (SPEC §11.1).
+ */
+
+const KIND = "ToolContract";
+
+/** An embedded JSON Schema carried as opaque data (the Tool's own input/output shape). */
+const embeddedJsonSchema = { type: "object", additionalProperties: true } as const;
+
+const toolSpecSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: [
+    "toolId",
+    "toolVersion",
+    "action",
+    "inputSchema",
+    "outputSchema",
+    "riskClass",
+    "mutating",
+    "dryRun",
+    "idempotency",
+    "adapter",
+  ],
+  properties: {
+    toolId: { type: "string", minLength: 1, maxLength: 256 },
+    toolVersion: { type: "string", minLength: 1, maxLength: 64 },
+    action: { type: "string", minLength: 1, maxLength: 128 },
+    inputSchema: embeddedJsonSchema,
+    outputSchema: embeddedJsonSchema,
+    errorSchema: embeddedJsonSchema,
+    riskClass: { type: "string", enum: [...TOOL_RISK_CLASSES] },
+    mutating: { type: "boolean" },
+    requiredActions: refListSchema,
+    requiredResources: refListSchema,
+    dataClasses: refListSchema,
+    allowedDestinations: refListSchema,
+    idempotency: {
+      type: "object",
+      additionalProperties: false,
+      required: ["strategy"],
+      properties: {
+        strategy: { type: "string", enum: [...TOOL_IDEMPOTENCY_STRATEGIES] },
+      },
+    },
+    timeout: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        activeMs: { type: "integer", minimum: 0 },
+        wallClockMs: { type: "integer", minimum: 0 },
+      },
+    },
+    retry: {
+      type: "object",
+      additionalProperties: false,
+      required: ["maxAttempts", "safeToRetry"],
+      properties: {
+        maxAttempts: { type: "integer", minimum: 0 },
+        safeToRetry: { type: "boolean" },
+      },
+    },
+    dryRun: { type: "boolean" },
+    compensation: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        operation: { type: "string", minLength: 1, maxLength: 256 },
+        reconciliation: { type: "string", minLength: 1, maxLength: 256 },
+      },
+    },
+    adapter: {
+      type: "object",
+      additionalProperties: false,
+      required: ["kind", "ref"],
+      properties: {
+        kind: { type: "string", enum: [...TOOL_ADAPTER_KINDS] },
+        ref: { type: "string", minLength: 1, maxLength: 256 },
+      },
+    },
+  },
+} as const;
+
+export const ToolContractDefinitionSchema = definitionSchema(KIND, toolSpecSchema);
+
+export const TOOL_CONTRACT_DEFINITION = definitionRegistration(KIND, ToolContractDefinitionSchema);
+
+export interface ToolContractSpec {
+  toolId: string;
+  toolVersion: string;
+  action: string;
+  inputSchema: Record<string, unknown>;
+  outputSchema: Record<string, unknown>;
+  errorSchema?: Record<string, unknown>;
+  riskClass: ToolRiskClass;
+  mutating: boolean;
+  requiredActions?: string[];
+  requiredResources?: string[];
+  dataClasses?: string[];
+  allowedDestinations?: string[];
+  idempotency: { strategy: ToolIdempotencyStrategy };
+  timeout?: { activeMs?: number; wallClockMs?: number };
+  retry?: { maxAttempts: number; safeToRetry: boolean };
+  dryRun: boolean;
+  compensation?: { operation?: string; reconciliation?: string };
+  adapter: { kind: ToolAdapterKind; ref: string };
+}
+
+export type ToolContractDefinition = DefinitionEnvelope<"ToolContract", ToolContractSpec>;

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -4,6 +4,7 @@ export { ajv } from "./ajv";
 export type { ValidationBoundary } from "./boundaries";
 export { BOUNDARIES } from "./boundaries";
 export { CANONICAL_HASH_ALGORITHM, canonicalHash, canonicalize } from "./canonicalize";
+export * from "./definitions";
 export { TulipFarmValidationError } from "./error";
 export type { SchemaContractErrorCode, SchemaValidationIssue } from "./errors";
 export {


### PR DESCRIPTION
## Summary
- Add the four canonical authored-definition JSON Schemas (`Agent`, `Skill`, `ToolContract`, `ModelProfile`) under `packages/schema/src/definitions/`, plugging into the AW-007 `SchemaRegistry` (strict `apiVersion`/`kind` discriminator, explicit unknown-property behaviour, deterministic canonical hash). Implements AW-008 (SPEC §7.1, §§10–11, §17).
- **Invariant 4 enforced:** a Skill declares `requiredToolAbilities` (a need) but never carries a permission grant — `additionalProperties:false` fails closed on any grant-shaped key; `SKILL_FORBIDDEN_GRANT_KEYS` drives an explicit denial test. Agent's `roles`/`permissionCeiling`/`allowedTools` are references only; authority is the runtime intersection (SPEC §12), never broadened by a definition.
- Every SPEC-named field is schema'd: lifecycle, trust tier, autonomy ceiling, limits, guardrail refs, memory/knowledge scopes, risk/mutation, idempotency, retry, compensation, adapter, provider constraints, fallbacks, caching. Exports `DEFINITION_REGISTRATIONS` for AW-011 to register on the Soul write path.

## Scope
New: `packages/schema/src/definitions/{common,agent,skill,tool,model,index}.ts` + colocated `*.test.ts`. Modified: one barrel line in `packages/schema/src/index.ts`. No `apps/*`, no legacy schema files touched, no migrations, no runtime wiring (deferred to AW-011).

## Test plan
- RED (impl moved aside): `Test Files 5 failed (5)` — `Cannot find module './agent'|'./common'|'./index'`.
- GREEN: `pnpm --filter @tulipfarm/schema test` → **143 passed** (51 new: happy, minimal-boundary, unknown-enum/lifecycle/tier denials, missing-required, malformed id/slug, Skill grant fail-closed, cross-kind single-registry, deterministic hash).
- `pnpm exec biome check` → clean.
- `pnpm typecheck` → 28/28.
- `pnpm build` → 5/5.