### PR TITLE
feat(authz): composable user/Agent roles, scoped grants, and intersection decisions (AW-018)

### DIFF
--- a/packages/authz/src/effective.test.ts
+++ b/packages/authz/src/effective.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { type AuthorityLayer, decideEffectivePermission, evaluateGrants } from "./effective";
+import type { AccessGrant, AccessRequest } from "./grants";
+
+const NOW = new Date("2026-07-23T12:00:00Z");
+
+const READ: AccessRequest = { action: "record.read", resourceType: "invoice" };
+const WRITE: AccessRequest = { action: "record.write", resourceType: "invoice" };
+
+const allowRead: AccessGrant = { action: "record.read", resourceType: "invoice", effect: "allow" };
+const allowAll: AccessGrant = { action: "*", resourceType: "*", effect: "allow" };
+const denyRead: AccessGrant = { action: "record.read", resourceType: "invoice", effect: "deny" };
+
+function layer(name: string, grants: readonly AccessGrant[]): AuthorityLayer {
+  return { name, grants };
+}
+
+describe("evaluateGrants", () => {
+  it("abstains with no matching grant (default deny at the layer)", () => {
+    expect(evaluateGrants([], READ, NOW)).toBe("abstain");
+    expect(evaluateGrants([allowRead], WRITE, NOW)).toBe("abstain");
+  });
+
+  it("allows on a matching allow", () => {
+    expect(evaluateGrants([allowRead], READ, NOW)).toBe("allow");
+  });
+
+  it("lets an explicit deny win over any matching allow", () => {
+    expect(evaluateGrants([allowAll, denyRead], READ, NOW)).toBe("deny");
+    expect(evaluateGrants([denyRead, allowAll], READ, NOW)).toBe("deny");
+  });
+
+  it("ignores an expired deny and an expired allow alike", () => {
+    const expiredDeny: AccessGrant = { ...denyRead, expiresAt: NOW };
+    expect(evaluateGrants([allowRead, expiredDeny], READ, NOW)).toBe("allow");
+    const expiredAllow: AccessGrant = { ...allowRead, expiresAt: NOW };
+    expect(evaluateGrants([expiredAllow], READ, NOW)).toBe("abstain");
+  });
+});
+
+describe("decideEffectivePermission", () => {
+  it("denies with no layers (fail closed)", () => {
+    const decision = decideEffectivePermission([], READ, NOW);
+    expect(decision.allowed).toBe(false);
+    expect(decision.reason).toBe("no_layers");
+  });
+
+  it("allows only when every layer allows", () => {
+    const decision = decideEffectivePermission(
+      [layer("user", [allowRead]), layer("agent", [allowAll]), layer("credential", [allowRead])],
+      READ,
+      NOW
+    );
+    expect(decision).toEqual({ allowed: true, reason: "allowed" });
+  });
+
+  it("denies when any layer has no matching allow, naming the layer", () => {
+    const decision = decideEffectivePermission(
+      [layer("user", [allowRead]), layer("agent", [])],
+      READ,
+      NOW
+    );
+    expect(decision).toEqual({
+      allowed: false,
+      reason: "no_matching_allow",
+      deniedLayer: "agent",
+    });
+  });
+
+  it("lets one layer's explicit deny beat every other layer's allow", () => {
+    const decision = decideEffectivePermission(
+      [layer("user", [allowAll]), layer("guardrail", [allowAll, denyRead])],
+      READ,
+      NOW
+    );
+    expect(decision).toEqual({ allowed: false, reason: "explicit_deny", deniedLayer: "guardrail" });
+  });
+
+  it("never unions: adding a broader layer cannot flip a denial", () => {
+    const denied = [layer("user", [allowRead]), layer("agent", [])];
+    expect(decideEffectivePermission(denied, READ, NOW).allowed).toBe(false);
+    const withBroadTeam = [...denied, layer("team", [allowAll])];
+    expect(decideEffectivePermission(withBroadTeam, READ, NOW).allowed).toBe(false);
+  });
+
+  it("only narrows for child Runs: child layers can drop but never add authority", () => {
+    const parent = [layer("user", [allowAll]), layer("agent", [allowAll])];
+    expect(decideEffectivePermission(parent, WRITE, NOW).allowed).toBe(true);
+
+    const child = [...parent, layer("child-contract", [allowRead])];
+    expect(decideEffectivePermission(child, READ, NOW).allowed).toBe(true);
+    expect(decideEffectivePermission(child, WRITE, NOW).allowed).toBe(false);
+  });
+});

--- a/packages/authz/src/effective.ts
+++ b/packages/authz/src/effective.ts
@@ -1,0 +1,72 @@
+/**
+ * Effective permission is the intersection of authority layers (invoking identity, Agent, Run
+ * Context, Tool/target Guardrail, AccessGrant/Credential scope — SPEC §12): every layer must
+ * independently allow, an explicit deny in any layer wins, and adding a layer can only narrow.
+ * Teams, delegation, and Agents therefore never union authority (SPEC §5.3, §10). The decision
+ * carries deterministic reason codes and the denying layer name as audit evidence — never
+ * request payloads.
+ */
+
+import { type AccessGrant, type AccessRequest, grantMatches } from "./grants";
+
+/** One layer's verdict: an explicit deny, an allow, or no matching grant at all. */
+export type GrantOutcome = "allow" | "deny" | "abstain";
+
+/**
+ * Evaluates one layer's grants against `request`. Any matching deny wins over every matching
+ * allow; with no matching grant the layer abstains — which the intersection treats as a denial
+ * (default deny).
+ */
+export function evaluateGrants(
+  grants: readonly AccessGrant[],
+  request: AccessRequest,
+  now: Date
+): GrantOutcome {
+  let outcome: GrantOutcome = "abstain";
+  for (const grant of grants) {
+    if (!grantMatches(grant, request, now)) continue;
+    if (grant.effect === "deny") return "deny";
+    outcome = "allow";
+  }
+  return outcome;
+}
+
+/** A named authority source contributing to the intersection (e.g. "user", "agent"). */
+export interface AuthorityLayer {
+  readonly name: string;
+  readonly grants: readonly AccessGrant[];
+}
+
+export type AuthzDecisionReason = "allowed" | "no_layers" | "explicit_deny" | "no_matching_allow";
+
+export interface AuthzDecision {
+  readonly allowed: boolean;
+  readonly reason: AuthzDecisionReason;
+  /** Name of the first layer that denied; absent when allowed or when no layers were given. */
+  readonly deniedLayer?: string;
+}
+
+/**
+ * Intersects `layers` over `request`: allowed only when every layer allows. An explicit deny
+ * or a missing allow in any layer denies, naming that layer. No layers at all denies
+ * (fail closed).
+ */
+export function decideEffectivePermission(
+  layers: readonly AuthorityLayer[],
+  request: AccessRequest,
+  now: Date = new Date()
+): AuthzDecision {
+  if (layers.length === 0) {
+    return { allowed: false, reason: "no_layers" };
+  }
+  for (const layer of layers) {
+    const outcome = evaluateGrants(layer.grants, request, now);
+    if (outcome === "deny") {
+      return { allowed: false, reason: "explicit_deny", deniedLayer: layer.name };
+    }
+    if (outcome === "abstain") {
+      return { allowed: false, reason: "no_matching_allow", deniedLayer: layer.name };
+    }
+  }
+  return { allowed: true, reason: "allowed" };
+}

--- a/packages/authz/src/grants.test.ts
+++ b/packages/authz/src/grants.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { type AccessGrant, type AccessRequest, grantMatches } from "./grants";
+
+const NOW = new Date("2026-07-23T12:00:00Z");
+
+function grant(overrides: Partial<AccessGrant> = {}): AccessGrant {
+  return {
+    action: "record.read",
+    resourceType: "invoice",
+    effect: "allow",
+    ...overrides,
+  };
+}
+
+function request(overrides: Partial<AccessRequest> = {}): AccessRequest {
+  return {
+    action: "record.read",
+    resourceType: "invoice",
+    ...overrides,
+  };
+}
+
+describe("grantMatches", () => {
+  it("matches an exact action and resource type", () => {
+    expect(grantMatches(grant(), request(), NOW)).toBe(true);
+  });
+
+  it("does not match a different action or resource type", () => {
+    expect(grantMatches(grant(), request({ action: "record.delete" }), NOW)).toBe(false);
+    expect(grantMatches(grant(), request({ resourceType: "customer" }), NOW)).toBe(false);
+  });
+
+  it("matches wildcard action and resource type", () => {
+    const wildcard = grant({ action: "*", resourceType: "*" });
+    expect(grantMatches(wildcard, request({ action: "record.delete" }), NOW)).toBe(true);
+    expect(grantMatches(wildcard, request({ resourceType: "customer" }), NOW)).toBe(true);
+  });
+
+  it("never matches at or past its expiry", () => {
+    const expiring = grant({ expiresAt: NOW });
+    expect(grantMatches(expiring, request(), NOW)).toBe(false);
+    const live = grant({ expiresAt: new Date(NOW.getTime() + 1) });
+    expect(grantMatches(live, request(), NOW)).toBe(true);
+  });
+
+  it("scopes to a record selector and fails closed without a record id", () => {
+    const scoped = grant({ recordSelector: "rec-1" });
+    expect(grantMatches(scoped, request({ recordId: "rec-1" }), NOW)).toBe(true);
+    expect(grantMatches(scoped, request({ recordId: "rec-2" }), NOW)).toBe(false);
+    expect(grantMatches(scoped, request(), NOW)).toBe(false);
+  });
+
+  it("scopes to a field selector and fails closed on a whole-record request", () => {
+    const scoped = grant({ fieldSelector: ["email"] });
+    expect(grantMatches(scoped, request({ field: "email" }), NOW)).toBe(true);
+    expect(grantMatches(scoped, request({ field: "salary" }), NOW)).toBe(false);
+    expect(grantMatches(scoped, request(), NOW)).toBe(false);
+  });
+
+  it("scopes to data class and destination, failing closed when the request omits them", () => {
+    const scoped = grant({ dataClass: "pii", destination: "internal" });
+    expect(grantMatches(scoped, request({ dataClass: "pii", destination: "internal" }), NOW)).toBe(
+      true
+    );
+    expect(grantMatches(scoped, request({ dataClass: "pii" }), NOW)).toBe(false);
+    expect(grantMatches(scoped, request({ destination: "internal" }), NOW)).toBe(false);
+  });
+
+  it("requires every grant condition to match the request context exactly", () => {
+    const scoped = grant({ conditions: { channel: "web" } });
+    expect(grantMatches(scoped, request({ conditions: { channel: "web" } }), NOW)).toBe(true);
+    expect(grantMatches(scoped, request({ conditions: { channel: "slack" } }), NOW)).toBe(false);
+    expect(grantMatches(scoped, request(), NOW)).toBe(false);
+  });
+
+  it("matches deny grants with the same scoping rules", () => {
+    const deny = grant({ effect: "deny", recordSelector: "rec-1" });
+    expect(grantMatches(deny, request({ recordId: "rec-1" }), NOW)).toBe(true);
+    expect(grantMatches(deny, request({ recordId: "rec-2" }), NOW)).toBe(false);
+  });
+});

--- a/packages/authz/src/grants.ts
+++ b/packages/authz/src/grants.ts
@@ -1,0 +1,72 @@
+/**
+ * AccessGrant shape and matching per SPEC §12: a grant scopes an action to Resource
+ * type/Record selector, field selector, data class, destination, conditions, and expiry, with
+ * an explicit allow/deny effect. Matching fails closed: a scoped grant never matches a request
+ * that omits the scoped dimension, for allow and deny alike, so scoping is deterministic and a
+ * grant cannot silently widen (SPEC §12 non-amplification, §24 fail-closed defaults).
+ */
+
+export type GrantEffect = "allow" | "deny";
+
+export interface AccessGrant {
+  /** Action identifier (e.g. "record.read") or "*" for any action. */
+  readonly action: string;
+  /** Resource type name or "*" for any type. */
+  readonly resourceType: string;
+  /** Specific Record id; absent or "*" covers every Record of the type. */
+  readonly recordSelector?: string;
+  /** Fields covered; absent covers every field. Present, it only matches field-level requests. */
+  readonly fieldSelector?: readonly string[];
+  /** Data classification the grant is scoped to; absent covers any classification. */
+  readonly dataClass?: string;
+  /** Destination/audience the grant is scoped to; absent covers any destination. */
+  readonly destination?: string;
+  /** Context conditions; every entry must equal the request's context value to match. */
+  readonly conditions?: Readonly<Record<string, string>>;
+  readonly effect: GrantEffect;
+  /** The grant stops matching at this instant; absent means no expiry. */
+  readonly expiresAt?: Date;
+}
+
+/** The concrete access being decided; absent optional dimensions mean "not narrowed here". */
+export interface AccessRequest {
+  readonly action: string;
+  readonly resourceType: string;
+  readonly recordId?: string;
+  readonly field?: string;
+  readonly dataClass?: string;
+  readonly destination?: string;
+  readonly conditions?: Readonly<Record<string, string>>;
+}
+
+/**
+ * True when `grant` covers `request` at `now`. Expired grants never match. Each scoped
+ * dimension on the grant requires an equal value on the request — a request that omits a
+ * scoped dimension does not match (fail closed).
+ */
+export function grantMatches(grant: AccessGrant, request: AccessRequest, now: Date): boolean {
+  if (grant.expiresAt && grant.expiresAt <= now) return false;
+  if (grant.action !== "*" && grant.action !== request.action) return false;
+  if (grant.resourceType !== "*" && grant.resourceType !== request.resourceType) return false;
+  if (
+    grant.recordSelector !== undefined &&
+    grant.recordSelector !== "*" &&
+    grant.recordSelector !== request.recordId
+  ) {
+    return false;
+  }
+  if (
+    grant.fieldSelector !== undefined &&
+    (request.field === undefined || !grant.fieldSelector.includes(request.field))
+  ) {
+    return false;
+  }
+  if (grant.dataClass !== undefined && grant.dataClass !== request.dataClass) return false;
+  if (grant.destination !== undefined && grant.destination !== request.destination) return false;
+  if (grant.conditions) {
+    for (const [key, value] of Object.entries(grant.conditions)) {
+      if (request.conditions?.[key] !== value) return false;
+    }
+  }
+  return true;
+}

--- a/packages/authz/src/index.ts
+++ b/packages/authz/src/index.ts
@@ -1,4 +1,13 @@
 export type {
+  AuthorityLayer,
+  AuthzDecision,
+  AuthzDecisionReason,
+  GrantOutcome,
+} from "./effective";
+export { decideEffectivePermission, evaluateGrants } from "./effective";
+export type { AccessGrant, AccessRequest, GrantEffect } from "./grants";
+export { grantMatches } from "./grants";
+export type {
   IdentityPort,
   IdentityResolution,
   IdentityResolutionRequest,
@@ -15,3 +24,12 @@ export {
   assertSessionMatchesPrincipal,
   PrincipalDeniedError,
 } from "./principals";
+export type { Role, RoleAssignableTo, RoleAssignmentDenialReason } from "./roles";
+export {
+  assertRoleAssignable,
+  assertRoleGraphAcyclic,
+  collectRoleGrants,
+  RoleAssignmentError,
+  RoleCycleError,
+  RoleResolutionError,
+} from "./roles";

--- a/packages/authz/src/roles.test.ts
+++ b/packages/authz/src/roles.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertRoleAssignable,
+  assertRoleGraphAcyclic,
+  collectRoleGrants,
+  type Role,
+  RoleAssignmentError,
+  RoleCycleError,
+  RoleResolutionError,
+} from "./roles";
+
+const NOW = new Date("2026-07-23T12:00:00Z");
+
+function role(overrides: Partial<Role> = {}): Role {
+  return {
+    id: "role-1",
+    businessId: "business-1",
+    assignableTo: "user",
+    parentRoleIds: [],
+    grants: [],
+    ...overrides,
+  };
+}
+
+function byId(roles: readonly Role[]): ReadonlyMap<string, Role> {
+  return new Map(roles.map((r) => [r.id, r]));
+}
+
+describe("assertRoleGraphAcyclic", () => {
+  it("accepts a diamond-shaped acyclic composition", () => {
+    const roles = [
+      role({ id: "top", parentRoleIds: ["left", "right"] }),
+      role({ id: "left", parentRoleIds: ["base"] }),
+      role({ id: "right", parentRoleIds: ["base"] }),
+      role({ id: "base" }),
+    ];
+    expect(() => assertRoleGraphAcyclic(roles)).not.toThrow();
+  });
+
+  it("rejects a self-referencing role", () => {
+    expect(() => assertRoleGraphAcyclic([role({ id: "a", parentRoleIds: ["a"] })])).toThrow(
+      RoleCycleError
+    );
+  });
+
+  it("rejects an indirect cycle", () => {
+    const roles = [
+      role({ id: "a", parentRoleIds: ["b"] }),
+      role({ id: "b", parentRoleIds: ["c"] }),
+      role({ id: "c", parentRoleIds: ["a"] }),
+    ];
+    expect(() => assertRoleGraphAcyclic(roles)).toThrow(RoleCycleError);
+  });
+});
+
+describe("assertRoleAssignable", () => {
+  const user = { kind: "user", businessId: "business-1" } as const;
+  const agent = { kind: "agent", businessId: "business-1" } as const;
+
+  it("allows a user role for a user and an agent role for an Agent", () => {
+    expect(() => assertRoleAssignable(role(), user, NOW)).not.toThrow();
+    expect(() => assertRoleAssignable(role({ assignableTo: "agent" }), agent, NOW)).not.toThrow();
+  });
+
+  it("allows a both role for either kind", () => {
+    expect(() => assertRoleAssignable(role({ assignableTo: "both" }), user, NOW)).not.toThrow();
+    expect(() => assertRoleAssignable(role({ assignableTo: "both" }), agent, NOW)).not.toThrow();
+  });
+
+  it("denies a user role for an Agent and vice versa", () => {
+    expect(() => assertRoleAssignable(role(), agent, NOW)).toThrow(RoleAssignmentError);
+    expect(() => assertRoleAssignable(role({ assignableTo: "agent" }), user, NOW)).toThrow(
+      RoleAssignmentError
+    );
+  });
+
+  it("denies kinds outside user/agent even for a both role", () => {
+    const service = { kind: "service", businessId: "business-1" } as const;
+    expect(() => assertRoleAssignable(role({ assignableTo: "both" }), service, NOW)).toThrow(
+      RoleAssignmentError
+    );
+  });
+
+  it("denies assignment across a business boundary", () => {
+    const other = { kind: "user", businessId: "business-2" } as const;
+    try {
+      assertRoleAssignable(role(), other, NOW);
+      throw new Error("expected denial");
+    } catch (error) {
+      expect(error).toBeInstanceOf(RoleAssignmentError);
+      expect((error as RoleAssignmentError).reason).toBe("business_mismatch");
+    }
+  });
+
+  it("denies an expired role", () => {
+    const expired = role({ expiresAt: NOW });
+    expect(() => assertRoleAssignable(expired, user, NOW)).toThrow(RoleAssignmentError);
+  });
+});
+
+describe("collectRoleGrants", () => {
+  const readGrant = { action: "record.read", resourceType: "invoice", effect: "allow" } as const;
+  const writeGrant = { action: "record.write", resourceType: "invoice", effect: "allow" } as const;
+
+  it("flattens grants across composed roles", () => {
+    const roles = byId([
+      role({ id: "child", parentRoleIds: ["parent"], grants: [readGrant] }),
+      role({ id: "parent", grants: [writeGrant] }),
+    ]);
+    const grants = collectRoleGrants(["child"], roles, NOW);
+    expect(grants).toEqual(expect.arrayContaining([readGrant, writeGrant]));
+    expect(grants).toHaveLength(2);
+  });
+
+  it("fails closed on an unknown role reference", () => {
+    const roles = byId([role({ id: "child", parentRoleIds: ["missing"] })]);
+    expect(() => collectRoleGrants(["child"], roles, NOW)).toThrow(RoleResolutionError);
+  });
+
+  it("fails closed on a cyclic composition", () => {
+    const roles = byId([
+      role({ id: "a", parentRoleIds: ["b"] }),
+      role({ id: "b", parentRoleIds: ["a"] }),
+    ]);
+    expect(() => collectRoleGrants(["a"], roles, NOW)).toThrow(RoleCycleError);
+  });
+
+  it("contributes nothing from an expired role, including its parents", () => {
+    const roles = byId([
+      role({ id: "dead", parentRoleIds: ["parent"], grants: [readGrant], expiresAt: NOW }),
+      role({ id: "parent", grants: [writeGrant] }),
+    ]);
+    expect(collectRoleGrants(["dead"], roles, NOW)).toEqual([]);
+  });
+
+  it("visits a shared parent once in a diamond", () => {
+    const roles = byId([
+      role({ id: "top", parentRoleIds: ["left", "right"] }),
+      role({ id: "left", parentRoleIds: ["base"] }),
+      role({ id: "right", parentRoleIds: ["base"] }),
+      role({ id: "base", grants: [readGrant] }),
+    ]);
+    expect(collectRoleGrants(["top"], roles, NOW)).toEqual([readGrant]);
+  });
+});

--- a/packages/authz/src/roles.ts
+++ b/packages/authz/src/roles.ts
@@ -1,0 +1,124 @@
+/**
+ * Custom composable roles per SPEC §12: administrators define roles assignable to users,
+ * Agents, or both; roles compose through parents but must stay cycle-free; assignment never
+ * crosses a business boundary or a principal-kind boundary. Resolution fails closed — an
+ * unknown or cyclic reference is an error, and an expired role contributes nothing.
+ */
+
+import type { AccessGrant } from "./grants";
+import type { Principal } from "./principals";
+
+export type RoleAssignableTo = "user" | "agent" | "both";
+
+export interface Role {
+  readonly id: string;
+  readonly businessId: string;
+  readonly assignableTo: RoleAssignableTo;
+  /** Composed parent roles whose grants this role inherits. */
+  readonly parentRoleIds: readonly string[];
+  readonly grants: readonly AccessGrant[];
+  /** The role stops granting anything at this instant; absent means no expiry. */
+  readonly expiresAt?: Date;
+}
+
+export class RoleCycleError extends Error {
+  constructor(public readonly cycle: readonly string[]) {
+    super(`role composition cycle: ${cycle.join(" -> ")}`);
+    this.name = "RoleCycleError";
+  }
+}
+
+export class RoleResolutionError extends Error {
+  constructor(public readonly roleId: string) {
+    super(`role ${roleId} does not exist`);
+    this.name = "RoleResolutionError";
+  }
+}
+
+export type RoleAssignmentDenialReason = "kind_mismatch" | "business_mismatch" | "expired";
+
+export class RoleAssignmentError extends Error {
+  constructor(
+    public readonly reason: RoleAssignmentDenialReason,
+    message: string
+  ) {
+    super(message);
+    this.name = "RoleAssignmentError";
+  }
+}
+
+/** Throws {@link RoleCycleError} when any composition path in `roles` revisits a role. */
+export function assertRoleGraphAcyclic(roles: readonly Role[]): void {
+  const byId = new Map(roles.map((role) => [role.id, role]));
+  const done = new Set<string>();
+  const visit = (id: string, path: readonly string[]): void => {
+    if (path.includes(id)) {
+      throw new RoleCycleError([...path.slice(path.indexOf(id)), id]);
+    }
+    if (done.has(id)) return;
+    const role = byId.get(id);
+    if (role) {
+      for (const parentId of role.parentRoleIds) visit(parentId, [...path, id]);
+    }
+    done.add(id);
+  };
+  for (const role of roles) visit(role.id, []);
+}
+
+/**
+ * Throws unless `role` may be assigned to `principal` at `now`: the kinds must agree with
+ * `assignableTo` (only user and Agent principals ever take these roles), the business must
+ * match, and the role must not be expired (SPEC §12).
+ */
+export function assertRoleAssignable(
+  role: Role,
+  principal: Pick<Principal, "kind" | "businessId">,
+  now: Date = new Date()
+): void {
+  if (role.businessId !== principal.businessId) {
+    throw new RoleAssignmentError(
+      "business_mismatch",
+      `role ${role.id} belongs to a different business than the principal`
+    );
+  }
+  if (role.expiresAt && role.expiresAt <= now) {
+    throw new RoleAssignmentError("expired", `role ${role.id} has expired`);
+  }
+  const kindAllowed =
+    (principal.kind === "user" && role.assignableTo !== "agent") ||
+    (principal.kind === "agent" && role.assignableTo !== "user");
+  if (!kindAllowed) {
+    throw new RoleAssignmentError(
+      "kind_mismatch",
+      `role ${role.id} (${role.assignableTo}) is not assignable to a ${principal.kind} principal`
+    );
+  }
+}
+
+/**
+ * Flattens the grants of `roleIds` and their composed parents. Fails closed: an unknown role
+ * throws {@link RoleResolutionError}, a cycle throws {@link RoleCycleError}, and an expired
+ * role contributes nothing (its parents included). Each role is visited once.
+ */
+export function collectRoleGrants(
+  roleIds: readonly string[],
+  rolesById: ReadonlyMap<string, Role>,
+  now: Date = new Date()
+): AccessGrant[] {
+  const grants: AccessGrant[] = [];
+  const done = new Set<string>();
+  const visit = (id: string, path: readonly string[]): void => {
+    if (path.includes(id)) {
+      throw new RoleCycleError([...path.slice(path.indexOf(id)), id]);
+    }
+    if (done.has(id)) return;
+    done.add(id);
+    const role = rolesById.get(id);
+    if (!role) throw new RoleResolutionError(id);
+    if (role.expiresAt && role.expiresAt <= now) return;
+    grants.push(...role.grants);
+    for (const parentId of role.parentRoleIds) visit(parentId, [...path, id]);
+  };
+  for (const id of roleIds) visit(id, []);
+  return grants;
+}

--- a/packages/storage/src/auth/index.ts
+++ b/packages/storage/src/auth/index.ts
@@ -5,5 +5,14 @@ export type {
   PrincipalStatus,
 } from "./principal-repo";
 export { InMemoryPrincipalRepo } from "./principal-repo";
+export type {
+  GrantEffect,
+  GrantRecord,
+  RoleAssignableTo,
+  RoleAssignmentRecord,
+  RoleRecord,
+  RoleRepo,
+} from "./role-repo";
+export { InMemoryRoleRepo } from "./role-repo";
 export type { SessionRecord, SessionRepo } from "./session-repo";
 export { InMemorySessionRepo } from "./session-repo";

--- a/packages/storage/src/auth/role-repo.test.ts
+++ b/packages/storage/src/auth/role-repo.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { InMemoryRoleRepo, type RoleAssignmentRecord, type RoleRecord } from "./role-repo";
+
+function roleRecord(overrides: Partial<RoleRecord> = {}): RoleRecord {
+  return {
+    id: "role-1",
+    businessId: "business-1",
+    assignableTo: "user",
+    parentRoleIds: [],
+    grants: [{ action: "record.read", resourceType: "invoice", effect: "allow" }],
+    ...overrides,
+  };
+}
+
+function assignment(overrides: Partial<RoleAssignmentRecord> = {}): RoleAssignmentRecord {
+  return {
+    principalId: "principal-1",
+    roleId: "role-1",
+    businessId: "business-1",
+    ...overrides,
+  };
+}
+
+describe("InMemoryRoleRepo", () => {
+  it("round-trips a role record and returns undefined for an unknown id", async () => {
+    const repo = new InMemoryRoleRepo();
+    const record = roleRecord();
+    await repo.putRole(record);
+    expect(await repo.getRole("role-1")).toEqual(record);
+    expect(await repo.getRole("missing")).toBeUndefined();
+  });
+
+  it("lists a principal's assignments", async () => {
+    const repo = new InMemoryRoleRepo();
+    await repo.assign(assignment());
+    await repo.assign(assignment({ roleId: "role-2" }));
+    await repo.assign(assignment({ principalId: "principal-2", roleId: "role-3" }));
+    const listed = await repo.listAssignments("principal-1");
+    expect(listed.map((a) => a.roleId).sort()).toEqual(["role-1", "role-2"]);
+  });
+
+  it("never lists an expired assignment", async () => {
+    const repo = new InMemoryRoleRepo();
+    await repo.assign(assignment({ expiresAt: new Date(Date.now() - 1_000) }));
+    expect(await repo.listAssignments("principal-1")).toEqual([]);
+  });
+});

--- a/packages/storage/src/auth/role-repo.ts
+++ b/packages/storage/src/auth/role-repo.ts
@@ -1,0 +1,74 @@
+/**
+ * Persistence for custom composable roles and role assignments (SPEC §12), scoped to a
+ * business_id. Storage owns the mechanics; `@tulipfarm/authz` owns cycle checks, assignability,
+ * and the effective-permission decision. Assignment expiry is enforced here (`listAssignments`
+ * never returns an expired row) so every caller sees the same durable truth.
+ */
+
+export type RoleAssignableTo = "user" | "agent" | "both";
+
+export type GrantEffect = "allow" | "deny";
+
+export interface GrantRecord {
+  readonly action: string;
+  readonly resourceType: string;
+  readonly recordSelector?: string;
+  readonly fieldSelector?: readonly string[];
+  readonly dataClass?: string;
+  readonly destination?: string;
+  readonly conditions?: Readonly<Record<string, string>>;
+  readonly effect: GrantEffect;
+  readonly expiresAt?: Date;
+}
+
+export interface RoleRecord {
+  readonly id: string;
+  readonly businessId: string;
+  readonly assignableTo: RoleAssignableTo;
+  readonly parentRoleIds: readonly string[];
+  readonly grants: readonly GrantRecord[];
+  readonly expiresAt?: Date;
+}
+
+export interface RoleAssignmentRecord {
+  readonly principalId: string;
+  readonly roleId: string;
+  readonly businessId: string;
+  readonly expiresAt?: Date;
+}
+
+export interface RoleRepo {
+  getRole(id: string): Promise<RoleRecord | undefined>;
+  putRole(record: RoleRecord): Promise<void>;
+  assign(record: RoleAssignmentRecord): Promise<void>;
+  /** Only unexpired assignments, even if expired rows have not been reaped yet. */
+  listAssignments(principalId: string): Promise<RoleAssignmentRecord[]>;
+}
+
+/**
+ * Process-local reference implementation for tests and single-process composition. A durable
+ * PostgreSQL adapter implements the same {@link RoleRepo} contract.
+ */
+export class InMemoryRoleRepo implements RoleRepo {
+  private readonly roles = new Map<string, RoleRecord>();
+  private readonly assignments: RoleAssignmentRecord[] = [];
+
+  async getRole(id: string): Promise<RoleRecord | undefined> {
+    return this.roles.get(id);
+  }
+
+  async putRole(record: RoleRecord): Promise<void> {
+    this.roles.set(record.id, Object.freeze({ ...record }));
+  }
+
+  async assign(record: RoleAssignmentRecord): Promise<void> {
+    this.assignments.push(Object.freeze({ ...record }));
+  }
+
+  async listAssignments(principalId: string): Promise<RoleAssignmentRecord[]> {
+    const now = new Date();
+    return this.assignments.filter(
+      (a) => a.principalId === principalId && (!a.expiresAt || a.expiresAt > now)
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- Implements AW-018: custom roles assignable to users, Agents, or both, with cycle-free composition (`assertRoleGraphAcyclic`, `collectRoleGrants`), kind/business/expiry-checked assignment, and fail-closed resolution (unknown reference throws, expired role contributes nothing).
- Adds scoped `AccessGrant` matching (action, resource type, record, field, data class, destination, conditions, expiry) with explicit allow/deny, and `decideEffectivePermission` — a strict intersection of named authority layers where explicit deny wins, every layer must allow, and zero layers deny. Teams, children, and Agents never union permissions (SPEC §12).
- Adds a `RoleRepo` storage port (`RoleRecord`/`GrantRecord`/`RoleAssignmentRecord`) with an in-memory reference implementation following the AW-017 principal-repo pattern; `listAssignments` never returns expired rows.

## Test plan

- [x] RED observed: new authz test files failed on missing modules before implementation
- [x] `pnpm exec vitest run` in `packages/authz` — 5 files, 42 tests pass (deny-wins, default-deny, no-union, child-narrow-only, cycle, expiry, business-boundary cases)
- [x] `pnpm exec vitest run` in `packages/storage` — 6 files, 19 tests pass
- [x] `pnpm --filter @tulipfarm/authz typecheck` and `pnpm --filter @tulipfarm/storage typecheck` clean
- [x] `pnpm exec biome check packages/authz packages/storage` clean