### PR TITLE
feat(authz): default-deny guest, JIT, external-identity, and recertification primitives (AW-020)

### DIFF
--- a/packages/authz/src/external-identities.test.ts
+++ b/packages/authz/src/external-identities.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertConversationSenderAuthorized,
+  assertExternalIdentityMapped,
+  ExternalIdentityDeniedError,
+  type ExternalIdentityMapping,
+} from "./external-identities";
+
+const NOW = new Date("2026-07-23T12:00:00Z");
+
+function mapping(overrides: Partial<ExternalIdentityMapping> = {}): ExternalIdentityMapping {
+  return {
+    businessId: "business-1",
+    provider: "slack",
+    externalSubject: "U123",
+    principalId: "principal-1",
+    verifiedAt: new Date("2026-07-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+describe("assertExternalIdentityMapped", () => {
+  it("allows a live, business-scoped mapping", () => {
+    expect(() => assertExternalIdentityMapped(mapping(), "business-1", NOW)).not.toThrow();
+  });
+
+  it("denies an unmapped sender", () => {
+    try {
+      assertExternalIdentityMapped(undefined, "business-1", NOW);
+      throw new Error("expected denial");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ExternalIdentityDeniedError);
+      expect((error as ExternalIdentityDeniedError).reason).toBe("unmapped");
+    }
+  });
+
+  it("denies a cross-business mapping", () => {
+    const other = mapping({ businessId: "business-2" });
+    expect(() => assertExternalIdentityMapped(other, "business-1", NOW)).toThrow(
+      ExternalIdentityDeniedError
+    );
+  });
+
+  it("denies an expired mapping", () => {
+    const expired = mapping({ expiresAt: new Date(NOW.getTime() - 1_000) });
+    expect(() => assertExternalIdentityMapped(expired, "business-1", NOW)).toThrow(
+      ExternalIdentityDeniedError
+    );
+  });
+});
+
+describe("assertConversationSenderAuthorized — Conversation-owner substitution fixture", () => {
+  it("allows the mapped owner to act as themselves", () => {
+    expect(() =>
+      assertConversationSenderAuthorized(mapping(), "principal-1", "business-1", NOW)
+    ).not.toThrow();
+  });
+
+  it("denies an unmapped external sender chiming into another principal's conversation", () => {
+    try {
+      assertConversationSenderAuthorized(undefined, "principal-1", "business-1", NOW);
+      throw new Error("expected denial");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ExternalIdentityDeniedError);
+      expect((error as ExternalIdentityDeniedError).reason).toBe("unmapped");
+    }
+  });
+
+  it("denies a mapped sender who is not the conversation owner (substitution)", () => {
+    const otherSender = mapping({ externalSubject: "U999", principalId: "principal-2" });
+    try {
+      assertConversationSenderAuthorized(otherSender, "principal-1", "business-1", NOW);
+      throw new Error("expected denial");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ExternalIdentityDeniedError);
+      expect((error as ExternalIdentityDeniedError).reason).toBe("substitution");
+    }
+  });
+});

--- a/packages/authz/src/external-identities.ts
+++ b/packages/authz/src/external-identities.ts
@@ -1,0 +1,79 @@
+/**
+ * External identity → principal mapping (SPEC §12): Slack/Telegram/GitHub/etc. subjects map to
+ * one verified TulipFarm principal per business. "Thread/channel membership alone never
+ * authorizes business data" — an unmapped sender, an expired mapping, or a sender mapped to a
+ * different principal than the conversation owner must never inherit that owner's authority.
+ * This closes the known Conversation-owner substitution fixture: today's ingress path lets any
+ * external sender chime into a mapped thread and silently run the turn as the thread's owner
+ * (see apps/api/src/ingress/service.ts `handleChat`); the assertion below is the fail-closed
+ * check that decision must be routed through.
+ */
+
+export interface ExternalIdentityMapping {
+  readonly businessId: string;
+  readonly provider: string;
+  readonly externalSubject: string;
+  readonly principalId: string;
+  readonly verifiedAt: Date;
+  /** Absent means no expiry (a standing verified mapping). */
+  readonly expiresAt?: Date;
+}
+
+export type ExternalIdentityDenialReason =
+  | "unmapped"
+  | "expired"
+  | "business_mismatch"
+  | "substitution";
+
+export class ExternalIdentityDeniedError extends Error {
+  constructor(
+    public readonly reason: ExternalIdentityDenialReason,
+    message: string
+  ) {
+    super(message);
+    this.name = "ExternalIdentityDeniedError";
+  }
+}
+
+/** Throws unless `mapping` is a live, business-scoped verified mapping at `now`. */
+export function assertExternalIdentityMapped(
+  mapping: ExternalIdentityMapping | undefined,
+  businessId: string,
+  now: Date = new Date()
+): asserts mapping is ExternalIdentityMapping {
+  if (!mapping) {
+    throw new ExternalIdentityDeniedError("unmapped", "external subject has no verified mapping");
+  }
+  if (mapping.businessId !== businessId) {
+    throw new ExternalIdentityDeniedError(
+      "business_mismatch",
+      `mapping for ${mapping.externalSubject} belongs to a different business`
+    );
+  }
+  if (mapping.expiresAt && mapping.expiresAt <= now) {
+    throw new ExternalIdentityDeniedError(
+      "expired",
+      `mapping for ${mapping.externalSubject} has expired`
+    );
+  }
+}
+
+/**
+ * Throws unless the sender's own verified mapping resolves to `conversationOwnerPrincipalId`.
+ * An unmapped, expired, cross-business, or differently-mapped sender never inherits the
+ * conversation owner's authority — denying the known Conversation-owner substitution fixture.
+ */
+export function assertConversationSenderAuthorized(
+  mapping: ExternalIdentityMapping | undefined,
+  conversationOwnerPrincipalId: string,
+  businessId: string,
+  now: Date = new Date()
+): void {
+  assertExternalIdentityMapped(mapping, businessId, now);
+  if (mapping.principalId !== conversationOwnerPrincipalId) {
+    throw new ExternalIdentityDeniedError(
+      "substitution",
+      `external subject ${mapping.externalSubject} does not authenticate the conversation owner`
+    );
+  }
+}

--- a/packages/authz/src/guests.test.ts
+++ b/packages/authz/src/guests.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { assertGuestActive, type Guest, GuestDeniedError, guestGrants } from "./guests";
+import type { Principal } from "./principals";
+
+const NOW = new Date("2026-07-23T12:00:00Z");
+const READ_GRANT = { action: "record.read", resourceType: "invoice", effect: "allow" } as const;
+
+function guest(overrides: Partial<Guest> = {}): Guest {
+  return {
+    principalId: "guest-1",
+    businessId: "business-1",
+    sponsorPrincipalId: "sponsor-1",
+    expiresAt: new Date(NOW.getTime() + 60_000),
+    grants: [READ_GRANT],
+    status: "active",
+    ...overrides,
+  };
+}
+
+function sponsor(
+  overrides: Partial<Principal> = {}
+): Pick<Principal, "id" | "businessId" | "status"> {
+  return { id: "sponsor-1", businessId: "business-1", status: "active", ...overrides };
+}
+
+describe("assertGuestActive", () => {
+  it("allows an active guest with a valid, active sponsor", () => {
+    expect(() => assertGuestActive(guest(), sponsor(), NOW)).not.toThrow();
+  });
+
+  it("denies a revoked guest", () => {
+    try {
+      assertGuestActive(guest({ status: "revoked" }), sponsor(), NOW);
+      throw new Error("expected denial");
+    } catch (error) {
+      expect(error).toBeInstanceOf(GuestDeniedError);
+      expect((error as GuestDeniedError).reason).toBe("revoked");
+    }
+  });
+
+  it("denies a guest past its expiry", () => {
+    const expired = guest({ expiresAt: new Date(NOW.getTime() - 1_000) });
+    expect(() => assertGuestActive(expired, sponsor(), NOW)).toThrow(GuestDeniedError);
+  });
+
+  it("denies when the sponsor does not match the guest's recorded sponsor", () => {
+    const wrongSponsor = sponsor({ id: "sponsor-2" });
+    try {
+      assertGuestActive(guest(), wrongSponsor, NOW);
+      throw new Error("expected denial");
+    } catch (error) {
+      expect(error).toBeInstanceOf(GuestDeniedError);
+      expect((error as GuestDeniedError).reason).toBe("sponsor_mismatch");
+    }
+  });
+
+  it("denies when the sponsor is no longer active", () => {
+    const disabledSponsor = sponsor({ status: "disabled" });
+    try {
+      assertGuestActive(guest(), disabledSponsor, NOW);
+      throw new Error("expected denial");
+    } catch (error) {
+      expect(error).toBeInstanceOf(GuestDeniedError);
+      expect((error as GuestDeniedError).reason).toBe("sponsor_inactive");
+    }
+  });
+});
+
+describe("guestGrants", () => {
+  it("returns the guest's own grants when active", () => {
+    expect(guestGrants(guest(), sponsor(), NOW)).toEqual([READ_GRANT]);
+  });
+
+  it("returns no grants for a revoked or expired guest, never the sponsor's authority", () => {
+    expect(guestGrants(guest({ status: "revoked" }), sponsor(), NOW)).toEqual([]);
+    expect(
+      guestGrants(guest({ expiresAt: new Date(NOW.getTime() - 1_000) }), sponsor(), NOW)
+    ).toEqual([]);
+  });
+});

--- a/packages/authz/src/guests.ts
+++ b/packages/authz/src/guests.ts
@@ -1,0 +1,72 @@
+/**
+ * Sponsored, expiring guest principals (SPEC §12): "Guests require a sponsor, expiry, and
+ * explicit access grants." A guest carries no authority beyond its own grants — it never
+ * inherits its sponsor's roles or grants (non-amplification) — and stops being usable the
+ * instant it is revoked or past expiry, regardless of its stored grants.
+ */
+
+import type { AccessGrant } from "./grants";
+import type { Principal } from "./principals";
+
+export type GuestStatus = "active" | "revoked";
+
+export interface Guest {
+  readonly principalId: string;
+  readonly businessId: string;
+  readonly sponsorPrincipalId: string;
+  readonly expiresAt: Date;
+  readonly grants: readonly AccessGrant[];
+  readonly status: GuestStatus;
+}
+
+export type GuestDenialReason = "revoked" | "expired" | "sponsor_inactive" | "sponsor_mismatch";
+
+export class GuestDeniedError extends Error {
+  constructor(
+    public readonly reason: GuestDenialReason,
+    message: string
+  ) {
+    super(message);
+    this.name = "GuestDeniedError";
+  }
+}
+
+/** Throws unless `guest` is active, unexpired, and its sponsor is authenticatable at `now`. */
+export function assertGuestActive(
+  guest: Guest,
+  sponsor: Pick<Principal, "id" | "businessId" | "status">,
+  now: Date = new Date()
+): void {
+  if (guest.status === "revoked") {
+    throw new GuestDeniedError("revoked", `guest ${guest.principalId} has been revoked`);
+  }
+  if (guest.expiresAt <= now) {
+    throw new GuestDeniedError("expired", `guest ${guest.principalId} has expired`);
+  }
+  if (sponsor.id !== guest.sponsorPrincipalId || sponsor.businessId !== guest.businessId) {
+    throw new GuestDeniedError(
+      "sponsor_mismatch",
+      `sponsor does not match guest ${guest.principalId}'s recorded sponsor`
+    );
+  }
+  if (sponsor.status !== "active") {
+    throw new GuestDeniedError(
+      "sponsor_inactive",
+      `sponsor for guest ${guest.principalId} is not active`
+    );
+  }
+}
+
+/** A guest's own explicit grants only — never the sponsor's. Empty when denied or expired. */
+export function guestGrants(
+  guest: Guest,
+  sponsor: Pick<Principal, "id" | "businessId" | "status">,
+  now: Date = new Date()
+): readonly AccessGrant[] {
+  try {
+    assertGuestActive(guest, sponsor, now);
+  } catch {
+    return [];
+  }
+  return guest.grants;
+}

--- a/packages/authz/src/index.ts
+++ b/packages/authz/src/index.ts
@@ -5,6 +5,15 @@ export type {
   GrantOutcome,
 } from "./effective";
 export { decideEffectivePermission, evaluateGrants } from "./effective";
+export type {
+  ExternalIdentityDenialReason,
+  ExternalIdentityMapping,
+} from "./external-identities";
+export {
+  assertConversationSenderAuthorized,
+  assertExternalIdentityMapped,
+  ExternalIdentityDeniedError,
+} from "./external-identities";
 export type { AccessGrant, AccessRequest, GrantEffect } from "./grants";
 export { grantMatches } from "./grants";
 export type {
@@ -18,6 +27,10 @@ export type { GuardrailContext, GuardrailRule } from "./guardrails/engine";
 export { evaluateGuardrail } from "./guardrails/engine";
 export type { AutonomyLevel, TaintLevel } from "./guardrails/risk";
 export { autonomyWithin, taintWithin } from "./guardrails/risk";
+export type { Guest, GuestDenialReason, GuestStatus } from "./guests";
+export { assertGuestActive, GuestDeniedError, guestGrants } from "./guests";
+export type { JitDenialReason, JitGrantRequest } from "./jit";
+export { assertJitGrantIssuable, JitDeniedError } from "./jit";
 export type {
   IdentityPort,
   IdentityResolution,
@@ -35,6 +48,15 @@ export {
   assertSessionMatchesPrincipal,
   PrincipalDeniedError,
 } from "./principals";
+export type {
+  RecertificationDenialReason,
+  RecertificationRecord,
+} from "./recertification";
+export {
+  assertRecertificationCurrent,
+  assertRecertificationReviewer,
+  RecertificationDeniedError,
+} from "./recertification";
 export type { Role, RoleAssignableTo, RoleAssignmentDenialReason } from "./roles";
 export {
   assertRoleAssignable,

--- a/packages/authz/src/jit.test.ts
+++ b/packages/authz/src/jit.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { assertJitGrantIssuable, JitDeniedError, type JitGrantRequest } from "./jit";
+
+const NOW = new Date("2026-07-23T12:00:00Z");
+const FUTURE_GRANT = {
+  action: "record.read",
+  resourceType: "invoice",
+  effect: "allow",
+  expiresAt: new Date(NOW.getTime() + 60_000),
+} as const;
+
+function request(overrides: Partial<JitGrantRequest> = {}): JitGrantRequest {
+  return {
+    principalId: "principal-1",
+    businessId: "business-1",
+    grant: FUTURE_GRANT,
+    justification: "one-off incident triage",
+    ...overrides,
+  };
+}
+
+describe("assertJitGrantIssuable", () => {
+  it("allows an expiring grant approved by a different in-business approver", () => {
+    expect(() =>
+      assertJitGrantIssuable(request(), { id: "approver-1", businessId: "business-1" }, NOW)
+    ).not.toThrow();
+  });
+
+  it("denies a grant without a future expiry", () => {
+    const standing = request({ grant: { ...FUTURE_GRANT, expiresAt: undefined } });
+    try {
+      assertJitGrantIssuable(standing, { id: "approver-1", businessId: "business-1" }, NOW);
+      throw new Error("expected denial");
+    } catch (error) {
+      expect(error).toBeInstanceOf(JitDeniedError);
+      expect((error as JitDeniedError).reason).toBe("missing_expiry");
+    }
+  });
+
+  it("denies a grant whose expiry has already passed", () => {
+    const past = request({ grant: { ...FUTURE_GRANT, expiresAt: new Date(NOW.getTime() - 1) } });
+    expect(() =>
+      assertJitGrantIssuable(past, { id: "approver-1", businessId: "business-1" }, NOW)
+    ).toThrow(JitDeniedError);
+  });
+
+  it("denies an approver from a different business", () => {
+    try {
+      assertJitGrantIssuable(request(), { id: "approver-1", businessId: "business-2" }, NOW);
+      throw new Error("expected denial");
+    } catch (error) {
+      expect(error).toBeInstanceOf(JitDeniedError);
+      expect((error as JitDeniedError).reason).toBe("business_mismatch");
+    }
+  });
+
+  it("denies self-approval", () => {
+    try {
+      assertJitGrantIssuable(request(), { id: "principal-1", businessId: "business-1" }, NOW);
+      throw new Error("expected denial");
+    } catch (error) {
+      expect(error).toBeInstanceOf(JitDeniedError);
+      expect((error as JitDeniedError).reason).toBe("self_approval");
+    }
+  });
+});

--- a/packages/authz/src/jit.ts
+++ b/packages/authz/src/jit.ts
@@ -1,0 +1,53 @@
+/**
+ * Just-in-time grant issuance (SPEC §12: "Sensitive grants support just-in-time issuance and
+ * periodic access review"). A JIT grant is issued for one principal by an approver in the same
+ * business, must carry its own expiry (never a standing grant), and separation of duties denies
+ * self-approval — an approver can never issue a JIT grant to themselves (SPEC §24 confused
+ * deputy / privilege-escalation controls).
+ */
+
+import type { AccessGrant } from "./grants";
+import type { Principal } from "./principals";
+
+export interface JitGrantRequest {
+  readonly principalId: string;
+  readonly businessId: string;
+  readonly grant: AccessGrant;
+  readonly justification: string;
+}
+
+export type JitDenialReason = "missing_expiry" | "business_mismatch" | "self_approval";
+
+export class JitDeniedError extends Error {
+  constructor(
+    public readonly reason: JitDenialReason,
+    message: string
+  ) {
+    super(message);
+    this.name = "JitDeniedError";
+  }
+}
+
+/**
+ * Throws unless `request` may be approved by `approver` at `now`: the grant must carry its own
+ * expiry, the approver must belong to the same business as the requesting principal, and the
+ * approver may not approve a grant for themselves.
+ */
+export function assertJitGrantIssuable(
+  request: JitGrantRequest,
+  approver: Pick<Principal, "id" | "businessId">,
+  now: Date = new Date()
+): void {
+  if (!request.grant.expiresAt || request.grant.expiresAt <= now) {
+    throw new JitDeniedError("missing_expiry", "a just-in-time grant must carry a future expiry");
+  }
+  if (approver.businessId !== request.businessId) {
+    throw new JitDeniedError(
+      "business_mismatch",
+      "approver does not belong to the requesting principal's business"
+    );
+  }
+  if (approver.id === request.principalId) {
+    throw new JitDeniedError("self_approval", "a principal cannot approve its own JIT grant");
+  }
+}

--- a/packages/authz/src/recertification.test.ts
+++ b/packages/authz/src/recertification.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertRecertificationCurrent,
+  assertRecertificationReviewer,
+  RecertificationDeniedError,
+  type RecertificationRecord,
+} from "./recertification";
+
+const NOW = new Date("2026-07-23T12:00:00Z");
+
+function record(overrides: Partial<RecertificationRecord> = {}): RecertificationRecord {
+  return {
+    principalId: "principal-1",
+    businessId: "business-1",
+    grantId: "grant-1",
+    dueAt: new Date(NOW.getTime() + 60_000),
+    ...overrides,
+  };
+}
+
+describe("assertRecertificationCurrent", () => {
+  it("allows a record not yet due", () => {
+    expect(() => assertRecertificationCurrent(record(), NOW)).not.toThrow();
+  });
+
+  it("allows a record reviewed at or after its due date's issuance window", () => {
+    const due = new Date(NOW.getTime() - 60_000);
+    const reviewed = record({ dueAt: due, reviewedAt: due });
+    expect(() => assertRecertificationCurrent(reviewed, NOW)).not.toThrow();
+  });
+
+  it("denies an overdue record with no review recorded", () => {
+    const overdue = record({ dueAt: new Date(NOW.getTime() - 1_000) });
+    try {
+      assertRecertificationCurrent(overdue, NOW);
+      throw new Error("expected denial");
+    } catch (error) {
+      expect(error).toBeInstanceOf(RecertificationDeniedError);
+      expect((error as RecertificationDeniedError).reason).toBe("overdue");
+    }
+  });
+
+  it("denies an overdue record whose only review predates the deadline", () => {
+    const dueAt = new Date(NOW.getTime() - 1_000);
+    const staleReview = record({ dueAt, reviewedAt: new Date(dueAt.getTime() - 60_000) });
+    expect(() => assertRecertificationCurrent(staleReview, NOW)).toThrow(
+      RecertificationDeniedError
+    );
+  });
+});
+
+describe("assertRecertificationReviewer", () => {
+  it("allows a different in-business reviewer", () => {
+    expect(() => assertRecertificationReviewer(record(), "reviewer-1", "business-1")).not.toThrow();
+  });
+
+  it("denies self-review", () => {
+    try {
+      assertRecertificationReviewer(record(), "principal-1", "business-1");
+      throw new Error("expected denial");
+    } catch (error) {
+      expect(error).toBeInstanceOf(RecertificationDeniedError);
+      expect((error as RecertificationDeniedError).reason).toBe("self_review");
+    }
+  });
+
+  it("denies a reviewer from a different business", () => {
+    try {
+      assertRecertificationReviewer(record(), "reviewer-1", "business-2");
+      throw new Error("expected denial");
+    } catch (error) {
+      expect(error).toBeInstanceOf(RecertificationDeniedError);
+      expect((error as RecertificationDeniedError).reason).toBe("business_mismatch");
+    }
+  });
+});

--- a/packages/authz/src/recertification.ts
+++ b/packages/authz/src/recertification.ts
@@ -1,0 +1,63 @@
+/**
+ * Periodic access review (SPEC §12: sensitive grants and service identities require
+ * recertification; SPEC §24 separation of duties). A grant under review stops counting the
+ * instant it passes its review deadline without a recorded review — recertification fails
+ * closed, it never auto-renews — and a reviewer can never recertify their own access.
+ */
+
+export interface RecertificationRecord {
+  readonly principalId: string;
+  readonly businessId: string;
+  readonly grantId: string;
+  readonly dueAt: Date;
+  readonly reviewedAt?: Date;
+  readonly reviewerPrincipalId?: string;
+}
+
+export type RecertificationDenialReason = "overdue" | "self_review" | "business_mismatch";
+
+export class RecertificationDeniedError extends Error {
+  constructor(
+    public readonly reason: RecertificationDenialReason,
+    message: string
+  ) {
+    super(message);
+    this.name = "RecertificationDeniedError";
+  }
+}
+
+/**
+ * Throws once `record.dueAt` has passed without a review recorded at or after issuance — an
+ * overdue recertification denies the grant it covers regardless of the grant's own expiry.
+ */
+export function assertRecertificationCurrent(
+  record: RecertificationRecord,
+  now: Date = new Date()
+): void {
+  if (record.dueAt <= now && (!record.reviewedAt || record.reviewedAt < record.dueAt)) {
+    throw new RecertificationDeniedError(
+      "overdue",
+      `grant ${record.grantId} is past its recertification deadline`
+    );
+  }
+}
+
+/**
+ * Throws unless `reviewerId` may record this review: same business as the reviewed principal,
+ * and never the reviewed principal itself (no self-review).
+ */
+export function assertRecertificationReviewer(
+  record: Pick<RecertificationRecord, "principalId" | "businessId">,
+  reviewerId: string,
+  reviewerBusinessId: string
+): void {
+  if (reviewerBusinessId !== record.businessId) {
+    throw new RecertificationDeniedError(
+      "business_mismatch",
+      "reviewer does not belong to the reviewed principal's business"
+    );
+  }
+  if (reviewerId === record.principalId) {
+    throw new RecertificationDeniedError("self_review", "a principal cannot recertify itself");
+  }
+}

--- a/packages/storage/src/auth/external-identity-repo.test.ts
+++ b/packages/storage/src/auth/external-identity-repo.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  type ExternalIdentityMappingRecord,
+  InMemoryExternalIdentityRepo,
+} from "./external-identity-repo";
+
+function mapping(
+  overrides: Partial<ExternalIdentityMappingRecord> = {}
+): ExternalIdentityMappingRecord {
+  return {
+    businessId: "business-1",
+    provider: "slack",
+    externalSubject: "U123",
+    principalId: "principal-1",
+    verifiedAt: new Date("2026-07-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+describe("InMemoryExternalIdentityRepo", () => {
+  it("round-trips a mapping by business/provider/subject", async () => {
+    const repo = new InMemoryExternalIdentityRepo();
+    await repo.put(mapping());
+    await expect(repo.find("business-1", "slack", "U123")).resolves.toEqual(mapping());
+  });
+
+  it("returns undefined for an unknown mapping", async () => {
+    const repo = new InMemoryExternalIdentityRepo();
+    await expect(repo.find("business-1", "slack", "missing")).resolves.toBeUndefined();
+  });
+
+  it("scopes mappings per business even for the same provider/subject", async () => {
+    const repo = new InMemoryExternalIdentityRepo();
+    await repo.put(mapping({ businessId: "business-1", principalId: "principal-1" }));
+    await repo.put(mapping({ businessId: "business-2", principalId: "principal-2" }));
+    await expect(repo.find("business-1", "slack", "U123")).resolves.toMatchObject({
+      principalId: "principal-1",
+    });
+    await expect(repo.find("business-2", "slack", "U123")).resolves.toMatchObject({
+      principalId: "principal-2",
+    });
+  });
+});

--- a/packages/storage/src/auth/external-identity-repo.ts
+++ b/packages/storage/src/auth/external-identity-repo.ts
@@ -1,0 +1,50 @@
+/**
+ * Persistence for verified external identity mappings (SPEC §12): one provider/externalSubject
+ * pair resolves to at most one principal per business. Storage owns the mechanics;
+ * `@tulipfarm/authz` owns the mapped/expired/substitution decision.
+ */
+
+export interface ExternalIdentityMappingRecord {
+  readonly businessId: string;
+  readonly provider: string;
+  readonly externalSubject: string;
+  readonly principalId: string;
+  readonly verifiedAt: Date;
+  readonly expiresAt?: Date;
+}
+
+export interface ExternalIdentityRepo {
+  find(
+    businessId: string,
+    provider: string,
+    externalSubject: string
+  ): Promise<ExternalIdentityMappingRecord | undefined>;
+  put(record: ExternalIdentityMappingRecord): Promise<void>;
+}
+
+/**
+ * Process-local reference implementation for tests and single-process composition. A durable
+ * PostgreSQL adapter implements the same {@link ExternalIdentityRepo} contract.
+ */
+export class InMemoryExternalIdentityRepo implements ExternalIdentityRepo {
+  private readonly records = new Map<string, ExternalIdentityMappingRecord>();
+
+  private key(businessId: string, provider: string, externalSubject: string): string {
+    return `${businessId}:${provider}:${externalSubject}`;
+  }
+
+  async find(
+    businessId: string,
+    provider: string,
+    externalSubject: string
+  ): Promise<ExternalIdentityMappingRecord | undefined> {
+    return this.records.get(this.key(businessId, provider, externalSubject));
+  }
+
+  async put(record: ExternalIdentityMappingRecord): Promise<void> {
+    this.records.set(
+      this.key(record.businessId, record.provider, record.externalSubject),
+      Object.freeze({ ...record })
+    );
+  }
+}

--- a/packages/storage/src/auth/guest-repo.test.ts
+++ b/packages/storage/src/auth/guest-repo.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { type GuestRecord, InMemoryGuestRepo } from "./guest-repo";
+
+function guest(overrides: Partial<GuestRecord> = {}): GuestRecord {
+  return {
+    principalId: "guest-1",
+    businessId: "business-1",
+    sponsorPrincipalId: "sponsor-1",
+    expiresAt: new Date("2026-08-01T00:00:00Z"),
+    grants: [{ action: "record.read", resourceType: "invoice", effect: "allow" }],
+    status: "active",
+    ...overrides,
+  };
+}
+
+describe("InMemoryGuestRepo", () => {
+  it("round-trips a guest record and returns undefined for an unknown id", async () => {
+    const repo = new InMemoryGuestRepo();
+    await repo.put(guest());
+    await expect(repo.get("guest-1")).resolves.toEqual(guest());
+    await expect(repo.get("missing")).resolves.toBeUndefined();
+  });
+
+  it("revokes an existing guest without touching its other fields", async () => {
+    const repo = new InMemoryGuestRepo();
+    await repo.put(guest());
+    await repo.revoke("guest-1");
+    await expect(repo.get("guest-1")).resolves.toMatchObject({ status: "revoked" });
+  });
+
+  it("revoking an unknown guest is a no-op", async () => {
+    const repo = new InMemoryGuestRepo();
+    await expect(repo.revoke("missing")).resolves.toBeUndefined();
+    await expect(repo.get("missing")).resolves.toBeUndefined();
+  });
+});

--- a/packages/storage/src/auth/guest-repo.ts
+++ b/packages/storage/src/auth/guest-repo.ts
@@ -1,0 +1,45 @@
+/**
+ * Persistence for sponsored, expiring guest principals (SPEC §12). Storage owns the mechanics;
+ * `@tulipfarm/authz` owns the active/expired/revoked/sponsor decision.
+ */
+
+import type { GrantRecord } from "./role-repo";
+
+export type GuestStatus = "active" | "revoked";
+
+export interface GuestRecord {
+  readonly principalId: string;
+  readonly businessId: string;
+  readonly sponsorPrincipalId: string;
+  readonly expiresAt: Date;
+  readonly grants: readonly GrantRecord[];
+  readonly status: GuestStatus;
+}
+
+export interface GuestRepo {
+  get(principalId: string): Promise<GuestRecord | undefined>;
+  put(record: GuestRecord): Promise<void>;
+  revoke(principalId: string): Promise<void>;
+}
+
+/**
+ * Process-local reference implementation for tests and single-process composition. A durable
+ * PostgreSQL adapter implements the same {@link GuestRepo} contract.
+ */
+export class InMemoryGuestRepo implements GuestRepo {
+  private readonly records = new Map<string, GuestRecord>();
+
+  async get(principalId: string): Promise<GuestRecord | undefined> {
+    return this.records.get(principalId);
+  }
+
+  async put(record: GuestRecord): Promise<void> {
+    this.records.set(record.principalId, Object.freeze({ ...record }));
+  }
+
+  async revoke(principalId: string): Promise<void> {
+    const existing = this.records.get(principalId);
+    if (!existing) return;
+    this.records.set(principalId, Object.freeze({ ...existing, status: "revoked" }));
+  }
+}

--- a/packages/storage/src/auth/index.ts
+++ b/packages/storage/src/auth/index.ts
@@ -1,10 +1,24 @@
 export type {
+  ExternalIdentityMappingRecord,
+  ExternalIdentityRepo,
+} from "./external-identity-repo";
+export { InMemoryExternalIdentityRepo } from "./external-identity-repo";
+export type { GuestRecord, GuestRepo, GuestStatus } from "./guest-repo";
+export { InMemoryGuestRepo } from "./guest-repo";
+export type { JitGrantIssuanceRecord, JitGrantRepo } from "./jit-repo";
+export { InMemoryJitGrantRepo } from "./jit-repo";
+export type {
   PrincipalKind,
   PrincipalRecord,
   PrincipalRepo,
   PrincipalStatus,
 } from "./principal-repo";
 export { InMemoryPrincipalRepo } from "./principal-repo";
+export type {
+  RecertificationDueRecord,
+  RecertificationRepo,
+} from "./recertification-repo";
+export { InMemoryRecertificationRepo } from "./recertification-repo";
 export type {
   GrantEffect,
   GrantRecord,

--- a/packages/storage/src/auth/jit-repo.test.ts
+++ b/packages/storage/src/auth/jit-repo.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { InMemoryJitGrantRepo, type JitGrantIssuanceRecord } from "./jit-repo";
+
+const NOW = new Date("2026-07-23T12:00:00Z");
+
+function issuance(overrides: Partial<JitGrantIssuanceRecord> = {}): JitGrantIssuanceRecord {
+  return {
+    id: "jit-1",
+    principalId: "principal-1",
+    businessId: "business-1",
+    grant: {
+      action: "record.read",
+      resourceType: "invoice",
+      effect: "allow",
+      expiresAt: new Date(NOW.getTime() + 60_000),
+    },
+    approverPrincipalId: "approver-1",
+    justification: "incident triage",
+    issuedAt: NOW,
+    ...overrides,
+  };
+}
+
+describe("InMemoryJitGrantRepo", () => {
+  it("lists active grants for a principal", async () => {
+    const repo = new InMemoryJitGrantRepo();
+    await repo.put(issuance());
+    await repo.put(issuance({ id: "jit-2", principalId: "principal-2" }));
+    const active = await repo.listActive("principal-1", NOW);
+    expect(active.map((r) => r.id)).toEqual(["jit-1"]);
+  });
+
+  it("never lists an expired grant", async () => {
+    const repo = new InMemoryJitGrantRepo();
+    await repo.put(
+      issuance({ grant: { ...issuance().grant, expiresAt: new Date(NOW.getTime() - 1_000) } })
+    );
+    expect(await repo.listActive("principal-1", NOW)).toEqual([]);
+  });
+});

--- a/packages/storage/src/auth/jit-repo.ts
+++ b/packages/storage/src/auth/jit-repo.ts
@@ -1,0 +1,40 @@
+/**
+ * Persistence for issued just-in-time grants (SPEC §12). Storage owns the mechanics;
+ * `@tulipfarm/authz` owns the expiry/separation-of-duties decision at issuance time.
+ */
+
+import type { GrantRecord } from "./role-repo";
+
+export interface JitGrantIssuanceRecord {
+  readonly id: string;
+  readonly principalId: string;
+  readonly businessId: string;
+  readonly grant: GrantRecord;
+  readonly approverPrincipalId: string;
+  readonly justification: string;
+  readonly issuedAt: Date;
+}
+
+export interface JitGrantRepo {
+  put(record: JitGrantIssuanceRecord): Promise<void>;
+  /** Only unexpired grants, even if expired rows have not been reaped yet. */
+  listActive(principalId: string, now: Date): Promise<JitGrantIssuanceRecord[]>;
+}
+
+/**
+ * Process-local reference implementation for tests and single-process composition. A durable
+ * PostgreSQL adapter implements the same {@link JitGrantRepo} contract.
+ */
+export class InMemoryJitGrantRepo implements JitGrantRepo {
+  private readonly records: JitGrantIssuanceRecord[] = [];
+
+  async put(record: JitGrantIssuanceRecord): Promise<void> {
+    this.records.push(Object.freeze({ ...record }));
+  }
+
+  async listActive(principalId: string, now: Date): Promise<JitGrantIssuanceRecord[]> {
+    return this.records.filter(
+      (r) => r.principalId === principalId && (!r.grant.expiresAt || r.grant.expiresAt > now)
+    );
+  }
+}

--- a/packages/storage/src/auth/recertification-repo.test.ts
+++ b/packages/storage/src/auth/recertification-repo.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { InMemoryRecertificationRepo, type RecertificationDueRecord } from "./recertification-repo";
+
+const NOW = new Date("2026-07-23T12:00:00Z");
+
+function due(overrides: Partial<RecertificationDueRecord> = {}): RecertificationDueRecord {
+  return {
+    principalId: "principal-1",
+    businessId: "business-1",
+    grantId: "grant-1",
+    dueAt: new Date(NOW.getTime() + 60_000),
+    ...overrides,
+  };
+}
+
+describe("InMemoryRecertificationRepo", () => {
+  it("round-trips a record by grant id and returns undefined for an unknown grant", async () => {
+    const repo = new InMemoryRecertificationRepo();
+    await repo.put(due());
+    await expect(repo.get("grant-1")).resolves.toEqual(due());
+    await expect(repo.get("missing")).resolves.toBeUndefined();
+  });
+
+  it("lists only records due at or before the given time", async () => {
+    const repo = new InMemoryRecertificationRepo();
+    await repo.put(due({ grantId: "overdue", dueAt: new Date(NOW.getTime() - 1_000) }));
+    await repo.put(due({ grantId: "future", dueAt: new Date(NOW.getTime() + 60_000) }));
+    const listed = await repo.listDue(NOW);
+    expect(listed.map((r) => r.grantId)).toEqual(["overdue"]);
+  });
+});

--- a/packages/storage/src/auth/recertification-repo.ts
+++ b/packages/storage/src/auth/recertification-repo.ts
@@ -1,0 +1,40 @@
+/**
+ * Persistence for periodic access review records (SPEC §12). Storage owns the mechanics;
+ * `@tulipfarm/authz` owns the overdue/self-review decision.
+ */
+
+export interface RecertificationDueRecord {
+  readonly principalId: string;
+  readonly businessId: string;
+  readonly grantId: string;
+  readonly dueAt: Date;
+  readonly reviewedAt?: Date;
+  readonly reviewerPrincipalId?: string;
+}
+
+export interface RecertificationRepo {
+  get(grantId: string): Promise<RecertificationDueRecord | undefined>;
+  put(record: RecertificationDueRecord): Promise<void>;
+  /** All records due at or before `at`, regardless of business. */
+  listDue(at: Date): Promise<RecertificationDueRecord[]>;
+}
+
+/**
+ * Process-local reference implementation for tests and single-process composition. A durable
+ * PostgreSQL adapter implements the same {@link RecertificationRepo} contract.
+ */
+export class InMemoryRecertificationRepo implements RecertificationRepo {
+  private readonly records = new Map<string, RecertificationDueRecord>();
+
+  async get(grantId: string): Promise<RecertificationDueRecord | undefined> {
+    return this.records.get(grantId);
+  }
+
+  async put(record: RecertificationDueRecord): Promise<void> {
+    this.records.set(record.grantId, Object.freeze({ ...record }));
+  }
+
+  async listDue(at: Date): Promise<RecertificationDueRecord[]> {
+    return [...this.records.values()].filter((r) => r.dueAt <= at);
+  }
+}


### PR DESCRIPTION
## Summary
- Adds SPEC §12 decision primitives to `@tulipfarm/authz`: verified `ExternalIdentityMapping` resolution (denies the known Conversation-owner substitution fixture — an unmapped/mismatched external sender chiming into another principal's mapped conversation never inherits that owner's authority), sponsored expiring guests (sponsor + expiry + own explicit grants, no inherited authority), just-in-time grant issuance (future-expiry-only, separation of duties denies self-approval), and periodic recertification (fail-closed on overdue, denies self-review).
- Adds matching in-memory repos under `packages/storage/src/auth/` (`external-identity-repo`, `guest-repo`, `jit-repo`, `recertification-repo`), following the existing principal/role-repo split: authz owns the decision, storage owns persistence mechanics.

## Test plan
- [x] `pnpm --filter @tulipfarm/authz --filter @tulipfarm/storage exec vitest run` — 29 + 95 tests pass
- [x] `pnpm exec biome check packages/authz/src packages/storage/src` — clean
- [x] `pnpm --filter @tulipfarm/authz typecheck` / `pnpm --filter @tulipfarm/storage typecheck` — clean