### PR TITLE
feat(run-kernel): persist runs states attempts and lineage

### DIFF
--- a/apps/api/src/pg-migrations/index.ts
+++ b/apps/api/src/pg-migrations/index.ts
@@ -1,4 +1,4 @@
-import { EVENT_STORAGE_STATEMENTS } from "@tulipfarm/storage";
+import { EVENT_STORAGE_STATEMENTS, RUN_STORAGE_STATEMENTS } from "@tulipfarm/storage";
 import type { Queryable } from "../db";
 
 export interface PgMigration {
@@ -439,6 +439,15 @@ export const PG_MIGRATIONS: PgMigration[] = [
     description: "transactional event inbox and outbox",
     up: async (q) => {
       for (const sql of EVENT_STORAGE_STATEMENTS) {
+        await q.query(sql);
+      }
+    },
+  },
+  {
+    version: 4,
+    description: "durable Runs, States, attempts, and lineage",
+    up: async (q) => {
+      for (const sql of RUN_STORAGE_STATEMENTS) {
         await q.query(sql);
       }
     },

--- a/packages/run-kernel/src/index.ts
+++ b/packages/run-kernel/src/index.ts
@@ -1,1 +1,1 @@
-export {};
+export * from "./model";

--- a/packages/run-kernel/src/model/index.ts
+++ b/packages/run-kernel/src/model/index.ts
@@ -1,0 +1,12 @@
+export type {
+  RunStatus,
+  RunTransitionErrorCode,
+  StateStatus,
+} from "./run";
+export {
+  assertRunTransition,
+  assertStateTransition,
+  RUN_STATUSES,
+  RunTransitionError,
+  STATE_STATUSES,
+} from "./run";

--- a/packages/run-kernel/src/model/run.test.ts
+++ b/packages/run-kernel/src/model/run.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertRunTransition,
+  assertStateTransition,
+  RUN_STATUSES,
+  RunTransitionError,
+  STATE_STATUSES,
+} from "./run";
+
+describe("Run model", () => {
+  it("exposes the complete canonical Run and State statuses", () => {
+    expect(RUN_STATUSES).toEqual([
+      "queued",
+      "claimed",
+      "running",
+      "waiting",
+      "succeeded",
+      "failed",
+      "cancelling",
+      "cancelled",
+      "attention_required",
+      "needs_reconciliation",
+    ]);
+    expect(STATE_STATUSES).toEqual([
+      "pending",
+      "ready",
+      "claimed",
+      "running",
+      "waiting",
+      "succeeded",
+      "failed",
+      "skipped",
+      "cancelling",
+      "cancelled",
+      "needs_reconciliation",
+    ]);
+  });
+
+  it("accepts declared recovery transitions and rejects invented transitions", () => {
+    expect(() => assertRunTransition("needs_reconciliation", "succeeded")).not.toThrow();
+    expect(() => assertStateTransition("running", "needs_reconciliation")).not.toThrow();
+
+    expect(() => assertRunTransition("succeeded", "running")).toThrow(
+      new RunTransitionError("invalid_run_transition", "succeeded", "running")
+    );
+    expect(() => assertStateTransition("pending", "succeeded")).toThrow(
+      new RunTransitionError("invalid_state_transition", "pending", "succeeded")
+    );
+  });
+});

--- a/packages/run-kernel/src/model/run.ts
+++ b/packages/run-kernel/src/model/run.ts
@@ -1,0 +1,90 @@
+export const RUN_STATUSES = [
+  "queued",
+  "claimed",
+  "running",
+  "waiting",
+  "succeeded",
+  "failed",
+  "cancelling",
+  "cancelled",
+  "attention_required",
+  "needs_reconciliation",
+] as const;
+
+export type RunStatus = (typeof RUN_STATUSES)[number];
+
+export const STATE_STATUSES = [
+  "pending",
+  "ready",
+  "claimed",
+  "running",
+  "waiting",
+  "succeeded",
+  "failed",
+  "skipped",
+  "cancelling",
+  "cancelled",
+  "needs_reconciliation",
+] as const;
+
+export type StateStatus = (typeof STATE_STATUSES)[number];
+
+export type RunTransitionErrorCode = "invalid_run_transition" | "invalid_state_transition";
+
+export class RunTransitionError extends Error {
+  readonly name = "RunTransitionError";
+
+  constructor(
+    readonly code: RunTransitionErrorCode,
+    readonly from: RunStatus | StateStatus,
+    readonly to: RunStatus | StateStatus
+  ) {
+    super(`${code}:${from}->${to}`);
+  }
+}
+
+const RUN_TRANSITIONS: Readonly<Record<RunStatus, readonly RunStatus[]>> = {
+  queued: ["claimed", "cancelling", "attention_required"],
+  claimed: ["queued", "running", "cancelling", "attention_required"],
+  running: [
+    "waiting",
+    "succeeded",
+    "failed",
+    "cancelling",
+    "attention_required",
+    "needs_reconciliation",
+  ],
+  waiting: ["queued", "cancelling", "attention_required"],
+  succeeded: [],
+  failed: [],
+  cancelling: ["cancelled", "needs_reconciliation"],
+  cancelled: [],
+  attention_required: ["queued", "failed", "cancelling"],
+  needs_reconciliation: ["queued", "failed", "cancelled", "succeeded"],
+};
+
+const STATE_TRANSITIONS: Readonly<Record<StateStatus, readonly StateStatus[]>> = {
+  pending: ["ready", "skipped", "cancelling", "cancelled"],
+  ready: ["claimed", "skipped", "cancelling", "cancelled"],
+  claimed: ["ready", "running", "cancelling"],
+  running: ["waiting", "succeeded", "failed", "cancelling", "needs_reconciliation"],
+  waiting: ["ready", "cancelling", "needs_reconciliation"],
+  succeeded: [],
+  failed: [],
+  skipped: [],
+  cancelling: ["cancelled", "needs_reconciliation"],
+  cancelled: [],
+  needs_reconciliation: ["ready", "failed", "cancelled", "succeeded"],
+};
+
+export function assertRunTransition(from: RunStatus, to: RunStatus): void {
+  if (!RUN_TRANSITIONS[from].includes(to)) {
+    throw new RunTransitionError("invalid_run_transition", from, to);
+  }
+}
+
+export function assertStateTransition(from: StateStatus, to: StateStatus): void {
+  if (!STATE_TRANSITIONS[from].includes(to)) {
+    throw new RunTransitionError("invalid_state_transition", from, to);
+  }
+}

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -2,4 +2,5 @@ export * from "./approvals";
 export * from "./auth";
 export * from "./events";
 export * from "./ports";
+export * from "./runs";
 export * from "./soul";

--- a/packages/storage/src/runs/index.ts
+++ b/packages/storage/src/runs/index.ts
@@ -1,0 +1,26 @@
+export type {
+  AppendAttemptInput,
+  AppendAttemptResult,
+  AttemptEvent,
+  AttemptEvidence,
+  PersistedRun,
+  PersistedRunStatus,
+  PersistedState,
+  PersistedStateStatus,
+  RunBounds,
+  RunBundle,
+  RunIdentity,
+  RunLineage,
+  RunLineageRelation,
+  RunPersistenceErrorCode,
+  RunPrincipal,
+  RunTransitionInput,
+  StartRunInput,
+  StartStateInput,
+  StateTransitionInput,
+} from "./run-store";
+export {
+  RUN_STORAGE_STATEMENTS,
+  RunPersistenceError,
+  RunStore,
+} from "./run-store";

--- a/packages/storage/src/runs/run-store.pg.test.ts
+++ b/packages/storage/src/runs/run-store.pg.test.ts
@@ -1,0 +1,284 @@
+import { PGlite } from "@electric-sql/pglite";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { Queryable, TransactionPort } from "../ports";
+import {
+  type AttemptEvidence,
+  RUN_STORAGE_STATEMENTS,
+  RunPersistenceError,
+  RunStore,
+  type StartRunInput,
+} from "./run-store";
+
+const CREATED_AT = "2026-07-24T10:00:00.000Z";
+
+function transactionPort(database: PGlite): TransactionPort {
+  return {
+    withTransaction: (operation) =>
+      database.transaction((transaction) => operation(transaction as Queryable)),
+  };
+}
+
+function run(overrides: Partial<StartRunInput> = {}): StartRunInput {
+  return {
+    id: "00000000-0000-4000-8000-000000000001",
+    businessId: "business-1",
+    bundle: {
+      digest: "sha256:bundle-1",
+      routineId: "routine-1",
+      routineVersion: "1",
+    },
+    identity: {
+      initiator: { kind: "user", id: "user-1" },
+      effectiveSubject: { kind: "agent", id: "agent-1" },
+      guardrailContextRef: "guardrail-context-1",
+    },
+    bounds: {
+      wallTimeMs: 60_000,
+      activeTimeMs: 30_000,
+      attempts: 3,
+      sideEffects: 2,
+    },
+    createdAt: CREATED_AT,
+    states: [
+      {
+        key: "classify",
+        definitionRef: "sha256:bundle-1#/states/classify",
+        resolvedInput: { artifactId: "artifact-input-1" },
+      },
+      {
+        key: "apply",
+        definitionRef: "sha256:bundle-1#/states/apply",
+        resolvedInput: { label: "triaged" },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("RunStore (PostgreSQL)", () => {
+  let database: PGlite;
+  let store: RunStore;
+
+  beforeAll(async () => {
+    database = await PGlite.create();
+    for (const statement of RUN_STORAGE_STATEMENTS) {
+      await database.query(statement);
+    }
+  }, 60_000);
+
+  beforeEach(async () => {
+    await database.query("TRUNCATE TABLE runs CASCADE");
+    store = new RunStore(transactionPort(database));
+  });
+
+  afterAll(async () => {
+    await database.close();
+  });
+
+  it("atomically persists immutable bundle, identity, bounds, and typed States", async () => {
+    const persisted = await store.start(run());
+
+    expect(persisted).toMatchObject({
+      businessId: "business-1",
+      status: "queued",
+      version: 0,
+      bundle: run().bundle,
+      identity: run().identity,
+      bounds: run().bounds,
+    });
+    expect(await store.listStates("business-1", persisted.id)).toEqual([
+      expect.objectContaining({
+        key: "apply",
+        status: "pending",
+        version: 0,
+        resolvedInput: { label: "triaged" },
+      }),
+      expect.objectContaining({
+        key: "classify",
+        status: "pending",
+        version: 0,
+        resolvedInput: { artifactId: "artifact-input-1" },
+      }),
+    ]);
+
+    const columns = await database.query<{ column_name: string }>(
+      `SELECT column_name
+         FROM information_schema.columns
+        WHERE table_name IN ('runs', 'run_states', 'state_attempts', 'run_lineage')`
+    );
+    expect(columns.rows.map((row) => row.column_name)).not.toContain("context");
+  });
+
+  it("rolls back the Run when a State violates a database constraint", async () => {
+    await expect(
+      store.start(
+        run({
+          states: [
+            {
+              key: "",
+              definitionRef: "sha256:bundle-1#/states/invalid",
+              resolvedInput: {},
+            },
+          ],
+        })
+      )
+    ).rejects.toThrow();
+
+    expect((await database.query("SELECT id FROM runs")).rows).toEqual([]);
+  });
+
+  it("default-denies cross-business reads and keeps foreign lineage impossible", async () => {
+    await store.start(run());
+    await store.start(
+      run({
+        id: "00000000-0000-4000-8000-000000000002",
+        businessId: "business-2",
+      })
+    );
+
+    expect(await store.find("business-2", run().id)).toBeNull();
+    await expect(
+      store.start(
+        run({
+          id: "00000000-0000-4000-8000-000000000003",
+          parentRunId: run().id,
+        })
+      )
+    ).resolves.toBeDefined();
+    await expect(
+      store.start(
+        run({
+          id: "00000000-0000-4000-8000-000000000004",
+          businessId: "business-2",
+          parentRunId: run().id,
+        })
+      )
+    ).rejects.toThrow();
+  });
+
+  it("uses optimistic versions so only one concurrent status transition wins", async () => {
+    await store.start(run());
+
+    const results = await Promise.all([
+      store.transitionRun("business-1", run().id, {
+        expectedVersion: 0,
+        expectedStatus: "queued",
+        status: "claimed",
+      }),
+      store.transitionRun("business-1", run().id, {
+        expectedVersion: 0,
+        expectedStatus: "queued",
+        status: "claimed",
+      }),
+    ]);
+
+    expect(results.filter(Boolean)).toHaveLength(1);
+    expect(await store.find("business-1", run().id)).toMatchObject({
+      status: "claimed",
+      version: 1,
+    });
+  });
+
+  it("persists State status with the same optimistic concurrency boundary", async () => {
+    await store.start(run());
+
+    const results = await Promise.all([
+      store.transitionState("business-1", run().id, "classify", {
+        expectedVersion: 0,
+        expectedStatus: "pending",
+        status: "ready",
+      }),
+      store.transitionState("business-1", run().id, "classify", {
+        expectedVersion: 0,
+        expectedStatus: "pending",
+        status: "ready",
+      }),
+    ]);
+
+    expect(results.filter(Boolean)).toHaveLength(1);
+    expect(await store.listStates("business-1", run().id)).toContainEqual(
+      expect.objectContaining({
+        key: "classify",
+        status: "ready",
+        version: 1,
+      })
+    );
+  });
+
+  it("appends idempotent immutable attempt evidence and rejects a conflicting replay", async () => {
+    await store.start(run());
+    const attempt = {
+      id: "00000000-0000-4000-8000-000000000101",
+      businessId: "business-1",
+      runId: run().id,
+      stateKey: "classify",
+      attempt: 1,
+      sequence: 1,
+      event: "started" as const,
+      eventDigest: "sha256:attempt-started",
+      occurredAt: CREATED_AT,
+      evidence: {
+        agentId: "agent-1",
+        modelProfileId: "model-profile-1",
+        auditEventId: "audit-event-1",
+      },
+    };
+
+    expect((await store.appendAttempt(attempt)).outcome).toBe("appended");
+    expect((await store.appendAttempt(attempt)).outcome).toBe("duplicate");
+    await expect(
+      store.appendAttempt({ ...attempt, eventDigest: "sha256:changed" })
+    ).rejects.toEqual(new RunPersistenceError("attempt_conflict"));
+    await expect(
+      store.appendAttempt({
+        ...attempt,
+        id: "00000000-0000-4000-8000-000000000102",
+        sequence: 2,
+        eventDigest: "sha256:protected-payload",
+        evidence: { secret: "sk-protected-value" } as unknown as AttemptEvidence,
+      })
+    ).rejects.toThrow();
+    await expect(
+      database.query("UPDATE state_attempts SET event = 'failed' WHERE id = $1", [attempt.id])
+    ).rejects.toThrow();
+    await expect(
+      database.query("DELETE FROM state_attempts WHERE id = $1", [attempt.id])
+    ).rejects.toThrow();
+  });
+
+  it("persists immutable child and replay lineage", async () => {
+    await store.start(run());
+    await store.start(
+      run({
+        id: "00000000-0000-4000-8000-000000000002",
+        parentRunId: run().id,
+        lineage: "child",
+      })
+    );
+
+    expect(await store.listLineage("business-1", "00000000-0000-4000-8000-000000000002")).toEqual([
+      {
+        businessId: "business-1",
+        sourceRunId: run().id,
+        targetRunId: "00000000-0000-4000-8000-000000000002",
+        relation: "child",
+        createdAt: CREATED_AT,
+      },
+    ]);
+    await expect(database.query("UPDATE run_lineage SET relation = 'replay'")).rejects.toThrow();
+    await expect(database.query("DELETE FROM run_lineage")).rejects.toThrow();
+  });
+
+  it("keeps immutable Run identity and State inputs unchanged at the database boundary", async () => {
+    await store.start(run());
+
+    await expect(
+      database.query("UPDATE runs SET bundle = '{}'::jsonb WHERE id = $1", [run().id])
+    ).rejects.toThrow();
+    await expect(
+      database.query("UPDATE run_states SET resolved_input = '{}'::jsonb WHERE run_id = $1", [
+        run().id,
+      ])
+    ).rejects.toThrow();
+  });
+});

--- a/packages/storage/src/runs/run-store.ts
+++ b/packages/storage/src/runs/run-store.ts
@@ -1,0 +1,621 @@
+import type { TransactionPort } from "../ports";
+
+export type PersistedRunStatus =
+  | "queued"
+  | "claimed"
+  | "running"
+  | "waiting"
+  | "succeeded"
+  | "failed"
+  | "cancelling"
+  | "cancelled"
+  | "attention_required"
+  | "needs_reconciliation";
+
+export type PersistedStateStatus =
+  | "pending"
+  | "ready"
+  | "claimed"
+  | "running"
+  | "waiting"
+  | "succeeded"
+  | "failed"
+  | "skipped"
+  | "cancelling"
+  | "cancelled"
+  | "needs_reconciliation";
+
+export interface RunBundle {
+  readonly digest: string;
+  readonly routineId: string;
+  readonly routineVersion: string;
+}
+
+export interface RunPrincipal {
+  readonly kind: string;
+  readonly id: string;
+}
+
+export interface RunIdentity {
+  readonly initiator: RunPrincipal;
+  readonly effectiveSubject: RunPrincipal;
+  readonly guardrailContextRef: string;
+}
+
+export interface RunBounds {
+  readonly wallTimeMs: number;
+  readonly activeTimeMs: number;
+  readonly attempts: number;
+  readonly sideEffects: number;
+}
+
+export interface StartStateInput {
+  readonly key: string;
+  readonly definitionRef: string;
+  readonly resolvedInput: Record<string, unknown>;
+}
+
+export type RunLineageRelation = "child" | "replay";
+
+export interface StartRunInput {
+  readonly id: string;
+  readonly businessId: string;
+  readonly bundle: RunBundle;
+  readonly identity: RunIdentity;
+  readonly bounds: RunBounds;
+  readonly createdAt: string;
+  readonly states: readonly StartStateInput[];
+  readonly parentRunId?: string;
+  readonly lineage?: RunLineageRelation;
+}
+
+export interface PersistedRun {
+  readonly id: string;
+  readonly businessId: string;
+  readonly bundle: RunBundle;
+  readonly identity: RunIdentity;
+  readonly bounds: RunBounds;
+  readonly status: PersistedRunStatus;
+  readonly version: number;
+  readonly createdAt: string;
+  readonly startedAt: string | null;
+  readonly finishedAt: string | null;
+  readonly resultArtifactId: string | null;
+  readonly errorEvidenceRef: string | null;
+}
+
+export interface PersistedState {
+  readonly businessId: string;
+  readonly runId: string;
+  readonly key: string;
+  readonly definitionRef: string;
+  readonly resolvedInput: Record<string, unknown>;
+  readonly status: PersistedStateStatus;
+  readonly version: number;
+  readonly createdAt: string;
+  readonly startedAt: string | null;
+  readonly finishedAt: string | null;
+  readonly resultArtifactId: string | null;
+  readonly errorEvidenceRef: string | null;
+}
+
+export interface RunTransitionInput {
+  readonly expectedVersion: number;
+  readonly expectedStatus: PersistedRunStatus;
+  readonly status: PersistedRunStatus;
+  readonly startedAt?: string;
+  readonly finishedAt?: string;
+  readonly resultArtifactId?: string;
+  readonly errorEvidenceRef?: string;
+}
+
+export interface StateTransitionInput {
+  readonly expectedVersion: number;
+  readonly expectedStatus: PersistedStateStatus;
+  readonly status: PersistedStateStatus;
+  readonly startedAt?: string;
+  readonly finishedAt?: string;
+  readonly resultArtifactId?: string;
+  readonly errorEvidenceRef?: string;
+}
+
+export type AttemptEvent =
+  | "claimed"
+  | "started"
+  | "waiting"
+  | "succeeded"
+  | "failed"
+  | "cancelled"
+  | "lease_expired"
+  | "reconciliation_required";
+
+/** Opaque evidence references only; protected payloads and Secret values are not accepted. */
+export interface AttemptEvidence {
+  readonly agentId?: string;
+  readonly modelProfileId?: string;
+  readonly toolIntentId?: string;
+  readonly auditEventId?: string;
+  readonly resultArtifactId?: string;
+  readonly errorEvidenceRef?: string;
+}
+
+export interface AppendAttemptInput {
+  readonly id: string;
+  readonly businessId: string;
+  readonly runId: string;
+  readonly stateKey: string;
+  readonly attempt: number;
+  readonly sequence: number;
+  readonly event: AttemptEvent;
+  readonly eventDigest: string;
+  readonly occurredAt: string;
+  readonly evidence: AttemptEvidence;
+}
+
+export interface AppendAttemptResult {
+  readonly outcome: "appended" | "duplicate";
+}
+
+export interface RunLineage {
+  readonly businessId: string;
+  readonly sourceRunId: string;
+  readonly targetRunId: string;
+  readonly relation: RunLineageRelation;
+  readonly createdAt: string;
+}
+
+export type RunPersistenceErrorCode = "attempt_conflict";
+
+export class RunPersistenceError extends Error {
+  readonly name = "RunPersistenceError";
+
+  constructor(readonly code: RunPersistenceErrorCode) {
+    super(code);
+  }
+}
+
+const RUN_STATUS_SQL =
+  "'queued', 'claimed', 'running', 'waiting', 'succeeded', 'failed', " +
+  "'cancelling', 'cancelled', 'attention_required', 'needs_reconciliation'";
+const STATE_STATUS_SQL =
+  "'pending', 'ready', 'claimed', 'running', 'waiting', 'succeeded', 'failed', " +
+  "'skipped', 'cancelling', 'cancelled', 'needs_reconciliation'";
+const ATTEMPT_EVENT_SQL =
+  "'claimed', 'started', 'waiting', 'succeeded', 'failed', 'cancelled', " +
+  "'lease_expired', 'reconciliation_required'";
+
+export const RUN_STORAGE_STATEMENTS: readonly string[] = [
+  `CREATE TABLE IF NOT EXISTS runs (
+    id                    uuid PRIMARY KEY,
+    business_id           text NOT NULL,
+    bundle                jsonb NOT NULL CHECK (jsonb_typeof(bundle) = 'object'),
+    identity              jsonb NOT NULL CHECK (jsonb_typeof(identity) = 'object'),
+    bounds                jsonb NOT NULL CHECK (
+      jsonb_typeof(bounds) = 'object'
+      AND bounds ?& ARRAY['wallTimeMs', 'activeTimeMs', 'attempts', 'sideEffects']
+      AND (bounds->>'wallTimeMs')::bigint > 0
+      AND (bounds->>'activeTimeMs')::bigint > 0
+      AND (bounds->>'attempts')::integer >= 0
+      AND (bounds->>'sideEffects')::integer >= 0
+    ),
+    status                text NOT NULL DEFAULT 'queued'
+      CHECK (status IN (${RUN_STATUS_SQL})),
+    version               integer NOT NULL DEFAULT 0 CHECK (version >= 0),
+    created_at            timestamptz NOT NULL,
+    started_at            timestamptz,
+    finished_at           timestamptz,
+    result_artifact_id    text,
+    error_evidence_ref    text,
+    UNIQUE (business_id, id)
+  )`,
+  `CREATE TABLE IF NOT EXISTS run_states (
+    business_id           text NOT NULL,
+    run_id                uuid NOT NULL,
+    state_key             text NOT NULL CHECK (length(state_key) > 0),
+    definition_ref        text NOT NULL CHECK (length(definition_ref) > 0),
+    resolved_input        jsonb NOT NULL CHECK (jsonb_typeof(resolved_input) = 'object'),
+    status                text NOT NULL DEFAULT 'pending'
+      CHECK (status IN (${STATE_STATUS_SQL})),
+    version               integer NOT NULL DEFAULT 0 CHECK (version >= 0),
+    created_at            timestamptz NOT NULL,
+    started_at            timestamptz,
+    finished_at           timestamptz,
+    result_artifact_id    text,
+    error_evidence_ref    text,
+    PRIMARY KEY (business_id, run_id, state_key),
+    FOREIGN KEY (business_id, run_id) REFERENCES runs(business_id, id)
+  )`,
+  `CREATE TABLE IF NOT EXISTS state_attempts (
+    id                    uuid PRIMARY KEY,
+    business_id           text NOT NULL,
+    run_id                uuid NOT NULL,
+    state_key             text NOT NULL,
+    attempt               integer NOT NULL CHECK (attempt > 0),
+    sequence              integer NOT NULL CHECK (sequence > 0),
+    event                 text NOT NULL CHECK (event IN (${ATTEMPT_EVENT_SQL})),
+    event_digest          text NOT NULL CHECK (length(event_digest) > 0),
+    occurred_at           timestamptz NOT NULL,
+    evidence              jsonb NOT NULL CHECK (
+      jsonb_typeof(evidence) = 'object'
+      AND evidence - ARRAY[
+        'agentId',
+        'modelProfileId',
+        'toolIntentId',
+        'auditEventId',
+        'resultArtifactId',
+        'errorEvidenceRef'
+      ] = '{}'::jsonb
+    ),
+    UNIQUE (business_id, id),
+    UNIQUE (business_id, run_id, state_key, attempt, sequence),
+    FOREIGN KEY (business_id, run_id, state_key)
+      REFERENCES run_states(business_id, run_id, state_key)
+  )`,
+  `CREATE TABLE IF NOT EXISTS run_lineage (
+    business_id           text NOT NULL,
+    source_run_id         uuid NOT NULL,
+    target_run_id         uuid NOT NULL,
+    relation              text NOT NULL CHECK (relation IN ('child', 'replay')),
+    created_at            timestamptz NOT NULL,
+    PRIMARY KEY (business_id, source_run_id, target_run_id, relation),
+    FOREIGN KEY (business_id, source_run_id) REFERENCES runs(business_id, id),
+    FOREIGN KEY (business_id, target_run_id) REFERENCES runs(business_id, id),
+    CHECK (source_run_id <> target_run_id)
+  )`,
+  `CREATE OR REPLACE FUNCTION reject_run_append_only_change()
+    RETURNS trigger LANGUAGE plpgsql AS $$
+    BEGIN
+      RAISE EXCEPTION 'run_append_only_record';
+    END;
+    $$`,
+  "DROP TRIGGER IF EXISTS state_attempts_append_only ON state_attempts",
+  `CREATE TRIGGER state_attempts_append_only
+    BEFORE UPDATE OR DELETE ON state_attempts
+    FOR EACH ROW EXECUTE FUNCTION reject_run_append_only_change()`,
+  "DROP TRIGGER IF EXISTS run_lineage_append_only ON run_lineage",
+  `CREATE TRIGGER run_lineage_append_only
+    BEFORE UPDATE OR DELETE ON run_lineage
+    FOR EACH ROW EXECUTE FUNCTION reject_run_append_only_change()`,
+  `CREATE OR REPLACE FUNCTION reject_run_identity_change()
+    RETURNS trigger LANGUAGE plpgsql AS $$
+    BEGIN
+      IF OLD.id IS DISTINCT FROM NEW.id
+        OR OLD.business_id IS DISTINCT FROM NEW.business_id
+        OR OLD.bundle IS DISTINCT FROM NEW.bundle
+        OR OLD.identity IS DISTINCT FROM NEW.identity
+        OR OLD.bounds IS DISTINCT FROM NEW.bounds
+        OR OLD.created_at IS DISTINCT FROM NEW.created_at THEN
+        RAISE EXCEPTION 'run_identity_immutable';
+      END IF;
+      RETURN NEW;
+    END;
+    $$`,
+  "DROP TRIGGER IF EXISTS runs_identity_immutable ON runs",
+  `CREATE TRIGGER runs_identity_immutable
+    BEFORE UPDATE ON runs
+    FOR EACH ROW EXECUTE FUNCTION reject_run_identity_change()`,
+  `CREATE OR REPLACE FUNCTION reject_state_identity_change()
+    RETURNS trigger LANGUAGE plpgsql AS $$
+    BEGIN
+      IF OLD.business_id IS DISTINCT FROM NEW.business_id
+        OR OLD.run_id IS DISTINCT FROM NEW.run_id
+        OR OLD.state_key IS DISTINCT FROM NEW.state_key
+        OR OLD.definition_ref IS DISTINCT FROM NEW.definition_ref
+        OR OLD.resolved_input IS DISTINCT FROM NEW.resolved_input
+        OR OLD.created_at IS DISTINCT FROM NEW.created_at THEN
+        RAISE EXCEPTION 'run_state_identity_immutable';
+      END IF;
+      RETURN NEW;
+    END;
+    $$`,
+  "DROP TRIGGER IF EXISTS run_states_identity_immutable ON run_states",
+  `CREATE TRIGGER run_states_identity_immutable
+    BEFORE UPDATE ON run_states
+    FOR EACH ROW EXECUTE FUNCTION reject_state_identity_change()`,
+  `CREATE INDEX IF NOT EXISTS runs_status_idx
+    ON runs (business_id, status, created_at)`,
+  `CREATE INDEX IF NOT EXISTS run_states_status_idx
+    ON run_states (business_id, run_id, status)`,
+  `CREATE INDEX IF NOT EXISTS state_attempts_order_idx
+    ON state_attempts (business_id, run_id, state_key, attempt, sequence)`,
+  `CREATE INDEX IF NOT EXISTS run_lineage_target_idx
+    ON run_lineage (business_id, target_run_id, created_at)`,
+];
+
+interface RunRow {
+  id: string;
+  business_id: string;
+  bundle: RunBundle;
+  identity: RunIdentity;
+  bounds: RunBounds;
+  status: PersistedRunStatus;
+  version: number;
+  created_at: string | Date;
+  started_at: string | Date | null;
+  finished_at: string | Date | null;
+  result_artifact_id: string | null;
+  error_evidence_ref: string | null;
+}
+
+interface StateRow {
+  business_id: string;
+  run_id: string;
+  state_key: string;
+  definition_ref: string;
+  resolved_input: Record<string, unknown>;
+  status: PersistedStateStatus;
+  version: number;
+  created_at: string | Date;
+  started_at: string | Date | null;
+  finished_at: string | Date | null;
+  result_artifact_id: string | null;
+  error_evidence_ref: string | null;
+}
+
+interface AttemptRow {
+  event_digest: string;
+}
+
+interface LineageRow {
+  business_id: string;
+  source_run_id: string;
+  target_run_id: string;
+  relation: RunLineageRelation;
+  created_at: string | Date;
+}
+
+function timestamp(value: string | Date): string {
+  return value instanceof Date ? value.toISOString() : value;
+}
+
+function optionalTimestamp(value: string | Date | null): string | null {
+  return value === null ? null : timestamp(value);
+}
+
+function persistedRun(row: RunRow): PersistedRun {
+  return {
+    id: row.id,
+    businessId: row.business_id,
+    bundle: row.bundle,
+    identity: row.identity,
+    bounds: row.bounds,
+    status: row.status,
+    version: row.version,
+    createdAt: timestamp(row.created_at),
+    startedAt: optionalTimestamp(row.started_at),
+    finishedAt: optionalTimestamp(row.finished_at),
+    resultArtifactId: row.result_artifact_id,
+    errorEvidenceRef: row.error_evidence_ref,
+  };
+}
+
+function persistedState(row: StateRow): PersistedState {
+  return {
+    businessId: row.business_id,
+    runId: row.run_id,
+    key: row.state_key,
+    definitionRef: row.definition_ref,
+    resolvedInput: row.resolved_input,
+    status: row.status,
+    version: row.version,
+    createdAt: timestamp(row.created_at),
+    startedAt: optionalTimestamp(row.started_at),
+    finishedAt: optionalTimestamp(row.finished_at),
+    resultArtifactId: row.result_artifact_id,
+    errorEvidenceRef: row.error_evidence_ref,
+  };
+}
+
+const RUN_COLUMNS = `id, business_id, bundle, identity, bounds, status, version, created_at,
+  started_at, finished_at, result_artifact_id, error_evidence_ref`;
+const STATE_COLUMNS = `business_id, run_id, state_key, definition_ref, resolved_input, status,
+  version, created_at, started_at, finished_at, result_artifact_id, error_evidence_ref`;
+
+/** PostgreSQL persistence for business-scoped Runs, States, attempts, and lineage. */
+export class RunStore {
+  constructor(private readonly transactions: TransactionPort) {}
+
+  async start(input: StartRunInput): Promise<PersistedRun> {
+    return this.transactions.withTransaction(async (transaction) => {
+      const inserted = await transaction.query<RunRow>(
+        `INSERT INTO runs (id, business_id, bundle, identity, bounds, created_at)
+         VALUES ($1, $2, $3::jsonb, $4::jsonb, $5::jsonb, $6::timestamptz)
+         RETURNING ${RUN_COLUMNS}`,
+        [
+          input.id,
+          input.businessId,
+          JSON.stringify(input.bundle),
+          JSON.stringify(input.identity),
+          JSON.stringify(input.bounds),
+          input.createdAt,
+        ]
+      );
+      const run = inserted.rows[0];
+      if (!run) throw new Error("run_insert_without_row");
+
+      for (const state of input.states) {
+        await transaction.query(
+          `INSERT INTO run_states (
+             business_id, run_id, state_key, definition_ref, resolved_input, created_at
+           ) VALUES ($1, $2, $3, $4, $5::jsonb, $6::timestamptz)`,
+          [
+            input.businessId,
+            input.id,
+            state.key,
+            state.definitionRef,
+            JSON.stringify(state.resolvedInput),
+            input.createdAt,
+          ]
+        );
+      }
+
+      if (input.parentRunId !== undefined) {
+        await transaction.query(
+          `INSERT INTO run_lineage (
+             business_id, source_run_id, target_run_id, relation, created_at
+           ) VALUES ($1, $2, $3, $4, $5::timestamptz)`,
+          [input.businessId, input.parentRunId, input.id, input.lineage ?? "child", input.createdAt]
+        );
+      }
+
+      return persistedRun(run);
+    });
+  }
+
+  async find(businessId: string, runId: string): Promise<PersistedRun | null> {
+    return this.transactions.withTransaction(async (transaction) => {
+      const result = await transaction.query<RunRow>(
+        `SELECT ${RUN_COLUMNS} FROM runs WHERE business_id = $1 AND id = $2`,
+        [businessId, runId]
+      );
+      const row = result.rows[0];
+      return row ? persistedRun(row) : null;
+    });
+  }
+
+  async listStates(businessId: string, runId: string): Promise<readonly PersistedState[]> {
+    return this.transactions.withTransaction(async (transaction) => {
+      const result = await transaction.query<StateRow>(
+        `SELECT ${STATE_COLUMNS}
+           FROM run_states
+          WHERE business_id = $1 AND run_id = $2
+          ORDER BY state_key`,
+        [businessId, runId]
+      );
+      return result.rows.map(persistedState);
+    });
+  }
+
+  async transitionRun(
+    businessId: string,
+    runId: string,
+    transition: RunTransitionInput
+  ): Promise<boolean> {
+    return this.transactions.withTransaction(async (transaction) => {
+      const result = await transaction.query<{ id: string }>(
+        `UPDATE runs
+            SET status = $5,
+                version = version + 1,
+                started_at = COALESCE($6::timestamptz, started_at),
+                finished_at = COALESCE($7::timestamptz, finished_at),
+                result_artifact_id = COALESCE($8, result_artifact_id),
+                error_evidence_ref = COALESCE($9, error_evidence_ref)
+          WHERE business_id = $1
+            AND id = $2
+            AND version = $3
+            AND status = $4
+          RETURNING id`,
+        [
+          businessId,
+          runId,
+          transition.expectedVersion,
+          transition.expectedStatus,
+          transition.status,
+          transition.startedAt ?? null,
+          transition.finishedAt ?? null,
+          transition.resultArtifactId ?? null,
+          transition.errorEvidenceRef ?? null,
+        ]
+      );
+      return result.rows.length === 1;
+    });
+  }
+
+  async transitionState(
+    businessId: string,
+    runId: string,
+    stateKey: string,
+    transition: StateTransitionInput
+  ): Promise<boolean> {
+    return this.transactions.withTransaction(async (transaction) => {
+      const result = await transaction.query<{ state_key: string }>(
+        `UPDATE run_states
+            SET status = $6,
+                version = version + 1,
+                started_at = COALESCE($7::timestamptz, started_at),
+                finished_at = COALESCE($8::timestamptz, finished_at),
+                result_artifact_id = COALESCE($9, result_artifact_id),
+                error_evidence_ref = COALESCE($10, error_evidence_ref)
+          WHERE business_id = $1
+            AND run_id = $2
+            AND state_key = $3
+            AND version = $4
+            AND status = $5
+          RETURNING state_key`,
+        [
+          businessId,
+          runId,
+          stateKey,
+          transition.expectedVersion,
+          transition.expectedStatus,
+          transition.status,
+          transition.startedAt ?? null,
+          transition.finishedAt ?? null,
+          transition.resultArtifactId ?? null,
+          transition.errorEvidenceRef ?? null,
+        ]
+      );
+      return result.rows.length === 1;
+    });
+  }
+
+  async appendAttempt(input: AppendAttemptInput): Promise<AppendAttemptResult> {
+    return this.transactions.withTransaction(async (transaction) => {
+      const inserted = await transaction.query<{ id: string }>(
+        `INSERT INTO state_attempts (
+           id, business_id, run_id, state_key, attempt, sequence, event,
+           event_digest, occurred_at, evidence
+         ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::timestamptz, $10::jsonb)
+         ON CONFLICT (business_id, run_id, state_key, attempt, sequence) DO NOTHING
+         RETURNING id`,
+        [
+          input.id,
+          input.businessId,
+          input.runId,
+          input.stateKey,
+          input.attempt,
+          input.sequence,
+          input.event,
+          input.eventDigest,
+          input.occurredAt,
+          JSON.stringify(input.evidence),
+        ]
+      );
+      if (inserted.rows.length === 1) return { outcome: "appended" };
+
+      const existing = await transaction.query<AttemptRow>(
+        `SELECT event_digest
+           FROM state_attempts
+          WHERE business_id = $1
+            AND run_id = $2
+            AND state_key = $3
+            AND attempt = $4
+            AND sequence = $5`,
+        [input.businessId, input.runId, input.stateKey, input.attempt, input.sequence]
+      );
+      if (existing.rows[0]?.event_digest !== input.eventDigest) {
+        throw new RunPersistenceError("attempt_conflict");
+      }
+      return { outcome: "duplicate" };
+    });
+  }
+
+  async listLineage(businessId: string, targetRunId: string): Promise<readonly RunLineage[]> {
+    return this.transactions.withTransaction(async (transaction) => {
+      const result = await transaction.query<LineageRow>(
+        `SELECT business_id, source_run_id, target_run_id, relation, created_at
+           FROM run_lineage
+          WHERE business_id = $1 AND target_run_id = $2
+          ORDER BY created_at, source_run_id`,
+        [businessId, targetRunId]
+      );
+      return result.rows.map((row) => ({
+        businessId: row.business_id,
+        sourceRunId: row.source_run_id,
+        targetRunId: row.target_run_id,
+        relation: row.relation,
+        createdAt: timestamp(row.created_at),
+      }));
+    });
+  }
+}


### PR DESCRIPTION
## Summary

- add canonical Run and State status/transition contracts
- add business-scoped PostgreSQL persistence for immutable Run identity, States, append-only attempts, and lineage
- register migration v4 with optimistic concurrency and evidence-only persistence constraints

## Test plan

- [x] pnpm --dir packages/run-kernel test
- [x] pnpm --dir packages/storage test
- [x] pnpm --dir packages/run-kernel typecheck
- [x] pnpm --dir packages/storage typecheck
- [x] pnpm --dir apps/api typecheck
- [x] pnpm --dir apps/api exec vitest run src/rate-limit.pg.test.ts
- [x] pnpm --dir packages/run-kernel lint
- [x] pnpm --dir packages/storage lint
- [x] pnpm architecture:check