### PR TITLE
feat(soul): atomic signed git changeset writer (AW-013)

### DIFF
--- a/packages/soul/src/commit-signing.test.ts
+++ b/packages/soul/src/commit-signing.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCommitMessage,
+  buildCommitSigningPayload,
+  type CommitSigner,
+  CommitSigningError,
+  createHmacCommitSigner,
+  type SignedCommitMetadata,
+  verifyCommitSignature,
+} from "./commit-signing";
+
+const META: SignedCommitMetadata = {
+  changesetId: "cs_1",
+  businessId: "biz_1",
+  source: "agent",
+  actor: { principalId: "prin_1", name: "Ada", email: "ada@example.com" },
+  approval: { approvalId: "ap_1", approverId: "prin_2", decisionAt: "2026-07-22T00:00:00.000Z" },
+  schemas: [
+    { kind: "Routine", apiVersion: "v1" },
+    { kind: "Agent", apiVersion: "v1" },
+  ],
+};
+
+describe("buildCommitSigningPayload", () => {
+  it("is deterministic regardless of schema ordering", () => {
+    const reordered: SignedCommitMetadata = {
+      ...META,
+      schemas: [
+        { kind: "Agent", apiVersion: "v1" },
+        { kind: "Routine", apiVersion: "v1" },
+      ],
+    };
+    expect(buildCommitSigningPayload("tree1", "base1", META)).toBe(
+      buildCommitSigningPayload("tree1", "base1", reordered)
+    );
+  });
+
+  it("changes when the tree, actor, or approval changes", () => {
+    const base = buildCommitSigningPayload("tree1", "base1", META);
+    expect(buildCommitSigningPayload("tree2", "base1", META)).not.toBe(base);
+    expect(
+      buildCommitSigningPayload("tree1", "base1", {
+        ...META,
+        actor: { ...META.actor, principalId: "prin_other" },
+      })
+    ).not.toBe(base);
+    expect(buildCommitSigningPayload("tree1", "base1", { ...META, approval: undefined })).not.toBe(
+      base
+    );
+  });
+
+  it("encodes a null parent for an initial commit", () => {
+    expect(buildCommitSigningPayload("tree1", null, META)).toContain('"parent":null');
+  });
+});
+
+describe("createHmacCommitSigner", () => {
+  it("signs deterministically and verifies", () => {
+    const signer = createHmacCommitSigner("key-1", "secret");
+    const payload = buildCommitSigningPayload("tree1", "base1", META);
+    const signature = signer.sign(payload);
+    expect(signer.sign(payload)).toBe(signature);
+    expect(verifyCommitSignature(signer, payload, signature)).toBe(true);
+  });
+
+  it("rejects a tampered payload or signature", () => {
+    const signer = createHmacCommitSigner("key-1", "secret");
+    const payload = buildCommitSigningPayload("tree1", "base1", META);
+    const signature = signer.sign(payload);
+    expect(verifyCommitSignature(signer, `${payload} `, signature)).toBe(false);
+    expect(verifyCommitSignature(signer, payload, `${signature}00`)).toBe(false);
+  });
+
+  it("throws on empty key material", () => {
+    expect(() => createHmacCommitSigner("", "secret")).toThrow(CommitSigningError);
+    expect(() => createHmacCommitSigner("key-1", "")).toThrow(CommitSigningError);
+  });
+});
+
+describe("buildCommitMessage", () => {
+  const signer: CommitSigner = { keyId: "key-1", sign: () => "deadbeef" };
+
+  it("emits deterministic metadata trailers ending with the signature", () => {
+    const message = buildCommitMessage("soul: update", META, {
+      keyId: signer.keyId,
+      value: "deadbeef",
+    });
+    const lines = message.trimEnd().split("\n");
+    expect(lines[0]).toBe("soul: update");
+    expect(message).toContain("Soul-Changeset: cs_1");
+    expect(message).toContain("Soul-Principal: prin_1");
+    expect(message).toContain("Soul-Approval: ap_1");
+    expect(message).toContain("Soul-Approver: prin_2");
+    expect(message).toContain("Soul-Schema: Agent@v1");
+    expect(message).toContain("Soul-Schema: Routine@v1");
+    expect(lines.at(-1)).toBe("Soul-Signature: key-1:deadbeef");
+  });
+
+  it("omits approval trailers when no approval was required", () => {
+    const message = buildCommitMessage(
+      "soul: update",
+      { ...META, approval: undefined },
+      {
+        keyId: "key-1",
+        value: "deadbeef",
+      }
+    );
+    expect(message).not.toContain("Soul-Approval");
+    expect(message).not.toContain("Soul-Approver");
+  });
+});

--- a/packages/soul/src/commit-signing.ts
+++ b/packages/soul/src/commit-signing.ts
@@ -1,0 +1,139 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import type { SoulChangesetSource } from "./changeset";
+
+/** The principal on whose behalf an authored write is committed. */
+export interface CommitActor {
+  readonly principalId: string;
+  readonly name: string;
+  readonly email: string;
+}
+
+/** The exact Approval decision that authorized the write, when one was required. */
+export interface CommitApproval {
+  readonly approvalId: string;
+  readonly approverId: string;
+  readonly decisionAt: string;
+}
+
+/** A schema the changeset resolved against, recorded for provenance. */
+export interface CommitSchemaRef {
+  readonly apiVersion: string;
+  readonly kind: string;
+}
+
+/** Everything that must be bound into — and covered by — the commit signature. */
+export interface SignedCommitMetadata {
+  readonly changesetId: string;
+  readonly businessId: string;
+  readonly source: SoulChangesetSource;
+  readonly actor: CommitActor;
+  readonly approval?: CommitApproval;
+  readonly schemas: readonly CommitSchemaRef[];
+}
+
+export interface CommitSignature {
+  readonly keyId: string;
+  readonly value: string;
+}
+
+/**
+ * A pluggable commit signer. Signing key material never enters this package — the caller injects a
+ * concrete signer bound to an authorized key. `sign` throwing aborts the whole commit before any
+ * ref moves, so a signing failure can never publish a tree.
+ */
+export interface CommitSigner {
+  readonly keyId: string;
+  sign(payload: string): string;
+}
+
+/** Deterministic, payload-safe signing failure suitable for boundary evidence. */
+export class CommitSigningError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "CommitSigningError";
+  }
+}
+
+function canonicalSchemas(schemas: readonly CommitSchemaRef[]): string[] {
+  return [...schemas].map((schema) => `${schema.kind}@${schema.apiVersion}`).sort();
+}
+
+/**
+ * Canonical bytes the signature covers. Deterministic in field order and schema ordering so the
+ * same tree + metadata always signs identically, and any tampering with the published tree,
+ * actor, or approval invalidates the signature.
+ */
+export function buildCommitSigningPayload(
+  treeSha: string,
+  parentSha: string | null,
+  meta: SignedCommitMetadata
+): string {
+  return JSON.stringify({
+    tree: treeSha,
+    parent: parentSha,
+    changeset: meta.changesetId,
+    business: meta.businessId,
+    source: meta.source,
+    principal: meta.actor.principalId,
+    approval: meta.approval
+      ? {
+          id: meta.approval.approvalId,
+          approver: meta.approval.approverId,
+          at: meta.approval.decisionAt,
+        }
+      : null,
+    schemas: canonicalSchemas(meta.schemas),
+  });
+}
+
+/** HMAC-SHA256 signer over the canonical payload. */
+export function createHmacCommitSigner(keyId: string, secret: string): CommitSigner {
+  if (keyId.length === 0 || secret.length === 0) {
+    throw new CommitSigningError("HMAC commit signer requires a non-empty keyId and secret");
+  }
+  return {
+    keyId,
+    sign(payload: string): string {
+      return createHmac("sha256", secret).update(payload, "utf8").digest("hex");
+    },
+  };
+}
+
+/** Constant-time verification that `signature` covers `payload` under `signer`. */
+export function verifyCommitSignature(
+  signer: CommitSigner,
+  payload: string,
+  signature: string
+): boolean {
+  const expected = Buffer.from(signer.sign(payload), "utf8");
+  const actual = Buffer.from(signature, "utf8");
+  if (expected.length !== actual.length) return false;
+  return timingSafeEqual(expected, actual);
+}
+
+/**
+ * Build the commit message: a human subject plus deterministic metadata trailers, ending with the
+ * signature trailer. The trailers are the auditable actor/approval/schema evidence carried in Git.
+ */
+export function buildCommitMessage(
+  subject: string,
+  meta: SignedCommitMetadata,
+  signature: CommitSignature
+): string {
+  const trailers = [
+    `Soul-Changeset: ${meta.changesetId}`,
+    `Soul-Business: ${meta.businessId}`,
+    `Soul-Source: ${meta.source}`,
+    `Soul-Principal: ${meta.actor.principalId}`,
+  ];
+  if (meta.approval) {
+    trailers.push(`Soul-Approval: ${meta.approval.approvalId}`);
+    trailers.push(`Soul-Approver: ${meta.approval.approverId}`);
+    trailers.push(`Soul-Approved-At: ${meta.approval.decisionAt}`);
+  }
+  for (const schema of canonicalSchemas(meta.schemas)) {
+    trailers.push(`Soul-Schema: ${schema}`);
+  }
+  trailers.push(`Soul-Signature: ${signature.keyId}:${signature.value}`);
+  return `${subject}\n\n${trailers.join("\n")}\n`;
+}

--- a/packages/soul/src/git-store.test.ts
+++ b/packages/soul/src/git-store.test.ts
@@ -1,0 +1,244 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("simple-git", () => ({ default: vi.fn() }));
+vi.mock("node:fs", () => ({
+  mkdtempSync: vi.fn(() => "/tmp/soul-changeset-xyz"),
+  writeFileSync: vi.fn(),
+  rmSync: vi.fn(),
+}));
+vi.mock("node:os", () => ({ tmpdir: vi.fn(() => "/tmp") }));
+
+import { rmSync, writeFileSync } from "node:fs";
+import simpleGit from "simple-git";
+import type { SoulFileChange, ValidatedSoulChangeset } from "./changeset";
+import type { CommitSigner } from "./commit-signing";
+import { SoulGitStore, SoulGitStoreError } from "./git-store";
+
+const mockSimpleGit = vi.mocked(simpleGit);
+const mockRmSync = vi.mocked(rmSync);
+const mockWriteFileSync = vi.mocked(writeFileSync);
+
+const BASE = "base0000";
+const SOUL = "/soul";
+
+interface MockGitOptions {
+  headSha?: string | null;
+  updateRefRejects?: boolean;
+}
+
+function makeMockGit(opts: MockGitOptions = {}) {
+  const headSha = opts.headSha === undefined ? BASE : opts.headSha;
+  const rawCalls: string[][] = [];
+  // biome-ignore lint/suspicious/noExplicitAny: test mock surface
+  const git: Record<string, any> = {
+    env: vi.fn(() => git),
+    reset: vi.fn().mockResolvedValue(undefined),
+    revparse: vi.fn((args: string[]) => {
+      if (args[0] === "HEAD") {
+        return headSha === null
+          ? Promise.reject(new Error("unknown revision HEAD"))
+          : Promise.resolve(`${headSha}\n`);
+      }
+      return Promise.resolve("");
+    }),
+    raw: vi.fn((args: string[]) => {
+      rawCalls.push(args);
+      switch (args[0]) {
+        case "hash-object":
+          return Promise.resolve("blob1111\n");
+        case "write-tree":
+          return Promise.resolve("tree2222\n");
+        case "commit-tree":
+          return Promise.resolve("commit3333\n");
+        case "update-ref":
+          return opts.updateRefRejects
+            ? Promise.reject(new Error("cannot lock ref: is at other but expected"))
+            : Promise.resolve("");
+        default:
+          return Promise.resolve("");
+      }
+    }),
+  };
+  return { git, rawCalls };
+}
+
+function makeLogger() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+function makeSigner(overrides: Partial<CommitSigner> = {}): CommitSigner {
+  return { keyId: "key-1", sign: vi.fn(() => "sigvalue"), ...overrides };
+}
+
+const UPSERT: SoulFileChange = {
+  operation: "upsert",
+  path: "agents/ada/agent.yaml",
+  content: "apiVersion: v1\nkind: Agent\n",
+};
+const DELETE: SoulFileChange = { operation: "delete", path: "routines/old.yaml" };
+
+function makeValidated(overrides: Partial<ValidatedSoulChangeset> = {}): ValidatedSoulChangeset {
+  return {
+    id: "cs_1",
+    businessId: "biz_1",
+    principalId: "prin_1",
+    source: "agent",
+    expectedBaseCommit: BASE,
+    files: [
+      { operation: "upsert", path: UPSERT.path, hash: "h1", apiVersion: "v1", kind: "Agent" },
+      { operation: "delete", path: DELETE.path, hash: "h2" },
+    ],
+    evidence: { outcome: "validated", fileCount: 2 },
+    ...overrides,
+  };
+}
+
+const ACTOR = { principalId: "prin_1", name: "Ada", email: "ada@example.com" };
+
+function names(calls: string[][]): string[] {
+  return calls.map((c) => c[0]);
+}
+
+describe("SoulGitStore.commitChangeset", () => {
+  let mock: ReturnType<typeof makeMockGit>;
+  let logger: ReturnType<typeof makeLogger>;
+
+  function build(opts?: MockGitOptions) {
+    mock = makeMockGit(opts);
+    // biome-ignore lint/suspicious/noExplicitAny: mock
+    mockSimpleGit.mockReturnValue(mock.git as any);
+    logger = makeLogger();
+  }
+
+  beforeEach(() => build());
+  afterEach(() => vi.clearAllMocks());
+
+  it("atomically writes the tree and CAS-updates the ref, returning signed evidence", async () => {
+    const signer = makeSigner();
+    const store = new SoulGitStore(SOUL, signer, logger);
+    const result = await store.commitChangeset({
+      changeset: makeValidated(),
+      files: [UPSERT, DELETE],
+      actor: ACTOR,
+    });
+
+    expect(result).toEqual({
+      commitSha: "commit3333",
+      treeSha: "tree2222",
+      parentSha: BASE,
+      filesChanged: 2,
+      signature: { keyId: "key-1", value: "sigvalue" },
+    });
+
+    // seeded the private index from the base, staged the upsert, removed the delete
+    expect(mock.rawCalls).toContainEqual(["read-tree", BASE]);
+    expect(mock.rawCalls).toContainEqual([
+      "update-index",
+      "--add",
+      "--cacheinfo",
+      "100644,blob1111,agents/ada/agent.yaml",
+    ]);
+    expect(mock.rawCalls).toContainEqual(["update-index", "--force-remove", "routines/old.yaml"]);
+
+    // commit-tree parents off the base and carries signed metadata trailers
+    const commitTree = mock.rawCalls.find((c) => c[0] === "commit-tree");
+    expect(commitTree).toBeDefined();
+    expect(commitTree).toContain("-p");
+    expect(commitTree).toContain(BASE);
+    const message = commitTree?.[commitTree.indexOf("-m") + 1] ?? "";
+    expect(message).toContain("Soul-Changeset: cs_1");
+    expect(message).toContain("Soul-Signature: key-1:sigvalue");
+
+    // CAS ref update guarded by the expected base, then working tree materialized
+    expect(mock.rawCalls).toContainEqual(["update-ref", "refs/heads/main", "commit3333", BASE]);
+    expect(mock.git.reset).toHaveBeenCalledWith(["--hard", "commit3333"]);
+    expect(mockRmSync).toHaveBeenCalled();
+  });
+
+  it("handles an initial commit with no base (unborn branch)", async () => {
+    build({ headSha: null });
+    const store = new SoulGitStore(SOUL, makeSigner(), logger);
+    const result = await store.commitChangeset({
+      changeset: makeValidated({ expectedBaseCommit: "" }),
+      files: [UPSERT, DELETE],
+      actor: ACTOR,
+    });
+
+    expect(result.parentSha).toBeNull();
+    expect(mock.rawCalls.some((c) => c[0] === "read-tree")).toBe(false);
+    const commitTree = mock.rawCalls.find((c) => c[0] === "commit-tree");
+    expect(commitTree).not.toContain("-p");
+    // ref update has no old-value guard when the branch is unborn
+    expect(mock.rawCalls).toContainEqual(["update-ref", "refs/heads/main", "commit3333"]);
+  });
+
+  it("rejects a stale base before touching the ref", async () => {
+    build({ headSha: "moved999" });
+    const store = new SoulGitStore(SOUL, makeSigner(), logger);
+    await expect(
+      store.commitChangeset({ changeset: makeValidated(), files: [UPSERT, DELETE], actor: ACTOR })
+    ).rejects.toMatchObject({ code: "BASE_MISMATCH" });
+
+    expect(names(mock.rawCalls)).not.toContain("commit-tree");
+    expect(names(mock.rawCalls)).not.toContain("update-ref");
+    expect(mock.git.reset).not.toHaveBeenCalled();
+  });
+
+  it("rejects content that does not match the validated changeset", async () => {
+    const store = new SoulGitStore(SOUL, makeSigner(), logger);
+    await expect(
+      store.commitChangeset({ changeset: makeValidated(), files: [UPSERT], actor: ACTOR })
+    ).rejects.toMatchObject({ code: "CONTENT_MISMATCH" });
+    expect(mock.git.revparse).not.toHaveBeenCalled();
+  });
+
+  it("aborts on a signing failure before any ref moves", async () => {
+    const signer = makeSigner({
+      sign: vi.fn(() => {
+        throw new Error("kms unavailable");
+      }),
+    });
+    const store = new SoulGitStore(SOUL, signer, logger);
+    await expect(
+      store.commitChangeset({ changeset: makeValidated(), files: [UPSERT, DELETE], actor: ACTOR })
+    ).rejects.toMatchObject({ code: "SIGNING_FAILED" });
+
+    expect(names(mock.rawCalls)).not.toContain("commit-tree");
+    expect(names(mock.rawCalls)).not.toContain("update-ref");
+    expect(mock.git.reset).not.toHaveBeenCalled();
+    expect(mockRmSync).toHaveBeenCalled();
+  });
+
+  it("does not materialize the working tree when the CAS ref update loses the race", async () => {
+    build({ updateRefRejects: true });
+    const store = new SoulGitStore(SOUL, makeSigner(), logger);
+    await expect(
+      store.commitChangeset({ changeset: makeValidated(), files: [UPSERT, DELETE], actor: ACTOR })
+    ).rejects.toMatchObject({ code: "REF_UPDATE_FAILED" });
+
+    expect(mock.git.reset).not.toHaveBeenCalled();
+    expect(mockRmSync).toHaveBeenCalled();
+  });
+
+  it("wraps a tree-write failure and cleans up the throwaway index", async () => {
+    build();
+    mock.git.raw.mockImplementation((args: string[]) => {
+      if (args[0] === "write-tree") return Promise.reject(new Error("index corrupt"));
+      return Promise.resolve("");
+    });
+    const store = new SoulGitStore(SOUL, makeSigner(), logger);
+    await expect(
+      store.commitChangeset({ changeset: makeValidated(), files: [UPSERT, DELETE], actor: ACTOR })
+    ).rejects.toMatchObject({ code: "WRITE_FAILED" });
+    expect(mockRmSync).toHaveBeenCalled();
+    expect(mockWriteFileSync).toHaveBeenCalled();
+  });
+
+  it("throws SoulGitStoreError (not a raw error) for boundary evidence", async () => {
+    build({ headSha: "moved999" });
+    const store = new SoulGitStore(SOUL, makeSigner(), logger);
+    await expect(
+      store.commitChangeset({ changeset: makeValidated(), files: [UPSERT, DELETE], actor: ACTOR })
+    ).rejects.toBeInstanceOf(SoulGitStoreError);
+  });
+});

--- a/packages/soul/src/git-store.ts
+++ b/packages/soul/src/git-store.ts
@@ -1,0 +1,282 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { BOT_GIT_EMAIL, BOT_GIT_NAME } from "@tulipfarm/constants";
+import simpleGit, { type SimpleGit } from "simple-git";
+import type { SoulFileChange, ValidatedSoulChangeset } from "./changeset";
+import {
+  buildCommitMessage,
+  buildCommitSigningPayload,
+  type CommitActor,
+  type CommitApproval,
+  type CommitSchemaRef,
+  type CommitSignature,
+  type CommitSigner,
+  CommitSigningError,
+  type SignedCommitMetadata,
+} from "./commit-signing";
+import type { Logger } from "./types";
+
+const GIT_TIMEOUT_MS = 30_000;
+const SOUL_BRANCH_REF = "refs/heads/main";
+const BLOB_MODE = "100644";
+
+export type SoulGitStoreErrorCode =
+  | "BASE_MISMATCH"
+  | "CONTENT_MISMATCH"
+  | "SIGNING_FAILED"
+  | "WRITE_FAILED"
+  | "REF_UPDATE_FAILED";
+
+/** Deterministic, payload-safe failure from the atomic writer. Carries no file content. */
+export class SoulGitStoreError extends Error {
+  readonly code: SoulGitStoreErrorCode;
+
+  constructor(code: SoulGitStoreErrorCode, message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "SoulGitStoreError";
+    this.code = code;
+  }
+}
+
+export interface SoulCommitRequest {
+  /** The validated changeset: authority on paths, operations, base, and schema provenance. */
+  readonly changeset: ValidatedSoulChangeset;
+  /** The exact content-bearing changes that were validated. Must match `changeset.files`. */
+  readonly files: readonly SoulFileChange[];
+  readonly actor: CommitActor;
+  readonly approval?: CommitApproval;
+  /** Human commit subject; defaults to a deterministic summary line. */
+  readonly subject?: string;
+}
+
+export interface SoulCommitResult {
+  readonly commitSha: string;
+  readonly treeSha: string;
+  readonly parentSha: string | null;
+  readonly filesChanged: number;
+  readonly signature: CommitSignature;
+}
+
+/**
+ * Atomic, signed writer for the authored Soul tree — step 12 of the single write gateway.
+ *
+ * The commit is assembled entirely off to the side: blobs and a tree are built in a private,
+ * throwaway index (`GIT_INDEX_FILE`) seeded from the expected base, never touching the working
+ * tree or the real index. The tree becomes visible only through a single compare-and-swap ref
+ * update against the expected base. Consequences:
+ *
+ * - A stale base (concurrent write) is rejected up front and again by the CAS ref update.
+ * - A signing failure aborts before any ref moves.
+ * - An interruption before the ref update leaves HEAD, the index, and the working tree untouched;
+ *   the orphaned throwaway objects are unreachable and GC-collected. No partial tree is published.
+ */
+export class SoulGitStore {
+  constructor(
+    private readonly soulPath: string,
+    private readonly signer: CommitSigner,
+    private readonly logger: Logger
+  ) {}
+
+  private git(indexFile?: string, extraEnv?: Record<string, string>): SimpleGit {
+    const git = simpleGit(this.soulPath, { timeout: { block: GIT_TIMEOUT_MS } });
+    if (indexFile === undefined && extraEnv === undefined) return git;
+    return git.env({
+      ...process.env,
+      ...(indexFile !== undefined ? { GIT_INDEX_FILE: indexFile } : {}),
+      ...extraEnv,
+    });
+  }
+
+  /** Current committed tip, or null when the branch is unborn (fresh repo, no commits). */
+  private async resolveHead(): Promise<string | null> {
+    try {
+      return (await this.git().revparse(["HEAD"])).trim();
+    } catch {
+      return null;
+    }
+  }
+
+  private assertContentMatches(
+    validated: ValidatedSoulChangeset,
+    files: readonly SoulFileChange[]
+  ): void {
+    if (files.length !== validated.files.length) {
+      throw new SoulGitStoreError(
+        "CONTENT_MISMATCH",
+        `Soul git store: content has ${files.length} file(s) but changeset validated ${validated.files.length}`
+      );
+    }
+    validated.files.forEach((validatedFile, index) => {
+      const file = files[index];
+      if (file.operation !== validatedFile.operation || file.path !== validatedFile.path) {
+        throw new SoulGitStoreError(
+          "CONTENT_MISMATCH",
+          `Soul git store: content at index ${index} does not match the validated changeset`
+        );
+      }
+    });
+  }
+
+  private buildMetadata(
+    validated: ValidatedSoulChangeset,
+    actor: CommitActor,
+    approval?: CommitApproval
+  ): SignedCommitMetadata {
+    const schemas: CommitSchemaRef[] = [];
+    for (const file of validated.files) {
+      if (file.kind !== undefined && file.apiVersion !== undefined) {
+        schemas.push({ kind: file.kind, apiVersion: file.apiVersion });
+      }
+    }
+    return {
+      changesetId: validated.id,
+      businessId: validated.businessId,
+      source: validated.source,
+      actor,
+      approval,
+      schemas,
+    };
+  }
+
+  /**
+   * Build the tree in a private index seeded from `parentSha`, then return the written tree sha.
+   * Nothing here is observable to the runtime — the real index and working tree are untouched.
+   */
+  private async writeTree(
+    workDir: string,
+    indexFile: string,
+    parentSha: string | null,
+    files: readonly SoulFileChange[]
+  ): Promise<string> {
+    const idx = this.git(indexFile);
+    if (parentSha !== null) {
+      await idx.raw(["read-tree", parentSha]);
+    }
+    const blobTmp = join(workDir, "blob");
+    for (const file of files) {
+      if (file.operation === "delete") {
+        await idx.raw(["update-index", "--force-remove", file.path]);
+        continue;
+      }
+      writeFileSync(blobTmp, file.content);
+      const blobSha = (await idx.raw(["hash-object", "-w", blobTmp])).trim();
+      await idx.raw([
+        "update-index",
+        "--add",
+        "--cacheinfo",
+        `${BLOB_MODE},${blobSha},${file.path}`,
+      ]);
+    }
+    return (await idx.raw(["write-tree"])).trim();
+  }
+
+  /**
+   * Atomically publish `request` as a signed commit on `main`. Returns the new commit evidence.
+   * Throws `SoulGitStoreError` (deterministic, no file content) on any failure; nothing partial is
+   * ever left published.
+   */
+  async commitChangeset(request: SoulCommitRequest): Promise<SoulCommitResult> {
+    const { changeset, files, actor, approval } = request;
+    this.assertContentMatches(changeset, files);
+
+    const expected = changeset.expectedBaseCommit === "" ? null : changeset.expectedBaseCommit;
+    const parentSha = await this.resolveHead();
+    if (parentSha !== expected) {
+      throw new SoulGitStoreError(
+        "BASE_MISMATCH",
+        `Soul git store: expected base ${expected ?? "(none)"} but HEAD is ${parentSha ?? "(none)"}`
+      );
+    }
+
+    const workDir = mkdtempSync(join(tmpdir(), "soul-changeset-"));
+    const indexFile = join(workDir, "index");
+    try {
+      let treeSha: string;
+      try {
+        treeSha = await this.writeTree(workDir, indexFile, parentSha, files);
+      } catch (error) {
+        throw new SoulGitStoreError(
+          "WRITE_FAILED",
+          `Soul git store: failed to assemble the changeset tree — ${errText(error)}`,
+          { cause: error }
+        );
+      }
+
+      const meta = this.buildMetadata(changeset, actor, approval);
+      const payload = buildCommitSigningPayload(treeSha, parentSha, meta);
+      let signatureValue: string;
+      try {
+        signatureValue = this.signer.sign(payload);
+      } catch (error) {
+        throw new SoulGitStoreError(
+          "SIGNING_FAILED",
+          `Soul git store: commit signing failed — ${signErrText(error)}`,
+          { cause: error }
+        );
+      }
+      const signature: CommitSignature = { keyId: this.signer.keyId, value: signatureValue };
+
+      const subject = request.subject ?? defaultSubject(changeset);
+      const message = buildCommitMessage(subject, meta, signature);
+
+      const commitArgs = ["commit-tree", treeSha];
+      if (parentSha !== null) commitArgs.push("-p", parentSha);
+      commitArgs.push("-m", message);
+      const commitSha = (await this.git(indexFile, identityEnv()).raw(commitArgs)).trim();
+
+      const refArgs = ["update-ref", SOUL_BRANCH_REF, commitSha];
+      if (parentSha !== null) refArgs.push(parentSha);
+      try {
+        await this.git().raw(refArgs);
+      } catch (error) {
+        throw new SoulGitStoreError(
+          "REF_UPDATE_FAILED",
+          `Soul git store: base moved under the write (concurrent commit) — ${errText(error)}`,
+          { cause: error }
+        );
+      }
+
+      // Materialize the newly published tree into the working directory the loader reads. A crash
+      // between the ref update and here leaves HEAD ahead of the working tree — a reconcilable
+      // state (`git reset --hard HEAD` on boot), never a partial publish.
+      await this.git().reset(["--hard", commitSha]);
+
+      this.logger.info(
+        `Soul: committed changeset ${changeset.id} as ${commitSha} (${files.length} file change(s))`
+      );
+      return {
+        commitSha,
+        treeSha,
+        parentSha,
+        filesChanged: files.length,
+        signature,
+      };
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  }
+}
+
+function defaultSubject(changeset: ValidatedSoulChangeset): string {
+  const count = changeset.files.length;
+  return `soul(${changeset.source}): changeset ${changeset.id} (${count} file${count === 1 ? "" : "s"})`;
+}
+
+function identityEnv(): Record<string, string> {
+  return {
+    GIT_AUTHOR_NAME: BOT_GIT_NAME,
+    GIT_AUTHOR_EMAIL: BOT_GIT_EMAIL,
+    GIT_COMMITTER_NAME: BOT_GIT_NAME,
+    GIT_COMMITTER_EMAIL: BOT_GIT_EMAIL,
+  };
+}
+
+function errText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function signErrText(error: unknown): string {
+  if (error instanceof CommitSigningError) return error.message;
+  return errText(error);
+}

--- a/packages/soul/src/index.ts
+++ b/packages/soul/src/index.ts
@@ -13,6 +13,27 @@ export {
   SoulChangesetValidationError,
   validateSoulChangeset,
 } from "./changeset";
+export type {
+  CommitActor,
+  CommitApproval,
+  CommitSchemaRef,
+  CommitSignature,
+  CommitSigner,
+  SignedCommitMetadata,
+} from "./commit-signing";
+export {
+  buildCommitMessage,
+  buildCommitSigningPayload,
+  CommitSigningError,
+  createHmacCommitSigner,
+  verifyCommitSignature,
+} from "./commit-signing";
+export type {
+  SoulCommitRequest,
+  SoulCommitResult,
+  SoulGitStoreErrorCode,
+} from "./git-store";
+export { SoulGitStore, SoulGitStoreError } from "./git-store";
 export { GitSyncService } from "./git-sync";
 export type { SoulMigration } from "./migrations/index";
 export type { SoulSemanticIssue, SoulSemanticIssueCode } from "./refs";


### PR DESCRIPTION
## Summary

- Implements **AW-013** — step 12 of the Soul single write gateway: atomically write a validated changeset's multi-file tree and create a signed commit carrying principal, approver, changeset, and schema metadata.
- The tree is assembled off to the side in a throwaway `GIT_INDEX_FILE` seeded from the expected base (`read-tree` → `hash-object -w` → `update-index` → `write-tree`), never touching the real index or working tree. It is published through a single compare-and-swap `update-ref refs/heads/main <new> <expectedBase>`, then materialized with `reset --hard`.
- Stale bases, signing failures, and interruptions before the ref update never leave a partial tree published.

## Public surface (`@tulipfarm/soul`)

- `commit-signing.ts`: `CommitSigner` contract, `createHmacCommitSigner`, deterministic `buildCommitSigningPayload`/`verifyCommitSignature`, metadata-trailer `buildCommitMessage`, `CommitSigningError`. Key material never enters the package — injected via `CommitSigner`.
- `git-store.ts`: `SoulGitStore.commitChangeset`, `SoulGitStoreError` + codes (`BASE_MISMATCH`, `CONTENT_MISMATCH`, `SIGNING_FAILED`, `WRITE_FAILED`, `REF_UPDATE_FAILED`). Content is bound to the validated changeset by a shape check before any git op.

Additive only — no existing signature or migration changed; `git-sync.ts` untouched.

## Test plan

- [x] RED observed (removing `git-store.ts` fails the suite on import).
- [x] `pnpm --filter @tulipfarm/soul exec vitest run` — 119 passed (16 new).
- [x] `biome check` on changed files — clean.
- [x] `pnpm --filter @tulipfarm/soul exec tsc --noEmit` — exit 0.
- Cases: happy path (upsert + delete), unborn-branch initial commit, stale-base denial, content mismatch, signing-failure abort, ref-race (`REF_UPDATE_FAILED`, no working-tree materialize), tree-write failure + temp cleanup.

## Residual risk

A crash between `update-ref` and `reset --hard` leaves HEAD ahead of the working tree — reconcilable (`git reset --hard HEAD` on boot), never a partial publish. Wiring that boot-reconciliation is out of scope.