### PR TITLE
feat(run-kernel): implement durable waits, timers, and resume tokens (AW-031)

### DIFF
--- a/apps/api/src/pg-migrations/index.ts
+++ b/apps/api/src/pg-migrations/index.ts
@@ -2,6 +2,7 @@ import {
   ARTIFACT_STORAGE_STATEMENTS,
   EVENT_STORAGE_STATEMENTS,
   RUN_STORAGE_STATEMENTS,
+  WAIT_STORAGE_STATEMENTS,
 } from "@tulipfarm/storage";
 import type { Queryable } from "../db";
 
@@ -461,6 +462,15 @@ export const PG_MIGRATIONS: PgMigration[] = [
     description: "immutable typed outputs and Artifacts",
     up: async (q) => {
       for (const sql of ARTIFACT_STORAGE_STATEMENTS) {
+        await q.query(sql);
+      }
+    },
+  },
+  {
+    version: 6,
+    description: "durable waits, timers, and resume tokens",
+    up: async (q) => {
+      for (const sql of WAIT_STORAGE_STATEMENTS) {
         await q.query(sql);
       }
     },

--- a/packages/run-kernel/AGENTS.md
+++ b/packages/run-kernel/AGENTS.md
@@ -4,8 +4,10 @@
 retries, cancellation, child Runs, and concurrency. **Today:** `src/model` (state machines),
 `src/lease` (worker leases), `src/outputs` (AJV-validated typed State outputs + canonical hashes),
 `src/artifacts` (immutable Artifact publish/read with ACL, classification, retention, redaction,
-and tamper checks), and `src/lineage` (named State-output mappings resolved into downstream
-Context). tsconfig extends `@tulipfarm/tsconfig/base.json`. See root `AGENTS.md` for commands/lint.
+and tamper checks), `src/lineage` (named State-output mappings resolved into downstream
+Context), and `src/waits`, `src/timers`, `src/resume` (durable timer/event/Approval/human-task/
+form/child-Run waits with `first`/`all`/`quorum`/window aggregation, deadline sweeps, and
+unguessable one-use resume tokens). tsconfig extends `@tulipfarm/tsconfig/base.json`. See root `AGENTS.md` for commands/lint.
 
 May import: `@tulipfarm/schema`, `@tulipfarm/audit`, `@tulipfarm/storage`,
 `@tulipfarm/observability`. See

--- a/packages/run-kernel/src/index.ts
+++ b/packages/run-kernel/src/index.ts
@@ -3,3 +3,6 @@ export * from "./lease";
 export * from "./lineage";
 export * from "./model";
 export * from "./outputs";
+export * from "./resume";
+export * from "./timers";
+export * from "./waits";

--- a/packages/run-kernel/src/resume.test.ts
+++ b/packages/run-kernel/src/resume.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+  hashResumeToken,
+  mintResumeToken,
+  RunResumeGateway,
+  type RunResumeStore,
+  resumeTokenHashEquals,
+} from "./resume";
+
+describe("resume tokens", () => {
+  it("mints unguessable, unique tokens with a matching digest", () => {
+    const minted = Array.from({ length: 64 }, () => mintResumeToken());
+
+    for (const { token, tokenHash } of minted) {
+      expect(token).toMatch(/^[A-Za-z0-9_-]{43}$/);
+      expect(tokenHash).toBe(hashResumeToken(token));
+      expect(tokenHash).not.toContain(token);
+    }
+    expect(new Set(minted.map((entry) => entry.token)).size).toBe(minted.length);
+  });
+
+  it("compares digests without leaking length mismatches as a throw", () => {
+    const { tokenHash } = mintResumeToken();
+
+    expect(resumeTokenHashEquals(tokenHash, tokenHash)).toBe(true);
+    expect(resumeTokenHashEquals(tokenHash, "short")).toBe(false);
+  });
+});
+
+describe("RunResumeGateway", () => {
+  it("requeues a waiting Run once and reports a Run that already moved", async () => {
+    const calls: string[] = [];
+    const waiting = new Set(["business-1:run-1"]);
+    const store: RunResumeStore = {
+      async requeueWaitingRun(businessId, runId) {
+        calls.push(`${businessId}:${runId}`);
+        return waiting.delete(`${businessId}:${runId}`);
+      },
+    };
+    const gateway = new RunResumeGateway(store);
+
+    expect(await gateway.resume("business-1", "run-1")).toBe(true);
+    expect(await gateway.resume("business-1", "run-1")).toBe(false);
+    expect(calls).toHaveLength(2);
+  });
+});

--- a/packages/run-kernel/src/resume.ts
+++ b/packages/run-kernel/src/resume.ts
@@ -1,0 +1,50 @@
+import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
+import { assertRunTransition } from "./model";
+
+/** Entropy of a resume token. 256 bits keeps the token unguessable under offline enumeration. */
+const RESUME_TOKEN_BYTES = 32;
+
+export interface MintedResumeToken {
+  /** Returned to the caller exactly once; never persisted, logged, or placed in an Artifact. */
+  readonly token: string;
+  /** SHA-256 of the token — the only form that reaches storage. */
+  readonly tokenHash: string;
+}
+
+/** Creates an unguessable one-use resume token and the digest stored beside the wait. */
+export function mintResumeToken(): MintedResumeToken {
+  const token = randomBytes(RESUME_TOKEN_BYTES).toString("base64url");
+  return { token, tokenHash: hashResumeToken(token) };
+}
+
+/** Digest used to look a wait up by presented token; storage never sees the token itself. */
+export function hashResumeToken(token: string): string {
+  return createHash("sha256").update(token, "utf8").digest("hex");
+}
+
+/** Constant-time digest comparison for callers that hold two hashes. */
+export function resumeTokenHashEquals(left: string, right: string): boolean {
+  const leftBytes = Buffer.from(left, "utf8");
+  const rightBytes = Buffer.from(right, "utf8");
+  if (leftBytes.length !== rightBytes.length) return false;
+  return timingSafeEqual(leftBytes, rightBytes);
+}
+
+/** Narrow surface `RunResumeGateway` needs; `@tulipfarm/storage`'s `RunStore` satisfies it. */
+export interface RunResumeStore {
+  requeueWaitingRun(businessId: string, runId: string): Promise<boolean>;
+}
+
+/**
+ * Moves a Run out of `waiting` once its durable wait resolved. The transition is validated
+ * against the canonical state machine and applied under a status guard, so duplicate delivery,
+ * a concurrent worker, or a restart requeues the Run exactly once.
+ */
+export class RunResumeGateway {
+  constructor(private readonly store: RunResumeStore) {}
+
+  async resume(businessId: string, runId: string): Promise<boolean> {
+    assertRunTransition("waiting", "queued");
+    return this.store.requeueWaitingRun(businessId, runId);
+  }
+}

--- a/packages/run-kernel/src/timers.test.ts
+++ b/packages/run-kernel/src/timers.test.ts
@@ -1,0 +1,152 @@
+import { MemoryWaitStore } from "@tulipfarm/storage";
+import { beforeEach, describe, expect, it } from "vitest";
+import { RunResumeGateway, type RunResumeStore } from "./resume";
+import { WaitTimerSweeper } from "./timers";
+import { DurableWaitManager, type RegisterWaitInput } from "./waits";
+
+const BUSINESS = "business-1";
+const RUN = "00000000-0000-4000-8000-000000000001";
+const CREATED_AT = "2026-07-25T10:00:00.000Z";
+const DEADLINE = "2026-07-25T10:05:00.000Z";
+const SCHEMA = "sha256:bundle-1#/states/wait/signal";
+const AFTER_DEADLINE = new Date("2026-07-25T10:06:00.000Z");
+
+class FakeResumeStore implements RunResumeStore {
+  readonly waiting = new Set<string>([`${BUSINESS}:${RUN}`]);
+  readonly requeued: string[] = [];
+
+  async requeueWaitingRun(businessId: string, runId: string): Promise<boolean> {
+    const key = `${businessId}:${runId}`;
+    if (!this.waiting.delete(key)) return false;
+    this.requeued.push(key);
+    return true;
+  }
+}
+
+function waitInput(overrides: Partial<RegisterWaitInput> = {}): RegisterWaitInput {
+  return {
+    id: "00000000-0000-4000-8000-0000000000a1",
+    businessId: BUSINESS,
+    runId: RUN,
+    stateKey: "await-approval",
+    kind: "event",
+    aggregation: "first",
+    schemaRef: SCHEMA,
+    allowedPrincipals: ["user:alice"],
+    expectedSignals: 1,
+    quorum: null,
+    deadlineAt: DEADLINE,
+    createdAt: CREATED_AT,
+    ...overrides,
+  };
+}
+
+describe("WaitTimerSweeper", () => {
+  let store: MemoryWaitStore;
+  let runs: FakeResumeStore;
+  let manager: DurableWaitManager;
+  let sweeper: WaitTimerSweeper;
+
+  beforeEach(() => {
+    store = new MemoryWaitStore();
+    runs = new FakeResumeStore();
+    const resume = new RunResumeGateway(runs);
+    manager = new DurableWaitManager(store, resume);
+    sweeper = new WaitTimerSweeper(store, resume);
+  });
+
+  it("fires a due timer and resumes its Run", async () => {
+    const { wait } = await manager.register(
+      waitInput({ kind: "timer", allowedPrincipals: [], stateKey: "sleep" })
+    );
+
+    const swept = await sweeper.sweep({ businessId: BUSINESS, now: AFTER_DEADLINE, limit: 10 });
+
+    expect(swept).toHaveLength(1);
+    expect(swept[0]).toMatchObject({ resumed: true });
+    expect(swept[0]?.wait.status).toBe("satisfied");
+    expect((await manager.find(BUSINESS, wait.id))?.status).toBe("satisfied");
+  });
+
+  it("times out an unsatisfied event wait and still resumes its Run", async () => {
+    await manager.register(waitInput());
+
+    const swept = await sweeper.sweep({ businessId: BUSINESS, now: AFTER_DEADLINE, limit: 10 });
+
+    expect(swept[0]?.wait.status).toBe("timed_out");
+    expect(swept[0]?.resumed).toBe(true);
+  });
+
+  it("closes a window wait as satisfied when it collected signals, timed out when empty", async () => {
+    const collected = await manager.register(
+      waitInput({ aggregation: "window", expectedSignals: 5 })
+    );
+    const empty = await manager.register(
+      waitInput({
+        id: "00000000-0000-4000-8000-0000000000a2",
+        aggregation: "window",
+        expectedSignals: 5,
+        stateKey: "await-window",
+      })
+    );
+    await manager.signal({
+      id: "00000000-0000-4000-8000-0000000000b1",
+      businessId: BUSINESS,
+      runId: RUN,
+      token: collected.token,
+      principal: "user:alice",
+      schemaRef: SCHEMA,
+      correlationKey: "delivery-1",
+      signalDigest: "sha256:signal-1",
+      receivedAt: "2026-07-25T10:01:00.000Z",
+    });
+
+    await sweeper.sweep({ businessId: BUSINESS, now: AFTER_DEADLINE, limit: 10 });
+
+    expect((await manager.find(BUSINESS, collected.wait.id))?.status).toBe("satisfied");
+    expect((await manager.find(BUSINESS, empty.wait.id))?.status).toBe("timed_out");
+  });
+
+  it("resolves and resumes exactly once when the sweep runs twice", async () => {
+    await manager.register(waitInput({ kind: "timer", allowedPrincipals: [], stateKey: "sleep" }));
+
+    await sweeper.sweep({ businessId: BUSINESS, now: AFTER_DEADLINE, limit: 10 });
+    const second = await sweeper.sweep({ businessId: BUSINESS, now: AFTER_DEADLINE, limit: 10 });
+
+    expect(second).toHaveLength(0);
+    expect(runs.requeued).toHaveLength(1);
+  });
+
+  it("leaves a wait pending before its deadline", async () => {
+    const { wait } = await manager.register(waitInput());
+
+    const swept = await sweeper.sweep({
+      businessId: BUSINESS,
+      now: new Date("2026-07-25T10:04:00.000Z"),
+      limit: 10,
+    });
+
+    expect(swept).toHaveLength(0);
+    expect((await manager.find(BUSINESS, wait.id))?.status).toBe("pending");
+  });
+
+  it("denies a signal that arrives after the timeout consumed the token", async () => {
+    const { token } = await manager.register(waitInput());
+    await sweeper.sweep({ businessId: BUSINESS, now: AFTER_DEADLINE, limit: 10 });
+
+    await expect(
+      manager.signal({
+        id: "00000000-0000-4000-8000-0000000000b1",
+        businessId: BUSINESS,
+        runId: RUN,
+        token,
+        principal: "user:alice",
+        schemaRef: SCHEMA,
+        correlationKey: "delivery-1",
+        signalDigest: "sha256:signal-1",
+        receivedAt: "2026-07-25T10:07:00.000Z",
+      })
+    ).rejects.toMatchObject({ code: "wait_already_resolved" });
+    expect(runs.requeued).toHaveLength(1);
+  });
+});

--- a/packages/run-kernel/src/timers.ts
+++ b/packages/run-kernel/src/timers.ts
@@ -1,0 +1,71 @@
+import type { DueWaitDecision, PersistedWait, ResolvedDueWait } from "@tulipfarm/storage";
+import type { RunResumeGateway } from "./resume";
+
+/** Narrow surface `WaitTimerSweeper` needs; `@tulipfarm/storage`'s `WaitStore` satisfies it. */
+export interface WaitTimerStore {
+  resolveDue(
+    businessId: string,
+    now: string,
+    limit: number,
+    decide: DueWaitDecision
+  ): Promise<readonly ResolvedDueWait[]>;
+}
+
+export interface SweptWait {
+  readonly wait: PersistedWait;
+  readonly signalCount: number;
+  /** False when the wait resolved but its Run had already left `waiting` — needs reconciliation. */
+  readonly resumed: boolean;
+}
+
+export interface SweepInput {
+  readonly businessId: string;
+  readonly now: Date;
+  readonly limit: number;
+}
+
+/**
+ * Deadline resolution for a due wait. A timer fires; a bounded window closes with whatever it
+ * collected; every other unsatisfied wait times out. Aggregation that could still be satisfied by
+ * a signal has already been resolved by the delivery path, so a due wait here never over-counts.
+ */
+export function resolveDueWait(
+  wait: PersistedWait,
+  signalCount: number
+): "satisfied" | "timed_out" {
+  if (wait.kind === "timer") return "satisfied";
+  if (wait.aggregation === "window" && signalCount > 0) return "satisfied";
+  return "timed_out";
+}
+
+/**
+ * Durable timer sweep. Resolves every wait past its deadline, consuming its one-use resume token
+ * in the same transaction, then requeues the waiting Run. Resolution is guarded on `pending`, so
+ * a concurrent sweeper, a duplicate delivery, or a restarted worker resumes each Run exactly once
+ * — the resolved status tells the Run whether it fired or timed out.
+ */
+export class WaitTimerSweeper {
+  constructor(
+    private readonly store: WaitTimerStore,
+    private readonly resume: RunResumeGateway
+  ) {}
+
+  async sweep(input: SweepInput): Promise<readonly SweptWait[]> {
+    const resolved = await this.store.resolveDue(
+      input.businessId,
+      input.now.toISOString(),
+      input.limit,
+      resolveDueWait
+    );
+
+    const swept: SweptWait[] = [];
+    for (const entry of resolved) {
+      swept.push({
+        wait: entry.wait,
+        signalCount: entry.signalCount,
+        resumed: await this.resume.resume(input.businessId, entry.wait.runId),
+      });
+    }
+    return swept;
+  }
+}

--- a/packages/run-kernel/src/waits.test.ts
+++ b/packages/run-kernel/src/waits.test.ts
@@ -1,0 +1,225 @@
+import { MemoryWaitStore } from "@tulipfarm/storage";
+import { beforeEach, describe, expect, it } from "vitest";
+import { RunResumeGateway, type RunResumeStore } from "./resume";
+import {
+  DurableWaitError,
+  DurableWaitManager,
+  type RegisterWaitInput,
+  type SignalWaitInput,
+} from "./waits";
+
+const BUSINESS = "business-1";
+const RUN = "00000000-0000-4000-8000-000000000001";
+const CREATED_AT = "2026-07-25T10:00:00.000Z";
+const DEADLINE = "2026-07-25T10:05:00.000Z";
+const SCHEMA = "sha256:bundle-1#/states/wait/signal";
+
+/** Requeues only Runs still in `waiting`, like `RunStore.requeueWaitingRun`. */
+class FakeResumeStore implements RunResumeStore {
+  readonly waiting = new Set<string>([`${BUSINESS}:${RUN}`]);
+  readonly requeued: string[] = [];
+
+  async requeueWaitingRun(businessId: string, runId: string): Promise<boolean> {
+    const key = `${businessId}:${runId}`;
+    if (!this.waiting.delete(key)) return false;
+    this.requeued.push(key);
+    return true;
+  }
+}
+
+function waitInput(overrides: Partial<RegisterWaitInput> = {}): RegisterWaitInput {
+  return {
+    id: "00000000-0000-4000-8000-0000000000a1",
+    businessId: BUSINESS,
+    runId: RUN,
+    stateKey: "await-approval",
+    kind: "event",
+    aggregation: "first",
+    schemaRef: SCHEMA,
+    allowedPrincipals: ["user:alice", "user:bob"],
+    expectedSignals: 1,
+    quorum: null,
+    deadlineAt: DEADLINE,
+    createdAt: CREATED_AT,
+    ...overrides,
+  };
+}
+
+function signalInput(token: string, overrides: Partial<SignalWaitInput> = {}): SignalWaitInput {
+  return {
+    id: "00000000-0000-4000-8000-0000000000b1",
+    businessId: BUSINESS,
+    runId: RUN,
+    token,
+    principal: "user:alice",
+    schemaRef: SCHEMA,
+    correlationKey: "delivery-1",
+    signalDigest: "sha256:signal-1",
+    receivedAt: "2026-07-25T10:01:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("DurableWaitManager", () => {
+  let store: MemoryWaitStore;
+  let runs: FakeResumeStore;
+  let manager: DurableWaitManager;
+
+  beforeEach(() => {
+    store = new MemoryWaitStore();
+    runs = new FakeResumeStore();
+    manager = new DurableWaitManager(store, new RunResumeGateway(runs));
+  });
+
+  it("resumes the Run when a first-aggregation wait receives one authorized signal", async () => {
+    const { token, wait } = await manager.register(waitInput());
+    expect(wait.status).toBe("pending");
+
+    const result = await manager.signal(signalInput(token));
+
+    expect(result.outcome).toBe("resumed");
+    expect(result.wait.status).toBe("satisfied");
+    expect(runs.requeued).toEqual([`${BUSINESS}:${RUN}`]);
+  });
+
+  it("never persists the resume token, only its digest", async () => {
+    const { token, wait } = await manager.register(waitInput());
+    expect(JSON.stringify(await manager.find(BUSINESS, wait.id))).not.toContain(token);
+  });
+
+  it("resumes exactly once under duplicate delivery of the same signal", async () => {
+    const { token } = await manager.register(waitInput());
+    await manager.signal(signalInput(token));
+
+    const replay = await manager.signal(signalInput(token));
+
+    expect(replay.outcome).toBe("duplicate");
+    expect(runs.requeued).toHaveLength(1);
+  });
+
+  it("denies a second signal after the wait resolved, without consuming aggregation", async () => {
+    const { token, wait } = await manager.register(waitInput());
+    await manager.signal(signalInput(token));
+
+    await expect(
+      manager.signal(
+        signalInput(token, {
+          id: "00000000-0000-4000-8000-0000000000b2",
+          correlationKey: "delivery-2",
+        })
+      )
+    ).rejects.toMatchObject({ code: "wait_already_resolved" });
+    expect(await manager.listSignals(BUSINESS, wait.id)).toHaveLength(1);
+  });
+
+  it("resumes exactly once across a restart, from a manager rebuilt over the same store", async () => {
+    const { token } = await manager.register(waitInput());
+    await manager.signal(signalInput(token));
+
+    const restarted = new DurableWaitManager(store, new RunResumeGateway(runs));
+
+    expect((await restarted.signal(signalInput(token))).outcome).toBe("duplicate");
+    expect(runs.requeued).toHaveLength(1);
+  });
+
+  it.each([
+    ["wrong_run", { runId: "00000000-0000-4000-8000-0000000000ff" }],
+    ["wrong_principal", { principal: "user:mallory" }],
+    ["wrong_schema", { schemaRef: `${SCHEMA}.v2` }],
+    ["wait_expired", { receivedAt: "2026-07-25T10:06:00.000Z" }],
+  ])("denies a signal with %s and records nothing", async (code, override) => {
+    const { token, wait } = await manager.register(waitInput());
+
+    await expect(manager.signal(signalInput(token, override))).rejects.toMatchObject({ code });
+    expect(await manager.listSignals(BUSINESS, wait.id)).toHaveLength(0);
+    expect((await manager.find(BUSINESS, wait.id))?.status).toBe("pending");
+    expect(runs.requeued).toHaveLength(0);
+  });
+
+  it("denies an unknown resume token without revealing a wait", async () => {
+    await manager.register(waitInput());
+
+    await expect(manager.signal(signalInput("not-a-real-token"))).rejects.toMatchObject({
+      code: "unknown_resume_token",
+    });
+  });
+
+  it("denies signalling a timer wait", async () => {
+    const { token } = await manager.register(
+      waitInput({ kind: "timer", allowedPrincipals: [], stateKey: "sleep" })
+    );
+
+    await expect(manager.signal(signalInput(token))).rejects.toMatchObject({
+      code: "wait_not_signalable",
+    });
+  });
+
+  it("resumes an all-aggregation wait only once every expected signal arrived", async () => {
+    const { token, wait } = await manager.register(
+      waitInput({ aggregation: "all", expectedSignals: 2 })
+    );
+
+    const first = await manager.signal(signalInput(token));
+    expect(first.outcome).toBe("recorded");
+    expect(runs.requeued).toHaveLength(0);
+
+    const second = await manager.signal(
+      signalInput(token, {
+        id: "00000000-0000-4000-8000-0000000000b2",
+        principal: "user:bob",
+        correlationKey: "delivery-2",
+      })
+    );
+
+    expect(second.outcome).toBe("resumed");
+    expect(second.signalCount).toBe(2);
+    expect((await manager.find(BUSINESS, wait.id))?.status).toBe("satisfied");
+  });
+
+  it("resumes a quorum wait at the quorum, not at the expected count", async () => {
+    const { token } = await manager.register(
+      waitInput({ aggregation: "quorum", expectedSignals: 3, quorum: 2 })
+    );
+
+    expect((await manager.signal(signalInput(token))).outcome).toBe("recorded");
+    const quorumReached = await manager.signal(
+      signalInput(token, {
+        id: "00000000-0000-4000-8000-0000000000b2",
+        principal: "user:bob",
+        correlationKey: "delivery-2",
+      })
+    );
+
+    expect(quorumReached.outcome).toBe("resumed");
+    expect(runs.requeued).toHaveLength(1);
+  });
+
+  it("never resolves a window wait on delivery; the deadline closes it", async () => {
+    const { token } = await manager.register(
+      waitInput({ aggregation: "window", expectedSignals: 5 })
+    );
+
+    expect((await manager.signal(signalInput(token))).outcome).toBe("recorded");
+    expect(runs.requeued).toHaveLength(0);
+  });
+
+  it("reports resolution without resume when the Run already left waiting", async () => {
+    const { token } = await manager.register(waitInput());
+    runs.waiting.clear();
+
+    const result = await manager.signal(signalInput(token));
+
+    expect(result.outcome).toBe("resolved_without_resume");
+    expect(result.wait.status).toBe("satisfied");
+  });
+
+  it.each([
+    ["timer aggregation", { kind: "timer" as const, aggregation: "all" as const }],
+    ["missing principals", { allowedPrincipals: [] }],
+    ["quorum above expected", { aggregation: "quorum" as const, expectedSignals: 2, quorum: 3 }],
+    ["quorum without aggregation", { quorum: 1 }],
+    ["deadline before creation", { deadlineAt: "2026-07-25T09:00:00.000Z" }],
+  ])("rejects an invalid wait definition: %s", async (_name, override) => {
+    await expect(manager.register(waitInput(override))).rejects.toBeInstanceOf(DurableWaitError);
+  });
+});

--- a/packages/run-kernel/src/waits.ts
+++ b/packages/run-kernel/src/waits.ts
@@ -1,0 +1,236 @@
+import type {
+  CreateWaitInput,
+  PersistedWait,
+  PersistedWaitKind,
+  PersistedWaitSignal,
+  WaitAggregation,
+  WaitDeliveryResult,
+  WaitSignalInput,
+  WaitSignalPolicy,
+} from "@tulipfarm/storage";
+import { hashResumeToken, mintResumeToken, type RunResumeGateway } from "./resume";
+
+export type { PersistedWait, PersistedWaitKind, WaitAggregation };
+
+export type DurableWaitErrorCode =
+  | "invalid_wait_definition"
+  | "unknown_resume_token"
+  | "wait_already_resolved"
+  | "wait_expired"
+  | "wait_not_signalable"
+  | "wrong_principal"
+  | "wrong_run"
+  | "wrong_schema";
+
+/**
+ * Durable-wait denial. The message carries the reason code and the wait/Run identity only —
+ * never the signal payload, principal credentials, or resume token.
+ */
+export class DurableWaitError extends Error {
+  readonly name = "DurableWaitError";
+
+  constructor(
+    readonly code: DurableWaitErrorCode,
+    readonly detail = ""
+  ) {
+    super(`${code}${detail ? `:${detail}` : ""}`);
+  }
+}
+
+export interface RegisterWaitInput {
+  readonly id: string;
+  readonly businessId: string;
+  readonly runId: string;
+  readonly stateKey: string;
+  readonly kind: PersistedWaitKind;
+  readonly aggregation: WaitAggregation;
+  /** Schema reference every accepted signal must declare; a timer still names its wait schema. */
+  readonly schemaRef: string;
+  /** Canonical `kind:id` principals authorized to signal; empty only for a timer. */
+  readonly allowedPrincipals: readonly string[];
+  readonly expectedSignals: number;
+  readonly quorum: number | null;
+  readonly deadlineAt: string;
+  readonly createdAt: string;
+}
+
+export interface RegisteredWait {
+  readonly wait: PersistedWait;
+  /** Plaintext resume token, returned once. Storage holds only its SHA-256 digest. */
+  readonly token: string;
+}
+
+export interface SignalWaitInput {
+  readonly id: string;
+  readonly businessId: string;
+  readonly runId: string;
+  readonly token: string;
+  readonly principal: string;
+  readonly schemaRef: string;
+  /** Stable identity of this signal; a repeat delivery of the same identity is deduplicated. */
+  readonly correlationKey: string;
+  readonly signalDigest: string;
+  readonly receivedAt: string;
+}
+
+export type WaitSignalOutcome = "resumed" | "resolved_without_resume" | "recorded" | "duplicate";
+
+export interface WaitSignalResult {
+  /**
+   * `resumed` — the wait resolved and its Run left `waiting`. `resolved_without_resume` — the
+   * wait resolved exactly once but the Run was no longer `waiting`, so it needs reconciliation.
+   * `recorded` — counted toward aggregation. `duplicate` — already-seen correlation key.
+   */
+  readonly outcome: WaitSignalOutcome;
+  readonly wait: PersistedWait;
+  readonly signalCount: number;
+}
+
+/** Narrow surface `DurableWaitManager` needs; `@tulipfarm/storage`'s `WaitStore` satisfies it. */
+export interface DurableWaitStore {
+  create(input: CreateWaitInput): Promise<PersistedWait>;
+  find(businessId: string, waitId: string): Promise<PersistedWait | null>;
+  listSignals(businessId: string, waitId: string): Promise<readonly PersistedWaitSignal[]>;
+  deliverSignal(input: WaitSignalInput, policy: WaitSignalPolicy): Promise<WaitDeliveryResult>;
+}
+
+function assertDefinition(input: RegisterWaitInput): void {
+  const fail = (detail: string): never => {
+    throw new DurableWaitError("invalid_wait_definition", detail);
+  };
+  if (input.schemaRef.length === 0) fail("schemaRef");
+  if (input.deadlineAt <= input.createdAt) fail("deadlineAt");
+  if (input.kind === "timer") {
+    if (input.aggregation !== "first" || input.expectedSignals !== 1) fail("timer");
+  } else if (input.allowedPrincipals.length === 0) {
+    fail("allowedPrincipals");
+  }
+  if (input.expectedSignals < 1) fail("expectedSignals");
+  if (input.aggregation === "first" && input.expectedSignals !== 1) fail("expectedSignals");
+  if (input.aggregation === "quorum") {
+    if (input.quorum === null || input.quorum < 1 || input.quorum > input.expectedSignals) {
+      fail("quorum");
+    }
+  } else if (input.quorum !== null) {
+    fail("quorum");
+  }
+}
+
+/**
+ * Default-deny authorization for one delivery, evaluated under the wait's lock. Identity checks
+ * always apply, so a replayed correlation key from another Run, schema, or principal is still
+ * denied. Lifecycle checks are skipped for a signal already recorded under this wait: an
+ * at-least-once redelivery of accepted work is idempotent, not a late or duplicate resume.
+ */
+export function authorizeSignal(
+  wait: PersistedWait,
+  input: SignalWaitInput,
+  isDuplicate: boolean
+): DurableWaitErrorCode | null {
+  if (wait.runId !== input.runId) return "wrong_run";
+  if (wait.kind === "timer") return "wait_not_signalable";
+  if (wait.schemaRef !== input.schemaRef) return "wrong_schema";
+  if (!wait.allowedPrincipals.includes(input.principal)) return "wrong_principal";
+  if (isDuplicate) return null;
+  if (wait.status !== "pending") return "wait_already_resolved";
+  if (input.receivedAt >= wait.deadlineAt) return "wait_expired";
+  return null;
+}
+
+/** SPEC §9.2 aggregation: `first`, `all`, `quorum`, or a bounded window closed by its deadline. */
+export function isWaitSatisfied(wait: PersistedWait, signalCount: number): boolean {
+  switch (wait.aggregation) {
+    case "first":
+      return signalCount >= 1;
+    case "all":
+      return signalCount >= wait.expectedSignals;
+    case "quorum":
+      return wait.quorum !== null && signalCount >= wait.quorum;
+    case "window":
+      return false;
+  }
+}
+
+/**
+ * Durable timer, event, Approval, human-task, form, and child-Run waits (SPEC §7.2, §9.2). A wait
+ * is persisted before the Run stops consuming a worker; it is redeemed through an unguessable
+ * one-use resume token whose digest alone is stored. Storage resolves the wait and consumes the
+ * token under one row lock, so a duplicate delivery, a wrong-principal attempt, a concurrent
+ * worker, or a restart still resumes the Run exactly once.
+ */
+export class DurableWaitManager {
+  constructor(
+    private readonly store: DurableWaitStore,
+    private readonly resume: RunResumeGateway
+  ) {}
+
+  /** Persists a wait and returns its resume token once. */
+  async register(input: RegisterWaitInput): Promise<RegisteredWait> {
+    assertDefinition(input);
+    const { token, tokenHash } = mintResumeToken();
+    const wait = await this.store.create({
+      id: input.id,
+      businessId: input.businessId,
+      runId: input.runId,
+      stateKey: input.stateKey,
+      kind: input.kind,
+      aggregation: input.aggregation,
+      schemaRef: input.schemaRef,
+      allowedPrincipals: input.allowedPrincipals,
+      expectedSignals: input.expectedSignals,
+      quorum: input.quorum,
+      tokenHash,
+      deadlineAt: input.deadlineAt,
+      createdAt: input.createdAt,
+    });
+    return { wait, token };
+  }
+
+  /** Redeems a resume token. Denials throw; accepted deliveries report their aggregation effect. */
+  async signal(input: SignalWaitInput): Promise<WaitSignalResult> {
+    const result = await this.store.deliverSignal(
+      {
+        id: input.id,
+        businessId: input.businessId,
+        tokenHash: hashResumeToken(input.token),
+        runId: input.runId,
+        correlationKey: input.correlationKey,
+        signalDigest: input.signalDigest,
+        principal: input.principal,
+        receivedAt: input.receivedAt,
+      },
+      {
+        authorize: (wait, isDuplicate) => authorizeSignal(wait, input, isDuplicate),
+        isSatisfied: isWaitSatisfied,
+      }
+    );
+
+    if (result.outcome === "unknown_token") {
+      throw new DurableWaitError("unknown_resume_token");
+    }
+    if (result.outcome === "denied" || result.wait === null) {
+      throw new DurableWaitError(
+        (result.reason ?? "unknown_resume_token") as DurableWaitErrorCode,
+        result.wait?.id ?? ""
+      );
+    }
+    if (result.outcome !== "resolved") {
+      return { outcome: result.outcome, wait: result.wait, signalCount: result.signalCount };
+    }
+
+    const resumed = await this.resume.resume(input.businessId, result.wait.runId);
+    return {
+      outcome: resumed ? "resumed" : "resolved_without_resume",
+      wait: result.wait,
+      signalCount: result.signalCount,
+    };
+  }
+
+  async find(businessId: string, waitId: string): Promise<PersistedWait | null> {
+    return this.store.find(businessId, waitId);
+  }
+
+  async listSignals(businessId: string, waitId: string): Promise<readonly PersistedWaitSignal[]> {
+    return this.store.listSignals(businessId, waitId);
+  }
+}

--- a/packages/storage/AGENTS.md
+++ b/packages/storage/AGENTS.md
@@ -7,7 +7,10 @@ contracts (no `pg`/SDK types leak across the boundary), and `src/soul/` defines 
 publication record/projection/outbox port (`SoulPublicationStore`, plus an in-memory
 implementation with real rollback) that `@tulipfarm/soul` drives. `src/artifacts/` owns the
 append-only `artifacts`, `state_output_bindings`, and `artifact_lineage` tables (`ArtifactStore`,
-plus `MemoryArtifactStore`) that `@tulipfarm/run-kernel` drives. tsconfig extends
+plus `MemoryArtifactStore`) that `@tulipfarm/run-kernel` drives. `src/runs/` owns the `runs`,
+`run_states`, `run_attempts`, `run_lineage`, `run_waits`, and `run_wait_signals` tables
+(`RunStore`, `WaitStore`, plus `MemoryWaitStore`), including resume-token digests and
+lock-guarded wait resolution. tsconfig extends
 `@tulipfarm/tsconfig/base.json`. See root `AGENTS.md` for commands/lint.
 
 May import: `@tulipfarm/schema`, `@tulipfarm/observability`. See

--- a/packages/storage/src/runs/index.ts
+++ b/packages/storage/src/runs/index.ts
@@ -1,3 +1,4 @@
+export { MemoryWaitStore } from "./memory-wait-store";
 export type {
   AppendAttemptInput,
   AppendAttemptResult,
@@ -26,3 +27,18 @@ export {
   RunPersistenceError,
   RunStore,
 } from "./run-store";
+export type {
+  CreateWaitInput,
+  DueWaitDecision,
+  PersistedWait,
+  PersistedWaitKind,
+  PersistedWaitSignal,
+  PersistedWaitStatus,
+  ResolvedDueWait,
+  WaitAggregation,
+  WaitDeliveryOutcome,
+  WaitDeliveryResult,
+  WaitSignalInput,
+  WaitSignalPolicy,
+} from "./wait-store";
+export { WAIT_STORAGE_STATEMENTS, WaitStore } from "./wait-store";

--- a/packages/storage/src/runs/memory-wait-store.test.ts
+++ b/packages/storage/src/runs/memory-wait-store.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { MemoryWaitStore } from "./memory-wait-store";
+import type { CreateWaitInput } from "./wait-store";
+
+function wait(overrides: Partial<CreateWaitInput> = {}): CreateWaitInput {
+  return {
+    id: "wait-1",
+    businessId: "business-1",
+    runId: "run-1",
+    stateKey: "await-approval",
+    kind: "event",
+    aggregation: "first",
+    schemaRef: "sha256:bundle-1#/states/await-approval/signal",
+    allowedPrincipals: ["user:alice"],
+    expectedSignals: 1,
+    quorum: null,
+    tokenHash: "sha256:token-1",
+    deadlineAt: "2026-07-25T10:05:00.000Z",
+    createdAt: "2026-07-25T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("MemoryWaitStore", () => {
+  it("rejects a duplicate wait id", async () => {
+    const store = new MemoryWaitStore();
+    await store.create(wait());
+
+    await expect(store.create(wait({ tokenHash: "sha256:token-2" }))).rejects.toThrow(
+      "run_wait_conflict"
+    );
+  });
+
+  it("rejects a reused resume token digest", async () => {
+    const store = new MemoryWaitStore();
+    await store.create(wait());
+
+    await expect(store.create(wait({ id: "wait-2" }))).rejects.toThrow("run_wait_token_conflict");
+  });
+
+  it("isolates waits by business", async () => {
+    const store = new MemoryWaitStore();
+    await store.create(wait());
+
+    expect(await store.find("business-2", "wait-1")).toBeNull();
+    expect(
+      await store.deliverSignal(
+        {
+          id: "signal-1",
+          businessId: "business-2",
+          tokenHash: "sha256:token-1",
+          runId: "run-1",
+          correlationKey: "delivery-1",
+          signalDigest: "sha256:signal-1",
+          principal: "user:alice",
+          receivedAt: "2026-07-25T10:01:00.000Z",
+        },
+        { authorize: () => null, isSatisfied: () => true }
+      )
+    ).toMatchObject({ outcome: "unknown_token" });
+  });
+});

--- a/packages/storage/src/runs/memory-wait-store.ts
+++ b/packages/storage/src/runs/memory-wait-store.ts
@@ -1,0 +1,165 @@
+import type {
+  CreateWaitInput,
+  DueWaitDecision,
+  PersistedWait,
+  PersistedWaitSignal,
+  ResolvedDueWait,
+  WaitDeliveryResult,
+  WaitSignalInput,
+  WaitSignalPolicy,
+} from "./wait-store";
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+interface StoredWait {
+  wait: PersistedWait;
+  tokenHash: string;
+}
+
+/**
+ * In-memory `WaitStore` with the same one-use-token, deduplication, and resolution semantics, for
+ * tests and local wiring. Single-threaded JavaScript gives the atomicity the row lock gives in
+ * PostgreSQL: each delivery runs to completion before the next observes state.
+ */
+export class MemoryWaitStore {
+  private readonly waits = new Map<string, StoredWait>();
+  private readonly signals = new Map<string, PersistedWaitSignal>();
+
+  private key(businessId: string, waitId: string): string {
+    return JSON.stringify([businessId, waitId]);
+  }
+
+  private byToken(businessId: string, tokenHash: string): StoredWait | undefined {
+    for (const stored of this.waits.values()) {
+      if (stored.wait.businessId === businessId && stored.tokenHash === tokenHash) return stored;
+    }
+    return undefined;
+  }
+
+  private countSignals(businessId: string, waitId: string): number {
+    let count = 0;
+    for (const signal of this.signals.values()) {
+      if (signal.businessId === businessId && signal.waitId === waitId) count += 1;
+    }
+    return count;
+  }
+
+  async create(input: CreateWaitInput): Promise<PersistedWait> {
+    if (this.waits.has(this.key(input.businessId, input.id))) {
+      throw new Error("run_wait_conflict");
+    }
+    if (this.byToken(input.businessId, input.tokenHash)) {
+      throw new Error("run_wait_token_conflict");
+    }
+    const wait: PersistedWait = {
+      id: input.id,
+      businessId: input.businessId,
+      runId: input.runId,
+      stateKey: input.stateKey,
+      kind: input.kind,
+      aggregation: input.aggregation,
+      status: "pending",
+      schemaRef: input.schemaRef,
+      allowedPrincipals: [...input.allowedPrincipals],
+      expectedSignals: input.expectedSignals,
+      quorum: input.quorum,
+      deadlineAt: input.deadlineAt,
+      createdAt: input.createdAt,
+      resolvedAt: null,
+      version: 0,
+    };
+    this.waits.set(this.key(input.businessId, input.id), { wait, tokenHash: input.tokenHash });
+    return clone(wait);
+  }
+
+  async find(businessId: string, waitId: string): Promise<PersistedWait | null> {
+    const stored = this.waits.get(this.key(businessId, waitId));
+    return stored ? clone(stored.wait) : null;
+  }
+
+  async listSignals(businessId: string, waitId: string): Promise<readonly PersistedWaitSignal[]> {
+    return [...this.signals.values()]
+      .filter((signal) => signal.businessId === businessId && signal.waitId === waitId)
+      .sort(
+        (left, right) =>
+          left.receivedAt.localeCompare(right.receivedAt) ||
+          left.correlationKey.localeCompare(right.correlationKey)
+      )
+      .map((signal) => clone(signal));
+  }
+
+  async deliverSignal(
+    input: WaitSignalInput,
+    policy: WaitSignalPolicy
+  ): Promise<WaitDeliveryResult> {
+    const stored = this.byToken(input.businessId, input.tokenHash);
+    if (!stored) return { outcome: "unknown_token", reason: null, wait: null, signalCount: 0 };
+
+    const wait = clone(stored.wait);
+    const signalKey = JSON.stringify([input.businessId, wait.id, input.correlationKey]);
+    const isDuplicate = this.signals.has(signalKey);
+
+    const denial = policy.authorize(wait, isDuplicate);
+    if (denial !== null) return { outcome: "denied", reason: denial, wait, signalCount: 0 };
+
+    if (isDuplicate) {
+      return {
+        outcome: "duplicate",
+        reason: null,
+        wait,
+        signalCount: this.countSignals(input.businessId, wait.id),
+      };
+    }
+    this.signals.set(signalKey, {
+      id: input.id,
+      businessId: input.businessId,
+      waitId: wait.id,
+      correlationKey: input.correlationKey,
+      signalDigest: input.signalDigest,
+      principal: input.principal,
+      receivedAt: input.receivedAt,
+    });
+    const signalCount = this.countSignals(input.businessId, wait.id);
+
+    if (!policy.isSatisfied(wait, signalCount)) {
+      return { outcome: "recorded", reason: null, wait, signalCount };
+    }
+    stored.wait = {
+      ...stored.wait,
+      status: "satisfied",
+      resolvedAt: input.receivedAt,
+      version: stored.wait.version + 1,
+    };
+    return { outcome: "resolved", reason: null, wait: clone(stored.wait), signalCount };
+  }
+
+  async resolveDue(
+    businessId: string,
+    now: string,
+    limit: number,
+    decide: DueWaitDecision
+  ): Promise<readonly ResolvedDueWait[]> {
+    const due = [...this.waits.values()]
+      .filter(
+        (stored) =>
+          stored.wait.businessId === businessId &&
+          stored.wait.status === "pending" &&
+          stored.wait.deadlineAt <= now
+      )
+      .sort((left, right) => left.wait.deadlineAt.localeCompare(right.wait.deadlineAt))
+      .slice(0, Math.max(0, limit));
+
+    return due.map((stored) => {
+      const signalCount = this.countSignals(businessId, stored.wait.id);
+      stored.wait = {
+        ...stored.wait,
+        status: decide(clone(stored.wait), signalCount),
+        resolvedAt: now,
+        version: stored.wait.version + 1,
+      };
+      return { wait: clone(stored.wait), signalCount };
+    });
+  }
+}

--- a/packages/storage/src/runs/run-store.pg.test.ts
+++ b/packages/storage/src/runs/run-store.pg.test.ts
@@ -349,6 +349,39 @@ describe("RunStore (PostgreSQL)", () => {
     ).toEqual([]);
   });
 
+  it("requeues a waiting Run exactly once and refuses any other status", async () => {
+    const persisted = await store.start(run());
+    await store.transitionRun("business-1", persisted.id, {
+      expectedVersion: 0,
+      expectedStatus: "queued",
+      status: "claimed",
+      leaseOwner: "worker-1",
+      leaseExpiresAt: "2026-07-24T10:01:00.000Z",
+    });
+    await store.transitionRun("business-1", persisted.id, {
+      expectedVersion: 1,
+      expectedStatus: "claimed",
+      status: "running",
+      leaseOwner: "worker-1",
+      leaseExpiresAt: "2026-07-24T10:01:00.000Z",
+    });
+    await store.transitionRun("business-1", persisted.id, {
+      expectedVersion: 2,
+      expectedStatus: "running",
+      status: "waiting",
+      leaseOwner: null,
+      leaseExpiresAt: null,
+    });
+
+    expect(await store.requeueWaitingRun("business-1", persisted.id)).toBe(true);
+    expect(await store.requeueWaitingRun("business-1", persisted.id)).toBe(false);
+    expect(await store.find("business-1", persisted.id)).toMatchObject({
+      status: "queued",
+      version: 4,
+      leaseOwner: null,
+    });
+  });
+
   it("persists State status with the same optimistic concurrency boundary", async () => {
     await store.start(run());
 

--- a/packages/storage/src/runs/run-store.ts
+++ b/packages/storage/src/runs/run-store.ts
@@ -649,6 +649,26 @@ export class RunStore {
     });
   }
 
+  /**
+   * Requeues a waiting Run whose durable wait resolved. Idempotent by construction: only a Run
+   * still in `waiting` moves, so a duplicate resume never requeues the same Run twice.
+   */
+  async requeueWaitingRun(businessId: string, runId: string): Promise<boolean> {
+    return this.transactions.withTransaction(async (transaction) => {
+      const result = await transaction.query<{ id: string }>(
+        `UPDATE runs
+            SET status = 'queued',
+                version = version + 1
+          WHERE business_id = $1
+            AND id = $2
+            AND status = 'waiting'
+          RETURNING id`,
+        [businessId, runId]
+      );
+      return result.rows.length === 1;
+    });
+  }
+
   async transitionState(
     businessId: string,
     runId: string,

--- a/packages/storage/src/runs/wait-store.pg.test.ts
+++ b/packages/storage/src/runs/wait-store.pg.test.ts
@@ -1,0 +1,264 @@
+import { PGlite } from "@electric-sql/pglite";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { Queryable, TransactionPort } from "../ports";
+import { RUN_STORAGE_STATEMENTS, RunStore, type StartRunInput } from "./run-store";
+import {
+  type CreateWaitInput,
+  type PersistedWait,
+  WAIT_STORAGE_STATEMENTS,
+  type WaitSignalInput,
+  type WaitSignalPolicy,
+  WaitStore,
+} from "./wait-store";
+
+const BUSINESS = "business-1";
+const RUN_ID = "00000000-0000-4000-8000-000000000001";
+const CREATED_AT = "2026-07-25T10:00:00.000Z";
+const DEADLINE = "2026-07-25T10:05:00.000Z";
+
+function transactionPort(database: PGlite): TransactionPort {
+  return {
+    withTransaction: (operation) =>
+      database.transaction((transaction) => operation(transaction as Queryable)),
+  };
+}
+
+function run(): StartRunInput {
+  return {
+    id: RUN_ID,
+    businessId: BUSINESS,
+    bundle: { digest: "sha256:bundle-1", routineId: "routine-1", routineVersion: "1" },
+    identity: {
+      initiator: { kind: "user", id: "user-1" },
+      effectiveSubject: { kind: "agent", id: "agent-1" },
+      guardrailContextRef: "guardrail-context-1",
+    },
+    bounds: { wallTimeMs: 60_000, activeTimeMs: 30_000, attempts: 3, sideEffects: 2 },
+    createdAt: CREATED_AT,
+    states: [
+      {
+        key: "await-approval",
+        definitionRef: "sha256:bundle-1#/states/await-approval",
+        resolvedInput: {},
+      },
+    ],
+  };
+}
+
+function wait(overrides: Partial<CreateWaitInput> = {}): CreateWaitInput {
+  return {
+    id: "00000000-0000-4000-8000-0000000000a1",
+    businessId: BUSINESS,
+    runId: RUN_ID,
+    stateKey: "await-approval",
+    kind: "event",
+    aggregation: "first",
+    schemaRef: "sha256:bundle-1#/states/await-approval/signal",
+    allowedPrincipals: ["user:alice"],
+    expectedSignals: 1,
+    quorum: null,
+    tokenHash: "sha256:token-1",
+    deadlineAt: DEADLINE,
+    createdAt: CREATED_AT,
+    ...overrides,
+  };
+}
+
+function signal(overrides: Partial<WaitSignalInput> = {}): WaitSignalInput {
+  return {
+    id: "00000000-0000-4000-8000-0000000000b1",
+    businessId: BUSINESS,
+    tokenHash: "sha256:token-1",
+    runId: RUN_ID,
+    correlationKey: "delivery-1",
+    signalDigest: "sha256:signal-1",
+    principal: "user:alice",
+    receivedAt: "2026-07-25T10:01:00.000Z",
+    ...overrides,
+  };
+}
+
+const ACCEPT_FIRST: WaitSignalPolicy = {
+  authorize: () => null,
+  isSatisfied: (_wait: PersistedWait, count: number) => count >= 1,
+};
+
+describe("WaitStore (PostgreSQL)", () => {
+  let database: PGlite;
+  let store: WaitStore;
+
+  beforeAll(async () => {
+    database = await PGlite.create();
+    for (const statement of [...RUN_STORAGE_STATEMENTS, ...WAIT_STORAGE_STATEMENTS]) {
+      await database.query(statement);
+    }
+  }, 60_000);
+
+  beforeEach(async () => {
+    await database.query("TRUNCATE TABLE runs CASCADE");
+    store = new WaitStore(transactionPort(database));
+    await new RunStore(transactionPort(database)).start(run());
+  });
+
+  afterAll(async () => {
+    await database.close();
+  });
+
+  it("persists a pending wait with an unconsumed token", async () => {
+    const persisted = await store.create(wait());
+
+    expect(persisted).toMatchObject({
+      status: "pending",
+      version: 0,
+      resolvedAt: null,
+      allowedPrincipals: ["user:alice"],
+    });
+    expect(JSON.stringify(persisted)).not.toContain("token");
+  });
+
+  it("rejects a second wait reusing a resume token digest", async () => {
+    await store.create(wait());
+
+    await expect(
+      store.create(wait({ id: "00000000-0000-4000-8000-0000000000a2" }))
+    ).rejects.toThrow();
+  });
+
+  it("rejects a wait bound to a State that does not exist", async () => {
+    await expect(store.create(wait({ stateKey: "no-such-state" }))).rejects.toThrow();
+  });
+
+  it("rejects a quorum above the expected signal count", async () => {
+    await expect(
+      store.create(wait({ aggregation: "quorum", expectedSignals: 2, quorum: 3 }))
+    ).rejects.toThrow();
+  });
+
+  it("resolves the wait and consumes its token in the delivery transaction", async () => {
+    const created = await store.create(wait());
+
+    const result = await store.deliverSignal(signal(), ACCEPT_FIRST);
+
+    expect(result.outcome).toBe("resolved");
+    expect(result.wait).toMatchObject({ status: "satisfied", version: 1 });
+    expect((await store.find(BUSINESS, created.id))?.resolvedAt).toBe("2026-07-25T10:01:00.000Z");
+  });
+
+  it("records the correlation identity and digest, never the payload", async () => {
+    const created = await store.create(wait());
+    await store.deliverSignal(signal(), ACCEPT_FIRST);
+
+    expect(await store.listSignals(BUSINESS, created.id)).toEqual([
+      expect.objectContaining({
+        correlationKey: "delivery-1",
+        signalDigest: "sha256:signal-1",
+        principal: "user:alice",
+      }),
+    ]);
+  });
+
+  it("deduplicates a redelivered correlation key and resolves once", async () => {
+    const created = await store.create(wait());
+    await store.deliverSignal(signal(), ACCEPT_FIRST);
+
+    const replay = await store.deliverSignal(
+      signal({ id: "00000000-0000-4000-8000-0000000000b2" }),
+      ACCEPT_FIRST
+    );
+
+    expect(replay.outcome).toBe("duplicate");
+    expect(replay.signalCount).toBe(1);
+    expect((await store.find(BUSINESS, created.id))?.version).toBe(1);
+    expect(await store.listSignals(BUSINESS, created.id)).toHaveLength(1);
+  });
+
+  it("tells the policy when a delivery is a known duplicate", async () => {
+    await store.create(wait());
+    const seen: boolean[] = [];
+    const policy: WaitSignalPolicy = {
+      authorize: (_wait, isDuplicate) => {
+        seen.push(isDuplicate);
+        return null;
+      },
+      isSatisfied: () => false,
+    };
+
+    await store.deliverSignal(signal(), policy);
+    await store.deliverSignal(signal({ id: "00000000-0000-4000-8000-0000000000b2" }), policy);
+
+    expect(seen).toEqual([false, true]);
+  });
+
+  it("returns unknown_token for a token digest no wait holds", async () => {
+    await store.create(wait());
+
+    const result = await store.deliverSignal(signal({ tokenHash: "sha256:other" }), ACCEPT_FIRST);
+
+    expect(result).toMatchObject({ outcome: "unknown_token", wait: null });
+  });
+
+  it("records no signal when the policy denies the delivery", async () => {
+    const created = await store.create(wait());
+
+    const result = await store.deliverSignal(signal(), {
+      authorize: () => "wrong_principal",
+      isSatisfied: () => true,
+    });
+
+    expect(result).toMatchObject({ outcome: "denied", reason: "wrong_principal" });
+    expect(await store.listSignals(BUSINESS, created.id)).toHaveLength(0);
+    expect((await store.find(BUSINESS, created.id))?.status).toBe("pending");
+  });
+
+  it("resolves a due wait once, even when two sweeps race", async () => {
+    const created = await store.create(wait());
+    const decide = () => "timed_out" as const;
+
+    const [left, right] = await Promise.all([
+      store.resolveDue(BUSINESS, "2026-07-25T10:06:00.000Z", 10, decide),
+      store.resolveDue(BUSINESS, "2026-07-25T10:06:00.000Z", 10, decide),
+    ]);
+
+    expect(left.length + right.length).toBe(1);
+    expect(await store.find(BUSINESS, created.id)).toMatchObject({
+      status: "timed_out",
+      version: 1,
+    });
+  });
+
+  it("leaves waits before their deadline pending", async () => {
+    await store.create(wait());
+
+    const resolved = await store.resolveDue(
+      BUSINESS,
+      "2026-07-25T10:04:00.000Z",
+      10,
+      () => "timed_out"
+    );
+
+    expect(resolved).toHaveLength(0);
+  });
+
+  it("refuses to mutate a resolved wait or an appended signal", async () => {
+    const created = await store.create(wait());
+    await store.deliverSignal(signal(), ACCEPT_FIRST);
+
+    await expect(
+      database.query("UPDATE run_waits SET status = 'timed_out' WHERE id = $1", [created.id])
+    ).rejects.toThrow(/run_wait_already_resolved/);
+    await expect(
+      database.query("UPDATE run_wait_signals SET principal = 'user:mallory'")
+    ).rejects.toThrow(/run_append_only_record/);
+    await expect(database.query("DELETE FROM run_wait_signals")).rejects.toThrow(
+      /run_append_only_record/
+    );
+  });
+
+  it("refuses to rewrite a wait's identity or its resume token digest", async () => {
+    const created = await store.create(wait());
+
+    await expect(
+      database.query("UPDATE run_waits SET token_hash = 'sha256:other' WHERE id = $1", [created.id])
+    ).rejects.toThrow(/run_wait_identity_immutable/);
+  });
+});

--- a/packages/storage/src/runs/wait-store.ts
+++ b/packages/storage/src/runs/wait-store.ts
@@ -1,0 +1,470 @@
+import type { TransactionPort } from "../ports";
+
+/** SPEC §7.2 `RunWait` kinds. */
+export type PersistedWaitKind =
+  | "timer"
+  | "event"
+  | "approval"
+  | "human_task"
+  | "form"
+  | "child_run";
+
+/** SPEC §9.2 external-event wait aggregation semantics. */
+export type WaitAggregation = "first" | "all" | "quorum" | "window";
+
+export type PersistedWaitStatus = "pending" | "satisfied" | "timed_out";
+
+export interface PersistedWait {
+  readonly id: string;
+  readonly businessId: string;
+  readonly runId: string;
+  readonly stateKey: string;
+  readonly kind: PersistedWaitKind;
+  readonly aggregation: WaitAggregation;
+  readonly status: PersistedWaitStatus;
+  /** Schema reference every accepted signal must declare. */
+  readonly schemaRef: string;
+  /** Canonical `kind:id` principals authorized to signal this wait. */
+  readonly allowedPrincipals: readonly string[];
+  readonly expectedSignals: number;
+  readonly quorum: number | null;
+  readonly deadlineAt: string;
+  readonly createdAt: string;
+  readonly resolvedAt: string | null;
+  readonly version: number;
+}
+
+export interface CreateWaitInput {
+  readonly id: string;
+  readonly businessId: string;
+  readonly runId: string;
+  readonly stateKey: string;
+  readonly kind: PersistedWaitKind;
+  readonly aggregation: WaitAggregation;
+  readonly schemaRef: string;
+  readonly allowedPrincipals: readonly string[];
+  readonly expectedSignals: number;
+  readonly quorum: number | null;
+  /** SHA-256 of the one-use resume token; the token itself is never persisted. */
+  readonly tokenHash: string;
+  readonly deadlineAt: string;
+  readonly createdAt: string;
+}
+
+/**
+ * One recorded signal. Only correlation identity, principal, and a content digest are stored —
+ * never the signal payload, which may carry protected data or Secret values.
+ */
+export interface PersistedWaitSignal {
+  readonly id: string;
+  readonly businessId: string;
+  readonly waitId: string;
+  readonly correlationKey: string;
+  readonly signalDigest: string;
+  readonly principal: string;
+  readonly receivedAt: string;
+}
+
+export interface WaitSignalInput {
+  readonly id: string;
+  readonly businessId: string;
+  readonly tokenHash: string;
+  readonly runId: string;
+  readonly correlationKey: string;
+  readonly signalDigest: string;
+  readonly principal: string;
+  readonly receivedAt: string;
+}
+
+/**
+ * Caller-owned policy evaluated inside the wait's row lock. `authorize` returns a denial reason
+ * code (never a payload) or `null`, and is told whether this correlation key was already
+ * recorded so an at-least-once redelivery stays idempotent; `isSatisfied` decides resolution
+ * from the post-insert count.
+ */
+export interface WaitSignalPolicy {
+  authorize(wait: PersistedWait, isDuplicate: boolean): string | null;
+  isSatisfied(wait: PersistedWait, signalCount: number): boolean;
+}
+
+export type WaitDeliveryOutcome =
+  | "unknown_token"
+  | "denied"
+  | "duplicate"
+  | "recorded"
+  | "resolved";
+
+export interface WaitDeliveryResult {
+  readonly outcome: WaitDeliveryOutcome;
+  /** Denial reason code from the policy; absent for accepted deliveries. */
+  readonly reason: string | null;
+  readonly wait: PersistedWait | null;
+  readonly signalCount: number;
+}
+
+/** Decides how a due wait resolves; called inside the sweep's row lock. */
+export type DueWaitDecision = (
+  wait: PersistedWait,
+  signalCount: number
+) => "satisfied" | "timed_out";
+
+export interface ResolvedDueWait {
+  readonly wait: PersistedWait;
+  readonly signalCount: number;
+}
+
+const WAIT_KIND_SQL = "'timer', 'event', 'approval', 'human_task', 'form', 'child_run'";
+const WAIT_AGGREGATION_SQL = "'first', 'all', 'quorum', 'window'";
+const WAIT_STATUS_SQL = "'pending', 'satisfied', 'timed_out'";
+
+export const WAIT_STORAGE_STATEMENTS: readonly string[] = [
+  `CREATE TABLE IF NOT EXISTS run_waits (
+    id                    uuid PRIMARY KEY,
+    business_id           text NOT NULL,
+    run_id                uuid NOT NULL,
+    state_key             text NOT NULL,
+    kind                  text NOT NULL CHECK (kind IN (${WAIT_KIND_SQL})),
+    aggregation           text NOT NULL CHECK (aggregation IN (${WAIT_AGGREGATION_SQL})),
+    status                text NOT NULL DEFAULT 'pending'
+      CHECK (status IN (${WAIT_STATUS_SQL})),
+    schema_ref            text NOT NULL CHECK (length(schema_ref) > 0),
+    allowed_principals    jsonb NOT NULL CHECK (jsonb_typeof(allowed_principals) = 'array'),
+    expected_signals      integer NOT NULL CHECK (expected_signals > 0),
+    quorum                integer,
+    token_hash            text NOT NULL CHECK (length(token_hash) > 0),
+    token_consumed_at     timestamptz,
+    deadline_at           timestamptz NOT NULL,
+    created_at            timestamptz NOT NULL,
+    resolved_at           timestamptz,
+    version               integer NOT NULL DEFAULT 0 CHECK (version >= 0),
+    UNIQUE (business_id, id),
+    UNIQUE (business_id, token_hash),
+    CHECK (deadline_at > created_at),
+    CHECK (
+      (aggregation = 'quorum' AND quorum IS NOT NULL AND quorum > 0 AND quorum <= expected_signals)
+      OR (aggregation <> 'quorum' AND quorum IS NULL)
+    ),
+    CHECK (kind <> 'timer' OR (aggregation = 'first' AND expected_signals = 1)),
+    CHECK (kind = 'timer' OR jsonb_array_length(allowed_principals) > 0),
+    CHECK (
+      (status = 'pending' AND resolved_at IS NULL AND token_consumed_at IS NULL)
+      OR (status <> 'pending' AND resolved_at IS NOT NULL AND token_consumed_at IS NOT NULL)
+    ),
+    FOREIGN KEY (business_id, run_id, state_key)
+      REFERENCES run_states(business_id, run_id, state_key)
+  )`,
+  `CREATE TABLE IF NOT EXISTS run_wait_signals (
+    id                    uuid PRIMARY KEY,
+    business_id           text NOT NULL,
+    wait_id               uuid NOT NULL,
+    correlation_key       text NOT NULL CHECK (length(correlation_key) > 0),
+    signal_digest         text NOT NULL CHECK (length(signal_digest) > 0),
+    principal             text NOT NULL CHECK (length(principal) > 0),
+    received_at           timestamptz NOT NULL,
+    UNIQUE (business_id, wait_id, correlation_key),
+    FOREIGN KEY (business_id, wait_id) REFERENCES run_waits(business_id, id)
+  )`,
+  "DROP TRIGGER IF EXISTS run_wait_signals_append_only ON run_wait_signals",
+  `CREATE TRIGGER run_wait_signals_append_only
+    BEFORE UPDATE OR DELETE ON run_wait_signals
+    FOR EACH ROW EXECUTE FUNCTION reject_run_append_only_change()`,
+  `CREATE OR REPLACE FUNCTION reject_run_wait_identity_change()
+    RETURNS trigger LANGUAGE plpgsql AS $$
+    BEGIN
+      IF OLD.id IS DISTINCT FROM NEW.id
+        OR OLD.business_id IS DISTINCT FROM NEW.business_id
+        OR OLD.run_id IS DISTINCT FROM NEW.run_id
+        OR OLD.state_key IS DISTINCT FROM NEW.state_key
+        OR OLD.kind IS DISTINCT FROM NEW.kind
+        OR OLD.aggregation IS DISTINCT FROM NEW.aggregation
+        OR OLD.schema_ref IS DISTINCT FROM NEW.schema_ref
+        OR OLD.allowed_principals IS DISTINCT FROM NEW.allowed_principals
+        OR OLD.expected_signals IS DISTINCT FROM NEW.expected_signals
+        OR OLD.quorum IS DISTINCT FROM NEW.quorum
+        OR OLD.token_hash IS DISTINCT FROM NEW.token_hash
+        OR OLD.deadline_at IS DISTINCT FROM NEW.deadline_at
+        OR OLD.created_at IS DISTINCT FROM NEW.created_at THEN
+        RAISE EXCEPTION 'run_wait_identity_immutable';
+      END IF;
+      IF OLD.status <> 'pending' THEN
+        RAISE EXCEPTION 'run_wait_already_resolved';
+      END IF;
+      RETURN NEW;
+    END;
+    $$`,
+  "DROP TRIGGER IF EXISTS run_waits_identity_immutable ON run_waits",
+  `CREATE TRIGGER run_waits_identity_immutable
+    BEFORE UPDATE ON run_waits
+    FOR EACH ROW EXECUTE FUNCTION reject_run_wait_identity_change()`,
+  `CREATE INDEX IF NOT EXISTS run_waits_due_idx
+    ON run_waits (business_id, status, deadline_at)`,
+  `CREATE INDEX IF NOT EXISTS run_waits_run_idx
+    ON run_waits (business_id, run_id, state_key)`,
+];
+
+interface WaitRow {
+  id: string;
+  business_id: string;
+  run_id: string;
+  state_key: string;
+  kind: PersistedWaitKind;
+  aggregation: WaitAggregation;
+  status: PersistedWaitStatus;
+  schema_ref: string;
+  allowed_principals: string[];
+  expected_signals: number;
+  quorum: number | null;
+  deadline_at: string | Date;
+  created_at: string | Date;
+  resolved_at: string | Date | null;
+  version: number;
+}
+
+interface SignalRow {
+  id: string;
+  business_id: string;
+  wait_id: string;
+  correlation_key: string;
+  signal_digest: string;
+  principal: string;
+  received_at: string | Date;
+}
+
+function timestamp(value: string | Date): string {
+  return value instanceof Date ? value.toISOString() : value;
+}
+
+function persistedWait(row: WaitRow): PersistedWait {
+  return {
+    id: row.id,
+    businessId: row.business_id,
+    runId: row.run_id,
+    stateKey: row.state_key,
+    kind: row.kind,
+    aggregation: row.aggregation,
+    status: row.status,
+    schemaRef: row.schema_ref,
+    allowedPrincipals: row.allowed_principals,
+    expectedSignals: row.expected_signals,
+    quorum: row.quorum,
+    deadlineAt: timestamp(row.deadline_at),
+    createdAt: timestamp(row.created_at),
+    resolvedAt: row.resolved_at === null ? null : timestamp(row.resolved_at),
+    version: row.version,
+  };
+}
+
+function persistedSignal(row: SignalRow): PersistedWaitSignal {
+  return {
+    id: row.id,
+    businessId: row.business_id,
+    waitId: row.wait_id,
+    correlationKey: row.correlation_key,
+    signalDigest: row.signal_digest,
+    principal: row.principal,
+    receivedAt: timestamp(row.received_at),
+  };
+}
+
+const WAIT_COLUMNS = `id, business_id, run_id, state_key, kind, aggregation, status, schema_ref,
+  allowed_principals, expected_signals, quorum, deadline_at, created_at, resolved_at, version`;
+const SIGNAL_COLUMNS =
+  "id, business_id, wait_id, correlation_key, signal_digest, principal, received_at";
+
+/**
+ * PostgreSQL persistence for durable Runs waits, their recorded signals, and one-use resume
+ * tokens. Every delivery and every due resolution runs inside the wait's row lock, so a duplicate
+ * delivery, a concurrent worker, or a restart resolves the wait — and consumes its token — once.
+ */
+export class WaitStore {
+  constructor(private readonly transactions: TransactionPort) {}
+
+  async create(input: CreateWaitInput): Promise<PersistedWait> {
+    return this.transactions.withTransaction(async (transaction) => {
+      const result = await transaction.query<WaitRow>(
+        `INSERT INTO run_waits (
+           id, business_id, run_id, state_key, kind, aggregation, schema_ref, allowed_principals,
+           expected_signals, quorum, token_hash, deadline_at, created_at
+         ) VALUES (
+           $1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9, $10, $11, $12::timestamptz, $13::timestamptz
+         )
+         RETURNING ${WAIT_COLUMNS}`,
+        [
+          input.id,
+          input.businessId,
+          input.runId,
+          input.stateKey,
+          input.kind,
+          input.aggregation,
+          input.schemaRef,
+          JSON.stringify(input.allowedPrincipals),
+          input.expectedSignals,
+          input.quorum,
+          input.tokenHash,
+          input.deadlineAt,
+          input.createdAt,
+        ]
+      );
+      const row = result.rows[0];
+      if (!row) throw new Error("run_wait_insert_without_row");
+      return persistedWait(row);
+    });
+  }
+
+  async find(businessId: string, waitId: string): Promise<PersistedWait | null> {
+    return this.transactions.withTransaction(async (transaction) => {
+      const result = await transaction.query<WaitRow>(
+        `SELECT ${WAIT_COLUMNS} FROM run_waits WHERE business_id = $1 AND id = $2`,
+        [businessId, waitId]
+      );
+      const row = result.rows[0];
+      return row ? persistedWait(row) : null;
+    });
+  }
+
+  async listSignals(businessId: string, waitId: string): Promise<readonly PersistedWaitSignal[]> {
+    return this.transactions.withTransaction(async (transaction) => {
+      const result = await transaction.query<SignalRow>(
+        `SELECT ${SIGNAL_COLUMNS}
+           FROM run_wait_signals
+          WHERE business_id = $1 AND wait_id = $2
+          ORDER BY received_at, correlation_key`,
+        [businessId, waitId]
+      );
+      return result.rows.map(persistedSignal);
+    });
+  }
+
+  /**
+   * Redeems a resume token: locks the wait, applies the caller's policy, records the signal
+   * (deduplicated by correlation key), and resolves the wait exactly once when satisfied.
+   */
+  async deliverSignal(
+    input: WaitSignalInput,
+    policy: WaitSignalPolicy
+  ): Promise<WaitDeliveryResult> {
+    return this.transactions.withTransaction(async (transaction) => {
+      const locked = await transaction.query<WaitRow>(
+        `SELECT ${WAIT_COLUMNS}
+           FROM run_waits
+          WHERE business_id = $1 AND token_hash = $2
+          FOR UPDATE`,
+        [input.businessId, input.tokenHash]
+      );
+      const row = locked.rows[0];
+      if (!row) return { outcome: "unknown_token", reason: null, wait: null, signalCount: 0 };
+
+      const wait = persistedWait(row);
+      const known = await transaction.query<{ id: string }>(
+        `SELECT id
+           FROM run_wait_signals
+          WHERE business_id = $1 AND wait_id = $2 AND correlation_key = $3`,
+        [input.businessId, wait.id, input.correlationKey]
+      );
+      const isDuplicate = known.rows.length === 1;
+
+      const denial = policy.authorize(wait, isDuplicate);
+      if (denial !== null) {
+        return { outcome: "denied", reason: denial, wait, signalCount: 0 };
+      }
+
+      const inserted = await transaction.query<{ id: string }>(
+        `INSERT INTO run_wait_signals (
+           id, business_id, wait_id, correlation_key, signal_digest, principal, received_at
+         ) VALUES ($1, $2, $3, $4, $5, $6, $7::timestamptz)
+         ON CONFLICT (business_id, wait_id, correlation_key) DO NOTHING
+         RETURNING id`,
+        [
+          input.id,
+          input.businessId,
+          wait.id,
+          input.correlationKey,
+          input.signalDigest,
+          input.principal,
+          input.receivedAt,
+        ]
+      );
+      const counted = await transaction.query<{ count: string | number }>(
+        "SELECT count(*)::int AS count FROM run_wait_signals WHERE business_id = $1 AND wait_id = $2",
+        [input.businessId, wait.id]
+      );
+      const signalCount = Number(counted.rows[0]?.count ?? 0);
+
+      if (inserted.rows.length === 0) {
+        return { outcome: "duplicate", reason: null, wait, signalCount };
+      }
+      if (!policy.isSatisfied(wait, signalCount)) {
+        return { outcome: "recorded", reason: null, wait, signalCount };
+      }
+
+      const resolved = await transaction.query<WaitRow>(
+        `UPDATE run_waits
+            SET status = 'satisfied',
+                version = version + 1,
+                resolved_at = $3::timestamptz,
+                token_consumed_at = $3::timestamptz
+          WHERE business_id = $1
+            AND id = $2
+            AND status = 'pending'
+          RETURNING ${WAIT_COLUMNS}`,
+        [input.businessId, wait.id, input.receivedAt]
+      );
+      const resolvedRow = resolved.rows[0];
+      if (!resolvedRow) throw new Error("run_wait_resolution_lost");
+      return {
+        outcome: "resolved",
+        reason: null,
+        wait: persistedWait(resolvedRow),
+        signalCount,
+      };
+    });
+  }
+
+  /** Resolves waits whose deadline has passed, consuming each token exactly once. */
+  async resolveDue(
+    businessId: string,
+    now: string,
+    limit: number,
+    decide: DueWaitDecision
+  ): Promise<readonly ResolvedDueWait[]> {
+    return this.transactions.withTransaction(async (transaction) => {
+      const due = await transaction.query<WaitRow>(
+        `SELECT ${WAIT_COLUMNS}
+           FROM run_waits
+          WHERE business_id = $1
+            AND status = 'pending'
+            AND deadline_at <= $2::timestamptz
+          ORDER BY deadline_at
+          FOR UPDATE SKIP LOCKED
+          LIMIT $3`,
+        [businessId, now, Math.max(0, limit)]
+      );
+
+      const resolved: ResolvedDueWait[] = [];
+      for (const row of due.rows) {
+        const wait = persistedWait(row);
+        const counted = await transaction.query<{ count: string | number }>(
+          "SELECT count(*)::int AS count FROM run_wait_signals WHERE business_id = $1 AND wait_id = $2",
+          [businessId, wait.id]
+        );
+        const signalCount = Number(counted.rows[0]?.count ?? 0);
+        const status = decide(wait, signalCount);
+        const updated = await transaction.query<WaitRow>(
+          `UPDATE run_waits
+              SET status = $3,
+                  version = version + 1,
+                  resolved_at = $4::timestamptz,
+                  token_consumed_at = $4::timestamptz
+            WHERE business_id = $1
+              AND id = $2
+              AND status = 'pending'
+            RETURNING ${WAIT_COLUMNS}`,
+          [businessId, wait.id, status, now]
+        );
+        const updatedRow = updated.rows[0];
+        if (updatedRow) resolved.push({ wait: persistedWait(updatedRow), signalCount });
+      }
+      return resolved;
+    });
+  }
+}


### PR DESCRIPTION
## Summary

- Persists timer, event, Approval, human-task, form, and child-Run waits (SPEC §7.2) with `first`/`all`/`quorum`/bounded-window aggregation (§9.2). New `run_waits` and `run_wait_signals` tables are added by migration v6; identity, resume-token digest, and resolved waits are immutable by trigger, and signals are append-only.
- Each wait is redeemed through an unguessable one-use resume token: 256 bits of entropy returned once, only its SHA-256 digest persisted, compared with `timingSafeEqual`. Signal payloads are never stored — only a correlation key, principal, and content digest.
- Dedup, aggregation, resolution, and token consumption happen under one row lock, and the deadline sweep uses `FOR UPDATE SKIP LOCKED` with a status-guarded CAS, so duplicate delivery, a racing sweeper, a wrong principal/schema/run, a timeout, or a worker restart all resume the Run exactly once. `RunStore.requeueWaitingRun` only moves Runs still in `waiting`, which makes the resume itself idempotent.
- Storage owns the atomicity; `@tulipfarm/run-kernel` owns the denial policy, evaluated inside the lock via a callback.

Implements AW-031.

## Test plan

- `pnpm --filter @tulipfarm/run-kernel exec vitest run` — 8 files, 72 tests passed. Covers resume-on-first-signal, token never persisted, duplicate delivery resuming once, restart replay, `wrong_run`/`wrong_principal`/`wrong_schema`/`wait_expired` denials recording nothing, unknown token, `all`/`quorum`/window aggregation, and timer sweeps (double sweep resolves once, window satisfied vs timed out, signal after timeout denied).
- `pnpm --filter @tulipfarm/storage exec vitest run src/runs` — 3 files, 33 tests passed, including PGlite tests against the real DDL: token-digest uniqueness, FK to `run_states`, quorum check, racing sweeps resolving once, and the immutability/append-only triggers.
- `pnpm exec tsc --noEmit` clean for `@tulipfarm/run-kernel`, `@tulipfarm/storage`, and `@tulipfarm/api`.
- `pnpm exec biome check` clean across the touched paths.

No worker loop schedules `WaitTimerSweeper` yet — that wiring belongs to the worker task.