### PR TITLE
feat(secrets): build scoped Secret Broker (AW-024)

### DIFF
--- a/packages/secrets/AGENTS.md
+++ b/packages/secrets/AGENTS.md
@@ -16,6 +16,18 @@
 - **`backfillSecretsToDek`** — migrate legacy (pre-envelope) secrets onto the DEK.
 - **`loadEncryptionKeys`** (+ type `EncryptionKeys`) — reads the env KEK(s).
 - **`assertValidSecretKey`** + `InvalidSecretKeyError` — key-name guard.
+- **`SecretBroker`** (`src/broker.ts`) — scoped, short-lived, in-memory Credential leases. Requires a
+  `SecretAuthorizer` (default-deny: a refusal *or* an authorizer failure denies), clamps TTL/uses to
+  what was authorized, resolves the value fresh on every use (so rotation/revocation apply to the
+  next invocation), and emits `SecretBrokerEvent` lease metadata — reference and scope, never value.
+  `revokeSecret` / `revokeLease` / `revokeAll` invalidate outstanding leases.
+- **`SecretLease`** (`src/lease.ts`) — non-serializable handle. Plaintext exists only as the argument
+  to `lease.use(cb)`; `toJSON` throws `SecretNotSerializableError`, string/inspect coercion yields
+  `[SecretLease redacted]`, a callback error is re-thrown redacted, and a callback that returns the
+  plaintext raises `SecretLeakError`. Denials are `SecretLeaseDeniedError` + reason code.
+- **`SecretProvider`** (`src/providers.ts`) — where the broker reads the *current* value from;
+  `inMemorySecretProvider` (dev/test only) and `secretsServiceProvider` (see its cache caveat).
+- **Redaction** (`src/redaction.ts`) — `redactSecrets`, `containsSecret`, `redactError`, `REDACTED`.
 - **KMS port** (`src/ports/kms.ts`) — provider-neutral `KmsPort` (`wrap`/`unwrap`/`activeKey`)
   with opaque `MasterKeyRef` / `WrappedKey`; the master key never crosses the boundary and no
   provider SDK type leaks. Adapters: local managed keys, cloud KMS, or Vault-compatible services.

--- a/packages/secrets/src/broker.test.ts
+++ b/packages/secrets/src/broker.test.ts
@@ -1,0 +1,198 @@
+import { inspect } from "node:util";
+import { beforeEach, describe, expect, it } from "vitest";
+import { SecretBroker, type SecretBrokerEvent } from "./broker";
+import { SecretLeakError, SecretLeaseDeniedError, SecretNotSerializableError } from "./lease";
+import { inMemorySecretProvider } from "./providers";
+
+const PLAINTEXT = "tok-live-abcdef";
+
+const SCOPE = {
+  secretRef: "github.token",
+  toolId: "github.create_issue",
+  integrationId: "github",
+  targetId: "acme/repo",
+  runId: "run-1",
+  stateId: "state-1",
+  purpose: "create issue",
+} as const;
+
+function harness(options: { allowed?: boolean; maxTtlMs?: number } = {}) {
+  const provider = inMemorySecretProvider({ [SCOPE.secretRef]: PLAINTEXT });
+  const events: SecretBrokerEvent[] = [];
+  let clock = 1_000;
+  const broker = new SecretBroker({
+    provider,
+    authorizer: {
+      authorize: async () =>
+        options.allowed === false
+          ? { allowed: false as const, reason: "not_authorized" as const }
+          : { allowed: true as const, maxTtlMs: options.maxTtlMs },
+    },
+    onEvent: (event) => events.push(event),
+    now: () => clock,
+    defaultTtlMs: 60_000,
+  });
+  return {
+    broker,
+    provider,
+    events,
+    advance: (ms: number) => {
+      clock += ms;
+    },
+  };
+}
+
+describe("SecretBroker.lease", () => {
+  it("denies by default when authorization fails, without naming the plaintext", async () => {
+    const { broker, events } = harness({ allowed: false });
+    const error = await broker.lease({ scope: SCOPE }).catch((err: unknown) => err);
+    expect(error).toBeInstanceOf(SecretLeaseDeniedError);
+    expect((error as SecretLeaseDeniedError).reason).toBe("not_authorized");
+    expect((error as Error).message).not.toContain(PLAINTEXT);
+    expect(events.map((event) => event.type)).toEqual(["secret.lease.denied"]);
+  });
+
+  it("denies when the authorizer itself throws", async () => {
+    const provider = inMemorySecretProvider({ [SCOPE.secretRef]: PLAINTEXT });
+    const broker = new SecretBroker({
+      provider,
+      authorizer: {
+        authorize: async () => {
+          throw new Error("authz backend down");
+        },
+      },
+    });
+    await expect(broker.lease({ scope: SCOPE })).rejects.toMatchObject({
+      reason: "not_authorized",
+    });
+  });
+
+  it("clamps the requested TTL to the authorized maximum", async () => {
+    const { broker, advance } = harness({ maxTtlMs: 5_000 });
+    const lease = await broker.lease({ scope: SCOPE, ttlMs: 600_000 });
+    advance(5_001);
+    await expect(lease.use(async (secret) => secret)).rejects.toMatchObject({
+      reason: "expired",
+    });
+  });
+});
+
+describe("SecretLease.use", () => {
+  it("resolves the current plaintext only inside the callback", async () => {
+    const { broker, events } = harness();
+    const lease = await broker.lease({ scope: SCOPE });
+    const seen = await lease.use(async (secret) => secret.length);
+    expect(seen).toBe(PLAINTEXT.length);
+    expect(events.map((event) => event.type)).toEqual(["secret.lease.issued", "secret.lease.used"]);
+    expect(JSON.stringify(events)).not.toContain(PLAINTEXT);
+  });
+
+  it("is single-use by default so a replayed lease is denied", async () => {
+    const { broker } = harness();
+    const lease = await broker.lease({ scope: SCOPE });
+    await lease.use(async () => "ok");
+    await expect(lease.use(async () => "ok")).rejects.toMatchObject({ reason: "exhausted" });
+  });
+
+  it("admits exactly one of two concurrent uses of a single-use lease", async () => {
+    const { broker } = harness();
+    const lease = await broker.lease({ scope: SCOPE });
+    const outcomes = await Promise.allSettled([
+      lease.use(async () => "a"),
+      lease.use(async () => "b"),
+    ]);
+    expect(outcomes.filter((entry) => entry.status === "fulfilled")).toHaveLength(1);
+    expect(outcomes.filter((entry) => entry.status === "rejected")).toHaveLength(1);
+  });
+
+  it("serves the rotated value on the next invocation", async () => {
+    const { broker, provider } = harness();
+    const lease = await broker.lease({ scope: SCOPE, maxUses: 2 });
+    // The callback reports what it saw rather than returning it: echoing the Credential back is a
+    // leak the broker refuses, so equality is asserted inside the scope.
+    await expect(lease.use(async (secret) => secret === PLAINTEXT)).resolves.toBe(true);
+    provider.set(SCOPE.secretRef, "tok-live-rotated");
+    await expect(lease.use(async (secret) => secret === "tok-live-rotated")).resolves.toBe(true);
+  });
+
+  it("denies immediately after the secret is revoked", async () => {
+    const { broker, provider, events } = harness();
+    const lease = await broker.lease({ scope: SCOPE, maxUses: 5 });
+    provider.revoke(SCOPE.secretRef);
+    await expect(lease.use(async (secret) => secret)).rejects.toMatchObject({
+      reason: "revoked",
+    });
+    expect(events.at(-1)?.type).toBe("secret.lease.denied");
+  });
+
+  it("denies every outstanding lease once the broker revokes the secret", async () => {
+    const { broker } = harness();
+    const lease = await broker.lease({ scope: SCOPE, maxUses: 5 });
+    broker.revokeSecret(SCOPE.secretRef);
+    await expect(lease.use(async (secret) => secret)).rejects.toMatchObject({
+      reason: "revoked",
+    });
+  });
+
+  it("denies a lease that outlived the broker, as after a crash or restart", async () => {
+    const { broker } = harness();
+    const lease = await broker.lease({ scope: SCOPE, maxUses: 5 });
+    broker.revokeAll();
+    await expect(lease.use(async (secret) => secret)).rejects.toMatchObject({
+      reason: "lease_unknown",
+    });
+  });
+
+  it("rejects a lease presented against a different scope", async () => {
+    const { broker } = harness();
+    const lease = await broker.lease({ scope: SCOPE });
+    await expect(
+      lease.use(async (secret) => secret, { ...SCOPE, targetId: "acme/other" })
+    ).rejects.toMatchObject({ reason: "scope_mismatch" });
+  });
+});
+
+describe("secret containment", () => {
+  let fixture: ReturnType<typeof harness>;
+
+  beforeEach(() => {
+    fixture = harness();
+  });
+
+  it("keeps plaintext out of the lease handle and blocks serialization", async () => {
+    const lease = await fixture.broker.lease({ scope: SCOPE });
+    expect(() => JSON.stringify(lease)).toThrow(SecretNotSerializableError);
+    expect(String(lease)).toBe("[SecretLease redacted]");
+    expect(`${lease}`).toBe("[SecretLease redacted]");
+    expect(inspect(lease, { depth: 5 })).not.toContain(PLAINTEXT);
+  });
+
+  it("redacts plaintext out of an error thrown by the callback", async () => {
+    const lease = await fixture.broker.lease({ scope: SCOPE });
+    const error = await lease
+      .use(async (secret) => {
+        throw new Error(`upstream rejected ${secret}`);
+      })
+      .catch((err: unknown) => err);
+    expect((error as Error).message).toBe("upstream rejected [redacted]");
+    expect((error as Error).stack ?? "").not.toContain(PLAINTEXT);
+  });
+
+  it("fails closed when the callback returns the plaintext", async () => {
+    const lease = await fixture.broker.lease({ scope: SCOPE });
+    const error = await lease
+      .use(async (secret) => ({ echoed: secret }))
+      .catch((err: unknown) => err);
+    expect(error).toBeInstanceOf(SecretLeakError);
+    expect((error as Error).message).not.toContain(PLAINTEXT);
+  });
+
+  it("never puts plaintext in lease evidence", async () => {
+    const lease = await fixture.broker.lease({ scope: SCOPE });
+    await lease.use(async () => "ok");
+    const issued = fixture.events.find((event) => event.type === "secret.lease.issued");
+    expect(issued?.scope.secretRef).toBe(SCOPE.secretRef);
+    expect(issued?.scope).not.toHaveProperty("value");
+    expect(inspect(fixture.events, { depth: 8 })).not.toContain(PLAINTEXT);
+  });
+});

--- a/packages/secrets/src/broker.ts
+++ b/packages/secrets/src/broker.ts
@@ -1,0 +1,263 @@
+/**
+ * The Secret Broker (SPEC §13, §24). It is the only place a Credential turns from an opaque
+ * reference into plaintext, and it does so inside one callback, after authorization, for a bounded
+ * number of uses, within a bounded window.
+ *
+ * Invariants it enforces:
+ *
+ * - Default deny. No authorization, a refusal, or an authorizer failure all mean no lease.
+ * - Non-amplification. A lease is clamped to the authorized TTL and use count, and can only be
+ *   redeemed under the scope it was issued for.
+ * - Freshness. Every use resolves the current value; no plaintext is cached between uses, so
+ *   rotation and revocation apply to the next invocation.
+ * - Containment. Plaintext never reaches the returned handle, the emitted evidence, an error
+ *   message, a stack, or the callback's return value.
+ *
+ * Leases are in-memory only and intentionally not durable: a restarted process must re-authorize.
+ */
+
+import {
+  type ScopedSecretCallback,
+  SecretLeakError,
+  SecretLease,
+  type SecretLeaseDenialReason,
+  SecretLeaseDeniedError,
+  type SecretScope,
+} from "./lease";
+import type { SecretProvider } from "./providers";
+import { containsSecret, redactError } from "./redaction";
+
+/** Authorizer verdict. `allowed: false` is the safe shape; every other field only narrows. */
+export type SecretAuthorization =
+  | { readonly allowed: false; readonly reason?: SecretLeaseDenialReason }
+  | {
+      readonly allowed: true;
+      /** Upper bound on lease lifetime; a longer request is clamped to it. */
+      readonly maxTtlMs?: number;
+      /** Upper bound on redemptions; a larger request is clamped to it. */
+      readonly maxUses?: number;
+    };
+
+/**
+ * The authority boundary in front of the broker. Implementations intersect user, Agent, Run
+ * Context, Tool/target Guardrail, AccessGrant, and Credential scope; the broker itself never
+ * decides authority, it only refuses to act without a positive decision.
+ */
+export interface SecretAuthorizer {
+  authorize(scope: SecretScope): Promise<SecretAuthorization> | SecretAuthorization;
+}
+
+export type SecretBrokerEventType =
+  | "secret.lease.issued"
+  | "secret.lease.denied"
+  | "secret.lease.used";
+
+/** Lease metadata for the audit ledger. Carries the Secret reference, never the Secret. */
+export interface SecretBrokerEvent {
+  readonly type: SecretBrokerEventType;
+  readonly leaseId: string;
+  readonly scope: SecretScope;
+  readonly at: number;
+  readonly reason?: SecretLeaseDenialReason;
+  /** Present on issue: when the lease stops being usable. */
+  readonly expiresAt?: number;
+  /** Present on use: redemptions spent so far, including this one. */
+  readonly uses?: number;
+}
+
+export interface SecretBrokerDeps {
+  readonly provider: SecretProvider;
+  readonly authorizer: SecretAuthorizer;
+  readonly onEvent?: (event: SecretBrokerEvent) => void;
+  readonly now?: () => number;
+  /** Lease lifetime when the caller does not ask for one. Short by design. */
+  readonly defaultTtlMs?: number;
+}
+
+export interface SecretLeaseRequest {
+  readonly scope: SecretScope;
+  readonly ttlMs?: number;
+  /** Redemptions this lease permits. Defaults to one, so a replayed lease is denied. */
+  readonly maxUses?: number;
+}
+
+interface LeaseRecord {
+  readonly scope: SecretScope;
+  readonly expiresAt: number;
+  readonly maxUses: number;
+  uses: number;
+  revoked: boolean;
+}
+
+const DEFAULT_TTL_MS = 60_000;
+
+/** Scope equality is exact: any differing field is a different authority, not a narrower one. */
+function sameScope(a: SecretScope, b: SecretScope): boolean {
+  return (
+    a.secretRef === b.secretRef &&
+    a.toolId === b.toolId &&
+    a.integrationId === b.integrationId &&
+    a.targetId === b.targetId &&
+    a.runId === b.runId &&
+    a.stateId === b.stateId &&
+    a.purpose === b.purpose
+  );
+}
+
+export class SecretBroker {
+  private readonly leases = new Map<string, LeaseRecord>();
+  private readonly provider: SecretProvider;
+  private readonly authorizer: SecretAuthorizer;
+  private readonly onEvent?: (event: SecretBrokerEvent) => void;
+  private readonly now: () => number;
+  private readonly defaultTtlMs: number;
+  private counter = 0;
+
+  constructor(deps: SecretBrokerDeps) {
+    this.provider = deps.provider;
+    this.authorizer = deps.authorizer;
+    this.onEvent = deps.onEvent;
+    this.now = deps.now ?? (() => Date.now());
+    this.defaultTtlMs = deps.defaultTtlMs ?? DEFAULT_TTL_MS;
+  }
+
+  /**
+   * Authorizes `request` and issues a lease. Throws {@link SecretLeaseDeniedError} when the
+   * authorizer refuses or fails — an authorizer that cannot answer is a denial, never an allowance.
+   */
+  async lease(request: SecretLeaseRequest): Promise<SecretLease> {
+    const leaseId = `lease-${++this.counter}`;
+    let decision: SecretAuthorization;
+    try {
+      decision = await this.authorizer.authorize(request.scope);
+    } catch {
+      decision = { allowed: false, reason: "not_authorized" };
+    }
+
+    if (!decision.allowed) {
+      this.deny(
+        leaseId,
+        request.scope,
+        decision.reason ?? "not_authorized",
+        "lease is not authorized"
+      );
+    }
+
+    const ttlMs = Math.min(
+      request.ttlMs ?? this.defaultTtlMs,
+      decision.maxTtlMs ?? Number.MAX_SAFE_INTEGER
+    );
+    const maxUses = Math.min(request.maxUses ?? 1, decision.maxUses ?? Number.MAX_SAFE_INTEGER);
+    const expiresAt = this.now() + ttlMs;
+    this.leases.set(leaseId, { scope: request.scope, expiresAt, maxUses, uses: 0, revoked: false });
+    this.emit({
+      type: "secret.lease.issued",
+      leaseId,
+      scope: request.scope,
+      at: this.now(),
+      expiresAt,
+    });
+
+    return new SecretLease(leaseId, request.scope, expiresAt, (id, presented, callback) =>
+      this.redeem(id, presented, callback)
+    );
+  }
+
+  /**
+   * Revokes every outstanding lease on `secretRef`. Rotation and revocation of the Credential
+   * itself happen in the store; this makes the change apply to leases already handed out.
+   */
+  revokeSecret(secretRef: string): void {
+    for (const record of this.leases.values()) {
+      if (record.scope.secretRef === secretRef) {
+        record.revoked = true;
+      }
+    }
+  }
+
+  /** Revokes one lease, e.g. when its Run is cancelled. */
+  revokeLease(leaseId: string): void {
+    const record = this.leases.get(leaseId);
+    if (record) {
+      record.revoked = true;
+    }
+  }
+
+  /** Drops all leases — shutdown, or an emergency stop. Every outstanding handle stops working. */
+  revokeAll(): void {
+    this.leases.clear();
+  }
+
+  private async redeem<T>(
+    leaseId: string,
+    presented: SecretScope | undefined,
+    callback: ScopedSecretCallback<T>
+  ): Promise<T> {
+    const record = this.leases.get(leaseId);
+    if (!record) {
+      // Revoked, or issued by a process that no longer exists. Both fail closed.
+      throw new SecretLeaseDeniedError("lease_unknown", `lease ${leaseId} is not usable`, leaseId);
+    }
+    if (record.revoked) {
+      this.deny(leaseId, record.scope, "revoked", `lease ${leaseId} was revoked`);
+    }
+    if (this.now() >= record.expiresAt) {
+      this.leases.delete(leaseId);
+      this.deny(leaseId, record.scope, "expired", `lease ${leaseId} has expired`);
+    }
+    if (presented && !sameScope(record.scope, presented)) {
+      this.deny(
+        leaseId,
+        record.scope,
+        "scope_mismatch",
+        `lease ${leaseId} was issued for another scope`
+      );
+    }
+    if (record.uses >= record.maxUses) {
+      this.deny(leaseId, record.scope, "exhausted", `lease ${leaseId} has no remaining uses`);
+    }
+    // Claimed before the await so two concurrent redemptions cannot both pass the check above.
+    record.uses += 1;
+
+    const resolved = await this.provider.resolveCurrent(record.scope.secretRef);
+    if (!resolved) {
+      record.revoked = true;
+      this.deny(leaseId, record.scope, "revoked", `the Credential for lease ${leaseId} is revoked`);
+    }
+
+    this.emit({
+      type: "secret.lease.used",
+      leaseId,
+      scope: record.scope,
+      at: this.now(),
+      uses: record.uses,
+    });
+
+    const secret = resolved.value;
+    let result: T;
+    try {
+      result = await callback(secret);
+    } catch (error) {
+      // The callee chose the message; it may quote the Credential it was handed.
+      throw redactError(error, [secret]);
+    }
+    if (containsSecret(result, [secret])) {
+      throw new SecretLeakError(leaseId);
+    }
+    return result;
+  }
+
+  private deny(
+    leaseId: string,
+    scope: SecretScope,
+    reason: SecretLeaseDenialReason,
+    message: string
+  ): never {
+    this.emit({ type: "secret.lease.denied", leaseId, scope, at: this.now(), reason });
+    throw new SecretLeaseDeniedError(reason, message, leaseId);
+  }
+
+  private emit(event: SecretBrokerEvent): void {
+    this.onEvent?.(event);
+  }
+}

--- a/packages/secrets/src/index.ts
+++ b/packages/secrets/src/index.ts
@@ -1,5 +1,14 @@
 export type { BackfillResult } from "./backfill";
 export { backfillSecretsToDek } from "./backfill";
+export type {
+  SecretAuthorization,
+  SecretAuthorizer,
+  SecretBrokerDeps,
+  SecretBrokerEvent,
+  SecretBrokerEventType,
+  SecretLeaseRequest,
+} from "./broker";
+export { SecretBroker } from "./broker";
 export type { SecretEnvelope } from "./crypto";
 export { DecryptError, decryptSecret, encryptSecret } from "./crypto";
 export type { DekRepo, InsertWrapInput, KekLabel, WrappedDekRow } from "./dek-repo";
@@ -21,7 +30,21 @@ export {
 } from "./key-manager";
 export type { EncryptionKeys } from "./keys";
 export { loadEncryptionKeys } from "./keys";
+export type {
+  ScopedSecretCallback,
+  SecretLeaseDenialReason,
+  SecretScope,
+} from "./lease";
+export {
+  SecretLeakError,
+  SecretLease,
+  SecretLeaseDeniedError,
+  SecretNotSerializableError,
+} from "./lease";
 export type { KmsPort, MasterKeyRef, WrappedKey } from "./ports";
+export type { InMemorySecretProvider, ResolvedSecret, SecretProvider } from "./providers";
+export { inMemorySecretProvider, secretsServiceProvider } from "./providers";
+export { containsSecret, REDACTED, redactError, redactSecrets } from "./redaction";
 export type { LlmProviderId, LlmProviderInfo, ProviderField, ProviderFieldRole } from "./registry";
 export {
   isProviderConfigured,

--- a/packages/secrets/src/lease.ts
+++ b/packages/secrets/src/lease.ts
@@ -1,0 +1,120 @@
+/**
+ * Secret leases (SPEC §13, §24). A lease is an in-memory, short-lived, scope-bound right to use one
+ * Credential — never the Credential itself. Plaintext exists only as an argument to the callback
+ * passed to {@link SecretLease.use}, for the duration of that call.
+ *
+ * The handle is deliberately hostile to escape: it holds no plaintext field, refuses JSON
+ * serialization, and renders as a fixed marker under string coercion and `util.inspect`. That keeps
+ * a lease out of prompts, Run state, Artifacts, sandbox fixtures, and logs even when a caller
+ * carelessly interpolates or dumps it.
+ *
+ * Issuing, authorizing, resolving, and revoking leases belongs to {@link SecretBroker} in
+ * `./broker`; this module owns the handle, its scope shape, and its typed errors.
+ */
+
+export type SecretLeaseDenialReason =
+  /** Authorization was refused, or could not be established at all. */
+  | "not_authorized"
+  /** The lease outlived its TTL. */
+  | "expired"
+  /** The Credential was revoked, or the lease was revoked with it. */
+  | "revoked"
+  /** All permitted uses were already spent — a replayed lease. */
+  | "exhausted"
+  /** The presented scope is not the scope the lease was issued for. */
+  | "scope_mismatch"
+  /** The broker no longer knows this lease, as after a restart or `revokeAll`. */
+  | "lease_unknown";
+
+/**
+ * The exact authority a lease carries. Every field narrows use; none of them may be widened after
+ * issue. `secretRef` is an opaque reference — the name of a Secret, never its value.
+ */
+export interface SecretScope {
+  readonly secretRef: string;
+  readonly toolId: string;
+  readonly integrationId?: string;
+  readonly targetId?: string;
+  readonly runId: string;
+  readonly stateId?: string;
+  readonly purpose: string;
+}
+
+/** Denial evidence: a reason code plus the lease id. Never the Credential or its value. */
+export class SecretLeaseDeniedError extends Error {
+  constructor(
+    public readonly reason: SecretLeaseDenialReason,
+    message: string,
+    public readonly leaseId?: string
+  ) {
+    super(message);
+    this.name = "SecretLeaseDeniedError";
+  }
+}
+
+/** Raised when a lease handle is serialized, which would move a Credential right into durable state. */
+export class SecretNotSerializableError extends Error {
+  constructor() {
+    super("a SecretLease cannot be serialized");
+    this.name = "SecretNotSerializableError";
+  }
+}
+
+/** Raised when a scoped callback returns the plaintext it was lent, which would amplify the lease. */
+export class SecretLeakError extends Error {
+  constructor(public readonly leaseId: string) {
+    super(`the scoped callback for lease ${leaseId} returned the Credential it was lent`);
+    this.name = "SecretLeakError";
+  }
+}
+
+/** Called with the plaintext for the duration of one authorized use, and no longer. */
+export type ScopedSecretCallback<T> = (secret: string) => T | Promise<T>;
+
+/** What the broker exposes to a handle: one guarded, evidence-producing use. */
+export type LeaseRedeemer = <T>(
+  leaseId: string,
+  presented: SecretScope | undefined,
+  callback: ScopedSecretCallback<T>
+) => Promise<T>;
+
+const REDACTED_LEASE = "[SecretLease redacted]";
+
+export class SecretLease {
+  constructor(
+    readonly leaseId: string,
+    readonly scope: SecretScope,
+    readonly expiresAt: number,
+    private readonly redeem: LeaseRedeemer
+  ) {}
+
+  /**
+   * Runs `callback` with the *current* plaintext for this lease. The value is resolved at call
+   * time, so a rotation or revocation that happened since issue takes effect here; nothing is
+   * cached between calls. Denials, expiry, replay, and scope mismatches throw
+   * {@link SecretLeaseDeniedError} and never reveal the Credential.
+   *
+   * `presented` re-states the scope the caller believes it is acting under. Supplying a different
+   * scope is a denial, not a re-authorization: a lease cannot be pointed at another Tool or target.
+   */
+  use<T>(callback: ScopedSecretCallback<T>, presented?: SecretScope): Promise<T> {
+    return this.redeem(this.leaseId, presented, callback);
+  }
+
+  toJSON(): never {
+    throw new SecretNotSerializableError();
+  }
+
+  toString(): string {
+    return REDACTED_LEASE;
+  }
+
+  [Symbol.toPrimitive](): string {
+    return REDACTED_LEASE;
+  }
+
+  /** `util.inspect` hook, so console and structured logs print the marker instead of the fields. */
+  [Symbol.for("nodejs.util.inspect.custom")](): string {
+    return REDACTED_LEASE;
+  }
+}

--- a/packages/secrets/src/providers.ts
+++ b/packages/secrets/src/providers.ts
@@ -1,0 +1,84 @@
+/**
+ * Where the Secret Broker reads a current Credential from (SPEC §13). The port is provider-neutral:
+ * a PostgreSQL-backed store, a cloud KMS-fronted store, or a Vault-compatible service all satisfy
+ * it, and no adapter type leaks into the broker.
+ *
+ * The freshness contract is the point of this boundary. `resolveCurrent` must return the value that
+ * is current *at call time* and must return `null` once the Credential is revoked or deleted. An
+ * adapter that serves stale plaintext defeats "rotation and revocation apply to the next
+ * invocation", so caching belongs behind an explicit invalidation the adapter controls.
+ */
+
+import type { SecretsService } from "./service";
+import { SecretUnavailableError } from "./service";
+
+export interface ResolvedSecret {
+  readonly value: string;
+  /** Opaque rotation marker, when the backend has one. Safe to log; it is not derived from value. */
+  readonly version?: string;
+}
+
+export interface SecretProvider {
+  /** Current plaintext for `secretRef`, or `null` when it is revoked, deleted, or unknown. */
+  resolveCurrent(secretRef: string): Promise<ResolvedSecret | null>;
+}
+
+export interface InMemorySecretProvider extends SecretProvider {
+  set(secretRef: string, value: string): void;
+  revoke(secretRef: string): void;
+}
+
+/**
+ * Development and test adapter. Holds plaintext in process memory with no encryption at rest, so it
+ * must never back a deployed business: it exists to exercise broker behavior deterministically.
+ */
+export function inMemorySecretProvider(
+  initial: Readonly<Record<string, string>> = {}
+): InMemorySecretProvider {
+  const values = new Map<string, string>(Object.entries(initial));
+  const versions = new Map<string, number>();
+  for (const key of values.keys()) {
+    versions.set(key, 1);
+  }
+  return {
+    async resolveCurrent(secretRef) {
+      const value = values.get(secretRef);
+      if (value === undefined) {
+        return null;
+      }
+      return { value, version: String(versions.get(secretRef) ?? 1) };
+    },
+    set(secretRef, value) {
+      values.set(secretRef, value);
+      versions.set(secretRef, (versions.get(secretRef) ?? 0) + 1);
+    },
+    revoke(secretRef) {
+      values.delete(secretRef);
+      versions.delete(secretRef);
+    },
+  };
+}
+
+/**
+ * Adapter over {@link SecretsService}, the PostgreSQL-backed Secret store.
+ *
+ * `SecretsService` keeps a TTL cache of decrypted values, so this adapter is only as fresh as that
+ * cache. It satisfies the freshness contract when the same service instance is the rotation and
+ * revocation authority — `set` and `delete` clear the entry — which is the single-process case. A
+ * deployment that rotates Secrets out of band must invalidate that cache, or resolve through an
+ * uncached provider, before a lease can be trusted to see the rotation.
+ */
+export function secretsServiceProvider(service: Pick<SecretsService, "get">): SecretProvider {
+  return {
+    async resolveCurrent(secretRef) {
+      try {
+        return { value: await service.get(secretRef) };
+      } catch (error) {
+        if (error instanceof SecretUnavailableError) {
+          return null;
+        }
+        throw error;
+      }
+    },
+  };
+}

--- a/packages/secrets/src/redaction.test.ts
+++ b/packages/secrets/src/redaction.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { containsSecret, REDACTED, redactError, redactSecrets } from "./redaction";
+
+describe("redactSecrets", () => {
+  it("replaces every occurrence of every secret", () => {
+    const text = "curl -H 'Authorization: Bearer tok-abc' https://x/tok-abc?k=pw-1";
+    expect(redactSecrets(text, ["tok-abc", "pw-1"])).toBe(
+      `curl -H 'Authorization: Bearer ${REDACTED}' https://x/${REDACTED}?k=${REDACTED}`
+    );
+  });
+
+  it("ignores empty secrets so the whole text is not shredded", () => {
+    expect(redactSecrets("hello", [""])).toBe("hello");
+  });
+});
+
+describe("containsSecret", () => {
+  it("finds a secret nested in objects, arrays, and keys", () => {
+    expect(containsSecret({ a: [{ b: "prefix tok-abc suffix" }] }, ["tok-abc"])).toBe(true);
+    expect(containsSecret({ "tok-abc": 1 }, ["tok-abc"])).toBe(true);
+    expect(containsSecret({ a: "clean" }, ["tok-abc"])).toBe(false);
+  });
+
+  it("treats a non-string scalar as clean", () => {
+    expect(containsSecret(42, ["42"])).toBe(false);
+  });
+});
+
+describe("redactError", () => {
+  it("redacts message and stack without changing the error type", () => {
+    class Boom extends Error {}
+    const original = new Boom("failed with tok-abc");
+    const redacted = redactError(original, ["tok-abc"]);
+    expect(redacted).toBeInstanceOf(Boom);
+    expect(redacted.message).toBe(`failed with ${REDACTED}`);
+    expect(redacted.stack ?? "").not.toContain("tok-abc");
+  });
+
+  it("wraps a non-Error throw into a redacted Error", () => {
+    const redacted = redactError("raw tok-abc", ["tok-abc"]);
+    expect(redacted).toBeInstanceOf(Error);
+    expect(redacted.message).toBe(`raw ${REDACTED}`);
+  });
+});

--- a/packages/secrets/src/redaction.ts
+++ b/packages/secrets/src/redaction.ts
@@ -1,0 +1,78 @@
+/**
+ * Secret redaction for text that is about to cross a log, error, Artifact, sandbox, or audit
+ * boundary (SPEC §13, §24). These helpers are the last line of defence, not the first: the Secret
+ * Broker already keeps plaintext inside a single callback. They exist because callee-produced
+ * strings — upstream error messages, stack frames, Tool output — can carry a Credential that the
+ * caller never chose to reveal.
+ *
+ * Everything here is pure. Nothing is logged, stored, or reported.
+ */
+
+export const REDACTED = "[redacted]";
+
+/** Secrets short enough to match unrelated text are still redacted; empty strings are skipped. */
+function usableSecrets(secrets: Iterable<string>): string[] {
+  return [...secrets].filter((secret) => secret.length > 0);
+}
+
+/** Replaces every occurrence of every secret in `text` with {@link REDACTED}. */
+export function redactSecrets(text: string, secrets: Iterable<string>): string {
+  let output = text;
+  for (const secret of usableSecrets(secrets)) {
+    output = output.split(secret).join(REDACTED);
+  }
+  return output;
+}
+
+/**
+ * True when any secret appears in `value` — inside a string, an array element, or an object key or
+ * property, at any depth. Non-string scalars never match: a secret is a string, and coercing
+ * numbers or symbols would only produce false positives.
+ */
+export function containsSecret(value: unknown, secrets: Iterable<string>): boolean {
+  const needles = usableSecrets(secrets);
+  if (needles.length === 0) {
+    return false;
+  }
+  const seen = new Set<object>();
+  const visit = (node: unknown): boolean => {
+    if (typeof node === "string") {
+      return needles.some((secret) => node.includes(secret));
+    }
+    if (node === null || typeof node !== "object") {
+      return false;
+    }
+    if (seen.has(node)) {
+      return false;
+    }
+    seen.add(node);
+    if (Array.isArray(node)) {
+      return node.some(visit);
+    }
+    if (node instanceof Error) {
+      return visit(node.message) || visit(node.stack ?? "");
+    }
+    return Object.entries(node).some(([key, entry]) => visit(key) || visit(entry));
+  };
+  return visit(value);
+}
+
+/**
+ * Returns a redacted copy of a thrown value. The copy keeps the original prototype so `instanceof`
+ * checks and typed-error handling still work; the original object is left untouched because the
+ * caller may hold other references to it. Non-`Error` throws become an `Error` with a redacted
+ * message.
+ */
+export function redactError(thrown: unknown, secrets: Iterable<string>): Error {
+  if (!(thrown instanceof Error)) {
+    return new Error(redactSecrets(String(thrown), secrets));
+  }
+  const copy = Object.create(Object.getPrototypeOf(thrown)) as Error;
+  Object.assign(copy, thrown);
+  copy.name = thrown.name;
+  copy.message = redactSecrets(thrown.message, secrets);
+  if (thrown.stack !== undefined) {
+    copy.stack = redactSecrets(thrown.stack, secrets);
+  }
+  return copy;
+}


### PR DESCRIPTION
## Summary

- Adds `SecretBroker` (`packages/secrets/src/broker.ts`): a Credential turns into plaintext only inside one scoped callback, after an explicit authorization, for a bounded number of uses within a bounded window. Denial is the default — a refusing authorizer and a failing authorizer both mean no lease — and leases clamp to the authorized TTL and use count, are single-use unless a caller asks for more, and are only redeemable under the scope they were issued for.
- Adds `SecretLease` (`lease.ts`), the `SecretProvider` port with in-memory and `SecretsService` adapters (`providers.ts`), and redaction helpers (`redaction.ts`). Every use resolves the value fresh, so rotation and revocation apply to the next invocation rather than after a cache expires; `revokeSecret` / `revokeLease` / `revokeAll` invalidate outstanding leases.
- Containment is enforced, not trusted: the handle refuses serialization and renders as `[SecretLease redacted]`, a callback error is re-thrown with the Credential redacted, a callback returning the plaintext fails closed with `SecretLeakError`, and lease evidence carries the Secret reference and scope but never the Secret.

Implements AW-024 (SPEC §§12–13, 20, 24). Additive only: no migrations, no new dependencies, and `SecretsService` is untouched. Wiring the broker into Tool dispatch belongs to AW-042.

## Test plan

- `pnpm --filter @tulipfarm/secrets exec vitest run` — 9 files, 78 tests pass (21 new).
- New cases cover default-deny (refusal and authorizer throw), TTL clamping, expiry, single-use replay denial, exactly-one-of-two concurrent redemptions, rotation served on the next use, revocation via the provider and via `revokeSecret`, `revokeAll` as the restart/crash path, scope mismatch, non-serializable handle, redacted callback errors, leaked-return denial, and plaintext-free audit evidence.
- `biome check packages/secrets/src` — clean.
- `pnpm --filter @tulipfarm/secrets typecheck` and `pnpm --filter @tulipfarm/api typecheck` — no errors; the new barrel exports do not disturb existing consumers.