### PR TITLE
feat(schema): define AW-010 governance and integration schemas

### DIFF
--- a/packages/schema/src/definitions/a2ui.ts
+++ b/packages/schema/src/definitions/a2ui.ts
@@ -1,0 +1,248 @@
+import { type Static, Type } from "@sinclair/typebox";
+import {
+  DEFINITION_API_VERSION,
+  type DefinitionMetadata,
+  definitionMetadataSchema,
+  definitionRegistration,
+} from "./common";
+
+const apiVersion = DEFINITION_API_VERSION;
+const idPattern =
+  "^(?:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9A-HJKMNP-TV-Z]{26})$";
+const slugPattern = "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$";
+const actionPattern = "^[a-z][a-z0-9-]*(?:\\.[a-z][a-z0-9-]*)+$";
+const dateTimePattern =
+  "^\\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\\d|3[01])T(?:[01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d(?:\\.\\d{1,9})?Z$";
+const digestPattern = "^[a-f0-9]{64}$";
+const opaqueTokenPattern = "^[A-Za-z0-9_-]+$";
+
+const MetadataSchema = Type.Unsafe<DefinitionMetadata>(definitionMetadataSchema);
+
+const BindingSchema = Type.Object(
+  { path: Type.String({ pattern: "^/(?:[^~/]|~0|~1)*(?:/(?:[^~/]|~0|~1)*)*$" }) },
+  { additionalProperties: false }
+);
+
+const ValueSchema = Type.Union([
+  Type.String(),
+  Type.Number(),
+  Type.Boolean(),
+  Type.Null(),
+  BindingSchema,
+]);
+
+const NodeSchema = Type.Recursive((Node) =>
+  Type.Union([
+    Type.Object(
+      {
+        id: Type.Optional(Type.String({ pattern: slugPattern })),
+        component: Type.Union([
+          Type.Literal("Card"),
+          Type.Literal("Row"),
+          Type.Literal("Column"),
+          Type.Literal("Grid"),
+        ]),
+        children: Type.Array(Node),
+      },
+      { additionalProperties: false }
+    ),
+    Type.Object(
+      {
+        id: Type.Optional(Type.String({ pattern: slugPattern })),
+        component: Type.Union([
+          Type.Literal("Heading"),
+          Type.Literal("Text"),
+          Type.Literal("Badge"),
+          Type.Literal("Alert"),
+        ]),
+        text: ValueSchema,
+      },
+      { additionalProperties: false }
+    ),
+    Type.Object(
+      {
+        id: Type.Optional(Type.String({ pattern: slugPattern })),
+        component: Type.Literal("Button"),
+        label: ValueSchema,
+        actionRef: Type.String({ pattern: slugPattern }),
+      },
+      { additionalProperties: false }
+    ),
+    Type.Object(
+      {
+        id: Type.Optional(Type.String({ pattern: slugPattern })),
+        component: Type.Literal("Form"),
+        formId: Type.String({ pattern: idPattern }),
+      },
+      { additionalProperties: false }
+    ),
+    Type.Object(
+      {
+        id: Type.Optional(Type.String({ pattern: slugPattern })),
+        component: Type.Union([
+          Type.Literal("MetricCard"),
+          Type.Literal("List"),
+          Type.Literal("DetailView"),
+          Type.Literal("DataTable"),
+          Type.Literal("BarChart"),
+          Type.Literal("LineChart"),
+          Type.Literal("ForceGraph"),
+        ]),
+        data: BindingSchema,
+      },
+      { additionalProperties: false }
+    ),
+  ])
+);
+
+const AudienceSchema = Type.Object(
+  {
+    roleIds: Type.Array(Type.String({ pattern: idPattern }), { minItems: 1, uniqueItems: true }),
+  },
+  { additionalProperties: false }
+);
+
+const InputValueSchema = Type.Recursive((Schema) =>
+  Type.Union([
+    Type.Boolean(),
+    Type.Object(
+      {
+        type: Type.Literal("string"),
+        minLength: Type.Optional(Type.Integer({ minimum: 0 })),
+        maxLength: Type.Optional(Type.Integer({ minimum: 0 })),
+        pattern: Type.Optional(Type.String({ minLength: 1 })),
+        enum: Type.Optional(Type.Array(Type.String(), { minItems: 1, uniqueItems: true })),
+      },
+      { additionalProperties: false }
+    ),
+    Type.Object(
+      {
+        type: Type.Union([Type.Literal("number"), Type.Literal("integer")]),
+        minimum: Type.Optional(Type.Number()),
+        maximum: Type.Optional(Type.Number()),
+      },
+      { additionalProperties: false }
+    ),
+    Type.Object({ type: Type.Literal("boolean") }, { additionalProperties: false }),
+    Type.Object({ type: Type.Literal("null") }, { additionalProperties: false }),
+    Type.Object(
+      {
+        type: Type.Literal("array"),
+        items: Schema,
+        minItems: Type.Optional(Type.Integer({ minimum: 0 })),
+        maxItems: Type.Optional(Type.Integer({ minimum: 0 })),
+      },
+      { additionalProperties: false }
+    ),
+    Type.Object(
+      {
+        type: Type.Literal("object"),
+        additionalProperties: Type.Boolean(),
+        properties: Type.Optional(Type.Object({}, { additionalProperties: Schema })),
+        required: Type.Optional(
+          Type.Array(Type.String({ minLength: 1 }), { minItems: 1, uniqueItems: true })
+        ),
+      },
+      { additionalProperties: false }
+    ),
+  ])
+);
+
+const ObjectInputSchema = Type.Object(
+  {
+    type: Type.Literal("object"),
+    additionalProperties: Type.Boolean(),
+    properties: Type.Optional(Type.Object({}, { additionalProperties: InputValueSchema })),
+    required: Type.Optional(
+      Type.Array(Type.String({ minLength: 1 }), { minItems: 1, uniqueItems: true })
+    ),
+  },
+  { additionalProperties: false }
+);
+
+const ActionSchema = Type.Object(
+  {
+    id: Type.String({ pattern: slugPattern }),
+    action: Type.String({ pattern: actionPattern }),
+    targetRefs: Type.Array(
+      Type.Object(
+        {
+          type: Type.String({ pattern: slugPattern }),
+          id: Type.String({ minLength: 1 }),
+        },
+        { additionalProperties: false }
+      ),
+      { minItems: 1 }
+    ),
+    routineId: Type.String({ pattern: idPattern }),
+    stateId: Type.String({ pattern: "^[A-Za-z][A-Za-z0-9]*$" }),
+    inputSchema: ObjectInputSchema,
+    audience: AudienceSchema,
+    expiresInSeconds: Type.Integer({ minimum: 1, maximum: 86400 }),
+    guardrailId: Type.String({ pattern: idPattern }),
+    guardrailVersion: Type.Integer({ minimum: 1 }),
+  },
+  { additionalProperties: false }
+);
+
+export const A2UITemplateSchema = Type.Object(
+  {
+    apiVersion: Type.Literal(apiVersion),
+    kind: Type.Literal("A2UITemplate"),
+    metadata: MetadataSchema,
+    spec: Type.Object(
+      {
+        root: NodeSchema,
+        actions: Type.Array(ActionSchema),
+      },
+      { additionalProperties: false }
+    ),
+  },
+  { $id: `${apiVersion}/A2UITemplate`, additionalProperties: false }
+);
+export const A2UI_TEMPLATE_DEFINITION = definitionRegistration("A2UITemplate", A2UITemplateSchema);
+
+export type A2UITemplateDefinition = Static<typeof A2UITemplateSchema>;
+
+const RuntimeTargetReferenceSchema = Type.Object(
+  {
+    type: Type.String({ pattern: slugPattern }),
+    id: Type.String({ minLength: 1 }),
+  },
+  { additionalProperties: false }
+);
+
+const RuntimeContextSchema = Type.Union([
+  Type.Object(
+    { kind: Type.Literal("run"), runId: Type.String({ pattern: idPattern }) },
+    { additionalProperties: false }
+  ),
+  Type.Object(
+    {
+      kind: Type.Literal("conversation"),
+      conversationId: Type.String({ pattern: idPattern }),
+    },
+    { additionalProperties: false }
+  ),
+]);
+
+export const A2UIActionDescriptorSchema = Type.Object(
+  {
+    apiVersion: Type.Literal(apiVersion),
+    kind: Type.Literal("A2UIActionDescriptor"),
+    action: Type.String({ pattern: actionPattern }),
+    targetRefs: Type.Array(RuntimeTargetReferenceSchema, { minItems: 1 }),
+    inputSchemaDigest: Type.String({ pattern: digestPattern }),
+    routineId: Type.String({ pattern: idPattern }),
+    stateId: Type.String({ pattern: "^[A-Za-z][A-Za-z0-9]*$" }),
+    audience: AudienceSchema,
+    context: RuntimeContextSchema,
+    nonce: Type.String({ minLength: 32, pattern: opaqueTokenPattern }),
+    expiresAt: Type.String({ pattern: dateTimePattern }),
+    guardrailRevision: Type.String({ pattern: digestPattern }),
+    signature: Type.String({ minLength: 43, pattern: opaqueTokenPattern }),
+  },
+  { $id: `${apiVersion}/A2UIActionDescriptor`, additionalProperties: false }
+);
+
+export type A2UIActionDescriptor = Static<typeof A2UIActionDescriptorSchema>;

--- a/packages/schema/src/definitions/contracts.test.ts
+++ b/packages/schema/src/definitions/contracts.test.ts
@@ -1,0 +1,788 @@
+import { describe, expect, it } from "vitest";
+import { SchemaRegistry, SchemaValidationError } from "../index";
+import { A2UIActionDescriptorSchema, A2UITemplateSchema } from "./a2ui";
+import { FormActionDescriptorSchema, FormSchema } from "./form";
+import { GuardrailSchema } from "./guardrail";
+import {
+  AccessGrantSchema,
+  AppSchema,
+  IntegrationAdapterSchema,
+  IntegrationSchema,
+} from "./integration";
+import * as knowledgeContracts from "./knowledge";
+import { KnowledgeCaptureSchema, KnowledgeSourceSchema } from "./knowledge";
+import { MemorySettingsSchema } from "./memory";
+import { RoleSchema } from "./role";
+import { SettingsSchema } from "./settings";
+
+const apiVersion = "tulipfarm.ai/v1";
+const definitionId = "018f3f8a-7b5c-7c9d-8e1f-2a3b4c5d6e7f";
+const digest = "a".repeat(64);
+const expiresAt = "2026-07-23T10:30:00Z";
+const approvalCategories = {
+  soulChange: true,
+  highRiskAction: true,
+  destructiveAction: true,
+  protectedDataEgress: true,
+  credentialUse: true,
+};
+
+const metadata = (slug: string) => ({
+  id: definitionId,
+  slug,
+  schemaVersion: 1,
+  authoredVersion: 1,
+  lifecycle: "draft",
+});
+
+const registrations = [
+  { apiVersion, kind: "Role", schema: RoleSchema },
+  { apiVersion, kind: "Guardrail", schema: GuardrailSchema },
+  { apiVersion, kind: "Settings", schema: SettingsSchema },
+  { apiVersion, kind: "IntegrationAdapter", schema: IntegrationAdapterSchema },
+  { apiVersion, kind: "App", schema: AppSchema },
+  { apiVersion, kind: "Integration", schema: IntegrationSchema },
+  { apiVersion, kind: "AccessGrant", schema: AccessGrantSchema },
+  { apiVersion, kind: "KnowledgeSource", schema: KnowledgeSourceSchema },
+  { apiVersion, kind: "KnowledgeCapture", schema: KnowledgeCaptureSchema },
+  { apiVersion, kind: "MemorySettings", schema: MemorySettingsSchema },
+  { apiVersion, kind: "Form", schema: FormSchema },
+  { apiVersion, kind: "FormActionDescriptor", schema: FormActionDescriptorSchema },
+  { apiVersion, kind: "A2UITemplate", schema: A2UITemplateSchema },
+  { apiVersion, kind: "A2UIActionDescriptor", schema: A2UIActionDescriptorSchema },
+] as const;
+
+function registry(): SchemaRegistry {
+  return new SchemaRegistry(registrations);
+}
+
+const validationRegistry = registry();
+
+function expectInvalid(document: unknown): void {
+  expect(() => validationRegistry.validate(document)).toThrow(SchemaValidationError);
+}
+
+function expectInvalidAt(document: unknown, path: string, keyword: string): void {
+  try {
+    validationRegistry.validate(document);
+    throw new Error("expected validation to fail");
+  } catch (error) {
+    expect(error).toBeInstanceOf(SchemaValidationError);
+    const validationError = error as SchemaValidationError;
+    expect(validationError.code).toBe("SCHEMA_VALIDATION_FAILED");
+    expect(validationError.issues).toEqual(
+      expect.arrayContaining([expect.objectContaining({ path, keyword })])
+    );
+  }
+}
+
+function expectInvalidRequired(document: unknown, field: string): void {
+  try {
+    validationRegistry.validate(document);
+    throw new Error("expected validation to fail");
+  } catch (error) {
+    expect(error).toBeInstanceOf(SchemaValidationError);
+    const validationError = error as SchemaValidationError;
+    expect(validationError.code).toBe("SCHEMA_VALIDATION_FAILED");
+    expect(validationError.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: "",
+          keyword: "required",
+          message: `must have required property '${field}'`,
+        }),
+      ])
+    );
+  }
+}
+
+describe("AW-010 authored definition schemas", () => {
+  it("does not register runtime Knowledge capture evidence as an authored definition", () => {
+    expect(knowledgeContracts).not.toHaveProperty("KNOWLEDGE_CAPTURE_DEFINITION");
+  });
+
+  it("validates every owned kind deterministically across registry restarts", () => {
+    const documents = [
+      {
+        apiVersion,
+        kind: "Role",
+        metadata: metadata("support-operator"),
+        spec: {
+          principalTypes: ["user", "agent"],
+          grants: [
+            {
+              effect: "allow",
+              actions: ["ticket.read"],
+              resource: { types: ["ticket"], recordIds: ["ticket-42"] },
+              fields: ["title", "status"],
+              conditions: [{ attribute: "context.channel", operator: "equals", value: "support" }],
+              delegable: false,
+            },
+          ],
+        },
+      },
+      {
+        apiVersion,
+        kind: "Guardrail",
+        metadata: metadata("protected-data"),
+        spec: {
+          defaultDecision: "deny",
+          rules: [
+            {
+              id: "block-secret-egress",
+              type: "dlp",
+              detectors: [{ type: "secret" }],
+              action: "block",
+              destinations: ["external"],
+              scope: {
+                resource: {
+                  types: ["ticket"],
+                  recordIds: ["ticket-42"],
+                  fields: ["description"],
+                },
+                conditions: [
+                  { attribute: "context.channel", operator: "equals", value: "support" },
+                ],
+                expiresAt,
+              },
+              constraints: {
+                maxRecords: 10,
+                maxBytes: 1048576,
+                maxCostUsd: 2.5,
+                timeWindow: { startsAt: "2026-07-22T10:30:00Z", expiresAt },
+                network: { allowedHosts: ["api.example.com"], allowPrivateNetworks: false },
+                executionEnvironments: ["managedAdapter"],
+              },
+            },
+            {
+              id: "approve-destructive",
+              type: "approval",
+              actions: ["record.delete"],
+              category: "destructiveAction",
+              minimumApprovers: 2,
+              separationOfDuties: true,
+            },
+          ],
+        },
+      },
+      {
+        apiVersion,
+        kind: "Settings",
+        metadata: metadata("business-settings"),
+        spec: {
+          approvalCategories: {
+            ...approvalCategories,
+            protectedDataEgress: false,
+          },
+        },
+      },
+      {
+        apiVersion,
+        kind: "IntegrationAdapter",
+        metadata: metadata("slack"),
+        spec: {
+          provider: "slack",
+          execution: { mode: "managed", adapter: "slack" },
+          authTypes: ["oauth2", "token"],
+          operations: ["message.read", "message.send"],
+          events: ["message.created"],
+        },
+      },
+      {
+        apiVersion,
+        kind: "App",
+        metadata: metadata("support-slack-app"),
+        spec: {
+          adapterId: definitionId,
+          externalAppId: "A012345",
+          credentialRefs: ["secret://credentials/slack/support-app"],
+        },
+      },
+      {
+        apiVersion,
+        kind: "Integration",
+        metadata: metadata("support-workspace"),
+        spec: {
+          appId: definitionId,
+          externalAccount: { tenantId: "T012345", accountId: "workspace-support" },
+          credentialRef: "secret://credentials/slack/support-workspace",
+        },
+      },
+      {
+        apiVersion,
+        kind: "AccessGrant",
+        metadata: metadata("support-channels"),
+        spec: {
+          integrationId: definitionId,
+          principals: [{ kind: "role", id: definitionId }],
+          actions: ["message.read", "message.send"],
+          externalTargets: [{ type: "channel", ids: ["C012345"] }],
+          delegable: false,
+        },
+      },
+      {
+        apiVersion,
+        kind: "KnowledgeSource",
+        metadata: metadata("support-handbook"),
+        spec: {
+          integrationId: definitionId,
+          source: {
+            provider: "google-drive",
+            externalId: "drive-42",
+            externalTenantId: "tenant-42",
+            ownerExternalId: "owner-42",
+          },
+          accessControl: { mode: "live", maximumAgeSeconds: 300 },
+          classification: ["internal"],
+        },
+      },
+      {
+        apiVersion,
+        kind: "KnowledgeCapture",
+        knowledgeSourceId: definitionId,
+        sourceRevision: "revision-7",
+        capturedAt: "2026-07-22T10:30:00Z",
+        contentHash: digest,
+        aclRevision: "acl-revision-3",
+      },
+      {
+        apiVersion,
+        kind: "MemorySettings",
+        metadata: metadata("business-memory"),
+        spec: {
+          scopes: ["user_private", "user_agent", "run_local"],
+          inferredDurableMemory: { enabled: true, confirmationRequired: true },
+          defaultExpiryDays: 90,
+        },
+      },
+      {
+        apiVersion,
+        kind: "Form",
+        metadata: metadata("incident-intake"),
+        spec: {
+          title: "Incident intake",
+          submission: { triggerId: definitionId, inputName: "incident" },
+          audience: { roleIds: [definitionId] },
+          fields: [
+            { name: "summary", label: "Summary", input: "text", required: true },
+            { name: "severity", label: "Severity", input: "select", options: ["low", "high"] },
+          ],
+        },
+      },
+      {
+        apiVersion,
+        kind: "A2UITemplate",
+        metadata: metadata("incident-card"),
+        spec: {
+          root: {
+            component: "Card",
+            children: [
+              { component: "Heading", text: { path: "/title" } },
+              { component: "Button", label: "Open", actionRef: "open-incident" },
+            ],
+          },
+          actions: [
+            {
+              id: "open-incident",
+              action: "incident.open",
+              targetRefs: [{ type: "incident", id: "incident-42" }],
+              routineId: definitionId,
+              stateId: "openIncident",
+              inputSchema: {
+                type: "object",
+                additionalProperties: false,
+                properties: {
+                  incident: {
+                    type: "object",
+                    additionalProperties: false,
+                    properties: { summary: { type: "string", minLength: 1 } },
+                    required: ["summary"],
+                  },
+                },
+                required: ["incident"],
+              },
+              audience: { roleIds: [definitionId] },
+              expiresInSeconds: 300,
+              guardrailId: definitionId,
+              guardrailVersion: 1,
+            },
+          ],
+        },
+      },
+      {
+        apiVersion,
+        kind: "FormActionDescriptor",
+        formId: definitionId,
+        runId: definitionId,
+        runWaitId: definitionId,
+        schemaDigest: digest,
+        audience: { kind: "user", id: definitionId },
+        resumeToken: "abcdefghijklmnopqrstuvwxyzABCDEFG123456",
+        nonce: "nonce-abcdefghijklmnopqrstuvwxyz123456",
+        expiresAt,
+      },
+      {
+        apiVersion,
+        kind: "A2UIActionDescriptor",
+        action: "incident.open",
+        targetRefs: [{ type: "incident", id: "incident-42" }],
+        inputSchemaDigest: digest,
+        routineId: definitionId,
+        stateId: "openIncident",
+        audience: { roleIds: [definitionId] },
+        context: { kind: "run", runId: definitionId },
+        nonce: "nonce-abcdefghijklmnopqrstuvwxyz123456",
+        expiresAt,
+        guardrailRevision: digest,
+        signature: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_",
+      },
+    ];
+
+    const firstRegistry = registry();
+    const restartedRegistry = registry();
+
+    for (const document of documents) {
+      const first = firstRegistry.validate(document);
+      const restarted = restartedRegistry.validate(JSON.parse(JSON.stringify(document)));
+      expect(first.hash).toBe(restarted.hash);
+    }
+  });
+
+  it("rejects wildcard authority and unknown grant properties", () => {
+    const base = {
+      apiVersion,
+      kind: "Role",
+      metadata: metadata("overpowered-role"),
+      spec: {
+        principalTypes: ["agent"],
+        grants: [{ effect: "allow", actions: ["*"], delegable: false }],
+      },
+    };
+
+    expectInvalidAt(base, "/spec/grants/0/actions/0", "pattern");
+    expectInvalidAt(
+      {
+        ...base,
+        spec: {
+          principalTypes: ["agent"],
+          grants: [
+            {
+              effect: "allow",
+              actions: ["ticket.read"],
+              delegable: false,
+              permissionCeiling: "all",
+            },
+          ],
+        },
+      },
+      "/spec/grants/0",
+      "additionalProperties"
+    );
+  });
+
+  it("requires explicit independent approval categories instead of a global bypass", () => {
+    expectInvalidAt(
+      {
+        apiVersion,
+        kind: "Settings",
+        metadata: metadata("unsafe-settings"),
+        spec: { approvalCategories, approvalsEnabled: false },
+      },
+      "/spec",
+      "additionalProperties"
+    );
+    expectInvalid({
+      apiVersion,
+      kind: "Settings",
+      metadata: metadata("incomplete-settings"),
+      spec: {
+        approvalCategories: {
+          soulChange: true,
+          highRiskAction: true,
+          destructiveAction: true,
+          protectedDataEgress: true,
+        },
+      },
+    });
+  });
+
+  it("keeps App and Agent identity separate and accepts only opaque Credential references", () => {
+    expectInvalidAt(
+      {
+        apiVersion,
+        kind: "App",
+        metadata: metadata("conflated-app"),
+        spec: {
+          adapterId: definitionId,
+          externalAppId: "A012345",
+          credentialRefs: [],
+          agentId: definitionId,
+        },
+      },
+      "/spec",
+      "additionalProperties"
+    );
+    expectInvalid({
+      apiVersion,
+      kind: "Integration",
+      metadata: metadata("plaintext-integration"),
+      spec: {
+        appId: definitionId,
+        externalAccount: { tenantId: "tenant" },
+        credentialRef: "xoxb-plaintext-token",
+      },
+    });
+    expectInvalid({
+      apiVersion,
+      kind: "IntegrationAdapter",
+      metadata: metadata("in-process-adapter"),
+      spec: {
+        provider: "custom",
+        execution: { mode: "command", command: "node untrusted.js" },
+        authTypes: ["none"],
+        operations: ["data.read"],
+        events: [],
+      },
+    });
+  });
+
+  it("rejects unverifiable Knowledge access and inferred Memory without confirmation", () => {
+    expectInvalid({
+      apiVersion,
+      kind: "KnowledgeSource",
+      metadata: metadata("unverifiable-source"),
+      spec: {
+        integrationId: definitionId,
+        source: {
+          provider: "drive",
+          externalId: "private",
+          externalTenantId: "tenant",
+          ownerExternalId: "owner",
+        },
+        accessControl: { mode: "unverified" },
+        classification: ["confidential"],
+      },
+    });
+    expectInvalid({
+      apiVersion,
+      kind: "MemorySettings",
+      metadata: metadata("unsafe-memory"),
+      spec: {
+        scopes: ["business"],
+        inferredDurableMemory: { enabled: true, confirmationRequired: false },
+      },
+    });
+  });
+
+  it("rejects executable A2UI actions and plaintext secret form fields", () => {
+    expectInvalidAt(
+      {
+        apiVersion,
+        kind: "A2UITemplate",
+        metadata: metadata("scripted-ui"),
+        spec: {
+          root: {
+            component: "Button",
+            label: "Run",
+            actionRef: "run-action",
+            onClick: "javascript:steal()",
+          },
+          actions: [
+            {
+              id: "run-action",
+              action: "incident.open",
+              targetRefs: [{ type: "incident", id: "incident-42" }],
+              routineId: definitionId,
+              stateId: "openIncident",
+              inputSchema: { type: "object", additionalProperties: false, properties: {} },
+              audience: { roleIds: [definitionId] },
+              expiresInSeconds: 300,
+              guardrailId: definitionId,
+              guardrailVersion: 1,
+            },
+          ],
+        },
+      },
+      "/spec/root",
+      "additionalProperties"
+    );
+    expectInvalid({
+      apiVersion,
+      kind: "Form",
+      metadata: metadata("secret-form"),
+      spec: {
+        title: "Credentials",
+        submission: { triggerId: definitionId, inputName: "credentials" },
+        audience: { roleIds: [definitionId] },
+        fields: [{ name: "apiKey", label: "API key", input: "secret" }],
+      },
+    });
+  });
+
+  it("rejects direct Form-to-Routine dispatch and incomplete resume descriptors", () => {
+    expectInvalidAt(
+      {
+        apiVersion,
+        kind: "Form",
+        metadata: metadata("direct-routine-form"),
+        spec: {
+          title: "Unsafe direct dispatch",
+          submission: { routineId: definitionId, inputName: "payload" },
+          audience: { roleIds: [definitionId] },
+          fields: [{ name: "summary", label: "Summary", input: "text" }],
+        },
+      },
+      "/spec/submission",
+      "additionalProperties"
+    );
+    expectInvalidAt(
+      {
+        apiVersion,
+        kind: "FormActionDescriptor",
+        formId: definitionId,
+        runId: definitionId,
+        runWaitId: definitionId,
+        schemaDigest: digest,
+        audience: { kind: "user", id: definitionId },
+        resumeToken: "short",
+        nonce: "nonce-abcdefghijklmnopqrstuvwxyz123456",
+        expiresAt,
+      },
+      "/resumeToken",
+      "minLength"
+    );
+
+    const descriptor: Record<string, unknown> = {
+      apiVersion,
+      kind: "FormActionDescriptor",
+      formId: definitionId,
+      runId: definitionId,
+      runWaitId: definitionId,
+      schemaDigest: digest,
+      audience: { kind: "user", id: definitionId },
+      resumeToken: "abcdefghijklmnopqrstuvwxyzABCDEFG123456",
+      nonce: "nonce-abcdefghijklmnopqrstuvwxyz123456",
+      expiresAt,
+    };
+    for (const field of [
+      "formId",
+      "runId",
+      "runWaitId",
+      "schemaDigest",
+      "audience",
+      "resumeToken",
+      "nonce",
+      "expiresAt",
+    ]) {
+      const incomplete = { ...descriptor };
+      delete incomplete[field];
+      expectInvalidRequired(incomplete, field);
+    }
+  });
+
+  it("requires signed A2UI actions to bind target, Context, nonce, expiry, and Guardrail", () => {
+    expectInvalidAt(
+      {
+        apiVersion,
+        kind: "A2UIActionDescriptor",
+        action: "incident.open",
+        targetRefs: [{ type: "incident", id: "incident-42" }],
+        inputSchemaDigest: digest,
+        routineId: definitionId,
+        stateId: "openIncident",
+        audience: { roleIds: [definitionId] },
+        context: { kind: "run", runId: definitionId },
+        nonce: "nonce-abcdefghijklmnopqrstuvwxyz123456",
+        expiresAt,
+        guardrailRevision: digest,
+        signature: "short",
+      },
+      "/signature",
+      "minLength"
+    );
+
+    const descriptor: Record<string, unknown> = {
+      apiVersion,
+      kind: "A2UIActionDescriptor",
+      action: "incident.open",
+      targetRefs: [{ type: "incident", id: "incident-42" }],
+      inputSchemaDigest: digest,
+      routineId: definitionId,
+      stateId: "openIncident",
+      audience: { roleIds: [definitionId] },
+      context: { kind: "run", runId: definitionId },
+      nonce: "nonce-abcdefghijklmnopqrstuvwxyz123456",
+      expiresAt,
+      guardrailRevision: digest,
+      signature: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_",
+    };
+    for (const field of [
+      "action",
+      "targetRefs",
+      "inputSchemaDigest",
+      "routineId",
+      "stateId",
+      "audience",
+      "context",
+      "nonce",
+      "expiresAt",
+      "guardrailRevision",
+      "signature",
+    ]) {
+      const incomplete = { ...descriptor };
+      delete incomplete[field];
+      expectInvalidRequired(incomplete, field);
+    }
+  });
+
+  it("rejects malformed property schemas in A2UI action inputs", () => {
+    expectInvalidAt(
+      {
+        apiVersion,
+        kind: "A2UITemplate",
+        metadata: metadata("malformed-input-schema"),
+        spec: {
+          root: { component: "Button", label: "Open", actionRef: "open-incident" },
+          actions: [
+            {
+              id: "open-incident",
+              action: "incident.open",
+              targetRefs: [{ type: "incident", id: "incident-42" }],
+              routineId: definitionId,
+              stateId: "openIncident",
+              inputSchema: {
+                type: "object",
+                additionalProperties: false,
+                properties: { amount: "not-a-schema" },
+              },
+              audience: { roleIds: [definitionId] },
+              expiresInSeconds: 300,
+              guardrailId: definitionId,
+              guardrailVersion: 1,
+            },
+          ],
+        },
+      },
+      "/spec/actions/0/inputSchema/properties/amount",
+      "type"
+    );
+  });
+
+  it("rejects unsafe Guardrail constraints without accepting free-form expressions", () => {
+    const guardrail = (constraints: Record<string, unknown>, scope: Record<string, unknown>) => ({
+      apiVersion,
+      kind: "Guardrail",
+      metadata: metadata("unsafe-constraints"),
+      spec: {
+        defaultDecision: "deny",
+        rules: [
+          {
+            id: "constrained-read",
+            type: "allow",
+            actions: ["ticket.read"],
+            scope,
+            constraints,
+          },
+        ],
+      },
+    });
+
+    expectInvalid(guardrail({ maxRecords: 0 }, {}));
+    expectInvalid(
+      guardrail({ network: { allowedHosts: ["api.example.com"], allowPrivateNetworks: true } }, {})
+    );
+    expectInvalid(guardrail({ executionEnvironments: ["localProcess"] }, {}));
+    expectInvalid(guardrail({}, { expiresAt: "tomorrow" }));
+    expectInvalid(guardrail({}, { conditionExpression: "actor.isAdmin || true" }));
+    expectInvalidAt(
+      {
+        ...guardrail({}, { resource: { types: ["ticket"] } }),
+        spec: {
+          defaultDecision: "deny",
+          rules: [
+            {
+              id: "contradictory-resource-scope",
+              type: "allow",
+              actions: ["ticket.read"],
+              resourceTypes: ["invoice"],
+              scope: { resource: { types: ["ticket"] } },
+            },
+          ],
+        },
+      },
+      "/spec/rules/0",
+      "additionalProperties"
+    );
+  });
+
+  it("rejects traversal-shaped Secret refs, malformed HTTPS endpoints, and invalid expiries", () => {
+    expectInvalid({
+      apiVersion,
+      kind: "Integration",
+      metadata: metadata("traversal-secret"),
+      spec: {
+        appId: definitionId,
+        externalAccount: { tenantId: "tenant" },
+        credentialRef: "secret://credentials/../../admin",
+      },
+    });
+    expectInvalid({
+      apiVersion,
+      kind: "IntegrationAdapter",
+      metadata: metadata("malformed-endpoint"),
+      spec: {
+        provider: "custom",
+        execution: { mode: "externalProtocol", endpoint: "https://", protocolVersion: 1 },
+        authTypes: ["none"],
+        operations: ["data.read"],
+        events: [],
+      },
+    });
+    expectInvalid({
+      apiVersion,
+      kind: "Role",
+      metadata: metadata("invalid-expiry"),
+      spec: {
+        principalTypes: ["user"],
+        grants: [
+          { effect: "allow", actions: ["ticket.read"], expiresAt: "tomorrow", delegable: false },
+        ],
+      },
+    });
+  });
+
+  it("keeps mutable Knowledge capture evidence out of authored source definitions", () => {
+    expectInvalidRequired(
+      {
+        apiVersion,
+        kind: "KnowledgeCapture",
+        knowledgeSourceId: definitionId,
+        capturedAt: "2026-07-22T10:30:00Z",
+        contentHash: digest,
+        aclRevision: "acl-revision-3",
+      },
+      "sourceRevision"
+    );
+  });
+
+  it("does not echo protected values in structured validation errors", () => {
+    const protectedValue = "xoxb-do-not-disclose";
+
+    try {
+      validationRegistry.validate({
+        apiVersion,
+        kind: "Integration",
+        metadata: metadata("redacted-error"),
+        spec: {
+          appId: definitionId,
+          externalAccount: { tenantId: "tenant" },
+          credentialRef: protectedValue,
+        },
+      });
+      throw new Error("expected validation to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(SchemaValidationError);
+      expect((error as Error).message).not.toContain(protectedValue);
+    }
+  });
+});

--- a/packages/schema/src/definitions/form.ts
+++ b/packages/schema/src/definitions/form.ts
@@ -1,0 +1,99 @@
+import { type Static, Type } from "@sinclair/typebox";
+import {
+  DEFINITION_API_VERSION,
+  type DefinitionMetadata,
+  definitionMetadataSchema,
+  definitionRegistration,
+} from "./common";
+
+const apiVersion = DEFINITION_API_VERSION;
+const idPattern =
+  "^(?:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9A-HJKMNP-TV-Z]{26})$";
+const dateTimePattern =
+  "^\\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\\d|3[01])T(?:[01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d(?:\\.\\d{1,9})?Z$";
+const digestPattern = "^[a-f0-9]{64}$";
+const opaqueTokenPattern = "^[A-Za-z0-9_-]+$";
+
+const MetadataSchema = Type.Unsafe<DefinitionMetadata>(definitionMetadataSchema);
+
+const AudienceSchema = Type.Object(
+  {
+    roleIds: Type.Array(Type.String({ pattern: idPattern }), { minItems: 1, uniqueItems: true }),
+  },
+  { additionalProperties: false }
+);
+
+const FormFieldSchema = Type.Object(
+  {
+    name: Type.String({ pattern: "^[A-Za-z][A-Za-z0-9_]*$" }),
+    label: Type.String({ minLength: 1 }),
+    input: Type.Union([
+      Type.Literal("text"),
+      Type.Literal("email"),
+      Type.Literal("number"),
+      Type.Literal("textarea"),
+      Type.Literal("select"),
+      Type.Literal("radio"),
+      Type.Literal("checkbox"),
+      Type.Literal("switch"),
+      Type.Literal("date"),
+    ]),
+    required: Type.Optional(Type.Boolean()),
+    options: Type.Optional(
+      Type.Array(Type.String({ minLength: 1 }), { minItems: 1, uniqueItems: true })
+    ),
+  },
+  { additionalProperties: false }
+);
+
+export const FormSchema = Type.Object(
+  {
+    apiVersion: Type.Literal(apiVersion),
+    kind: Type.Literal("Form"),
+    metadata: MetadataSchema,
+    spec: Type.Object(
+      {
+        title: Type.String({ minLength: 1 }),
+        submission: Type.Object(
+          {
+            triggerId: Type.String({ pattern: idPattern }),
+            inputName: Type.String({ pattern: "^[A-Za-z][A-Za-z0-9_]*$" }),
+          },
+          { additionalProperties: false }
+        ),
+        audience: AudienceSchema,
+        fields: Type.Array(FormFieldSchema, { minItems: 1 }),
+        expiresInSeconds: Type.Optional(Type.Integer({ minimum: 1, maximum: 604800 })),
+      },
+      { additionalProperties: false }
+    ),
+  },
+  { $id: `${apiVersion}/Form`, additionalProperties: false }
+);
+export const FORM_DEFINITION = definitionRegistration("Form", FormSchema);
+
+export type FormDefinition = Static<typeof FormSchema>;
+
+export const FormActionDescriptorSchema = Type.Object(
+  {
+    apiVersion: Type.Literal(apiVersion),
+    kind: Type.Literal("FormActionDescriptor"),
+    formId: Type.String({ pattern: idPattern }),
+    runId: Type.String({ pattern: idPattern }),
+    runWaitId: Type.String({ pattern: idPattern }),
+    schemaDigest: Type.String({ pattern: digestPattern }),
+    audience: Type.Object(
+      {
+        kind: Type.Union([Type.Literal("user"), Type.Literal("role")]),
+        id: Type.String({ pattern: idPattern }),
+      },
+      { additionalProperties: false }
+    ),
+    resumeToken: Type.String({ minLength: 32, pattern: opaqueTokenPattern }),
+    nonce: Type.String({ minLength: 32, pattern: opaqueTokenPattern }),
+    expiresAt: Type.String({ pattern: dateTimePattern }),
+  },
+  { $id: `${apiVersion}/FormActionDescriptor`, additionalProperties: false }
+);
+
+export type FormActionDescriptor = Static<typeof FormActionDescriptorSchema>;

--- a/packages/schema/src/definitions/guardrail.ts
+++ b/packages/schema/src/definitions/guardrail.ts
@@ -1,0 +1,213 @@
+import { type Static, Type } from "@sinclair/typebox";
+import {
+  DEFINITION_API_VERSION,
+  type DefinitionMetadata,
+  definitionMetadataSchema,
+  definitionRegistration,
+} from "./common";
+
+const apiVersion = DEFINITION_API_VERSION;
+const slugPattern = "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$";
+const actionPattern = "^[a-z][a-z0-9-]*(?:\\.[a-z][a-z0-9-]*)+$";
+const dateTimePattern =
+  "^\\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\\d|3[01])T(?:[01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d(?:\\.\\d{1,9})?Z$";
+
+const GuardrailConditionSchema = Type.Object(
+  {
+    attribute: Type.String({ pattern: "^[a-z][A-Za-z0-9]*(?:\\.[a-z][A-Za-z0-9]*)*$" }),
+    operator: Type.Union([
+      Type.Literal("equals"),
+      Type.Literal("notEquals"),
+      Type.Literal("in"),
+      Type.Literal("notIn"),
+    ]),
+    value: Type.Union([
+      Type.String(),
+      Type.Number(),
+      Type.Boolean(),
+      Type.Array(Type.String(), { minItems: 1, uniqueItems: true }),
+    ]),
+  },
+  { additionalProperties: false }
+);
+
+const GuardrailScopeSchema = Type.Object(
+  {
+    resource: Type.Optional(
+      Type.Object(
+        {
+          types: Type.Array(Type.String({ pattern: slugPattern }), {
+            minItems: 1,
+            uniqueItems: true,
+          }),
+          recordIds: Type.Optional(
+            Type.Array(Type.String({ minLength: 1 }), { minItems: 1, uniqueItems: true })
+          ),
+          fields: Type.Optional(
+            Type.Array(Type.String({ minLength: 1 }), { minItems: 1, uniqueItems: true })
+          ),
+        },
+        { additionalProperties: false }
+      )
+    ),
+    conditions: Type.Optional(Type.Array(GuardrailConditionSchema, { minItems: 1 })),
+    expiresAt: Type.Optional(Type.String({ pattern: dateTimePattern })),
+  },
+  { additionalProperties: false }
+);
+
+const GuardrailConstraintsSchema = Type.Object(
+  {
+    maxRecords: Type.Optional(Type.Integer({ minimum: 1 })),
+    maxBytes: Type.Optional(Type.Integer({ minimum: 1 })),
+    maxCostUsd: Type.Optional(Type.Number({ minimum: 0.01 })),
+    timeWindow: Type.Optional(
+      Type.Object(
+        {
+          startsAt: Type.String({ pattern: dateTimePattern }),
+          expiresAt: Type.String({ pattern: dateTimePattern }),
+        },
+        { additionalProperties: false }
+      )
+    ),
+    network: Type.Optional(
+      Type.Object(
+        {
+          allowedHosts: Type.Array(
+            Type.String({ pattern: "^[A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?$" }),
+            { minItems: 1, uniqueItems: true }
+          ),
+          allowPrivateNetworks: Type.Literal(false),
+        },
+        { additionalProperties: false }
+      )
+    ),
+    executionEnvironments: Type.Optional(
+      Type.Array(
+        Type.Union([
+          Type.Literal("sandbox"),
+          Type.Literal("managedAdapter"),
+          Type.Literal("externalProtocol"),
+        ]),
+        { minItems: 1, uniqueItems: true }
+      )
+    ),
+  },
+  { additionalProperties: false }
+);
+
+const MetadataSchema = Type.Unsafe<DefinitionMetadata>(definitionMetadataSchema);
+
+const ScopedRuleSchema = Type.Object(
+  {
+    id: Type.String({ pattern: slugPattern }),
+    type: Type.Union([Type.Literal("allow"), Type.Literal("deny")]),
+    actions: Type.Array(Type.String({ pattern: actionPattern }), {
+      minItems: 1,
+      uniqueItems: true,
+    }),
+    dataClasses: Type.Optional(
+      Type.Array(Type.String({ pattern: slugPattern }), { minItems: 1, uniqueItems: true })
+    ),
+    destinations: Type.Optional(
+      Type.Array(Type.String({ minLength: 1 }), { minItems: 1, uniqueItems: true })
+    ),
+    audiences: Type.Optional(
+      Type.Array(Type.String({ minLength: 1 }), { minItems: 1, uniqueItems: true })
+    ),
+    scope: Type.Optional(GuardrailScopeSchema),
+    constraints: Type.Optional(GuardrailConstraintsSchema),
+  },
+  { additionalProperties: false }
+);
+
+const ApprovalRuleSchema = Type.Object(
+  {
+    id: Type.String({ pattern: slugPattern }),
+    type: Type.Literal("approval"),
+    actions: Type.Array(Type.String({ pattern: actionPattern }), {
+      minItems: 1,
+      uniqueItems: true,
+    }),
+    category: Type.Union([
+      Type.Literal("soulChange"),
+      Type.Literal("highRiskAction"),
+      Type.Literal("destructiveAction"),
+      Type.Literal("protectedDataEgress"),
+      Type.Literal("credentialUse"),
+    ]),
+    minimumApprovers: Type.Integer({ minimum: 1, maximum: 10 }),
+    separationOfDuties: Type.Boolean(),
+    scope: Type.Optional(GuardrailScopeSchema),
+    constraints: Type.Optional(GuardrailConstraintsSchema),
+  },
+  { additionalProperties: false }
+);
+
+const DlpRuleSchema = Type.Object(
+  {
+    id: Type.String({ pattern: slugPattern }),
+    type: Type.Literal("dlp"),
+    detectors: Type.Array(
+      Type.Union([
+        Type.Object({ type: Type.Literal("secret") }, { additionalProperties: false }),
+        Type.Object(
+          {
+            type: Type.Literal("dataClass"),
+            values: Type.Array(Type.String({ pattern: slugPattern }), {
+              minItems: 1,
+              uniqueItems: true,
+            }),
+          },
+          { additionalProperties: false }
+        ),
+        Type.Object(
+          {
+            type: Type.Literal("protectedField"),
+            values: Type.Array(Type.String({ minLength: 1 }), {
+              minItems: 1,
+              uniqueItems: true,
+            }),
+          },
+          { additionalProperties: false }
+        ),
+      ]),
+      { minItems: 1 }
+    ),
+    action: Type.Union([
+      Type.Literal("block"),
+      Type.Literal("redact"),
+      Type.Literal("requireApproval"),
+    ]),
+    destinations: Type.Optional(
+      Type.Array(Type.String({ minLength: 1 }), { minItems: 1, uniqueItems: true })
+    ),
+    audiences: Type.Optional(
+      Type.Array(Type.String({ minLength: 1 }), { minItems: 1, uniqueItems: true })
+    ),
+    scope: Type.Optional(GuardrailScopeSchema),
+    constraints: Type.Optional(GuardrailConstraintsSchema),
+  },
+  { additionalProperties: false }
+);
+
+export const GuardrailSchema = Type.Object(
+  {
+    apiVersion: Type.Literal(apiVersion),
+    kind: Type.Literal("Guardrail"),
+    metadata: MetadataSchema,
+    spec: Type.Object(
+      {
+        defaultDecision: Type.Literal("deny"),
+        rules: Type.Array(Type.Union([ScopedRuleSchema, ApprovalRuleSchema, DlpRuleSchema]), {
+          minItems: 1,
+        }),
+      },
+      { additionalProperties: false }
+    ),
+  },
+  { $id: `${apiVersion}/Guardrail`, additionalProperties: false }
+);
+export const GUARDRAIL_DEFINITION = definitionRegistration("Guardrail", GuardrailSchema);
+
+export type GuardrailDefinition = Static<typeof GuardrailSchema>;

--- a/packages/schema/src/definitions/integration.ts
+++ b/packages/schema/src/definitions/integration.ts
@@ -1,0 +1,163 @@
+import { type Static, Type } from "@sinclair/typebox";
+import {
+  DEFINITION_API_VERSION,
+  type DefinitionMetadata,
+  definitionMetadataSchema,
+  definitionRegistration,
+} from "./common";
+
+const apiVersion = DEFINITION_API_VERSION;
+const idPattern =
+  "^(?:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9A-HJKMNP-TV-Z]{26})$";
+const slugPattern = "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$";
+const actionPattern = "^[a-z][a-z0-9-]*(?:\\.[a-z][a-z0-9-]*)+$";
+const secretReferencePattern =
+  "^secret://[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?(?:/[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?)*$";
+const httpsEndpointPattern =
+  "^https://[A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?(?::[1-9][0-9]{0,4})?(?:/[A-Za-z0-9._~!$&'()*+,;=:@%/-]*)?$";
+const dateTimePattern =
+  "^\\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\\d|3[01])T(?:[01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d(?:\\.\\d{1,9})?Z$";
+
+const MetadataSchema = Type.Unsafe<DefinitionMetadata>(definitionMetadataSchema);
+
+const ManagedExecutionSchema = Type.Object(
+  {
+    mode: Type.Literal("managed"),
+    adapter: Type.String({ pattern: slugPattern }),
+  },
+  { additionalProperties: false }
+);
+
+const ExternalExecutionSchema = Type.Object(
+  {
+    mode: Type.Literal("externalProtocol"),
+    endpoint: Type.String({ pattern: httpsEndpointPattern }),
+    protocolVersion: Type.Integer({ minimum: 1 }),
+  },
+  { additionalProperties: false }
+);
+
+export const IntegrationAdapterSchema = Type.Object(
+  {
+    apiVersion: Type.Literal(apiVersion),
+    kind: Type.Literal("IntegrationAdapter"),
+    metadata: MetadataSchema,
+    spec: Type.Object(
+      {
+        provider: Type.String({ pattern: slugPattern }),
+        execution: Type.Union([ManagedExecutionSchema, ExternalExecutionSchema]),
+        authTypes: Type.Array(
+          Type.Union([
+            Type.Literal("none"),
+            Type.Literal("oauth2"),
+            Type.Literal("token"),
+            Type.Literal("app"),
+            Type.Literal("password"),
+          ]),
+          { minItems: 1, uniqueItems: true }
+        ),
+        operations: Type.Array(Type.String({ pattern: actionPattern }), {
+          minItems: 1,
+          uniqueItems: true,
+        }),
+        events: Type.Array(Type.String({ pattern: actionPattern }), { uniqueItems: true }),
+      },
+      { additionalProperties: false }
+    ),
+  },
+  { $id: `${apiVersion}/IntegrationAdapter`, additionalProperties: false }
+);
+
+export const AppSchema = Type.Object(
+  {
+    apiVersion: Type.Literal(apiVersion),
+    kind: Type.Literal("App"),
+    metadata: MetadataSchema,
+    spec: Type.Object(
+      {
+        adapterId: Type.String({ pattern: idPattern }),
+        externalAppId: Type.String({ minLength: 1 }),
+        credentialRefs: Type.Array(Type.String({ pattern: secretReferencePattern }), {
+          uniqueItems: true,
+        }),
+      },
+      { additionalProperties: false }
+    ),
+  },
+  { $id: `${apiVersion}/App`, additionalProperties: false }
+);
+
+export const IntegrationSchema = Type.Object(
+  {
+    apiVersion: Type.Literal(apiVersion),
+    kind: Type.Literal("Integration"),
+    metadata: MetadataSchema,
+    spec: Type.Object(
+      {
+        appId: Type.String({ pattern: idPattern }),
+        externalAccount: Type.Object(
+          {
+            tenantId: Type.String({ minLength: 1 }),
+            accountId: Type.Optional(Type.String({ minLength: 1 })),
+          },
+          { additionalProperties: false }
+        ),
+        credentialRef: Type.Optional(Type.String({ pattern: secretReferencePattern })),
+      },
+      { additionalProperties: false }
+    ),
+  },
+  { $id: `${apiVersion}/Integration`, additionalProperties: false }
+);
+
+const PrincipalReferenceSchema = Type.Object(
+  {
+    kind: Type.Union([Type.Literal("user"), Type.Literal("agent"), Type.Literal("role")]),
+    id: Type.String({ pattern: idPattern }),
+  },
+  { additionalProperties: false }
+);
+
+const ExternalTargetSchema = Type.Object(
+  {
+    type: Type.String({ pattern: slugPattern }),
+    ids: Type.Array(Type.String({ minLength: 1 }), { minItems: 1, uniqueItems: true }),
+  },
+  { additionalProperties: false }
+);
+
+export const AccessGrantSchema = Type.Object(
+  {
+    apiVersion: Type.Literal(apiVersion),
+    kind: Type.Literal("AccessGrant"),
+    metadata: MetadataSchema,
+    spec: Type.Object(
+      {
+        integrationId: Type.String({ pattern: idPattern }),
+        principals: Type.Array(PrincipalReferenceSchema, { minItems: 1 }),
+        actions: Type.Array(Type.String({ pattern: actionPattern }), {
+          minItems: 1,
+          uniqueItems: true,
+        }),
+        externalTargets: Type.Array(ExternalTargetSchema, { minItems: 1 }),
+        expiresAt: Type.Optional(Type.String({ pattern: dateTimePattern })),
+        delegable: Type.Boolean(),
+      },
+      { additionalProperties: false }
+    ),
+  },
+  { $id: `${apiVersion}/AccessGrant`, additionalProperties: false }
+);
+
+export const INTEGRATION_ADAPTER_DEFINITION = definitionRegistration(
+  "IntegrationAdapter",
+  IntegrationAdapterSchema
+);
+export const APP_DEFINITION = definitionRegistration("App", AppSchema);
+export const INTEGRATION_DEFINITION = definitionRegistration("Integration", IntegrationSchema);
+export const ACCESS_GRANT_DEFINITION = definitionRegistration("AccessGrant", AccessGrantSchema);
+
+export type IntegrationAdapterDefinition = Static<typeof IntegrationAdapterSchema>;
+export type AppDefinition = Static<typeof AppSchema>;
+export type IntegrationDefinition = Static<typeof IntegrationSchema>;
+export type AccessGrantDefinition = Static<typeof AccessGrantSchema>;

--- a/packages/schema/src/definitions/knowledge.ts
+++ b/packages/schema/src/definitions/knowledge.ts
@@ -1,0 +1,85 @@
+import { type Static, Type } from "@sinclair/typebox";
+import {
+  DEFINITION_API_VERSION,
+  type DefinitionMetadata,
+  definitionMetadataSchema,
+  definitionRegistration,
+} from "./common";
+
+const apiVersion = DEFINITION_API_VERSION;
+const idPattern =
+  "^(?:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9A-HJKMNP-TV-Z]{26})$";
+const slugPattern = "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$";
+const dateTimePattern =
+  "^\\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\\d|3[01])T(?:[01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d(?:\\.\\d{1,9})?Z$";
+const digestPattern = "^[a-f0-9]{64}$";
+
+const MetadataSchema = Type.Unsafe<DefinitionMetadata>(definitionMetadataSchema);
+
+const LiveAccessControlSchema = Type.Object(
+  {
+    mode: Type.Literal("live"),
+    maximumAgeSeconds: Type.Integer({ minimum: 1, maximum: 3600 }),
+  },
+  { additionalProperties: false }
+);
+
+const SnapshotAccessControlSchema = Type.Object(
+  {
+    mode: Type.Literal("snapshot"),
+    aclArtifactId: Type.String({ pattern: idPattern }),
+    aclRevision: Type.String({ minLength: 1 }),
+    maximumAgeSeconds: Type.Integer({ minimum: 1, maximum: 3600 }),
+  },
+  { additionalProperties: false }
+);
+
+export const KnowledgeSourceSchema = Type.Object(
+  {
+    apiVersion: Type.Literal(apiVersion),
+    kind: Type.Literal("KnowledgeSource"),
+    metadata: MetadataSchema,
+    spec: Type.Object(
+      {
+        integrationId: Type.String({ pattern: idPattern }),
+        source: Type.Object(
+          {
+            provider: Type.String({ pattern: slugPattern }),
+            externalId: Type.String({ minLength: 1 }),
+            externalTenantId: Type.String({ minLength: 1 }),
+            ownerExternalId: Type.String({ minLength: 1 }),
+          },
+          { additionalProperties: false }
+        ),
+        accessControl: Type.Union([LiveAccessControlSchema, SnapshotAccessControlSchema]),
+        classification: Type.Array(Type.String({ pattern: slugPattern }), {
+          minItems: 1,
+          uniqueItems: true,
+        }),
+      },
+      { additionalProperties: false }
+    ),
+  },
+  { $id: `${apiVersion}/KnowledgeSource`, additionalProperties: false }
+);
+export const KNOWLEDGE_SOURCE_DEFINITION = definitionRegistration(
+  "KnowledgeSource",
+  KnowledgeSourceSchema
+);
+
+export type KnowledgeSourceDefinition = Static<typeof KnowledgeSourceSchema>;
+
+export const KnowledgeCaptureSchema = Type.Object(
+  {
+    apiVersion: Type.Literal(apiVersion),
+    kind: Type.Literal("KnowledgeCapture"),
+    knowledgeSourceId: Type.String({ pattern: idPattern }),
+    sourceRevision: Type.String({ minLength: 1 }),
+    capturedAt: Type.String({ pattern: dateTimePattern }),
+    contentHash: Type.String({ pattern: digestPattern }),
+    aclRevision: Type.String({ minLength: 1 }),
+  },
+  { $id: `${apiVersion}/KnowledgeCapture`, additionalProperties: false }
+);
+
+export type KnowledgeCapture = Static<typeof KnowledgeCaptureSchema>;

--- a/packages/schema/src/definitions/memory.ts
+++ b/packages/schema/src/definitions/memory.ts
@@ -1,0 +1,56 @@
+import { type Static, Type } from "@sinclair/typebox";
+import {
+  DEFINITION_API_VERSION,
+  type DefinitionMetadata,
+  definitionMetadataSchema,
+  definitionRegistration,
+  MEMORY_SCOPES,
+} from "./common";
+
+const apiVersion = DEFINITION_API_VERSION;
+const MetadataSchema = Type.Unsafe<DefinitionMetadata>(definitionMetadataSchema);
+
+const EnabledInferredMemorySchema = Type.Object(
+  {
+    enabled: Type.Literal(true),
+    confirmationRequired: Type.Literal(true),
+  },
+  { additionalProperties: false }
+);
+
+const DisabledInferredMemorySchema = Type.Object(
+  { enabled: Type.Literal(false) },
+  { additionalProperties: false }
+);
+
+export const MemorySettingsSchema = Type.Object(
+  {
+    apiVersion: Type.Literal(apiVersion),
+    kind: Type.Literal("MemorySettings"),
+    metadata: MetadataSchema,
+    spec: Type.Object(
+      {
+        scopes: Type.Array(
+          Type.Unsafe<(typeof MEMORY_SCOPES)[number]>({
+            type: "string",
+            enum: [...MEMORY_SCOPES],
+          }),
+          { minItems: 1, uniqueItems: true }
+        ),
+        inferredDurableMemory: Type.Union([
+          EnabledInferredMemorySchema,
+          DisabledInferredMemorySchema,
+        ]),
+        defaultExpiryDays: Type.Optional(Type.Integer({ minimum: 1, maximum: 3650 })),
+      },
+      { additionalProperties: false }
+    ),
+  },
+  { $id: `${apiVersion}/MemorySettings`, additionalProperties: false }
+);
+export const MEMORY_SETTINGS_DEFINITION = definitionRegistration(
+  "MemorySettings",
+  MemorySettingsSchema
+);
+
+export type MemorySettingsDefinition = Static<typeof MemorySettingsSchema>;

--- a/packages/schema/src/definitions/role.ts
+++ b/packages/schema/src/definitions/role.ts
@@ -1,0 +1,99 @@
+import { type Static, Type } from "@sinclair/typebox";
+import {
+  DEFINITION_API_VERSION,
+  type DefinitionMetadata,
+  definitionMetadataSchema,
+  definitionRegistration,
+} from "./common";
+
+const apiVersion = DEFINITION_API_VERSION;
+const idPattern =
+  "^(?:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9A-HJKMNP-TV-Z]{26})$";
+const slugPattern = "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$";
+const actionPattern = "^[a-z][a-z0-9-]*(?:\\.[a-z][a-z0-9-]*)+$";
+const dateTimePattern =
+  "^\\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\\d|3[01])T(?:[01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d(?:\\.\\d{1,9})?Z$";
+
+const MetadataSchema = Type.Unsafe<DefinitionMetadata>(definitionMetadataSchema);
+
+const GrantConditionSchema = Type.Object(
+  {
+    attribute: Type.String({ pattern: "^[a-z][A-Za-z0-9]*(?:\\.[a-z][A-Za-z0-9]*)*$" }),
+    operator: Type.Union([
+      Type.Literal("equals"),
+      Type.Literal("notEquals"),
+      Type.Literal("in"),
+      Type.Literal("notIn"),
+    ]),
+    value: Type.Union([
+      Type.String(),
+      Type.Number(),
+      Type.Boolean(),
+      Type.Array(Type.String(), { minItems: 1, uniqueItems: true }),
+    ]),
+  },
+  { additionalProperties: false }
+);
+
+const ResourceSelectorSchema = Type.Object(
+  {
+    types: Type.Array(Type.String({ pattern: slugPattern }), { minItems: 1, uniqueItems: true }),
+    recordIds: Type.Optional(
+      Type.Array(Type.String({ minLength: 1 }), { minItems: 1, uniqueItems: true })
+    ),
+  },
+  { additionalProperties: false }
+);
+
+export const RoleGrantSchema = Type.Object(
+  {
+    effect: Type.Union([Type.Literal("allow"), Type.Literal("deny")]),
+    actions: Type.Array(Type.String({ pattern: actionPattern }), {
+      minItems: 1,
+      uniqueItems: true,
+    }),
+    resource: Type.Optional(ResourceSelectorSchema),
+    fields: Type.Optional(
+      Type.Array(Type.String({ minLength: 1 }), { minItems: 1, uniqueItems: true })
+    ),
+    dataClasses: Type.Optional(
+      Type.Array(Type.String({ pattern: slugPattern }), { minItems: 1, uniqueItems: true })
+    ),
+    destinations: Type.Optional(
+      Type.Array(Type.String({ minLength: 1 }), { minItems: 1, uniqueItems: true })
+    ),
+    audiences: Type.Optional(
+      Type.Array(Type.String({ minLength: 1 }), { minItems: 1, uniqueItems: true })
+    ),
+    conditions: Type.Optional(Type.Array(GrantConditionSchema, { minItems: 1 })),
+    expiresAt: Type.Optional(Type.String({ pattern: dateTimePattern })),
+    delegable: Type.Boolean(),
+  },
+  { additionalProperties: false }
+);
+
+export const RoleSchema = Type.Object(
+  {
+    apiVersion: Type.Literal(apiVersion),
+    kind: Type.Literal("Role"),
+    metadata: MetadataSchema,
+    spec: Type.Object(
+      {
+        principalTypes: Type.Array(Type.Union([Type.Literal("user"), Type.Literal("agent")]), {
+          minItems: 1,
+          uniqueItems: true,
+        }),
+        inherits: Type.Optional(
+          Type.Array(Type.String({ pattern: idPattern }), { minItems: 1, uniqueItems: true })
+        ),
+        grants: Type.Array(RoleGrantSchema),
+      },
+      { additionalProperties: false }
+    ),
+  },
+  { $id: `${apiVersion}/Role`, additionalProperties: false }
+);
+export const ROLE_DEFINITION = definitionRegistration("Role", RoleSchema);
+
+export type RoleDefinition = Static<typeof RoleSchema>;
+export type RoleGrant = Static<typeof RoleGrantSchema>;

--- a/packages/schema/src/definitions/settings.ts
+++ b/packages/schema/src/definitions/settings.ts
@@ -1,0 +1,38 @@
+import { type Static, Type } from "@sinclair/typebox";
+import {
+  DEFINITION_API_VERSION,
+  type DefinitionMetadata,
+  definitionMetadataSchema,
+  definitionRegistration,
+} from "./common";
+
+const apiVersion = DEFINITION_API_VERSION;
+const MetadataSchema = Type.Unsafe<DefinitionMetadata>(definitionMetadataSchema);
+
+export const ApprovalCategorySettingsSchema = Type.Object(
+  {
+    soulChange: Type.Boolean({ default: true }),
+    highRiskAction: Type.Boolean({ default: true }),
+    destructiveAction: Type.Boolean({ default: true }),
+    protectedDataEgress: Type.Boolean({ default: true }),
+    credentialUse: Type.Boolean({ default: true }),
+  },
+  { additionalProperties: false }
+);
+
+export const SettingsSchema = Type.Object(
+  {
+    apiVersion: Type.Literal(apiVersion),
+    kind: Type.Literal("Settings"),
+    metadata: MetadataSchema,
+    spec: Type.Object(
+      { approvalCategories: ApprovalCategorySettingsSchema },
+      { additionalProperties: false }
+    ),
+  },
+  { $id: `${apiVersion}/Settings`, additionalProperties: false }
+);
+export const SETTINGS_DEFINITION = definitionRegistration("Settings", SettingsSchema);
+
+export type ApprovalCategorySettings = Static<typeof ApprovalCategorySettingsSchema>;
+export type SettingsDefinition = Static<typeof SettingsSchema>;


### PR DESCRIPTION
## Summary

- define strict Role, Guardrail/DLP, independent approval settings, and Integration contracts for AW-010
- add Knowledge, Memory, Form, and A2UI authored/runtime schemas with explicit security boundaries
- reject plaintext Secrets, unsafe actions, wildcard authority, Agent/App identity conflation, and runtime-record publication

## Test plan

- [x] pnpm --filter @tulipfarm/schema test (18 files, 188 tests after rebase)
- [x] pnpm --filter @tulipfarm/schema lint
- [x] pnpm --dir packages/schema typecheck
- [x] pnpm lint
- [x] pnpm typecheck
- [x] pnpm test
- [x] pnpm build
- [x] Independent review: PASS, 4.59/5, no blockers