### PR TITLE
feat(authz): persist principal and session ports with business_id scoping (AW-017)

### DIFF
--- a/packages/authz/src/index.ts
+++ b/packages/authz/src/index.ts
@@ -3,3 +3,15 @@ export type {
   IdentityResolution,
   IdentityResolutionRequest,
 } from "./ports";
+export type {
+  Principal,
+  PrincipalDenialReason,
+  PrincipalKind,
+  PrincipalStatus,
+  SessionBinding,
+} from "./principals";
+export {
+  assertPrincipalAuthenticatable,
+  assertSessionMatchesPrincipal,
+  PrincipalDeniedError,
+} from "./principals";

--- a/packages/authz/src/principals.test.ts
+++ b/packages/authz/src/principals.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertPrincipalAuthenticatable,
+  assertSessionMatchesPrincipal,
+  type Principal,
+  PrincipalDeniedError,
+  type SessionBinding,
+} from "./principals";
+
+function principal(overrides: Partial<Principal> = {}): Principal {
+  return {
+    id: "principal-1",
+    businessId: "business-1",
+    kind: "user",
+    status: "active",
+    ...overrides,
+  };
+}
+
+function session(overrides: Partial<SessionBinding> = {}): SessionBinding {
+  return {
+    sid: "sid-1",
+    principalId: "principal-1",
+    businessId: "business-1",
+    expiresAt: new Date(Date.now() + 60_000),
+    ...overrides,
+  };
+}
+
+describe("assertPrincipalAuthenticatable", () => {
+  it("allows an active, unexpired principal of every kind", () => {
+    const kinds: Principal["kind"][] = [
+      "user",
+      "agent",
+      "routine",
+      "integration_adapter",
+      "api",
+      "service",
+    ];
+    for (const kind of kinds) {
+      expect(() => assertPrincipalAuthenticatable(principal({ kind }))).not.toThrow();
+    }
+  });
+
+  it("denies a disabled principal", () => {
+    expect(() => assertPrincipalAuthenticatable(principal({ status: "disabled" }))).toThrow(
+      PrincipalDeniedError
+    );
+  });
+
+  it("denies a principal past its expiry", () => {
+    const expired = principal({ expiresAt: new Date(Date.now() - 1_000) });
+    expect(() => assertPrincipalAuthenticatable(expired)).toThrow(PrincipalDeniedError);
+  });
+
+  it("carries a deterministic reason code per denial cause", () => {
+    try {
+      assertPrincipalAuthenticatable(principal({ status: "expired" }));
+      throw new Error("expected denial");
+    } catch (error) {
+      expect(error).toBeInstanceOf(PrincipalDeniedError);
+      expect((error as PrincipalDeniedError).reason).toBe("expired");
+    }
+  });
+});
+
+describe("assertSessionMatchesPrincipal", () => {
+  it("allows a session bound to its own principal and business", () => {
+    expect(() => assertSessionMatchesPrincipal(session(), principal())).not.toThrow();
+  });
+
+  it("denies substitution across a business boundary", () => {
+    const other = principal({ businessId: "business-2" });
+    expect(() => assertSessionMatchesPrincipal(session(), other)).toThrow(PrincipalDeniedError);
+  });
+
+  it("denies substitution with a different principal in the same business", () => {
+    const other = principal({ id: "principal-2" });
+    expect(() => assertSessionMatchesPrincipal(session(), other)).toThrow(PrincipalDeniedError);
+  });
+
+  it("denies an expired session even for the correct principal", () => {
+    const expiredSession = session({ expiresAt: new Date(Date.now() - 1_000) });
+    expect(() => assertSessionMatchesPrincipal(expiredSession, principal())).toThrow(
+      PrincipalDeniedError
+    );
+  });
+});

--- a/packages/authz/src/principals.ts
+++ b/packages/authz/src/principals.ts
@@ -1,0 +1,75 @@
+/**
+ * Distinct principal kinds SPEC §12 requires (user/Agent/Routine/integration adapter/API/service),
+ * plus the checks that keep a disabled, expired, or business-mismatched principal from
+ * authenticating or substituting for another (SPEC §12 non-amplification, §24 confused-deputy).
+ */
+
+export type PrincipalKind =
+  | "user"
+  | "agent"
+  | "routine"
+  | "integration_adapter"
+  | "api"
+  | "service";
+
+export type PrincipalStatus = "active" | "disabled" | "expired";
+
+export interface Principal {
+  readonly id: string;
+  readonly businessId: string;
+  readonly kind: PrincipalKind;
+  readonly status: PrincipalStatus;
+  /** Absent for principals without a fixed lease/expiry (e.g. a standing user account). */
+  readonly expiresAt?: Date;
+}
+
+/** A session's durable binding to the principal it was issued for. */
+export interface SessionBinding {
+  readonly sid: string;
+  readonly principalId: string;
+  readonly businessId: string;
+  readonly expiresAt: Date;
+}
+
+export type PrincipalDenialReason = "disabled" | "expired" | "substitution";
+
+export class PrincipalDeniedError extends Error {
+  constructor(
+    public readonly reason: PrincipalDenialReason,
+    message: string
+  ) {
+    super(message);
+    this.name = "PrincipalDeniedError";
+  }
+}
+
+/** Throws when the principal cannot authenticate: disabled, or past its recorded expiry. */
+export function assertPrincipalAuthenticatable(principal: Principal, now: Date = new Date()): void {
+  if (principal.status === "disabled") {
+    throw new PrincipalDeniedError("disabled", `principal ${principal.id} is disabled`);
+  }
+  if (principal.status === "expired" || (principal.expiresAt && principal.expiresAt <= now)) {
+    throw new PrincipalDeniedError("expired", `principal ${principal.id} has expired`);
+  }
+}
+
+/**
+ * Throws unless `session` was issued for exactly `principal` — same principal id, same
+ * business_id, not expired. A session never authenticates a different principal or crosses a
+ * business boundary (SPEC §12 non-amplification).
+ */
+export function assertSessionMatchesPrincipal(
+  session: SessionBinding,
+  principal: Principal,
+  now: Date = new Date()
+): void {
+  if (session.expiresAt <= now) {
+    throw new PrincipalDeniedError("expired", `session ${session.sid} has expired`);
+  }
+  if (session.principalId !== principal.id || session.businessId !== principal.businessId) {
+    throw new PrincipalDeniedError(
+      "substitution",
+      `session ${session.sid} does not authenticate principal ${principal.id}`
+    );
+  }
+}

--- a/packages/storage/src/auth/index.ts
+++ b/packages/storage/src/auth/index.ts
@@ -1,0 +1,9 @@
+export type {
+  PrincipalKind,
+  PrincipalRecord,
+  PrincipalRepo,
+  PrincipalStatus,
+} from "./principal-repo";
+export { InMemoryPrincipalRepo } from "./principal-repo";
+export type { SessionRecord, SessionRepo } from "./session-repo";
+export { InMemorySessionRepo } from "./session-repo";

--- a/packages/storage/src/auth/principal-repo.test.ts
+++ b/packages/storage/src/auth/principal-repo.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { InMemoryPrincipalRepo, type PrincipalRecord } from "./principal-repo";
+
+function record(overrides: Partial<PrincipalRecord> = {}): PrincipalRecord {
+  return {
+    id: "principal-1",
+    businessId: "business-1",
+    kind: "user",
+    status: "active",
+    ...overrides,
+  };
+}
+
+describe("InMemoryPrincipalRepo", () => {
+  it("round-trips a stored principal by id", async () => {
+    const repo = new InMemoryPrincipalRepo();
+    await repo.put(record());
+    await expect(repo.get("principal-1")).resolves.toEqual(record());
+  });
+
+  it("returns undefined for an unknown principal", async () => {
+    const repo = new InMemoryPrincipalRepo();
+    await expect(repo.get("missing")).resolves.toBeUndefined();
+  });
+
+  it("stores every distinct principal kind with its own business_id", async () => {
+    const repo = new InMemoryPrincipalRepo();
+    const kinds: PrincipalRecord["kind"][] = [
+      "user",
+      "agent",
+      "routine",
+      "integration_adapter",
+      "api",
+      "service",
+    ];
+    for (const kind of kinds) {
+      await repo.put(record({ id: `p-${kind}`, kind, businessId: "business-9" }));
+    }
+    for (const kind of kinds) {
+      await expect(repo.get(`p-${kind}`)).resolves.toMatchObject({
+        kind,
+        businessId: "business-9",
+      });
+    }
+  });
+});

--- a/packages/storage/src/auth/principal-repo.ts
+++ b/packages/storage/src/auth/principal-repo.ts
@@ -1,0 +1,44 @@
+/**
+ * Persistence for the distinct principal kinds SPEC §12 requires — user, Agent, Routine,
+ * integration adapter, API, and service — each scoped to a business_id. Storage owns the
+ * mechanics; `@tulipfarm/authz` owns the authenticate/substitute decision.
+ */
+
+export type PrincipalKind =
+  | "user"
+  | "agent"
+  | "routine"
+  | "integration_adapter"
+  | "api"
+  | "service";
+
+export type PrincipalStatus = "active" | "disabled" | "expired";
+
+export interface PrincipalRecord {
+  readonly id: string;
+  readonly businessId: string;
+  readonly kind: PrincipalKind;
+  readonly status: PrincipalStatus;
+  readonly expiresAt?: Date;
+}
+
+export interface PrincipalRepo {
+  get(id: string): Promise<PrincipalRecord | undefined>;
+  put(record: PrincipalRecord): Promise<void>;
+}
+
+/**
+ * Process-local reference implementation for tests and single-process composition. A durable
+ * PostgreSQL adapter implements the same {@link PrincipalRepo} contract.
+ */
+export class InMemoryPrincipalRepo implements PrincipalRepo {
+  private readonly records = new Map<string, PrincipalRecord>();
+
+  async get(id: string): Promise<PrincipalRecord | undefined> {
+    return this.records.get(id);
+  }
+
+  async put(record: PrincipalRecord): Promise<void> {
+    this.records.set(record.id, Object.freeze({ ...record }));
+  }
+}

--- a/packages/storage/src/auth/session-repo.test.ts
+++ b/packages/storage/src/auth/session-repo.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { InMemorySessionRepo, type SessionRecord } from "./session-repo";
+
+function record(overrides: Partial<SessionRecord> = {}): SessionRecord {
+  return {
+    sid: "sid-1",
+    principalId: "principal-1",
+    businessId: "business-1",
+    expiresAt: new Date(Date.now() + 60_000),
+    ...overrides,
+  };
+}
+
+describe("InMemorySessionRepo", () => {
+  it("round-trips a created session by sid", async () => {
+    const repo = new InMemorySessionRepo();
+    await repo.create(record());
+    await expect(repo.get("sid-1")).resolves.toEqual(record());
+  });
+
+  it("returns undefined once the session has expired", async () => {
+    const repo = new InMemorySessionRepo();
+    await repo.create(record({ expiresAt: new Date(Date.now() - 1_000) }));
+    await expect(repo.get("sid-1")).resolves.toBeUndefined();
+  });
+
+  it("returns undefined after destroy", async () => {
+    const repo = new InMemorySessionRepo();
+    await repo.create(record());
+    await repo.destroy("sid-1");
+    await expect(repo.get("sid-1")).resolves.toBeUndefined();
+  });
+
+  it("keeps sessions for distinct principals in the same business isolated", async () => {
+    const repo = new InMemorySessionRepo();
+    await repo.create(record({ sid: "sid-a", principalId: "principal-a" }));
+    await repo.create(record({ sid: "sid-b", principalId: "principal-b" }));
+    await expect(repo.get("sid-a")).resolves.toMatchObject({ principalId: "principal-a" });
+    await expect(repo.get("sid-b")).resolves.toMatchObject({ principalId: "principal-b" });
+  });
+});

--- a/packages/storage/src/auth/session-repo.test.ts
+++ b/packages/storage/src/auth/session-repo.test.ts
@@ -14,8 +14,9 @@ function record(overrides: Partial<SessionRecord> = {}): SessionRecord {
 describe("InMemorySessionRepo", () => {
   it("round-trips a created session by sid", async () => {
     const repo = new InMemorySessionRepo();
-    await repo.create(record());
-    await expect(repo.get("sid-1")).resolves.toEqual(record());
+    const stored = record();
+    await repo.create(stored);
+    await expect(repo.get("sid-1")).resolves.toEqual(stored);
   });
 
   it("returns undefined once the session has expired", async () => {

--- a/packages/storage/src/auth/session-repo.ts
+++ b/packages/storage/src/auth/session-repo.ts
@@ -1,0 +1,41 @@
+/**
+ * Session persistence scoped to business_id (SPEC §12). Storage owns the mechanics; expiry
+ * itself is enforced here (`get` never returns an expired row) so every caller sees the same
+ * durable truth regardless of adapter.
+ */
+
+export interface SessionRecord {
+  readonly sid: string;
+  readonly principalId: string;
+  readonly businessId: string;
+  readonly expiresAt: Date;
+}
+
+export interface SessionRepo {
+  create(record: SessionRecord): Promise<void>;
+  /** Returns undefined once past `expiresAt`, even if the row has not been reaped yet. */
+  get(sid: string): Promise<SessionRecord | undefined>;
+  destroy(sid: string): Promise<void>;
+}
+
+/**
+ * Process-local reference implementation for tests and single-process composition. A durable
+ * PostgreSQL adapter implements the same {@link SessionRepo} contract.
+ */
+export class InMemorySessionRepo implements SessionRepo {
+  private readonly records = new Map<string, SessionRecord>();
+
+  async create(record: SessionRecord): Promise<void> {
+    this.records.set(record.sid, Object.freeze({ ...record }));
+  }
+
+  async get(sid: string): Promise<SessionRecord | undefined> {
+    const record = this.records.get(sid);
+    if (!record || record.expiresAt <= new Date()) return undefined;
+    return record;
+  }
+
+  async destroy(sid: string): Promise<void> {
+    this.records.delete(sid);
+  }
+}

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -1,2 +1,3 @@
+export * from "./auth";
 export * from "./ports";
 export * from "./soul";


### PR DESCRIPTION
## Summary
- Adds distinct user/Agent/Routine/integration-adapter/API/service principal kinds, business_id-scoped, with checks that deny a disabled or expired principal from authenticating (SPEC §12).
- Adds business_id-scoped session ports and a substitution check so a session can never authenticate a different principal or cross a business boundary (SPEC §12 non-amplification, §24 confused-deputy).
- Ports + in-memory reference implementations only (matches AW-012–016 precedent for this wave); Postgres adapters and apps/api schema wiring deferred to a later integration task.

## Test plan
- [x] `pnpm --filter @tulipfarm/authz --filter @tulipfarm/storage exec vitest run` — 21 tests pass
- [x] RED confirmed before implementation (missing-module failure)
- [x] `pnpm exec biome check` clean on changed files
- [x] `pnpm --filter @tulipfarm/authz --filter @tulipfarm/storage exec tsc --noEmit` clean