### PR TITLE
feat(approvals): persist exact approval bindings and one-use decisions (AW-023)

### DIFF
--- a/packages/authz/src/approval/binding.test.ts
+++ b/packages/authz/src/approval/binding.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { type ApprovalBindingInput, bindingsMatch, computeApprovalBinding } from "./binding";
+
+function input(overrides: Partial<ApprovalBindingInput> = {}): ApprovalBindingInput {
+  return {
+    intent: {
+      toolId: "crm.contact",
+      toolVersion: "2.1.0",
+      action: "contact.update",
+      targetRefs: [{ type: "contact", id: "c-1" }],
+      arguments: { email: "a@example.com", tier: "gold" },
+      destination: "crm.example.com",
+      credentialRef: "secret://crm/writer",
+    },
+    evidenceHashes: ["e1", "e2"],
+    guardrailRevision: "gr-17",
+    ...overrides,
+  };
+}
+
+describe("computeApprovalBinding", () => {
+  it("is deterministic and independent of argument key order", () => {
+    const a = computeApprovalBinding(input());
+    const b = computeApprovalBinding(
+      input({
+        intent: { ...input().intent, arguments: { tier: "gold", email: "a@example.com" } },
+      })
+    );
+    expect(a).toEqual(b);
+  });
+
+  it("orders evidence hashes so the evidence digest is set-based", () => {
+    const a = computeApprovalBinding(input({ evidenceHashes: ["e1", "e2"] }));
+    const b = computeApprovalBinding(input({ evidenceHashes: ["e2", "e1"] }));
+    expect(a.evidenceDigest).toBe(b.evidenceDigest);
+  });
+
+  it("carries the Guardrail revision verbatim", () => {
+    expect(computeApprovalBinding(input()).guardrailRevision).toBe("gr-17");
+  });
+
+  it.each([
+    ["arguments", { arguments: { email: "b@example.com", tier: "gold" } }],
+    ["toolVersion", { toolVersion: "2.1.1" }],
+    ["action", { action: "contact.delete" }],
+    ["targetRefs", { targetRefs: [{ type: "contact", id: "c-2" }] }],
+    [
+      "target order",
+      {
+        targetRefs: [
+          { type: "contact", id: "c-1" },
+          { type: "contact", id: "c-0" },
+        ],
+      },
+    ],
+    ["destination", { destination: "other.example.com" }],
+    ["credentialRef", { credentialRef: "secret://crm/admin" }],
+  ])("changes the intent digest when %s changes", (_label, patch) => {
+    const base = computeApprovalBinding(input());
+    const changed = computeApprovalBinding(
+      input({ intent: { ...input().intent, ...(patch as object) } })
+    );
+    expect(changed.intentDigest).not.toBe(base.intentDigest);
+  });
+
+  it("changes the evidence digest when evidence changes", () => {
+    expect(computeApprovalBinding(input({ evidenceHashes: ["e1", "e3"] })).evidenceDigest).not.toBe(
+      computeApprovalBinding(input()).evidenceDigest
+    );
+  });
+
+  it("distinguishes an absent optional field from a present one", () => {
+    const withoutDestination = { ...input().intent };
+    delete (withoutDestination as { destination?: string }).destination;
+    expect(computeApprovalBinding(input({ intent: withoutDestination })).intentDigest).not.toBe(
+      computeApprovalBinding(input()).intentDigest
+    );
+  });
+
+  it("rejects non-canonicalizable arguments instead of hashing a lossy form", () => {
+    expect(() =>
+      computeApprovalBinding(
+        input({ intent: { ...input().intent, arguments: { at: new Date() } } })
+      )
+    ).toThrow();
+  });
+
+  it("never embeds argument values in the digest output", () => {
+    const binding = computeApprovalBinding(input());
+    expect(JSON.stringify(binding)).not.toContain("a@example.com");
+    expect(JSON.stringify(binding)).not.toContain("secret://crm/writer");
+  });
+});
+
+describe("bindingsMatch", () => {
+  it("matches identical bindings", () => {
+    expect(bindingsMatch(computeApprovalBinding(input()), computeApprovalBinding(input()))).toBe(
+      true
+    );
+  });
+
+  it.each([
+    ["intent", { intent: { ...input().intent, action: "contact.delete" } }],
+    ["evidence", { evidenceHashes: ["e9"] }],
+    ["guardrail revision", { guardrailRevision: "gr-18" }],
+  ])("rejects a binding whose %s differs", (_label, patch) => {
+    expect(
+      bindingsMatch(
+        computeApprovalBinding(input()),
+        computeApprovalBinding(input(patch as Partial<ApprovalBindingInput>))
+      )
+    ).toBe(false);
+  });
+});

--- a/packages/authz/src/approval/binding.ts
+++ b/packages/authz/src/approval/binding.ts
@@ -1,0 +1,70 @@
+/**
+ * The exact binding an Approval is granted for (SPEC §11.2). An Approval authorizes one canonical
+ * Tool intent against one evidence set under one Guardrail revision; if any of those change, the
+ * binding changes and the Approval no longer applies. The binding is three digests, never the
+ * underlying values, so a persisted Approval, an audit event, or a denial reason can carry it
+ * without exposing arguments, destinations, or Credential references (SPEC §13, §20).
+ *
+ * Normalization is applied only where it cannot weaken the binding: absent optional fields hash as
+ * `null` (distinct from any present value) and evidence hashes are order-insensitive because
+ * evidence is a set. Everything else — including `targetRefs` order — is bound verbatim, so an
+ * unexplained difference fails closed rather than being normalized away.
+ */
+
+import { canonicalHash } from "@tulipfarm/schema";
+
+/** The canonical Tool intent fields an Approval is bound to (SPEC §11.1 `ToolIntent`). */
+export interface ApprovalIntent {
+  readonly toolId: string;
+  readonly toolVersion: string;
+  readonly action: string;
+  readonly targetRefs: readonly { readonly type: string; readonly id: string }[];
+  readonly arguments: unknown;
+  readonly destination?: string;
+  readonly credentialRef?: string;
+}
+
+export interface ApprovalBindingInput {
+  readonly intent: ApprovalIntent;
+  /** Hashes of the input Artifacts/evidence the approver saw. Order-insensitive. */
+  readonly evidenceHashes: readonly string[];
+  /** Revision identifier of the Guardrail set that required this Approval. */
+  readonly guardrailRevision: string;
+}
+
+export interface ApprovalBinding {
+  readonly intentDigest: string;
+  readonly evidenceDigest: string;
+  readonly guardrailRevision: string;
+}
+
+/**
+ * Computes the binding for `input`. Throws `CanonicalizationError` when the intent arguments
+ * cannot be canonicalized (dates, class instances, non-finite numbers) — an intent that cannot be
+ * hashed exactly is never approximated into a digest.
+ */
+export function computeApprovalBinding(input: ApprovalBindingInput): ApprovalBinding {
+  const { intent } = input;
+  return {
+    intentDigest: canonicalHash({
+      toolId: intent.toolId,
+      toolVersion: intent.toolVersion,
+      action: intent.action,
+      targetRefs: intent.targetRefs.map((ref) => ({ type: ref.type, id: ref.id })),
+      arguments: intent.arguments,
+      destination: intent.destination ?? null,
+      credentialRef: intent.credentialRef ?? null,
+    }),
+    evidenceDigest: canonicalHash([...input.evidenceHashes].sort()),
+    guardrailRevision: input.guardrailRevision,
+  };
+}
+
+/** True only when both bindings agree on intent, evidence, and Guardrail revision. */
+export function bindingsMatch(a: ApprovalBinding, b: ApprovalBinding): boolean {
+  return (
+    a.intentDigest === b.intentDigest &&
+    a.evidenceDigest === b.evidenceDigest &&
+    a.guardrailRevision === b.guardrailRevision
+  );
+}

--- a/packages/authz/src/approval/decision.test.ts
+++ b/packages/authz/src/approval/decision.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it } from "vitest";
+import { type ApprovalBindingInput, computeApprovalBinding } from "./binding";
+import {
+  type ApprovalApprover,
+  ApprovalDeniedError,
+  type ApprovalRecord,
+  assertApprovalUsable,
+  assertApproverEligible,
+  requiredApproverCount,
+} from "./decision";
+
+const BASE_INPUT: ApprovalBindingInput = {
+  intent: {
+    toolId: "billing.refund",
+    toolVersion: "1.0.0",
+    action: "refund.issue",
+    targetRefs: [{ type: "invoice", id: "inv-1" }],
+    arguments: { amount: 500 },
+  },
+  evidenceHashes: ["ev-1"],
+  guardrailRevision: "gr-3",
+};
+
+const BINDING = computeApprovalBinding(BASE_INPUT);
+const NOW = new Date("2026-07-24T12:00:00.000Z");
+
+function record(overrides: Partial<ApprovalRecord> = {}): ApprovalRecord {
+  return {
+    approvalId: "ap-1",
+    businessId: "biz-1",
+    binding: BINDING,
+    risk: "high",
+    allowedApproverRoles: ["finance_approver"],
+    proposerPrincipalId: "user-proposer",
+    performerPrincipalId: "user-performer",
+    agentPrincipalId: "agent-1",
+    expiresAt: new Date("2026-07-24T13:00:00.000Z"),
+    decisions: [],
+    ...overrides,
+  };
+}
+
+function approver(overrides: Partial<ApprovalApprover> = {}): ApprovalApprover {
+  return {
+    principalId: "user-approver-1",
+    businessId: "biz-1",
+    roles: ["finance_approver"],
+    ...overrides,
+  };
+}
+
+function approved(principalId: string) {
+  return {
+    approverPrincipalId: principalId,
+    approverRoles: ["finance_approver"],
+    outcome: "approved" as const,
+    decidedAt: NOW,
+  };
+}
+
+function denialReason(fn: () => void): string {
+  try {
+    fn();
+  } catch (error) {
+    expect(error).toBeInstanceOf(ApprovalDeniedError);
+    return (error as ApprovalDeniedError).reason;
+  }
+  throw new Error("expected the Approval to be denied");
+}
+
+describe("requiredApproverCount", () => {
+  it("requires four-eyes for high risk by default", () => {
+    expect(requiredApproverCount("high")).toBe(2);
+  });
+
+  it("requires a single approver below high risk", () => {
+    expect(requiredApproverCount("low")).toBe(1);
+    expect(requiredApproverCount("medium")).toBe(1);
+  });
+});
+
+describe("assertApproverEligible", () => {
+  it("accepts a qualified approver from the same business", () => {
+    expect(() => assertApproverEligible(record(), approver(), NOW)).not.toThrow();
+  });
+
+  it.each([
+    ["proposer", "user-proposer"],
+    ["performer", "user-performer"],
+    ["executing Agent", "agent-1"],
+  ])("denies self-approval by the %s", (_label, principalId) => {
+    expect(
+      denialReason(() => assertApproverEligible(record(), approver({ principalId }), NOW))
+    ).toBe("self_approval");
+  });
+
+  it("denies an approver holding none of the allowed roles", () => {
+    expect(
+      denialReason(() => assertApproverEligible(record(), approver({ roles: ["viewer"] }), NOW))
+    ).toBe("approver_not_qualified");
+  });
+
+  it("denies an approver with no roles at all", () => {
+    expect(denialReason(() => assertApproverEligible(record(), approver({ roles: [] }), NOW))).toBe(
+      "approver_not_qualified"
+    );
+  });
+
+  it("denies an approver from another business", () => {
+    expect(
+      denialReason(() => assertApproverEligible(record(), approver({ businessId: "biz-2" }), NOW))
+    ).toBe("business_mismatch");
+  });
+
+  it("denies a second decision from the same approver", () => {
+    expect(
+      denialReason(() =>
+        assertApproverEligible(
+          record({ decisions: [approved("user-approver-1")] }),
+          approver(),
+          NOW
+        )
+      )
+    ).toBe("duplicate_approver");
+  });
+
+  it("denies deciding an expired Approval", () => {
+    expect(
+      denialReason(() =>
+        assertApproverEligible(record(), approver(), new Date("2026-07-24T13:00:00.000Z"))
+      )
+    ).toBe("expired");
+  });
+
+  it("denies deciding a consumed Approval", () => {
+    expect(
+      denialReason(() => assertApproverEligible(record({ consumedAt: NOW }), approver(), NOW))
+    ).toBe("already_used");
+  });
+
+  it("denies deciding a revoked Approval", () => {
+    expect(
+      denialReason(() => assertApproverEligible(record({ revokedAt: NOW }), approver(), NOW))
+    ).toBe("revoked");
+  });
+});
+
+describe("assertApprovalUsable", () => {
+  const satisfied = record({
+    decisions: [approved("user-approver-1"), approved("user-approver-2")],
+  });
+
+  it("accepts a satisfied, unexpired, unused Approval for its exact binding", () => {
+    expect(() => assertApprovalUsable(satisfied, BINDING, NOW)).not.toThrow();
+  });
+
+  it.each([
+    ["arguments", { intent: { ...BASE_INPUT.intent, arguments: { amount: 5000 } } }],
+    ["Tool version", { intent: { ...BASE_INPUT.intent, toolVersion: "1.0.1" } }],
+    [
+      "target Record",
+      { intent: { ...BASE_INPUT.intent, targetRefs: [{ type: "invoice", id: "inv-2" }] } },
+    ],
+    ["destination", { intent: { ...BASE_INPUT.intent, destination: "elsewhere" } }],
+    ["Credential scope", { intent: { ...BASE_INPUT.intent, credentialRef: "secret://admin" } }],
+    ["evidence", { evidenceHashes: ["ev-2"] }],
+    ["Guardrail revision", { guardrailRevision: "gr-4" }],
+  ])("denies substitution when the %s changed", (_label, patch) => {
+    const substituted = computeApprovalBinding({ ...BASE_INPUT, ...(patch as object) });
+    expect(denialReason(() => assertApprovalUsable(satisfied, substituted, NOW))).toBe(
+      "binding_mismatch"
+    );
+  });
+
+  it("denies when fewer than four eyes approved a high-risk action", () => {
+    expect(
+      denialReason(() =>
+        assertApprovalUsable(record({ decisions: [approved("user-approver-1")] }), BINDING, NOW)
+      )
+    ).toBe("insufficient_approvals");
+  });
+
+  it("accepts a single approver below high risk", () => {
+    expect(() =>
+      assertApprovalUsable(
+        record({ risk: "medium", decisions: [approved("user-approver-1")] }),
+        BINDING,
+        NOW
+      )
+    ).not.toThrow();
+  });
+
+  it("denies when no decision was recorded at all", () => {
+    expect(denialReason(() => assertApprovalUsable(record(), BINDING, NOW))).toBe(
+      "insufficient_approvals"
+    );
+  });
+
+  it("lets an explicit denial win over sufficient approvals", () => {
+    expect(
+      denialReason(() =>
+        assertApprovalUsable(
+          record({
+            decisions: [
+              approved("user-approver-1"),
+              approved("user-approver-2"),
+              {
+                approverPrincipalId: "user-approver-3",
+                approverRoles: ["finance_approver"],
+                outcome: "denied",
+                decidedAt: NOW,
+              },
+            ],
+          }),
+          BINDING,
+          NOW
+        )
+      )
+    ).toBe("denied");
+  });
+
+  it("denies an expired Approval at its expiry instant", () => {
+    expect(
+      denialReason(() =>
+        assertApprovalUsable(satisfied, BINDING, new Date("2026-07-24T13:00:00.000Z"))
+      )
+    ).toBe("expired");
+  });
+
+  it("denies replay of a one-use Approval", () => {
+    expect(
+      denialReason(() => assertApprovalUsable({ ...satisfied, consumedAt: NOW }, BINDING, NOW))
+    ).toBe("already_used");
+  });
+
+  it("denies a revoked Approval", () => {
+    expect(
+      denialReason(() => assertApprovalUsable({ ...satisfied, revokedAt: NOW }, BINDING, NOW))
+    ).toBe("revoked");
+  });
+
+  it("keeps denial evidence free of intent payloads", () => {
+    const substituted = computeApprovalBinding({
+      ...BASE_INPUT,
+      intent: { ...BASE_INPUT.intent, arguments: { amount: 5000, iban: "DE00 1234" } },
+    });
+    try {
+      assertApprovalUsable(satisfied, substituted, NOW);
+    } catch (error) {
+      expect((error as Error).message).not.toContain("DE00 1234");
+      expect((error as Error).message).not.toContain("5000");
+    }
+  });
+});

--- a/packages/authz/src/approval/decision.ts
+++ b/packages/authz/src/approval/decision.ts
@@ -1,0 +1,171 @@
+/**
+ * Approval validity decisions (SPEC §11.2, §24). Two questions are decided here and nowhere else:
+ * whether a principal may record a decision on an Approval, and whether a recorded Approval
+ * authorizes one specific use. Both fail closed — an Approval that is expired, consumed, revoked,
+ * under-approved, or bound to a different intent authorizes nothing.
+ *
+ * Denial evidence is a reason code plus the Approval id. Intent arguments, destinations, evidence
+ * contents, and Credential references never reach an error message, so audit and error paths
+ * cannot leak what the Approval was about (SPEC §13, §20).
+ *
+ * Storing and mutating Approvals belongs to `@tulipfarm/storage`; this module is a pure decision
+ * over a record it is handed.
+ */
+
+import { type ApprovalBinding, bindingsMatch } from "./binding";
+
+export type ApprovalRiskLevel = "low" | "medium" | "high";
+
+export type ApprovalOutcome = "approved" | "denied";
+
+export type ApprovalDenialReason =
+  | "business_mismatch"
+  | "revoked"
+  | "expired"
+  | "already_used"
+  | "self_approval"
+  | "approver_not_qualified"
+  | "duplicate_approver"
+  | "binding_mismatch"
+  | "denied"
+  | "insufficient_approvals";
+
+export class ApprovalDeniedError extends Error {
+  constructor(
+    public readonly reason: ApprovalDenialReason,
+    message: string
+  ) {
+    super(message);
+    this.name = "ApprovalDeniedError";
+  }
+}
+
+/** One recorded approver decision. Decisions are append-only; an approver decides at most once. */
+export interface ApprovalDecisionRecord {
+  readonly approverPrincipalId: string;
+  readonly approverRoles: readonly string[];
+  readonly outcome: ApprovalOutcome;
+  readonly decidedAt: Date;
+}
+
+export interface ApprovalRecord {
+  readonly approvalId: string;
+  readonly businessId: string;
+  readonly binding: ApprovalBinding;
+  readonly risk: ApprovalRiskLevel;
+  /** Roles that may decide this Approval; an approver needs at least one of them. */
+  readonly allowedApproverRoles: readonly string[];
+  /** Principal that proposed the action — separation of duties bars it from approving. */
+  readonly proposerPrincipalId: string;
+  /** Principal that will perform the action, when it differs from the proposer. */
+  readonly performerPrincipalId?: string;
+  /** Agent identity executing the action; an Agent never approves its own action. */
+  readonly agentPrincipalId?: string;
+  readonly expiresAt: Date;
+  readonly decisions: readonly ApprovalDecisionRecord[];
+  /** Set the instant the one-use decision was spent; a consumed Approval never applies again. */
+  readonly consumedAt?: Date;
+  readonly revokedAt?: Date;
+}
+
+export interface ApprovalApprover {
+  readonly principalId: string;
+  readonly businessId: string;
+  readonly roles: readonly string[];
+}
+
+/** Four-eyes for high risk by default (SPEC §11.2); one qualified approver below it. */
+export function requiredApproverCount(risk: ApprovalRiskLevel): number {
+  return risk === "high" ? 2 : 1;
+}
+
+/** Principals barred from approving because they proposed, will perform, or will execute. */
+function prohibitedApprovers(record: ApprovalRecord): readonly string[] {
+  return [record.proposerPrincipalId, record.performerPrincipalId, record.agentPrincipalId].filter(
+    (id): id is string => id !== undefined
+  );
+}
+
+/** Throws when the Approval is no longer open to any decision or use. */
+function assertOpen(record: ApprovalRecord, now: Date): void {
+  if (record.revokedAt !== undefined) {
+    throw new ApprovalDeniedError("revoked", `Approval ${record.approvalId} was revoked`);
+  }
+  if (record.consumedAt !== undefined) {
+    throw new ApprovalDeniedError("already_used", `Approval ${record.approvalId} was already used`);
+  }
+  if (record.expiresAt <= now) {
+    throw new ApprovalDeniedError("expired", `Approval ${record.approvalId} has expired`);
+  }
+}
+
+/**
+ * Throws unless `approver` may record a decision on `record`. Precedence: wrong business, then the
+ * Approval's own state (revoked, consumed, expired), then separation of duties, then role
+ * qualification, then a repeat decision by the same approver.
+ */
+export function assertApproverEligible(
+  record: ApprovalRecord,
+  approver: ApprovalApprover,
+  now: Date = new Date()
+): void {
+  if (approver.businessId !== record.businessId) {
+    throw new ApprovalDeniedError(
+      "business_mismatch",
+      `approver does not belong to the business of Approval ${record.approvalId}`
+    );
+  }
+  assertOpen(record, now);
+  if (prohibitedApprovers(record).includes(approver.principalId)) {
+    throw new ApprovalDeniedError(
+      "self_approval",
+      `the proposing, performing, or executing principal cannot approve Approval ${record.approvalId}`
+    );
+  }
+  if (!approver.roles.some((role) => record.allowedApproverRoles.includes(role))) {
+    throw new ApprovalDeniedError(
+      "approver_not_qualified",
+      `approver holds no role allowed to decide Approval ${record.approvalId}`
+    );
+  }
+  if (record.decisions.some((entry) => entry.approverPrincipalId === approver.principalId)) {
+    throw new ApprovalDeniedError(
+      "duplicate_approver",
+      `approver already decided Approval ${record.approvalId}`
+    );
+  }
+}
+
+/**
+ * Throws unless `record` authorizes the use described by `presented`. Precedence: the Approval's
+ * own state (revoked, consumed, expired), then the exact binding — changed arguments, Tool
+ * version, target Record, destination, Credential scope, evidence, or Guardrail revision all
+ * surface as `binding_mismatch` — then any explicit denial, then the required approver count.
+ */
+export function assertApprovalUsable(
+  record: ApprovalRecord,
+  presented: ApprovalBinding,
+  now: Date = new Date()
+): void {
+  assertOpen(record, now);
+  if (!bindingsMatch(record.binding, presented)) {
+    throw new ApprovalDeniedError(
+      "binding_mismatch",
+      `Approval ${record.approvalId} was not granted for this intent, evidence, or Guardrail revision`
+    );
+  }
+  if (record.decisions.some((entry) => entry.outcome === "denied")) {
+    throw new ApprovalDeniedError("denied", `Approval ${record.approvalId} was denied`);
+  }
+  const approvers = new Set(
+    record.decisions
+      .filter((entry) => entry.outcome === "approved")
+      .map((entry) => entry.approverPrincipalId)
+  );
+  if (approvers.size < requiredApproverCount(record.risk)) {
+    throw new ApprovalDeniedError(
+      "insufficient_approvals",
+      `Approval ${record.approvalId} lacks the required number of qualified approvers`
+    );
+  }
+}

--- a/packages/authz/src/index.ts
+++ b/packages/authz/src/index.ts
@@ -1,4 +1,24 @@
 export type {
+  ApprovalBinding,
+  ApprovalBindingInput,
+  ApprovalIntent,
+} from "./approval/binding";
+export { bindingsMatch, computeApprovalBinding } from "./approval/binding";
+export type {
+  ApprovalApprover,
+  ApprovalDecisionRecord,
+  ApprovalDenialReason,
+  ApprovalOutcome,
+  ApprovalRecord,
+  ApprovalRiskLevel,
+} from "./approval/decision";
+export {
+  ApprovalDeniedError,
+  assertApprovalUsable,
+  assertApproverEligible,
+  requiredApproverCount,
+} from "./approval/decision";
+export type {
   AuthorityLayer,
   AuthzDecision,
   AuthzDecisionReason,

--- a/packages/storage/src/approvals/approval-repo.test.ts
+++ b/packages/storage/src/approvals/approval-repo.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "vitest";
+import {
+  type ApprovalBindingRecord,
+  type ApprovalGrantRecord,
+  ApprovalStoreError,
+  InMemoryApprovalRepo,
+  type NewApprovalGrant,
+} from "./approval-repo";
+
+const BINDING: ApprovalBindingRecord = {
+  intentDigest: "digest-intent-a",
+  evidenceDigest: "digest-evidence-a",
+  guardrailRevision: "gr-3",
+};
+
+const OTHER_BINDING: ApprovalBindingRecord = { ...BINDING, intentDigest: "digest-intent-b" };
+
+const CREATED_AT = new Date("2026-07-24T12:00:00.000Z");
+const EXPIRES_AT = new Date("2026-07-24T13:00:00.000Z");
+
+function grant(overrides: Partial<NewApprovalGrant> = {}): NewApprovalGrant {
+  return {
+    approvalId: "ap-1",
+    businessId: "biz-1",
+    binding: BINDING,
+    risk: "high",
+    allowedApproverRoles: ["finance_approver"],
+    proposerPrincipalId: "user-proposer",
+    performerPrincipalId: "user-performer",
+    agentPrincipalId: "agent-1",
+    preview: "Refund invoice inv-1",
+    riskSummary: "irreversible external payment",
+    expiresAt: EXPIRES_AT,
+    createdAt: CREATED_AT,
+    ...overrides,
+  };
+}
+
+function decision(approverPrincipalId: string, outcome: "approved" | "denied" = "approved") {
+  return {
+    approverPrincipalId,
+    approverRoles: ["finance_approver"],
+    outcome,
+    decidedAt: CREATED_AT,
+  };
+}
+
+async function storeErrorCode(fn: () => Promise<unknown>): Promise<string> {
+  try {
+    await fn();
+  } catch (error) {
+    expect(error).toBeInstanceOf(ApprovalStoreError);
+    return (error as ApprovalStoreError).code;
+  }
+  throw new Error("expected an ApprovalStoreError");
+}
+
+async function seededRepo(): Promise<InMemoryApprovalRepo> {
+  const repo = new InMemoryApprovalRepo();
+  await repo.create(grant());
+  await repo.appendDecision("biz-1", "ap-1", decision("user-approver-1"));
+  await repo.appendDecision("biz-1", "ap-1", decision("user-approver-2"));
+  return repo;
+}
+
+describe("InMemoryApprovalRepo persistence", () => {
+  it("persists the exact binding, approver constraints, expiry, and preview", async () => {
+    const repo = new InMemoryApprovalRepo();
+    const created = await repo.create(grant());
+    expect(created).toMatchObject({
+      approvalId: "ap-1",
+      binding: BINDING,
+      risk: "high",
+      allowedApproverRoles: ["finance_approver"],
+      proposerPrincipalId: "user-proposer",
+      performerPrincipalId: "user-performer",
+      agentPrincipalId: "agent-1",
+      preview: "Refund invoice inv-1",
+      riskSummary: "irreversible external payment",
+      expiresAt: EXPIRES_AT,
+      decisions: [],
+    });
+    expect(created.consumedAt).toBeUndefined();
+    expect(await repo.get("biz-1", "ap-1")).toEqual(created);
+  });
+
+  it("rejects a duplicate approvalId", async () => {
+    const repo = new InMemoryApprovalRepo();
+    await repo.create(grant());
+    expect(await storeErrorCode(() => repo.create(grant()))).toBe("duplicate_approval");
+  });
+
+  it("isolates Approvals by business", async () => {
+    const repo = new InMemoryApprovalRepo();
+    await repo.create(grant());
+    expect(await repo.get("biz-2", "ap-1")).toBeUndefined();
+    expect(
+      await storeErrorCode(() => repo.appendDecision("biz-2", "ap-1", decision("user-approver-1")))
+    ).toBe("not_found");
+  });
+
+  it("appends decisions in order and rejects a repeat approver", async () => {
+    const repo = await seededRepo();
+    const stored = await repo.get("biz-1", "ap-1");
+    expect(stored?.decisions.map((entry) => entry.approverPrincipalId)).toEqual([
+      "user-approver-1",
+      "user-approver-2",
+    ]);
+    expect(
+      await storeErrorCode(() => repo.appendDecision("biz-1", "ap-1", decision("user-approver-1")))
+    ).toBe("duplicate_approver");
+  });
+
+  it("does not let a caller mutate stored state through a returned record", async () => {
+    const repo = await seededRepo();
+    const stored = (await repo.get("biz-1", "ap-1")) as ApprovalGrantRecord;
+    expect(() => {
+      (stored.decisions as unknown[]).push(decision("user-intruder"));
+    }).toThrow();
+    expect((await repo.get("biz-1", "ap-1"))?.decisions).toHaveLength(2);
+  });
+});
+
+describe("InMemoryApprovalRepo one-use consumption", () => {
+  it("consumes once and denies replay", async () => {
+    const repo = await seededRepo();
+    const consumed = await repo.consume("biz-1", "ap-1", BINDING, EXPIRES_AT);
+    expect(consumed.consumedAt).toEqual(EXPIRES_AT);
+    expect(await storeErrorCode(() => repo.consume("biz-1", "ap-1", BINDING, EXPIRES_AT))).toBe(
+      "already_used"
+    );
+  });
+
+  it("denies substitution of a different intent binding and leaves the Approval unconsumed", async () => {
+    const repo = await seededRepo();
+    expect(
+      await storeErrorCode(() => repo.consume("biz-1", "ap-1", OTHER_BINDING, CREATED_AT))
+    ).toBe("binding_mismatch");
+    expect((await repo.get("biz-1", "ap-1"))?.consumedAt).toBeUndefined();
+  });
+
+  it("lets exactly one of two concurrent consumptions win", async () => {
+    const repo = await seededRepo();
+    const results = await Promise.allSettled([
+      repo.consume("biz-1", "ap-1", BINDING, CREATED_AT),
+      repo.consume("biz-1", "ap-1", BINDING, CREATED_AT),
+    ]);
+    expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    const rejected = results.find(
+      (result) => result.status === "rejected"
+    ) as PromiseRejectedResult;
+    expect((rejected.reason as ApprovalStoreError).code).toBe("already_used");
+  });
+
+  it("denies decisions and revocation after consumption", async () => {
+    const repo = await seededRepo();
+    await repo.consume("biz-1", "ap-1", BINDING, CREATED_AT);
+    expect(
+      await storeErrorCode(() => repo.appendDecision("biz-1", "ap-1", decision("user-approver-3")))
+    ).toBe("already_used");
+    expect(await storeErrorCode(() => repo.revoke("biz-1", "ap-1", CREATED_AT))).toBe(
+      "already_used"
+    );
+  });
+
+  it("denies consumption and decisions after revocation", async () => {
+    const repo = await seededRepo();
+    await repo.revoke("biz-1", "ap-1", CREATED_AT);
+    expect(await storeErrorCode(() => repo.consume("biz-1", "ap-1", BINDING, CREATED_AT))).toBe(
+      "revoked"
+    );
+    expect(
+      await storeErrorCode(() => repo.appendDecision("biz-1", "ap-1", decision("user-approver-3")))
+    ).toBe("revoked");
+  });
+});
+
+describe("InMemoryApprovalRepo restart recovery", () => {
+  it("keeps decisions and one-use consumption across a restart", async () => {
+    const repo = await seededRepo();
+    await repo.consume("biz-1", "ap-1", BINDING, CREATED_AT);
+    const rows = await repo.list("biz-1");
+
+    const restarted = new InMemoryApprovalRepo(rows);
+    const restored = await restarted.get("biz-1", "ap-1");
+    expect(restored?.decisions).toHaveLength(2);
+    expect(restored?.consumedAt).toEqual(CREATED_AT);
+    expect(
+      await storeErrorCode(() => restarted.consume("biz-1", "ap-1", BINDING, CREATED_AT))
+    ).toBe("already_used");
+  });
+
+  it("keeps an undecided Approval pending and its expiry intact across a restart", async () => {
+    const repo = new InMemoryApprovalRepo();
+    await repo.create(grant());
+    const restarted = new InMemoryApprovalRepo(await repo.list("biz-1"));
+    const restored = await restarted.get("biz-1", "ap-1");
+    expect(restored?.decisions).toEqual([]);
+    expect(restored?.consumedAt).toBeUndefined();
+    expect(restored?.expiresAt).toEqual(EXPIRES_AT);
+  });
+});

--- a/packages/storage/src/approvals/approval-repo.ts
+++ b/packages/storage/src/approvals/approval-repo.ts
@@ -1,0 +1,224 @@
+/**
+ * Persistence for Approvals and their decisions (SPEC §11.2). Storage owns the durable mechanics —
+ * uniqueness, append-only decisions, and the atomic one-use consumption — while `@tulipfarm/authz`
+ * owns whether an Approval is valid. Everything an Approval decision depends on lives in the
+ * record, never in process memory, so decisions, expiry, and the spent one-use marker survive a
+ * restart; an adapter rehydrates the same rows and reaches the same answers.
+ *
+ * The binding is stored as digests only, and the human-facing `preview`/`riskSummary` are safe
+ * summary text — no intent arguments, Credential material, or Secrets are persisted here
+ * (SPEC §13, §20).
+ */
+
+/** Digests identifying the exact intent, evidence, and Guardrail revision an Approval covers. */
+export interface ApprovalBindingRecord {
+  readonly intentDigest: string;
+  readonly evidenceDigest: string;
+  readonly guardrailRevision: string;
+}
+
+export type ApprovalRiskLevel = "low" | "medium" | "high";
+
+export interface ApprovalDecisionEntry {
+  readonly approverPrincipalId: string;
+  readonly approverRoles: readonly string[];
+  readonly outcome: "approved" | "denied";
+  readonly decidedAt: Date;
+}
+
+export interface ApprovalGrantRecord {
+  readonly approvalId: string;
+  readonly businessId: string;
+  readonly binding: ApprovalBindingRecord;
+  readonly risk: ApprovalRiskLevel;
+  readonly allowedApproverRoles: readonly string[];
+  readonly proposerPrincipalId: string;
+  readonly performerPrincipalId?: string;
+  readonly agentPrincipalId?: string;
+  /** Readable diff/preview shown to approvers. Safe summary text only. */
+  readonly preview: string;
+  /** Readable risk summary shown to approvers. Safe summary text only. */
+  readonly riskSummary: string;
+  readonly expiresAt: Date;
+  readonly createdAt: Date;
+  readonly decisions: readonly ApprovalDecisionEntry[];
+  readonly consumedAt?: Date;
+  readonly revokedAt?: Date;
+}
+
+/** A new Approval: decisions, consumption, and revocation are recorded through the repo. */
+export type NewApprovalGrant = Omit<ApprovalGrantRecord, "decisions" | "consumedAt" | "revokedAt">;
+
+export type ApprovalStoreErrorCode =
+  | "not_found"
+  | "duplicate_approval"
+  | "duplicate_approver"
+  | "already_used"
+  | "revoked"
+  | "binding_mismatch";
+
+export class ApprovalStoreError extends Error {
+  constructor(
+    public readonly code: ApprovalStoreErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = "ApprovalStoreError";
+  }
+}
+
+export interface ApprovalRepo {
+  create(grant: NewApprovalGrant): Promise<ApprovalGrantRecord>;
+  get(businessId: string, approvalId: string): Promise<ApprovalGrantRecord | undefined>;
+  /** All Approvals of one business, oldest first — the rehydration source after a restart. */
+  list(businessId: string): Promise<ApprovalGrantRecord[]>;
+  appendDecision(
+    businessId: string,
+    approvalId: string,
+    decision: ApprovalDecisionEntry
+  ): Promise<ApprovalGrantRecord>;
+  /**
+   * Spends the one-use decision, but only for the exact `binding` it was granted for. Consumption
+   * is atomic: of any number of concurrent attempts exactly one succeeds and the rest see
+   * `already_used`.
+   */
+  consume(
+    businessId: string,
+    approvalId: string,
+    binding: ApprovalBindingRecord,
+    at: Date
+  ): Promise<ApprovalGrantRecord>;
+  revoke(businessId: string, approvalId: string, at: Date): Promise<ApprovalGrantRecord>;
+}
+
+function freeze(record: ApprovalGrantRecord): ApprovalGrantRecord {
+  return Object.freeze({
+    ...record,
+    binding: Object.freeze({ ...record.binding }),
+    allowedApproverRoles: Object.freeze([...record.allowedApproverRoles]),
+    decisions: Object.freeze(
+      record.decisions.map((entry) =>
+        Object.freeze({ ...entry, approverRoles: Object.freeze([...entry.approverRoles]) })
+      )
+    ),
+  });
+}
+
+function bindingsEqual(a: ApprovalBindingRecord, b: ApprovalBindingRecord): boolean {
+  return (
+    a.intentDigest === b.intentDigest &&
+    a.evidenceDigest === b.evidenceDigest &&
+    a.guardrailRevision === b.guardrailRevision
+  );
+}
+
+/**
+ * Process-local reference implementation for tests and single-process composition. A durable
+ * PostgreSQL adapter implements the same {@link ApprovalRepo} contract, where `create` maps to a
+ * primary key, `appendDecision` to a unique `(approval_id, approver_principal_id)` constraint, and
+ * `consume` to a conditional `UPDATE … WHERE consumed_at IS NULL` returning the affected row.
+ */
+export class InMemoryApprovalRepo implements ApprovalRepo {
+  private readonly records = new Map<string, ApprovalGrantRecord>();
+
+  /** `seed` rehydrates previously stored rows, as a restarted process would. */
+  constructor(seed: readonly ApprovalGrantRecord[] = []) {
+    for (const record of seed) {
+      this.records.set(this.key(record.businessId, record.approvalId), freeze({ ...record }));
+    }
+  }
+
+  private key(businessId: string, approvalId: string): string {
+    return JSON.stringify([businessId, approvalId]);
+  }
+
+  /** The stored record, or a `not_found` error. Callers must not await between this and a write. */
+  private require(businessId: string, approvalId: string): ApprovalGrantRecord {
+    const record = this.records.get(this.key(businessId, approvalId));
+    if (!record) {
+      throw new ApprovalStoreError("not_found", `Approval ${approvalId} does not exist`);
+    }
+    return record;
+  }
+
+  private assertOpen(record: ApprovalGrantRecord): void {
+    if (record.revokedAt !== undefined) {
+      throw new ApprovalStoreError("revoked", `Approval ${record.approvalId} was revoked`);
+    }
+    if (record.consumedAt !== undefined) {
+      throw new ApprovalStoreError(
+        "already_used",
+        `Approval ${record.approvalId} was already used`
+      );
+    }
+  }
+
+  private write(record: ApprovalGrantRecord): ApprovalGrantRecord {
+    const stored = freeze(record);
+    this.records.set(this.key(stored.businessId, stored.approvalId), stored);
+    return stored;
+  }
+
+  async create(grant: NewApprovalGrant): Promise<ApprovalGrantRecord> {
+    if (this.records.has(this.key(grant.businessId, grant.approvalId))) {
+      throw new ApprovalStoreError(
+        "duplicate_approval",
+        `Approval ${grant.approvalId} already exists`
+      );
+    }
+    return this.write({ ...grant, decisions: [] });
+  }
+
+  async get(businessId: string, approvalId: string): Promise<ApprovalGrantRecord | undefined> {
+    return this.records.get(this.key(businessId, approvalId));
+  }
+
+  async list(businessId: string): Promise<ApprovalGrantRecord[]> {
+    return [...this.records.values()]
+      .filter((record) => record.businessId === businessId)
+      .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+  }
+
+  async appendDecision(
+    businessId: string,
+    approvalId: string,
+    decision: ApprovalDecisionEntry
+  ): Promise<ApprovalGrantRecord> {
+    const record = this.require(businessId, approvalId);
+    this.assertOpen(record);
+    if (
+      record.decisions.some((entry) => entry.approverPrincipalId === decision.approverPrincipalId)
+    ) {
+      throw new ApprovalStoreError(
+        "duplicate_approver",
+        `approver already decided Approval ${approvalId}`
+      );
+    }
+    return this.write({ ...record, decisions: [...record.decisions, decision] });
+  }
+
+  async consume(
+    businessId: string,
+    approvalId: string,
+    binding: ApprovalBindingRecord,
+    at: Date
+  ): Promise<ApprovalGrantRecord> {
+    // Check and mark in one synchronous step: no await may separate them, or two concurrent
+    // callers could both observe an unconsumed Approval and both spend it.
+    const record = this.require(businessId, approvalId);
+    this.assertOpen(record);
+    if (!bindingsEqual(record.binding, binding)) {
+      throw new ApprovalStoreError(
+        "binding_mismatch",
+        `Approval ${approvalId} was not granted for this binding`
+      );
+    }
+    return this.write({ ...record, consumedAt: at });
+  }
+
+  async revoke(businessId: string, approvalId: string, at: Date): Promise<ApprovalGrantRecord> {
+    const record = this.require(businessId, approvalId);
+    this.assertOpen(record);
+    return this.write({ ...record, revokedAt: at });
+  }
+}

--- a/packages/storage/src/approvals/index.ts
+++ b/packages/storage/src/approvals/index.ts
@@ -1,0 +1,10 @@
+export type {
+  ApprovalBindingRecord,
+  ApprovalDecisionEntry,
+  ApprovalGrantRecord,
+  ApprovalRepo,
+  ApprovalRiskLevel,
+  ApprovalStoreErrorCode,
+  NewApprovalGrant,
+} from "./approval-repo";
+export { ApprovalStoreError, InMemoryApprovalRepo } from "./approval-repo";

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./approvals";
 export * from "./auth";
 export * from "./ports";
 export * from "./soul";


### PR DESCRIPTION
## Summary

- Bind an Approval to digests of the canonical Tool intent, the evidence set, and the Guardrail revision (`@tulipfarm/authz` `computeApprovalBinding`), so changed arguments, Tool version, target Record, destination, Credential scope, evidence, or Guardrail invalidate it and a decision cannot be substituted onto a different action (SPEC §11.2).
- Decide Approval validity in one place (`assertApproverEligible`, `assertApprovalUsable`): separation of duties bars the proposing, performing, and executing principals from approving, high risk requires four eyes by default, and expiry, revocation, one-use consumption, and explicit denials all fail closed. Denial evidence carries reason codes and digests only — never intent payloads or Credential references.
- Persist Approvals and their decisions in `@tulipfarm/storage` (`ApprovalRepo`, `InMemoryApprovalRepo`). Decisions, expiry, and the spent one-use marker live in the record rather than process memory, so a restart cannot resurrect a consumed Approval or lose an approver's decision; consumption checks and marks in one synchronous step so concurrent attempts cannot both spend it.

Implements AW-023. The durable PostgreSQL adapter and Tool Broker wiring are out of scope here — `apps/api`'s existing ephemeral approval registry is untouched, and AW-041 binds Approvals into Tool execution.

## Test plan

- `pnpm --filter @tulipfarm/authz --filter @tulipfarm/storage exec vitest run` — authz 47 passed, storage 145 passed. RED first: both new suites failed on missing modules before the implementation landed.
- Denial coverage: self-approval by proposer/performer/Agent; substitution across arguments, Tool version, target Record, destination, Credential scope, evidence, and Guardrail revision; expiry at its exact instant; one-use replay; revocation; unqualified, role-less, and duplicate approvers; cross-business isolation; four-eyes shortfall; explicit denial beating a satisfied quorum.
- Concurrency: two simultaneous `consume` calls — exactly one succeeds, the other sees `already_used`.
- Restart: rows rehydrated into a fresh repo keep decisions, expiry, and the spent one-use marker, and a replayed consumption is denied.
- Redaction: binding output and error messages assert-checked to contain no argument values or Credential references.
- `pnpm exec biome check packages/authz packages/storage` and `tsc --noEmit` on both packages — clean.