### PR TITLE
feat(audit): append-only hash-linked audit ledger (AW-021)

### DIFF
--- a/packages/audit/package.json
+++ b/packages/audit/package.json
@@ -8,8 +8,13 @@
     "test": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit"
   },
+  "dependencies": {
+    "@tulipfarm/schema": "workspace:*",
+    "@tulipfarm/storage": "workspace:*"
+  },
   "devDependencies": {
     "@tulipfarm/tsconfig": "workspace:*",
+    "@types/node": "^26.1.1",
     "typescript": "^6.0.3"
   }
 }

--- a/packages/audit/src/chain.test.ts
+++ b/packages/audit/src/chain.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { computeEventHash } from "./chain";
+import type { AuditEventInput } from "./event";
+
+function input(overrides: Partial<AuditEventInput> = {}): AuditEventInput {
+  return {
+    actor: { principalId: "user-1", businessId: "biz-1" },
+    effectivePrincipal: { principalId: "user-1", businessId: "biz-1" },
+    action: "record.read",
+    target: "resource:invoice/1",
+    decision: "allow",
+    reasonCodes: [],
+    correlationId: "corr-1",
+    occurredAt: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+describe("computeEventHash", () => {
+  it("is deterministic for identical input", () => {
+    const a = computeEventHash(input(), "id-1", "biz-1", 0, null);
+    const b = computeEventHash(input(), "id-1", "biz-1", 0, null);
+    expect(a).toBe(b);
+  });
+
+  it("changes when previousHash changes (chain linkage is covered by the hash)", () => {
+    const a = computeEventHash(input(), "id-1", "biz-1", 1, "hash-a");
+    const b = computeEventHash(input(), "id-1", "biz-1", 1, "hash-b");
+    expect(a).not.toBe(b);
+  });
+
+  it("only hashes safeRefs key/hash, never arbitrary payload fields (DLP boundary)", () => {
+    const withExtraProps = computeEventHash(
+      input({
+        safeRefs: [
+          { key: "k1", hash: "h1", plaintext: "secret" } as unknown as {
+            key: string;
+            hash: string;
+          },
+        ],
+      }),
+      "id-1",
+      "biz-1",
+      0,
+      null
+    );
+    const withoutExtraProps = computeEventHash(
+      input({ safeRefs: [{ key: "k1", hash: "h1" }] }),
+      "id-1",
+      "biz-1",
+      0,
+      null
+    );
+    expect(withExtraProps).toBe(withoutExtraProps);
+  });
+});

--- a/packages/audit/src/chain.ts
+++ b/packages/audit/src/chain.ts
@@ -1,0 +1,61 @@
+/**
+ * Hash-linking for append-only audit evidence (SPEC §20). Each event's hash covers its own
+ * fields plus the previous event's hash, so altering, reordering, or dropping any event changes
+ * every hash after it — {@link verifyChain} in `verify.ts` detects the break.
+ */
+
+import { canonicalHash } from "@tulipfarm/schema";
+import type { AuditEvent, AuditEventInput } from "./event";
+
+/** Fields hashed into an event, with `occurredAt` normalized to an ISO string (Date is not
+ *  canonicalizable) and `safeRefs` flattened to plain arrays for deterministic serialization. */
+function hashableBody(
+  input: AuditEventInput,
+  id: string,
+  businessId: string,
+  chainIndex: number,
+  previousHash: string | null
+): Record<string, unknown> {
+  return {
+    id,
+    businessId,
+    chainIndex,
+    previousHash,
+    actor: input.actor,
+    effectivePrincipal: input.effectivePrincipal,
+    agentId: input.agentId ?? null,
+    runId: input.runId ?? null,
+    stateId: input.stateId ?? null,
+    action: input.action,
+    target: input.target,
+    decision: input.decision,
+    reasonCodes: [...input.reasonCodes],
+    guardrailDigest: input.guardrailDigest ?? null,
+    bundleDigest: input.bundleDigest ?? null,
+    sourceClassification: input.sourceClassification ?? null,
+    destinationClassification: input.destinationClassification ?? null,
+    requestHash: input.requestHash ?? null,
+    resultHash: input.resultHash ?? null,
+    correlationId: input.correlationId,
+    causationId: input.causationId ?? null,
+    occurredAt: input.occurredAt.toISOString(),
+    safeMetadata: input.safeMetadata ?? {},
+    safeRefs: (input.safeRefs ?? []).map((ref) => ({ key: ref.key, hash: ref.hash })),
+  };
+}
+
+/** Computes the hash for a new event given its input and its position in the chain. */
+export function computeEventHash(
+  input: AuditEventInput,
+  id: string,
+  businessId: string,
+  chainIndex: number,
+  previousHash: string | null
+): string {
+  return canonicalHash(hashableBody(input, id, businessId, chainIndex, previousHash));
+}
+
+/** Recomputes the hash of an already-stored event, to check it against its recorded `hash`. */
+export function recomputeEventHash(event: AuditEvent): string {
+  return computeEventHash(event, event.id, event.businessId, event.chainIndex, event.previousHash);
+}

--- a/packages/audit/src/event.ts
+++ b/packages/audit/src/event.ts
@@ -1,0 +1,49 @@
+/**
+ * Canonical audit event shape (SPEC §20): actor/effective principal, correlation, lineage, and
+ * safe (non-protected) evidence only. Protected contents never enter the event body — callers
+ * pass a {@link BlobRef} under separate access control instead (SPEC §13 DLP boundary).
+ */
+
+import type { BlobRef } from "@tulipfarm/storage";
+
+export type AuditDecision = "allow" | "deny";
+
+/** Minimal principal reference. `@tulipfarm/audit` does not depend on `@tulipfarm/authz`. */
+export interface AuditPrincipalRef {
+  readonly principalId: string;
+  readonly businessId: string;
+}
+
+/** Caller-supplied fields for one audit event, before chain linkage is computed. */
+export interface AuditEventInput {
+  readonly actor: AuditPrincipalRef;
+  readonly effectivePrincipal: AuditPrincipalRef;
+  readonly agentId?: string;
+  readonly runId?: string;
+  readonly stateId?: string;
+  readonly action: string;
+  readonly target: string;
+  readonly decision: AuditDecision;
+  readonly reasonCodes: readonly string[];
+  readonly guardrailDigest?: string;
+  readonly bundleDigest?: string;
+  readonly sourceClassification?: string;
+  readonly destinationClassification?: string;
+  readonly requestHash?: string;
+  readonly resultHash?: string;
+  readonly correlationId: string;
+  readonly causationId?: string;
+  readonly occurredAt: Date;
+  readonly safeMetadata?: Record<string, unknown>;
+  /** References to Artifacts holding sensitive contents, never the contents themselves. */
+  readonly safeRefs?: readonly BlobRef[];
+}
+
+/** A stored, hash-linked audit event. `businessId` scopes the chain (one ledger per business). */
+export interface AuditEvent extends AuditEventInput {
+  readonly id: string;
+  readonly businessId: string;
+  readonly chainIndex: number;
+  readonly previousHash: string | null;
+  readonly hash: string;
+}

--- a/packages/audit/src/index.ts
+++ b/packages/audit/src/index.ts
@@ -1,1 +1,12 @@
-export {};
+export { computeEventHash, recomputeEventHash } from "./chain";
+export type {
+  AuditDecision,
+  AuditEvent,
+  AuditEventInput,
+  AuditPrincipalRef,
+} from "./event";
+export type { AuditEventRepo } from "./storage";
+export { InMemoryAuditEventRepo } from "./storage";
+export type { VerifyIssue, VerifyIssueType, VerifyResult } from "./verify";
+export { verifyChain } from "./verify";
+export { AuditWriter } from "./writer";

--- a/packages/audit/src/storage.ts
+++ b/packages/audit/src/storage.ts
@@ -1,0 +1,39 @@
+/**
+ * Append-only persistence for audit events (SPEC §20: "Events are appended in PostgreSQL for
+ * query and hash-linked into signed, sealed immutable segments in independently protected blob
+ * storage"). This module defines the query-side repository contract; a PostgreSQL adapter
+ * implements the same {@link AuditEventRepo} contract, and sealing to blob storage is a separate
+ * concern layered on top of `listChain`.
+ */
+
+import type { AuditEvent } from "./event";
+
+export interface AuditEventRepo {
+  /** Appends `event` to its business's chain. Callers must not mutate `chainIndex`/`previousHash`
+   *  after construction — this is an append-only ledger, never an update. */
+  append(event: AuditEvent): Promise<void>;
+  /** The most recently appended event for `businessId`, or `undefined` if the chain is empty. */
+  getLatest(businessId: string): Promise<AuditEvent | undefined>;
+  /** The full chain for `businessId`, in ascending `chainIndex` order. */
+  listChain(businessId: string): Promise<AuditEvent[]>;
+}
+
+/** Process-local reference implementation for tests and single-process composition. */
+export class InMemoryAuditEventRepo implements AuditEventRepo {
+  private readonly chains = new Map<string, AuditEvent[]>();
+
+  async append(event: AuditEvent): Promise<void> {
+    const chain = this.chains.get(event.businessId) ?? [];
+    chain.push(Object.freeze({ ...event }));
+    this.chains.set(event.businessId, chain);
+  }
+
+  async getLatest(businessId: string): Promise<AuditEvent | undefined> {
+    const chain = this.chains.get(businessId);
+    return chain?.at(-1);
+  }
+
+  async listChain(businessId: string): Promise<AuditEvent[]> {
+    return [...(this.chains.get(businessId) ?? [])];
+  }
+}

--- a/packages/audit/src/verify.test.ts
+++ b/packages/audit/src/verify.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import type { AuditEventInput } from "./event";
+import { InMemoryAuditEventRepo } from "./storage";
+import { verifyChain } from "./verify";
+import { AuditWriter } from "./writer";
+
+function input(overrides: Partial<AuditEventInput> = {}): AuditEventInput {
+  return {
+    actor: { principalId: "user-1", businessId: "biz-1" },
+    effectivePrincipal: { principalId: "user-1", businessId: "biz-1" },
+    action: "record.read",
+    target: "resource:invoice/1",
+    decision: "allow",
+    reasonCodes: [],
+    correlationId: "corr-1",
+    occurredAt: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+async function buildChain(n: number) {
+  const repo = new InMemoryAuditEventRepo();
+  const writer = new AuditWriter(repo);
+  for (let i = 0; i < n; i += 1) {
+    await writer.append(input({ action: `action.${i}` }));
+  }
+  return repo.listChain("biz-1");
+}
+
+describe("verifyChain", () => {
+  it("passes an untouched chain", async () => {
+    const chain = await buildChain(3);
+    expect(verifyChain(chain)).toEqual({ valid: true, issues: [] });
+  });
+
+  it("passes an empty chain", () => {
+    expect(verifyChain([])).toEqual({ valid: true, issues: [] });
+  });
+
+  it("detects a tampered payload (recorded hash no longer matches recomputed hash)", async () => {
+    const chain = await buildChain(3);
+    const tampered = [...chain];
+    tampered[1] = { ...tampered[1], target: "resource:invoice/999" };
+
+    const result = verifyChain(tampered);
+
+    expect(result.valid).toBe(false);
+    expect(result.issues).toContainEqual({
+      type: "tampered",
+      chainIndex: 1,
+      eventIds: [chain[1].id],
+    });
+  });
+
+  it("detects a deleted segment (chainIndex gap)", async () => {
+    const chain = await buildChain(3);
+    const withDeletion = [chain[0], chain[2]];
+
+    const result = verifyChain(withDeletion);
+
+    expect(result.valid).toBe(false);
+    expect(result.issues).toContainEqual({ type: "missing", chainIndex: 1, eventIds: [] });
+  });
+
+  it("detects a forked chain (two events at the same chainIndex)", async () => {
+    const chain = await buildChain(2);
+    const forkedEvent = { ...chain[1], id: "forked-event", target: "resource:invoice/fork" };
+
+    const result = verifyChain([...chain, forkedEvent]);
+
+    expect(result.valid).toBe(false);
+    expect(result.issues.some((issue) => issue.type === "forked" && issue.chainIndex === 1)).toBe(
+      true
+    );
+  });
+
+  it("detects a reordered previousHash link", async () => {
+    const chain = await buildChain(3);
+    const reordered = [...chain];
+    reordered[2] = { ...reordered[2], previousHash: chain[0].hash };
+
+    const result = verifyChain(reordered);
+
+    expect(result.valid).toBe(false);
+    expect(
+      result.issues.some((issue) => issue.type === "reordered" && issue.chainIndex === 2)
+    ).toBe(true);
+  });
+});

--- a/packages/audit/src/verify.ts
+++ b/packages/audit/src/verify.ts
@@ -1,0 +1,80 @@
+/**
+ * Verifies a business's audit chain against tamper, reorder, deletion, and fork (SPEC §20, §24:
+ * "audit tampering, deletion, reordering, forked chains ... " must be detectable). Takes the
+ * chain as returned by {@link AuditEventRepo.listChain} — callers decide the query boundary;
+ * this module only re-derives evidence from what it is given.
+ */
+
+import { recomputeEventHash } from "./chain";
+import type { AuditEvent } from "./event";
+
+export type VerifyIssueType = "tampered" | "reordered" | "missing" | "forked";
+
+export interface VerifyIssue {
+  readonly type: VerifyIssueType;
+  readonly chainIndex: number;
+  readonly eventIds: readonly string[];
+}
+
+export interface VerifyResult {
+  readonly valid: boolean;
+  readonly issues: readonly VerifyIssue[];
+}
+
+/**
+ * Verifies `events` as a single business's chain, in the order given.
+ *
+ * - **tampered**: an event's recomputed hash does not match its recorded `hash`.
+ * - **forked**: more than one event claims the same `chainIndex`.
+ * - **missing**: a `chainIndex` gap (a segment was deleted).
+ * - **reordered**: an event's `previousHash` does not match the preceding index's recorded hash.
+ */
+export function verifyChain(events: readonly AuditEvent[]): VerifyResult {
+  const issues: VerifyIssue[] = [];
+  const byIndex = new Map<number, AuditEvent[]>();
+  for (const event of events) {
+    const group = byIndex.get(event.chainIndex) ?? [];
+    group.push(event);
+    byIndex.set(event.chainIndex, group);
+  }
+
+  for (const [chainIndex, group] of byIndex) {
+    if (group.length > 1) {
+      issues.push({
+        type: "forked",
+        chainIndex,
+        eventIds: group.map((event) => event.id),
+      });
+    }
+  }
+
+  if (events.length === 0) {
+    return { valid: true, issues: [] };
+  }
+
+  const maxIndex = Math.max(...events.map((event) => event.chainIndex));
+  for (let index = 0; index <= maxIndex; index += 1) {
+    if (!byIndex.has(index)) {
+      issues.push({ type: "missing", chainIndex: index, eventIds: [] });
+    }
+  }
+
+  const sorted = [...events].sort((a, b) => a.chainIndex - b.chainIndex);
+  let previous: AuditEvent | undefined;
+  for (const event of sorted) {
+    if (recomputeEventHash(event) !== event.hash) {
+      issues.push({ type: "tampered", chainIndex: event.chainIndex, eventIds: [event.id] });
+    }
+    const expectedPreviousHash = previous ? previous.hash : null;
+    if (
+      previous &&
+      previous.chainIndex === event.chainIndex - 1 &&
+      event.previousHash !== expectedPreviousHash
+    ) {
+      issues.push({ type: "reordered", chainIndex: event.chainIndex, eventIds: [event.id] });
+    }
+    previous = event;
+  }
+
+  return { valid: issues.length === 0, issues };
+}

--- a/packages/audit/src/writer.test.ts
+++ b/packages/audit/src/writer.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import type { AuditEventInput } from "./event";
+import { InMemoryAuditEventRepo } from "./storage";
+import { verifyChain } from "./verify";
+import { AuditWriter } from "./writer";
+
+function input(overrides: Partial<AuditEventInput> = {}): AuditEventInput {
+  return {
+    actor: { principalId: "user-1", businessId: "biz-1" },
+    effectivePrincipal: { principalId: "user-1", businessId: "biz-1" },
+    action: "record.read",
+    target: "resource:invoice/1",
+    decision: "allow",
+    reasonCodes: [],
+    correlationId: "corr-1",
+    occurredAt: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+describe("AuditWriter.append", () => {
+  it("appends the first event with no previous hash and chainIndex 0", async () => {
+    const repo = new InMemoryAuditEventRepo();
+    const writer = new AuditWriter(repo);
+
+    const event = await writer.append(input());
+
+    expect(event.chainIndex).toBe(0);
+    expect(event.previousHash).toBeNull();
+    expect(event.hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("links each event's previousHash to the prior event's hash", async () => {
+    const repo = new InMemoryAuditEventRepo();
+    const writer = new AuditWriter(repo);
+
+    const first = await writer.append(input());
+    const second = await writer.append(input({ action: "record.update" }));
+
+    expect(second.chainIndex).toBe(1);
+    expect(second.previousHash).toBe(first.hash);
+  });
+
+  it("scopes chains per business_id", async () => {
+    const repo = new InMemoryAuditEventRepo();
+    const writer = new AuditWriter(repo);
+
+    await writer.append(input({ actor: { principalId: "u1", businessId: "biz-1" } }));
+    const other = await writer.append(input({ actor: { principalId: "u2", businessId: "biz-2" } }));
+
+    expect(other.chainIndex).toBe(0);
+    expect(other.previousHash).toBeNull();
+  });
+
+  it("produces a chain that verifies clean end to end", async () => {
+    const repo = new InMemoryAuditEventRepo();
+    const writer = new AuditWriter(repo);
+
+    await writer.append(input());
+    await writer.append(input({ action: "record.update", decision: "deny" }));
+    await writer.append(input({ action: "record.delete" }));
+
+    const chain = await repo.listChain("biz-1");
+    expect(verifyChain(chain)).toEqual({ valid: true, issues: [] });
+  });
+});

--- a/packages/audit/src/writer.ts
+++ b/packages/audit/src/writer.ts
@@ -1,0 +1,35 @@
+/**
+ * Single append path for audit evidence (SPEC §20). Computes chain linkage (`chainIndex`,
+ * `previousHash`, `hash`) from the business's current chain tail, then appends through the repo.
+ * This is the only place a chained hash is produced — callers never set it themselves.
+ */
+
+import { randomUUID } from "node:crypto";
+import { computeEventHash } from "./chain";
+import type { AuditEvent, AuditEventInput } from "./event";
+import type { AuditEventRepo } from "./storage";
+
+export class AuditWriter {
+  constructor(private readonly repo: AuditEventRepo) {}
+
+  async append(input: AuditEventInput): Promise<AuditEvent> {
+    const businessId = input.actor.businessId;
+    const previous = await this.repo.getLatest(businessId);
+    const chainIndex = previous ? previous.chainIndex + 1 : 0;
+    const previousHash = previous ? previous.hash : null;
+    const id = randomUUID();
+    const hash = computeEventHash(input, id, businessId, chainIndex, previousHash);
+
+    const event: AuditEvent = {
+      ...input,
+      id,
+      businessId,
+      chainIndex,
+      previousHash,
+      hash,
+    };
+
+    await this.repo.append(event);
+    return event;
+  }
+}

--- a/packages/audit/tsconfig.json
+++ b/packages/audit/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "moduleResolution": "bundler",
     "module": "ESNext",
-    "noEmit": true
+    "noEmit": true,
+    "types": ["node"]
   },
   "include": ["src"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -409,10 +409,20 @@ importers:
         version: 6.0.3
 
   packages/audit:
+    dependencies:
+      '@tulipfarm/schema':
+        specifier: workspace:*
+        version: link:../schema
+      '@tulipfarm/storage':
+        specifier: workspace:*
+        version: link:../storage
     devDependencies:
       '@tulipfarm/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      '@types/node':
+        specifier: ^26.1.1
+        version: 26.1.1
       typescript:
         specifier: ^6.0.3
         version: 6.0.3


### PR DESCRIPTION
## Summary
- Adds `@tulipfarm/audit` event/writer/chain/verify: canonical evidence (actor/effective principal, correlation/causation, run/state lineage, safe Artifact refs — no raw payload field) hash-linked per business_id (SPEC §20).
- `verifyChain` detects tamper, reorder, deletion (chainIndex gap), and fork.
- No PostgreSQL adapter yet — `InMemoryAuditEventRepo` matches the sibling scaffold-package pattern; a later task wires persistence + blob sealing.

## Test plan
- [x] `pnpm --filter @tulipfarm/audit test` — 13/13 passing (happy-path append/link, business_id scoping, tamper/reorder/deletion/fork detection, DLP-boundary hash scope)
- [x] `pnpm --filter @tulipfarm/audit typecheck`
- [x] `pnpm exec biome check packages/audit`