### PR TITLE
feat(run-kernel): add durable worker leases and Run dispatch

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
+    "@tulipfarm/run-kernel": "workspace:*",
     "@tulipfarm/storage": "workspace:*"
   },
   "scripts": {

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -3,3 +3,9 @@ export {
   EventOutboxDispatcher,
   type EventOutboxDispatcherOptions,
 } from "./event-dispatcher";
+export {
+  type DispatchRunsResult,
+  RunDispatcher,
+  type RunDispatcherOptions,
+  type RunOutcome,
+} from "./run-dispatcher";

--- a/apps/worker/src/run-dispatcher.test.ts
+++ b/apps/worker/src/run-dispatcher.test.ts
@@ -1,0 +1,134 @@
+import { RunLeaseManager, type RunLeaseStore } from "@tulipfarm/run-kernel";
+import type { PersistedRun, PersistedRunStatus } from "@tulipfarm/storage";
+import { describe, expect, it } from "vitest";
+import { RunDispatcher } from "./run-dispatcher";
+
+const BUSINESS_ID = "business-1";
+
+function persistedRun(overrides: Partial<PersistedRun> = {}): PersistedRun {
+  return {
+    id: "00000000-0000-4000-8000-000000000001",
+    businessId: BUSINESS_ID,
+    bundle: { digest: "sha256:bundle-1", routineId: "routine-1", routineVersion: "1" },
+    identity: {
+      initiator: { kind: "user", id: "user-1" },
+      effectiveSubject: { kind: "agent", id: "agent-1" },
+      guardrailContextRef: "guardrail-context-1",
+    },
+    bounds: { wallTimeMs: 60_000, activeTimeMs: 30_000, attempts: 3, sideEffects: 2 },
+    status: "claimed",
+    version: 1,
+    createdAt: "2026-07-24T10:00:00.000Z",
+    startedAt: null,
+    finishedAt: null,
+    resultArtifactId: null,
+    errorEvidenceRef: null,
+    leaseOwner: "worker-1",
+    leaseExpiresAt: "2026-07-24T10:01:00.000Z",
+    ...overrides,
+  };
+}
+
+class FakeRunStore implements RunLeaseStore {
+  releaseCalls: unknown[] = [];
+  claimBatchResult: readonly PersistedRun[] = [];
+  reclaimResult: readonly PersistedRun[] = [];
+
+  async transitionRun(
+    _businessId: string,
+    _runId: string,
+    transition: {
+      expectedVersion: number;
+      expectedStatus: PersistedRunStatus;
+      status: PersistedRunStatus;
+      leaseOwner: string | null;
+      leaseExpiresAt: string | null;
+    }
+  ): Promise<boolean> {
+    if (transition.leaseOwner === null) this.releaseCalls.push(transition);
+    return true;
+  }
+
+  async heartbeat(): Promise<boolean> {
+    return true;
+  }
+
+  async reclaimExpiredRuns(): Promise<readonly PersistedRun[]> {
+    return this.reclaimResult;
+  }
+
+  async claimNextQueued(): Promise<readonly PersistedRun[]> {
+    return this.claimBatchResult;
+  }
+
+  async find(_businessId: string, runId: string): Promise<PersistedRun | null> {
+    return persistedRun({ id: runId, status: "running", version: 2 });
+  }
+}
+
+describe("RunDispatcher", () => {
+  it("drives a claimed Run through running to succeeded", async () => {
+    const store = new FakeRunStore();
+    store.claimBatchResult = [persistedRun()];
+    const leases = new RunLeaseManager(store);
+    const dispatched: string[] = [];
+    const dispatcher = new RunDispatcher({
+      leases,
+      businessId: BUSINESS_ID,
+      owner: "worker-1",
+      now: () => new Date("2026-07-24T10:00:00.000Z"),
+      handler: async (run) => {
+        dispatched.push(run.id);
+        return "succeeded";
+      },
+    });
+
+    const result = await dispatcher.dispatchBatch();
+
+    expect(result).toEqual({ reclaimed: 0, claimed: 1, dispatched: 1, failed: 0 });
+    expect(dispatched).toEqual([persistedRun().id]);
+    expect(store.releaseCalls).toEqual([
+      expect.objectContaining({ status: "succeeded", leaseOwner: null, leaseExpiresAt: null }),
+    ]);
+  });
+
+  it("releases to needs_reconciliation when the handler throws", async () => {
+    const store = new FakeRunStore();
+    store.claimBatchResult = [persistedRun()];
+    const leases = new RunLeaseManager(store);
+    const dispatcher = new RunDispatcher({
+      leases,
+      businessId: BUSINESS_ID,
+      owner: "worker-1",
+      now: () => new Date("2026-07-24T10:00:00.000Z"),
+      handler: async () => {
+        throw new Error("boom");
+      },
+    });
+
+    const result = await dispatcher.dispatchBatch();
+
+    expect(result).toEqual({ reclaimed: 0, claimed: 1, dispatched: 0, failed: 1 });
+    expect(store.releaseCalls).toEqual([
+      expect.objectContaining({ status: "needs_reconciliation" }),
+    ]);
+  });
+
+  it("skips a Run whose lease was lost before it could advance to running", async () => {
+    const store = new FakeRunStore();
+    store.claimBatchResult = [persistedRun()];
+    const leases = new RunLeaseManager(store);
+    store.transitionRun = async () => false;
+    const dispatcher = new RunDispatcher({
+      leases,
+      businessId: BUSINESS_ID,
+      owner: "worker-1",
+      now: () => new Date("2026-07-24T10:00:00.000Z"),
+      handler: async () => "succeeded",
+    });
+
+    const result = await dispatcher.dispatchBatch();
+
+    expect(result).toEqual({ reclaimed: 0, claimed: 1, dispatched: 0, failed: 0 });
+  });
+});

--- a/apps/worker/src/run-dispatcher.ts
+++ b/apps/worker/src/run-dispatcher.ts
@@ -1,0 +1,85 @@
+import type { RunLeaseManager } from "@tulipfarm/run-kernel";
+import type { PersistedRun } from "@tulipfarm/storage";
+
+export type RunOutcome = "succeeded" | "failed";
+
+export interface RunDispatcherOptions {
+  leases: RunLeaseManager;
+  businessId: string;
+  owner: string;
+  handler: (run: PersistedRun) => Promise<RunOutcome>;
+  now: () => Date;
+  leaseDurationMs?: number;
+  batchSize?: number;
+}
+
+export interface DispatchRunsResult {
+  reclaimed: number;
+  claimed: number;
+  dispatched: number;
+  failed: number;
+}
+
+/** Claims a batch of due Runs and drives each through `running` to a terminal outcome. */
+export class RunDispatcher {
+  constructor(private readonly options: RunDispatcherOptions) {}
+
+  async dispatchBatch(): Promise<DispatchRunsResult> {
+    const limit = this.options.batchSize ?? 25;
+    const leaseDurationMs = this.options.leaseDurationMs ?? 60_000;
+
+    const reclaimed = await this.options.leases.reclaimExpired({
+      businessId: this.options.businessId,
+      now: this.options.now(),
+      limit,
+    });
+
+    const claimed = await this.options.leases.claimBatch({
+      businessId: this.options.businessId,
+      owner: this.options.owner,
+      now: this.options.now(),
+      leaseDurationMs,
+      limit,
+    });
+
+    let dispatched = 0;
+    let failed = 0;
+    for (const run of claimed) {
+      const started = await this.options.leases.claim({
+        businessId: this.options.businessId,
+        runId: run.id,
+        owner: this.options.owner,
+        now: this.options.now(),
+        leaseDurationMs,
+        expectedVersion: run.version,
+        expectedStatus: "claimed",
+        status: "running",
+      });
+      if (!started.claimed || !started.run) continue;
+
+      try {
+        const outcome = await this.options.handler(started.run);
+        await this.options.leases.release({
+          businessId: this.options.businessId,
+          runId: run.id,
+          expectedVersion: started.run.version,
+          expectedStatus: "running",
+          status: outcome,
+        });
+        if (outcome === "succeeded") dispatched += 1;
+        else failed += 1;
+      } catch {
+        await this.options.leases.release({
+          businessId: this.options.businessId,
+          runId: run.id,
+          expectedVersion: started.run.version,
+          expectedStatus: "running",
+          status: "needs_reconciliation",
+        });
+        failed += 1;
+      }
+    }
+
+    return { reclaimed: reclaimed.length, claimed: claimed.length, dispatched, failed };
+  }
+}

--- a/packages/run-kernel/package.json
+++ b/packages/run-kernel/package.json
@@ -8,6 +8,9 @@
     "test": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit"
   },
+  "dependencies": {
+    "@tulipfarm/storage": "workspace:*"
+  },
   "devDependencies": {
     "@tulipfarm/tsconfig": "workspace:*",
     "typescript": "^6.0.3"

--- a/packages/run-kernel/src/index.ts
+++ b/packages/run-kernel/src/index.ts
@@ -1,1 +1,2 @@
+export * from "./lease";
 export * from "./model";

--- a/packages/run-kernel/src/lease.test.ts
+++ b/packages/run-kernel/src/lease.test.ts
@@ -1,0 +1,285 @@
+import type { PersistedRun, PersistedRunStatus } from "@tulipfarm/storage";
+import { describe, expect, it } from "vitest";
+import { RunLeaseManager, type RunLeaseStore } from "./lease";
+import { RunTransitionError } from "./model";
+
+const RUN_ID = "00000000-0000-4000-8000-000000000001";
+const BUSINESS_ID = "business-1";
+
+function persistedRun(overrides: Partial<PersistedRun> = {}): PersistedRun {
+  return {
+    id: RUN_ID,
+    businessId: BUSINESS_ID,
+    bundle: { digest: "sha256:bundle-1", routineId: "routine-1", routineVersion: "1" },
+    identity: {
+      initiator: { kind: "user", id: "user-1" },
+      effectiveSubject: { kind: "agent", id: "agent-1" },
+      guardrailContextRef: "guardrail-context-1",
+    },
+    bounds: { wallTimeMs: 60_000, activeTimeMs: 30_000, attempts: 3, sideEffects: 2 },
+    status: "claimed",
+    version: 1,
+    createdAt: "2026-07-24T10:00:00.000Z",
+    startedAt: null,
+    finishedAt: null,
+    resultArtifactId: null,
+    errorEvidenceRef: null,
+    leaseOwner: "worker-1",
+    leaseExpiresAt: "2026-07-24T10:01:00.000Z",
+    ...overrides,
+  };
+}
+
+class FakeRunStore implements RunLeaseStore {
+  transitionCalls: unknown[] = [];
+  heartbeatCalls: unknown[] = [];
+  reclaimCalls: unknown[] = [];
+  claimBatchCalls: unknown[] = [];
+  transitionResult = true;
+  heartbeatResult = true;
+  reclaimResult: readonly PersistedRun[] = [];
+  claimBatchResult: readonly PersistedRun[] = [];
+  foundRun: PersistedRun | null = persistedRun();
+
+  async transitionRun(
+    businessId: string,
+    runId: string,
+    transition: {
+      expectedVersion: number;
+      expectedStatus: PersistedRunStatus;
+      status: PersistedRunStatus;
+      leaseOwner: string | null;
+      leaseExpiresAt: string | null;
+    }
+  ): Promise<boolean> {
+    this.transitionCalls.push({ businessId, runId, transition });
+    return this.transitionResult;
+  }
+
+  async heartbeat(
+    businessId: string,
+    runId: string,
+    owner: string,
+    heartbeat: { expectedVersion: number; leaseExpiresAt: string }
+  ): Promise<boolean> {
+    this.heartbeatCalls.push({ businessId, runId, owner, heartbeat });
+    return this.heartbeatResult;
+  }
+
+  async reclaimExpiredRuns(
+    businessId: string,
+    now: string,
+    limit: number
+  ): Promise<readonly PersistedRun[]> {
+    this.reclaimCalls.push({ businessId, now, limit });
+    return this.reclaimResult;
+  }
+
+  async claimNextQueued(
+    businessId: string,
+    owner: string,
+    input: { now: string; leaseDurationMs: number; limit: number }
+  ): Promise<readonly PersistedRun[]> {
+    this.claimBatchCalls.push({ businessId, owner, input });
+    return this.claimBatchResult;
+  }
+
+  async find(_businessId: string, _runId: string): Promise<PersistedRun | null> {
+    return this.foundRun;
+  }
+}
+
+describe("RunLeaseManager", () => {
+  it("claims a queued Run, computing the lease expiry from now + duration", async () => {
+    const store = new FakeRunStore();
+    const manager = new RunLeaseManager(store);
+
+    const result = await manager.claim({
+      businessId: BUSINESS_ID,
+      runId: RUN_ID,
+      owner: "worker-1",
+      now: new Date("2026-07-24T10:00:00.000Z"),
+      leaseDurationMs: 60_000,
+      expectedVersion: 0,
+      expectedStatus: "queued",
+      status: "claimed",
+    });
+
+    expect(result).toEqual({ claimed: true, run: persistedRun() });
+    expect(store.transitionCalls).toEqual([
+      {
+        businessId: BUSINESS_ID,
+        runId: RUN_ID,
+        transition: {
+          expectedVersion: 0,
+          expectedStatus: "queued",
+          status: "claimed",
+          leaseOwner: "worker-1",
+          leaseExpiresAt: "2026-07-24T10:01:00.000Z",
+        },
+      },
+    ]);
+  });
+
+  it("advances an owned claim into running while keeping the lease", async () => {
+    const store = new FakeRunStore();
+    const manager = new RunLeaseManager(store);
+
+    await manager.claim({
+      businessId: BUSINESS_ID,
+      runId: RUN_ID,
+      owner: "worker-1",
+      now: new Date("2026-07-24T10:00:30.000Z"),
+      leaseDurationMs: 60_000,
+      expectedVersion: 1,
+      expectedStatus: "claimed",
+      status: "running",
+    });
+
+    expect(store.transitionCalls).toEqual([
+      {
+        businessId: BUSINESS_ID,
+        runId: RUN_ID,
+        transition: {
+          expectedVersion: 1,
+          expectedStatus: "claimed",
+          status: "running",
+          leaseOwner: "worker-1",
+          leaseExpiresAt: "2026-07-24T10:01:30.000Z",
+        },
+      },
+    ]);
+  });
+
+  it("does not call storage for an illegal claim transition", async () => {
+    const store = new FakeRunStore();
+    const manager = new RunLeaseManager(store);
+
+    await expect(
+      manager.claim({
+        businessId: BUSINESS_ID,
+        runId: RUN_ID,
+        owner: "worker-1",
+        now: new Date("2026-07-24T10:00:00.000Z"),
+        leaseDurationMs: 60_000,
+        expectedVersion: 0,
+        expectedStatus: "succeeded",
+        status: "claimed",
+      })
+    ).rejects.toEqual(new RunTransitionError("invalid_run_transition", "succeeded", "claimed"));
+    expect(store.transitionCalls).toEqual([]);
+  });
+
+  it("reports an unclaimed lease as not claimed without reading the Run", async () => {
+    const store = new FakeRunStore();
+    store.transitionResult = false;
+    const manager = new RunLeaseManager(store);
+
+    const result = await manager.claim({
+      businessId: BUSINESS_ID,
+      runId: RUN_ID,
+      owner: "worker-2",
+      now: new Date("2026-07-24T10:00:00.000Z"),
+      leaseDurationMs: 60_000,
+      expectedVersion: 0,
+      expectedStatus: "queued",
+      status: "claimed",
+    });
+
+    expect(result).toEqual({ claimed: false, run: null });
+  });
+
+  it("releases a claimed lease, clearing the owner and expiry", async () => {
+    const store = new FakeRunStore();
+    const manager = new RunLeaseManager(store);
+
+    const released = await manager.release({
+      businessId: BUSINESS_ID,
+      runId: RUN_ID,
+      expectedVersion: 2,
+      expectedStatus: "running",
+      status: "succeeded",
+    });
+
+    expect(released).toBe(true);
+    expect(store.transitionCalls).toEqual([
+      {
+        businessId: BUSINESS_ID,
+        runId: RUN_ID,
+        transition: {
+          expectedVersion: 2,
+          expectedStatus: "running",
+          status: "succeeded",
+          leaseOwner: null,
+          leaseExpiresAt: null,
+        },
+      },
+    ]);
+  });
+
+  it("computes the heartbeat's new expiry from now + duration and forwards the owner", async () => {
+    const store = new FakeRunStore();
+    const manager = new RunLeaseManager(store);
+
+    const ok = await manager.heartbeat({
+      businessId: BUSINESS_ID,
+      runId: RUN_ID,
+      owner: "worker-1",
+      now: new Date("2026-07-24T10:00:30.000Z"),
+      leaseDurationMs: 60_000,
+      expectedVersion: 1,
+    });
+
+    expect(ok).toBe(true);
+    expect(store.heartbeatCalls).toEqual([
+      {
+        businessId: BUSINESS_ID,
+        runId: RUN_ID,
+        owner: "worker-1",
+        heartbeat: { expectedVersion: 1, leaseExpiresAt: "2026-07-24T10:01:30.000Z" },
+      },
+    ]);
+  });
+
+  it("delegates bulk reclaim with an ISO timestamp", async () => {
+    const store = new FakeRunStore();
+    store.reclaimResult = [
+      persistedRun({ status: "queued", leaseOwner: null, leaseExpiresAt: null }),
+    ];
+    const manager = new RunLeaseManager(store);
+
+    const reclaimed = await manager.reclaimExpired({
+      businessId: BUSINESS_ID,
+      now: new Date("2026-07-24T10:01:00.001Z"),
+      limit: 10,
+    });
+
+    expect(reclaimed).toEqual(store.reclaimResult);
+    expect(store.reclaimCalls).toEqual([
+      { businessId: BUSINESS_ID, now: "2026-07-24T10:01:00.001Z", limit: 10 },
+    ]);
+  });
+
+  it("claims a batch of due queued Runs with an owned, timed lease", async () => {
+    const store = new FakeRunStore();
+    store.claimBatchResult = [persistedRun({ status: "claimed" })];
+    const manager = new RunLeaseManager(store);
+
+    const claimed = await manager.claimBatch({
+      businessId: BUSINESS_ID,
+      owner: "worker-1",
+      now: new Date("2026-07-24T10:00:00.000Z"),
+      leaseDurationMs: 60_000,
+      limit: 10,
+    });
+
+    expect(claimed).toEqual(store.claimBatchResult);
+    expect(store.claimBatchCalls).toEqual([
+      {
+        businessId: BUSINESS_ID,
+        owner: "worker-1",
+        input: { now: "2026-07-24T10:00:00.000Z", leaseDurationMs: 60_000, limit: 10 },
+      },
+    ]);
+  });
+});

--- a/packages/run-kernel/src/lease.ts
+++ b/packages/run-kernel/src/lease.ts
@@ -1,0 +1,143 @@
+import type { PersistedRun, PersistedRunStatus } from "@tulipfarm/storage";
+import { assertRunTransition, type RunStatus } from "./model";
+
+/** Statuses that require an owned, timed worker lease (`runs` table CHECK enforces this). */
+export type LeasedRunStatus = "claimed" | "running";
+
+/** Narrow surface `RunLeaseManager` needs; `@tulipfarm/storage`'s `RunStore` satisfies it. */
+export interface RunLeaseStore {
+  transitionRun(
+    businessId: string,
+    runId: string,
+    transition: {
+      expectedVersion: number;
+      expectedStatus: PersistedRunStatus;
+      status: PersistedRunStatus;
+      leaseOwner: string | null;
+      leaseExpiresAt: string | null;
+    }
+  ): Promise<boolean>;
+  heartbeat(
+    businessId: string,
+    runId: string,
+    owner: string,
+    heartbeat: { expectedVersion: number; leaseExpiresAt: string }
+  ): Promise<boolean>;
+  reclaimExpiredRuns(
+    businessId: string,
+    now: string,
+    limit: number
+  ): Promise<readonly PersistedRun[]>;
+  claimNextQueued(
+    businessId: string,
+    owner: string,
+    input: { now: string; leaseDurationMs: number; limit: number }
+  ): Promise<readonly PersistedRun[]>;
+  find(businessId: string, runId: string): Promise<PersistedRun | null>;
+}
+
+export interface ClaimInput {
+  readonly businessId: string;
+  readonly runId: string;
+  readonly owner: string;
+  readonly now: Date;
+  readonly leaseDurationMs: number;
+  readonly expectedVersion: number;
+  readonly expectedStatus: RunStatus;
+  readonly status: LeasedRunStatus;
+}
+
+export interface ClaimResult {
+  readonly claimed: boolean;
+  readonly run: PersistedRun | null;
+}
+
+export interface HeartbeatInput {
+  readonly businessId: string;
+  readonly runId: string;
+  readonly owner: string;
+  readonly now: Date;
+  readonly leaseDurationMs: number;
+  readonly expectedVersion: number;
+}
+
+export interface ReleaseInput {
+  readonly businessId: string;
+  readonly runId: string;
+  readonly expectedVersion: number;
+  readonly expectedStatus: RunStatus;
+  readonly status: Exclude<RunStatus, LeasedRunStatus>;
+}
+
+export interface ReclaimInput {
+  readonly businessId: string;
+  readonly now: Date;
+  readonly limit: number;
+}
+
+export interface ClaimBatchInput {
+  readonly businessId: string;
+  readonly owner: string;
+  readonly now: Date;
+  readonly leaseDurationMs: number;
+  readonly limit: number;
+}
+
+/**
+ * Worker-lease behavior for durable Runs: claim (fresh or reclaimed), heartbeat, release, and
+ * bulk expiry reclaim. Every transition is validated against the canonical state machine before
+ * the CAS-guarded, persist-first write, so an illegal transition never reaches storage.
+ */
+export class RunLeaseManager {
+  constructor(private readonly store: RunLeaseStore) {}
+
+  /** Enters or stays in a leased status (`queued`->`claimed` or `claimed`->`running`). */
+  async claim(input: ClaimInput): Promise<ClaimResult> {
+    assertRunTransition(input.expectedStatus, input.status);
+    const leaseExpiresAt = new Date(input.now.getTime() + input.leaseDurationMs).toISOString();
+    const claimed = await this.store.transitionRun(input.businessId, input.runId, {
+      expectedVersion: input.expectedVersion,
+      expectedStatus: input.expectedStatus,
+      status: input.status,
+      leaseOwner: input.owner,
+      leaseExpiresAt,
+    });
+    if (!claimed) return { claimed: false, run: null };
+    return { claimed: true, run: await this.store.find(input.businessId, input.runId) };
+  }
+
+  /** Extends an owned lease without changing status; fails if another worker now owns it. */
+  async heartbeat(input: HeartbeatInput): Promise<boolean> {
+    const leaseExpiresAt = new Date(input.now.getTime() + input.leaseDurationMs).toISOString();
+    return this.store.heartbeat(input.businessId, input.runId, input.owner, {
+      expectedVersion: input.expectedVersion,
+      leaseExpiresAt,
+    });
+  }
+
+  /** Leaves a leased status for a non-leased one, clearing the lease. */
+  async release(input: ReleaseInput): Promise<boolean> {
+    assertRunTransition(input.expectedStatus, input.status);
+    return this.store.transitionRun(input.businessId, input.runId, {
+      expectedVersion: input.expectedVersion,
+      expectedStatus: input.expectedStatus,
+      status: input.status,
+      leaseOwner: null,
+      leaseExpiresAt: null,
+    });
+  }
+
+  /** Requeues Runs whose worker lease expired so a new worker can claim them. */
+  async reclaimExpired(input: ReclaimInput): Promise<readonly PersistedRun[]> {
+    return this.store.reclaimExpiredRuns(input.businessId, input.now.toISOString(), input.limit);
+  }
+
+  /** Claims a batch of due, queued Runs with an owned lease for a worker to dispatch. */
+  async claimBatch(input: ClaimBatchInput): Promise<readonly PersistedRun[]> {
+    return this.store.claimNextQueued(input.businessId, input.owner, {
+      now: input.now.toISOString(),
+      leaseDurationMs: input.leaseDurationMs,
+      limit: input.limit,
+    });
+  }
+}

--- a/packages/storage/src/runs/index.ts
+++ b/packages/storage/src/runs/index.ts
@@ -3,6 +3,8 @@ export type {
   AppendAttemptResult,
   AttemptEvent,
   AttemptEvidence,
+  ClaimNextQueuedInput,
+  HeartbeatInput,
   PersistedRun,
   PersistedRunStatus,
   PersistedState,

--- a/packages/storage/src/runs/run-store.pg.test.ts
+++ b/packages/storage/src/runs/run-store.pg.test.ts
@@ -164,11 +164,15 @@ describe("RunStore (PostgreSQL)", () => {
         expectedVersion: 0,
         expectedStatus: "queued",
         status: "claimed",
+        leaseOwner: "worker-1",
+        leaseExpiresAt: "2026-07-24T10:01:00.000Z",
       }),
       store.transitionRun("business-1", run().id, {
         expectedVersion: 0,
         expectedStatus: "queued",
         status: "claimed",
+        leaseOwner: "worker-2",
+        leaseExpiresAt: "2026-07-24T10:01:00.000Z",
       }),
     ]);
 
@@ -177,6 +181,172 @@ describe("RunStore (PostgreSQL)", () => {
       status: "claimed",
       version: 1,
     });
+  });
+
+  it("claims a queued Run with an owned lease and rejects a stale double-claim", async () => {
+    await store.start(run());
+
+    const results = await Promise.all([
+      store.transitionRun("business-1", run().id, {
+        expectedVersion: 0,
+        expectedStatus: "queued",
+        status: "claimed",
+        leaseOwner: "worker-1",
+        leaseExpiresAt: "2026-07-24T10:01:00.000Z",
+      }),
+      store.transitionRun("business-1", run().id, {
+        expectedVersion: 0,
+        expectedStatus: "queued",
+        status: "claimed",
+        leaseOwner: "worker-2",
+        leaseExpiresAt: "2026-07-24T10:01:00.000Z",
+      }),
+    ]);
+
+    expect(results.filter(Boolean)).toHaveLength(1);
+    expect(await store.find("business-1", run().id)).toMatchObject({
+      status: "claimed",
+      version: 1,
+      leaseOwner: "worker-1",
+      leaseExpiresAt: "2026-07-24T10:01:00.000Z",
+    });
+  });
+
+  it("clears the lease when a Run transitions off claimed/running", async () => {
+    await store.start(run());
+    await store.transitionRun("business-1", run().id, {
+      expectedVersion: 0,
+      expectedStatus: "queued",
+      status: "claimed",
+      leaseOwner: "worker-1",
+      leaseExpiresAt: "2026-07-24T10:01:00.000Z",
+    });
+
+    await store.transitionRun("business-1", run().id, {
+      expectedVersion: 1,
+      expectedStatus: "claimed",
+      status: "queued",
+      leaseOwner: null,
+      leaseExpiresAt: null,
+    });
+
+    expect(await store.find("business-1", run().id)).toMatchObject({
+      status: "queued",
+      leaseOwner: null,
+      leaseExpiresAt: null,
+    });
+  });
+
+  it("extends the lease on heartbeat only for the owning worker", async () => {
+    await store.start(run());
+    await store.transitionRun("business-1", run().id, {
+      expectedVersion: 0,
+      expectedStatus: "queued",
+      status: "claimed",
+      leaseOwner: "worker-1",
+      leaseExpiresAt: "2026-07-24T10:01:00.000Z",
+    });
+
+    expect(
+      await store.heartbeat("business-1", run().id, "worker-2", {
+        expectedVersion: 1,
+        leaseExpiresAt: "2026-07-24T10:02:00.000Z",
+      })
+    ).toBe(false);
+
+    expect(
+      await store.heartbeat("business-1", run().id, "worker-1", {
+        expectedVersion: 1,
+        leaseExpiresAt: "2026-07-24T10:02:00.000Z",
+      })
+    ).toBe(true);
+
+    expect(await store.find("business-1", run().id)).toMatchObject({
+      version: 2,
+      leaseOwner: "worker-1",
+      leaseExpiresAt: "2026-07-24T10:02:00.000Z",
+    });
+  });
+
+  it("reclaims a Run whose lease expired so a new worker can take it over", async () => {
+    await store.start(run());
+    await store.transitionRun("business-1", run().id, {
+      expectedVersion: 0,
+      expectedStatus: "queued",
+      status: "claimed",
+      leaseOwner: "worker-1",
+      leaseExpiresAt: "2026-07-24T10:01:00.000Z",
+    });
+
+    const reclaimed = await store.reclaimExpiredRuns("business-1", "2026-07-24T10:01:00.001Z", 10);
+
+    expect(reclaimed).toEqual([
+      expect.objectContaining({ id: run().id, status: "queued", leaseOwner: null }),
+    ]);
+    expect(await store.find("business-1", run().id)).toMatchObject({
+      status: "queued",
+      version: 2,
+      leaseOwner: null,
+      leaseExpiresAt: null,
+    });
+  });
+
+  it("does not reclaim a Run whose lease has not expired", async () => {
+    await store.start(run());
+    await store.transitionRun("business-1", run().id, {
+      expectedVersion: 0,
+      expectedStatus: "queued",
+      status: "claimed",
+      leaseOwner: "worker-1",
+      leaseExpiresAt: "2026-07-24T10:01:00.000Z",
+    });
+
+    expect(await store.reclaimExpiredRuns("business-1", "2026-07-24T10:00:59.000Z", 10)).toEqual(
+      []
+    );
+  });
+
+  it("claims a batch of queued Runs with an owned, timed lease", async () => {
+    await store.start(run());
+    await store.start(run({ id: "00000000-0000-4000-8000-000000000002" }));
+
+    const claimed = await store.claimNextQueued("business-1", "worker-1", {
+      now: "2026-07-24T10:00:00.000Z",
+      leaseDurationMs: 60_000,
+      limit: 10,
+    });
+
+    expect(claimed).toEqual([
+      expect.objectContaining({
+        id: run().id,
+        status: "claimed",
+        leaseOwner: "worker-1",
+        leaseExpiresAt: "2026-07-24T10:01:00.000Z",
+      }),
+      expect.objectContaining({
+        id: "00000000-0000-4000-8000-000000000002",
+        status: "claimed",
+        leaseOwner: "worker-1",
+        leaseExpiresAt: "2026-07-24T10:01:00.000Z",
+      }),
+    ]);
+  });
+
+  it("does not claim an already-claimed Run for a second worker", async () => {
+    await store.start(run());
+    await store.claimNextQueued("business-1", "worker-1", {
+      now: "2026-07-24T10:00:00.000Z",
+      leaseDurationMs: 60_000,
+      limit: 10,
+    });
+
+    expect(
+      await store.claimNextQueued("business-1", "worker-2", {
+        now: "2026-07-24T10:00:01.000Z",
+        leaseDurationMs: 60_000,
+        limit: 10,
+      })
+    ).toEqual([]);
   });
 
   it("persists State status with the same optimistic concurrency boundary", async () => {

--- a/packages/storage/src/runs/run-store.ts
+++ b/packages/storage/src/runs/run-store.ts
@@ -82,6 +82,8 @@ export interface PersistedRun {
   readonly finishedAt: string | null;
   readonly resultArtifactId: string | null;
   readonly errorEvidenceRef: string | null;
+  readonly leaseOwner: string | null;
+  readonly leaseExpiresAt: string | null;
 }
 
 export interface PersistedState {
@@ -107,6 +109,20 @@ export interface RunTransitionInput {
   readonly finishedAt?: string;
   readonly resultArtifactId?: string;
   readonly errorEvidenceRef?: string;
+  /** Worker lease: required non-null for `claimed`/`running`, required null otherwise. */
+  readonly leaseOwner: string | null;
+  readonly leaseExpiresAt: string | null;
+}
+
+export interface HeartbeatInput {
+  readonly expectedVersion: number;
+  readonly leaseExpiresAt: string;
+}
+
+export interface ClaimNextQueuedInput {
+  readonly now: string;
+  readonly leaseDurationMs: number;
+  readonly limit: number;
 }
 
 export interface StateTransitionInput {
@@ -206,7 +222,13 @@ export const RUN_STORAGE_STATEMENTS: readonly string[] = [
     finished_at           timestamptz,
     result_artifact_id    text,
     error_evidence_ref    text,
-    UNIQUE (business_id, id)
+    lease_owner           text,
+    lease_expires_at      timestamptz,
+    UNIQUE (business_id, id),
+    CHECK (
+      (status IN ('claimed', 'running') AND lease_owner IS NOT NULL AND lease_expires_at IS NOT NULL)
+      OR (status NOT IN ('claimed', 'running') AND lease_owner IS NULL AND lease_expires_at IS NULL)
+    )
   )`,
   `CREATE TABLE IF NOT EXISTS run_states (
     business_id           text NOT NULL,
@@ -314,6 +336,8 @@ export const RUN_STORAGE_STATEMENTS: readonly string[] = [
     FOR EACH ROW EXECUTE FUNCTION reject_state_identity_change()`,
   `CREATE INDEX IF NOT EXISTS runs_status_idx
     ON runs (business_id, status, created_at)`,
+  `CREATE INDEX IF NOT EXISTS runs_lease_reclaim_idx
+    ON runs (business_id, status, lease_expires_at)`,
   `CREATE INDEX IF NOT EXISTS run_states_status_idx
     ON run_states (business_id, run_id, status)`,
   `CREATE INDEX IF NOT EXISTS state_attempts_order_idx
@@ -335,6 +359,8 @@ interface RunRow {
   finished_at: string | Date | null;
   result_artifact_id: string | null;
   error_evidence_ref: string | null;
+  lease_owner: string | null;
+  lease_expires_at: string | Date | null;
 }
 
 interface StateRow {
@@ -386,6 +412,8 @@ function persistedRun(row: RunRow): PersistedRun {
     finishedAt: optionalTimestamp(row.finished_at),
     resultArtifactId: row.result_artifact_id,
     errorEvidenceRef: row.error_evidence_ref,
+    leaseOwner: row.lease_owner,
+    leaseExpiresAt: optionalTimestamp(row.lease_expires_at),
   };
 }
 
@@ -407,7 +435,7 @@ function persistedState(row: StateRow): PersistedState {
 }
 
 const RUN_COLUMNS = `id, business_id, bundle, identity, bounds, status, version, created_at,
-  started_at, finished_at, result_artifact_id, error_evidence_ref`;
+  started_at, finished_at, result_artifact_id, error_evidence_ref, lease_owner, lease_expires_at`;
 const STATE_COLUMNS = `business_id, run_id, state_key, definition_ref, resolved_input, status,
   version, created_at, started_at, finished_at, result_artifact_id, error_evidence_ref`;
 
@@ -499,7 +527,9 @@ export class RunStore {
                 started_at = COALESCE($6::timestamptz, started_at),
                 finished_at = COALESCE($7::timestamptz, finished_at),
                 result_artifact_id = COALESCE($8, result_artifact_id),
-                error_evidence_ref = COALESCE($9, error_evidence_ref)
+                error_evidence_ref = COALESCE($9, error_evidence_ref),
+                lease_owner = $10,
+                lease_expires_at = $11::timestamptz
           WHERE business_id = $1
             AND id = $2
             AND version = $3
@@ -515,9 +545,107 @@ export class RunStore {
           transition.finishedAt ?? null,
           transition.resultArtifactId ?? null,
           transition.errorEvidenceRef ?? null,
+          transition.leaseOwner,
+          transition.leaseExpiresAt,
         ]
       );
       return result.rows.length === 1;
+    });
+  }
+
+  /** Extends an owned lease without changing status; fails if the lease moved to another worker. */
+  async heartbeat(
+    businessId: string,
+    runId: string,
+    owner: string,
+    heartbeat: HeartbeatInput
+  ): Promise<boolean> {
+    return this.transactions.withTransaction(async (transaction) => {
+      const result = await transaction.query<{ id: string }>(
+        `UPDATE runs
+            SET version = version + 1,
+                lease_expires_at = $5::timestamptz
+          WHERE business_id = $1
+            AND id = $2
+            AND version = $3
+            AND lease_owner = $4
+            AND status IN ('claimed', 'running')
+          RETURNING id`,
+        [businessId, runId, heartbeat.expectedVersion, owner, heartbeat.leaseExpiresAt]
+      );
+      return result.rows.length === 1;
+    });
+  }
+
+  /** Requeues Runs whose worker lease expired so another worker can claim them. */
+  async reclaimExpiredRuns(
+    businessId: string,
+    now: string,
+    limit: number
+  ): Promise<readonly PersistedRun[]> {
+    return this.transactions.withTransaction(async (transaction) => {
+      const result = await transaction.query<RunRow>(
+        `WITH candidates AS (
+           SELECT id
+             FROM runs
+            WHERE business_id = $1
+              AND status IN ('claimed', 'running')
+              AND lease_expires_at <= $2::timestamptz
+            ORDER BY lease_expires_at
+            FOR UPDATE SKIP LOCKED
+            LIMIT $3
+         )
+         UPDATE runs
+            SET status = 'queued',
+                version = version + 1,
+                lease_owner = NULL,
+                lease_expires_at = NULL
+           FROM candidates
+          WHERE runs.id = candidates.id
+         RETURNING runs.id, runs.business_id, runs.bundle, runs.identity, runs.bounds,
+                   runs.status, runs.version, runs.created_at, runs.started_at, runs.finished_at,
+                   runs.result_artifact_id, runs.error_evidence_ref, runs.lease_owner,
+                   runs.lease_expires_at`,
+        [businessId, now, Math.max(0, limit)]
+      );
+      return result.rows.map(persistedRun);
+    });
+  }
+
+  /** Claims a batch of queued Runs with an owned, timed lease so a worker can start them. */
+  async claimNextQueued(
+    businessId: string,
+    owner: string,
+    input: ClaimNextQueuedInput
+  ): Promise<readonly PersistedRun[]> {
+    return this.transactions.withTransaction(async (transaction) => {
+      const leaseExpiresAt = new Date(
+        new Date(input.now).getTime() + input.leaseDurationMs
+      ).toISOString();
+      const result = await transaction.query<RunRow>(
+        `WITH candidates AS (
+           SELECT id
+             FROM runs
+            WHERE business_id = $1
+              AND status = 'queued'
+            ORDER BY created_at
+            FOR UPDATE SKIP LOCKED
+            LIMIT $4
+         )
+         UPDATE runs
+            SET status = 'claimed',
+                version = version + 1,
+                lease_owner = $2,
+                lease_expires_at = $3::timestamptz
+           FROM candidates
+          WHERE runs.id = candidates.id
+         RETURNING runs.id, runs.business_id, runs.bundle, runs.identity, runs.bounds,
+                   runs.status, runs.version, runs.created_at, runs.started_at, runs.finished_at,
+                   runs.result_artifact_id, runs.error_evidence_ref, runs.lease_owner,
+                   runs.lease_expires_at`,
+        [businessId, owner, leaseExpiresAt, Math.max(0, input.limit)]
+      );
+      return result.rows.map(persistedRun);
     });
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -380,6 +380,9 @@ importers:
 
   apps/worker:
     dependencies:
+      '@tulipfarm/run-kernel':
+        specifier: workspace:*
+        version: link:../../packages/run-kernel
       '@tulipfarm/storage':
         specifier: workspace:*
         version: link:../../packages/storage
@@ -619,6 +622,10 @@ importers:
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.0(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/run-kernel:
+    dependencies:
+      '@tulipfarm/storage':
+        specifier: workspace:*
+        version: link:../storage
     devDependencies:
       '@tulipfarm/tsconfig':
         specifier: workspace:*


### PR DESCRIPTION
## Summary
- Extend `packages/storage`'s `runs` table with `lease_owner`/`lease_expires_at` (CHECK-enforced only for `claimed`/`running`), plus `heartbeat`, `reclaimExpiredRuns`, and `claimNextQueued` bulk-claim methods, all CAS-guarded via the existing `version` column.
- Add `RunLeaseManager` in `packages/run-kernel` (`claim`, `heartbeat`, `release`, `reclaimExpired`, `claimBatch`) validating every transition against the canonical state machine (`model/run.ts`) before any persistence call.
- Compose `RunDispatcher` in `apps/worker`, mirroring `EventOutboxDispatcher`: reclaims expired leases, claims a batch of due Runs, advances each to `running`, and releases to a terminal status (or `needs_reconciliation` on a thrown handler error).

## Test plan
- `pnpm --filter @tulipfarm/storage exec vitest run` — 13 files, 70 passed
- `pnpm --filter @tulipfarm/run-kernel exec vitest run` — 2 files, 10 passed
- `pnpm --filter @tulipfarm/worker exec vitest run` — 2 files, 5 passed
- `biome check --write` + `tsc --noEmit` clean for all three packages