### PR TITLE
feat(authz): default-deny Guardrail engine, risk ceilings, and DLP boundary decisions (AW-019)

### DIFF
--- a/packages/authz/src/guardrails/decision.ts
+++ b/packages/authz/src/guardrails/decision.ts
@@ -1,0 +1,35 @@
+/**
+ * Guardrail decision contract (SPEC §12, §20, §24). Decisions are deterministic and carry only
+ * safe reason evidence: a reason code, the deciding rule id, the failing dimension name, or a
+ * data classification name. Context values (record ids, destinations, field contents, payloads,
+ * Secrets) never appear in a decision, so denial evidence cannot reveal protected content
+ * (SPEC §13 DLP, §20 audit reason codes).
+ */
+
+export type GuardrailEffect = "allow" | "deny" | "require_approval";
+
+export type GuardrailDecisionReason =
+  | "allowed"
+  | "approval_required"
+  | "explicit_deny"
+  | "no_matching_rule"
+  | "missing_context"
+  | "volume_exceeded"
+  | "taint_exceeded"
+  | "autonomy_exceeded"
+  | "unclassified_data"
+  | "no_dlp_rule"
+  | "destination_not_allowed"
+  | "audience_not_allowed"
+  | "secret_detected";
+
+export interface GuardrailDecision {
+  readonly effect: GuardrailEffect;
+  readonly reason: GuardrailDecisionReason;
+  /** Id of the rule that decided (denied, required approval, or allowed), when one did. */
+  readonly ruleId?: string;
+  /** Name of the Context dimension that failed a ceiling (e.g. "recordCount", "taint"). */
+  readonly dimension?: string;
+  /** Data classification name a DLP denial is about — the class name, never the content. */
+  readonly dataClass?: string;
+}

--- a/packages/authz/src/guardrails/dlp.test.ts
+++ b/packages/authz/src/guardrails/dlp.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { checkDlpBoundary, type DlpCrossing, type DlpRule } from "./dlp";
+
+const piiToSlack: DlpRule = {
+  dataClass: "pii",
+  allowedDestinations: ["slack"],
+  allowedAudiences: ["team"],
+};
+const internalAnywhere: DlpRule = { dataClass: "internal" };
+
+const okCrossing: DlpCrossing = {
+  dataClasses: ["pii"],
+  destination: "slack",
+  audience: "team",
+};
+
+describe("checkDlpBoundary — default deny", () => {
+  it("denies unclassified data (empty data classes are unverifiable)", () => {
+    const decision = checkDlpBoundary([piiToSlack], { ...okCrossing, dataClasses: [] });
+    expect(decision).toEqual({ effect: "deny", reason: "unclassified_data" });
+  });
+
+  it("denies a data class with no DLP rule, naming only the class", () => {
+    const decision = checkDlpBoundary([piiToSlack], {
+      ...okCrossing,
+      dataClasses: ["pii", "financial"],
+    });
+    expect(decision).toEqual({
+      effect: "deny",
+      reason: "no_dlp_rule",
+      dataClass: "financial",
+    });
+  });
+
+  it("denies a detected secret before anything else", () => {
+    const decision = checkDlpBoundary([piiToSlack], { ...okCrossing, secretDetected: true });
+    expect(decision).toEqual({ effect: "deny", reason: "secret_detected" });
+  });
+
+  it("allows only when every crossing class has a permitting rule", () => {
+    const decision = checkDlpBoundary([piiToSlack, internalAnywhere], {
+      ...okCrossing,
+      dataClasses: ["pii", "internal"],
+    });
+    expect(decision).toEqual({ effect: "allow", reason: "allowed" });
+  });
+});
+
+describe("checkDlpBoundary — destination and audience scoping", () => {
+  it("denies a destination outside the rule's allowlist", () => {
+    const decision = checkDlpBoundary([piiToSlack], { ...okCrossing, destination: "email" });
+    expect(decision).toEqual({
+      effect: "deny",
+      reason: "destination_not_allowed",
+      dataClass: "pii",
+    });
+  });
+
+  it("denies when the crossing omits a destination the rule scopes (fail closed)", () => {
+    const { destination: _destination, ...noDest } = okCrossing;
+    expect(checkDlpBoundary([piiToSlack], noDest)).toEqual({
+      effect: "deny",
+      reason: "destination_not_allowed",
+      dataClass: "pii",
+    });
+  });
+
+  it("denies an audience outside the rule's allowlist, and a missing audience alike", () => {
+    expect(checkDlpBoundary([piiToSlack], { ...okCrossing, audience: "public" })).toEqual({
+      effect: "deny",
+      reason: "audience_not_allowed",
+      dataClass: "pii",
+    });
+    const { audience: _audience, ...noAudience } = okCrossing;
+    expect(checkDlpBoundary([piiToSlack], noAudience)).toEqual({
+      effect: "deny",
+      reason: "audience_not_allowed",
+      dataClass: "pii",
+    });
+  });
+
+  it("leaves destination and audience unconstrained when the rule does not scope them", () => {
+    const decision = checkDlpBoundary([internalAnywhere], {
+      dataClasses: ["internal"],
+      destination: "anywhere",
+    });
+    expect(decision).toEqual({ effect: "allow", reason: "allowed" });
+  });
+});
+
+describe("checkDlpBoundary — safe evidence", () => {
+  it("never echoes destination or audience values in the decision", () => {
+    const decision = checkDlpBoundary([piiToSlack], {
+      dataClasses: ["pii"],
+      destination: "PROTECTED-dest",
+      audience: "PROTECTED-aud",
+    });
+    expect(decision.effect).toBe("deny");
+    expect(JSON.stringify(decision)).not.toContain("PROTECTED");
+  });
+
+  it("is deterministic for identical inputs", () => {
+    const crossing: DlpCrossing = { dataClasses: ["pii", "internal"], destination: "email" };
+    const rules = [piiToSlack, internalAnywhere];
+    expect(checkDlpBoundary(rules, crossing)).toEqual(checkDlpBoundary(rules, crossing));
+  });
+});

--- a/packages/authz/src/guardrails/dlp.ts
+++ b/packages/authz/src/guardrails/dlp.ts
@@ -1,0 +1,77 @@
+/**
+ * DLP boundary check (SPEC §13): before data crosses a model, Tool, integration, sandbox, UI,
+ * notification, or export boundary, every crossing data classification must have a DLP rule
+ * permitting the destination and audience. Default deny: unclassified data, a class with no
+ * rule, or a detected secret denies. Denials carry only the reason code and the classification
+ * name — never destination, audience, field values, or content — so a blocked response cannot
+ * reveal the protected content through its evidence.
+ */
+
+import type { GuardrailDecision } from "./decision";
+
+export interface DlpRule {
+  /** Data classification this rule permits to cross. */
+  readonly dataClass: string;
+  /** Destinations permitted; absent leaves destination unconstrained for this class. */
+  readonly allowedDestinations?: readonly string[];
+  /** Audiences permitted; absent leaves audience unconstrained for this class. */
+  readonly allowedAudiences?: readonly string[];
+}
+
+/** Data about to cross a boundary; absent dimensions mean "not established". */
+export interface DlpCrossing {
+  /** Classifications of every piece of crossing data; empty means unverifiable. */
+  readonly dataClasses: readonly string[];
+  readonly destination?: string;
+  readonly audience?: string;
+  /** True when a secret scan flagged the crossing content. */
+  readonly secretDetected?: boolean;
+}
+
+/**
+ * Decides whether `crossing` may pass. Allowed only when no secret is detected, the data is
+ * classified, and every class has a rule whose destination and audience scopes are satisfied —
+ * a scoped rule never permits a crossing that omits the scoped dimension (fail closed).
+ */
+export function checkDlpBoundary(
+  rules: readonly DlpRule[],
+  crossing: DlpCrossing
+): GuardrailDecision {
+  if (crossing.secretDetected) {
+    return { effect: "deny", reason: "secret_detected" };
+  }
+  if (crossing.dataClasses.length === 0) {
+    return { effect: "deny", reason: "unclassified_data" };
+  }
+  for (const dataClass of crossing.dataClasses) {
+    const classRules = rules.filter((rule) => rule.dataClass === dataClass);
+    if (classRules.length === 0) {
+      return { effect: "deny", reason: "no_dlp_rule", dataClass };
+    }
+    let destinationPassed = false;
+    let permitted = false;
+    for (const rule of classRules) {
+      const destinationOk =
+        rule.allowedDestinations === undefined ||
+        (crossing.destination !== undefined &&
+          rule.allowedDestinations.includes(crossing.destination));
+      if (!destinationOk) continue;
+      destinationPassed = true;
+      const audienceOk =
+        rule.allowedAudiences === undefined ||
+        (crossing.audience !== undefined && rule.allowedAudiences.includes(crossing.audience));
+      if (audienceOk) {
+        permitted = true;
+        break;
+      }
+    }
+    if (!permitted) {
+      return {
+        effect: "deny",
+        reason: destinationPassed ? "audience_not_allowed" : "destination_not_allowed",
+        dataClass,
+      };
+    }
+  }
+  return { effect: "allow", reason: "allowed" };
+}

--- a/packages/authz/src/guardrails/engine.test.ts
+++ b/packages/authz/src/guardrails/engine.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from "vitest";
+import { evaluateGuardrail, type GuardrailContext, type GuardrailRule } from "./engine";
+
+const READ: GuardrailContext = {
+  action: "record.read",
+  resourceType: "invoice",
+  autonomy: "interactive",
+  taint: "trusted",
+};
+
+const allowRead: GuardrailRule = {
+  id: "allow-read",
+  effect: "allow",
+  action: "record.read",
+  resourceType: "invoice",
+};
+const allowAll: GuardrailRule = {
+  id: "allow-all",
+  effect: "allow",
+  action: "*",
+  resourceType: "*",
+};
+const denyRead: GuardrailRule = {
+  id: "deny-read",
+  effect: "deny",
+  action: "record.read",
+  resourceType: "invoice",
+};
+
+describe("evaluateGuardrail — default deny", () => {
+  it("denies with no rules at all", () => {
+    expect(evaluateGuardrail([], READ)).toEqual({
+      effect: "deny",
+      reason: "no_matching_rule",
+    });
+  });
+
+  it("denies when no rule matches the action or Resource type", () => {
+    const decision = evaluateGuardrail([allowRead], { ...READ, action: "record.write" });
+    expect(decision).toEqual({ effect: "deny", reason: "no_matching_rule" });
+  });
+
+  it("allows on a fully matching allow rule, citing the rule", () => {
+    expect(evaluateGuardrail([allowRead], READ)).toEqual({
+      effect: "allow",
+      reason: "allowed",
+      ruleId: "allow-read",
+    });
+  });
+
+  it("lets an explicit deny win over every matching allow, regardless of order", () => {
+    for (const rules of [
+      [allowAll, denyRead],
+      [denyRead, allowAll],
+    ]) {
+      expect(evaluateGuardrail(rules, READ)).toEqual({
+        effect: "deny",
+        reason: "explicit_deny",
+        ruleId: "deny-read",
+      });
+    }
+  });
+});
+
+describe("evaluateGuardrail — scoped selectors fail closed", () => {
+  it("never matches a Record-scoped rule when the Context omits the Record", () => {
+    const scoped: GuardrailRule = { ...allowRead, id: "rec", recordSelector: "inv-1" };
+    expect(evaluateGuardrail([scoped], READ)).toEqual({
+      effect: "deny",
+      reason: "no_matching_rule",
+    });
+    expect(evaluateGuardrail([scoped], { ...READ, recordId: "inv-1" }).effect).toBe("allow");
+    expect(evaluateGuardrail([scoped], { ...READ, recordId: "inv-2" }).effect).toBe("deny");
+  });
+
+  it("never matches a field-scoped rule when the Context omits the field", () => {
+    const scoped: GuardrailRule = { ...allowRead, id: "field", fieldSelector: ["amount"] };
+    expect(evaluateGuardrail([scoped], READ).effect).toBe("deny");
+    expect(evaluateGuardrail([scoped], { ...READ, field: "amount" }).effect).toBe("allow");
+    expect(evaluateGuardrail([scoped], { ...READ, field: "ssn" }).effect).toBe("deny");
+  });
+
+  it("scopes data class, destination, and audience the same way", () => {
+    const scoped: GuardrailRule = {
+      ...allowRead,
+      id: "scoped",
+      dataClass: "internal",
+      destination: "slack",
+      audience: "team",
+    };
+    expect(evaluateGuardrail([scoped], READ).effect).toBe("deny");
+    const full = { ...READ, dataClass: "internal", destination: "slack", audience: "team" };
+    expect(evaluateGuardrail([scoped], full).effect).toBe("allow");
+    expect(evaluateGuardrail([scoped], { ...full, audience: "public" }).effect).toBe("deny");
+  });
+
+  it("applies deny-rule scoping identically, so a deny cannot silently widen", () => {
+    const scopedDeny: GuardrailRule = { ...denyRead, id: "deny-rec", recordSelector: "inv-1" };
+    expect(evaluateGuardrail([allowRead, scopedDeny], { ...READ, recordId: "inv-2" }).effect).toBe(
+      "allow"
+    );
+    expect(evaluateGuardrail([allowRead, scopedDeny], { ...READ, recordId: "inv-1" })).toEqual({
+      effect: "deny",
+      reason: "explicit_deny",
+      ruleId: "deny-rec",
+    });
+  });
+});
+
+describe("evaluateGuardrail — volume, taint, autonomy ceilings", () => {
+  it("denies when the volume ceiling is exceeded", () => {
+    const capped: GuardrailRule = { ...allowRead, id: "cap", maxRecordCount: 10 };
+    expect(evaluateGuardrail([capped], { ...READ, recordCount: 11 })).toEqual({
+      effect: "deny",
+      reason: "volume_exceeded",
+      ruleId: "cap",
+      dimension: "recordCount",
+    });
+    expect(evaluateGuardrail([capped], { ...READ, recordCount: 10 }).effect).toBe("allow");
+  });
+
+  it("denies a volume-capped rule when the Context has no record count (unverifiable)", () => {
+    const capped: GuardrailRule = { ...allowRead, id: "cap", maxRecordCount: 10 };
+    expect(evaluateGuardrail([capped], READ)).toEqual({
+      effect: "deny",
+      reason: "missing_context",
+      ruleId: "cap",
+      dimension: "recordCount",
+    });
+  });
+
+  it("denies untrusted taint above the ceiling and missing taint alike", () => {
+    const trustedOnly: GuardrailRule = { ...allowRead, id: "taint", maxTaint: "trusted" };
+    expect(evaluateGuardrail([trustedOnly], { ...READ, taint: "untrusted" })).toEqual({
+      effect: "deny",
+      reason: "taint_exceeded",
+      ruleId: "taint",
+      dimension: "taint",
+    });
+    const { taint: _taint, ...noTaint } = READ;
+    expect(evaluateGuardrail([trustedOnly], noTaint)).toEqual({
+      effect: "deny",
+      reason: "missing_context",
+      ruleId: "taint",
+      dimension: "taint",
+    });
+  });
+
+  it("denies autonomy above the ceiling and missing autonomy alike", () => {
+    const supervised: GuardrailRule = { ...allowRead, id: "auto", maxAutonomy: "approved" };
+    expect(evaluateGuardrail([supervised], { ...READ, autonomy: "autonomous" })).toEqual({
+      effect: "deny",
+      reason: "autonomy_exceeded",
+      ruleId: "auto",
+      dimension: "autonomy",
+    });
+    expect(evaluateGuardrail([supervised], { ...READ, autonomy: "approved" }).effect).toBe("allow");
+    const { autonomy: _autonomy, ...noAutonomy } = READ;
+    expect(evaluateGuardrail([supervised], noAutonomy)).toEqual({
+      effect: "deny",
+      reason: "missing_context",
+      ruleId: "auto",
+      dimension: "autonomy",
+    });
+  });
+});
+
+describe("evaluateGuardrail — approval and precedence", () => {
+  it("prefers require_approval over a plain allow when both fully match (stricter wins)", () => {
+    const approval: GuardrailRule = {
+      id: "approve",
+      effect: "require_approval",
+      action: "record.read",
+      resourceType: "invoice",
+    };
+    expect(evaluateGuardrail([allowRead, approval], READ)).toEqual({
+      effect: "require_approval",
+      reason: "approval_required",
+      ruleId: "approve",
+    });
+  });
+
+  it("escalates to approval when autonomy exceeds the allow ceiling", () => {
+    const interactiveAllow: GuardrailRule = { ...allowRead, id: "ia", maxAutonomy: "interactive" };
+    const approval: GuardrailRule = {
+      id: "approve",
+      effect: "require_approval",
+      action: "record.read",
+      resourceType: "invoice",
+    };
+    const autonomous = { ...READ, autonomy: "autonomous" as const };
+    expect(evaluateGuardrail([interactiveAllow, approval], autonomous)).toEqual({
+      effect: "require_approval",
+      reason: "approval_required",
+      ruleId: "approve",
+    });
+    expect(evaluateGuardrail([interactiveAllow], autonomous)).toEqual({
+      effect: "deny",
+      reason: "autonomy_exceeded",
+      ruleId: "ia",
+      dimension: "autonomy",
+    });
+  });
+
+  it("explicit deny beats require_approval", () => {
+    const approval: GuardrailRule = {
+      id: "approve",
+      effect: "require_approval",
+      action: "record.read",
+      resourceType: "invoice",
+    };
+    expect(evaluateGuardrail([approval, denyRead], READ).effect).toBe("deny");
+  });
+});
+
+describe("evaluateGuardrail — determinism and safe evidence", () => {
+  it("returns an identical decision for identical inputs", () => {
+    const rules: readonly GuardrailRule[] = [
+      { ...allowRead, id: "cap", maxRecordCount: 5 },
+      denyRead,
+      allowAll,
+    ];
+    const first = evaluateGuardrail(rules, READ);
+    const second = evaluateGuardrail(rules, READ);
+    expect(second).toEqual(first);
+  });
+
+  it("emits only reason evidence — never Context values", () => {
+    const scoped: GuardrailRule = { ...allowRead, id: "rec", recordSelector: "inv-secret" };
+    const context = { ...READ, recordId: "PROTECTED-record-id", destination: "PROTECTED-dest" };
+    const decision = evaluateGuardrail([scoped, denyRead], context);
+    const serialized = JSON.stringify(decision);
+    expect(serialized).not.toContain("PROTECTED");
+    expect(
+      Object.keys(decision).every((k) => ["effect", "reason", "ruleId", "dimension"].includes(k))
+    ).toBe(true);
+  });
+});

--- a/packages/authz/src/guardrails/engine.ts
+++ b/packages/authz/src/guardrails/engine.ts
@@ -1,0 +1,154 @@
+/**
+ * Deterministic Guardrail evaluation over action, Resource type, Record, field, data class,
+ * destination, audience, volume, taint, and autonomy (SPEC §12). Default deny: with no fully
+ * matching allow the decision is a denial. Selector scoping mirrors AccessGrant matching — a
+ * rule scoped to a dimension never matches a Context that omits it, for allow and deny alike,
+ * so a rule cannot silently widen (SPEC §24 fail-closed defaults). Ceilings (volume, taint,
+ * autonomy) deny when exceeded and deny as unverifiable when the Context omits the measured
+ * value (missing Context is never assumed safe, SPEC §13). Evaluation is a pure function of its
+ * arguments; evidence rules live in ./decision.
+ */
+
+import type { GuardrailDecision, GuardrailEffect } from "./decision";
+import { type AutonomyLevel, autonomyWithin, type TaintLevel, taintWithin } from "./risk";
+
+export interface GuardrailRule {
+  readonly id: string;
+  readonly effect: GuardrailEffect;
+  /** Action identifier (e.g. "record.read") or "*" for any action. */
+  readonly action: string;
+  /** Resource type name or "*" for any type. */
+  readonly resourceType: string;
+  /** Specific Record id; absent or "*" covers every Record of the type. */
+  readonly recordSelector?: string;
+  /** Fields covered; present, it only matches field-level Contexts. */
+  readonly fieldSelector?: readonly string[];
+  /** Data classification the rule is scoped to; absent covers any classification. */
+  readonly dataClass?: string;
+  /** Destination the rule is scoped to; absent covers any destination. */
+  readonly destination?: string;
+  /** Audience the rule is scoped to; absent covers any audience. */
+  readonly audience?: string;
+  /** Volume ceiling: highest record count this rule permits. Ignored on deny rules. */
+  readonly maxRecordCount?: number;
+  /** Taint ceiling: most-tainted input influence this rule permits. Ignored on deny rules. */
+  readonly maxTaint?: TaintLevel;
+  /** Autonomy ceiling: most-autonomous mode this rule permits. Ignored on deny rules. */
+  readonly maxAutonomy?: AutonomyLevel;
+}
+
+/** The concrete guarded action being decided; absent dimensions mean "not established". */
+export interface GuardrailContext {
+  readonly action: string;
+  readonly resourceType: string;
+  readonly recordId?: string;
+  readonly field?: string;
+  readonly dataClass?: string;
+  readonly destination?: string;
+  readonly audience?: string;
+  readonly recordCount?: number;
+  readonly taint?: TaintLevel;
+  readonly autonomy?: AutonomyLevel;
+}
+
+function selectorsMatch(rule: GuardrailRule, context: GuardrailContext): boolean {
+  if (rule.action !== "*" && rule.action !== context.action) return false;
+  if (rule.resourceType !== "*" && rule.resourceType !== context.resourceType) return false;
+  if (
+    rule.recordSelector !== undefined &&
+    rule.recordSelector !== "*" &&
+    rule.recordSelector !== context.recordId
+  ) {
+    return false;
+  }
+  if (
+    rule.fieldSelector !== undefined &&
+    (context.field === undefined || !rule.fieldSelector.includes(context.field))
+  ) {
+    return false;
+  }
+  if (rule.dataClass !== undefined && rule.dataClass !== context.dataClass) return false;
+  if (rule.destination !== undefined && rule.destination !== context.destination) return false;
+  if (rule.audience !== undefined && rule.audience !== context.audience) return false;
+  return true;
+}
+
+/** A ceiling denial for `rule`, or undefined when every ceiling is satisfied. */
+function checkCeilings(
+  rule: GuardrailRule,
+  context: GuardrailContext
+): GuardrailDecision | undefined {
+  if (rule.maxRecordCount !== undefined) {
+    if (context.recordCount === undefined) {
+      return {
+        effect: "deny",
+        reason: "missing_context",
+        ruleId: rule.id,
+        dimension: "recordCount",
+      };
+    }
+    if (context.recordCount > rule.maxRecordCount) {
+      return {
+        effect: "deny",
+        reason: "volume_exceeded",
+        ruleId: rule.id,
+        dimension: "recordCount",
+      };
+    }
+  }
+  if (rule.maxTaint !== undefined) {
+    if (context.taint === undefined) {
+      return { effect: "deny", reason: "missing_context", ruleId: rule.id, dimension: "taint" };
+    }
+    if (!taintWithin(context.taint, rule.maxTaint)) {
+      return { effect: "deny", reason: "taint_exceeded", ruleId: rule.id, dimension: "taint" };
+    }
+  }
+  if (rule.maxAutonomy !== undefined) {
+    if (context.autonomy === undefined) {
+      return { effect: "deny", reason: "missing_context", ruleId: rule.id, dimension: "autonomy" };
+    }
+    if (!autonomyWithin(context.autonomy, rule.maxAutonomy)) {
+      return {
+        effect: "deny",
+        reason: "autonomy_exceeded",
+        ruleId: rule.id,
+        dimension: "autonomy",
+      };
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Decides `context` against `rules` in order. Precedence: a matching explicit deny wins; then a
+ * fully passing require_approval (stricter than allow); then a fully passing allow; then the
+ * first ceiling denial among matching candidates; otherwise default deny (`no_matching_rule`).
+ */
+export function evaluateGuardrail(
+  rules: readonly GuardrailRule[],
+  context: GuardrailContext
+): GuardrailDecision {
+  let approval: GuardrailDecision | undefined;
+  let allow: GuardrailDecision | undefined;
+  let ceilingDenial: GuardrailDecision | undefined;
+
+  for (const rule of rules) {
+    if (!selectorsMatch(rule, context)) continue;
+    if (rule.effect === "deny") {
+      return { effect: "deny", reason: "explicit_deny", ruleId: rule.id };
+    }
+    const denial = checkCeilings(rule, context);
+    if (denial) {
+      ceilingDenial ??= denial;
+      continue;
+    }
+    if (rule.effect === "require_approval") {
+      approval ??= { effect: "require_approval", reason: "approval_required", ruleId: rule.id };
+    } else {
+      allow ??= { effect: "allow", reason: "allowed", ruleId: rule.id };
+    }
+  }
+
+  return approval ?? allow ?? ceilingDenial ?? { effect: "deny", reason: "no_matching_rule" };
+}

--- a/packages/authz/src/guardrails/risk.ts
+++ b/packages/authz/src/guardrails/risk.ts
@@ -1,0 +1,31 @@
+/**
+ * Risk dimension orderings for Guardrail ceilings (SPEC §13). Taint tracks whether untrusted
+ * input influenced the action; autonomy tracks how much human oversight the Run has. Both are
+ * totally ordered so a ceiling check is deterministic: an actual level is within a ceiling only
+ * when its rank does not exceed the ceiling's rank.
+ */
+
+export type TaintLevel = "trusted" | "untrusted";
+
+export type AutonomyLevel = "interactive" | "approved" | "autonomous";
+
+const TAINT_RANK: Readonly<Record<TaintLevel, number>> = {
+  trusted: 0,
+  untrusted: 1,
+};
+
+const AUTONOMY_RANK: Readonly<Record<AutonomyLevel, number>> = {
+  interactive: 0,
+  approved: 1,
+  autonomous: 2,
+};
+
+/** True when `actual` taint is at or below the `ceiling`. */
+export function taintWithin(actual: TaintLevel, ceiling: TaintLevel): boolean {
+  return TAINT_RANK[actual] <= TAINT_RANK[ceiling];
+}
+
+/** True when `actual` autonomy is at or below the `ceiling`. */
+export function autonomyWithin(actual: AutonomyLevel, ceiling: AutonomyLevel): boolean {
+  return AUTONOMY_RANK[actual] <= AUTONOMY_RANK[ceiling];
+}

--- a/packages/authz/src/index.ts
+++ b/packages/authz/src/index.ts
@@ -8,6 +8,17 @@ export { decideEffectivePermission, evaluateGrants } from "./effective";
 export type { AccessGrant, AccessRequest, GrantEffect } from "./grants";
 export { grantMatches } from "./grants";
 export type {
+  GuardrailDecision,
+  GuardrailDecisionReason,
+  GuardrailEffect,
+} from "./guardrails/decision";
+export type { DlpCrossing, DlpRule } from "./guardrails/dlp";
+export { checkDlpBoundary } from "./guardrails/dlp";
+export type { GuardrailContext, GuardrailRule } from "./guardrails/engine";
+export { evaluateGuardrail } from "./guardrails/engine";
+export type { AutonomyLevel, TaintLevel } from "./guardrails/risk";
+export { autonomyWithin, taintWithin } from "./guardrails/risk";
+export type {
   IdentityPort,
   IdentityResolution,
   IdentityResolutionRequest,


### PR DESCRIPTION
## Summary
- Add `evaluateGuardrail` to `@tulipfarm/authz`: deterministic, pure evaluation over action, Resource type, Record, field, data class, destination, audience selectors plus volume/taint/autonomy ceilings. Default deny; explicit deny wins; `require_approval` is stricter than allow; a scoped selector never matches a Context that omits the dimension (fail closed, mirrors AW-018 `grantMatches`).
- Add `checkDlpBoundary` per SPEC §13: detected secret, unclassified data, a class with no DLP rule, or a destination/audience outside the allowlist all deny.
- Decisions carry only safe reason evidence (reason code, rule id, dimension name, data class name) — never Context values or protected content. Missing or unverifiable ceiling Context denies with `missing_context` naming the dimension.

Implements AW-019.

## Test plan
- [x] RED observed: `vitest run src/guardrails` failed with modules absent
- [x] GREEN: 27 new tests pass; full `@tulipfarm/authz` suite 69/69
- [x] `tsc --noEmit` clean
- [x] `biome check` clean