### PR TITLE
feat(soul): convert legacy Agent/Skill definitions to validated proposals (AW-016)

### DIFF
--- a/packages/soul/src/converters/agent.test.ts
+++ b/packages/soul/src/converters/agent.test.ts
@@ -1,0 +1,101 @@
+import { DEFINITION_REGISTRATIONS, SchemaRegistry } from "@tulipfarm/schema";
+import { describe, expect, it } from "vitest";
+import type { SoulAgent } from "../types";
+import { convertLegacyAgent } from "./agent";
+
+const registry = new SchemaRegistry(DEFINITION_REGISTRATIONS);
+
+function agentYaml(result: ReturnType<typeof convertLegacyAgent>): string {
+  const file = result.files.find((f) => f.path.endsWith("agent.yaml"));
+  if (file?.operation !== "upsert") throw new Error("agent.yaml not emitted");
+  return file.content;
+}
+
+describe("convertLegacyAgent", () => {
+  const validLegacy: SoulAgent = {
+    name: "Support Bot",
+    frontmatter: {
+      owner: "team-support",
+      modelProfile: "gpt-tier-1",
+      autonomy: "propose_actions",
+      trustTier: "business_authored",
+      roles: ["support-agent"],
+    },
+    body: "# Support Bot\n\nHandles support tickets.",
+  };
+
+  it("converts the happy path into a validated agent.yaml + instructions.md", () => {
+    const result = convertLegacyAgent(validLegacy);
+
+    expect(result.warnings).toEqual([]);
+    expect(result.files).toHaveLength(2);
+
+    const agentFile = result.files.find((f) => f.path === "agents/support-bot/agent.yaml");
+    const instructionsFile = result.files.find(
+      (f) => f.path === "agents/support-bot/instructions.md"
+    );
+    expect(agentFile?.operation).toBe("upsert");
+    expect(instructionsFile).toEqual({
+      operation: "upsert",
+      path: "agents/support-bot/instructions.md",
+      content: validLegacy.body,
+    });
+
+    // GREEN proof: emitted YAML round-trips through the real AJV-backed registry validator.
+    const validated = registry.validateYaml(agentYaml(result));
+    expect(validated.kind).toBe("Agent");
+    const document = validated.document as unknown as {
+      spec: { owner: string; modelProfile: string; autonomy: string; trustTier: string };
+      metadata: { slug: string; id: string };
+    };
+    expect(document.spec.owner).toBe("team-support");
+    expect(document.metadata.slug).toBe("support-bot");
+    expect(document.metadata.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    );
+  });
+
+  it("warns and drops unmapped frontmatter fields", () => {
+    const result = convertLegacyAgent({
+      ...validLegacy,
+      frontmatter: { ...validLegacy.frontmatter, legacyOnlyField: "keep-me-out" },
+    });
+
+    expect(result.warnings).toContainEqual({ code: "UNMAPPED_FIELD", field: "legacyOnlyField" });
+    const agentDoc = registry.validateYaml(agentYaml(result)).document as unknown as {
+      spec: Record<string, unknown>;
+    };
+    expect(agentDoc.spec.legacyOnlyField).toBeUndefined();
+  });
+
+  it("never copies secret-shaped fields, even if they collide with an allowlisted name", () => {
+    const result = convertLegacyAgent({
+      ...validLegacy,
+      frontmatter: {
+        ...validLegacy.frontmatter,
+        apiKey: "sk-should-never-appear",
+        roles: "secret_token_value",
+      },
+    });
+
+    expect(result.warnings).toContainEqual({ code: "SECRET_FIELD_DROPPED", field: "apiKey" });
+    const yaml = agentYaml(result);
+    expect(yaml).not.toContain("sk-should-never-appear");
+  });
+
+  it("skips emitting agent.yaml when a required field is missing, without inventing a default", () => {
+    const { owner: _owner, ...rest } = validLegacy.frontmatter;
+    const result = convertLegacyAgent({ ...validLegacy, frontmatter: rest });
+
+    expect(result.files).toEqual([]);
+    expect(result.warnings).toContainEqual({ code: "MISSING_REQUIRED_FIELD", field: "owner" });
+  });
+
+  it("is idempotent: same legacy input yields byte-identical files and warnings", () => {
+    const first = convertLegacyAgent(validLegacy);
+    const second = convertLegacyAgent(validLegacy);
+
+    expect(second).toEqual(first);
+    expect(agentYaml(second)).toBe(agentYaml(first));
+  });
+});

--- a/packages/soul/src/converters/agent.ts
+++ b/packages/soul/src/converters/agent.ts
@@ -1,0 +1,95 @@
+import { DEFINITION_API_VERSION } from "@tulipfarm/schema";
+import { stringify } from "yaml";
+import type { SoulFileChange } from "../changeset";
+import type { SoulAgent } from "../types";
+import { type ConversionResult, deriveDefinitionId, mapAllowlistedFields, slugify } from "./shared";
+
+const KIND = "Agent";
+
+/** `AgentSpec` fields sourced from legacy frontmatter (`instructions` is always derived, never copied). */
+const AGENT_FRONTMATTER_ALLOWLIST = [
+  "owner",
+  "maintainers",
+  "personality",
+  "roles",
+  "permissionCeiling",
+  "modelProfile",
+  "skills",
+  "allowedTools",
+  "autonomy",
+  "limits",
+  "guardrails",
+  "memoryScopes",
+  "knowledgeScopes",
+  "trustTier",
+  "evaluationSuite",
+] as const;
+
+const AGENT_REQUIRED_FIELDS = ["owner", "modelProfile", "autonomy", "trustTier"] as const;
+
+/**
+ * Convert a legacy `SoulAgent` (AGENT.md frontmatter + body) into a proposed authored `Agent`
+ * definition (`agents/<slug>/agent.yaml` + companion `instructions.md`). Never publishes; the
+ * caller decides whether/how to route the returned files through the changeset gateway.
+ */
+export function convertLegacyAgent(agent: SoulAgent): ConversionResult {
+  const slug = slugify(agent.name);
+  const { mapped, warnings } = mapAllowlistedFields(agent.frontmatter, AGENT_FRONTMATTER_ALLOWLIST);
+
+  const missing = AGENT_REQUIRED_FIELDS.filter((field) => mapped[field] === undefined);
+  if (missing.length > 0) {
+    return {
+      files: [],
+      warnings: [
+        ...warnings,
+        ...missing.map((field) => ({ code: "MISSING_REQUIRED_FIELD" as const, field })),
+      ],
+    };
+  }
+
+  const spec: Record<string, unknown> = { owner: mapped.owner };
+  if (mapped.maintainers !== undefined) spec.maintainers = mapped.maintainers;
+  spec.instructions = { path: "instructions.md" };
+  if (mapped.personality !== undefined) spec.personality = mapped.personality;
+  if (mapped.roles !== undefined) spec.roles = mapped.roles;
+  if (mapped.permissionCeiling !== undefined) spec.permissionCeiling = mapped.permissionCeiling;
+  spec.modelProfile = mapped.modelProfile;
+  if (mapped.skills !== undefined) spec.skills = mapped.skills;
+  if (mapped.allowedTools !== undefined) spec.allowedTools = mapped.allowedTools;
+  spec.autonomy = mapped.autonomy;
+  if (mapped.limits !== undefined) spec.limits = mapped.limits;
+  if (mapped.guardrails !== undefined) spec.guardrails = mapped.guardrails;
+  if (mapped.memoryScopes !== undefined) spec.memoryScopes = mapped.memoryScopes;
+  if (mapped.knowledgeScopes !== undefined) spec.knowledgeScopes = mapped.knowledgeScopes;
+  spec.trustTier = mapped.trustTier;
+  if (mapped.evaluationSuite !== undefined) spec.evaluationSuite = mapped.evaluationSuite;
+
+  const document = {
+    apiVersion: DEFINITION_API_VERSION,
+    kind: KIND,
+    metadata: {
+      id: deriveDefinitionId(KIND, agent.name),
+      slug,
+      displayName: agent.name,
+      schemaVersion: 1,
+      authoredVersion: 1,
+      lifecycle: "draft",
+    },
+    spec,
+  };
+
+  const files: SoulFileChange[] = [
+    {
+      operation: "upsert",
+      path: `agents/${slug}/agent.yaml`,
+      content: stringify(document),
+    },
+    {
+      operation: "upsert",
+      path: `agents/${slug}/instructions.md`,
+      content: agent.body,
+    },
+  ];
+
+  return { files, warnings };
+}

--- a/packages/soul/src/converters/legacy-definitions.test.ts
+++ b/packages/soul/src/converters/legacy-definitions.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import type { SoulAgent, SoulSkill } from "../types";
+import { convertLegacyDefinitions } from "./legacy-definitions";
+
+describe("convertLegacyDefinitions (batch)", () => {
+  it("aggregates files and warnings across agents and skills", () => {
+    const agents: SoulAgent[] = [
+      {
+        name: "Support Bot",
+        frontmatter: {
+          owner: "team-support",
+          modelProfile: "gpt-tier-1",
+          autonomy: "propose_actions",
+          trustTier: "business_authored",
+        },
+        body: "agent body",
+      },
+    ];
+    const skills: SoulSkill[] = [
+      {
+        name: "PDF Summarizer",
+        frontmatter: { trustTier: "first_party" },
+        body: "skill body",
+      },
+    ];
+
+    const result = convertLegacyDefinitions({ agents, skills });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.files.map((f) => f.path).sort()).toEqual([
+      "agents/support-bot/agent.yaml",
+      "agents/support-bot/instructions.md",
+      "skills/pdf-summarizer/SKILL.md",
+      "skills/pdf-summarizer/skill.yaml",
+    ]);
+  });
+
+  it("returns nothing for an empty batch", () => {
+    expect(convertLegacyDefinitions({})).toEqual({ files: [], warnings: [] });
+  });
+});

--- a/packages/soul/src/converters/legacy-definitions.ts
+++ b/packages/soul/src/converters/legacy-definitions.ts
@@ -1,0 +1,32 @@
+import type { SoulAgent, SoulSkill } from "../types";
+import { convertLegacyAgent } from "./agent";
+import type { ConversionResult } from "./shared";
+import { convertLegacySkill } from "./skill";
+
+export { convertLegacyAgent } from "./agent";
+export type { ConversionResult, ConversionWarning, ConversionWarningCode } from "./shared";
+export { convertLegacySkill } from "./skill";
+
+/** Legacy artifacts to convert in one batch. Resources/Routines/Integrations are out of scope (AW-016). */
+export interface LegacyDefinitionBatch {
+  readonly agents?: readonly SoulAgent[];
+  readonly skills?: readonly SoulSkill[];
+}
+
+/**
+ * Convert a batch of legacy Agents/Skills, aggregating every proposed file and warning across the
+ * whole set. Each item is converted independently and deterministically (see `convertLegacyAgent`
+ * / `convertLegacySkill`); this is purely a fan-out convenience, it does not change per-item
+ * semantics and never publishes.
+ */
+export function convertLegacyDefinitions(batch: LegacyDefinitionBatch): ConversionResult {
+  const results = [
+    ...(batch.agents ?? []).map(convertLegacyAgent),
+    ...(batch.skills ?? []).map(convertLegacySkill),
+  ];
+
+  return {
+    files: results.flatMap((result) => result.files),
+    warnings: results.flatMap((result) => result.warnings),
+  };
+}

--- a/packages/soul/src/converters/shared.ts
+++ b/packages/soul/src/converters/shared.ts
@@ -50,7 +50,8 @@ export function slugify(name: string): string {
   const base = name
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
+    .replace(/^-+/, "")
+    .replace(/-+$/, "");
   return /^[a-z]/.test(base) ? base : `x-${base || "unnamed"}`;
 }
 

--- a/packages/soul/src/converters/shared.ts
+++ b/packages/soul/src/converters/shared.ts
@@ -45,14 +45,33 @@ export function deriveDefinitionId(kind: string, name: string): string {
   return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
 }
 
-/** Kebab-case-normalize a legacy name into a slug satisfying the schema's slug pattern. */
+/** True for the 36 characters a slug may contain: `a`-`z`, `0`-`9`. */
+function isSlugChar(char: string): boolean {
+  return (char >= "a" && char <= "z") || (char >= "0" && char <= "9");
+}
+
+/**
+ * Kebab-case-normalize a legacy name into a slug satisfying the schema's slug pattern. Built as a
+ * single-pass character scan (no regex) so it stays linear-time regardless of input shape — the
+ * legacy `name` is uncontrolled data, and CodeQL flags regex-based collapsing/trimming here as a
+ * polynomial-ReDoS shape even when each step is individually anchored.
+ */
 export function slugify(name: string): string {
-  const base = name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+/, "")
-    .replace(/-+$/, "");
-  return /^[a-z]/.test(base) ? base : `x-${base || "unnamed"}`;
+  const lower = name.toLowerCase();
+  let base = "";
+  let pendingHyphen = false;
+  for (const char of lower) {
+    if (isSlugChar(char)) {
+      if (pendingHyphen && base.length > 0) base += "-";
+      pendingHyphen = false;
+      base += char;
+    } else {
+      pendingHyphen = true;
+    }
+  }
+  return base.length > 0 && base.charAt(0) >= "a" && base.charAt(0) <= "z"
+    ? base
+    : `x-${base || "unnamed"}`;
 }
 
 /**

--- a/packages/soul/src/converters/shared.ts
+++ b/packages/soul/src/converters/shared.ts
@@ -1,0 +1,84 @@
+import { createHash } from "node:crypto";
+import type { SoulFileChange } from "../changeset";
+
+/**
+ * Shared building blocks for legacy Soul -> authored-definition conversion (AW-016).
+ *
+ * Conversion is a pure, read-only transform: it never writes to disk, never calls the changeset
+ * gateway, and never publishes. Callers get back proposed `SoulFileChange`s plus warnings and
+ * decide what (if anything) to do with them.
+ */
+
+/** Why a legacy value did not make it into the converted definition. */
+export type ConversionWarningCode =
+  | "UNMAPPED_FIELD"
+  | "SECRET_FIELD_DROPPED"
+  | "MISSING_REQUIRED_FIELD";
+
+export interface ConversionWarning {
+  readonly code: ConversionWarningCode;
+  readonly field: string;
+}
+
+/** Result of converting one legacy artifact: proposed file writes plus any loss warnings. */
+export interface ConversionResult {
+  readonly files: readonly SoulFileChange[];
+  readonly warnings: readonly ConversionWarning[];
+}
+
+/** Field-name pattern that always excludes a legacy value, even if it collides with an allowlisted name. */
+const SECRET_FIELD_PATTERN = /secret|token|password|credential|apikey|api_key/i;
+
+/** Fixed namespace so the same (kind, name) always derives the same id (SOUL-AW-016 stable id). */
+const ID_NAMESPACE = "tulipfarm.ai/soul/legacy-definition/v1";
+
+/**
+ * Deterministically derive a UUID-shaped id from a legacy artifact's (kind, name). Not a real
+ * UUIDv4/v5 — a documented SHA-256-derived hex string matching the schema's UUID-or-ULID id
+ * pattern, which is what makes conversion idempotent without a new dependency.
+ */
+export function deriveDefinitionId(kind: string, name: string): string {
+  const digest = createHash("sha256")
+    .update(`${ID_NAMESPACE}\0${kind}\0${name}`, "utf8")
+    .digest("hex");
+  const hex = digest.slice(0, 32);
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
+}
+
+/** Kebab-case-normalize a legacy name into a slug satisfying the schema's slug pattern. */
+export function slugify(name: string): string {
+  const base = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return /^[a-z]/.test(base) ? base : `x-${base || "unnamed"}`;
+}
+
+/**
+ * Allowlist-copy frontmatter fields onto the new spec shape. Any secret-shaped field name is
+ * always dropped (defense in depth: legacy Soul data must never carry a real secret forward).
+ * Any other field not on the allowlist is dropped with an `UNMAPPED_FIELD` warning. Nothing not
+ * explicitly named on `allowlist` is ever copied through.
+ */
+export function mapAllowlistedFields(
+  frontmatter: Record<string, unknown>,
+  allowlist: readonly string[]
+): { mapped: Record<string, unknown>; warnings: ConversionWarning[] } {
+  const allowed = new Set(allowlist);
+  const mapped: Record<string, unknown> = {};
+  const warnings: ConversionWarning[] = [];
+
+  for (const [field, value] of Object.entries(frontmatter)) {
+    if (SECRET_FIELD_PATTERN.test(field)) {
+      warnings.push({ code: "SECRET_FIELD_DROPPED", field });
+      continue;
+    }
+    if (allowed.has(field)) {
+      mapped[field] = value;
+      continue;
+    }
+    warnings.push({ code: "UNMAPPED_FIELD", field });
+  }
+
+  return { mapped, warnings };
+}

--- a/packages/soul/src/converters/skill.test.ts
+++ b/packages/soul/src/converters/skill.test.ts
@@ -1,0 +1,84 @@
+import { DEFINITION_REGISTRATIONS, SchemaRegistry } from "@tulipfarm/schema";
+import { describe, expect, it } from "vitest";
+import type { SoulSkill } from "../types";
+import { convertLegacySkill } from "./skill";
+
+const registry = new SchemaRegistry(DEFINITION_REGISTRATIONS);
+
+function skillYaml(result: ReturnType<typeof convertLegacySkill>): string {
+  const file = result.files.find((f) => f.path.endsWith("skill.yaml"));
+  if (file?.operation !== "upsert") throw new Error("skill.yaml not emitted");
+  return file.content;
+}
+
+describe("convertLegacySkill", () => {
+  const validLegacy: SoulSkill = {
+    name: "PDF Summarizer",
+    frontmatter: {
+      trustTier: "first_party",
+      requiredToolAbilities: ["read_file"],
+    },
+    body: "# PDF Summarizer\n\nSummarizes PDFs.",
+  };
+
+  it("converts the happy path into a validated skill.yaml + SKILL.md", () => {
+    const result = convertLegacySkill(validLegacy);
+
+    expect(result.warnings).toEqual([]);
+    expect(result.files).toHaveLength(2);
+
+    const instructionsFile = result.files.find((f) => f.path === "skills/pdf-summarizer/SKILL.md");
+    expect(instructionsFile).toEqual({
+      operation: "upsert",
+      path: "skills/pdf-summarizer/SKILL.md",
+      content: validLegacy.body,
+    });
+
+    const validated = registry.validateYaml(skillYaml(result));
+    expect(validated.kind).toBe("Skill");
+    const document = validated.document as unknown as {
+      spec: { trustTier: string };
+      metadata: { slug: string };
+    };
+    expect(document.spec.trustTier).toBe("first_party");
+    expect(document.metadata.slug).toBe("pdf-summarizer");
+  });
+
+  it("warns and drops unmapped frontmatter fields", () => {
+    const result = convertLegacySkill({
+      ...validLegacy,
+      frontmatter: { ...validLegacy.frontmatter, unknownLegacyKey: 1 },
+    });
+
+    expect(result.warnings).toContainEqual({ code: "UNMAPPED_FIELD", field: "unknownLegacyKey" });
+  });
+
+  it("never copies secret-shaped fields", () => {
+    const result = convertLegacySkill({
+      ...validLegacy,
+      frontmatter: { ...validLegacy.frontmatter, credentialRef: "should-not-appear" },
+    });
+
+    expect(result.warnings).toContainEqual({
+      code: "SECRET_FIELD_DROPPED",
+      field: "credentialRef",
+    });
+    expect(skillYaml(result)).not.toContain("should-not-appear");
+  });
+
+  it("skips emitting skill.yaml when trustTier is missing", () => {
+    const { trustTier: _trustTier, ...rest } = validLegacy.frontmatter;
+    const result = convertLegacySkill({ ...validLegacy, frontmatter: rest });
+
+    expect(result.files).toEqual([]);
+    expect(result.warnings).toContainEqual({ code: "MISSING_REQUIRED_FIELD", field: "trustTier" });
+  });
+
+  it("is idempotent: same legacy input yields byte-identical files and warnings", () => {
+    const first = convertLegacySkill(validLegacy);
+    const second = convertLegacySkill(validLegacy);
+
+    expect(second).toEqual(first);
+    expect(skillYaml(second)).toBe(skillYaml(first));
+  });
+});

--- a/packages/soul/src/converters/skill.ts
+++ b/packages/soul/src/converters/skill.ts
@@ -1,0 +1,85 @@
+import { DEFINITION_API_VERSION } from "@tulipfarm/schema";
+import { stringify } from "yaml";
+import type { SoulFileChange } from "../changeset";
+import type { SoulSkill } from "../types";
+import { type ConversionResult, deriveDefinitionId, mapAllowlistedFields, slugify } from "./shared";
+
+const KIND = "Skill";
+
+/** `SkillSpec` fields sourced from legacy frontmatter (`instructions` is always derived, never copied). */
+const SKILL_FRONTMATTER_ALLOWLIST = [
+  "references",
+  "templates",
+  "examples",
+  "schemas",
+  "assets",
+  "scripts",
+  "dependencies",
+  "requiredToolAbilities",
+  "trustTier",
+] as const;
+
+const SKILL_REQUIRED_FIELDS = ["trustTier"] as const;
+
+/**
+ * Convert a legacy `SoulSkill` (SKILL.md frontmatter + body) into a proposed authored `Skill`
+ * definition (`skills/<slug>/skill.yaml` + companion `SKILL.md`). Never publishes; the caller
+ * decides whether/how to route the returned files through the changeset gateway.
+ */
+export function convertLegacySkill(skill: SoulSkill): ConversionResult {
+  const slug = slugify(skill.name);
+  const { mapped, warnings } = mapAllowlistedFields(skill.frontmatter, SKILL_FRONTMATTER_ALLOWLIST);
+
+  const missing = SKILL_REQUIRED_FIELDS.filter((field) => mapped[field] === undefined);
+  if (missing.length > 0) {
+    return {
+      files: [],
+      warnings: [
+        ...warnings,
+        ...missing.map((field) => ({ code: "MISSING_REQUIRED_FIELD" as const, field })),
+      ],
+    };
+  }
+
+  const spec: Record<string, unknown> = { instructions: { path: "SKILL.md" } };
+  if (mapped.references !== undefined) spec.references = mapped.references;
+  if (mapped.templates !== undefined) spec.templates = mapped.templates;
+  if (mapped.examples !== undefined) spec.examples = mapped.examples;
+  if (mapped.schemas !== undefined) spec.schemas = mapped.schemas;
+  if (mapped.assets !== undefined) spec.assets = mapped.assets;
+  if (mapped.scripts !== undefined) spec.scripts = mapped.scripts;
+  if (mapped.dependencies !== undefined) spec.dependencies = mapped.dependencies;
+  if (mapped.requiredToolAbilities !== undefined) {
+    spec.requiredToolAbilities = mapped.requiredToolAbilities;
+  }
+  spec.trustTier = mapped.trustTier;
+
+  const document = {
+    apiVersion: DEFINITION_API_VERSION,
+    kind: KIND,
+    metadata: {
+      id: deriveDefinitionId(KIND, skill.name),
+      slug,
+      displayName: skill.name,
+      schemaVersion: 1,
+      authoredVersion: 1,
+      lifecycle: "draft",
+    },
+    spec,
+  };
+
+  const files: SoulFileChange[] = [
+    {
+      operation: "upsert",
+      path: `skills/${slug}/skill.yaml`,
+      content: stringify(document),
+    },
+    {
+      operation: "upsert",
+      path: `skills/${slug}/SKILL.md`,
+      content: skill.body,
+    },
+  ];
+
+  return { files, warnings };
+}

--- a/packages/soul/src/index.ts
+++ b/packages/soul/src/index.ts
@@ -47,6 +47,17 @@ export {
 export type { BundleCompileRequest } from "./compiler";
 export { compileExecutionBundle } from "./compiler";
 export type {
+  ConversionResult,
+  ConversionWarning,
+  ConversionWarningCode,
+  LegacyDefinitionBatch,
+} from "./converters/legacy-definitions";
+export {
+  convertLegacyAgent,
+  convertLegacyDefinitions,
+  convertLegacySkill,
+} from "./converters/legacy-definitions";
+export type {
   SoulCommitRequest,
   SoulCommitResult,
   SoulGitStoreErrorCode,


### PR DESCRIPTION
## Summary
- Adds `packages/soul/src/converters/*`: converts legacy `AGENT.md`/`SKILL.md` definitions (frontmatter + body, as loaded by `SoulLoader`) into new-format Agent/Skill Soul proposals validated against `@tulipfarm/schema`.
- Deterministic, stable IDs (SHA-256-derived, UUID-shaped) so conversion is idempotent across runs; unmapped/secret-like frontmatter fields are dropped and surfaced as loss warnings instead of silently kept or fabricated; missing required fields skip emitting that definition (never propose an invalid file).
- Never calls the Git commit/publication path — output is proposal data only (`SoulFileChange[]` + warnings); no auto-publish.
- Deliberately out of scope: `SoulResource`, `SoulRoutine`, `SoulIntegration` conversion — no clean 1:1 counterpart in the new model (no Resource kind; Routine needs a typed State graph; Integration needs execution-mode/credential decisions not present in legacy data). Flagging as a known gap, not silently dropped.

## Test plan
- [x] `pnpm --filter @tulipfarm/soul test` — 168/168 passing (12 new, no regressions)
- [x] `pnpm --filter @tulipfarm/soul lint`
- [x] `pnpm --filter @tulipfarm/soul typecheck`
- [x] RED proved by temporarily disabling the missing-required-field guard, confirming the corresponding test fails, then restoring GREEN