### PR TITLE
feat(audit): seal, retain, export, and erase audit evidence (AW-022)

### DIFF
--- a/packages/audit/src/erase.test.ts
+++ b/packages/audit/src/erase.test.ts
@@ -1,0 +1,114 @@
+import { createHmac, randomUUID } from "node:crypto";
+import type { BlobPort, BlobRef } from "@tulipfarm/storage";
+import { describe, expect, it } from "vitest";
+import { EraseError, eraseSegment, type SegmentKeyPort } from "./erase";
+import { placeLegalHold } from "./legal-hold";
+import { type SealSigner, sealSegment } from "./seal";
+import { InMemoryAuditEventRepo } from "./storage";
+import { AuditWriter } from "./writer";
+
+function hmacSigner(): SealSigner {
+  return {
+    async sign(bytes) {
+      return createHmac("sha256", "key").update(bytes).digest("base64");
+    },
+    async verify(bytes, signature) {
+      return createHmac("sha256", "key").update(bytes).digest("base64") === signature;
+    },
+  };
+}
+
+function inMemoryBlob(): BlobPort {
+  const store = new Map<string, Uint8Array>();
+  return {
+    async put(bytes) {
+      const hash = createHmac("sha256", "blob").update(bytes).digest("hex");
+      const ref: BlobRef = { key: hash, hash };
+      store.set(ref.key, bytes);
+      return ref;
+    },
+    async get(ref) {
+      const bytes = store.get(ref.key);
+      if (!bytes) throw new Error("not found");
+      return bytes;
+    },
+    async delete(ref) {
+      store.delete(ref.key);
+    },
+  };
+}
+
+function fakeKeyPort(): SegmentKeyPort & { destroyed: string[] } {
+  const destroyed: string[] = [];
+  return {
+    destroyed,
+    async destroy(segmentId) {
+      destroyed.push(segmentId);
+    },
+  };
+}
+
+async function sealedFixture() {
+  const writer = new AuditWriter(new InMemoryAuditEventRepo());
+  const events = [
+    await writer.append({
+      actor: { principalId: "user-1", businessId: "biz-1" },
+      effectivePrincipal: { principalId: "user-1", businessId: "biz-1" },
+      action: "test.action",
+      target: "target-1",
+      decision: "allow",
+      reasonCodes: [],
+      correlationId: randomUUID(),
+      occurredAt: new Date("2026-07-01T00:00:00.000Z"),
+    }),
+  ];
+  return sealSegment(events, null, hmacSigner(), inMemoryBlob(), new Date());
+}
+
+describe("eraseSegment", () => {
+  it("destroys the segment key and returns a tombstone with only hash/count evidence", async () => {
+    const segment = await sealedFixture();
+    const keyPort = fakeKeyPort();
+    const tombstone = await eraseSegment(
+      "segment-1",
+      segment,
+      "security",
+      "target-1",
+      "retention expired",
+      [],
+      keyPort,
+      new Date("2026-08-01")
+    );
+
+    expect(keyPort.destroyed).toEqual(["segment-1"]);
+    expect(tombstone.segmentHash).toBe(segment.segmentHash);
+    expect(tombstone.eventCount).toBe(segment.eventCount);
+    expect(Object.keys(tombstone).sort()).not.toContain("payload");
+  });
+
+  it("refuses to erase a segment under active legal hold", async () => {
+    const segment = await sealedFixture();
+    const keyPort = fakeKeyPort();
+    const hold = placeLegalHold({
+      id: "hold-1",
+      businessId: "biz-1",
+      scope: { type: "target", target: "target-1" },
+      reason: "litigation",
+      createdAt: new Date("2026-01-01"),
+    });
+
+    await expect(
+      eraseSegment(
+        "segment-1",
+        segment,
+        "security",
+        "target-1",
+        "retention expired",
+        [hold],
+        keyPort,
+        new Date("2026-08-01")
+      )
+    ).rejects.toThrow(EraseError);
+    expect(keyPort.destroyed).toEqual([]);
+  });
+});

--- a/packages/audit/src/erase.ts
+++ b/packages/audit/src/erase.ts
@@ -1,0 +1,68 @@
+/**
+ * Crypto erase for sealed segments (SPEC §20: "Where erasure is required, content encryption
+ * keys can be destroyed while retaining tombstone and integrity evidence."). This module never
+ * decrypts or reads segment content; it destroys the segment's content encryption key through an
+ * injected port and records a tombstone carrying only hash/count evidence.
+ */
+
+import { isDeletionBlocked, type LegalHold } from "./legal-hold";
+import type { SealedSegment } from "./seal";
+
+/** Destroys the content encryption key for a sealed segment. Never returns key material. */
+export interface SegmentKeyPort {
+  destroy(segmentId: string): Promise<void>;
+}
+
+export type EraseErrorCode = "LEGAL_HOLD" | "ALREADY_ERASED";
+
+export class EraseError extends Error {
+  constructor(
+    public readonly code: EraseErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = "EraseError";
+  }
+}
+
+export interface Tombstone {
+  readonly segmentId: string;
+  readonly businessId: string;
+  readonly startIndex: number;
+  readonly endIndex: number;
+  readonly eventCount: number;
+  readonly segmentHash: string;
+  readonly reason: string;
+  readonly erasedAt: Date;
+}
+
+/**
+ * Destroys `segment`'s content encryption key via `keyPort` and returns a tombstone. Refuses if
+ * `category`/`target` is under an active legal hold — hold must block erase, not just plain
+ * delete, or "grants no read" would be trivially bypassed by erasing instead of reading.
+ */
+export async function eraseSegment(
+  segmentId: string,
+  segment: SealedSegment,
+  category: string,
+  target: string,
+  reason: string,
+  holds: readonly LegalHold[],
+  keyPort: SegmentKeyPort,
+  now: Date
+): Promise<Tombstone> {
+  if (isDeletionBlocked(holds, segment.businessId, category, target, now)) {
+    throw new EraseError("LEGAL_HOLD", `segment ${segmentId} is under legal hold`);
+  }
+  await keyPort.destroy(segmentId);
+  return Object.freeze({
+    segmentId,
+    businessId: segment.businessId,
+    startIndex: segment.startIndex,
+    endIndex: segment.endIndex,
+    eventCount: segment.eventCount,
+    segmentHash: segment.segmentHash,
+    reason,
+    erasedAt: new Date(now.getTime()),
+  });
+}

--- a/packages/audit/src/export.test.ts
+++ b/packages/audit/src/export.test.ts
@@ -1,0 +1,117 @@
+import { createHmac, randomUUID } from "node:crypto";
+import type { BlobPort, BlobRef } from "@tulipfarm/storage";
+import { describe, expect, it } from "vitest";
+import type { AuditEvent } from "./event";
+import { buildExport, ExportError, verifyExport } from "./export";
+import { type SealSigner, sealSegment } from "./seal";
+import { InMemoryAuditEventRepo } from "./storage";
+import { AuditWriter } from "./writer";
+
+function hmacSigner(): SealSigner {
+  return {
+    async sign(bytes) {
+      return createHmac("sha256", "key").update(bytes).digest("base64");
+    },
+    async verify(bytes, signature) {
+      return createHmac("sha256", "key").update(bytes).digest("base64") === signature;
+    },
+  };
+}
+
+function inMemoryBlob(): BlobPort {
+  const store = new Map<string, Uint8Array>();
+  return {
+    async put(bytes) {
+      const hash = createHmac("sha256", "blob").update(bytes).digest("hex");
+      const ref: BlobRef = { key: hash, hash };
+      store.set(ref.key, bytes);
+      return ref;
+    },
+    async get(ref) {
+      const bytes = store.get(ref.key);
+      if (!bytes) throw new Error("not found");
+      return bytes;
+    },
+    async delete(ref) {
+      store.delete(ref.key);
+    },
+  };
+}
+
+async function appendEvents(count: number): Promise<AuditEvent[]> {
+  const writer = new AuditWriter(new InMemoryAuditEventRepo());
+  const events: AuditEvent[] = [];
+  for (let i = 0; i < count; i += 1) {
+    events.push(
+      await writer.append({
+        actor: { principalId: "user-1", businessId: "biz-1" },
+        effectivePrincipal: { principalId: "user-1", businessId: "biz-1" },
+        action: "test.action",
+        target: `target-${i}`,
+        decision: "allow",
+        reasonCodes: [],
+        correlationId: randomUUID(),
+        occurredAt: new Date("2026-07-01T00:00:00.000Z"),
+      })
+    );
+  }
+  return events;
+}
+
+describe("export", () => {
+  it("builds and verifies a bundle without reading blob content", async () => {
+    const events = await appendEvents(3);
+    const blob = inMemoryBlob();
+    const seal = await sealSegment(events, null, hmacSigner(), blob, new Date());
+    const bundle = buildExport("biz-1", events, [seal], new Date());
+
+    let readCalled = false;
+    const spiedSigner: SealSigner = {
+      ...hmacSigner(),
+    };
+    void spiedSigner;
+    const originalGet = blob.get.bind(blob);
+    blob.get = async (ref) => {
+      readCalled = true;
+      return originalGet(ref);
+    };
+
+    const result = await verifyExport(bundle, hmacSigner());
+    expect(result.chain.valid).toBe(true);
+    expect(result.sealsValid).toBe(true);
+    expect(readCalled).toBe(false);
+  });
+
+  it("flags a tampered event as invalid", async () => {
+    const events = await appendEvents(2);
+    const seal = await sealSegment(events, null, hmacSigner(), inMemoryBlob(), new Date());
+    const tampered = { ...events[1], target: "tampered" } as AuditEvent;
+    const bundle = buildExport("biz-1", [events[0], tampered], [seal], new Date());
+
+    const result = await verifyExport(bundle, hmacSigner());
+    expect(result.chain.valid).toBe(false);
+  });
+
+  it("flags an invalid seal signature", async () => {
+    const events = await appendEvents(1);
+    const seal = await sealSegment(events, null, hmacSigner(), inMemoryBlob(), new Date());
+    const bundle = buildExport("biz-1", events, [seal], new Date());
+
+    const wrongSigner: SealSigner = {
+      async sign(bytes) {
+        return createHmac("sha256", "wrong").update(bytes).digest("base64");
+      },
+      async verify(bytes, signature) {
+        return createHmac("sha256", "wrong").update(bytes).digest("base64") === signature;
+      },
+    };
+    const result = await verifyExport(bundle, wrongSigner);
+    expect(result.sealsValid).toBe(false);
+    expect(result.invalidSeals).toEqual([seal.segmentHash]);
+  });
+
+  it("rejects mixing another business's events into the bundle", async () => {
+    const events = await appendEvents(1);
+    expect(() => buildExport("biz-2", events, [], new Date())).toThrow(ExportError);
+  });
+});

--- a/packages/audit/src/export.ts
+++ b/packages/audit/src/export.ts
@@ -1,0 +1,85 @@
+/**
+ * Exports audit evidence that stays verifiable without protected payload access (SPEC §20:
+ * "Separate access is required to query, export, or administer audit."; SPEC §13: protected
+ * content never enters audit payloads). An export bundle carries events (already payload-free —
+ * `normalizeAuditEventInput` rejects payload fields) plus seal signatures; verifying it only
+ * recomputes hashes and checks signatures, never fetches blob content.
+ */
+
+import type { AuditEvent } from "./event";
+import type { SealedSegment, SealSigner } from "./seal";
+import { verifySegmentSeal } from "./seal";
+import type { VerifyExpectation, VerifyResult } from "./verify";
+import { verifyChain } from "./verify";
+
+export interface AuditExportBundle {
+  readonly businessId: string;
+  readonly generatedAt: Date;
+  readonly events: readonly AuditEvent[];
+  readonly seals: readonly SealedSegment[];
+}
+
+export type ExportErrorCode = "EMPTY" | "BUSINESS_MISMATCH";
+
+export class ExportError extends Error {
+  constructor(
+    public readonly code: ExportErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = "ExportError";
+  }
+}
+
+/** Builds an export bundle for one business. `events` and `seals` must already be scoped to it. */
+export function buildExport(
+  businessId: string,
+  events: readonly AuditEvent[],
+  seals: readonly SealedSegment[],
+  generatedAt: Date
+): AuditExportBundle {
+  for (const event of events) {
+    if (event.businessId !== businessId) {
+      throw new ExportError("BUSINESS_MISMATCH", `event ${event.id} belongs to another business`);
+    }
+  }
+  for (const seal of seals) {
+    if (seal.businessId !== businessId) {
+      throw new ExportError(
+        "BUSINESS_MISMATCH",
+        `segment ${seal.segmentHash} belongs to another business`
+      );
+    }
+  }
+  return Object.freeze({
+    businessId,
+    generatedAt: new Date(generatedAt.getTime()),
+    events: Object.freeze([...events]),
+    seals: Object.freeze([...seals]),
+  });
+}
+
+export interface ExportVerifyResult {
+  readonly chain: VerifyResult;
+  readonly sealsValid: boolean;
+  readonly invalidSeals: readonly string[];
+}
+
+/**
+ * Verifies `bundle` using only hashes and signatures — never reads blob storage. A tombstoned
+ * (crypto-erased) segment still verifies: its seal signature and segment hash are independent of
+ * whether the underlying blob content can still be decrypted.
+ */
+export async function verifyExport(
+  bundle: AuditExportBundle,
+  signer: SealSigner,
+  expectation: VerifyExpectation = {}
+): Promise<ExportVerifyResult> {
+  const chain = verifyChain(bundle.events, expectation);
+  const invalidSeals: string[] = [];
+  for (const seal of bundle.seals) {
+    const ok = await verifySegmentSeal(seal, signer);
+    if (!ok) invalidSeals.push(seal.segmentHash);
+  }
+  return { chain, sealsValid: invalidSeals.length === 0, invalidSeals };
+}

--- a/packages/audit/src/index.ts
+++ b/packages/audit/src/index.ts
@@ -1,4 +1,6 @@
 export { computeEventHash, recomputeEventHash } from "./chain";
+export type { EraseErrorCode, SegmentKeyPort, Tombstone } from "./erase";
+export { EraseError, eraseSegment } from "./erase";
 export type {
   AuditDecision,
   AuditEvent,
@@ -7,6 +9,20 @@ export type {
   AuditPrincipalRef,
 } from "./event";
 export { AuditInputError, normalizeAuditEventInput } from "./event";
+export type { AuditExportBundle, ExportErrorCode, ExportVerifyResult } from "./export";
+export { buildExport, ExportError, verifyExport } from "./export";
+export type { LegalHold, LegalHoldErrorCode, LegalHoldInput, LegalHoldScope } from "./legal-hold";
+export {
+  isDeletionBlocked,
+  isHeld,
+  LegalHoldError,
+  placeLegalHold,
+  releaseLegalHold,
+} from "./legal-hold";
+export type { RetentionErrorCode, RetentionPolicy } from "./retention";
+export { eligibleForDeletion, isRetentionExpired, RetentionError } from "./retention";
+export type { SealErrorCode, SealedSegment, SealSigner } from "./seal";
+export { SealError, sealSegment, verifySegmentSeal } from "./seal";
 export type { AuditEventRepo } from "./storage";
 export { AuditAppendConflictError, InMemoryAuditEventRepo } from "./storage";
 export type { VerifyExpectation, VerifyIssue, VerifyIssueType, VerifyResult } from "./verify";

--- a/packages/audit/src/legal-hold.test.ts
+++ b/packages/audit/src/legal-hold.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import {
+  isDeletionBlocked,
+  isHeld,
+  LegalHoldError,
+  placeLegalHold,
+  releaseLegalHold,
+} from "./legal-hold";
+
+describe("legal-hold", () => {
+  it("blocks deletion for its scope while active", () => {
+    const hold = placeLegalHold({
+      id: "hold-1",
+      businessId: "biz-1",
+      scope: { type: "category", category: "security" },
+      reason: "litigation",
+      createdAt: new Date("2026-01-01"),
+    });
+    const now = new Date("2026-06-01");
+    expect(isHeld(hold, "biz-1", "security", "target-1", now)).toBe(true);
+    expect(isHeld(hold, "biz-1", "financial", "target-1", now)).toBe(false);
+    expect(isHeld(hold, "biz-2", "security", "target-1", now)).toBe(false);
+  });
+
+  it("stops blocking once released", () => {
+    const hold = placeLegalHold({
+      id: "hold-1",
+      businessId: "biz-1",
+      scope: { type: "business" },
+      reason: "litigation",
+      createdAt: new Date("2026-01-01"),
+    });
+    const released = releaseLegalHold(hold, new Date("2026-02-01"));
+    expect(isHeld(released, "biz-1", "any", "target-1", new Date("2026-03-01"))).toBe(false);
+    expect(isHeld(released, "biz-1", "any", "target-1", new Date("2026-01-15"))).toBe(true);
+  });
+
+  it("refuses to release an already-released hold", () => {
+    const hold = placeLegalHold({
+      id: "hold-1",
+      businessId: "biz-1",
+      scope: { type: "business" },
+      reason: "litigation",
+      createdAt: new Date("2026-01-01"),
+    });
+    const released = releaseLegalHold(hold, new Date("2026-02-01"));
+    expect(() => releaseLegalHold(released, new Date("2026-03-01"))).toThrow(LegalHoldError);
+  });
+
+  it("requires a reason", () => {
+    expect(() =>
+      placeLegalHold({
+        id: "hold-1",
+        businessId: "biz-1",
+        scope: { type: "business" },
+        reason: "",
+        createdAt: new Date(),
+      })
+    ).toThrow(LegalHoldError);
+  });
+
+  it("isDeletionBlocked is true if any hold in the list covers the target", () => {
+    const holds = [
+      placeLegalHold({
+        id: "hold-1",
+        businessId: "biz-1",
+        scope: { type: "target", target: "target-9" },
+        reason: "litigation",
+        createdAt: new Date("2026-01-01"),
+      }),
+    ];
+    expect(isDeletionBlocked(holds, "biz-1", "any", "target-9", new Date("2026-02-01"))).toBe(true);
+    expect(isDeletionBlocked(holds, "biz-1", "any", "target-1", new Date("2026-02-01"))).toBe(
+      false
+    );
+  });
+
+  it("exposes no way to read event content — only hold-state functions", async () => {
+    const module = await import("./legal-hold");
+    const exported = Object.keys(module).sort();
+    expect(exported).toEqual(
+      ["LegalHoldError", "isDeletionBlocked", "isHeld", "placeLegalHold", "releaseLegalHold"].sort()
+    );
+  });
+});

--- a/packages/audit/src/legal-hold.ts
+++ b/packages/audit/src/legal-hold.ts
@@ -1,0 +1,92 @@
+/**
+ * Legal hold blocks eligible deletion without itself granting read access (SPEC §20: "Legal hold
+ * prevents eligible deletion without itself granting read access."). This module only decides
+ * hold state; it exposes no event content and no way to read protected payloads.
+ */
+
+export type LegalHoldScope =
+  | { readonly type: "business" }
+  | { readonly type: "category"; readonly category: string }
+  | { readonly type: "target"; readonly target: string };
+
+export interface LegalHold {
+  readonly id: string;
+  readonly businessId: string;
+  readonly scope: LegalHoldScope;
+  readonly reason: string;
+  readonly createdAt: Date;
+  readonly releasedAt?: Date;
+}
+
+export type LegalHoldErrorCode = "INVALID_INPUT" | "ALREADY_RELEASED";
+
+export class LegalHoldError extends Error {
+  constructor(
+    public readonly code: LegalHoldErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = "LegalHoldError";
+  }
+}
+
+export interface LegalHoldInput {
+  readonly id: string;
+  readonly businessId: string;
+  readonly scope: LegalHoldScope;
+  readonly reason: string;
+  readonly createdAt: Date;
+}
+
+export function placeLegalHold(input: LegalHoldInput): LegalHold {
+  if (!input.id || !input.businessId) {
+    throw new LegalHoldError("INVALID_INPUT", "legal hold requires id and businessId");
+  }
+  if (!input.reason) {
+    throw new LegalHoldError("INVALID_INPUT", "legal hold requires a reason");
+  }
+  return Object.freeze({
+    id: input.id,
+    businessId: input.businessId,
+    scope: input.scope,
+    reason: input.reason,
+    createdAt: new Date(input.createdAt.getTime()),
+  });
+}
+
+export function releaseLegalHold(hold: LegalHold, releasedAt: Date): LegalHold {
+  if (hold.releasedAt !== undefined) {
+    throw new LegalHoldError("ALREADY_RELEASED", `legal hold ${hold.id} is already released`);
+  }
+  return Object.freeze({ ...hold, releasedAt: new Date(releasedAt.getTime()) });
+}
+
+function scopeCovers(scope: LegalHoldScope, category: string, target: string): boolean {
+  if (scope.type === "business") return true;
+  if (scope.type === "category") return scope.category === category;
+  return scope.target === target;
+}
+
+/** Whether `hold` blocks deletion of an item in `category`/`target` at `now`. Never reads content. */
+export function isHeld(
+  hold: LegalHold,
+  businessId: string,
+  category: string,
+  target: string,
+  now: Date
+): boolean {
+  if (hold.businessId !== businessId) return false;
+  if (hold.releasedAt !== undefined && hold.releasedAt.getTime() <= now.getTime()) return false;
+  return scopeCovers(hold.scope, category, target);
+}
+
+/** True if any active hold in `holds` blocks deletion of this category/target at `now`. */
+export function isDeletionBlocked(
+  holds: readonly LegalHold[],
+  businessId: string,
+  category: string,
+  target: string,
+  now: Date
+): boolean {
+  return holds.some((hold) => isHeld(hold, businessId, category, target, now));
+}

--- a/packages/audit/src/retention.test.ts
+++ b/packages/audit/src/retention.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { placeLegalHold } from "./legal-hold";
+import { eligibleForDeletion, isRetentionExpired, RetentionError } from "./retention";
+
+const POLICIES = [
+  { category: "security", retainForDays: 365 },
+  { category: "access", retainForDays: 90 },
+];
+
+describe("retention", () => {
+  it("is not expired before the policy window elapses", () => {
+    expect(
+      isRetentionExpired(new Date("2026-01-01"), "access", POLICIES, new Date("2026-02-01"))
+    ).toBe(false);
+  });
+
+  it("is expired once the policy window elapses", () => {
+    expect(
+      isRetentionExpired(new Date("2026-01-01"), "access", POLICIES, new Date("2026-06-01"))
+    ).toBe(true);
+  });
+
+  it("throws for an unconfigured category", () => {
+    expect(() =>
+      isRetentionExpired(new Date("2026-01-01"), "unknown", POLICIES, new Date("2026-06-01"))
+    ).toThrow(RetentionError);
+  });
+
+  it("is eligible for deletion once expired and unheld", () => {
+    expect(
+      eligibleForDeletion(
+        "biz-1",
+        "access",
+        "target-1",
+        new Date("2026-01-01"),
+        POLICIES,
+        [],
+        new Date("2026-06-01")
+      )
+    ).toBe(true);
+  });
+
+  it("legal hold blocks deletion even after retention expires", () => {
+    const hold = placeLegalHold({
+      id: "hold-1",
+      businessId: "biz-1",
+      scope: { type: "category", category: "access" },
+      reason: "litigation",
+      createdAt: new Date("2026-01-01"),
+    });
+    expect(
+      eligibleForDeletion(
+        "biz-1",
+        "access",
+        "target-1",
+        new Date("2026-01-01"),
+        POLICIES,
+        [hold],
+        new Date("2026-06-01")
+      )
+    ).toBe(false);
+  });
+
+  it("is not eligible for deletion before retention expires, even without a hold", () => {
+    expect(
+      eligibleForDeletion(
+        "biz-1",
+        "access",
+        "target-1",
+        new Date("2026-01-01"),
+        POLICIES,
+        [],
+        new Date("2026-01-15")
+      )
+    ).toBe(false);
+  });
+});

--- a/packages/audit/src/retention.ts
+++ b/packages/audit/src/retention.ts
@@ -1,0 +1,71 @@
+/**
+ * Category retention (SPEC §20: "Retention varies by category."). A category is the caller's
+ * classification of an event or segment (e.g. security, access, financial) — this module never
+ * infers category from event content; it only evaluates a supplied category against policy and
+ * legal hold.
+ */
+
+import { isDeletionBlocked, type LegalHold } from "./legal-hold";
+
+export interface RetentionPolicy {
+  readonly category: string;
+  readonly retainForDays: number;
+}
+
+export type RetentionErrorCode = "INVALID_INPUT" | "NO_POLICY";
+
+export class RetentionError extends Error {
+  constructor(
+    public readonly code: RetentionErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = "RetentionError";
+  }
+}
+
+function findPolicy(policies: readonly RetentionPolicy[], category: string): RetentionPolicy {
+  const policy = policies.find((candidate) => candidate.category === category);
+  if (!policy) {
+    throw new RetentionError(
+      "NO_POLICY",
+      `no retention policy configured for category "${category}"`
+    );
+  }
+  if (!Number.isFinite(policy.retainForDays) || policy.retainForDays < 0) {
+    throw new RetentionError(
+      "INVALID_INPUT",
+      `retention policy for "${category}" must have a non-negative retainForDays`
+    );
+  }
+  return policy;
+}
+
+/** True once `retainForDays` has elapsed since `occurredAt`, independent of legal hold. */
+export function isRetentionExpired(
+  occurredAt: Date,
+  category: string,
+  policies: readonly RetentionPolicy[],
+  now: Date
+): boolean {
+  const policy = findPolicy(policies, category);
+  const expiresAt = occurredAt.getTime() + policy.retainForDays * 24 * 60 * 60 * 1000;
+  return now.getTime() >= expiresAt;
+}
+
+/**
+ * Whether an item in `category`/`target` may be deleted now: retention must have expired AND no
+ * legal hold may block it. Hold always wins over an expired policy.
+ */
+export function eligibleForDeletion(
+  businessId: string,
+  category: string,
+  target: string,
+  occurredAt: Date,
+  policies: readonly RetentionPolicy[],
+  holds: readonly LegalHold[],
+  now: Date
+): boolean {
+  if (!isRetentionExpired(occurredAt, category, policies, now)) return false;
+  return !isDeletionBlocked(holds, businessId, category, target, now);
+}

--- a/packages/audit/src/seal.test.ts
+++ b/packages/audit/src/seal.test.ts
@@ -1,0 +1,126 @@
+import { createHmac, randomUUID } from "node:crypto";
+import type { BlobPort, BlobRef } from "@tulipfarm/storage";
+import { describe, expect, it } from "vitest";
+import type { AuditEvent } from "./event";
+import { SealError, type SealSigner, sealSegment, verifySegmentSeal } from "./seal";
+import { InMemoryAuditEventRepo } from "./storage";
+import { AuditWriter } from "./writer";
+
+const HMAC_KEY = "test-seal-key";
+
+function hmacSigner(): SealSigner {
+  return {
+    async sign(bytes) {
+      return createHmac("sha256", HMAC_KEY).update(bytes).digest("base64");
+    },
+    async verify(bytes, signature) {
+      const expected = createHmac("sha256", HMAC_KEY).update(bytes).digest("base64");
+      return expected === signature;
+    },
+  };
+}
+
+function inMemoryBlob(): BlobPort {
+  const store = new Map<string, Uint8Array>();
+  return {
+    async put(bytes) {
+      const hash = createHmac("sha256", "blob").update(bytes).digest("hex");
+      const ref: BlobRef = { key: hash, hash };
+      store.set(ref.key, bytes);
+      return ref;
+    },
+    async get(ref) {
+      const bytes = store.get(ref.key);
+      if (!bytes) throw new Error("not found");
+      return bytes;
+    },
+    async delete(ref) {
+      store.delete(ref.key);
+    },
+  };
+}
+
+async function appendEvents(count: number): Promise<AuditEvent[]> {
+  const writer = new AuditWriter(new InMemoryAuditEventRepo());
+  const events: AuditEvent[] = [];
+  for (let i = 0; i < count; i += 1) {
+    events.push(
+      await writer.append({
+        actor: { principalId: "user-1", businessId: "biz-1" },
+        effectivePrincipal: { principalId: "user-1", businessId: "biz-1" },
+        action: "test.action",
+        target: `target-${i}`,
+        decision: "allow",
+        reasonCodes: [],
+        correlationId: randomUUID(),
+        occurredAt: new Date("2026-07-01T00:00:00.000Z"),
+      })
+    );
+  }
+  return events;
+}
+
+describe("sealSegment", () => {
+  it("seals a contiguous chain slice and produces a verifiable signature", async () => {
+    const events = await appendEvents(3);
+    const sealed = await sealSegment(events, null, hmacSigner(), inMemoryBlob(), new Date());
+
+    expect(sealed.startIndex).toBe(0);
+    expect(sealed.endIndex).toBe(2);
+    expect(sealed.eventCount).toBe(3);
+    expect(await verifySegmentSeal(sealed, hmacSigner())).toBe(true);
+  });
+
+  it("rejects an empty segment", async () => {
+    await expect(sealSegment([], null, hmacSigner(), inMemoryBlob(), new Date())).rejects.toThrow(
+      SealError
+    );
+  });
+
+  it("rejects a non-contiguous segment", async () => {
+    const events = await appendEvents(3);
+    await expect(
+      sealSegment([events[0], events[2]], null, hmacSigner(), inMemoryBlob(), new Date())
+    ).rejects.toThrow(SealError);
+  });
+
+  it("rejects a tampered event instead of signing broken evidence", async () => {
+    const events = await appendEvents(2);
+    const tampered = { ...events[1], target: "tampered" } as AuditEvent;
+    await expect(
+      sealSegment([events[0], tampered], null, hmacSigner(), inMemoryBlob(), new Date())
+    ).rejects.toThrow(SealError);
+  });
+
+  it("detects a signature that does not match a different key", async () => {
+    const events = await appendEvents(2);
+    const sealed = await sealSegment(events, null, hmacSigner(), inMemoryBlob(), new Date());
+    const otherSigner: SealSigner = {
+      async sign(bytes) {
+        return createHmac("sha256", "wrong-key").update(bytes).digest("base64");
+      },
+      async verify(bytes, signature) {
+        const expected = createHmac("sha256", "wrong-key").update(bytes).digest("base64");
+        return expected === signature;
+      },
+    };
+    expect(await verifySegmentSeal(sealed, otherSigner)).toBe(false);
+  });
+
+  it("verifies signature without ever reading blob content", async () => {
+    const events = await appendEvents(2);
+    const blob = inMemoryBlob();
+    const sealed = await sealSegment(events, null, hmacSigner(), blob, new Date());
+    let readCalled = false;
+    const spiedBlob: BlobPort = {
+      ...blob,
+      async get(ref) {
+        readCalled = true;
+        return blob.get(ref);
+      },
+    };
+    expect(await verifySegmentSeal(sealed, hmacSigner())).toBe(true);
+    expect(readCalled).toBe(false);
+    void spiedBlob;
+  });
+});

--- a/packages/audit/src/seal.ts
+++ b/packages/audit/src/seal.ts
@@ -1,0 +1,121 @@
+/**
+ * Signs and seals a contiguous slice of a hash-linked chain into independently protected blob
+ * storage (SPEC §20: "hash-linked into signed, sealed immutable segments in independently
+ * protected blob storage. A verifier can detect missing, reordered, or altered evidence.").
+ * Sealing does not replace {@link verifyChain}; it adds an offline-verifiable anchor so tamper
+ * can be detected even if the PostgreSQL chain itself is altered.
+ */
+
+import { canonicalHash } from "@tulipfarm/schema";
+import type { BlobPort, BlobRef } from "@tulipfarm/storage";
+import { recomputeEventHash } from "./chain";
+import type { AuditEvent } from "./event";
+
+/** Signs/verifies opaque bytes. Key material and algorithm choice belong to the adapter. */
+export interface SealSigner {
+  sign(bytes: Uint8Array): Promise<string>;
+  verify(bytes: Uint8Array, signature: string): Promise<boolean>;
+}
+
+export type SealErrorCode = "EMPTY_SEGMENT" | "NON_CONTIGUOUS" | "CHAIN_BROKEN";
+
+export class SealError extends Error {
+  constructor(
+    public readonly code: SealErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = "SealError";
+  }
+}
+
+export interface SealedSegment {
+  readonly businessId: string;
+  readonly startIndex: number;
+  readonly endIndex: number;
+  readonly eventCount: number;
+  readonly segmentHash: string;
+  readonly previousSegmentHash: string | null;
+  readonly signature: string;
+  readonly blobRef: BlobRef;
+  readonly sealedAt: Date;
+}
+
+function serializeSegment(events: readonly AuditEvent[]): Uint8Array {
+  const body = events.map((event) => ({
+    id: event.id,
+    chainIndex: event.chainIndex,
+    previousHash: event.previousHash,
+    hash: event.hash,
+  }));
+  return new TextEncoder().encode(JSON.stringify(body));
+}
+
+/**
+ * Seals `events` (one business's contiguous chain slice, ascending `chainIndex`, no gaps) into
+ * blob storage and signs the result. Throws {@link SealError} instead of sealing evidence that
+ * would already fail {@link verifyChain} — a broken chain must never be signed as authentic.
+ */
+export async function sealSegment(
+  events: readonly AuditEvent[],
+  previousSegmentHash: string | null,
+  signer: SealSigner,
+  blob: BlobPort,
+  sealedAt: Date
+): Promise<SealedSegment> {
+  if (events.length === 0) {
+    throw new SealError("EMPTY_SEGMENT", "cannot seal an empty segment");
+  }
+  const businessId = events[0].businessId;
+  for (let i = 0; i < events.length; i += 1) {
+    const event = events[i];
+    if (event.businessId !== businessId) {
+      throw new SealError("NON_CONTIGUOUS", "segment mixes events from different businesses");
+    }
+    if (i > 0 && event.chainIndex !== events[i - 1].chainIndex + 1) {
+      throw new SealError("NON_CONTIGUOUS", "segment chainIndex must be contiguous and ascending");
+    }
+    if (recomputeEventHash(event) !== event.hash) {
+      throw new SealError("CHAIN_BROKEN", `event ${event.id} hash does not match its content`);
+    }
+  }
+
+  const bytes = serializeSegment(events);
+  const blobRef = await blob.put(bytes, "application/json");
+  const segmentHash = canonicalHash({
+    businessId,
+    startIndex: events[0].chainIndex,
+    endIndex: events.at(-1)?.chainIndex ?? -1,
+    previousSegmentHash,
+    blobHash: blobRef.hash,
+  });
+  const signature = await signer.sign(new TextEncoder().encode(segmentHash));
+
+  return Object.freeze({
+    businessId,
+    startIndex: events[0].chainIndex,
+    endIndex: events.at(-1)?.chainIndex ?? -1,
+    eventCount: events.length,
+    segmentHash,
+    previousSegmentHash,
+    signature,
+    blobRef,
+    sealedAt: new Date(sealedAt.getTime()),
+  });
+}
+
+/** Recomputes `segment.segmentHash` and checks its signature, without reading blob contents. */
+export async function verifySegmentSeal(
+  segment: SealedSegment,
+  signer: SealSigner
+): Promise<boolean> {
+  const segmentHash = canonicalHash({
+    businessId: segment.businessId,
+    startIndex: segment.startIndex,
+    endIndex: segment.endIndex,
+    previousSegmentHash: segment.previousSegmentHash,
+    blobHash: segment.blobRef.hash,
+  });
+  if (segmentHash !== segment.segmentHash) return false;
+  return signer.verify(new TextEncoder().encode(segmentHash), segment.signature);
+}


### PR DESCRIPTION
## Summary
- Sign/seal contiguous hash-chain segments into blob storage (`seal.ts`), refusing to seal a broken/non-contiguous slice.
- Category retention with legal-hold override (`retention.ts`, `legal-hold.ts`) — hold blocks deletion but grants no read.
- Crypto-erase a sealed segment via an injected key-destroy port, leaving a hash/count-only tombstone (`erase.ts`); blocked under active hold.
- Export bundles that verify (chain + seal signatures) without ever reading blob content (`export.ts`).

Implements AW-022 (SPEC §§12–13, 20, 24).

## Test plan
- [x] `pnpm --filter @tulipfarm/audit test` — 44/44 passing (8 files)
- [x] `pnpm --filter @tulipfarm/audit typecheck` — clean
- [x] `pnpm exec biome check packages/audit/src` — no issues
- [x] Regression check: disabled legal-hold guard in `erase.ts`, confirmed test failure, restored — RED/GREEN verified