### PR TITLE
feat(soul): project and reconcile published Soul versions (AW-015)

### DIFF
--- a/packages/soul/AGENTS.md
+++ b/packages/soul/AGENTS.md
@@ -18,6 +18,11 @@ git remote. Implements `specs/SOUL.md`. See root `AGENTS.md` for commands/lint.
   immutable execution bundles: exact-version resolution, canonical digest, signature, and the
   Git-free `RuntimeBundle` workers execute against. `InMemoryBundleStore` implements the
   content-addressed `BundleStore` port.
+- **`SoulPublicationCoordinator`** — projects a signed bundle through the outbox and activates one
+  digest only after every stage (`committed → projected → stored → active`) committed. `publish()`
+  records + enqueues, `drain()` is the durable job (resumes at the recorded stage after a crash),
+  `activeDigest()`/`activeBundle()` are the runtime read side, `rebuildProjection()` recompiles the
+  authored projection from Git. Persistence is `@tulipfarm/storage`'s `SoulPublicationStore`.
 - **`runSoulMigrations()`** + type `SoulMigration`.
 - Types: `SoulAgent`, `SoulSkill`, `SoulResource`, `SoulRoutine`, `SoulIntegration`.
 

--- a/packages/soul/package.json
+++ b/packages/soul/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@tulipfarm/constants": "workspace:*",
     "@tulipfarm/schema": "workspace:*",
+    "@tulipfarm/storage": "workspace:*",
     "simple-git": "^3.36.0",
     "yaml": "^2.9.0"
   },

--- a/packages/soul/src/index.ts
+++ b/packages/soul/src/index.ts
@@ -54,6 +54,17 @@ export type {
 export { SoulGitStore, SoulGitStoreError } from "./git-store";
 export { GitSyncService } from "./git-sync";
 export type { SoulMigration } from "./migrations/index";
+export type {
+  SoulPublicationErrorCode,
+  SoulPublicationOutcome,
+  SoulPublishRequest,
+  SoulTreeReader,
+} from "./publication";
+export {
+  SOUL_PUBLICATION_TOPIC,
+  SoulPublicationCoordinator,
+  SoulPublicationError,
+} from "./publication";
 export type { SoulSemanticIssue, SoulSemanticIssueCode } from "./refs";
 export { SoulSemanticValidationError } from "./refs";
 export { validateSoulSemantics } from "./semantic";

--- a/packages/soul/src/publication.test.ts
+++ b/packages/soul/src/publication.test.ts
@@ -1,0 +1,287 @@
+import type { VersionedSchemaDocument } from "@tulipfarm/schema";
+import { InMemorySoulPublicationStore, type SoulPublicationTx } from "@tulipfarm/storage";
+import { beforeEach, describe, expect, it } from "vitest";
+import { BundleError, computeBundleDigest, InMemoryBundleStore } from "./bundle";
+import { compileExecutionBundle } from "./compiler";
+import {
+  SoulPublicationCoordinator,
+  SoulPublicationError,
+  type SoulTreeReader,
+} from "./publication";
+import { createHmacBundleSigner, signExecutionBundle } from "./signatures";
+import type { Logger } from "./types";
+
+const API = "tulipfarm.ai/v1";
+const BUSINESS = "biz-1";
+const CONSUMER = "worker-1";
+
+function doc(slug: string, spec: Record<string, unknown>): VersionedSchemaDocument {
+  return {
+    apiVersion: API,
+    kind: "ModelProfile",
+    metadata: {
+      id: `id-${slug}`,
+      slug,
+      schemaVersion: 1,
+      authoredVersion: 1,
+      lifecycle: "published",
+    },
+    spec,
+  } as unknown as VersionedSchemaDocument;
+}
+
+function signedBundle(
+  changesetId: string,
+  commitSha: string,
+  documents: VersionedSchemaDocument[]
+) {
+  const bundle = compileExecutionBundle({
+    businessId: BUSINESS,
+    changesetId,
+    commitSha,
+    documents,
+  });
+  return signExecutionBundle(bundle, signer);
+}
+
+const signer = createHmacBundleSigner("key-1", "secret");
+
+class RecordingLogger implements Logger {
+  readonly lines: string[] = [];
+  info = (msg: string) => {
+    this.lines.push(msg);
+  };
+  warn = (msg: string) => {
+    this.lines.push(msg);
+  };
+  error = (msg: string) => {
+    this.lines.push(msg);
+  };
+}
+
+/** A store whose named transaction method fails once, simulating a crash mid-publication. */
+function failOnce(store: InMemorySoulPublicationStore, method: keyof SoulPublicationTx): void {
+  let fired = false;
+  const original = store.withTransaction.bind(store);
+  store.withTransaction = async <T>(fn: (tx: SoulPublicationTx) => Promise<T>): Promise<T> =>
+    original(async (tx) => {
+      const patched = new Proxy(tx, {
+        get(target, prop, receiver) {
+          if (prop === method && !fired) {
+            return async () => {
+              fired = true;
+              throw new Error("simulated crash");
+            };
+          }
+          return Reflect.get(target, prop, receiver);
+        },
+      });
+      return fn(patched as SoulPublicationTx);
+    });
+}
+
+describe("SoulPublicationCoordinator", () => {
+  let store: InMemorySoulPublicationStore;
+  let bundles: InMemoryBundleStore;
+  let logger: RecordingLogger;
+  let coordinator: SoulPublicationCoordinator;
+
+  const docsV1 = [doc("fast", { provider: "anthropic" })];
+  const docsV2 = [doc("fast", { provider: "anthropic", temperature: 0 })];
+
+  beforeEach(() => {
+    store = new InMemorySoulPublicationStore();
+    bundles = new InMemoryBundleStore();
+    logger = new RecordingLogger();
+    coordinator = new SoulPublicationCoordinator(store, bundles, logger);
+  });
+
+  async function publishAndDrain(changesetId: string, commitSha: string, docs = docsV1) {
+    const record = signedBundle(changesetId, commitSha, docs);
+    await coordinator.publish({ bundle: record });
+    await coordinator.drain(CONSUMER);
+    return record;
+  }
+
+  it("does not activate a digest until every stage succeeded", async () => {
+    const record = signedBundle("cs-1", "c0ffee", docsV1);
+
+    await coordinator.publish({ bundle: record });
+    expect(await coordinator.activeDigest(BUSINESS)).toBeUndefined();
+
+    const outcomes = await coordinator.drain(CONSUMER);
+
+    expect(outcomes).toEqual([{ changesetId: "cs-1", digest: record.digest, stage: "active" }]);
+    expect(await coordinator.activeDigest(BUSINESS)).toBe(record.digest);
+  });
+
+  it("projects the bundle's definitions through the outbox", async () => {
+    const record = await publishAndDrain("cs-1", "c0ffee");
+
+    const projection = await store.withTransaction((tx) => tx.listProjection(BUSINESS));
+    expect(projection).toEqual([
+      {
+        businessId: BUSINESS,
+        digest: record.digest,
+        kind: "ModelProfile",
+        id: "id-fast",
+        slug: "fast",
+        authoredVersion: 1,
+        hash: record.bundle.definitions[0].hash,
+      },
+    ]);
+  });
+
+  it("keeps the previous active version when projection crashes", async () => {
+    const first = await publishAndDrain("cs-1", "c0ffee");
+
+    const second = signedBundle("cs-2", "beef", docsV2);
+    await coordinator.publish({ bundle: second });
+    failOnce(store, "replaceProjection");
+
+    await expect(coordinator.drain(CONSUMER)).rejects.toThrow(SoulPublicationError);
+    expect(await coordinator.activeDigest(BUSINESS)).toBe(first.digest);
+
+    // The outbox message stayed unconsumed, so the durable job resumes and completes it.
+    const outcomes = await coordinator.drain(CONSUMER);
+    expect(outcomes).toEqual([{ changesetId: "cs-2", digest: second.digest, stage: "active" }]);
+    expect(await coordinator.activeDigest(BUSINESS)).toBe(second.digest);
+  });
+
+  it("keeps the previous active version when activation crashes, then resumes", async () => {
+    const first = await publishAndDrain("cs-1", "c0ffee");
+
+    const second = signedBundle("cs-2", "beef", docsV2);
+    await coordinator.publish({ bundle: second });
+    failOnce(store, "setActiveDigest");
+
+    await expect(coordinator.drain(CONSUMER)).rejects.toThrow(SoulPublicationError);
+    expect(await coordinator.activeDigest(BUSINESS)).toBe(first.digest);
+
+    await coordinator.drain(CONSUMER);
+    expect(await coordinator.activeDigest(BUSINESS)).toBe(second.digest);
+  });
+
+  it("fails closed and keeps the active version when the stored bundle is gone", async () => {
+    const first = await publishAndDrain("cs-1", "c0ffee");
+
+    const second = signedBundle("cs-2", "beef", docsV2);
+    await coordinator.publish({ bundle: second });
+    bundles = new InMemoryBundleStore();
+    coordinator = new SoulPublicationCoordinator(store, bundles, logger);
+
+    await expect(coordinator.drain(CONSUMER)).rejects.toMatchObject({
+      code: "BUNDLE_UNAVAILABLE",
+    });
+    expect(await coordinator.activeDigest(BUSINESS)).toBe(first.digest);
+  });
+
+  it("is idempotent under duplicate publish and duplicate delivery", async () => {
+    const record = signedBundle("cs-1", "c0ffee", docsV1);
+
+    await coordinator.publish({ bundle: record });
+    await coordinator.publish({ bundle: record });
+
+    const first = await coordinator.drain(CONSUMER);
+    const second = await coordinator.drain(CONSUMER);
+
+    expect(first).toHaveLength(1);
+    expect(second).toEqual([]);
+    expect(await coordinator.activeDigest(BUSINESS)).toBe(record.digest);
+  });
+
+  it("rejects a record whose digest does not cover its bundle", async () => {
+    const record = signedBundle("cs-1", "c0ffee", docsV1);
+
+    await expect(
+      coordinator.publish({ bundle: { ...record, digest: "not-the-digest" } })
+    ).rejects.toMatchObject({ code: "DIGEST_MISMATCH" });
+
+    const stored = await store.withTransaction((tx) => tx.getPublication("cs-1"));
+    expect(stored).toBeUndefined();
+  });
+
+  it("rejects a second publication that reuses a changeset id with another digest", async () => {
+    await coordinator.publish({ bundle: signedBundle("cs-1", "c0ffee", docsV1) });
+
+    await expect(
+      coordinator.publish({ bundle: signedBundle("cs-1", "beef", docsV2) })
+    ).rejects.toMatchObject({ code: "DIGEST_CONFLICT" });
+  });
+
+  it("rebuilds projections from Git for the active version", async () => {
+    const record = await publishAndDrain("cs-1", "c0ffee");
+    const before = await store.withTransaction((tx) => tx.listProjection(BUSINESS));
+
+    // Projection rows are lost (restore from an older backup, failed migration, wiped table).
+    await store.withTransaction((tx) => tx.replaceProjection(BUSINESS, []));
+    expect(await store.withTransaction((tx) => tx.listProjection(BUSINESS))).toEqual([]);
+
+    const reader: SoulTreeReader = { readDefinitions: async () => docsV1 };
+    const digest = await coordinator.rebuildProjection(BUSINESS, reader);
+
+    expect(digest).toBe(record.digest);
+    expect(await store.withTransaction((tx) => tx.listProjection(BUSINESS))).toEqual(before);
+    expect(await coordinator.activeDigest(BUSINESS)).toBe(record.digest);
+  });
+
+  it("refuses to rebuild when Git no longer produces the active digest", async () => {
+    await publishAndDrain("cs-1", "c0ffee");
+
+    const reader: SoulTreeReader = { readDefinitions: async () => docsV2 };
+
+    await expect(coordinator.rebuildProjection(BUSINESS, reader)).rejects.toMatchObject({
+      code: "DIGEST_MISMATCH",
+    });
+  });
+
+  it("serves the active bundle only through signature verification", async () => {
+    const record = await publishAndDrain("cs-1", "c0ffee");
+
+    const runtime = await coordinator.activeBundle(BUSINESS, signer);
+    expect(runtime?.digest).toBe(record.digest);
+    expect(runtime?.get("ModelProfile", "fast")?.id).toBe("id-fast");
+
+    const otherKey = createHmacBundleSigner("key-2", "other");
+    await expect(coordinator.activeBundle(BUSINESS, otherKey)).rejects.toThrow(BundleError);
+  });
+
+  it("has no active bundle before the first publication completes", async () => {
+    expect(await coordinator.activeBundle(BUSINESS, signer)).toBeUndefined();
+  });
+
+  it("logs stage evidence without authored content", async () => {
+    await publishAndDrain("cs-1", "c0ffee", [doc("fast", { provider: "anthropic" })]);
+
+    expect(logger.lines.length).toBeGreaterThan(0);
+    for (const line of logger.lines) {
+      expect(line).not.toContain("anthropic");
+    }
+    expect(logger.lines.join("\n")).toContain("cs-1");
+  });
+});
+
+describe("digest activation ordering", () => {
+  it("never exposes a digest whose bundle failed to store", async () => {
+    const store = new InMemorySoulPublicationStore();
+    const bundles = new InMemoryBundleStore();
+    const logger = new RecordingLogger();
+    const coordinator = new SoulPublicationCoordinator(store, bundles, logger);
+    const record = signedBundle("cs-1", "c0ffee", [doc("fast", {})]);
+
+    bundles.put = async () => {
+      throw new Error("blob backend unavailable");
+    };
+
+    await expect(coordinator.publish({ bundle: record })).rejects.toMatchObject({
+      code: "BUNDLE_STORE_FAILED",
+    });
+    expect(await coordinator.activeDigest("biz-1")).toBeUndefined();
+    expect(await store.withTransaction((tx) => tx.getPublication("cs-1"))).toBeUndefined();
+  });
+});
+
+it("computes the same digest the store addresses", () => {
+  const record = signedBundle("cs-1", "c0ffee", [doc("fast", {})]);
+  expect(computeBundleDigest(record.bundle)).toBe(record.digest);
+});

--- a/packages/soul/src/publication.ts
+++ b/packages/soul/src/publication.ts
@@ -1,0 +1,391 @@
+import type { VersionedSchemaDocument } from "@tulipfarm/schema";
+import type {
+  SoulDefinitionProjection,
+  SoulPublicationRecord,
+  SoulPublicationStage,
+  SoulPublicationStore,
+} from "@tulipfarm/storage";
+import {
+  type BundleDefinition,
+  type BundleStore,
+  computeBundleDigest,
+  type RuntimeBundle,
+  type SignedExecutionBundle,
+} from "./bundle";
+import { compileExecutionBundle } from "./compiler";
+import { type BundleSigner, verifyExecutionBundle } from "./signatures";
+import type { Logger } from "./types";
+
+/**
+ * Publication projection and reconciliation (SPEC §8.2 steps 13–15).
+ *
+ * A signed bundle (AW-014) becomes the version the runtime executes only after every stage
+ * committed, in this order:
+ *
+ * 1. `committed` — the immutable bundle is written to content-addressed storage (inert: addressed
+ *    by digest, referenced by nothing), then the publication record and one outbox message commit
+ *    in a single transaction. Nothing is active yet.
+ * 2. `projected` — the authored metadata of that digest replaces the business projection.
+ * 3. `stored`    — the bundle is confirmed present and digest-intact in bundle storage.
+ * 4. `active`    — the digest becomes the one the runtime reads, and the outbox message is
+ *    acknowledged with the consumer identity, in a single transaction.
+ *
+ * Every stage is idempotent and its own transaction, so an interruption anywhere leaves the
+ * previously active digest untouched and the outbox message unconsumed: {@link
+ * SoulPublicationCoordinator.drain} resumes at the recorded stage. Publication failure therefore
+ * never leaves a partially active version.
+ *
+ * The authored projection is derived data. {@link SoulPublicationCoordinator.rebuildProjection}
+ * recompiles it from the Git commit the active digest was published from and refuses to write when
+ * Git no longer reproduces that digest.
+ */
+
+export const SOUL_PUBLICATION_TOPIC = "soul.publication.requested";
+
+export type SoulPublicationErrorCode =
+  | "DIGEST_MISMATCH"
+  | "DIGEST_CONFLICT"
+  | "BUNDLE_STORE_FAILED"
+  | "BUNDLE_UNAVAILABLE"
+  | "PROJECTION_FAILED"
+  | "ACTIVATION_FAILED"
+  | "NO_ACTIVE_VERSION"
+  | "UNKNOWN_PUBLICATION";
+
+/**
+ * Deterministic, payload-safe publication failure. Carries changeset/digest identifiers only —
+ * never authored content, secret references, or user data.
+ */
+export class SoulPublicationError extends Error {
+  readonly code: SoulPublicationErrorCode;
+  readonly changesetId?: string;
+
+  constructor(
+    code: SoulPublicationErrorCode,
+    message: string,
+    details: { changesetId?: string; cause?: unknown } = {}
+  ) {
+    super(message, details.cause !== undefined ? { cause: details.cause } : undefined);
+    this.name = "SoulPublicationError";
+    this.code = code;
+    if (details.changesetId !== undefined) this.changesetId = details.changesetId;
+  }
+}
+
+export interface SoulPublishRequest {
+  /** The compiled, hashed, and signed bundle for the committed tree. */
+  readonly bundle: SignedExecutionBundle;
+}
+
+/** Reads the authored definitions of a Soul commit — the Git side of a projection rebuild. */
+export interface SoulTreeReader {
+  readDefinitions(commitSha: string): Promise<readonly VersionedSchemaDocument[]>;
+}
+
+export interface SoulPublicationOutcome {
+  readonly changesetId: string;
+  readonly digest: string;
+  readonly stage: SoulPublicationStage;
+}
+
+function projectionOf(
+  businessId: string,
+  digest: string,
+  definitions: readonly BundleDefinition[]
+): SoulDefinitionProjection[] {
+  return definitions.map((definition) => ({
+    businessId,
+    digest,
+    kind: definition.kind,
+    id: definition.id,
+    slug: definition.slug,
+    authoredVersion: definition.authoredVersion,
+    hash: definition.hash,
+  }));
+}
+
+export class SoulPublicationCoordinator {
+  constructor(
+    private readonly store: SoulPublicationStore,
+    private readonly bundles: BundleStore,
+    private readonly logger: Logger
+  ) {}
+
+  /**
+   * Stage 1. Store the immutable bundle, then record the publication and enqueue its outbox
+   * message in one transaction. Returns without activating anything; {@link drain} finishes the
+   * publication. A duplicate request for the same changeset and digest is a no-op.
+   */
+  async publish(request: SoulPublishRequest): Promise<void> {
+    const record = request.bundle;
+    const { businessId, changesetId, commitSha } = record.bundle;
+    const digest = computeBundleDigest(record.bundle);
+    if (digest !== record.digest) {
+      throw new SoulPublicationError(
+        "DIGEST_MISMATCH",
+        `Soul publication: changeset ${changesetId} record digest does not cover its bundle`,
+        { changesetId }
+      );
+    }
+
+    // Written before the transaction on purpose: the blob is content-addressed and inert until a
+    // publication record points at it, so a crash here leaves an unreachable blob, never a
+    // publication that cannot find its bundle.
+    try {
+      await this.bundles.put(record);
+    } catch (error) {
+      throw new SoulPublicationError(
+        `BUNDLE_STORE_FAILED`,
+        `Soul publication: changeset ${changesetId} bundle could not be stored`,
+        { changesetId, cause: error }
+      );
+    }
+
+    await this.store.withTransaction(async (tx) => {
+      const existing = await tx.getPublication(changesetId);
+      if (existing) {
+        if (existing.digest !== digest) {
+          throw new SoulPublicationError(
+            "DIGEST_CONFLICT",
+            `Soul publication: changeset ${changesetId} is already published with another digest`,
+            { changesetId }
+          );
+        }
+        return;
+      }
+      await tx.putPublication({
+        changesetId,
+        businessId,
+        commitSha,
+        digest,
+        stage: "committed",
+        attempts: 0,
+      });
+      await tx.enqueue({
+        id: `${changesetId}:publish`,
+        businessId,
+        changesetId,
+        topic: SOUL_PUBLICATION_TOPIC,
+      });
+    });
+
+    this.logger.info(
+      `Soul publication: changeset ${changesetId} committed at ${digest} (awaiting projection)`
+    );
+  }
+
+  /**
+   * The durable job. Advances every unconsumed publication from its recorded stage to `active`.
+   * Throws on the first failure with the previously active digest intact and the message still
+   * unconsumed, so a later run resumes exactly where this one stopped.
+   */
+  async drain(consumer: string, max = 10): Promise<readonly SoulPublicationOutcome[]> {
+    const messages = await this.store.withTransaction((tx) => tx.pendingOutbox(max));
+    const outcomes: SoulPublicationOutcome[] = [];
+    for (const message of messages) {
+      outcomes.push(await this.advance(message.changesetId, consumer));
+    }
+    return outcomes;
+  }
+
+  /** Active digest for a business, or `undefined` before the first publication completes. */
+  async activeDigest(businessId: string): Promise<string | undefined> {
+    return this.store.withTransaction((tx) => tx.getActiveDigest(businessId));
+  }
+
+  /**
+   * The verified bundle the runtime executes: the explicitly active digest, opened only through
+   * signature verification. `undefined` when nothing is active yet.
+   */
+  async activeBundle(businessId: string, signer: BundleSigner): Promise<RuntimeBundle | undefined> {
+    const digest = await this.activeDigest(businessId);
+    if (digest === undefined) return undefined;
+    const record = await this.bundles.get(digest);
+    if (!record) {
+      throw new SoulPublicationError(
+        "BUNDLE_UNAVAILABLE",
+        `Soul publication: active digest ${digest} is not present in bundle storage`
+      );
+    }
+    return verifyExecutionBundle(record, signer);
+  }
+
+  /**
+   * Rebuild the authored projection for the active version from Git. The definitions read at the
+   * published commit are recompiled and must reproduce the active digest exactly; anything else
+   * means Git and the active version disagree, and nothing is written.
+   */
+  async rebuildProjection(businessId: string, reader: SoulTreeReader): Promise<string> {
+    const record = await this.store.withTransaction(async (tx) => {
+      const digest = await tx.getActiveDigest(businessId);
+      if (digest === undefined) {
+        throw new SoulPublicationError(
+          "NO_ACTIVE_VERSION",
+          `Soul publication: business ${businessId} has no active version to rebuild`
+        );
+      }
+      const found = await tx.findPublicationByDigest(businessId, digest);
+      if (!found) {
+        throw new SoulPublicationError(
+          "UNKNOWN_PUBLICATION",
+          `Soul publication: active digest ${digest} has no publication record`
+        );
+      }
+      return found;
+    });
+    const documents = await reader.readDefinitions(record.commitSha);
+    const bundle = compileExecutionBundle({
+      businessId,
+      changesetId: record.changesetId,
+      commitSha: record.commitSha,
+      documents,
+    });
+    const digest = computeBundleDigest(bundle);
+    if (digest !== record.digest) {
+      throw new SoulPublicationError(
+        "DIGEST_MISMATCH",
+        `Soul publication: commit ${record.commitSha} no longer compiles to the active digest`,
+        { changesetId: record.changesetId }
+      );
+    }
+
+    await this.store.withTransaction((tx) =>
+      tx.replaceProjection(businessId, projectionOf(businessId, digest, bundle.definitions))
+    );
+    this.logger.info(
+      `Soul publication: rebuilt projection for ${businessId} from commit ${record.commitSha}`
+    );
+    return digest;
+  }
+
+  /** Run the remaining stages for one publication. Each stage commits before the next begins. */
+  private async advance(changesetId: string, consumer: string): Promise<SoulPublicationOutcome> {
+    let record = await this.require(changesetId);
+    try {
+      if (record.stage === "committed") {
+        record = await this.project(record);
+      }
+      if (record.stage === "projected") {
+        record = await this.confirmStored(record);
+      }
+      if (record.stage === "stored") {
+        record = await this.activate(record, consumer);
+      }
+    } catch (error) {
+      await this.recordFailure(record, error);
+      throw error;
+    }
+    return { changesetId, digest: record.digest, stage: record.stage };
+  }
+
+  private async project(record: SoulPublicationRecord): Promise<SoulPublicationRecord> {
+    const stored = await this.bundles.get(record.digest);
+    if (!stored) throw this.missingBundle(record);
+    const next: SoulPublicationRecord = {
+      ...record,
+      stage: "projected",
+      attempts: record.attempts,
+    };
+    try {
+      await this.store.withTransaction(async (tx) => {
+        await tx.replaceProjection(
+          record.businessId,
+          projectionOf(record.businessId, record.digest, stored.bundle.definitions)
+        );
+        await tx.putPublication(next);
+      });
+    } catch (error) {
+      throw this.wrap("PROJECTION_FAILED", record, "authored projection failed", error);
+    }
+    this.logger.info(
+      `Soul publication: changeset ${record.changesetId} projected ${stored.bundle.definitions.length} definition(s)`
+    );
+    return next;
+  }
+
+  /** Confirm the bundle is retrievable and intact before any digest is allowed to go active. */
+  private async confirmStored(record: SoulPublicationRecord): Promise<SoulPublicationRecord> {
+    const stored = await this.bundles.get(record.digest);
+    if (!stored) throw this.missingBundle(record);
+    if (computeBundleDigest(stored.bundle) !== record.digest) {
+      throw new SoulPublicationError(
+        "DIGEST_MISMATCH",
+        `Soul publication: stored bundle for changeset ${record.changesetId} does not match its digest`,
+        { changesetId: record.changesetId }
+      );
+    }
+    const next: SoulPublicationRecord = { ...record, stage: "stored" };
+    await this.persist(next);
+    return next;
+  }
+
+  private async activate(
+    record: SoulPublicationRecord,
+    consumer: string
+  ): Promise<SoulPublicationRecord> {
+    const next: SoulPublicationRecord = { ...record, stage: "active" };
+    try {
+      await this.store.withTransaction(async (tx) => {
+        await tx.setActiveDigest(record.businessId, record.digest);
+        await tx.putPublication(next);
+        await tx.markConsumed(`${record.changesetId}:publish`, consumer);
+      });
+    } catch (error) {
+      throw this.wrap("ACTIVATION_FAILED", record, "activation failed", error);
+    }
+    this.logger.info(
+      `Soul publication: changeset ${record.changesetId} activated digest ${record.digest}`
+    );
+    return next;
+  }
+
+  private async persist(record: SoulPublicationRecord): Promise<void> {
+    await this.store.withTransaction((tx) => tx.putPublication(record));
+  }
+
+  private async require(changesetId: string): Promise<SoulPublicationRecord> {
+    const record = await this.store.withTransaction((tx) => tx.getPublication(changesetId));
+    if (!record) {
+      throw new SoulPublicationError(
+        "UNKNOWN_PUBLICATION",
+        `Soul publication: no publication record for changeset ${changesetId}`,
+        { changesetId }
+      );
+    }
+    return record;
+  }
+
+  private async recordFailure(record: SoulPublicationRecord, error: unknown): Promise<void> {
+    const failureCode = error instanceof SoulPublicationError ? error.code : "PROJECTION_FAILED";
+    await this.persist({
+      ...record,
+      attempts: record.attempts + 1,
+      failureCode,
+    });
+    this.logger.error(
+      `Soul publication: changeset ${record.changesetId} stopped at stage ${record.stage} (${failureCode}); active version unchanged`
+    );
+  }
+
+  private missingBundle(record: SoulPublicationRecord): SoulPublicationError {
+    return new SoulPublicationError(
+      "BUNDLE_UNAVAILABLE",
+      `Soul publication: bundle ${record.digest} for changeset ${record.changesetId} is not in bundle storage`,
+      { changesetId: record.changesetId }
+    );
+  }
+
+  private wrap(
+    code: SoulPublicationErrorCode,
+    record: SoulPublicationRecord,
+    what: string,
+    error: unknown
+  ): SoulPublicationError {
+    if (error instanceof SoulPublicationError) return error;
+    return new SoulPublicationError(
+      code,
+      `Soul publication: changeset ${record.changesetId} ${what}`,
+      { changesetId: record.changesetId, cause: error }
+    );
+  }
+}

--- a/packages/storage/AGENTS.md
+++ b/packages/storage/AGENTS.md
@@ -3,7 +3,9 @@
 `@tulipfarm/storage` — PostgreSQL repositories, transaction helpers, outbox/inbox, and
 blob/vector/cache provider ports. **Today:** `src/ports/` defines the provider-neutral
 `TransactionPort`/`Queryable`, `BlobPort`, `VectorPort`, `CachePort`, and `QueueAcceleratorPort`
-contracts (no `pg`/SDK types leak across the boundary). tsconfig extends
+contracts (no `pg`/SDK types leak across the boundary), and `src/soul/` defines the Soul
+publication record/projection/outbox port (`SoulPublicationStore`, plus an in-memory
+implementation with real rollback) that `@tulipfarm/soul` drives. tsconfig extends
 `@tulipfarm/tsconfig/base.json`. See root `AGENTS.md` for commands/lint.
 
 May import: `@tulipfarm/schema`, `@tulipfarm/observability`. See

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./ports";
+export * from "./soul";

--- a/packages/storage/src/soul/index.ts
+++ b/packages/storage/src/soul/index.ts
@@ -1,0 +1,9 @@
+export type {
+  SoulDefinitionProjection,
+  SoulPublicationOutboxMessage,
+  SoulPublicationRecord,
+  SoulPublicationStage,
+  SoulPublicationStore,
+  SoulPublicationTx,
+} from "./publication-store";
+export { InMemorySoulPublicationStore, SOUL_PUBLICATION_STAGES } from "./publication-store";

--- a/packages/storage/src/soul/publication-store.test.ts
+++ b/packages/storage/src/soul/publication-store.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import { InMemorySoulPublicationStore, type SoulPublicationRecord } from "./publication-store";
+
+const BUSINESS = "biz-1";
+
+function record(overrides: Partial<SoulPublicationRecord> = {}): SoulPublicationRecord {
+  return {
+    changesetId: "cs-1",
+    businessId: BUSINESS,
+    commitSha: "c0ffee",
+    digest: "digest-1",
+    stage: "committed",
+    attempts: 0,
+    ...overrides,
+  };
+}
+
+describe("InMemorySoulPublicationStore", () => {
+  it("rolls back every write when the transaction throws", async () => {
+    const store = new InMemorySoulPublicationStore();
+
+    await expect(
+      store.withTransaction(async (tx) => {
+        await tx.putPublication(record());
+        await tx.setActiveDigest(BUSINESS, "digest-1");
+        await tx.enqueue({
+          id: "cs-1:publish",
+          businessId: BUSINESS,
+          changesetId: "cs-1",
+          topic: "soul.publication.requested",
+        });
+        throw new Error("crash before commit");
+      })
+    ).rejects.toThrow("crash before commit");
+
+    await store.withTransaction(async (tx) => {
+      expect(await tx.getPublication("cs-1")).toBeUndefined();
+      expect(await tx.getActiveDigest(BUSINESS)).toBeUndefined();
+      expect(await tx.pendingOutbox(10)).toEqual([]);
+    });
+  });
+
+  it("hides consumed messages and keeps the first consumer", async () => {
+    const store = new InMemorySoulPublicationStore();
+    await store.withTransaction((tx) =>
+      tx.enqueue({
+        id: "cs-1:publish",
+        businessId: BUSINESS,
+        changesetId: "cs-1",
+        topic: "soul.publication.requested",
+      })
+    );
+
+    await store.withTransaction(async (tx) => {
+      expect(await tx.pendingOutbox(10)).toHaveLength(1);
+      await tx.markConsumed("cs-1:publish", "worker-1");
+      await tx.markConsumed("cs-1:publish", "worker-2");
+      expect(await tx.pendingOutbox(10)).toEqual([]);
+    });
+  });
+
+  it("ignores a duplicate enqueue of the same message id", async () => {
+    const store = new InMemorySoulPublicationStore();
+    const message = {
+      id: "cs-1:publish",
+      businessId: BUSINESS,
+      changesetId: "cs-1",
+      topic: "soul.publication.requested",
+    };
+
+    await store.withTransaction(async (tx) => {
+      await tx.enqueue(message);
+      await tx.enqueue(message);
+      expect(await tx.pendingOutbox(10)).toHaveLength(1);
+    });
+  });
+
+  it("replaces the projection rather than appending to it", async () => {
+    const store = new InMemorySoulPublicationStore();
+    const row = {
+      businessId: BUSINESS,
+      digest: "digest-1",
+      kind: "ModelProfile",
+      id: "id-fast",
+      slug: "fast",
+      authoredVersion: 1,
+      hash: "hash-1",
+    };
+
+    await store.withTransaction(async (tx) => {
+      await tx.replaceProjection(BUSINESS, [row]);
+      await tx.replaceProjection(BUSINESS, [{ ...row, digest: "digest-2", authoredVersion: 2 }]);
+    });
+
+    const projection = await store.withTransaction((tx) => tx.listProjection(BUSINESS));
+    expect(projection).toEqual([{ ...row, digest: "digest-2", authoredVersion: 2 }]);
+  });
+
+  it("finds the publication behind a digest and isolates businesses", async () => {
+    const store = new InMemorySoulPublicationStore();
+
+    await store.withTransaction(async (tx) => {
+      await tx.putPublication(record());
+      await tx.putPublication(
+        record({ changesetId: "cs-2", businessId: "biz-2", digest: "digest-2" })
+      );
+    });
+
+    await store.withTransaction(async (tx) => {
+      expect(await tx.findPublicationByDigest(BUSINESS, "digest-1")).toMatchObject({
+        changesetId: "cs-1",
+      });
+      expect(await tx.findPublicationByDigest(BUSINESS, "digest-2")).toBeUndefined();
+      expect(await tx.getActiveDigest("biz-2")).toBeUndefined();
+    });
+  });
+});

--- a/packages/storage/src/soul/publication-store.ts
+++ b/packages/storage/src/soul/publication-store.ts
@@ -1,0 +1,175 @@
+/**
+ * Soul publication persistence (SPEC §8.2 steps 13–15).
+ *
+ * Storage owns the mechanics; `@tulipfarm/soul` owns the publication behaviour and is the only
+ * writer of these rows. Three record families back one invariant: a digest becomes active only
+ * after every earlier stage committed.
+ *
+ * - the publication record: which changeset/commit/digest is in flight and how far it got;
+ * - the authored projection: rebuildable-from-Git metadata for the definitions of one digest;
+ * - the outbox: the durable handoff to the job that finishes the publication.
+ *
+ * Rows carry only authored identifiers, digests, and stage names — never definition content,
+ * secret material, or user data.
+ */
+
+/**
+ * Publication progress, in order. Each stage is committed before the next begins, so a crash
+ * resumes at the recorded stage and the previously active digest is never disturbed.
+ */
+export const SOUL_PUBLICATION_STAGES = ["committed", "projected", "stored", "active"] as const;
+
+export type SoulPublicationStage = (typeof SOUL_PUBLICATION_STAGES)[number];
+
+export interface SoulPublicationRecord {
+  readonly changesetId: string;
+  readonly businessId: string;
+  /** The signed Soul commit the bundle was compiled from. */
+  readonly commitSha: string;
+  readonly digest: string;
+  readonly stage: SoulPublicationStage;
+  /** Durable retry counter — never a process-memory counter. */
+  readonly attempts: number;
+  /** Deterministic code of the last stage failure, for operator evidence. */
+  readonly failureCode?: string;
+}
+
+/** One authored definition of one published digest, as projected for queries and rebuild. */
+export interface SoulDefinitionProjection {
+  readonly businessId: string;
+  readonly digest: string;
+  readonly kind: string;
+  readonly id: string;
+  readonly slug: string;
+  readonly authoredVersion: number;
+  /** Canonical hash of the authored document. */
+  readonly hash: string;
+}
+
+export interface SoulPublicationOutboxMessage {
+  readonly id: string;
+  readonly businessId: string;
+  readonly changesetId: string;
+  readonly topic: string;
+  /** Consumer identity, recorded before acknowledging (dependency-rules §"Data and event ownership"). */
+  readonly consumedBy?: string;
+}
+
+/** Transaction-scoped writes. Every method here commits or rolls back with its enclosing unit. */
+export interface SoulPublicationTx {
+  putPublication(record: SoulPublicationRecord): Promise<void>;
+  getPublication(changesetId: string): Promise<SoulPublicationRecord | undefined>;
+  /** The publication that produced one digest — the commit lineage behind an active version. */
+  findPublicationByDigest(
+    businessId: string,
+    digest: string
+  ): Promise<SoulPublicationRecord | undefined>;
+
+  enqueue(message: SoulPublicationOutboxMessage): Promise<void>;
+  /** Unconsumed messages, oldest first. */
+  pendingOutbox(max: number): Promise<readonly SoulPublicationOutboxMessage[]>;
+  /** Idempotent: a message already consumed keeps its original consumer. */
+  markConsumed(id: string, consumer: string): Promise<void>;
+
+  replaceProjection(
+    businessId: string,
+    definitions: readonly SoulDefinitionProjection[]
+  ): Promise<void>;
+  listProjection(businessId: string): Promise<readonly SoulDefinitionProjection[]>;
+
+  setActiveDigest(businessId: string, digest: string): Promise<void>;
+  getActiveDigest(businessId: string): Promise<string | undefined>;
+}
+
+export interface SoulPublicationStore {
+  /** Run `fn` in one transaction: commit when it resolves, roll back every write if it throws. */
+  withTransaction<T>(fn: (tx: SoulPublicationTx) => Promise<T>): Promise<T>;
+}
+
+interface State {
+  publications: Map<string, SoulPublicationRecord>;
+  outbox: SoulPublicationOutboxMessage[];
+  projections: Map<string, readonly SoulDefinitionProjection[]>;
+  active: Map<string, string>;
+}
+
+function snapshot(state: State): State {
+  return {
+    publications: new Map(state.publications),
+    outbox: [...state.outbox],
+    projections: new Map(state.projections),
+    active: new Map(state.active),
+  };
+}
+
+/**
+ * Process-local store with real rollback, for tests and single-process composition. The durable
+ * PostgreSQL adapter implements the same {@link SoulPublicationStore} contract; authoritative
+ * publication state never lives only in process memory in production.
+ */
+export class InMemorySoulPublicationStore implements SoulPublicationStore {
+  private state: State = {
+    publications: new Map(),
+    outbox: [],
+    projections: new Map(),
+    active: new Map(),
+  };
+
+  async withTransaction<T>(fn: (tx: SoulPublicationTx) => Promise<T>): Promise<T> {
+    const rollback = snapshot(this.state);
+    const staged = snapshot(this.state);
+    try {
+      const result = await fn(this.tx(staged));
+      this.state = staged;
+      return result;
+    } catch (error) {
+      this.state = rollback;
+      throw error;
+    }
+  }
+
+  private tx(state: State): SoulPublicationTx {
+    return {
+      async putPublication(record) {
+        state.publications.set(record.changesetId, Object.freeze({ ...record }));
+      },
+      async getPublication(changesetId) {
+        return state.publications.get(changesetId);
+      },
+      async findPublicationByDigest(businessId, digest) {
+        return [...state.publications.values()].find(
+          (record) => record.businessId === businessId && record.digest === digest
+        );
+      },
+      async enqueue(message) {
+        if (state.outbox.some((existing) => existing.id === message.id)) return;
+        state.outbox.push(Object.freeze({ ...message }));
+      },
+      async pendingOutbox(max) {
+        return state.outbox.filter((message) => message.consumedBy === undefined).slice(0, max);
+      },
+      async markConsumed(id, consumer) {
+        state.outbox = state.outbox.map((message) =>
+          message.id === id && message.consumedBy === undefined
+            ? Object.freeze({ ...message, consumedBy: consumer })
+            : message
+        );
+      },
+      async replaceProjection(businessId, definitions) {
+        state.projections.set(
+          businessId,
+          Object.freeze(definitions.map((definition) => Object.freeze({ ...definition })))
+        );
+      },
+      async listProjection(businessId) {
+        return state.projections.get(businessId) ?? [];
+      },
+      async setActiveDigest(businessId, digest) {
+        state.active.set(businessId, digest);
+      },
+      async getActiveDigest(businessId) {
+        return state.active.get(businessId);
+      },
+    };
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -657,6 +657,9 @@ importers:
       '@tulipfarm/schema':
         specifier: workspace:*
         version: link:../schema
+      '@tulipfarm/storage':
+        specifier: workspace:*
+        version: link:../storage
       simple-git:
         specifier: ^3.36.0
         version: 3.36.0


### PR DESCRIPTION
## Summary

- Adds `SoulPublicationCoordinator` (`packages/soul/src/publication.ts`): a signed execution bundle reaches the runtime only through the staged, outbox-driven pipeline `committed → projected → stored → active`. `publish()` writes the content-addressed bundle, then commits the publication record and one outbox message in a single transaction; `drain()` is the durable job that finishes the publication and activates exactly one digest after every earlier stage committed (SPEC §8.2 steps 13–15).
- Adds the Soul publication persistence port in `packages/storage/src/soul/` — publication record, authored projection, and outbox rows, plus an in-memory store with real transaction rollback. Rows carry only authored identifiers, digests, and stage names.
- `rebuildProjection()` recompiles the authored projection from the Git commit the active digest was published from, and refuses to write when Git no longer reproduces that digest — keeping the projection derived data rather than a second source of truth.

Implements AW-015.

### Scope note

The task plan proposed `apps/worker/src/soul/*`, but `docs/architecture/dependency-rules.md` and `scripts/lib/architecture-rules.ts` forbid `apps/worker → packages/soul`. Rather than add a forbidden edge, the durable job is exposed as `SoulPublicationCoordinator.drain()` for composition by an app that is allowed to import `soul` (today `apps/api`). No new migrations: `packages/storage` has no PostgreSQL adapter yet, so the in-memory store mirrors the existing `InMemoryBundleStore` precedent from AW-014 and is documented as non-production.

## Test plan

- `pnpm --filter @tulipfarm/soul --filter @tulipfarm/storage exec vitest run` — soul 156 tests, storage 9 tests, all passing.
- Crash/recovery cases: projection failure, activation failure, and a missing bundle blob each leave the previously active digest intact and the outbox message unconsumed; a later `drain()` resumes at the recorded stage and completes.
- Denial/boundary cases: digest that does not cover its bundle, changeset id reused with another digest, rebuild against a drifted Git tree, and `activeBundle()` opened with the wrong signing key.
- Idempotence: duplicate `publish()` and duplicate delivery activate once.
- Redaction: stage log evidence asserted to contain changeset ids and digests but no authored content.
- `pnpm exec biome check packages/soul packages/storage`, `typecheck` for both packages plus `apps/api`, and `pnpm architecture:check` all pass.