### PR TITLE
feat(events): add transactional inbox and outbox

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -26,6 +26,7 @@
     "@tulipfarm/schema": "workspace:*",
     "@tulipfarm/secrets": "workspace:*",
     "@tulipfarm/soul": "workspace:*",
+    "@tulipfarm/storage": "workspace:*",
     "ai": "^7.0.2",
     "dotenv": "^17.4.2",
     "fastify": "^5.8.5",

--- a/apps/api/src/pg-migrations/index.ts
+++ b/apps/api/src/pg-migrations/index.ts
@@ -1,3 +1,4 @@
+import { EVENT_STORAGE_STATEMENTS } from "@tulipfarm/storage";
 import type { Queryable } from "../db";
 
 export interface PgMigration {
@@ -429,6 +430,15 @@ export const PG_MIGRATIONS: PgMigration[] = [
     description: "hardened authentication and identity",
     up: async (q) => {
       for (const sql of IDENTITY_STATEMENTS) {
+        await q.query(sql);
+      }
+    },
+  },
+  {
+    version: 3,
+    description: "transactional event inbox and outbox",
+    up: async (q) => {
+      for (const sql of EVENT_STORAGE_STATEMENTS) {
         await q.query(sql);
       }
     },

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -2,6 +2,9 @@
   "name": "@tulipfarm/worker",
   "version": "0.0.0",
   "private": true,
+  "dependencies": {
+    "@tulipfarm/storage": "workspace:*"
+  },
   "scripts": {
     "build": "tsc",
     "dev": "tsx watch src/index.ts",

--- a/apps/worker/src/event-dispatcher.test.ts
+++ b/apps/worker/src/event-dispatcher.test.ts
@@ -1,0 +1,88 @@
+import type { ClaimedOutboxMessage, EventOutboxPort, OutboxFailure } from "@tulipfarm/storage";
+import { describe, expect, it } from "vitest";
+import { EventOutboxDispatcher } from "./event-dispatcher";
+
+class FakeOutbox implements EventOutboxPort {
+  readonly failures: OutboxFailure[] = [];
+  readonly completed: string[] = [];
+  messages: ClaimedOutboxMessage[] = [];
+
+  async claim(): Promise<readonly ClaimedOutboxMessage[]> {
+    return this.messages.splice(0);
+  }
+
+  async complete(_businessId: string, messageId: string): Promise<"recorded" | "duplicate"> {
+    this.completed.push(messageId);
+    return "recorded";
+  }
+
+  async fail(
+    _businessId: string,
+    _messageId: string,
+    _owner: string,
+    failure: OutboxFailure
+  ): Promise<"released" | "quarantined"> {
+    this.failures.push(failure);
+    return "released";
+  }
+}
+
+const MESSAGE: ClaimedOutboxMessage = {
+  id: "message-1",
+  businessId: "business-1",
+  inboxId: "inbox-1",
+  topic: "event.accepted",
+  payload: { inboxId: "inbox-1", eventId: "event-1" },
+  attempts: 1,
+  leaseOwner: "worker-1",
+  leaseExpiresAt: "2026-07-24T10:01:00.000Z",
+};
+
+describe("EventOutboxDispatcher", () => {
+  it("records a receipt only after successful delivery", async () => {
+    const outbox = new FakeOutbox();
+    outbox.messages.push(MESSAGE);
+    const delivered: string[] = [];
+    const dispatcher = new EventOutboxDispatcher({
+      outbox,
+      businessId: "business-1",
+      owner: "worker-1",
+      consumer: "trigger-router",
+      now: () => "2026-07-24T10:00:00.000Z",
+      handler: async (message) => {
+        delivered.push(message.id);
+      },
+    });
+
+    expect(await dispatcher.dispatchBatch()).toEqual({ claimed: 1, dispatched: 1, failed: 0 });
+    expect(delivered).toEqual(["message-1"]);
+    expect(outbox.completed).toEqual(["message-1"]);
+  });
+
+  it("uses a bounded safe failure code without retaining a thrown protected payload", async () => {
+    const outbox = new FakeOutbox();
+    outbox.messages.push(MESSAGE);
+    const dispatcher = new EventOutboxDispatcher({
+      outbox,
+      businessId: "business-1",
+      owner: "worker-1",
+      consumer: "trigger-router",
+      now: () => "2026-07-24T10:00:00.000Z",
+      handler: async () => {
+        throw new Error("secret webhook payload");
+      },
+    });
+
+    expect(await dispatcher.dispatchBatch()).toEqual({ claimed: 1, dispatched: 0, failed: 1 });
+    expect(outbox.completed).toEqual([]);
+    expect(outbox.failures).toEqual([
+      {
+        code: "handler_failed",
+        maxAttempts: 5,
+        quarantineOwner: "integration-operations",
+        replayEligible: true,
+      },
+    ]);
+    expect(JSON.stringify(outbox.failures)).not.toContain("secret webhook payload");
+  });
+});

--- a/apps/worker/src/event-dispatcher.ts
+++ b/apps/worker/src/event-dispatcher.ts
@@ -1,0 +1,57 @@
+import type { EventOutboxPort } from "@tulipfarm/storage";
+
+export interface EventOutboxDispatcherOptions {
+  outbox: EventOutboxPort;
+  businessId: string;
+  owner: string;
+  consumer: string;
+  handler: (message: Awaited<ReturnType<EventOutboxPort["claim"]>>[number]) => Promise<void>;
+  now: () => string;
+  leaseDurationMs?: number;
+  batchSize?: number;
+  maxAttempts?: number;
+  quarantineOwner?: string;
+}
+
+export interface DispatchBatchResult {
+  claimed: number;
+  dispatched: number;
+  failed: number;
+}
+
+export class EventOutboxDispatcher {
+  constructor(private readonly options: EventOutboxDispatcherOptions) {}
+
+  async dispatchBatch(): Promise<DispatchBatchResult> {
+    const messages = await this.options.outbox.claim({
+      businessId: this.options.businessId,
+      owner: this.options.owner,
+      now: this.options.now(),
+      leaseDurationMs: this.options.leaseDurationMs ?? 60_000,
+      limit: this.options.batchSize ?? 25,
+    });
+    let dispatched = 0;
+    let failed = 0;
+    for (const message of messages) {
+      try {
+        await this.options.handler(message);
+        await this.options.outbox.complete(
+          message.businessId,
+          message.id,
+          this.options.owner,
+          this.options.consumer
+        );
+        dispatched += 1;
+      } catch {
+        await this.options.outbox.fail(message.businessId, message.id, this.options.owner, {
+          code: "handler_failed",
+          maxAttempts: this.options.maxAttempts ?? 5,
+          quarantineOwner: this.options.quarantineOwner ?? "integration-operations",
+          replayEligible: true,
+        });
+        failed += 1;
+      }
+    }
+    return { claimed: messages.length, dispatched, failed };
+  }
+}

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,1 +1,5 @@
-export {};
+export {
+  type DispatchBatchResult,
+  EventOutboxDispatcher,
+  type EventOutboxDispatcherOptions,
+} from "./event-dispatcher";

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -9,6 +9,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
+    "@electric-sql/pglite": "^0.5.3",
     "@tulipfarm/tsconfig": "workspace:*",
     "typescript": "^6.0.3"
   }

--- a/packages/storage/src/events/event-store.pg.test.ts
+++ b/packages/storage/src/events/event-store.pg.test.ts
@@ -1,5 +1,5 @@
 import { PGlite } from "@electric-sql/pglite";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import type { Queryable, TransactionPort } from "../ports";
 import {
   EVENT_STORAGE_STATEMENTS,
@@ -49,11 +49,15 @@ describe("EventStore (PostgreSQL)", () => {
   let store: EventStore;
   let nextId: () => string;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     database = await PGlite.create();
     for (const statement of EVENT_STORAGE_STATEMENTS) {
       await database.query(statement);
     }
+  }, 60_000);
+
+  beforeEach(async () => {
+    await database.query("TRUNCATE TABLE events_inbox CASCADE");
     let id = 0;
     nextId = () => {
       id += 1;
@@ -62,7 +66,7 @@ describe("EventStore (PostgreSQL)", () => {
     store = new EventStore(transactionPort(database), nextId);
   });
 
-  afterEach(async () => {
+  afterAll(async () => {
     await database.close();
   });
 

--- a/packages/storage/src/events/event-store.pg.test.ts
+++ b/packages/storage/src/events/event-store.pg.test.ts
@@ -1,0 +1,245 @@
+import { PGlite } from "@electric-sql/pglite";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Queryable, TransactionPort } from "../ports";
+import {
+  EVENT_STORAGE_STATEMENTS,
+  EventStore,
+  OutboxLeaseError,
+  type StoreEventInput,
+} from "./event-store";
+
+const FIRST_RECEIVED_AT = "2026-07-24T10:00:00.000Z";
+const AFTER_LEASE = "2026-07-24T10:01:01.000Z";
+
+function event(overrides: Partial<StoreEventInput> = {}): StoreEventInput {
+  return {
+    eventId: "event-1",
+    type: "github.issue.created",
+    version: 1,
+    occurredAt: "2026-07-24T09:59:00.000Z",
+    receivedAt: FIRST_RECEIVED_AT,
+    businessId: "business-1",
+    source: {
+      provider: "github",
+      integrationId: "integration-1",
+      externalTenantId: "tenant-1",
+      deliveryId: "delivery-1",
+    },
+    principal: { kind: "service", internalId: "principal-1" },
+    record: { type: "Issue", id: "42", version: "1" },
+    deduplicationKey: "delivery-1",
+    classification: ["internal"],
+    data: { action: "opened" },
+    rawArtifactId: "artifact-1",
+    rawPayloadHash: "sha256:abc",
+    verification: { status: "verified", method: "hmac-sha256" },
+    ...overrides,
+  };
+}
+
+function transactionPort(database: PGlite): TransactionPort {
+  return {
+    withTransaction: (operation) =>
+      database.transaction((transaction) => operation(transaction as Queryable)),
+  };
+}
+
+describe("EventStore (PostgreSQL)", () => {
+  let database: PGlite;
+  let store: EventStore;
+  let nextId: () => string;
+
+  beforeEach(async () => {
+    database = await PGlite.create();
+    for (const statement of EVENT_STORAGE_STATEMENTS) {
+      await database.query(statement);
+    }
+    let id = 0;
+    nextId = () => {
+      id += 1;
+      return `00000000-0000-4000-8000-${id.toString().padStart(12, "0")}`;
+    };
+    store = new EventStore(transactionPort(database), nextId);
+  });
+
+  afterEach(async () => {
+    await database.close();
+  });
+
+  it("atomically persists the canonical event, raw references, and outbox before ack", async () => {
+    const accepted = await store.accept(event());
+
+    expect(accepted.outcome).toBe("accepted");
+    const inbox = await database.query<{
+      canonical_event: StoreEventInput;
+      raw_artifact_id: string;
+      raw_payload_hash: string;
+    }>("SELECT canonical_event, raw_artifact_id, raw_payload_hash FROM events_inbox");
+    expect(inbox.rows[0]?.canonical_event).toEqual(event());
+    expect(inbox.rows[0]?.raw_artifact_id).toBe("artifact-1");
+    expect(inbox.rows[0]?.raw_payload_hash).toBe("sha256:abc");
+
+    const outbox = await database.query<{ inbox_id: string }>(
+      "SELECT inbox_id FROM outbox_messages"
+    );
+    expect(outbox.rows).toEqual([{ inbox_id: accepted.event.id }]);
+  });
+
+  it("rolls back the inbox when creating its outbox message fails", async () => {
+    const failingTransactions: TransactionPort = {
+      withTransaction: (operation) =>
+        database.transaction((transaction) =>
+          operation({
+            query: (text, params) => {
+              if (text.includes("INSERT INTO outbox_messages")) {
+                throw new Error("injected outbox failure");
+              }
+              return (transaction as Queryable).query(text, params);
+            },
+          })
+        ),
+    };
+
+    await expect(new EventStore(failingTransactions, nextId).accept(event())).rejects.toThrow(
+      "injected outbox failure"
+    );
+    expect((await database.query("SELECT id FROM events_inbox")).rows).toEqual([]);
+  });
+
+  it("deduplicates concurrent delivery retries without creating another logical event", async () => {
+    const results = await Promise.all([
+      store.accept(event()),
+      store.accept(event({ eventId: "event-retry-1" })),
+      store.accept(event({ eventId: "event-retry-2" })),
+    ]);
+
+    expect(results.filter((result) => result.outcome === "accepted")).toHaveLength(1);
+    expect(new Set(results.map((result) => result.event.id))).toHaveLength(1);
+    expect((await database.query("SELECT id FROM events_inbox")).rows).toHaveLength(1);
+    expect((await database.query("SELECT id FROM outbox_messages")).rows).toHaveLength(1);
+  });
+
+  it("isolates identical source deduplication keys between businesses", async () => {
+    const first = await store.accept(event());
+    const second = await store.accept(event({ eventId: "event-2", businessId: "business-2" }));
+
+    expect(first.outcome).toBe("accepted");
+    expect(second.outcome).toBe("accepted");
+    expect(second.event.id).not.toBe(first.event.id);
+  });
+
+  it("does not lease another business's outbox message", async () => {
+    await store.accept(event({ businessId: "business-2" }));
+
+    expect(
+      await store.claim({
+        businessId: "business-1",
+        owner: "worker-1",
+        now: FIRST_RECEIVED_AT,
+        leaseDurationMs: 60_000,
+        limit: 1,
+      })
+    ).toEqual([]);
+  });
+
+  it("recovers an expired lease with the same stable message identity", async () => {
+    await store.accept(event());
+    const first = await store.claim({
+      businessId: "business-1",
+      owner: "worker-crashed",
+      now: FIRST_RECEIVED_AT,
+      leaseDurationMs: 60_000,
+      limit: 1,
+    });
+    expect(first).toHaveLength(1);
+
+    expect(
+      await store.claim({
+        businessId: "business-1",
+        owner: "worker-early",
+        now: "2026-07-24T10:00:30.000Z",
+        leaseDurationMs: 60_000,
+        limit: 1,
+      })
+    ).toEqual([]);
+
+    const recovered = await store.claim({
+      businessId: "business-1",
+      owner: "worker-recovery",
+      now: AFTER_LEASE,
+      leaseDurationMs: 60_000,
+      limit: 1,
+    });
+    expect(recovered[0]?.id).toBe(first[0]?.id);
+    expect(recovered[0]?.attempts).toBe(2);
+  });
+
+  it("records a receipt and dispatch outcome atomically and idempotently", async () => {
+    await store.accept(event());
+    const [message] = await store.claim({
+      businessId: "business-1",
+      owner: "worker-1",
+      now: FIRST_RECEIVED_AT,
+      leaseDurationMs: 60_000,
+      limit: 1,
+    });
+    if (!message) throw new Error("expected a claimed message");
+
+    expect(await store.complete(message.businessId, message.id, "worker-1", "trigger-router")).toBe(
+      "recorded"
+    );
+    expect(await store.complete(message.businessId, message.id, "worker-1", "trigger-router")).toBe(
+      "duplicate"
+    );
+    expect((await database.query("SELECT id FROM consumer_receipts")).rows).toHaveLength(1);
+    expect(
+      (await database.query<{ status: string }>("SELECT status FROM outbox_messages")).rows[0]
+        ?.status
+    ).toBe("dispatched");
+  });
+
+  it("quarantines exhausted dispatches with safe evidence and rejects a foreign lease owner", async () => {
+    await store.accept(event());
+    const [message] = await store.claim({
+      businessId: "business-1",
+      owner: "worker-1",
+      now: FIRST_RECEIVED_AT,
+      leaseDurationMs: 60_000,
+      limit: 1,
+    });
+    if (!message) throw new Error("expected a claimed message");
+
+    await expect(
+      store.fail(message.businessId, message.id, "worker-other", {
+        code: "handler_failed",
+        maxAttempts: 1,
+        quarantineOwner: "integration-operations",
+        replayEligible: true,
+      })
+    ).rejects.toEqual(new OutboxLeaseError("lease_not_owned"));
+
+    expect(
+      await store.fail(message.businessId, message.id, "worker-1", {
+        code: "handler_failed",
+        evidenceRef: "audit-event-1",
+        maxAttempts: 1,
+        quarantineOwner: "integration-operations",
+        replayEligible: true,
+      })
+    ).toBe("quarantined");
+    const quarantine = await database.query<{
+      reason_code: string;
+      evidence_ref: string;
+      owner: string;
+      replay_eligible: boolean;
+    }>("SELECT reason_code, evidence_ref, owner, replay_eligible FROM quarantine_records");
+    expect(quarantine.rows).toEqual([
+      {
+        reason_code: "handler_failed",
+        evidence_ref: "audit-event-1",
+        owner: "integration-operations",
+        replay_eligible: true,
+      },
+    ]);
+  });
+});

--- a/packages/storage/src/events/event-store.ts
+++ b/packages/storage/src/events/event-store.ts
@@ -1,0 +1,423 @@
+import type { Queryable, TransactionPort } from "../ports";
+
+export interface EventEnvelope<T = unknown> {
+  eventId: string;
+  type: string;
+  version: number;
+  occurredAt: string;
+  receivedAt: string;
+  businessId: string;
+  source: {
+    provider: string;
+    integrationId?: string;
+    externalTenantId?: string;
+    deliveryId?: string;
+  };
+  principal: { kind: string; internalId?: string; externalId?: string };
+  record: { type?: string; id?: string; version?: string };
+  deduplicationKey: string;
+  correlationId?: string;
+  causationId?: string;
+  classification: string[];
+  data: T;
+  rawArtifactId?: string;
+  rawPayloadHash?: string;
+  verification: { status: "verified" | "unverified" | "failed"; method?: string };
+}
+
+export type StoreEventInput = EventEnvelope<Record<string, unknown>>;
+export type EventInboxStatus = "pending" | "processed" | "quarantined";
+export type OutboxStatus = "pending" | "leased" | "dispatched" | "quarantined";
+
+export interface StoredEvent {
+  id: string;
+  businessId: string;
+  sourceKey: string;
+  deduplicationKey: string;
+  status: EventInboxStatus;
+  canonicalEvent: StoreEventInput;
+}
+
+export interface AcceptEventResult {
+  /** `duplicate` returns the originally accepted logical event and never creates another outbox. */
+  outcome: "accepted" | "duplicate";
+  event: StoredEvent;
+}
+
+export interface ClaimedOutboxMessage {
+  id: string;
+  businessId: string;
+  inboxId: string;
+  topic: "event.accepted";
+  payload: { inboxId: string; eventId: string };
+  attempts: number;
+  leaseOwner: string;
+  leaseExpiresAt: string;
+}
+
+export interface ClaimOutboxOptions {
+  businessId: string;
+  owner: string;
+  now: string;
+  leaseDurationMs: number;
+  limit: number;
+}
+
+export interface OutboxFailure {
+  code: "handler_failed";
+  evidenceRef?: string;
+  maxAttempts: number;
+  quarantineOwner: string;
+  replayEligible: boolean;
+}
+
+export type OutboxLeaseDenialReason = "lease_not_owned";
+
+export class OutboxLeaseError extends Error {
+  readonly name = "OutboxLeaseError";
+
+  constructor(readonly reason: OutboxLeaseDenialReason) {
+    super(reason);
+  }
+}
+
+export interface EventOutboxPort {
+  /** Atomically lease pending or expired messages for one business. */
+  claim(options: ClaimOutboxOptions): Promise<readonly ClaimedOutboxMessage[]>;
+  /** Persist the consumer receipt and dispatched state in one transaction. */
+  complete(
+    businessId: string,
+    messageId: string,
+    owner: string,
+    consumer: string
+  ): Promise<"recorded" | "duplicate">;
+  /** Release a retryable lease or create a visible quarantine record after exhaustion. */
+  fail(
+    businessId: string,
+    messageId: string,
+    owner: string,
+    failure: OutboxFailure
+  ): Promise<"released" | "quarantined">;
+}
+
+export type EventStorageIdSource = () => string;
+
+export const EVENT_STORAGE_STATEMENTS: readonly string[] = [
+  `CREATE TABLE IF NOT EXISTS events_inbox (
+    id                    uuid PRIMARY KEY,
+    business_id           text NOT NULL,
+    source_key            text NOT NULL,
+    deduplication_key     text NOT NULL,
+    event_id              text NOT NULL,
+    canonical_event       jsonb NOT NULL,
+    raw_artifact_id       text,
+    raw_payload_hash      text,
+    verification_status   text NOT NULL
+      CHECK (verification_status IN ('verified', 'unverified', 'failed')),
+    status                text NOT NULL DEFAULT 'pending'
+      CHECK (status IN ('pending', 'processed', 'quarantined')),
+    received_at           timestamptz NOT NULL,
+    UNIQUE (business_id, id),
+    UNIQUE (business_id, source_key, deduplication_key)
+  )`,
+  `CREATE TABLE IF NOT EXISTS outbox_messages (
+    id                uuid PRIMARY KEY,
+    business_id       text NOT NULL,
+    inbox_id          uuid NOT NULL,
+    topic             text NOT NULL CHECK (topic = 'event.accepted'),
+    payload           jsonb NOT NULL,
+    status            text NOT NULL DEFAULT 'pending'
+      CHECK (status IN ('pending', 'leased', 'dispatched', 'quarantined')),
+    attempts          integer NOT NULL DEFAULT 0 CHECK (attempts >= 0),
+    lease_owner       text,
+    lease_expires_at  timestamptz,
+    created_at        timestamptz NOT NULL,
+    dispatched_at     timestamptz,
+    UNIQUE (business_id, id),
+    UNIQUE (inbox_id, topic),
+    FOREIGN KEY (business_id, inbox_id) REFERENCES events_inbox(business_id, id),
+    CHECK (
+      (status = 'leased' AND lease_owner IS NOT NULL AND lease_expires_at IS NOT NULL)
+      OR status <> 'leased'
+    )
+  )`,
+  `CREATE INDEX IF NOT EXISTS outbox_messages_claim_idx
+    ON outbox_messages (business_id, status, lease_expires_at, created_at)`,
+  `CREATE TABLE IF NOT EXISTS consumer_receipts (
+    id            uuid PRIMARY KEY,
+    business_id   text NOT NULL,
+    message_id    uuid NOT NULL,
+    consumer      text NOT NULL,
+    received_at   timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (business_id, message_id, consumer),
+    FOREIGN KEY (business_id, message_id) REFERENCES outbox_messages(business_id, id)
+  )`,
+  `CREATE TABLE IF NOT EXISTS quarantine_records (
+    id                uuid PRIMARY KEY,
+    business_id       text NOT NULL,
+    message_id        uuid NOT NULL UNIQUE,
+    reason_code       text NOT NULL,
+    evidence_ref      text,
+    owner             text NOT NULL,
+    replay_eligible   boolean NOT NULL,
+    quarantined_at    timestamptz NOT NULL DEFAULT now(),
+    FOREIGN KEY (business_id, message_id) REFERENCES outbox_messages(business_id, id)
+  )`,
+];
+
+interface InboxRow {
+  id: string;
+  business_id: string;
+  source_key: string;
+  deduplication_key: string;
+  status: EventInboxStatus;
+  canonical_event: StoreEventInput;
+}
+
+interface OutboxRow {
+  id: string;
+  business_id: string;
+  inbox_id: string;
+  topic: "event.accepted";
+  payload: { inboxId: string; eventId: string };
+  attempts: number;
+  lease_owner: string;
+  lease_expires_at: string | Date;
+}
+
+function sourceKey(source: StoreEventInput["source"]): string {
+  return JSON.stringify([
+    source.provider,
+    source.integrationId ?? null,
+    source.externalTenantId ?? null,
+  ]);
+}
+
+function storedEvent(row: InboxRow): StoredEvent {
+  return {
+    id: row.id,
+    businessId: row.business_id,
+    sourceKey: row.source_key,
+    deduplicationKey: row.deduplication_key,
+    status: row.status,
+    canonicalEvent: row.canonical_event,
+  };
+}
+
+function claimedMessage(row: OutboxRow): ClaimedOutboxMessage {
+  return {
+    id: row.id,
+    businessId: row.business_id,
+    inboxId: row.inbox_id,
+    topic: row.topic,
+    payload: row.payload,
+    attempts: row.attempts,
+    leaseOwner: row.lease_owner,
+    leaseExpiresAt:
+      row.lease_expires_at instanceof Date
+        ? row.lease_expires_at.toISOString()
+        : row.lease_expires_at,
+  };
+}
+
+async function existingInbox(
+  transaction: Queryable,
+  businessId: string,
+  eventSourceKey: string,
+  deduplicationKey: string
+): Promise<InboxRow> {
+  const result = await transaction.query<InboxRow>(
+    `SELECT id, business_id, source_key, deduplication_key, status, canonical_event
+       FROM events_inbox
+      WHERE business_id = $1 AND source_key = $2 AND deduplication_key = $3`,
+    [businessId, eventSourceKey, deduplicationKey]
+  );
+  const row = result.rows[0];
+  if (!row) throw new Error("events_inbox_conflict_without_row");
+  return row;
+}
+
+/** PostgreSQL-backed transactional intake and delivery-evidence repository. */
+export class EventStore implements EventOutboxPort {
+  constructor(
+    private readonly transactions: TransactionPort,
+    private readonly nextId: EventStorageIdSource
+  ) {}
+
+  /** Return only after both the canonical inbox row and its outbox message commit. */
+  async accept(input: StoreEventInput): Promise<AcceptEventResult> {
+    return this.transactions.withTransaction(async (transaction) => {
+      const id = this.nextId();
+      const eventSourceKey = sourceKey(input.source);
+      const inserted = await transaction.query<InboxRow>(
+        `INSERT INTO events_inbox (
+           id, business_id, source_key, deduplication_key, event_id, canonical_event,
+           raw_artifact_id, raw_payload_hash, verification_status, received_at
+         ) VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8, $9, $10::timestamptz)
+         ON CONFLICT (business_id, source_key, deduplication_key) DO NOTHING
+         RETURNING id, business_id, source_key, deduplication_key, status, canonical_event`,
+        [
+          id,
+          input.businessId,
+          eventSourceKey,
+          input.deduplicationKey,
+          input.eventId,
+          JSON.stringify(input),
+          input.rawArtifactId ?? null,
+          input.rawPayloadHash ?? null,
+          input.verification.status,
+          input.receivedAt,
+        ]
+      );
+      const row = inserted.rows[0];
+      if (!row) {
+        return {
+          outcome: "duplicate",
+          event: storedEvent(
+            await existingInbox(
+              transaction,
+              input.businessId,
+              eventSourceKey,
+              input.deduplicationKey
+            )
+          ),
+        };
+      }
+
+      await transaction.query(
+        `INSERT INTO outbox_messages (
+           id, business_id, inbox_id, topic, payload, created_at
+         ) VALUES ($1, $2, $3, 'event.accepted', $4::jsonb, $5::timestamptz)`,
+        [
+          this.nextId(),
+          input.businessId,
+          id,
+          JSON.stringify({ inboxId: id, eventId: input.eventId }),
+          input.receivedAt,
+        ]
+      );
+      return { outcome: "accepted", event: storedEvent(row) };
+    });
+  }
+
+  async claim(options: ClaimOutboxOptions): Promise<readonly ClaimedOutboxMessage[]> {
+    return this.transactions.withTransaction(async (transaction) => {
+      const result = await transaction.query<OutboxRow>(
+        `WITH candidates AS (
+           SELECT id
+             FROM outbox_messages
+            WHERE business_id = $1
+              AND (
+                status = 'pending'
+                OR (status = 'leased' AND lease_expires_at <= $2::timestamptz)
+              )
+            ORDER BY created_at, id
+            FOR UPDATE SKIP LOCKED
+            LIMIT $3
+         )
+         UPDATE outbox_messages AS messages
+            SET status = 'leased',
+                lease_owner = $4,
+                lease_expires_at =
+                  $2::timestamptz + ($5::integer * interval '1 millisecond'),
+                attempts = attempts + 1
+           FROM candidates
+          WHERE messages.id = candidates.id
+         RETURNING messages.id, messages.business_id, messages.inbox_id, messages.topic,
+                   messages.payload, messages.attempts, messages.lease_owner,
+                   messages.lease_expires_at`,
+        [
+          options.businessId,
+          options.now,
+          Math.max(0, options.limit),
+          options.owner,
+          Math.max(1, options.leaseDurationMs),
+        ]
+      );
+      return result.rows.map(claimedMessage);
+    });
+  }
+
+  async complete(
+    businessId: string,
+    messageId: string,
+    owner: string,
+    consumer: string
+  ): Promise<"recorded" | "duplicate"> {
+    return this.transactions.withTransaction(async (transaction) => {
+      const updated = await transaction.query(
+        `UPDATE outbox_messages
+            SET status = 'dispatched', lease_owner = NULL, lease_expires_at = NULL,
+                dispatched_at = now()
+          WHERE id = $1 AND business_id = $2 AND status = 'leased' AND lease_owner = $3
+          RETURNING id`,
+        [messageId, businessId, owner]
+      );
+      if (updated.rows.length === 0) {
+        const receipt = await transaction.query(
+          `SELECT 1 FROM consumer_receipts
+            WHERE business_id = $1 AND message_id = $2 AND consumer = $3`,
+          [businessId, messageId, consumer]
+        );
+        if (receipt.rows.length > 0) return "duplicate";
+        throw new OutboxLeaseError("lease_not_owned");
+      }
+      await transaction.query(
+        `INSERT INTO consumer_receipts (id, business_id, message_id, consumer)
+         VALUES ($1, $2, $3, $4)`,
+        [this.nextId(), businessId, messageId, consumer]
+      );
+      return "recorded";
+    });
+  }
+
+  async fail(
+    businessId: string,
+    messageId: string,
+    owner: string,
+    failure: OutboxFailure
+  ): Promise<"released" | "quarantined"> {
+    return this.transactions.withTransaction(async (transaction) => {
+      const selected = await transaction.query<{ attempts: number }>(
+        `SELECT attempts FROM outbox_messages
+          WHERE id = $1 AND business_id = $2 AND status = 'leased' AND lease_owner = $3
+          FOR UPDATE`,
+        [messageId, businessId, owner]
+      );
+      const row = selected.rows[0];
+      if (!row) throw new OutboxLeaseError("lease_not_owned");
+
+      if (row.attempts < failure.maxAttempts) {
+        await transaction.query(
+          `UPDATE outbox_messages
+              SET status = 'pending', lease_owner = NULL, lease_expires_at = NULL
+            WHERE id = $1 AND business_id = $2`,
+          [messageId, businessId]
+        );
+        return "released";
+      }
+
+      await transaction.query(
+        `INSERT INTO quarantine_records (
+           id, business_id, message_id, reason_code, evidence_ref, owner, replay_eligible
+         ) VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+        [
+          this.nextId(),
+          businessId,
+          messageId,
+          failure.code,
+          failure.evidenceRef ?? null,
+          failure.quarantineOwner,
+          failure.replayEligible,
+        ]
+      );
+      await transaction.query(
+        `UPDATE outbox_messages
+            SET status = 'quarantined', lease_owner = NULL, lease_expires_at = NULL
+          WHERE id = $1 AND business_id = $2`,
+        [messageId, businessId]
+      );
+      return "quarantined";
+    });
+  }
+}

--- a/packages/storage/src/events/index.ts
+++ b/packages/storage/src/events/index.ts
@@ -1,0 +1,19 @@
+export type {
+  AcceptEventResult,
+  ClaimedOutboxMessage,
+  ClaimOutboxOptions,
+  EventEnvelope,
+  EventInboxStatus,
+  EventOutboxPort,
+  EventStorageIdSource,
+  OutboxFailure,
+  OutboxLeaseDenialReason,
+  OutboxStatus,
+  StoredEvent,
+  StoreEventInput,
+} from "./event-store";
+export {
+  EVENT_STORAGE_STATEMENTS,
+  EventStore,
+  OutboxLeaseError,
+} from "./event-store";

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./approvals";
 export * from "./auth";
+export * from "./events";
 export * from "./ports";
 export * from "./soul";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       '@tulipfarm/soul':
         specifier: workspace:*
         version: link:../../packages/soul
+      '@tulipfarm/storage':
+        specifier: workspace:*
+        version: link:../../packages/storage
       ai:
         specifier: ^7.0.2
         version: 7.0.2(zod@4.4.3)
@@ -376,6 +379,10 @@ importers:
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.0(@types/node@26.1.1)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   apps/worker:
+    dependencies:
+      '@tulipfarm/storage':
+        specifier: workspace:*
+        version: link:../../packages/storage
     devDependencies:
       '@tulipfarm/tsconfig':
         specifier: workspace:*
@@ -702,6 +709,9 @@ importers:
 
   packages/storage:
     devDependencies:
+      '@electric-sql/pglite':
+        specifier: ^0.5.3
+        version: 0.5.3
       '@tulipfarm/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig


### PR DESCRIPTION
## Summary

- add a PostgreSQL-backed, business-isolated EventInbox and transactional OutboxMessage store with stable deduplication
- add leased dispatch, idempotent consumer receipts, retry recovery, and visible quarantine evidence
- expose a composition-only worker dispatcher and wire migration v3 through the API migration runner

## Test plan

- [x] `pnpm --filter @tulipfarm/storage test src/events/event-store.pg.test.ts` (8 passed)
- [x] `pnpm --filter @tulipfarm/worker test src/event-dispatcher.test.ts` (2 passed)
- [x] `pnpm --filter @tulipfarm/api test src/ingress/repo.pg.test.ts` (6 passed)
- [x] storage, worker, and API package typechecks
- [x] scoped Biome checks and `git diff --check`