### PR TITLE
feat(soul): add fail-closed changeset validation

### DIFF
--- a/packages/soul/src/changeset.test.ts
+++ b/packages/soul/src/changeset.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from "vitest";
+import { stringify } from "yaml";
+import {
+  type SoulChangeset,
+  type SoulChangesetSource,
+  SoulChangesetValidationError,
+  validateSoulChangeset,
+} from "./index";
+
+const baseCommit = "a".repeat(40);
+
+const agent = {
+  apiVersion: "tulipfarm.ai/v1",
+  kind: "Agent",
+  metadata: {
+    id: "11111111-1111-1111-1111-111111111111",
+    slug: "general-assistant",
+    schemaVersion: 1,
+    authoredVersion: 1,
+    lifecycle: "draft",
+  },
+  spec: {
+    owner: "user_01",
+    instructions: { path: "instructions.md" },
+    modelProfile: "sol-high",
+    autonomy: "answer_only",
+    trustTier: "first_party",
+  },
+};
+
+function changeset(overrides: Partial<SoulChangeset> = {}): SoulChangeset {
+  return {
+    id: "changeset_01",
+    businessId: "business_01",
+    principalId: "user_01",
+    source: "api",
+    expectedBaseCommit: baseCommit,
+    files: [
+      {
+        operation: "upsert",
+        path: "agents/general-assistant/agent.yaml",
+        content: stringify(agent),
+      },
+      {
+        operation: "upsert",
+        path: "agents/general-assistant/instructions.md",
+        content: "Be helpful and precise.\n",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("validateSoulChangeset", () => {
+  it.each<SoulChangesetSource>([
+    "ui",
+    "api",
+    "import",
+    "migration",
+    "agent",
+    "discovery",
+  ])("accepts a valid %s changeset through the same public validator", (source) => {
+    const result = validateSoulChangeset(changeset({ source }), baseCommit);
+
+    expect(result).toMatchObject({
+      id: "changeset_01",
+      businessId: "business_01",
+      principalId: "user_01",
+      source,
+      expectedBaseCommit: baseCommit,
+      evidence: { outcome: "validated", fileCount: 2 },
+    });
+    expect(result.files).toEqual([
+      expect.objectContaining({
+        operation: "upsert",
+        path: "agents/general-assistant/agent.yaml",
+        kind: "Agent",
+      }),
+      expect.objectContaining({
+        operation: "upsert",
+        path: "agents/general-assistant/instructions.md",
+      }),
+    ]);
+    expect(result.files.every((file) => /^[a-f0-9]{64}$/.test(file.hash))).toBe(true);
+    expect(JSON.stringify(result)).not.toContain("Be helpful and precise");
+  });
+
+  it("rejects the whole set when one file fails strict schema validation", () => {
+    const invalid = { ...agent, spec: { ...agent.spec, authority: "superuser" } };
+    const input = changeset({
+      files: [
+        ...changeset().files,
+        {
+          operation: "upsert",
+          path: "agents/unsafe/agent.yaml",
+          content: stringify(invalid),
+        },
+      ],
+    });
+
+    expect(() => validateSoulChangeset(input, baseCommit)).toThrowError(
+      expect.objectContaining({
+        code: "FILE_VALIDATION_FAILED",
+        issues: [
+          expect.objectContaining({
+            code: "SCHEMA_VALIDATION_FAILED",
+            path: "agents/unsafe/agent.yaml",
+          }),
+        ],
+      })
+    );
+  });
+
+  it("aggregates deterministic safe diagnostics without file contents", () => {
+    const secret = "protected-payload-do-not-log";
+    const input = changeset({
+      files: [
+        { operation: "upsert", path: "tools/z.yaml", content: secret },
+        { operation: "upsert", path: "tools/a.yaml", content: "kind: ToolContract" },
+      ],
+    });
+
+    try {
+      validateSoulChangeset(input, baseCommit);
+      throw new Error("expected validation to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(SoulChangesetValidationError);
+      const validationError = error as SoulChangesetValidationError;
+      expect(validationError.issues.map((issue) => issue.path)).toEqual([
+        "tools/a.yaml",
+        "tools/z.yaml",
+      ]);
+      expect(JSON.stringify(validationError)).not.toContain(secret);
+      expect(validationError.message).not.toContain(secret);
+    }
+  });
+
+  it("rejects a stale expected base before validating protected contents", () => {
+    const secret = "protected-payload-do-not-log";
+    const input = changeset({
+      expectedBaseCommit: "b".repeat(40),
+      files: [{ operation: "upsert", path: "tools/private.yaml", content: secret }],
+    });
+
+    expect(() => validateSoulChangeset(input, baseCommit)).toThrowError(
+      expect.objectContaining({ code: "BASE_MISMATCH", issues: [] })
+    );
+  });
+
+  it.each([
+    ["empty set", { files: [] }, "EMPTY_CHANGESET"],
+    [
+      "duplicate path",
+      {
+        files: [
+          { operation: "delete", path: "agents/a/agent.yaml" },
+          { operation: "delete", path: "agents/a/agent.yaml" },
+        ],
+      },
+      "DUPLICATE_PATH",
+    ],
+    [
+      "path traversal",
+      { files: [{ operation: "delete", path: "../agents/a/agent.yaml" }] },
+      "INVALID_PATH",
+    ],
+  ])("rejects the %s boundary", (_name, overrides, issueCode) => {
+    expect(() => validateSoulChangeset(changeset(overrides), baseCommit)).toThrowError(
+      expect.objectContaining({
+        code: "INVALID_CHANGESET",
+        issues: [expect.objectContaining({ code: issueCode })],
+      })
+    );
+  });
+
+  it("validates deletions without requiring removed content", () => {
+    const result = validateSoulChangeset(
+      changeset({ files: [{ operation: "delete", path: "agents/old/agent.yaml" }] }),
+      baseCommit
+    );
+
+    expect(result.files).toEqual([
+      { operation: "delete", path: "agents/old/agent.yaml", hash: expect.any(String) },
+    ]);
+  });
+
+  it("denies deletion outside the canonical Soul layout", () => {
+    const input = changeset({ files: [{ operation: "delete", path: ".git/config" }] });
+
+    expect(() => validateSoulChangeset(input, baseCommit)).toThrowError(
+      expect.objectContaining({
+        code: "FILE_VALIDATION_FAILED",
+        issues: [expect.objectContaining({ code: "UNSUPPORTED_SOUL_PATH" })],
+      })
+    );
+  });
+
+  it("is deterministic across retries and validator reconstruction", () => {
+    const first = validateSoulChangeset(changeset(), baseCommit);
+    const retried = validateSoulChangeset(changeset(), baseCommit);
+
+    expect(retried).toEqual(first);
+  });
+
+  it("rejects a definition whose kind does not match its canonical path", () => {
+    const input = changeset({
+      files: [
+        {
+          operation: "upsert",
+          path: "skills/general-assistant/skill.yaml",
+          content: stringify(agent),
+        },
+      ],
+    });
+
+    expect(() => validateSoulChangeset(input, baseCommit)).toThrowError(
+      expect.objectContaining({
+        code: "FILE_VALIDATION_FAILED",
+        issues: [expect.objectContaining({ code: "KIND_PATH_MISMATCH" })],
+      })
+    );
+  });
+});

--- a/packages/soul/src/changeset.test.ts
+++ b/packages/soul/src/changeset.test.ts
@@ -147,7 +147,7 @@ describe("validateSoulChangeset", () => {
     );
   });
 
-  it.each([
+  it.each<readonly [string, Partial<SoulChangeset>, string]>([
     ["empty set", { files: [] }, "EMPTY_CHANGESET"],
     [
       "duplicate path",

--- a/packages/soul/src/changeset.ts
+++ b/packages/soul/src/changeset.ts
@@ -1,0 +1,140 @@
+import type { SchemaContractErrorCode, ValidatedSchemaDocument } from "@tulipfarm/schema";
+import { validateChangesetFiles, validateChangesetShape } from "./validate";
+
+export const SOUL_CHANGESET_SOURCES = [
+  "ui",
+  "api",
+  "import",
+  "migration",
+  "agent",
+  "discovery",
+] as const;
+
+export type SoulChangesetSource = (typeof SOUL_CHANGESET_SOURCES)[number];
+
+export type SoulFileChange =
+  | { readonly operation: "upsert"; readonly path: string; readonly content: string }
+  | { readonly operation: "delete"; readonly path: string };
+
+/** The sole input contract for proposed writes to the authored Soul tree. */
+export interface SoulChangeset {
+  readonly id: string;
+  readonly businessId: string;
+  readonly principalId: string;
+  readonly source: SoulChangesetSource;
+  readonly expectedBaseCommit: string;
+  readonly files: readonly SoulFileChange[];
+}
+
+export type SoulChangesetErrorCode =
+  | "INVALID_CHANGESET"
+  | "BASE_MISMATCH"
+  | "FILE_VALIDATION_FAILED";
+
+export type SoulChangesetValidationIssueCode =
+  | SchemaContractErrorCode
+  | "DUPLICATE_PATH"
+  | "EMPTY_CHANGESET"
+  | "FILE_PARSE_FAILED"
+  | "INVALID_CHANGESET"
+  | "INVALID_CONTENT"
+  | "INVALID_FILE_CHANGE"
+  | "INVALID_OPERATION"
+  | "INVALID_PATH"
+  | "INVALID_SOURCE"
+  | "KIND_PATH_MISMATCH"
+  | "REQUIRED_FIELD"
+  | "UNKNOWN_FIELD"
+  | "UNSUPPORTED_SOUL_PATH";
+
+export interface SoulChangesetValidationIssue {
+  readonly code: SoulChangesetValidationIssueCode;
+  readonly path: string;
+  readonly field?: string;
+}
+
+/** A deterministic, payload-safe changeset rejection suitable for boundary evidence. */
+export class SoulChangesetValidationError extends Error {
+  readonly code: SoulChangesetErrorCode;
+  readonly issues: readonly SoulChangesetValidationIssue[];
+
+  constructor(code: SoulChangesetErrorCode, issues: readonly SoulChangesetValidationIssue[]) {
+    super(
+      code === "BASE_MISMATCH"
+        ? "Soul changeset expected base does not match the current base"
+        : `Soul changeset validation failed (${issues.length} issue${issues.length === 1 ? "" : "s"})`
+    );
+    this.name = "SoulChangesetValidationError";
+    this.code = code;
+    this.issues = Object.freeze([...issues]);
+  }
+}
+
+export interface ValidatedSoulFileChange {
+  readonly operation: SoulFileChange["operation"];
+  readonly path: string;
+  readonly hash: string;
+  readonly apiVersion?: string;
+  readonly kind?: string;
+}
+
+export interface ValidatedSoulChangeset {
+  readonly id: string;
+  readonly businessId: string;
+  readonly principalId: string;
+  readonly source: SoulChangesetSource;
+  readonly expectedBaseCommit: string;
+  readonly files: readonly ValidatedSoulFileChange[];
+  readonly evidence: {
+    readonly outcome: "validated";
+    readonly fileCount: number;
+  };
+}
+
+function freezeValidatedFile(
+  file: ValidatedSoulFileChange,
+  definition?: ValidatedSchemaDocument
+): ValidatedSoulFileChange {
+  return Object.freeze({
+    ...file,
+    ...(definition ? { apiVersion: definition.apiVersion, kind: definition.kind } : {}),
+  });
+}
+
+/**
+ * Validate an entire expected-base proposal before any file can be written.
+ *
+ * The function is deliberately synchronous and side-effect free. Callers must compare against the
+ * base they resolved at their durable boundary, then pass only a successful result to the atomic
+ * writer. A stale base or any invalid file rejects the complete proposal.
+ */
+export function validateSoulChangeset(
+  changeset: SoulChangeset,
+  currentBaseCommit: string
+): ValidatedSoulChangeset {
+  const shapeIssues = validateChangesetShape(changeset);
+  if (shapeIssues.length > 0) {
+    throw new SoulChangesetValidationError("INVALID_CHANGESET", shapeIssues);
+  }
+  if (changeset.expectedBaseCommit !== currentBaseCommit) {
+    throw new SoulChangesetValidationError("BASE_MISMATCH", []);
+  }
+
+  const validation = validateChangesetFiles(changeset.files);
+  if (validation.issues.length > 0) {
+    throw new SoulChangesetValidationError("FILE_VALIDATION_FAILED", validation.issues);
+  }
+
+  const files = validation.files.map(({ file, definition }) =>
+    freezeValidatedFile(file, definition)
+  );
+  return Object.freeze({
+    id: changeset.id,
+    businessId: changeset.businessId,
+    principalId: changeset.principalId,
+    source: changeset.source,
+    expectedBaseCommit: changeset.expectedBaseCommit,
+    files: Object.freeze(files),
+    evidence: Object.freeze({ outcome: "validated" as const, fileCount: files.length }),
+  });
+}

--- a/packages/soul/src/index.ts
+++ b/packages/soul/src/index.ts
@@ -1,3 +1,18 @@
+export type {
+  SoulChangeset,
+  SoulChangesetErrorCode,
+  SoulChangesetSource,
+  SoulChangesetValidationIssue,
+  SoulChangesetValidationIssueCode,
+  SoulFileChange,
+  ValidatedSoulChangeset,
+  ValidatedSoulFileChange,
+} from "./changeset";
+export {
+  SOUL_CHANGESET_SOURCES,
+  SoulChangesetValidationError,
+  validateSoulChangeset,
+} from "./changeset";
 export { GitSyncService } from "./git-sync";
 export type { SoulMigration } from "./migrations/index";
 export { SoulLoader } from "./soul-loader";

--- a/packages/soul/src/parse.ts
+++ b/packages/soul/src/parse.ts
@@ -1,0 +1,94 @@
+import { createHash } from "node:crypto";
+import {
+  DEFINITION_REGISTRATIONS,
+  SchemaContractError,
+  SchemaRegistry,
+  type ValidatedSchemaDocument,
+} from "@tulipfarm/schema";
+import type { SoulChangesetValidationIssue, SoulFileChange } from "./changeset";
+
+const registry = new SchemaRegistry(DEFINITION_REGISTRATIONS);
+
+const DEFINITION_PATHS: ReadonlyArray<readonly [RegExp, string]> = [
+  [/^agents\/[^/]+\/agent\.ya?ml$/, "Agent"],
+  [/^skills\/[^/]+\/skill\.ya?ml$/, "Skill"],
+  [/^tools\/[^/]+\.ya?ml$/, "ToolContract"],
+  [/^routines\/[^/]+\.ya?ml$/, "Routine"],
+  [/^triggers\/[^/]+\.ya?ml$/, "Trigger"],
+  [/^roles\/[^/]+\.ya?ml$/, "Role"],
+  [/^guardrails\/[^/]+\.ya?ml$/, "Guardrail"],
+  [/^integrations\/providers\/[^/]+\.ya?ml$/, "IntegrationAdapter"],
+  [/^integrations\/apps\/[^/]+\.ya?ml$/, "App"],
+  [/^integrations\/[^/]+\.ya?ml$/, "Integration"],
+  [/^knowledge\/[^/]+\.ya?ml$/, "KnowledgeSource"],
+  [/^forms\/[^/]+\.ya?ml$/, "Form"],
+  [/^models\/[^/]+\.ya?ml$/, "ModelProfile"],
+  [/^soul\.ya?ml$/, "Settings"],
+];
+
+const COMPANION_PATHS = [
+  /^agents\/[^/]+\/instructions\.md$/,
+  /^skills\/[^/]+\/SKILL\.md$/,
+  /^skills\/[^/]+\/(?:assets|references|schemas)\/.+$/,
+  /^skills\/[^/]+\/scripts\/.+$/,
+] as const;
+
+export interface ParsedSoulFile {
+  readonly hash: string;
+  readonly definition?: ValidatedSchemaDocument;
+}
+
+function sha256(content: string): string {
+  return createHash("sha256").update(content, "utf8").digest("hex");
+}
+
+function expectedKind(path: string): string | undefined {
+  return DEFINITION_PATHS.find(([pattern]) => pattern.test(path))?.[1];
+}
+
+function companionPath(path: string): boolean {
+  return COMPANION_PATHS.some((pattern) => pattern.test(path));
+}
+
+export function parseSoulFile(change: SoulFileChange): {
+  parsed?: ParsedSoulFile;
+  issue?: SoulChangesetValidationIssue;
+} {
+  if (change.operation === "delete") {
+    if (!expectedKind(change.path) && !companionPath(change.path)) {
+      return { issue: { code: "UNSUPPORTED_SOUL_PATH", path: change.path } };
+    }
+    return { parsed: { hash: sha256(`delete\0${change.path}`) } };
+  }
+
+  const kind = expectedKind(change.path);
+  if (!kind) {
+    if (companionPath(change.path)) return { parsed: { hash: sha256(change.content) } };
+    return { issue: { code: "UNSUPPORTED_SOUL_PATH", path: change.path } };
+  }
+
+  try {
+    const definition = registry.validateYaml(change.content);
+    if (definition.kind !== kind) {
+      return {
+        issue: {
+          code: "KIND_PATH_MISMATCH",
+          path: change.path,
+          field: "/kind",
+        },
+      };
+    }
+    return { parsed: { hash: definition.hash, definition } };
+  } catch (error) {
+    if (error instanceof SchemaContractError) {
+      return {
+        issue: {
+          code: error.code,
+          path: change.path,
+          ...(error.path ? { field: error.path } : {}),
+        },
+      };
+    }
+    return { issue: { code: "FILE_PARSE_FAILED", path: change.path } };
+  }
+}

--- a/packages/soul/src/validate.ts
+++ b/packages/soul/src/validate.ts
@@ -1,0 +1,146 @@
+import type {
+  SoulChangeset,
+  SoulChangesetValidationIssue,
+  SoulFileChange,
+  ValidatedSoulFileChange,
+} from "./changeset";
+import { SOUL_CHANGESET_SOURCES } from "./changeset";
+import { type ParsedSoulFile, parseSoulFile } from "./parse";
+
+const CHANGESET_KEYS = new Set([
+  "id",
+  "businessId",
+  "principalId",
+  "source",
+  "expectedBaseCommit",
+  "files",
+]);
+const UPSERT_KEYS = new Set(["operation", "path", "content"]);
+const DELETE_KEYS = new Set(["operation", "path"]);
+
+function issueSort(
+  left: SoulChangesetValidationIssue,
+  right: SoulChangesetValidationIssue
+): number {
+  const leftKey = `${left.path}\u0000${left.code}\u0000${left.field ?? ""}`;
+  const rightKey = `${right.path}\u0000${right.code}\u0000${right.field ?? ""}`;
+  if (leftKey < rightKey) return -1;
+  if (leftKey > rightKey) return 1;
+  return 0;
+}
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0 && value.trim() === value;
+}
+
+function safePath(path: string): boolean {
+  if (path.length === 0 || path.length > 1024 || path.startsWith("/") || path.includes("\\")) {
+    return false;
+  }
+  const segments = path.split("/");
+  return segments.every((segment) => segment.length > 0 && segment !== "." && segment !== "..");
+}
+
+function validUnicode(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (next < 0xdc00 || next > 0xdfff) return false;
+      index += 1;
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function unknownKeys(value: object, allowed: ReadonlySet<string>): string[] {
+  return Object.keys(value)
+    .filter((key) => !allowed.has(key))
+    .sort();
+}
+
+export function validateChangesetShape(changeset: SoulChangeset): SoulChangesetValidationIssue[] {
+  const issues: SoulChangesetValidationIssue[] = [];
+  if (typeof changeset !== "object" || changeset === null || Array.isArray(changeset)) {
+    return [{ code: "INVALID_CHANGESET", path: "", field: "/" }];
+  }
+  for (const key of unknownKeys(changeset, CHANGESET_KEYS)) {
+    issues.push({ code: "UNKNOWN_FIELD", path: "", field: `/${key}` });
+  }
+  for (const field of ["id", "businessId", "principalId", "expectedBaseCommit"] as const) {
+    if (!nonEmptyString(changeset[field])) {
+      issues.push({ code: "REQUIRED_FIELD", path: "", field: `/${field}` });
+    }
+  }
+  if (!(SOUL_CHANGESET_SOURCES as readonly unknown[]).includes(changeset.source)) {
+    issues.push({ code: "INVALID_SOURCE", path: "", field: "/source" });
+  }
+  if (!Array.isArray(changeset.files) || changeset.files.length === 0) {
+    issues.push({ code: "EMPTY_CHANGESET", path: "", field: "/files" });
+    return issues.sort(issueSort);
+  }
+
+  const paths = new Set<string>();
+  for (const [index, file] of changeset.files.entries()) {
+    const field = `/files/${index}`;
+    if (typeof file !== "object" || file === null || Array.isArray(file)) {
+      issues.push({ code: "INVALID_FILE_CHANGE", path: "", field });
+      continue;
+    }
+    const allowed = file.operation === "delete" ? DELETE_KEYS : UPSERT_KEYS;
+    for (const key of unknownKeys(file, allowed)) {
+      issues.push({ code: "UNKNOWN_FIELD", path: "", field: `${field}/${key}` });
+    }
+    if (file.operation !== "upsert" && file.operation !== "delete") {
+      issues.push({ code: "INVALID_OPERATION", path: "", field: `${field}/operation` });
+    }
+    if (!nonEmptyString(file.path) || !safePath(file.path)) {
+      issues.push({
+        code: "INVALID_PATH",
+        path: nonEmptyString(file.path) ? file.path : "",
+        field,
+      });
+      continue;
+    }
+    if (paths.has(file.path)) issues.push({ code: "DUPLICATE_PATH", path: file.path });
+    paths.add(file.path);
+    if (
+      file.operation === "upsert" &&
+      (typeof file.content !== "string" || !validUnicode(file.content))
+    ) {
+      issues.push({ code: "INVALID_CONTENT", path: file.path, field: `${field}/content` });
+    }
+  }
+  return issues.sort(issueSort);
+}
+
+interface ValidatedFileResult {
+  readonly file: ValidatedSoulFileChange;
+  readonly definition?: ParsedSoulFile["definition"];
+}
+
+export function validateChangesetFiles(files: readonly SoulFileChange[]): {
+  readonly files: readonly ValidatedFileResult[];
+  readonly issues: readonly SoulChangesetValidationIssue[];
+} {
+  const validated: ValidatedFileResult[] = [];
+  const issues: SoulChangesetValidationIssue[] = [];
+  for (const change of files) {
+    const result = parseSoulFile(change);
+    if (result.issue) {
+      issues.push(result.issue);
+      continue;
+    }
+    if (!result.parsed) {
+      issues.push({ code: "FILE_PARSE_FAILED", path: change.path });
+      continue;
+    }
+    validated.push({
+      file: { operation: change.operation, path: change.path, hash: result.parsed.hash },
+      definition: result.parsed.definition,
+    });
+  }
+  return { files: validated, issues: issues.sort(issueSort) };
+}


### PR DESCRIPTION
## Summary

- add one public expected-base Soul changeset validation boundary for UI, API, import, migration, Agent, and discovery proposals
- reject the complete changeset when its shape, base commit, path, YAML, discriminator, or canonical schema validation fails
- return deterministic payload-safe validation evidence and canonical hashes without writing the Soul tree

## Test plan

- [x] Captured RED: 15 new tests failed before `validateSoulChangeset` existed; 78 existing Soul tests passed
- [x] `pnpm --filter @tulipfarm/soul test` — 94 tests passed
- [x] `pnpm lint` — passed with pre-existing warnings only
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `git diff --check`

## Independent review

The independent AW-011 review scored this diff 2.5/5 and identified a sequencing conflict that requires maintainer direction: AW-011 says every existing write must be routed and direct-write exports removed, while AW-013 owns the not-yet-implemented atomic writer and the task guardrails prohibit deleting legacy paths early.

The review also requested follow-up for an opaque application plan retaining normalized bytes, support for `schemas/<kind>/<version>.json`, and deterministic validation size limits. These findings are intentionally disclosed rather than hidden or addressed by broadening this task beyond its declared scope.