### PR TITLE
fix(governance): close AW-011 through AW-021 gaps

### DIFF
--- a/packages/audit/src/event.ts
+++ b/packages/audit/src/event.ts
@@ -8,6 +8,18 @@ import type { BlobRef } from "@tulipfarm/storage";
 
 export type AuditDecision = "allow" | "deny";
 
+export type AuditInputErrorCode = "BUSINESS_MISMATCH" | "INVALID_INPUT" | "PROTECTED_PAYLOAD";
+
+export class AuditInputError extends Error {
+  constructor(
+    public readonly code: AuditInputErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = "AuditInputError";
+  }
+}
+
 /** Minimal principal reference. `@tulipfarm/audit` does not depend on `@tulipfarm/authz`. */
 export interface AuditPrincipalRef {
   readonly principalId: string;
@@ -46,4 +58,181 @@ export interface AuditEvent extends AuditEventInput {
   readonly chainIndex: number;
   readonly previousHash: string | null;
   readonly hash: string;
+}
+
+const INPUT_KEYS = new Set([
+  "actor",
+  "effectivePrincipal",
+  "agentId",
+  "runId",
+  "stateId",
+  "action",
+  "target",
+  "decision",
+  "reasonCodes",
+  "guardrailDigest",
+  "bundleDigest",
+  "sourceClassification",
+  "destinationClassification",
+  "requestHash",
+  "resultHash",
+  "correlationId",
+  "causationId",
+  "occurredAt",
+  "safeMetadata",
+  "safeRefs",
+]);
+
+const PROTECTED_KEY =
+  /^(?:body|content|message|payload|prompt|secret|password|passwd|token|credential|api[-_]?key|private[-_]?key)$/i;
+const PROTECTED_VALUE: readonly RegExp[] = [
+  /-----BEGIN [A-Z ]*PRIVATE KEY-----/,
+  /\bsk-[A-Za-z0-9]{16,}/,
+  /\bxox[baprs]-[A-Za-z0-9-]{10,}/,
+  /\bgh[pousr]_[A-Za-z0-9]{20,}/,
+  /\bgithub_pat_[A-Za-z0-9_]{20,}/,
+];
+
+function invalid(message: string): never {
+  throw new AuditInputError("INVALID_INPUT", message);
+}
+
+function protectedPayload(): never {
+  throw new AuditInputError(
+    "PROTECTED_PAYLOAD",
+    "audit event contains payload data; store protected content as an Artifact reference"
+  );
+}
+
+function safeString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    return invalid(`audit event ${field} must be a non-empty string`);
+  }
+  return value;
+}
+
+function cloneSafeMetadata(value: unknown, ancestors = new Set<object>()): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return invalid("audit event safeMetadata must be an object");
+  }
+  if (ancestors.has(value)) return invalid("audit event safeMetadata must not contain cycles");
+  ancestors.add(value);
+  const result: Record<string, unknown> = {};
+  try {
+    for (const [key, child] of Object.entries(value)) {
+      if (PROTECTED_KEY.test(key)) protectedPayload();
+      if (child === null || typeof child === "boolean") {
+        result[key] = child;
+      } else if (typeof child === "number") {
+        if (!Number.isFinite(child)) return invalid("audit event safeMetadata must be finite");
+        result[key] = child;
+      } else if (typeof child === "string") {
+        if (PROTECTED_VALUE.some((pattern) => pattern.test(child))) protectedPayload();
+        result[key] = child;
+      } else if (Array.isArray(child)) {
+        result[key] = Object.freeze(
+          child.map((item) => {
+            if (
+              item === null ||
+              typeof item === "boolean" ||
+              (typeof item === "number" && Number.isFinite(item))
+            ) {
+              return item;
+            }
+            if (typeof item === "string") {
+              if (PROTECTED_VALUE.some((pattern) => pattern.test(item))) protectedPayload();
+              return item;
+            }
+            return cloneSafeMetadata(item, ancestors);
+          })
+        );
+      } else if (typeof child === "object") {
+        result[key] = cloneSafeMetadata(child, ancestors);
+      } else {
+        return invalid("audit event safeMetadata contains an unsupported value");
+      }
+    }
+  } finally {
+    ancestors.delete(value);
+  }
+  return Object.freeze(result);
+}
+
+/**
+ * Validate and snapshot an event before hashing or persistence. Runtime callers cannot smuggle
+ * extra payload fields through TypeScript casts, principal attribution cannot cross a business,
+ * and mutable caller-owned arrays/objects cannot change stored evidence after hashing.
+ */
+export function normalizeAuditEventInput(input: AuditEventInput): AuditEventInput {
+  for (const key of Object.keys(input)) {
+    if (!INPUT_KEYS.has(key)) protectedPayload();
+  }
+  const actorBusinessId = safeString(input.actor?.businessId, "actor.businessId");
+  const effectiveBusinessId = safeString(
+    input.effectivePrincipal?.businessId,
+    "effectivePrincipal.businessId"
+  );
+  if (actorBusinessId !== effectiveBusinessId) {
+    throw new AuditInputError(
+      "BUSINESS_MISMATCH",
+      "audit actor and effective principal must belong to the same business"
+    );
+  }
+  if (!(input.occurredAt instanceof Date) || !Number.isFinite(input.occurredAt.getTime())) {
+    return invalid("audit event occurredAt must be a valid Date");
+  }
+  if (input.decision !== "allow" && input.decision !== "deny") {
+    return invalid("audit event decision is invalid");
+  }
+  if (
+    !Array.isArray(input.reasonCodes) ||
+    input.reasonCodes.some((code) => typeof code !== "string")
+  ) {
+    return invalid("audit event reasonCodes must contain strings");
+  }
+
+  const normalized: AuditEventInput = {
+    actor: Object.freeze({
+      principalId: safeString(input.actor.principalId, "actor.principalId"),
+      businessId: actorBusinessId,
+    }),
+    effectivePrincipal: Object.freeze({
+      principalId: safeString(
+        input.effectivePrincipal.principalId,
+        "effectivePrincipal.principalId"
+      ),
+      businessId: effectiveBusinessId,
+    }),
+    action: safeString(input.action, "action"),
+    target: safeString(input.target, "target"),
+    decision: input.decision,
+    reasonCodes: Object.freeze([...input.reasonCodes]),
+    correlationId: safeString(input.correlationId, "correlationId"),
+    occurredAt: new Date(input.occurredAt.getTime()),
+    ...(input.agentId !== undefined ? { agentId: input.agentId } : {}),
+    ...(input.runId !== undefined ? { runId: input.runId } : {}),
+    ...(input.stateId !== undefined ? { stateId: input.stateId } : {}),
+    ...(input.guardrailDigest !== undefined ? { guardrailDigest: input.guardrailDigest } : {}),
+    ...(input.bundleDigest !== undefined ? { bundleDigest: input.bundleDigest } : {}),
+    ...(input.sourceClassification !== undefined
+      ? { sourceClassification: input.sourceClassification }
+      : {}),
+    ...(input.destinationClassification !== undefined
+      ? { destinationClassification: input.destinationClassification }
+      : {}),
+    ...(input.requestHash !== undefined ? { requestHash: input.requestHash } : {}),
+    ...(input.resultHash !== undefined ? { resultHash: input.resultHash } : {}),
+    ...(input.causationId !== undefined ? { causationId: input.causationId } : {}),
+    ...(input.safeMetadata !== undefined
+      ? { safeMetadata: cloneSafeMetadata(input.safeMetadata) }
+      : {}),
+    ...(input.safeRefs !== undefined
+      ? {
+          safeRefs: Object.freeze(
+            input.safeRefs.map((ref) => Object.freeze({ key: ref.key, hash: ref.hash }))
+          ),
+        }
+      : {}),
+  };
+  return Object.freeze(normalized);
 }

--- a/packages/audit/src/index.ts
+++ b/packages/audit/src/index.ts
@@ -3,10 +3,12 @@ export type {
   AuditDecision,
   AuditEvent,
   AuditEventInput,
+  AuditInputErrorCode,
   AuditPrincipalRef,
 } from "./event";
+export { AuditInputError, normalizeAuditEventInput } from "./event";
 export type { AuditEventRepo } from "./storage";
-export { InMemoryAuditEventRepo } from "./storage";
-export type { VerifyIssue, VerifyIssueType, VerifyResult } from "./verify";
+export { AuditAppendConflictError, InMemoryAuditEventRepo } from "./storage";
+export type { VerifyExpectation, VerifyIssue, VerifyIssueType, VerifyResult } from "./verify";
 export { verifyChain } from "./verify";
 export { AuditWriter } from "./writer";

--- a/packages/audit/src/storage.ts
+++ b/packages/audit/src/storage.ts
@@ -6,11 +6,39 @@
  * concern layered on top of `listChain`.
  */
 
+import { recomputeEventHash } from "./chain";
 import type { AuditEvent } from "./event";
 
+function snapshotEvent(event: AuditEvent): AuditEvent {
+  return Object.freeze({
+    ...event,
+    occurredAt: new Date(event.occurredAt.getTime()),
+    reasonCodes: Object.freeze([...event.reasonCodes]),
+    ...(event.safeMetadata ? { safeMetadata: event.safeMetadata } : {}),
+    ...(event.safeRefs
+      ? {
+          safeRefs: Object.freeze(
+            event.safeRefs.map((ref) => Object.freeze({ key: ref.key, hash: ref.hash }))
+          ),
+        }
+      : {}),
+  });
+}
+
+/** Compare-and-append failed because another event advanced the chain first. */
+export class AuditAppendConflictError extends Error {
+  constructor() {
+    super("audit chain advanced before the event could be appended");
+    this.name = "AuditAppendConflictError";
+  }
+}
+
 export interface AuditEventRepo {
-  /** Appends `event` to its business's chain. Callers must not mutate `chainIndex`/`previousHash`
-   *  after construction — this is an append-only ledger, never an update. */
+  /**
+   * Compare-and-append `event`. Implementations must reject unless `chainIndex` and
+   * `previousHash` still describe the current tail, and must enforce this in the same durable
+   * transaction as the insert.
+   */
   append(event: AuditEvent): Promise<void>;
   /** The most recently appended event for `businessId`, or `undefined` if the chain is empty. */
   getLatest(businessId: string): Promise<AuditEvent | undefined>;
@@ -24,16 +52,27 @@ export class InMemoryAuditEventRepo implements AuditEventRepo {
 
   async append(event: AuditEvent): Promise<void> {
     const chain = this.chains.get(event.businessId) ?? [];
-    chain.push(Object.freeze({ ...event }));
+    const previous = chain.at(-1);
+    const expectedIndex = previous ? previous.chainIndex + 1 : 0;
+    const expectedPreviousHash = previous?.hash ?? null;
+    if (
+      event.chainIndex !== expectedIndex ||
+      event.previousHash !== expectedPreviousHash ||
+      recomputeEventHash(event) !== event.hash
+    ) {
+      throw new AuditAppendConflictError();
+    }
+    chain.push(snapshotEvent(event));
     this.chains.set(event.businessId, chain);
   }
 
   async getLatest(businessId: string): Promise<AuditEvent | undefined> {
     const chain = this.chains.get(businessId);
-    return chain?.at(-1);
+    const event = chain?.at(-1);
+    return event ? snapshotEvent(event) : undefined;
   }
 
   async listChain(businessId: string): Promise<AuditEvent[]> {
-    return [...(this.chains.get(businessId) ?? [])];
+    return (this.chains.get(businessId) ?? []).map(snapshotEvent);
   }
 }

--- a/packages/audit/src/verify.test.ts
+++ b/packages/audit/src/verify.test.ts
@@ -86,4 +86,29 @@ describe("verifyChain", () => {
       result.issues.some((issue) => issue.type === "reordered" && issue.chainIndex === 2)
     ).toBe(true);
   });
+
+  it("detects events returned out of chain order", async () => {
+    const chain = await buildChain(3);
+    const result = verifyChain([chain[1], chain[0], chain[2]]);
+
+    expect(result.valid).toBe(false);
+    expect(result.issues.some((issue) => issue.type === "reordered")).toBe(true);
+  });
+
+  it("uses a durable anchor to detect tail or whole-chain deletion", async () => {
+    const chain = await buildChain(3);
+    const expectation = { eventCount: chain.length, tailHash: chain.at(-1)?.hash };
+
+    expect(verifyChain(chain.slice(0, 2), expectation).valid).toBe(false);
+    expect(verifyChain([], expectation).valid).toBe(false);
+  });
+
+  it("detects a protected payload smuggled into a stored event", async () => {
+    const chain = await buildChain(1);
+    const injected = { ...chain[0], payload: "private body" };
+    const result = verifyChain([injected]);
+
+    expect(result.valid).toBe(false);
+    expect(result.issues.some((issue) => issue.type === "protected_payload")).toBe(true);
+  });
 });

--- a/packages/audit/src/verify.ts
+++ b/packages/audit/src/verify.ts
@@ -6,9 +6,16 @@
  */
 
 import { recomputeEventHash } from "./chain";
-import type { AuditEvent } from "./event";
+import { type AuditEvent, AuditInputError, normalizeAuditEventInput } from "./event";
 
-export type VerifyIssueType = "tampered" | "reordered" | "missing" | "forked";
+export type VerifyIssueType =
+  | "tampered"
+  | "reordered"
+  | "missing"
+  | "forked"
+  | "business_mismatch"
+  | "protected_payload"
+  | "anchor_mismatch";
 
 export interface VerifyIssue {
   readonly type: VerifyIssueType;
@@ -21,6 +28,25 @@ export interface VerifyResult {
   readonly issues: readonly VerifyIssue[];
 }
 
+export interface VerifyExpectation {
+  /** Durable event count or sealed-segment count used to detect tail/all-event deletion. */
+  readonly eventCount?: number;
+  /** Durable or sealed tail hash used to detect truncation or replacement of the final event. */
+  readonly tailHash?: string | null;
+}
+
+function inputOf(event: AuditEvent) {
+  const {
+    id: _id,
+    businessId: _businessId,
+    chainIndex: _index,
+    previousHash: _previous,
+    hash: _hash,
+    ...input
+  } = event;
+  return input;
+}
+
 /**
  * Verifies `events` as a single business's chain, in the order given.
  *
@@ -29,13 +55,39 @@ export interface VerifyResult {
  * - **missing**: a `chainIndex` gap (a segment was deleted).
  * - **reordered**: an event's `previousHash` does not match the preceding index's recorded hash.
  */
-export function verifyChain(events: readonly AuditEvent[]): VerifyResult {
+export function verifyChain(
+  events: readonly AuditEvent[],
+  expectation: VerifyExpectation = {}
+): VerifyResult {
   const issues: VerifyIssue[] = [];
   const byIndex = new Map<number, AuditEvent[]>();
+  const businessId = events[0]?.businessId;
   for (const event of events) {
     const group = byIndex.get(event.chainIndex) ?? [];
     group.push(event);
     byIndex.set(event.chainIndex, group);
+    if (
+      (businessId !== undefined && event.businessId !== businessId) ||
+      event.businessId !== event.actor.businessId
+    ) {
+      issues.push({
+        type: "business_mismatch",
+        chainIndex: event.chainIndex,
+        eventIds: [event.id],
+      });
+    }
+    try {
+      normalizeAuditEventInput(inputOf(event));
+    } catch (error) {
+      issues.push({
+        type:
+          error instanceof AuditInputError && error.code === "PROTECTED_PAYLOAD"
+            ? "protected_payload"
+            : "tampered",
+        chainIndex: event.chainIndex,
+        eventIds: [event.id],
+      });
+    }
   }
 
   for (const [chainIndex, group] of byIndex) {
@@ -48,11 +100,17 @@ export function verifyChain(events: readonly AuditEvent[]): VerifyResult {
     }
   }
 
-  if (events.length === 0) {
-    return { valid: true, issues: [] };
+  if (
+    events.length === 0 &&
+    expectation.eventCount === undefined &&
+    expectation.tailHash === undefined
+  ) {
+    return { valid: true, issues };
   }
 
-  const maxIndex = Math.max(...events.map((event) => event.chainIndex));
+  const maxObservedIndex =
+    events.length === 0 ? -1 : Math.max(...events.map((event) => event.chainIndex));
+  const maxIndex = Math.max(maxObservedIndex, (expectation.eventCount ?? 0) - 1);
   for (let index = 0; index <= maxIndex; index += 1) {
     if (!byIndex.has(index)) {
       issues.push({ type: "missing", chainIndex: index, eventIds: [] });
@@ -60,20 +118,52 @@ export function verifyChain(events: readonly AuditEvent[]): VerifyResult {
   }
 
   const sorted = [...events].sort((a, b) => a.chainIndex - b.chainIndex);
+  for (let index = 1; index < events.length; index += 1) {
+    if (events[index].chainIndex !== events[index - 1].chainIndex + 1) {
+      issues.push({
+        type: "reordered",
+        chainIndex: events[index].chainIndex,
+        eventIds: [events[index].id],
+      });
+    }
+  }
   let previous: AuditEvent | undefined;
   for (const event of sorted) {
-    if (recomputeEventHash(event) !== event.hash) {
+    let recomputed: string | undefined;
+    try {
+      recomputed = recomputeEventHash(event);
+    } catch {
+      recomputed = undefined;
+    }
+    if (recomputed !== event.hash) {
       issues.push({ type: "tampered", chainIndex: event.chainIndex, eventIds: [event.id] });
     }
     const expectedPreviousHash = previous ? previous.hash : null;
     if (
-      previous &&
-      previous.chainIndex === event.chainIndex - 1 &&
+      event.chainIndex === (previous?.chainIndex ?? -1) + 1 &&
       event.previousHash !== expectedPreviousHash
     ) {
       issues.push({ type: "reordered", chainIndex: event.chainIndex, eventIds: [event.id] });
     }
     previous = event;
+  }
+
+  if (expectation.eventCount !== undefined && events.length !== expectation.eventCount) {
+    issues.push({
+      type: "anchor_mismatch",
+      chainIndex: expectation.eventCount,
+      eventIds: [],
+    });
+  }
+  if (expectation.tailHash !== undefined) {
+    const tail = sorted.at(-1)?.hash ?? null;
+    if (tail !== expectation.tailHash) {
+      issues.push({
+        type: "anchor_mismatch",
+        chainIndex: sorted.at(-1)?.chainIndex ?? -1,
+        eventIds: sorted.at(-1) ? [sorted.at(-1)?.id ?? ""] : [],
+      });
+    }
   }
 
   return { valid: issues.length === 0, issues };

--- a/packages/audit/src/writer.test.ts
+++ b/packages/audit/src/writer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { AuditEventInput } from "./event";
+import { type AuditEventInput, AuditInputError } from "./event";
 import { InMemoryAuditEventRepo } from "./storage";
 import { verifyChain } from "./verify";
 import { AuditWriter } from "./writer";
@@ -46,7 +46,12 @@ describe("AuditWriter.append", () => {
     const writer = new AuditWriter(repo);
 
     await writer.append(input({ actor: { principalId: "u1", businessId: "biz-1" } }));
-    const other = await writer.append(input({ actor: { principalId: "u2", businessId: "biz-2" } }));
+    const other = await writer.append(
+      input({
+        actor: { principalId: "u2", businessId: "biz-2" },
+        effectivePrincipal: { principalId: "u2", businessId: "biz-2" },
+      })
+    );
 
     expect(other.chainIndex).toBe(0);
     expect(other.previousHash).toBeNull();
@@ -62,5 +67,57 @@ describe("AuditWriter.append", () => {
 
     const chain = await repo.listChain("biz-1");
     expect(verifyChain(chain)).toEqual({ valid: true, issues: [] });
+  });
+
+  it("rejects cross-business actor substitution", async () => {
+    const writer = new AuditWriter(new InMemoryAuditEventRepo());
+
+    await expect(
+      writer.append(
+        input({
+          effectivePrincipal: { principalId: "other", businessId: "biz-2" },
+        })
+      )
+    ).rejects.toMatchObject({ code: "BUSINESS_MISMATCH" });
+  });
+
+  it("rejects extra and nested protected payloads before persistence", async () => {
+    const repo = new InMemoryAuditEventRepo();
+    const writer = new AuditWriter(repo);
+    const extraPayload = { ...input(), payload: "private body" } as AuditEventInput;
+
+    await expect(writer.append(extraPayload)).rejects.toBeInstanceOf(AuditInputError);
+    await expect(
+      writer.append(input({ safeMetadata: { password: "hunter2" } }))
+    ).rejects.toMatchObject({ code: "PROTECTED_PAYLOAD" });
+    await expect(repo.listChain("biz-1")).resolves.toEqual([]);
+  });
+
+  it("retries compare-and-append conflicts without forking the chain", async () => {
+    const repo = new InMemoryAuditEventRepo();
+    const writer = new AuditWriter(repo);
+
+    await Promise.all(
+      Array.from({ length: 8 }, (_, index) =>
+        writer.append(input({ action: `record.concurrent-${index}` }))
+      )
+    );
+
+    const chain = await repo.listChain("biz-1");
+    expect(chain).toHaveLength(8);
+    expect(verifyChain(chain)).toEqual({ valid: true, issues: [] });
+  });
+
+  it("does not expose mutable stored timestamps through repository reads", async () => {
+    const repo = new InMemoryAuditEventRepo();
+    const writer = new AuditWriter(repo);
+    await writer.append(input());
+
+    const exposed = await repo.getLatest("biz-1");
+    exposed?.occurredAt.setUTCFullYear(2030);
+
+    const stored = await repo.listChain("biz-1");
+    expect(stored[0].occurredAt.toISOString()).toBe("2026-01-01T00:00:00.000Z");
+    expect(verifyChain(stored)).toEqual({ valid: true, issues: [] });
   });
 });

--- a/packages/audit/src/writer.ts
+++ b/packages/audit/src/writer.ts
@@ -6,30 +6,39 @@
 
 import { randomUUID } from "node:crypto";
 import { computeEventHash } from "./chain";
-import type { AuditEvent, AuditEventInput } from "./event";
-import type { AuditEventRepo } from "./storage";
+import { type AuditEvent, type AuditEventInput, normalizeAuditEventInput } from "./event";
+import { AuditAppendConflictError, type AuditEventRepo } from "./storage";
+
+const MAX_APPEND_ATTEMPTS = 32;
 
 export class AuditWriter {
   constructor(private readonly repo: AuditEventRepo) {}
 
   async append(input: AuditEventInput): Promise<AuditEvent> {
-    const businessId = input.actor.businessId;
-    const previous = await this.repo.getLatest(businessId);
-    const chainIndex = previous ? previous.chainIndex + 1 : 0;
-    const previousHash = previous ? previous.hash : null;
-    const id = randomUUID();
-    const hash = computeEventHash(input, id, businessId, chainIndex, previousHash);
+    const normalized = normalizeAuditEventInput(input);
+    const businessId = normalized.actor.businessId;
+    for (let attempt = 0; attempt < MAX_APPEND_ATTEMPTS; attempt += 1) {
+      const previous = await this.repo.getLatest(businessId);
+      const chainIndex = previous ? previous.chainIndex + 1 : 0;
+      const previousHash = previous ? previous.hash : null;
+      const id = randomUUID();
+      const hash = computeEventHash(normalized, id, businessId, chainIndex, previousHash);
+      const event: AuditEvent = Object.freeze({
+        ...normalized,
+        id,
+        businessId,
+        chainIndex,
+        previousHash,
+        hash,
+      });
 
-    const event: AuditEvent = {
-      ...input,
-      id,
-      businessId,
-      chainIndex,
-      previousHash,
-      hash,
-    };
-
-    await this.repo.append(event);
-    return event;
+      try {
+        await this.repo.append(event);
+        return event;
+      } catch (error) {
+        if (!(error instanceof AuditAppendConflictError)) throw error;
+      }
+    }
+    throw new AuditAppendConflictError();
   }
 }

--- a/packages/authz/package.json
+++ b/packages/authz/package.json
@@ -8,8 +8,12 @@
     "test": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit"
   },
+  "dependencies": {
+    "@tulipfarm/schema": "workspace:*"
+  },
   "devDependencies": {
     "@tulipfarm/tsconfig": "workspace:*",
+    "@types/node": "^26.1.1",
     "typescript": "^6.0.3"
   }
 }

--- a/packages/authz/src/guardrails/engine.test.ts
+++ b/packages/authz/src/guardrails/engine.test.ts
@@ -4,7 +4,7 @@ import { evaluateGuardrail, type GuardrailContext, type GuardrailRule } from "./
 const READ: GuardrailContext = {
   action: "record.read",
   resourceType: "invoice",
-  autonomy: "interactive",
+  autonomy: "answer_only",
   taint: "trusted",
 };
 
@@ -147,16 +147,27 @@ describe("evaluateGuardrail — volume, taint, autonomy ceilings", () => {
   });
 
   it("denies autonomy above the ceiling and missing autonomy alike", () => {
-    const supervised: GuardrailRule = { ...allowRead, id: "auto", maxAutonomy: "approved" };
-    expect(evaluateGuardrail([supervised], { ...READ, autonomy: "autonomous" })).toEqual({
+    const lowRisk: GuardrailRule = {
+      ...allowRead,
+      id: "auto",
+      maxAutonomy: "execute_low_risk",
+    };
+    expect(
+      evaluateGuardrail([lowRisk], {
+        ...READ,
+        autonomy: "execute_policy_authorized",
+      })
+    ).toEqual({
       effect: "deny",
       reason: "autonomy_exceeded",
       ruleId: "auto",
       dimension: "autonomy",
     });
-    expect(evaluateGuardrail([supervised], { ...READ, autonomy: "approved" }).effect).toBe("allow");
+    expect(evaluateGuardrail([lowRisk], { ...READ, autonomy: "execute_low_risk" }).effect).toBe(
+      "allow"
+    );
     const { autonomy: _autonomy, ...noAutonomy } = READ;
-    expect(evaluateGuardrail([supervised], noAutonomy)).toEqual({
+    expect(evaluateGuardrail([lowRisk], noAutonomy)).toEqual({
       effect: "deny",
       reason: "missing_context",
       ruleId: "auto",
@@ -181,23 +192,30 @@ describe("evaluateGuardrail — approval and precedence", () => {
   });
 
   it("escalates to approval when autonomy exceeds the allow ceiling", () => {
-    const interactiveAllow: GuardrailRule = { ...allowRead, id: "ia", maxAutonomy: "interactive" };
+    const answerOnly: GuardrailRule = {
+      ...allowRead,
+      id: "answer",
+      maxAutonomy: "answer_only",
+    };
     const approval: GuardrailRule = {
       id: "approve",
       effect: "require_approval",
       action: "record.read",
       resourceType: "invoice",
     };
-    const autonomous = { ...READ, autonomy: "autonomous" as const };
-    expect(evaluateGuardrail([interactiveAllow, approval], autonomous)).toEqual({
+    const policyAuthorized = {
+      ...READ,
+      autonomy: "execute_policy_authorized" as const,
+    };
+    expect(evaluateGuardrail([answerOnly, approval], policyAuthorized)).toEqual({
       effect: "require_approval",
       reason: "approval_required",
       ruleId: "approve",
     });
-    expect(evaluateGuardrail([interactiveAllow], autonomous)).toEqual({
+    expect(evaluateGuardrail([answerOnly], policyAuthorized)).toEqual({
       effect: "deny",
       reason: "autonomy_exceeded",
-      ruleId: "ia",
+      ruleId: "answer",
       dimension: "autonomy",
     });
   });

--- a/packages/authz/src/guardrails/risk.ts
+++ b/packages/authz/src/guardrails/risk.ts
@@ -1,13 +1,15 @@
 /**
  * Risk dimension orderings for Guardrail ceilings (SPEC §13). Taint tracks whether untrusted
- * input influenced the action; autonomy tracks how much human oversight the Run has. Both are
- * totally ordered so a ceiling check is deterministic: an actual level is within a ceiling only
- * when its rank does not exceed the ceiling's rank.
+ * input influenced the action; autonomy uses the canonical Agent autonomy ceilings from the
+ * authored schema. Both are totally ordered so a ceiling check is deterministic: an actual level
+ * is within a ceiling only when its rank does not exceed the ceiling's rank.
  */
+
+import type { AgentAutonomyCeiling } from "@tulipfarm/schema";
 
 export type TaintLevel = "trusted" | "untrusted";
 
-export type AutonomyLevel = "interactive" | "approved" | "autonomous";
+export type AutonomyLevel = AgentAutonomyCeiling;
 
 const TAINT_RANK: Readonly<Record<TaintLevel, number>> = {
   trusted: 0,
@@ -15,9 +17,10 @@ const TAINT_RANK: Readonly<Record<TaintLevel, number>> = {
 };
 
 const AUTONOMY_RANK: Readonly<Record<AutonomyLevel, number>> = {
-  interactive: 0,
-  approved: 1,
-  autonomous: 2,
+  answer_only: 0,
+  propose_actions: 1,
+  execute_low_risk: 2,
+  execute_policy_authorized: 3,
 };
 
 /** True when `actual` taint is at or below the `ceiling`. */

--- a/packages/authz/src/guests.test.ts
+++ b/packages/authz/src/guests.test.ts
@@ -19,7 +19,7 @@ function guest(overrides: Partial<Guest> = {}): Guest {
 
 function sponsor(
   overrides: Partial<Principal> = {}
-): Pick<Principal, "id" | "businessId" | "status"> {
+): Pick<Principal, "id" | "businessId" | "status" | "expiresAt"> {
   return { id: "sponsor-1", businessId: "business-1", status: "active", ...overrides };
 }
 
@@ -63,6 +63,13 @@ describe("assertGuestActive", () => {
       expect(error).toBeInstanceOf(GuestDeniedError);
       expect((error as GuestDeniedError).reason).toBe("sponsor_inactive");
     }
+  });
+
+  it("denies when an active-status sponsor is past its expiry", () => {
+    const expiredSponsor = sponsor({ expiresAt: new Date(NOW.getTime() - 1) });
+    expect(() => assertGuestActive(guest(), expiredSponsor, NOW)).toThrow(
+      expect.objectContaining({ reason: "sponsor_inactive" })
+    );
   });
 });
 

--- a/packages/authz/src/guests.ts
+++ b/packages/authz/src/guests.ts
@@ -34,7 +34,7 @@ export class GuestDeniedError extends Error {
 /** Throws unless `guest` is active, unexpired, and its sponsor is authenticatable at `now`. */
 export function assertGuestActive(
   guest: Guest,
-  sponsor: Pick<Principal, "id" | "businessId" | "status">,
+  sponsor: Pick<Principal, "id" | "businessId" | "status" | "expiresAt">,
   now: Date = new Date()
 ): void {
   if (guest.status === "revoked") {
@@ -49,7 +49,10 @@ export function assertGuestActive(
       `sponsor does not match guest ${guest.principalId}'s recorded sponsor`
     );
   }
-  if (sponsor.status !== "active") {
+  if (
+    sponsor.status !== "active" ||
+    (sponsor.expiresAt !== undefined && sponsor.expiresAt <= now)
+  ) {
     throw new GuestDeniedError(
       "sponsor_inactive",
       `sponsor for guest ${guest.principalId} is not active`
@@ -60,7 +63,7 @@ export function assertGuestActive(
 /** A guest's own explicit grants only — never the sponsor's. Empty when denied or expired. */
 export function guestGrants(
   guest: Guest,
-  sponsor: Pick<Principal, "id" | "businessId" | "status">,
+  sponsor: Pick<Principal, "id" | "businessId" | "status" | "expiresAt">,
   now: Date = new Date()
 ): readonly AccessGrant[] {
   try {

--- a/packages/authz/src/jit.test.ts
+++ b/packages/authz/src/jit.test.ts
@@ -8,6 +8,11 @@ const FUTURE_GRANT = {
   effect: "allow",
   expiresAt: new Date(NOW.getTime() + 60_000),
 } as const;
+const APPROVER = {
+  id: "approver-1",
+  businessId: "business-1",
+  status: "active",
+} as const;
 
 function request(overrides: Partial<JitGrantRequest> = {}): JitGrantRequest {
   return {
@@ -21,15 +26,13 @@ function request(overrides: Partial<JitGrantRequest> = {}): JitGrantRequest {
 
 describe("assertJitGrantIssuable", () => {
   it("allows an expiring grant approved by a different in-business approver", () => {
-    expect(() =>
-      assertJitGrantIssuable(request(), { id: "approver-1", businessId: "business-1" }, NOW)
-    ).not.toThrow();
+    expect(() => assertJitGrantIssuable(request(), APPROVER, NOW)).not.toThrow();
   });
 
   it("denies a grant without a future expiry", () => {
     const standing = request({ grant: { ...FUTURE_GRANT, expiresAt: undefined } });
     try {
-      assertJitGrantIssuable(standing, { id: "approver-1", businessId: "business-1" }, NOW);
+      assertJitGrantIssuable(standing, APPROVER, NOW);
       throw new Error("expected denial");
     } catch (error) {
       expect(error).toBeInstanceOf(JitDeniedError);
@@ -39,14 +42,12 @@ describe("assertJitGrantIssuable", () => {
 
   it("denies a grant whose expiry has already passed", () => {
     const past = request({ grant: { ...FUTURE_GRANT, expiresAt: new Date(NOW.getTime() - 1) } });
-    expect(() =>
-      assertJitGrantIssuable(past, { id: "approver-1", businessId: "business-1" }, NOW)
-    ).toThrow(JitDeniedError);
+    expect(() => assertJitGrantIssuable(past, APPROVER, NOW)).toThrow(JitDeniedError);
   });
 
   it("denies an approver from a different business", () => {
     try {
-      assertJitGrantIssuable(request(), { id: "approver-1", businessId: "business-2" }, NOW);
+      assertJitGrantIssuable(request(), { ...APPROVER, businessId: "business-2" }, NOW);
       throw new Error("expected denial");
     } catch (error) {
       expect(error).toBeInstanceOf(JitDeniedError);
@@ -56,11 +57,24 @@ describe("assertJitGrantIssuable", () => {
 
   it("denies self-approval", () => {
     try {
-      assertJitGrantIssuable(request(), { id: "principal-1", businessId: "business-1" }, NOW);
+      assertJitGrantIssuable(request(), { ...APPROVER, id: "principal-1" }, NOW);
       throw new Error("expected denial");
     } catch (error) {
       expect(error).toBeInstanceOf(JitDeniedError);
       expect((error as JitDeniedError).reason).toBe("self_approval");
     }
+  });
+
+  it("denies a disabled or expired approver", () => {
+    expect(() =>
+      assertJitGrantIssuable(request(), { ...APPROVER, status: "disabled" }, NOW)
+    ).toThrow(expect.objectContaining({ reason: "approver_inactive" }));
+    expect(() =>
+      assertJitGrantIssuable(
+        request(),
+        { ...APPROVER, expiresAt: new Date(NOW.getTime() - 1) },
+        NOW
+      )
+    ).toThrow(expect.objectContaining({ reason: "approver_inactive" }));
   });
 });

--- a/packages/authz/src/jit.ts
+++ b/packages/authz/src/jit.ts
@@ -16,7 +16,11 @@ export interface JitGrantRequest {
   readonly justification: string;
 }
 
-export type JitDenialReason = "missing_expiry" | "business_mismatch" | "self_approval";
+export type JitDenialReason =
+  | "missing_expiry"
+  | "business_mismatch"
+  | "self_approval"
+  | "approver_inactive";
 
 export class JitDeniedError extends Error {
   constructor(
@@ -35,7 +39,7 @@ export class JitDeniedError extends Error {
  */
 export function assertJitGrantIssuable(
   request: JitGrantRequest,
-  approver: Pick<Principal, "id" | "businessId">,
+  approver: Pick<Principal, "id" | "businessId" | "status" | "expiresAt">,
   now: Date = new Date()
 ): void {
   if (!request.grant.expiresAt || request.grant.expiresAt <= now) {
@@ -46,6 +50,12 @@ export function assertJitGrantIssuable(
       "business_mismatch",
       "approver does not belong to the requesting principal's business"
     );
+  }
+  if (
+    approver.status !== "active" ||
+    (approver.expiresAt !== undefined && approver.expiresAt <= now)
+  ) {
+    throw new JitDeniedError("approver_inactive", "approver is not an active principal");
   }
   if (approver.id === request.principalId) {
     throw new JitDeniedError("self_approval", "a principal cannot approve its own JIT grant");

--- a/packages/authz/src/principals.test.ts
+++ b/packages/authz/src/principals.test.ts
@@ -85,4 +85,16 @@ describe("assertSessionMatchesPrincipal", () => {
       PrincipalDeniedError
     );
   });
+
+  it("denies a valid session when its bound principal is disabled or expired", () => {
+    expect(() =>
+      assertSessionMatchesPrincipal(session(), principal({ status: "disabled" }))
+    ).toThrow(PrincipalDeniedError);
+    expect(() =>
+      assertSessionMatchesPrincipal(
+        session(),
+        principal({ expiresAt: new Date(Date.now() - 1_000) })
+      )
+    ).toThrow(PrincipalDeniedError);
+  });
 });

--- a/packages/authz/src/principals.ts
+++ b/packages/authz/src/principals.ts
@@ -63,6 +63,7 @@ export function assertSessionMatchesPrincipal(
   principal: Principal,
   now: Date = new Date()
 ): void {
+  assertPrincipalAuthenticatable(principal, now);
   if (session.expiresAt <= now) {
     throw new PrincipalDeniedError("expired", `session ${session.sid} has expired`);
   }

--- a/packages/authz/tsconfig.json
+++ b/packages/authz/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "moduleResolution": "bundler",
     "module": "ESNext",
-    "noEmit": true
+    "noEmit": true,
+    "types": ["node"]
   },
   "include": ["src"]
 }

--- a/packages/soul/src/compiler.test.ts
+++ b/packages/soul/src/compiler.test.ts
@@ -117,6 +117,28 @@ describe("compileExecutionBundle", () => {
     expect(error.field).toBe("/spec/routineRef/version");
   });
 
+  it("rejects an ID-based reference whose version constraint does not match", () => {
+    const routineId = "11111111-1111-1111-1111-111111111111";
+    const error = failure(() =>
+      compileExecutionBundle(
+        request([
+          def(
+            "Routine",
+            "child",
+            { start: "s", states: [] },
+            { id: routineId, authoredVersion: 2 }
+          ),
+          def("Trigger", "t", {
+            routineRef: { id: routineId, name: "child", version: "1" },
+          }),
+        ])
+      )
+    );
+
+    expect(error.code).toBe("VERSION_UNSATISFIED");
+    expect(error.field).toBe("/spec/routineRef/version");
+  });
+
   it("rejects inline credential material instead of an opaque reference", () => {
     const error = failure(() =>
       compileExecutionBundle(

--- a/packages/soul/src/compiler.ts
+++ b/packages/soul/src/compiler.ts
@@ -142,6 +142,17 @@ function resolveEdge(
   if (ref.id !== undefined) {
     const byId = index.get(ref.id);
     if (byId?.kind !== edge.kind) throw unresolved(def, `${edge.field}/id`);
+    if (
+      ref.version !== "*" &&
+      ref.version !== "latest" &&
+      String(byId.authoredVersion) !== ref.version
+    ) {
+      throw new BundleError(
+        "VERSION_UNSATISFIED",
+        `Execution bundle: ${def.subject} requests a version the published tree does not contain`,
+        { subject: def.subject, field: `${edge.field}/version` }
+      );
+    }
     return toResolved(edge.field, byId);
   }
 

--- a/packages/soul/src/git-store.test.ts
+++ b/packages/soul/src/git-store.test.ts
@@ -1,4 +1,7 @@
+import { createHash } from "node:crypto";
+import { canonicalHash, canonicalize } from "@tulipfarm/schema";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { stringify } from "yaml";
 
 vi.mock("simple-git", () => ({ default: vi.fn() }));
 vi.mock("node:fs", () => ({
@@ -70,10 +73,29 @@ function makeSigner(overrides: Partial<CommitSigner> = {}): CommitSigner {
   return { keyId: "key-1", sign: vi.fn(() => "sigvalue"), ...overrides };
 }
 
+const AGENT_DOCUMENT = {
+  apiVersion: "tulipfarm.ai/v1",
+  kind: "Agent",
+  metadata: {
+    id: "11111111-1111-1111-1111-111111111111",
+    slug: "ada",
+    schemaVersion: 1,
+    authoredVersion: 1,
+    lifecycle: "draft",
+  },
+  spec: {
+    owner: "prin_1",
+    instructions: { path: "instructions.md" },
+    modelProfile: "sol-high",
+    autonomy: "answer_only",
+    trustTier: "first_party",
+  },
+};
+
 const UPSERT: SoulFileChange = {
   operation: "upsert",
   path: "agents/ada/agent.yaml",
-  content: "apiVersion: v1\nkind: Agent\n",
+  content: stringify(AGENT_DOCUMENT),
 };
 const DELETE: SoulFileChange = { operation: "delete", path: "routines/old.yaml" };
 
@@ -85,8 +107,18 @@ function makeValidated(overrides: Partial<ValidatedSoulChangeset> = {}): Validat
     source: "agent",
     expectedBaseCommit: BASE,
     files: [
-      { operation: "upsert", path: UPSERT.path, hash: "h1", apiVersion: "v1", kind: "Agent" },
-      { operation: "delete", path: DELETE.path, hash: "h2" },
+      {
+        operation: "upsert",
+        path: UPSERT.path,
+        hash: canonicalHash(AGENT_DOCUMENT),
+        apiVersion: "tulipfarm.ai/v1",
+        kind: "Agent",
+      },
+      {
+        operation: "delete",
+        path: DELETE.path,
+        hash: createHash("sha256").update(`delete\0${DELETE.path}`).digest("hex"),
+      },
     ],
     evidence: { outcome: "validated", fileCount: 2 },
     ...overrides,
@@ -168,8 +200,13 @@ describe("SoulGitStore.commitChangeset", () => {
     expect(mock.rawCalls.some((c) => c[0] === "read-tree")).toBe(false);
     const commitTree = mock.rawCalls.find((c) => c[0] === "commit-tree");
     expect(commitTree).not.toContain("-p");
-    // ref update has no old-value guard when the branch is unborn
-    expect(mock.rawCalls).toContainEqual(["update-ref", "refs/heads/main", "commit3333"]);
+    // all-zero old value makes creation compare-and-swap: the ref must still not exist
+    expect(mock.rawCalls).toContainEqual([
+      "update-ref",
+      "refs/heads/main",
+      "commit3333",
+      "0000000000000000000000000000000000000000",
+    ]);
   });
 
   it("rejects a stale base before touching the ref", async () => {
@@ -189,6 +226,51 @@ describe("SoulGitStore.commitChangeset", () => {
     await expect(
       store.commitChangeset({ changeset: makeValidated(), files: [UPSERT], actor: ACTOR })
     ).rejects.toMatchObject({ code: "CONTENT_MISMATCH" });
+    expect(mock.git.revparse).not.toHaveBeenCalled();
+  });
+
+  it("rejects content changed after validation even when operation and path still match", async () => {
+    const changed = {
+      ...UPSERT,
+      content: UPSERT.content.replace("answer_only", "propose_actions"),
+    };
+    const store = new SoulGitStore(SOUL, makeSigner(), logger);
+
+    await expect(
+      store.commitChangeset({
+        changeset: makeValidated(),
+        files: [changed, DELETE],
+        actor: ACTOR,
+      })
+    ).rejects.toMatchObject({ code: "CONTENT_MISMATCH" });
+
+    expect(mock.git.revparse).not.toHaveBeenCalled();
+  });
+
+  it("writes definitions in deterministic canonical form", async () => {
+    const store = new SoulGitStore(SOUL, makeSigner(), logger);
+    await store.commitChangeset({
+      changeset: makeValidated(),
+      files: [UPSERT, DELETE],
+      actor: ACTOR,
+    });
+
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      "/tmp/soul-changeset-xyz/blob",
+      `${canonicalize(AGENT_DOCUMENT)}\n`
+    );
+  });
+
+  it("rejects an actor that differs from the validated principal", async () => {
+    const store = new SoulGitStore(SOUL, makeSigner(), logger);
+    await expect(
+      store.commitChangeset({
+        changeset: makeValidated(),
+        files: [UPSERT, DELETE],
+        actor: { ...ACTOR, principalId: "other-principal" },
+      })
+    ).rejects.toMatchObject({ code: "ACTOR_MISMATCH" });
+
     expect(mock.git.revparse).not.toHaveBeenCalled();
   });
 

--- a/packages/soul/src/git-store.ts
+++ b/packages/soul/src/git-store.ts
@@ -15,13 +15,16 @@ import {
   CommitSigningError,
   type SignedCommitMetadata,
 } from "./commit-signing";
+import { parseSoulFile } from "./parse";
 import type { Logger } from "./types";
 
 const GIT_TIMEOUT_MS = 30_000;
 const SOUL_BRANCH_REF = "refs/heads/main";
 const BLOB_MODE = "100644";
+const ZERO_OID = "0".repeat(40);
 
 export type SoulGitStoreErrorCode =
+  | "ACTOR_MISMATCH"
   | "BASE_MISMATCH"
   | "CONTENT_MISMATCH"
   | "SIGNING_FAILED"
@@ -97,10 +100,10 @@ export class SoulGitStore {
     }
   }
 
-  private assertContentMatches(
+  private validatedFiles(
     validated: ValidatedSoulChangeset,
     files: readonly SoulFileChange[]
-  ): void {
+  ): SoulFileChange[] {
     if (files.length !== validated.files.length) {
       throw new SoulGitStoreError(
         "CONTENT_MISMATCH",
@@ -115,6 +118,19 @@ export class SoulGitStore {
           `Soul git store: content at index ${index} does not match the validated changeset`
         );
       }
+      const parsed = parseSoulFile(file);
+      if (!parsed.parsed || parsed.parsed.hash !== validatedFile.hash) {
+        throw new SoulGitStoreError(
+          "CONTENT_MISMATCH",
+          `Soul git store: content at index ${index} changed after validation`
+        );
+      }
+    });
+    return files.map((file) => {
+      if (file.operation === "delete") return file;
+      const parsed = parseSoulFile(file).parsed;
+      if (parsed?.definition === undefined) return file;
+      return { ...file, content: `${parsed.definition.canonical}\n` };
     });
   }
 
@@ -178,7 +194,13 @@ export class SoulGitStore {
    */
   async commitChangeset(request: SoulCommitRequest): Promise<SoulCommitResult> {
     const { changeset, files, actor, approval } = request;
-    this.assertContentMatches(changeset, files);
+    if (actor.principalId !== changeset.principalId) {
+      throw new SoulGitStoreError(
+        "ACTOR_MISMATCH",
+        "Soul git store: commit actor does not match the validated changeset principal"
+      );
+    }
+    const canonicalFiles = this.validatedFiles(changeset, files);
 
     const expected = changeset.expectedBaseCommit === "" ? null : changeset.expectedBaseCommit;
     const parentSha = await this.resolveHead();
@@ -194,7 +216,7 @@ export class SoulGitStore {
     try {
       let treeSha: string;
       try {
-        treeSha = await this.writeTree(workDir, indexFile, parentSha, files);
+        treeSha = await this.writeTree(workDir, indexFile, parentSha, canonicalFiles);
       } catch (error) {
         throw new SoulGitStoreError(
           "WRITE_FAILED",
@@ -226,7 +248,7 @@ export class SoulGitStore {
       const commitSha = (await this.git(indexFile, identityEnv()).raw(commitArgs)).trim();
 
       const refArgs = ["update-ref", SOUL_BRANCH_REF, commitSha];
-      if (parentSha !== null) refArgs.push(parentSha);
+      refArgs.push(parentSha ?? ZERO_OID);
       try {
         await this.git().raw(refArgs);
       } catch (error) {

--- a/packages/soul/src/semantic.test.ts
+++ b/packages/soul/src/semantic.test.ts
@@ -181,6 +181,32 @@ describe("validateSoulSemantics", () => {
     expect(codes(() => validateSoulSemantics(docs))).toEqual(["VERSION_UNSATISFIED"]);
   });
 
+  it("enforces the version constraint when a reference uses a stable id", () => {
+    const routineId = "11111111-1111-1111-1111-111111111111";
+    const docs = [
+      def(
+        "Routine",
+        "flow",
+        {
+          owner: "u",
+          start: "S",
+          states: [{ type: "x", name: "S", end: true }],
+        },
+        { id: routineId, authoredVersion: 2 }
+      ),
+      def("Trigger", "t", {
+        type: "manual",
+        routineRef: { id: routineId, name: "flow", version: "1" },
+        eventType: "e",
+        eventVersion: 1,
+        backgroundIdentity: { principalKind: "service", principalId: "s" },
+        deduplication: { key: "k" },
+      }),
+    ];
+
+    expect(codes(() => validateSoulSemantics(docs))).toEqual(["VERSION_UNSATISFIED"]);
+  });
+
   it("rejects a broken Routine State graph", () => {
     const docs = [
       def("Routine", "flow", {

--- a/packages/soul/src/semantic.ts
+++ b/packages/soul/src/semantic.ts
@@ -2,6 +2,8 @@ import type { VersionedSchemaDocument } from "@tulipfarm/schema";
 import { analyzeCapabilities } from "./capability-analysis";
 import {
   type AuthoredDefinition,
+  asDefinitionRef,
+  collectReferenceEdges,
   DefinitionIndex,
   resolveReferences,
   type SoulSemanticIssue,
@@ -163,6 +165,29 @@ function checkCycles(index: DefinitionIndex): SoulSemanticIssue[] {
   ];
 }
 
+function checkStableIdVersions(index: DefinitionIndex): SoulSemanticIssue[] {
+  const issues: SoulSemanticIssue[] = [];
+  for (const def of index.all) {
+    for (const edge of collectReferenceEdges(def)) {
+      if (edge.form !== "versioned") continue;
+      const ref = asDefinitionRef(edge.value);
+      if (ref?.id === undefined || ref.version === "*" || ref.version === "latest") {
+        continue;
+      }
+      const target = index.get(ref.id);
+      if (target?.kind === edge.kind && String(target.authoredVersion) !== ref.version) {
+        issues.push({
+          code: "VERSION_UNSATISFIED",
+          subject: def.subject,
+          ref: ref.version,
+          field: `${edge.field}/version`,
+        });
+      }
+    }
+  }
+  return issues;
+}
+
 // ── Public entrypoint ───────────────────────────────────────────────────────────
 
 /**
@@ -175,6 +200,7 @@ export function validateSoulSemantics(documents: readonly VersionedSchemaDocumen
   const issues = sortIssues([
     ...identityIssues,
     ...resolveReferences(index),
+    ...checkStableIdVersions(index),
     ...checkRoutineGraphs(index),
     ...checkCycles(index),
     ...analyzeCapabilities(index),

--- a/packages/storage/src/auth/guest-repo.test.ts
+++ b/packages/storage/src/auth/guest-repo.test.ts
@@ -17,20 +17,35 @@ describe("InMemoryGuestRepo", () => {
   it("round-trips a guest record and returns undefined for an unknown id", async () => {
     const repo = new InMemoryGuestRepo();
     await repo.put(guest());
-    await expect(repo.get("guest-1")).resolves.toEqual(guest());
-    await expect(repo.get("missing")).resolves.toBeUndefined();
+    await expect(repo.get("business-1", "guest-1")).resolves.toEqual(guest());
+    await expect(repo.get("business-1", "missing")).resolves.toBeUndefined();
   });
 
   it("revokes an existing guest without touching its other fields", async () => {
     const repo = new InMemoryGuestRepo();
     await repo.put(guest());
-    await repo.revoke("guest-1");
-    await expect(repo.get("guest-1")).resolves.toMatchObject({ status: "revoked" });
+    await repo.revoke("business-1", "guest-1");
+    await expect(repo.get("business-1", "guest-1")).resolves.toMatchObject({
+      status: "revoked",
+    });
   });
 
   it("revoking an unknown guest is a no-op", async () => {
     const repo = new InMemoryGuestRepo();
-    await expect(repo.revoke("missing")).resolves.toBeUndefined();
-    await expect(repo.get("missing")).resolves.toBeUndefined();
+    await expect(repo.revoke("business-1", "missing")).resolves.toBeUndefined();
+    await expect(repo.get("business-1", "missing")).resolves.toBeUndefined();
+  });
+
+  it("isolates the same guest principal id across businesses", async () => {
+    const repo = new InMemoryGuestRepo();
+    await repo.put(guest({ businessId: "business-1", sponsorPrincipalId: "sponsor-1" }));
+    await repo.put(guest({ businessId: "business-2", sponsorPrincipalId: "sponsor-2" }));
+
+    await expect(repo.get("business-1", "guest-1")).resolves.toMatchObject({
+      sponsorPrincipalId: "sponsor-1",
+    });
+    await expect(repo.get("business-2", "guest-1")).resolves.toMatchObject({
+      sponsorPrincipalId: "sponsor-2",
+    });
   });
 });

--- a/packages/storage/src/auth/guest-repo.ts
+++ b/packages/storage/src/auth/guest-repo.ts
@@ -17,9 +17,9 @@ export interface GuestRecord {
 }
 
 export interface GuestRepo {
-  get(principalId: string): Promise<GuestRecord | undefined>;
+  get(businessId: string, principalId: string): Promise<GuestRecord | undefined>;
   put(record: GuestRecord): Promise<void>;
-  revoke(principalId: string): Promise<void>;
+  revoke(businessId: string, principalId: string): Promise<void>;
 }
 
 /**
@@ -29,17 +29,22 @@ export interface GuestRepo {
 export class InMemoryGuestRepo implements GuestRepo {
   private readonly records = new Map<string, GuestRecord>();
 
-  async get(principalId: string): Promise<GuestRecord | undefined> {
-    return this.records.get(principalId);
+  private key(businessId: string, principalId: string): string {
+    return JSON.stringify([businessId, principalId]);
+  }
+
+  async get(businessId: string, principalId: string): Promise<GuestRecord | undefined> {
+    return this.records.get(this.key(businessId, principalId));
   }
 
   async put(record: GuestRecord): Promise<void> {
-    this.records.set(record.principalId, Object.freeze({ ...record }));
+    this.records.set(this.key(record.businessId, record.principalId), Object.freeze({ ...record }));
   }
 
-  async revoke(principalId: string): Promise<void> {
-    const existing = this.records.get(principalId);
+  async revoke(businessId: string, principalId: string): Promise<void> {
+    const key = this.key(businessId, principalId);
+    const existing = this.records.get(key);
     if (!existing) return;
-    this.records.set(principalId, Object.freeze({ ...existing, status: "revoked" }));
+    this.records.set(key, Object.freeze({ ...existing, status: "revoked" }));
   }
 }

--- a/packages/storage/src/auth/jit-repo.test.ts
+++ b/packages/storage/src/auth/jit-repo.test.ts
@@ -26,7 +26,7 @@ describe("InMemoryJitGrantRepo", () => {
     const repo = new InMemoryJitGrantRepo();
     await repo.put(issuance());
     await repo.put(issuance({ id: "jit-2", principalId: "principal-2" }));
-    const active = await repo.listActive("principal-1", NOW);
+    const active = await repo.listActive("business-1", "principal-1", NOW);
     expect(active.map((r) => r.id)).toEqual(["jit-1"]);
   });
 
@@ -35,6 +35,13 @@ describe("InMemoryJitGrantRepo", () => {
     await repo.put(
       issuance({ grant: { ...issuance().grant, expiresAt: new Date(NOW.getTime() - 1_000) } })
     );
-    expect(await repo.listActive("principal-1", NOW)).toEqual([]);
+    expect(await repo.listActive("business-1", "principal-1", NOW)).toEqual([]);
+  });
+
+  it("does not return another business's grant for the same principal id", async () => {
+    const repo = new InMemoryJitGrantRepo();
+    await repo.put(issuance({ businessId: "business-2" }));
+
+    expect(await repo.listActive("business-1", "principal-1", NOW)).toEqual([]);
   });
 });

--- a/packages/storage/src/auth/jit-repo.ts
+++ b/packages/storage/src/auth/jit-repo.ts
@@ -18,7 +18,7 @@ export interface JitGrantIssuanceRecord {
 export interface JitGrantRepo {
   put(record: JitGrantIssuanceRecord): Promise<void>;
   /** Only unexpired grants, even if expired rows have not been reaped yet. */
-  listActive(principalId: string, now: Date): Promise<JitGrantIssuanceRecord[]>;
+  listActive(businessId: string, principalId: string, now: Date): Promise<JitGrantIssuanceRecord[]>;
 }
 
 /**
@@ -32,9 +32,16 @@ export class InMemoryJitGrantRepo implements JitGrantRepo {
     this.records.push(Object.freeze({ ...record }));
   }
 
-  async listActive(principalId: string, now: Date): Promise<JitGrantIssuanceRecord[]> {
+  async listActive(
+    businessId: string,
+    principalId: string,
+    now: Date
+  ): Promise<JitGrantIssuanceRecord[]> {
     return this.records.filter(
-      (r) => r.principalId === principalId && (!r.grant.expiresAt || r.grant.expiresAt > now)
+      (r) =>
+        r.businessId === businessId &&
+        r.principalId === principalId &&
+        (!r.grant.expiresAt || r.grant.expiresAt > now)
     );
   }
 }

--- a/packages/storage/src/auth/principal-repo.test.ts
+++ b/packages/storage/src/auth/principal-repo.test.ts
@@ -15,12 +15,12 @@ describe("InMemoryPrincipalRepo", () => {
   it("round-trips a stored principal by id", async () => {
     const repo = new InMemoryPrincipalRepo();
     await repo.put(record());
-    await expect(repo.get("principal-1")).resolves.toEqual(record());
+    await expect(repo.get("business-1", "principal-1")).resolves.toEqual(record());
   });
 
   it("returns undefined for an unknown principal", async () => {
     const repo = new InMemoryPrincipalRepo();
-    await expect(repo.get("missing")).resolves.toBeUndefined();
+    await expect(repo.get("business-1", "missing")).resolves.toBeUndefined();
   });
 
   it("stores every distinct principal kind with its own business_id", async () => {
@@ -37,10 +37,23 @@ describe("InMemoryPrincipalRepo", () => {
       await repo.put(record({ id: `p-${kind}`, kind, businessId: "business-9" }));
     }
     for (const kind of kinds) {
-      await expect(repo.get(`p-${kind}`)).resolves.toMatchObject({
+      await expect(repo.get("business-9", `p-${kind}`)).resolves.toMatchObject({
         kind,
         businessId: "business-9",
       });
     }
+  });
+
+  it("isolates the same principal id across businesses", async () => {
+    const repo = new InMemoryPrincipalRepo();
+    await repo.put(record({ businessId: "business-1", status: "active" }));
+    await repo.put(record({ businessId: "business-2", status: "disabled" }));
+
+    await expect(repo.get("business-1", "principal-1")).resolves.toMatchObject({
+      status: "active",
+    });
+    await expect(repo.get("business-2", "principal-1")).resolves.toMatchObject({
+      status: "disabled",
+    });
   });
 });

--- a/packages/storage/src/auth/principal-repo.ts
+++ b/packages/storage/src/auth/principal-repo.ts
@@ -23,7 +23,7 @@ export interface PrincipalRecord {
 }
 
 export interface PrincipalRepo {
-  get(id: string): Promise<PrincipalRecord | undefined>;
+  get(businessId: string, id: string): Promise<PrincipalRecord | undefined>;
   put(record: PrincipalRecord): Promise<void>;
 }
 
@@ -34,11 +34,15 @@ export interface PrincipalRepo {
 export class InMemoryPrincipalRepo implements PrincipalRepo {
   private readonly records = new Map<string, PrincipalRecord>();
 
-  async get(id: string): Promise<PrincipalRecord | undefined> {
-    return this.records.get(id);
+  private key(businessId: string, id: string): string {
+    return JSON.stringify([businessId, id]);
+  }
+
+  async get(businessId: string, id: string): Promise<PrincipalRecord | undefined> {
+    return this.records.get(this.key(businessId, id));
   }
 
   async put(record: PrincipalRecord): Promise<void> {
-    this.records.set(record.id, Object.freeze({ ...record }));
+    this.records.set(this.key(record.businessId, record.id), Object.freeze({ ...record }));
   }
 }

--- a/packages/storage/src/auth/recertification-repo.test.ts
+++ b/packages/storage/src/auth/recertification-repo.test.ts
@@ -17,15 +17,28 @@ describe("InMemoryRecertificationRepo", () => {
   it("round-trips a record by grant id and returns undefined for an unknown grant", async () => {
     const repo = new InMemoryRecertificationRepo();
     await repo.put(due());
-    await expect(repo.get("grant-1")).resolves.toEqual(due());
-    await expect(repo.get("missing")).resolves.toBeUndefined();
+    await expect(repo.get("business-1", "grant-1")).resolves.toEqual(due());
+    await expect(repo.get("business-1", "missing")).resolves.toBeUndefined();
   });
 
   it("lists only records due at or before the given time", async () => {
     const repo = new InMemoryRecertificationRepo();
     await repo.put(due({ grantId: "overdue", dueAt: new Date(NOW.getTime() - 1_000) }));
     await repo.put(due({ grantId: "future", dueAt: new Date(NOW.getTime() + 60_000) }));
-    const listed = await repo.listDue(NOW);
+    const listed = await repo.listDue("business-1", NOW);
     expect(listed.map((r) => r.grantId)).toEqual(["overdue"]);
+  });
+
+  it("isolates due records and duplicate grant ids by business", async () => {
+    const repo = new InMemoryRecertificationRepo();
+    await repo.put(due({ businessId: "business-1", grantId: "shared", principalId: "p1" }));
+    await repo.put(due({ businessId: "business-2", grantId: "shared", principalId: "p2" }));
+
+    await expect(repo.get("business-1", "shared")).resolves.toMatchObject({
+      principalId: "p1",
+    });
+    await expect(repo.get("business-2", "shared")).resolves.toMatchObject({
+      principalId: "p2",
+    });
   });
 });

--- a/packages/storage/src/auth/recertification-repo.ts
+++ b/packages/storage/src/auth/recertification-repo.ts
@@ -13,10 +13,10 @@ export interface RecertificationDueRecord {
 }
 
 export interface RecertificationRepo {
-  get(grantId: string): Promise<RecertificationDueRecord | undefined>;
+  get(businessId: string, grantId: string): Promise<RecertificationDueRecord | undefined>;
   put(record: RecertificationDueRecord): Promise<void>;
-  /** All records due at or before `at`, regardless of business. */
-  listDue(at: Date): Promise<RecertificationDueRecord[]>;
+  /** Records for one business due at or before `at`. */
+  listDue(businessId: string, at: Date): Promise<RecertificationDueRecord[]>;
 }
 
 /**
@@ -26,15 +26,21 @@ export interface RecertificationRepo {
 export class InMemoryRecertificationRepo implements RecertificationRepo {
   private readonly records = new Map<string, RecertificationDueRecord>();
 
-  async get(grantId: string): Promise<RecertificationDueRecord | undefined> {
-    return this.records.get(grantId);
+  private key(businessId: string, grantId: string): string {
+    return JSON.stringify([businessId, grantId]);
+  }
+
+  async get(businessId: string, grantId: string): Promise<RecertificationDueRecord | undefined> {
+    return this.records.get(this.key(businessId, grantId));
   }
 
   async put(record: RecertificationDueRecord): Promise<void> {
-    this.records.set(record.grantId, Object.freeze({ ...record }));
+    this.records.set(this.key(record.businessId, record.grantId), Object.freeze({ ...record }));
   }
 
-  async listDue(at: Date): Promise<RecertificationDueRecord[]> {
-    return [...this.records.values()].filter((r) => r.dueAt <= at);
+  async listDue(businessId: string, at: Date): Promise<RecertificationDueRecord[]> {
+    return [...this.records.values()].filter(
+      (record) => record.businessId === businessId && record.dueAt <= at
+    );
   }
 }

--- a/packages/storage/src/auth/role-repo.test.ts
+++ b/packages/storage/src/auth/role-repo.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { InMemoryRoleRepo, type RoleAssignmentRecord, type RoleRecord } from "./role-repo";
 
+const NOW = new Date("2026-07-23T12:00:00Z");
+
 function roleRecord(overrides: Partial<RoleRecord> = {}): RoleRecord {
   return {
     id: "role-1",
@@ -26,8 +28,8 @@ describe("InMemoryRoleRepo", () => {
     const repo = new InMemoryRoleRepo();
     const record = roleRecord();
     await repo.putRole(record);
-    expect(await repo.getRole("role-1")).toEqual(record);
-    expect(await repo.getRole("missing")).toBeUndefined();
+    expect(await repo.getRole("business-1", "role-1")).toEqual(record);
+    expect(await repo.getRole("business-1", "missing")).toBeUndefined();
   });
 
   it("lists a principal's assignments", async () => {
@@ -35,13 +37,28 @@ describe("InMemoryRoleRepo", () => {
     await repo.assign(assignment());
     await repo.assign(assignment({ roleId: "role-2" }));
     await repo.assign(assignment({ principalId: "principal-2", roleId: "role-3" }));
-    const listed = await repo.listAssignments("principal-1");
+    const listed = await repo.listAssignments("business-1", "principal-1", NOW);
     expect(listed.map((a) => a.roleId).sort()).toEqual(["role-1", "role-2"]);
   });
 
   it("never lists an expired assignment", async () => {
     const repo = new InMemoryRoleRepo();
-    await repo.assign(assignment({ expiresAt: new Date(Date.now() - 1_000) }));
-    expect(await repo.listAssignments("principal-1")).toEqual([]);
+    await repo.assign(assignment({ expiresAt: new Date(NOW.getTime() - 1_000) }));
+    expect(await repo.listAssignments("business-1", "principal-1", NOW)).toEqual([]);
+  });
+
+  it("isolates roles and assignments by business", async () => {
+    const repo = new InMemoryRoleRepo();
+    await repo.putRole(roleRecord({ businessId: "business-1", assignableTo: "user" }));
+    await repo.putRole(roleRecord({ businessId: "business-2", assignableTo: "agent" }));
+    await repo.assign(assignment({ businessId: "business-2" }));
+
+    await expect(repo.getRole("business-1", "role-1")).resolves.toMatchObject({
+      assignableTo: "user",
+    });
+    await expect(repo.getRole("business-2", "role-1")).resolves.toMatchObject({
+      assignableTo: "agent",
+    });
+    expect(await repo.listAssignments("business-1", "principal-1", NOW)).toEqual([]);
   });
 });

--- a/packages/storage/src/auth/role-repo.ts
+++ b/packages/storage/src/auth/role-repo.ts
@@ -38,11 +38,15 @@ export interface RoleAssignmentRecord {
 }
 
 export interface RoleRepo {
-  getRole(id: string): Promise<RoleRecord | undefined>;
+  getRole(businessId: string, id: string): Promise<RoleRecord | undefined>;
   putRole(record: RoleRecord): Promise<void>;
   assign(record: RoleAssignmentRecord): Promise<void>;
   /** Only unexpired assignments, even if expired rows have not been reaped yet. */
-  listAssignments(principalId: string): Promise<RoleAssignmentRecord[]>;
+  listAssignments(
+    businessId: string,
+    principalId: string,
+    now: Date
+  ): Promise<RoleAssignmentRecord[]>;
 }
 
 /**
@@ -53,22 +57,32 @@ export class InMemoryRoleRepo implements RoleRepo {
   private readonly roles = new Map<string, RoleRecord>();
   private readonly assignments: RoleAssignmentRecord[] = [];
 
-  async getRole(id: string): Promise<RoleRecord | undefined> {
-    return this.roles.get(id);
+  private roleKey(businessId: string, id: string): string {
+    return JSON.stringify([businessId, id]);
+  }
+
+  async getRole(businessId: string, id: string): Promise<RoleRecord | undefined> {
+    return this.roles.get(this.roleKey(businessId, id));
   }
 
   async putRole(record: RoleRecord): Promise<void> {
-    this.roles.set(record.id, Object.freeze({ ...record }));
+    this.roles.set(this.roleKey(record.businessId, record.id), Object.freeze({ ...record }));
   }
 
   async assign(record: RoleAssignmentRecord): Promise<void> {
     this.assignments.push(Object.freeze({ ...record }));
   }
 
-  async listAssignments(principalId: string): Promise<RoleAssignmentRecord[]> {
-    const now = new Date();
+  async listAssignments(
+    businessId: string,
+    principalId: string,
+    now: Date
+  ): Promise<RoleAssignmentRecord[]> {
     return this.assignments.filter(
-      (a) => a.principalId === principalId && (!a.expiresAt || a.expiresAt > now)
+      (assignment) =>
+        assignment.businessId === businessId &&
+        assignment.principalId === principalId &&
+        (!assignment.expiresAt || assignment.expiresAt > now)
     );
   }
 }

--- a/packages/storage/src/auth/session-repo.test.ts
+++ b/packages/storage/src/auth/session-repo.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it } from "vitest";
 import { InMemorySessionRepo, type SessionRecord } from "./session-repo";
 
+const NOW = new Date("2026-07-23T12:00:00Z");
+
 function record(overrides: Partial<SessionRecord> = {}): SessionRecord {
   return {
     sid: "sid-1",
     principalId: "principal-1",
     businessId: "business-1",
-    expiresAt: new Date(Date.now() + 60_000),
+    expiresAt: new Date(NOW.getTime() + 60_000),
     ...overrides,
   };
 }
@@ -16,27 +18,44 @@ describe("InMemorySessionRepo", () => {
     const repo = new InMemorySessionRepo();
     const stored = record();
     await repo.create(stored);
-    await expect(repo.get("sid-1")).resolves.toEqual(stored);
+    await expect(repo.get("business-1", "sid-1", NOW)).resolves.toEqual(stored);
   });
 
   it("returns undefined once the session has expired", async () => {
     const repo = new InMemorySessionRepo();
-    await repo.create(record({ expiresAt: new Date(Date.now() - 1_000) }));
-    await expect(repo.get("sid-1")).resolves.toBeUndefined();
+    await repo.create(record({ expiresAt: new Date(NOW.getTime() - 1_000) }));
+    await expect(repo.get("business-1", "sid-1", NOW)).resolves.toBeUndefined();
   });
 
   it("returns undefined after destroy", async () => {
     const repo = new InMemorySessionRepo();
     await repo.create(record());
-    await repo.destroy("sid-1");
-    await expect(repo.get("sid-1")).resolves.toBeUndefined();
+    await repo.destroy("business-1", "sid-1");
+    await expect(repo.get("business-1", "sid-1", NOW)).resolves.toBeUndefined();
   });
 
   it("keeps sessions for distinct principals in the same business isolated", async () => {
     const repo = new InMemorySessionRepo();
     await repo.create(record({ sid: "sid-a", principalId: "principal-a" }));
     await repo.create(record({ sid: "sid-b", principalId: "principal-b" }));
-    await expect(repo.get("sid-a")).resolves.toMatchObject({ principalId: "principal-a" });
-    await expect(repo.get("sid-b")).resolves.toMatchObject({ principalId: "principal-b" });
+    await expect(repo.get("business-1", "sid-a", NOW)).resolves.toMatchObject({
+      principalId: "principal-a",
+    });
+    await expect(repo.get("business-1", "sid-b", NOW)).resolves.toMatchObject({
+      principalId: "principal-b",
+    });
+  });
+
+  it("isolates the same session id across businesses", async () => {
+    const repo = new InMemorySessionRepo();
+    await repo.create(record({ businessId: "business-1", principalId: "principal-1" }));
+    await repo.create(record({ businessId: "business-2", principalId: "principal-2" }));
+
+    await expect(repo.get("business-1", "sid-1", NOW)).resolves.toMatchObject({
+      principalId: "principal-1",
+    });
+    await expect(repo.get("business-2", "sid-1", NOW)).resolves.toMatchObject({
+      principalId: "principal-2",
+    });
   });
 });

--- a/packages/storage/src/auth/session-repo.ts
+++ b/packages/storage/src/auth/session-repo.ts
@@ -14,8 +14,8 @@ export interface SessionRecord {
 export interface SessionRepo {
   create(record: SessionRecord): Promise<void>;
   /** Returns undefined once past `expiresAt`, even if the row has not been reaped yet. */
-  get(sid: string): Promise<SessionRecord | undefined>;
-  destroy(sid: string): Promise<void>;
+  get(businessId: string, sid: string, now: Date): Promise<SessionRecord | undefined>;
+  destroy(businessId: string, sid: string): Promise<void>;
 }
 
 /**
@@ -25,17 +25,21 @@ export interface SessionRepo {
 export class InMemorySessionRepo implements SessionRepo {
   private readonly records = new Map<string, SessionRecord>();
 
-  async create(record: SessionRecord): Promise<void> {
-    this.records.set(record.sid, Object.freeze({ ...record }));
+  private key(businessId: string, sid: string): string {
+    return JSON.stringify([businessId, sid]);
   }
 
-  async get(sid: string): Promise<SessionRecord | undefined> {
-    const record = this.records.get(sid);
-    if (!record || record.expiresAt <= new Date()) return undefined;
+  async create(record: SessionRecord): Promise<void> {
+    this.records.set(this.key(record.businessId, record.sid), Object.freeze({ ...record }));
+  }
+
+  async get(businessId: string, sid: string, now: Date): Promise<SessionRecord | undefined> {
+    const record = this.records.get(this.key(businessId, sid));
+    if (!record || record.expiresAt <= now) return undefined;
     return record;
   }
 
-  async destroy(sid: string): Promise<void> {
-    this.records.delete(sid);
+  async destroy(businessId: string, sid: string): Promise<void> {
+    this.records.delete(this.key(businessId, sid));
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -428,10 +428,17 @@ importers:
         version: 6.0.3
 
   packages/authz:
+    dependencies:
+      '@tulipfarm/schema':
+        specifier: workspace:*
+        version: link:../schema
     devDependencies:
       '@tulipfarm/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      '@types/node':
+        specifier: ^26.1.1
+        version: 26.1.1
       typescript:
         specifier: ^6.0.3
         version: 6.0.3


### PR DESCRIPTION
## Summary

- bind Soul publication to the validated content and principal, canonicalize authored definitions, use CAS for unborn refs, and enforce exact stable-ID versions
- align guardrail autonomy with the canonical schema and enforce active/expiry and business isolation across identity and storage contracts
- harden audit events against protected-payload smuggling, mutation, cross-business attribution, concurrent chain forks, reorder, and anchored deletion

## Verification verdict

The focused AW-011 through AW-021 contracts now pass their package tests and the repository-wide typecheck, test, and build suites. Two architectural follow-ups remain visible rather than being hidden by this correctness patch:

- the new identity, Soul publication, and audit repository contracts still have only in-memory reference implementations; durable PostgreSQL adapters/migrations are needed before calling those tasks production-complete
- legacy API Soul mutation paths still bypass the new publication gateway; the planned cutover appears to belong to AW-095/AW-096 and should remain explicitly tracked

Neither follow-up blocks beginning AW-022, but both should stay on the delivery path.

## Test plan

- [x] pnpm --filter @tulipfarm/soul test
- [x] pnpm --filter @tulipfarm/authz test
- [x] pnpm --filter @tulipfarm/audit test
- [x] pnpm --filter @tulipfarm/storage test
- [x] pnpm typecheck
- [x] pnpm test (27 workspaces; API: 1,691 tests)
- [x] pnpm build
- [x] package lint checks for all affected packages
- [x] pnpm lint completed all 28 workspace tasks; pre-existing warnings remain in untouched web/API files