### PR TITLE
feat(runs): stream persisted Run events and prove crash recovery (AW-034, AW-035)

### DIFF
--- a/apps/api/AGENTS.md
+++ b/apps/api/AGENTS.md
@@ -19,6 +19,7 @@ src/
   memory/         # per-user working memory
   secrets/        # secret storage
   soul/           # soul git ops (commit, push) + agents/, skills/, resource-types/ CRUD
+  runs/           # persisted Run event SSE stream (GET /api/v1/runs/:id/events, cursor recovery)
   pg-migrations/  # Postgres schema migrations (applied on boot)
 ```
 

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -53,6 +53,7 @@ import type { CounterStore, ResourceRepoFactory } from "./resources/repo";
 import { registerResourceRoutes } from "./resources/routes";
 import type { RoutineRoutesDeps } from "./routines/routes";
 import { registerRoutineRoutes } from "./routines/routes";
+import { type RunEventRouteDeps, registerRunEventRoutes } from "./runs/events";
 import { registerSecretsRoutes } from "./secrets/routes";
 import { registerSetupRoutes, registerSetupStatusRoute } from "./setup/routes";
 import { isHeadlessBoot } from "./setup/service";
@@ -85,6 +86,7 @@ export interface AppOptions {
   conversationRepo?: ConversationRepo;
   messageRepo?: MessageRepo;
   feedbackRepo?: FeedbackRepo;
+  runEvents?: RunEventRouteDeps;
   streamResumeRepo?: StreamResumeRepo;
   streamHub?: StreamHub;
   workingMemoryService?: WorkingMemoryService;
@@ -421,6 +423,9 @@ export async function buildApp(opts: AppOptions = {}) {
             }
           : undefined
       );
+    }
+    if (opts.runEvents) {
+      registerRunEventRoutes(app, opts.runEvents, requireAuth);
     }
     if (opts.feedbackRepo) {
       registerFeedbackRoutes(app, opts.feedbackRepo, requireAuth);

--- a/apps/api/src/pg-migrations/index.ts
+++ b/apps/api/src/pg-migrations/index.ts
@@ -4,6 +4,7 @@ import {
   CHILD_STORAGE_STATEMENTS,
   CONCURRENCY_STORAGE_STATEMENTS,
   EVENT_STORAGE_STATEMENTS,
+  RUN_EVENT_STORAGE_STATEMENTS,
   RUN_STORAGE_STATEMENTS,
   WAIT_STORAGE_STATEMENTS,
 } from "@tulipfarm/storage";
@@ -492,6 +493,15 @@ export const PG_MIGRATIONS: PgMigration[] = [
     description: "child Run links",
     up: async (q) => {
       for (const sql of CHILD_STORAGE_STATEMENTS) {
+        await q.query(sql);
+      }
+    },
+  },
+  {
+    version: 9,
+    description: "persisted Run event stream",
+    up: async (q) => {
+      for (const sql of RUN_EVENT_STORAGE_STATEMENTS) {
         await q.query(sql);
       }
     },

--- a/apps/api/src/runs/events.test.ts
+++ b/apps/api/src/runs/events.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseAfterCursor,
+  type RunEventReader,
+  type RunEventRecord,
+  type RunStatusReader,
+  type RunStreamGrant,
+  type SseSink,
+  streamRunEvents,
+} from "./events";
+
+const BUSINESS_ID = "business-1";
+const RUN_ID = "00000000-0000-4000-8000-000000000001";
+const GRANT: RunStreamGrant = { businessId: BUSINESS_ID, audiences: ["participant"] };
+
+function record(sequence: number, overrides: Partial<RunEventRecord> = {}): RunEventRecord {
+  return {
+    sequence,
+    eventType: "state.transitioned",
+    audience: "participant",
+    payload: { stateKey: "apply" },
+    occurredAt: "2026-07-25T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+class FakeEventReader implements RunEventReader {
+  calls: Array<{ after: number; audiences: readonly string[] }> = [];
+
+  constructor(private readonly events: RunEventRecord[]) {}
+
+  async list(
+    _businessId: string,
+    _runId: string,
+    options: { after: number; audiences: readonly string[]; limit?: number }
+  ): Promise<readonly RunEventRecord[]> {
+    this.calls.push({ after: options.after, audiences: options.audiences });
+    return this.events
+      .filter(
+        (event) => event.sequence > options.after && options.audiences.includes(event.audience)
+      )
+      .slice(0, options.limit ?? 200);
+  }
+}
+
+class FakeRunReader implements RunStatusReader {
+  constructor(private readonly status: string | null) {}
+  async find() {
+    return this.status === null ? null : { status: this.status };
+  }
+}
+
+class RecordingSink implements SseSink {
+  chunks: string[] = [];
+  destroyed = false;
+  ended = false;
+  drains = 0;
+  /** Sequence numbers at which `write` reports a full buffer. */
+  backpressureAt = new Set<number>();
+  private writes = 0;
+
+  write(chunk: string): boolean {
+    this.chunks.push(chunk);
+    this.writes += 1;
+    return !this.backpressureAt.has(this.writes);
+  }
+
+  async waitForDrain(): Promise<void> {
+    this.drains += 1;
+  }
+
+  end(): void {
+    this.ended = true;
+  }
+}
+
+const noSleep = async () => {};
+
+function ids(sink: RecordingSink): number[] {
+  return sink.chunks.map((chunk) => Number(/^id: (\d+)/.exec(chunk)?.[1]));
+}
+
+function types(sink: RecordingSink): string[] {
+  return sink.chunks.map((chunk) => /event: (.+)/.exec(chunk)?.[1] ?? "");
+}
+
+describe("parseAfterCursor", () => {
+  it("prefers an explicit query cursor", () => {
+    expect(parseAfterCursor("7", 3)).toBe(3);
+  });
+
+  it("falls back to the SSE reconnect header", () => {
+    expect(parseAfterCursor("7", undefined)).toBe(7);
+  });
+
+  it("treats a missing or malformed cursor as the start of the stream", () => {
+    expect(parseAfterCursor(undefined, undefined)).toBe(0);
+    expect(parseAfterCursor("not-a-number", undefined)).toBe(0);
+    expect(parseAfterCursor("-4", undefined)).toBe(0);
+  });
+});
+
+describe("streamRunEvents", () => {
+  const deps = (
+    events: RunEventRecord[],
+    status: string | null,
+    grant: () => Promise<RunStreamGrant | null> = async () => GRANT
+  ) => ({
+    events: new FakeEventReader(events),
+    runs: new FakeRunReader(status),
+    authorize: grant,
+    sleep: noSleep,
+  });
+
+  it("delivers the backlog in sequence order and closes on a terminal Run", async () => {
+    const sink = new RecordingSink();
+
+    const outcome = await streamRunEvents(sink, deps([record(1), record(2)], "succeeded"), {
+      runId: RUN_ID,
+      after: 0,
+    });
+
+    expect(outcome).toBe("completed");
+    expect(ids(sink)).toEqual([1, 2, 2]);
+    expect(types(sink)).toEqual(["state.transitioned", "state.transitioned", "stream.closed"]);
+    expect(sink.ended).toBe(true);
+  });
+
+  it("replays strictly after the reconnect cursor, so no event is delivered twice", async () => {
+    const sink = new RecordingSink();
+
+    await streamRunEvents(sink, deps([record(1), record(2), record(3)], "succeeded"), {
+      runId: RUN_ID,
+      after: 2,
+    });
+
+    expect(ids(sink)).toEqual([3, 3]);
+  });
+
+  it("withholds events outside the caller's audience", async () => {
+    const sink = new RecordingSink();
+    const events = [record(1), record(2, { audience: "operator", eventType: "cost.recorded" })];
+
+    await streamRunEvents(sink, deps(events, "succeeded"), { runId: RUN_ID, after: 0 });
+
+    expect(types(sink)).toEqual(["state.transitioned", "stream.closed"]);
+  });
+
+  it("waits for the consumer to drain before writing more", async () => {
+    const sink = new RecordingSink();
+    sink.backpressureAt.add(1);
+
+    await streamRunEvents(sink, deps([record(1), record(2)], "succeeded"), {
+      runId: RUN_ID,
+      after: 0,
+    });
+
+    expect(sink.drains).toBe(1);
+    expect(ids(sink)).toEqual([1, 2, 2]);
+  });
+
+  it("closes the stream when the caller's grant is revoked mid-stream", async () => {
+    const sink = new RecordingSink();
+    let calls = 0;
+    const grant = async () => {
+      calls += 1;
+      return calls === 1 ? GRANT : null;
+    };
+
+    const outcome = await streamRunEvents(sink, deps([record(1)], "running", grant), {
+      runId: RUN_ID,
+      after: 0,
+    });
+
+    expect(outcome).toBe("authorization_revoked");
+    expect(types(sink)).toEqual(["state.transitioned", "stream.revoked"]);
+    expect(sink.ended).toBe(true);
+  });
+
+  it("never delivers anything when the grant is denied up front", async () => {
+    const sink = new RecordingSink();
+
+    const outcome = await streamRunEvents(
+      sink,
+      deps([record(1)], "running", async () => null),
+      {
+        runId: RUN_ID,
+        after: 0,
+      }
+    );
+
+    expect(outcome).toBe("authorization_revoked");
+    expect(types(sink)).toEqual(["stream.revoked"]);
+  });
+
+  it("stops without writing when the client disconnected", async () => {
+    const sink = new RecordingSink();
+    sink.destroyed = true;
+
+    const outcome = await streamRunEvents(sink, deps([record(1)], "running"), {
+      runId: RUN_ID,
+      after: 0,
+    });
+
+    expect(outcome).toBe("client_disconnected");
+    expect(sink.chunks).toEqual([]);
+  });
+
+  it("polls again while the Run is still live, resuming from the last cursor", async () => {
+    const sink = new RecordingSink();
+    const events = [record(1)];
+    const reader = new FakeEventReader(events);
+    let polls = 0;
+
+    const outcome = await streamRunEvents(
+      sink,
+      {
+        events: reader,
+        runs: {
+          async find() {
+            polls += 1;
+            if (polls === 1) {
+              events.push(record(2));
+              return { status: "running" };
+            }
+            return { status: "succeeded" };
+          },
+        },
+        authorize: async () => GRANT,
+        sleep: noSleep,
+      },
+      { runId: RUN_ID, after: 0 }
+    );
+
+    expect(outcome).toBe("completed");
+    expect(ids(sink)).toEqual([1, 2, 2]);
+    expect(reader.calls.map((call) => call.after)).toEqual([0, 1]);
+  });
+
+  it("ends the stream when the Run cannot be read, without inventing an outcome", async () => {
+    const sink = new RecordingSink();
+
+    const outcome = await streamRunEvents(sink, deps([], null), { runId: RUN_ID, after: 0 });
+
+    expect(outcome).toBe("run_not_found");
+    expect(sink.chunks).toEqual([]);
+    expect(sink.ended).toBe(true);
+  });
+});

--- a/apps/api/src/runs/events.ts
+++ b/apps/api/src/runs/events.ts
@@ -1,0 +1,240 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { ErrorSchema } from "../auth/schemas";
+import { formatSseEvent, writeSseHeaders } from "../chat/sse";
+
+/** Who a persisted Run event may be shown to (mirrors `@tulipfarm/storage`'s `RunEventAudience`). */
+export type RunEventAudience = "participant" | "operator";
+
+export interface RunEventRecord {
+  readonly sequence: number;
+  readonly eventType: string;
+  readonly audience: RunEventAudience;
+  readonly payload: Record<string, unknown>;
+  readonly occurredAt: string;
+}
+
+/** Read-only surface of the persisted Run event stream. The stream never writes Run state. */
+export interface RunEventReader {
+  list(
+    businessId: string,
+    runId: string,
+    options: { after: number; audiences: readonly RunEventAudience[]; limit?: number }
+  ): Promise<readonly RunEventRecord[]>;
+}
+
+export interface RunStatusReader {
+  find(businessId: string, runId: string): Promise<{ status: string } | null>;
+}
+
+/** Reader's access to one Run, re-checked on every poll so a revoked grant closes the stream. */
+export interface RunStreamGrant {
+  readonly businessId: string;
+  readonly audiences: readonly RunEventAudience[];
+}
+
+/** Minimal writable surface an SSE stream needs; a Node `ServerResponse` satisfies it. */
+export interface SseSink {
+  readonly destroyed: boolean;
+  write(chunk: string): boolean;
+  waitForDrain(): Promise<void>;
+  end(): void;
+}
+
+export type RunStreamOutcome =
+  | "completed"
+  | "client_disconnected"
+  | "authorization_revoked"
+  | "run_not_found";
+
+export interface RunEventStreamDeps {
+  readonly events: RunEventReader;
+  readonly runs: RunStatusReader;
+  /** Re-evaluated each poll; `null` means the reader may no longer see this Run. */
+  readonly authorize: () => Promise<RunStreamGrant | null>;
+  readonly sleep: (ms: number) => Promise<void>;
+  readonly pollIntervalMs?: number;
+  readonly pageSize?: number;
+}
+
+export interface RunEventStreamRequest {
+  readonly runId: string;
+  readonly after: number;
+}
+
+const TERMINAL_RUN_STATUSES: readonly string[] = ["succeeded", "failed", "cancelled"];
+const DEFAULT_POLL_INTERVAL_MS = 500;
+const DEFAULT_PAGE_SIZE = 200;
+
+/**
+ * Streams a Run's persisted events over SSE (SPEC §18). Delivery starts strictly after the
+ * client's cursor, so a reconnect replays in order with no duplicates; the stream is a pure reader,
+ * so losing it — or never reading it — cannot change the Run. Authorization is re-checked every
+ * poll, a slow consumer is respected through backpressure, and the stream ends once the Run is
+ * terminal and its backlog is fully delivered.
+ */
+export async function streamRunEvents(
+  sink: SseSink,
+  deps: RunEventStreamDeps,
+  request: RunEventStreamRequest
+): Promise<RunStreamOutcome> {
+  const pageSize = deps.pageSize ?? DEFAULT_PAGE_SIZE;
+  let cursor = request.after;
+
+  for (;;) {
+    if (sink.destroyed) return "client_disconnected";
+
+    const grant = await deps.authorize();
+    if (!grant) {
+      await emit(sink, { seq: cursor, eventType: "stream.revoked", data: { reason: "revoked" } });
+      sink.end();
+      return "authorization_revoked";
+    }
+
+    const page = await deps.events.list(grant.businessId, request.runId, {
+      after: cursor,
+      audiences: grant.audiences,
+      limit: pageSize,
+    });
+    for (const event of page) {
+      if (sink.destroyed) return "client_disconnected";
+      cursor = event.sequence;
+      await emit(sink, {
+        seq: event.sequence,
+        eventType: event.eventType,
+        data: { ...event.payload, occurredAt: event.occurredAt },
+      });
+    }
+    // A full page means more backlog is waiting; drain it before polling for Run status.
+    if (page.length === pageSize) continue;
+
+    const run = await deps.runs.find(grant.businessId, request.runId);
+    if (!run) {
+      sink.end();
+      return "run_not_found";
+    }
+    if (TERMINAL_RUN_STATUSES.includes(run.status)) {
+      await emit(sink, {
+        seq: cursor,
+        eventType: "stream.closed",
+        data: { status: run.status },
+      });
+      sink.end();
+      return "completed";
+    }
+    await deps.sleep(deps.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS);
+  }
+}
+
+async function emit(
+  sink: SseSink,
+  event: { seq: number; eventType: string; data: unknown }
+): Promise<void> {
+  if (!sink.write(formatSseEvent(event))) await sink.waitForDrain();
+}
+
+type PreHandler = (req: FastifyRequest, reply: FastifyReply) => Promise<void>;
+
+export interface RunEventRouteDeps {
+  readonly events: RunEventReader;
+  readonly runs: RunStatusReader;
+  /** Resolves the caller's grant for a Run; `null` denies the stream. */
+  readonly authorize: (req: FastifyRequest, runId: string) => Promise<RunStreamGrant | null>;
+  readonly pollIntervalMs?: number;
+  readonly pageSize?: number;
+}
+
+/** Parses the reconnect cursor: an explicit `?after=` wins, else the SSE `Last-Event-ID` header. */
+export function parseAfterCursor(
+  header: string | string[] | undefined,
+  query: number | undefined
+): number {
+  if (typeof query === "number" && Number.isSafeInteger(query) && query >= 0) return query;
+  const raw = Array.isArray(header) ? header[0] : header;
+  const parsed = Number(raw);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : 0;
+}
+
+function sinkFor(reply: FastifyReply): SseSink {
+  const raw = reply.raw;
+  return {
+    get destroyed() {
+      return raw.destroyed;
+    },
+    write: (chunk) => raw.write(chunk),
+    waitForDrain: () =>
+      new Promise((resolve) => {
+        raw.once("drain", resolve);
+      }),
+    end: () => raw.end(),
+  };
+}
+
+/** `GET /api/v1/runs/:id/events` — persisted Run event stream with cursor recovery (SPEC §18). */
+export function registerRunEventRoutes(
+  app: FastifyInstance,
+  deps: RunEventRouteDeps,
+  requireAuth: PreHandler
+): void {
+  app.get(
+    "/api/v1/runs/:id/events",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description:
+          "SSE stream of a Run's persisted events. Delivery resumes strictly after the cursor — " +
+          "`?after=<sequence>` or the `Last-Event-ID` header — so a reconnect is ordered and free " +
+          "of duplicates. The stream is read-only: losing it never changes the Run. Events the " +
+          "caller's audience does not cover are withheld, and the stream closes if that grant is " +
+          "revoked.",
+        tags: ["runs"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        params: {
+          type: "object",
+          required: ["id"],
+          properties: { id: { type: "string", minLength: 1 } },
+        },
+        querystring: {
+          type: "object",
+          additionalProperties: false,
+          properties: { after: { type: "integer", minimum: 0 } },
+        },
+        response: {
+          200: {
+            type: "string",
+            description: "Server-sent Run events; `id:` carries the resume cursor.",
+          },
+          401: ErrorSchema,
+          403: ErrorSchema,
+          404: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const { id } = req.params as { id: string };
+      const grant = await deps.authorize(req, id);
+      if (!grant) return reply.code(403).send({ error: "run stream not authorized" });
+
+      const run = await deps.runs.find(grant.businessId, id);
+      if (!run) return reply.code(404).send({ error: "run not found" });
+
+      const after = parseAfterCursor(
+        req.headers["last-event-id"],
+        (req.query as { after?: number }).after
+      );
+      writeSseHeaders(reply.raw);
+      reply.hijack();
+      await streamRunEvents(
+        sinkFor(reply),
+        {
+          events: deps.events,
+          runs: deps.runs,
+          authorize: () => deps.authorize(req, id),
+          sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+          pollIntervalMs: deps.pollIntervalMs,
+          pageSize: deps.pageSize,
+        },
+        { runId: id, after }
+      );
+    }
+  );
+}

--- a/apps/api/src/runs/routes.test.ts
+++ b/apps/api/src/runs/routes.test.ts
@@ -1,0 +1,170 @@
+import type { FastifyInstance } from "fastify";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildApp } from "../app";
+import type { TokenDoc, TokenRepo } from "../auth/api-tokens";
+import { CSRF_COOKIE } from "../auth/csrf";
+import { SESSION_COOKIE } from "../auth/routes";
+import { MemorySessionStore } from "../auth/session-store";
+import { createUser, type UserDoc, type UserRepo } from "../auth/users";
+import type { PaginatedResult } from "../pagination";
+import type { RunEventRecord, RunStreamGrant } from "./events";
+
+const TEST_CSRF = "a".repeat(64);
+const RUN_ID = "00000000-0000-4000-8000-000000000001";
+const BUSINESS_ID = "business-1";
+
+class FakeUserRepo implements UserRepo {
+  private users: UserDoc[] = [];
+  async findByEmail(email: string): Promise<UserDoc | null> {
+    return this.users.find((user) => user.email === email.trim().toLowerCase()) ?? null;
+  }
+  async findById(id: string): Promise<UserDoc | null> {
+    return this.users.find((user) => user._id === id) ?? null;
+  }
+  async count(): Promise<number> {
+    return this.users.length;
+  }
+  async insert(user: UserDoc): Promise<void> {
+    this.users.push(user);
+  }
+}
+
+class FakeTokenRepo implements TokenRepo {
+  async create(): Promise<void> {}
+  async findByHash(): Promise<TokenDoc | null> {
+    return null;
+  }
+  async findByUserId(): Promise<TokenDoc[]> {
+    return [];
+  }
+  async findAll(): Promise<TokenDoc[]> {
+    return [];
+  }
+  async findById(): Promise<TokenDoc | null> {
+    return null;
+  }
+  async deleteById(): Promise<void> {}
+  async findAllPaginated(): Promise<PaginatedResult<TokenDoc>> {
+    return { items: [], nextCursor: null };
+  }
+  async findByUserIdPaginated(): Promise<PaginatedResult<TokenDoc>> {
+    return { items: [], nextCursor: null };
+  }
+}
+
+function event(sequence: number): RunEventRecord {
+  return {
+    sequence,
+    eventType: "state.transitioned",
+    audience: "participant",
+    payload: { stateKey: "apply", status: "succeeded" },
+    occurredAt: "2026-07-25T10:00:00.000Z",
+  };
+}
+
+describe("GET /api/v1/runs/:id/events", () => {
+  let app: FastifyInstance;
+  let sid: string;
+  let grant: RunStreamGrant | null;
+  let runStatus: string | null;
+
+  beforeEach(async () => {
+    const store = new MemorySessionStore();
+    const userRepo = new FakeUserRepo();
+    const user = await createUser(userRepo, "user@example.com", "pass", "member");
+    sid = await store.create(user._id);
+    grant = { businessId: BUSINESS_ID, audiences: ["participant"] };
+    runStatus = "succeeded";
+
+    app = await buildApp({
+      sessionStore: store,
+      userRepo,
+      tokenRepo: new FakeTokenRepo(),
+      runEvents: {
+        events: {
+          async list(_businessId, _runId, options) {
+            return [event(1), event(2)].filter((entry) => entry.sequence > options.after);
+          },
+        },
+        runs: {
+          async find() {
+            return runStatus === null ? null : { status: runStatus };
+          },
+        },
+        authorize: async () => grant,
+      },
+    });
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  const authed = () => ({ [SESSION_COOKIE]: sid, [CSRF_COOKIE]: TEST_CSRF });
+
+  it("streams the persisted events with resume cursors", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/runs/${RUN_ID}/events`,
+      cookies: authed(),
+    });
+
+    expect(res.headers["content-type"]).toBe("text/event-stream");
+    expect(res.payload).toContain("id: 1\nevent: state.transitioned\n");
+    expect(res.payload).toContain("id: 2\nevent: state.transitioned\n");
+    expect(res.payload).toContain("event: stream.closed");
+  });
+
+  it("resumes strictly after the requested cursor", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/runs/${RUN_ID}/events?after=1`,
+      cookies: authed(),
+    });
+
+    expect(res.payload).not.toContain("id: 1\nevent: state.transitioned");
+    expect(res.payload).toContain("id: 2\nevent: state.transitioned");
+  });
+
+  it("resumes from the Last-Event-ID header when no cursor is given", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/runs/${RUN_ID}/events`,
+      cookies: authed(),
+      headers: { "last-event-id": "1" },
+    });
+
+    expect(res.payload).not.toContain("id: 1\nevent: state.transitioned");
+    expect(res.payload).toContain("id: 2\nevent: state.transitioned");
+  });
+
+  it("requires authentication", async () => {
+    const res = await app.inject({ method: "GET", url: `/api/v1/runs/${RUN_ID}/events` });
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("denies a caller with no grant for the Run", async () => {
+    grant = null;
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/runs/${RUN_ID}/events`,
+      cookies: authed(),
+    });
+
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("reports an unknown Run before opening a stream", async () => {
+    runStatus = null;
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/runs/${RUN_ID}/events`,
+      cookies: authed(),
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+});

--- a/apps/api/src/runs/stream-recovery.test.ts
+++ b/apps/api/src/runs/stream-recovery.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { type RunEventRecord, type RunStreamGrant, type SseSink, streamRunEvents } from "./events";
+
+const BUSINESS_ID = "business-1";
+const RUN_ID = "00000000-0000-4000-8000-000000000001";
+const GRANT: RunStreamGrant = { businessId: BUSINESS_ID, audiences: ["participant"] };
+
+function record(sequence: number): RunEventRecord {
+  return {
+    sequence,
+    eventType: "state.transitioned",
+    audience: "participant",
+    payload: { stateKey: `state-${sequence}` },
+    occurredAt: "2026-07-25T10:00:00.000Z",
+  };
+}
+
+/** Sink that drops the connection after a fixed number of frames, as a lost client would. */
+class DroppingSink implements SseSink {
+  readonly chunks: string[] = [];
+  destroyed = false;
+  ended = false;
+
+  constructor(private readonly dropAfter = Number.POSITIVE_INFINITY) {}
+
+  write(chunk: string): boolean {
+    this.chunks.push(chunk);
+    if (this.chunks.length >= this.dropAfter) this.destroyed = true;
+    return true;
+  }
+
+  async waitForDrain(): Promise<void> {}
+
+  end(): void {
+    this.ended = true;
+  }
+}
+
+function deliveredIds(sink: DroppingSink): number[] {
+  return sink.chunks
+    .filter((chunk) => chunk.includes("event: state.transitioned"))
+    .map((chunk) => Number(/^id: (\d+)/.exec(chunk)?.[1]));
+}
+
+const log = [record(1), record(2), record(3), record(4)];
+
+const deps = (onList?: () => void) => ({
+  events: {
+    async list(
+      _businessId: string,
+      _runId: string,
+      options: { after: number; audiences: readonly string[]; limit?: number }
+    ) {
+      onList?.();
+      return log.filter((event) => event.sequence > options.after);
+    },
+  },
+  runs: {
+    async find() {
+      return { status: "succeeded" };
+    },
+  },
+  authorize: async () => GRANT,
+  sleep: async () => {},
+});
+
+describe("Run event stream recovery", () => {
+  it("resumes from the last delivered cursor with no gap and no duplicate", async () => {
+    const dropped = new DroppingSink(2);
+
+    const firstOutcome = await streamRunEvents(dropped, deps(), { runId: RUN_ID, after: 0 });
+    expect(firstOutcome).toBe("client_disconnected");
+    const seen = deliveredIds(dropped);
+    expect(seen).toEqual([1, 2]);
+
+    const reconnected = new DroppingSink();
+    const secondOutcome = await streamRunEvents(reconnected, deps(), {
+      runId: RUN_ID,
+      after: seen[seen.length - 1],
+    });
+
+    expect(secondOutcome).toBe("completed");
+    expect(deliveredIds(reconnected)).toEqual([3, 4]);
+    expect([...seen, ...deliveredIds(reconnected)]).toEqual([1, 2, 3, 4]);
+  });
+
+  it("replays the whole log when a client reconnects without a cursor", async () => {
+    const sink = new DroppingSink();
+
+    await streamRunEvents(sink, deps(), { runId: RUN_ID, after: 0 });
+
+    expect(deliveredIds(sink)).toEqual([1, 2, 3, 4]);
+  });
+
+  it("never reads events for a caller whose grant is gone, even mid-recovery", async () => {
+    let listed = 0;
+    const sink = new DroppingSink();
+
+    const outcome = await streamRunEvents(
+      sink,
+      {
+        ...deps(() => {
+          listed += 1;
+        }),
+        authorize: async () => null,
+      },
+      { runId: RUN_ID, after: 2 }
+    );
+
+    expect(outcome).toBe("authorization_revoked");
+    expect(listed).toBe(0);
+    expect(deliveredIds(sink)).toEqual([]);
+  });
+});

--- a/apps/worker/src/recovery/event-delivery.test.ts
+++ b/apps/worker/src/recovery/event-delivery.test.ts
@@ -1,0 +1,134 @@
+import type { ClaimedOutboxMessage, EventOutboxPort, OutboxFailure } from "@tulipfarm/storage";
+import { describe, expect, it } from "vitest";
+import { EventOutboxDispatcher } from "../event-dispatcher";
+
+const BUSINESS_ID = "business-1";
+const OWNER = "worker-1";
+const CONSUMER = "trigger-router";
+const NOW = "2026-07-25T10:00:00.000Z";
+
+function message(overrides: Partial<ClaimedOutboxMessage> = {}): ClaimedOutboxMessage {
+  return {
+    id: "message-1",
+    businessId: BUSINESS_ID,
+    inboxId: "inbox-1",
+    topic: "event.accepted",
+    payload: { inboxId: "inbox-1", eventId: "event-1" },
+    attempts: 1,
+    leaseOwner: OWNER,
+    leaseExpiresAt: "2026-07-25T10:01:00.000Z",
+    ...overrides,
+  };
+}
+
+/** Outbox with the receipt-uniqueness and attempt-exhaustion semantics the tables enforce. */
+class DurableOutbox implements EventOutboxPort {
+  readonly receipts: string[] = [];
+  readonly failures: OutboxFailure[] = [];
+  readonly quarantined: string[] = [];
+  pending: ClaimedOutboxMessage[] = [];
+
+  async claim(): Promise<readonly ClaimedOutboxMessage[]> {
+    return this.pending.splice(0);
+  }
+
+  async complete(
+    _businessId: string,
+    messageId: string,
+    _owner: string,
+    consumer: string
+  ): Promise<"recorded" | "duplicate"> {
+    const receipt = `${messageId}:${consumer}`;
+    if (this.receipts.includes(receipt)) return "duplicate";
+    this.receipts.push(receipt);
+    return "recorded";
+  }
+
+  async fail(
+    _businessId: string,
+    messageId: string,
+    _owner: string,
+    failure: OutboxFailure
+  ): Promise<"released" | "quarantined"> {
+    this.failures.push(failure);
+    const attempts = this.failures.length;
+    if (attempts < failure.maxAttempts) return "released";
+    this.quarantined.push(messageId);
+    return "quarantined";
+  }
+}
+
+function dispatcher(
+  outbox: DurableOutbox,
+  handler: (delivered: ClaimedOutboxMessage) => Promise<void>,
+  maxAttempts?: number
+): EventOutboxDispatcher {
+  return new EventOutboxDispatcher({
+    outbox,
+    businessId: BUSINESS_ID,
+    owner: OWNER,
+    consumer: CONSUMER,
+    handler,
+    now: () => NOW,
+    maxAttempts,
+  });
+}
+
+describe("event delivery recovery", () => {
+  it("records one receipt when a message is redelivered after a lost acknowledgement", async () => {
+    const outbox = new DurableOutbox();
+    const delivered: string[] = [];
+    const dispatch = dispatcher(outbox, async (msg) => {
+      delivered.push(msg.id);
+    });
+
+    outbox.pending.push(message());
+    await dispatch.dispatchBatch();
+    // The lease expired before the receipt was observed, so the same message is claimed again.
+    outbox.pending.push(message({ attempts: 2 }));
+    await dispatch.dispatchBatch();
+
+    expect(delivered).toEqual(["message-1", "message-1"]);
+    expect(outbox.receipts).toEqual(["message-1:trigger-router"]);
+  });
+
+  it("keeps a failing message replayable until its attempts are exhausted", async () => {
+    const outbox = new DurableOutbox();
+    const dispatch = dispatcher(
+      outbox,
+      async () => {
+        throw new Error("downstream unavailable");
+      },
+      2
+    );
+
+    outbox.pending.push(message());
+    const first = await dispatch.dispatchBatch();
+    outbox.pending.push(message({ attempts: 2 }));
+    const second = await dispatch.dispatchBatch();
+
+    expect(first).toEqual({ claimed: 1, dispatched: 0, failed: 1 });
+    expect(second).toEqual({ claimed: 1, dispatched: 0, failed: 1 });
+    expect(outbox.failures.every((failure) => failure.replayEligible)).toBe(true);
+    expect(outbox.quarantined).toEqual(["message-1"]);
+    expect(outbox.receipts).toEqual([]);
+  });
+
+  it("delivers a message that only succeeds on replay, without losing it", async () => {
+    const outbox = new DurableOutbox();
+    let attempts = 0;
+    const dispatch = dispatcher(outbox, async () => {
+      attempts += 1;
+      if (attempts === 1) throw new Error("transient");
+    });
+
+    outbox.pending.push(message());
+    await dispatch.dispatchBatch();
+    outbox.pending.push(message({ attempts: 2 }));
+    const replay = await dispatch.dispatchBatch();
+
+    expect(replay).toEqual({ claimed: 1, dispatched: 1, failed: 0 });
+    expect(outbox.receipts).toEqual(["message-1:trigger-router"]);
+    expect(outbox.quarantined).toEqual([]);
+  });
+});

--- a/apps/worker/src/recovery/run-dispatch.test.ts
+++ b/apps/worker/src/recovery/run-dispatch.test.ts
@@ -1,0 +1,255 @@
+import { RunLeaseManager } from "@tulipfarm/run-kernel";
+import type { PersistedRun, PersistedRunStatus } from "@tulipfarm/storage";
+import { describe, expect, it } from "vitest";
+import { RunDispatcher, type RunOutcome } from "../run-dispatcher";
+
+const BUSINESS_ID = "business-1";
+const RUN_ID = "00000000-0000-4000-8000-000000000001";
+const OWNER = "worker-1";
+const SURVIVOR = "worker-2";
+const T0 = new Date("2026-07-25T10:00:00.000Z");
+const AFTER_LEASE = new Date("2026-07-25T10:05:00.000Z");
+
+function run(overrides: Partial<PersistedRun> = {}): PersistedRun {
+  return {
+    id: RUN_ID,
+    businessId: BUSINESS_ID,
+    bundle: { digest: "sha256:bundle-1", routineId: "routine-1", routineVersion: "1" },
+    identity: {
+      initiator: { kind: "user", id: "user-1" },
+      effectiveSubject: { kind: "agent", id: "agent-1" },
+      guardrailContextRef: "guardrail-context-1",
+    },
+    bounds: { wallTimeMs: 60_000, activeTimeMs: 30_000, attempts: 3, sideEffects: 2 },
+    status: "queued",
+    version: 0,
+    createdAt: "2026-07-25T09:00:00.000Z",
+    startedAt: null,
+    finishedAt: null,
+    resultArtifactId: null,
+    errorEvidenceRef: null,
+    leaseOwner: null,
+    leaseExpiresAt: null,
+    ...overrides,
+  };
+}
+
+/** Run store with the CAS, lease-ownership, and expiry semantics the `runs` table enforces. */
+class DurableRunStore {
+  private readonly runs = new Map<string, PersistedRun>();
+  readonly commits: Array<{ from: string; to: string }> = [];
+
+  seed(overrides: Partial<PersistedRun> = {}): void {
+    const seeded = run(overrides);
+    this.runs.set(seeded.id, seeded);
+  }
+
+  async transitionRun(
+    _businessId: string,
+    runId: string,
+    transition: {
+      expectedVersion: number;
+      expectedStatus: PersistedRunStatus;
+      status: PersistedRunStatus;
+      leaseOwner: string | null;
+      leaseExpiresAt: string | null;
+    }
+  ): Promise<boolean> {
+    const current = this.runs.get(runId);
+    if (
+      !current ||
+      current.status !== transition.expectedStatus ||
+      current.version !== transition.expectedVersion
+    ) {
+      return false;
+    }
+    this.runs.set(runId, {
+      ...current,
+      status: transition.status,
+      version: current.version + 1,
+      leaseOwner: transition.leaseOwner,
+      leaseExpiresAt: transition.leaseExpiresAt,
+    });
+    this.commits.push({ from: current.status, to: transition.status });
+    return true;
+  }
+
+  async heartbeat(
+    _businessId: string,
+    runId: string,
+    owner: string,
+    heartbeat: { expectedVersion: number; leaseExpiresAt: string }
+  ): Promise<boolean> {
+    const current = this.runs.get(runId);
+    if (!current || current.leaseOwner !== owner || current.version !== heartbeat.expectedVersion) {
+      return false;
+    }
+    this.runs.set(runId, { ...current, leaseExpiresAt: heartbeat.leaseExpiresAt });
+    return true;
+  }
+
+  async reclaimExpiredRuns(
+    _businessId: string,
+    now: string,
+    limit: number
+  ): Promise<readonly PersistedRun[]> {
+    const reclaimed: PersistedRun[] = [];
+    for (const current of this.runs.values()) {
+      if (reclaimed.length >= limit) break;
+      const leased = current.status === "claimed" || current.status === "running";
+      if (!leased || current.leaseExpiresAt === null || current.leaseExpiresAt > now) continue;
+      const requeued: PersistedRun = {
+        ...current,
+        status: "queued",
+        version: current.version + 1,
+        leaseOwner: null,
+        leaseExpiresAt: null,
+      };
+      this.runs.set(current.id, requeued);
+      this.commits.push({ from: current.status, to: "queued" });
+      reclaimed.push(requeued);
+    }
+    return reclaimed;
+  }
+
+  async claimNextQueued(
+    _businessId: string,
+    owner: string,
+    input: { now: string; leaseDurationMs: number; limit: number }
+  ): Promise<readonly PersistedRun[]> {
+    const claimed: PersistedRun[] = [];
+    const leaseExpiresAt = new Date(
+      new Date(input.now).getTime() + input.leaseDurationMs
+    ).toISOString();
+    for (const current of this.runs.values()) {
+      if (claimed.length >= input.limit) break;
+      if (current.status !== "queued") continue;
+      const next: PersistedRun = {
+        ...current,
+        status: "claimed",
+        version: current.version + 1,
+        leaseOwner: owner,
+        leaseExpiresAt,
+      };
+      this.runs.set(current.id, next);
+      this.commits.push({ from: "queued", to: "claimed" });
+      claimed.push(next);
+    }
+    return claimed;
+  }
+
+  async find(_businessId: string, runId: string): Promise<PersistedRun | null> {
+    return this.runs.get(runId) ?? null;
+  }
+}
+
+function dispatcher(
+  store: DurableRunStore,
+  owner: string,
+  handler: (dispatched: PersistedRun) => Promise<RunOutcome>,
+  now: () => Date = () => T0
+): RunDispatcher {
+  return new RunDispatcher({
+    leases: new RunLeaseManager(store),
+    businessId: BUSINESS_ID,
+    owner,
+    handler,
+    now,
+    leaseDurationMs: 60_000,
+  });
+}
+
+describe("Run dispatch recovery", () => {
+  it("parks a Run for reconciliation when the handler crashes mid-effect", async () => {
+    const store = new DurableRunStore();
+    store.seed();
+
+    const result = await dispatcher(store, OWNER, async () => {
+      throw new Error("effect ambiguous");
+    }).dispatchBatch();
+
+    expect(result).toEqual({ reclaimed: 0, claimed: 1, dispatched: 0, failed: 1 });
+    expect(await store.find(BUSINESS_ID, RUN_ID)).toMatchObject({
+      status: "needs_reconciliation",
+      leaseOwner: null,
+    });
+  });
+
+  it("re-dispatches an accepted Run after the worker holding it died", async () => {
+    const store = new DurableRunStore();
+    // Worker 1 claimed and started the Run, then died without releasing its lease.
+    store.seed({
+      status: "running",
+      version: 2,
+      leaseOwner: OWNER,
+      leaseExpiresAt: T0.toISOString(),
+    });
+
+    const handled: string[] = [];
+    const recovered = await dispatcher(
+      store,
+      SURVIVOR,
+      async (dispatched) => {
+        handled.push(dispatched.id);
+        return "succeeded";
+      },
+      () => AFTER_LEASE
+    ).dispatchBatch();
+
+    expect(recovered).toEqual({ reclaimed: 1, claimed: 1, dispatched: 1, failed: 0 });
+    expect(handled).toEqual([RUN_ID]);
+    expect(await store.find(BUSINESS_ID, RUN_ID)).toMatchObject({
+      status: "succeeded",
+      leaseOwner: null,
+    });
+  });
+
+  it("never runs a Run twice when a stale worker claims alongside the current one", async () => {
+    const store = new DurableRunStore();
+    store.seed();
+    const handled: string[] = [];
+    const handler = async (dispatched: PersistedRun): Promise<RunOutcome> => {
+      handled.push(dispatched.leaseOwner ?? "");
+      return "succeeded";
+    };
+
+    // Both workers claim the same batch; only the first `claimed`->`running` CAS can win.
+    const stale = dispatcher(store, OWNER, handler);
+    const current = dispatcher(store, SURVIVOR, handler);
+    const [first, second] = [await stale.dispatchBatch(), await current.dispatchBatch()];
+
+    expect(first).toEqual({ reclaimed: 0, claimed: 1, dispatched: 1, failed: 0 });
+    expect(second).toEqual({ reclaimed: 0, claimed: 0, dispatched: 0, failed: 0 });
+    expect(handled).toEqual([OWNER]);
+    expect(store.commits.filter((commit) => commit.to === "succeeded")).toHaveLength(1);
+  });
+
+  it("leaves a Run untouched when its version moved after the batch claim", async () => {
+    const store = new DurableRunStore();
+    store.seed();
+    const claimed = await store.claimNextQueued(BUSINESS_ID, OWNER, {
+      now: T0.toISOString(),
+      leaseDurationMs: 60_000,
+      limit: 1,
+    });
+    expect(claimed).toHaveLength(1);
+
+    // The Run is reclaimed out from under the batch before the worker starts it.
+    const leases = new RunLeaseManager(store);
+    await leases.reclaimExpired({ businessId: BUSINESS_ID, now: AFTER_LEASE, limit: 10 });
+
+    const started = await leases.claim({
+      businessId: BUSINESS_ID,
+      runId: RUN_ID,
+      owner: OWNER,
+      now: AFTER_LEASE,
+      leaseDurationMs: 60_000,
+      expectedVersion: claimed[0].version,
+      expectedStatus: "claimed",
+      status: "running",
+    });
+
+    expect(started.claimed).toBe(false);
+    expect(await store.find(BUSINESS_ID, RUN_ID)).toMatchObject({ status: "queued", version: 2 });
+  });
+});

--- a/apps/worker/vitest.config.ts
+++ b/apps/worker/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    // `pnpm build` emits compiled copies of these tests into dist/; running those CJS files under
+    // vitest fails. Only the TypeScript sources are the suite.
+    include: ["src/**/*.test.ts"],
+    exclude: ["dist/**"],
+  },
+});

--- a/packages/run-kernel/AGENTS.md
+++ b/packages/run-kernel/AGENTS.md
@@ -13,7 +13,8 @@ with a declared exhaustion disposition, and `serialize`/`queue`/`coalesce`/`reje
 target-concurrency admission over a deterministic target key), and `src/children`, `src/cancel`,
 `src/reconcile-state` (never-broadening child authority with explicit detach, cancellation that
 cancels future work and parks in-flight effects, and evidence-driven reconciliation where an
-ambiguous effect never becomes `cancelled`). tsconfig extends `@tulipfarm/tsconfig/base.json`. See root `AGENTS.md` for commands/lint.
+ambiguous effect never becomes `cancelled`), and `src/resilience` (crash/duplicate/recovery proofs
+over a `SimulatedRunStore` that injects failure before and after each durable write). tsconfig extends `@tulipfarm/tsconfig/base.json`. See root `AGENTS.md` for commands/lint.
 
 May import: `@tulipfarm/schema`, `@tulipfarm/audit`, `@tulipfarm/storage`,
 `@tulipfarm/observability`. See

--- a/packages/run-kernel/src/resilience/recovery.test.ts
+++ b/packages/run-kernel/src/resilience/recovery.test.ts
@@ -1,0 +1,352 @@
+import { MemoryWaitStore } from "@tulipfarm/storage";
+import { describe, expect, it } from "vitest";
+import { RunLeaseManager } from "../lease";
+import { StateReconciler } from "../reconcile-state";
+import { RunResumeGateway } from "../resume";
+import { DurableWaitManager } from "../waits";
+import { SimulatedCrash, SimulatedRunStore } from "./simulator";
+
+const BUSINESS_ID = "business-1";
+const RUN_ID = "00000000-0000-4000-8000-000000000001";
+const OWNER = "worker-1";
+const OTHER_OWNER = "worker-2";
+const T0 = new Date("2026-07-25T10:00:00.000Z");
+const AFTER_LEASE = new Date("2026-07-25T10:05:00.000Z");
+
+function leaseFixture() {
+  const store = new SimulatedRunStore();
+  store.seedRun({ status: "queued" });
+  return { store, leases: new RunLeaseManager(store) };
+}
+
+describe("crash at the claim boundary", () => {
+  it("keeps the Run claimable when the claim never committed", async () => {
+    const { store, leases } = leaseFixture();
+    store.crashBefore("transitionRun");
+
+    await expect(
+      leases.claim({
+        businessId: BUSINESS_ID,
+        runId: RUN_ID,
+        owner: OWNER,
+        now: T0,
+        leaseDurationMs: 60_000,
+        expectedVersion: 0,
+        expectedStatus: "queued",
+        status: "claimed",
+      })
+    ).rejects.toBeInstanceOf(SimulatedCrash);
+
+    const run = await store.find(BUSINESS_ID, RUN_ID);
+    expect(run?.status).toBe("queued");
+    expect(run?.version).toBe(0);
+    expect(run?.leaseOwner).toBeNull();
+
+    const retried = await leases.claim({
+      businessId: BUSINESS_ID,
+      runId: RUN_ID,
+      owner: OWNER,
+      now: T0,
+      leaseDurationMs: 60_000,
+      expectedVersion: 0,
+      expectedStatus: "queued",
+      status: "claimed",
+    });
+    expect(retried.claimed).toBe(true);
+  });
+
+  it("does not claim twice when the commit landed but the acknowledgement was lost", async () => {
+    const { store, leases } = leaseFixture();
+    store.crashAfter("transitionRun");
+
+    await expect(
+      leases.claim({
+        businessId: BUSINESS_ID,
+        runId: RUN_ID,
+        owner: OWNER,
+        now: T0,
+        leaseDurationMs: 60_000,
+        expectedVersion: 0,
+        expectedStatus: "queued",
+        status: "claimed",
+      })
+    ).rejects.toBeInstanceOf(SimulatedCrash);
+
+    // The write survived the crash, so the blind retry loses the CAS instead of re-claiming.
+    const retried = await leases.claim({
+      businessId: BUSINESS_ID,
+      runId: RUN_ID,
+      owner: OWNER,
+      now: T0,
+      leaseDurationMs: 60_000,
+      expectedVersion: 0,
+      expectedStatus: "queued",
+      status: "claimed",
+    });
+    expect(retried.claimed).toBe(false);
+    expect(store.transitions).toHaveLength(1);
+    const run = await store.find(BUSINESS_ID, RUN_ID);
+    expect(run).toMatchObject({ status: "claimed", version: 1, leaseOwner: OWNER });
+  });
+});
+
+describe("crash while holding a lease", () => {
+  it("recovers an accepted Run once its lease expires", async () => {
+    const { store, leases } = leaseFixture();
+    await leases.claim({
+      businessId: BUSINESS_ID,
+      runId: RUN_ID,
+      owner: OWNER,
+      now: T0,
+      leaseDurationMs: 60_000,
+      expectedVersion: 0,
+      expectedStatus: "queued",
+      status: "claimed",
+    });
+    await leases.claim({
+      businessId: BUSINESS_ID,
+      runId: RUN_ID,
+      owner: OWNER,
+      now: T0,
+      leaseDurationMs: 60_000,
+      expectedVersion: 1,
+      expectedStatus: "claimed",
+      status: "running",
+    });
+
+    // Worker dies mid-Run: no release, no heartbeat.
+    const reclaimed = await leases.reclaimExpired({
+      businessId: BUSINESS_ID,
+      now: AFTER_LEASE,
+      limit: 10,
+    });
+
+    expect(reclaimed.map((run) => run.id)).toEqual([RUN_ID]);
+    expect(reclaimed[0]).toMatchObject({
+      status: "queued",
+      leaseOwner: null,
+      leaseExpiresAt: null,
+    });
+
+    const reclaimedRun = reclaimed[0];
+    const second = await leases.claim({
+      businessId: BUSINESS_ID,
+      runId: RUN_ID,
+      owner: OTHER_OWNER,
+      now: AFTER_LEASE,
+      leaseDurationMs: 60_000,
+      expectedVersion: reclaimedRun.version,
+      expectedStatus: "queued",
+      status: "claimed",
+    });
+    expect(second.claimed).toBe(true);
+  });
+
+  it("refuses a resurrected worker's commit after its lease was reclaimed", async () => {
+    const { store, leases } = leaseFixture();
+    await leases.claim({
+      businessId: BUSINESS_ID,
+      runId: RUN_ID,
+      owner: OWNER,
+      now: T0,
+      leaseDurationMs: 60_000,
+      expectedVersion: 0,
+      expectedStatus: "queued",
+      status: "claimed",
+    });
+    const running = await leases.claim({
+      businessId: BUSINESS_ID,
+      runId: RUN_ID,
+      owner: OWNER,
+      now: T0,
+      leaseDurationMs: 60_000,
+      expectedVersion: 1,
+      expectedStatus: "claimed",
+      status: "running",
+    });
+    const staleVersion = running.run?.version ?? -1;
+
+    await leases.reclaimExpired({ businessId: BUSINESS_ID, now: AFTER_LEASE, limit: 10 });
+
+    const released = await leases.release({
+      businessId: BUSINESS_ID,
+      runId: RUN_ID,
+      expectedVersion: staleVersion,
+      expectedStatus: "running",
+      status: "succeeded",
+    });
+    const heartbeat = await leases.heartbeat({
+      businessId: BUSINESS_ID,
+      runId: RUN_ID,
+      owner: OWNER,
+      now: AFTER_LEASE,
+      leaseDurationMs: 60_000,
+      expectedVersion: staleVersion,
+    });
+
+    expect(released).toBe(false);
+    expect(heartbeat).toBe(false);
+    expect((await store.find(BUSINESS_ID, RUN_ID))?.status).toBe("queued");
+  });
+
+  it("commits a terminal outcome exactly once under duplicate release", async () => {
+    const { store, leases } = leaseFixture();
+    store.seedRun({ status: "running", version: 4, leaseOwner: OWNER });
+
+    const first = await leases.release({
+      businessId: BUSINESS_ID,
+      runId: RUN_ID,
+      expectedVersion: 4,
+      expectedStatus: "running",
+      status: "succeeded",
+    });
+    const replay = await leases.release({
+      businessId: BUSINESS_ID,
+      runId: RUN_ID,
+      expectedVersion: 4,
+      expectedStatus: "running",
+      status: "failed",
+    });
+
+    expect(first).toBe(true);
+    expect(replay).toBe(false);
+    expect(await store.find(BUSINESS_ID, RUN_ID)).toMatchObject({
+      status: "succeeded",
+      version: 5,
+    });
+  });
+});
+
+describe("crash at the wait boundary", () => {
+  const waitFixture = () => {
+    const runs = new SimulatedRunStore();
+    runs.seedRun({ status: "waiting", version: 3 });
+    const waits = new MemoryWaitStore();
+    return { runs, manager: new DurableWaitManager(waits, new RunResumeGateway(runs)) };
+  };
+
+  const register = (manager: DurableWaitManager, expectedSignals: number) =>
+    manager.register({
+      id: "wait-1",
+      businessId: BUSINESS_ID,
+      runId: RUN_ID,
+      stateKey: "approve",
+      kind: "approval",
+      aggregation: expectedSignals === 1 ? "first" : "all",
+      schemaRef: "schema://approval/1",
+      allowedPrincipals: ["user:alice", "user:bob"],
+      expectedSignals,
+      quorum: null,
+      deadlineAt: "2026-07-25T12:00:00.000Z",
+      createdAt: "2026-07-25T09:00:00.000Z",
+    });
+
+  const signal = (
+    manager: DurableWaitManager,
+    token: string,
+    overrides: { id: string; principal: string; correlationKey: string; receivedAt: string }
+  ) =>
+    manager.signal({
+      businessId: BUSINESS_ID,
+      runId: RUN_ID,
+      token,
+      schemaRef: "schema://approval/1",
+      signalDigest: `sha256:${overrides.correlationKey}`,
+      ...overrides,
+    });
+
+  it("resumes a Run once when the same signal is delivered twice", async () => {
+    const { runs, manager } = waitFixture();
+    const { token } = await register(manager, 1);
+
+    const first = await signal(manager, token, {
+      id: "signal-1",
+      principal: "user:alice",
+      correlationKey: "approval-1",
+      receivedAt: "2026-07-25T10:00:00.000Z",
+    });
+    const redelivered = await signal(manager, token, {
+      id: "signal-1-retry",
+      principal: "user:alice",
+      correlationKey: "approval-1",
+      receivedAt: "2026-07-25T10:00:05.000Z",
+    });
+
+    expect(first.outcome).toBe("resumed");
+    expect(redelivered.outcome).toBe("duplicate");
+    expect(runs.requeues).toBe(1);
+    expect((await runs.find(BUSINESS_ID, RUN_ID))?.status).toBe("queued");
+  });
+
+  it("resolves an aggregated wait once regardless of signal arrival order", async () => {
+    const { runs, manager } = waitFixture();
+    const { token } = await register(manager, 2);
+
+    const later = await signal(manager, token, {
+      id: "signal-b",
+      principal: "user:bob",
+      correlationKey: "approval-b",
+      receivedAt: "2026-07-25T10:02:00.000Z",
+    });
+    const earlier = await signal(manager, token, {
+      id: "signal-a",
+      principal: "user:alice",
+      correlationKey: "approval-a",
+      receivedAt: "2026-07-25T10:01:00.000Z",
+    });
+
+    expect(later.outcome).toBe("recorded");
+    expect(earlier.outcome).toBe("resumed");
+    expect(runs.requeues).toBe(1);
+  });
+
+  it("parks the wait for reconciliation when the Run already left `waiting`", async () => {
+    const { runs, manager } = waitFixture();
+    const { token } = await register(manager, 1);
+    runs.seedRun({ status: "cancelling", version: 4 });
+
+    const delivered = await signal(manager, token, {
+      id: "signal-1",
+      principal: "user:alice",
+      correlationKey: "approval-1",
+      receivedAt: "2026-07-25T10:00:00.000Z",
+    });
+
+    expect(delivered.outcome).toBe("resolved_without_resume");
+    expect(runs.requeues).toBe(0);
+  });
+});
+
+describe("crash mid-effect", () => {
+  it("settles a parked State only on evidence, never by assumption", async () => {
+    const store = new SimulatedRunStore();
+    store.seedState("charge", { status: "needs_reconciliation", version: 2 });
+    const reconciler = new StateReconciler(store);
+
+    const ambiguous = await reconciler.reconcile({
+      businessId: BUSINESS_ID,
+      runId: RUN_ID,
+      stateKey: "charge",
+      evidence: {
+        outcome: "ambiguous",
+        evidenceRef: "evidence://probe-1",
+        observedAt: "2026-07-25T10:10:00.000Z",
+      },
+    });
+    expect(ambiguous).toMatchObject({ kind: "unresolved", status: "needs_reconciliation" });
+    expect(store.stateOf("charge")).toMatchObject({ status: "needs_reconciliation", version: 2 });
+
+    const settled = await reconciler.reconcile({
+      businessId: BUSINESS_ID,
+      runId: RUN_ID,
+      stateKey: "charge",
+      evidence: {
+        outcome: "applied",
+        evidenceRef: "evidence://probe-2",
+        observedAt: "2026-07-25T10:11:00.000Z",
+      },
+    });
+    expect(settled).toMatchObject({ kind: "resolved", status: "succeeded" });
+    expect(store.stateOf("charge")).toMatchObject({ status: "succeeded", version: 3 });
+  });
+});

--- a/packages/run-kernel/src/resilience/simulator.ts
+++ b/packages/run-kernel/src/resilience/simulator.ts
@@ -1,0 +1,273 @@
+import type { PersistedRun, PersistedRunStatus } from "@tulipfarm/storage";
+import type { RunLeaseStore } from "../lease";
+import type { ReconcilableStateStore } from "../reconcile-state";
+import type { RunResumeStore } from "../resume";
+
+const BUSINESS_ID = "business-1";
+const RUN_ID = "00000000-0000-4000-8000-000000000001";
+
+/** Failure injected at a durable write boundary; distinct from a real defect. */
+export class SimulatedCrash extends Error {
+  readonly name = "SimulatedCrash";
+
+  constructor(
+    readonly operation: string,
+    readonly when: "before" | "after"
+  ) {
+    super(`simulated_crash:${when}:${operation}`);
+  }
+}
+
+export interface SimulatedState {
+  status: string;
+  version: number;
+  finishedAt: string | null;
+  errorEvidenceRef: string | null;
+}
+
+function baseRun(overrides: Partial<PersistedRun>): PersistedRun {
+  return {
+    id: RUN_ID,
+    businessId: BUSINESS_ID,
+    bundle: { digest: "sha256:bundle-1", routineId: "routine-1", routineVersion: "1" },
+    identity: {
+      initiator: { kind: "user", id: "user-1" },
+      effectiveSubject: { kind: "agent", id: "agent-1" },
+      guardrailContextRef: "guardrail-context-1",
+    },
+    bounds: { wallTimeMs: 60_000, activeTimeMs: 30_000, attempts: 3, sideEffects: 2 },
+    status: "queued",
+    version: 0,
+    createdAt: "2026-07-25T09:00:00.000Z",
+    startedAt: null,
+    finishedAt: null,
+    resultArtifactId: null,
+    errorEvidenceRef: null,
+    leaseOwner: null,
+    leaseExpiresAt: null,
+    ...overrides,
+  };
+}
+
+/**
+ * In-memory Run store with the durability semantics the PostgreSQL tables enforce — compare-and-set
+ * on `(status, version)`, owner-checked heartbeats, and expiry-driven lease reclaim — plus failure
+ * injection at each write boundary. It exists so recovery can be proven at the boundary a crash
+ * actually lands on: `crashBefore` loses the write, `crashAfter` commits it and loses the
+ * acknowledgement. Both must leave the Run recoverable and must not admit a second commit.
+ */
+export class SimulatedRunStore implements RunLeaseStore, RunResumeStore, ReconcilableStateStore {
+  private readonly runs = new Map<string, PersistedRun>();
+  private readonly states = new Map<string, SimulatedState>();
+  private readonly crashesBefore = new Set<string>();
+  private readonly crashesAfter = new Set<string>();
+
+  /** Every write that reached storage, in order — a duplicate commit would show up here. */
+  readonly transitions: Array<{ runId: string; from: string; to: string; version: number }> = [];
+  /** Number of Runs actually requeued out of `waiting`. */
+  requeues = 0;
+
+  seedRun(overrides: Partial<PersistedRun> = {}): PersistedRun {
+    const run = baseRun(overrides);
+    this.runs.set(run.id, run);
+    return run;
+  }
+
+  seedState(stateKey: string, state: { status: string; version: number }): void {
+    this.states.set(stateKey, {
+      status: state.status,
+      version: state.version,
+      finishedAt: null,
+      errorEvidenceRef: null,
+    });
+  }
+
+  stateOf(stateKey: string): SimulatedState | undefined {
+    return this.states.get(stateKey);
+  }
+
+  /** The next call to `operation` throws without writing. */
+  crashBefore(operation: string): void {
+    this.crashesBefore.add(operation);
+  }
+
+  /** The next call to `operation` writes, then throws — the caller never learns it committed. */
+  crashAfter(operation: string): void {
+    this.crashesAfter.add(operation);
+  }
+
+  private guard(operation: string, when: "before" | "after"): void {
+    const crashes = when === "before" ? this.crashesBefore : this.crashesAfter;
+    if (!crashes.delete(operation)) return;
+    throw new SimulatedCrash(operation, when);
+  }
+
+  async transitionRun(
+    _businessId: string,
+    runId: string,
+    transition: {
+      expectedVersion: number;
+      expectedStatus: PersistedRunStatus;
+      status: PersistedRunStatus;
+      leaseOwner: string | null;
+      leaseExpiresAt: string | null;
+    }
+  ): Promise<boolean> {
+    this.guard("transitionRun", "before");
+    const run = this.runs.get(runId);
+    if (
+      !run ||
+      run.status !== transition.expectedStatus ||
+      run.version !== transition.expectedVersion
+    ) {
+      return false;
+    }
+    this.runs.set(runId, {
+      ...run,
+      status: transition.status,
+      version: run.version + 1,
+      leaseOwner: transition.leaseOwner,
+      leaseExpiresAt: transition.leaseExpiresAt,
+    });
+    this.transitions.push({
+      runId,
+      from: run.status,
+      to: transition.status,
+      version: run.version + 1,
+    });
+    this.guard("transitionRun", "after");
+    return true;
+  }
+
+  async heartbeat(
+    _businessId: string,
+    runId: string,
+    owner: string,
+    heartbeat: { expectedVersion: number; leaseExpiresAt: string }
+  ): Promise<boolean> {
+    this.guard("heartbeat", "before");
+    const run = this.runs.get(runId);
+    if (!run || run.leaseOwner !== owner || run.version !== heartbeat.expectedVersion) return false;
+    this.runs.set(runId, { ...run, leaseExpiresAt: heartbeat.leaseExpiresAt });
+    this.guard("heartbeat", "after");
+    return true;
+  }
+
+  async reclaimExpiredRuns(
+    _businessId: string,
+    now: string,
+    limit: number
+  ): Promise<readonly PersistedRun[]> {
+    this.guard("reclaimExpiredRuns", "before");
+    const reclaimed: PersistedRun[] = [];
+    for (const run of this.runs.values()) {
+      if (reclaimed.length >= limit) break;
+      const leased = run.status === "claimed" || run.status === "running";
+      if (!leased || run.leaseExpiresAt === null || run.leaseExpiresAt > now) continue;
+      const requeued: PersistedRun = {
+        ...run,
+        status: "queued",
+        version: run.version + 1,
+        leaseOwner: null,
+        leaseExpiresAt: null,
+      };
+      this.runs.set(run.id, requeued);
+      this.transitions.push({
+        runId: run.id,
+        from: run.status,
+        to: "queued",
+        version: requeued.version,
+      });
+      reclaimed.push(requeued);
+    }
+    this.guard("reclaimExpiredRuns", "after");
+    return reclaimed;
+  }
+
+  async claimNextQueued(
+    _businessId: string,
+    owner: string,
+    input: { now: string; leaseDurationMs: number; limit: number }
+  ): Promise<readonly PersistedRun[]> {
+    this.guard("claimNextQueued", "before");
+    const claimed: PersistedRun[] = [];
+    const leaseExpiresAt = new Date(
+      new Date(input.now).getTime() + input.leaseDurationMs
+    ).toISOString();
+    for (const run of this.runs.values()) {
+      if (claimed.length >= input.limit) break;
+      if (run.status !== "queued") continue;
+      const next: PersistedRun = {
+        ...run,
+        status: "claimed",
+        version: run.version + 1,
+        leaseOwner: owner,
+        leaseExpiresAt,
+      };
+      this.runs.set(run.id, next);
+      this.transitions.push({
+        runId: run.id,
+        from: "queued",
+        to: "claimed",
+        version: next.version,
+      });
+      claimed.push(next);
+    }
+    this.guard("claimNextQueued", "after");
+    return claimed;
+  }
+
+  async find(_businessId: string, runId: string): Promise<PersistedRun | null> {
+    return this.runs.get(runId) ?? null;
+  }
+
+  async requeueWaitingRun(_businessId: string, runId: string): Promise<boolean> {
+    this.guard("requeueWaitingRun", "before");
+    const run = this.runs.get(runId);
+    if (!run || run.status !== "waiting") return false;
+    this.runs.set(runId, { ...run, status: "queued", version: run.version + 1 });
+    this.requeues += 1;
+    this.guard("requeueWaitingRun", "after");
+    return true;
+  }
+
+  async findState(
+    _businessId: string,
+    _runId: string,
+    stateKey: string
+  ): Promise<{ status: string; version: number } | null> {
+    const state = this.states.get(stateKey);
+    return state ? { status: state.status, version: state.version } : null;
+  }
+
+  async transitionState(
+    _businessId: string,
+    _runId: string,
+    stateKey: string,
+    transition: {
+      expectedVersion: number;
+      expectedStatus: string;
+      status: string;
+      finishedAt?: string;
+      errorEvidenceRef?: string;
+    }
+  ): Promise<boolean> {
+    this.guard("transitionState", "before");
+    const state = this.states.get(stateKey);
+    if (
+      !state ||
+      state.status !== transition.expectedStatus ||
+      state.version !== transition.expectedVersion
+    ) {
+      return false;
+    }
+    this.states.set(stateKey, {
+      status: transition.status,
+      version: state.version + 1,
+      finishedAt: transition.finishedAt ?? null,
+      errorEvidenceRef: transition.errorEvidenceRef ?? null,
+    });
+    this.guard("transitionState", "after");
+    return true;
+  }
+}

--- a/packages/storage/AGENTS.md
+++ b/packages/storage/AGENTS.md
@@ -12,7 +12,8 @@ plus `MemoryArtifactStore`) that `@tulipfarm/run-kernel` drives. `src/runs/` own
 (`RunStore`, `WaitStore`, plus `MemoryWaitStore`), including resume-token digests and
 lock-guarded wait resolution, plus the write-once `run_budgets` ledger (`BudgetStore`) and the
 lock-guarded `run_concurrency_keys`/`run_concurrency_slots` tables (`ConcurrencyStore`), plus the
-authority-immutable, detach-final `run_child_links` table (`ChildLinkStore`). tsconfig extends
+authority-immutable, detach-final `run_child_links` table (`ChildLinkStore`), plus the append-only,
+audience-scoped `run_events` stream with a gapless per-Run sequence (`RunEventStore`). tsconfig extends
 `@tulipfarm/tsconfig/base.json`. See root `AGENTS.md` for commands/lint.
 
 May import: `@tulipfarm/schema`, `@tulipfarm/observability`. See

--- a/packages/storage/src/runs/events.pg.test.ts
+++ b/packages/storage/src/runs/events.pg.test.ts
@@ -1,0 +1,167 @@
+import { PGlite } from "@electric-sql/pglite";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { Queryable, TransactionPort } from "../ports";
+import { type AppendRunEventInput, RUN_EVENT_STORAGE_STATEMENTS, RunEventStore } from "./events";
+import { RUN_STORAGE_STATEMENTS, RunStore, type StartRunInput } from "./run-store";
+
+const BUSINESS = "business-1";
+const RUN_ID = "00000000-0000-4000-8000-000000000001";
+const OTHER_RUN_ID = "00000000-0000-4000-8000-000000000002";
+const OCCURRED_AT = "2026-07-25T10:00:00.000Z";
+
+function transactionPort(database: PGlite): TransactionPort {
+  return {
+    withTransaction: (operation) =>
+      database.transaction((transaction) => operation(transaction as Queryable)),
+  };
+}
+
+function run(id: string): StartRunInput {
+  return {
+    id,
+    businessId: BUSINESS,
+    bundle: { digest: "sha256:bundle-1", routineId: "routine-1", routineVersion: "1" },
+    identity: {
+      initiator: { kind: "user", id: "user-1" },
+      effectiveSubject: { kind: "agent", id: "agent-1" },
+      guardrailContextRef: "guardrail-context-1",
+    },
+    bounds: { wallTimeMs: 60_000, activeTimeMs: 30_000, attempts: 3, sideEffects: 2 },
+    createdAt: OCCURRED_AT,
+    states: [{ key: "apply", definitionRef: "sha256:bundle-1#/states/apply", resolvedInput: {} }],
+  };
+}
+
+describe("RunEventStore", () => {
+  let database: PGlite;
+  let store: RunEventStore;
+  let runs: RunStore;
+
+  beforeAll(async () => {
+    database = new PGlite();
+    for (const statement of [...RUN_STORAGE_STATEMENTS, ...RUN_EVENT_STORAGE_STATEMENTS]) {
+      await database.exec(statement);
+    }
+    const transactions = transactionPort(database);
+    store = new RunEventStore(transactions);
+    runs = new RunStore(transactions);
+  });
+
+  afterAll(async () => {
+    await database.close();
+  });
+
+  beforeEach(async () => {
+    await database.query("TRUNCATE TABLE runs CASCADE");
+    for (const id of [RUN_ID, OTHER_RUN_ID]) {
+      await runs.start(run(id));
+    }
+  });
+
+  function event(overrides: Partial<AppendRunEventInput> = {}): AppendRunEventInput {
+    return {
+      businessId: BUSINESS,
+      runId: RUN_ID,
+      eventType: "state.transitioned",
+      audience: "participant",
+      payload: { stateKey: "apply", status: "running" },
+      idempotencyKey: "attempt-1:running",
+      occurredAt: OCCURRED_AT,
+      ...overrides,
+    };
+  }
+
+  it("assigns a gapless monotonic sequence per Run", async () => {
+    const first = await store.append(event());
+    const second = await store.append(event({ idempotencyKey: "attempt-1:succeeded" }));
+    const otherRun = await store.append(event({ runId: OTHER_RUN_ID }));
+
+    expect([first.sequence, second.sequence]).toEqual([1, 2]);
+    expect(otherRun.sequence).toBe(1);
+  });
+
+  it("collapses a duplicate delivery onto the event it already recorded", async () => {
+    const first = await store.append(event());
+
+    const replay = await store.append(event({ payload: { tampered: true } }));
+
+    expect(replay).toEqual(first);
+    expect(
+      await store.list(BUSINESS, RUN_ID, { after: 0, audiences: ["participant"] })
+    ).toHaveLength(1);
+  });
+
+  it("lists only events after the cursor, in sequence order", async () => {
+    await store.append(event({ idempotencyKey: "a" }));
+    await store.append(event({ idempotencyKey: "b" }));
+    await store.append(event({ idempotencyKey: "c" }));
+
+    const page = await store.list(BUSINESS, RUN_ID, { after: 1, audiences: ["participant"] });
+
+    expect(page.map((entry) => entry.sequence)).toEqual([2, 3]);
+  });
+
+  it("bounds a page so a reconnecting client cannot pull an unbounded backlog", async () => {
+    for (let index = 0; index < 5; index += 1) {
+      await store.append(event({ idempotencyKey: `k-${index}` }));
+    }
+
+    const page = await store.list(BUSINESS, RUN_ID, {
+      after: 0,
+      audiences: ["participant"],
+      limit: 2,
+    });
+
+    expect(page.map((entry) => entry.sequence)).toEqual([1, 2]);
+  });
+
+  it("withholds events the reader's audience does not cover", async () => {
+    await store.append(event({ audience: "participant", idempotencyKey: "p" }));
+    await store.append(event({ audience: "operator", idempotencyKey: "o" }));
+
+    const asParticipant = await store.list(BUSINESS, RUN_ID, {
+      after: 0,
+      audiences: ["participant"],
+    });
+    const asOperator = await store.list(BUSINESS, RUN_ID, {
+      after: 0,
+      audiences: ["participant", "operator"],
+    });
+
+    expect(asParticipant.map((entry) => entry.audience)).toEqual(["participant"]);
+    expect(asOperator).toHaveLength(2);
+  });
+
+  it("returns nothing when the reader has no audience, so access is default-deny", async () => {
+    await store.append(event());
+
+    expect(await store.list(BUSINESS, RUN_ID, { after: 0, audiences: [] })).toEqual([]);
+  });
+
+  it("never returns another business's events for the same Run id", async () => {
+    await store.append(event());
+
+    expect(
+      await store.list("business-2", RUN_ID, { after: 0, audiences: ["participant"] })
+    ).toEqual([]);
+  });
+
+  it("reports the latest sequence so a reader can detect a gap", async () => {
+    await store.append(event({ idempotencyKey: "a" }));
+    await store.append(event({ idempotencyKey: "b" }));
+
+    expect(await store.latestSequence(BUSINESS, RUN_ID)).toBe(2);
+    expect(await store.latestSequence(BUSINESS, OTHER_RUN_ID)).toBe(0);
+  });
+
+  it("keeps the stream append-only so a delivered event cannot be rewritten", async () => {
+    await store.append(event());
+
+    await expect(database.exec("UPDATE run_events SET payload = '{}'::jsonb")).rejects.toThrow(
+      /run_event_append_only/
+    );
+    await expect(database.exec("DELETE FROM run_events WHERE sequence = 1")).rejects.toThrow(
+      /run_event_append_only/
+    );
+  });
+});

--- a/packages/storage/src/runs/events.ts
+++ b/packages/storage/src/runs/events.ts
@@ -1,0 +1,186 @@
+import type { TransactionPort } from "../ports";
+
+/**
+ * Who an event may be shown to. Listing requires the reader's audiences explicitly, so an event is
+ * withheld unless the reader was granted its audience (default-deny).
+ */
+export type RunEventAudience = "participant" | "operator";
+
+export interface PersistedRunEvent {
+  readonly businessId: string;
+  readonly runId: string;
+  /** Gapless per-Run cursor; the SSE `id:` field and the `?after=` cursor. */
+  readonly sequence: number;
+  readonly eventType: string;
+  readonly audience: RunEventAudience;
+  readonly payload: Record<string, unknown>;
+  readonly occurredAt: string;
+}
+
+export interface AppendRunEventInput {
+  readonly businessId: string;
+  readonly runId: string;
+  readonly eventType: string;
+  readonly audience: RunEventAudience;
+  readonly payload: Record<string, unknown>;
+  /** Producer-side de-duplication key; a duplicate delivery reuses the recorded event. */
+  readonly idempotencyKey: string;
+  readonly occurredAt: string;
+}
+
+export interface ListRunEventsOptions {
+  readonly after: number;
+  readonly audiences: readonly RunEventAudience[];
+  readonly limit?: number;
+}
+
+export const DEFAULT_RUN_EVENT_PAGE_SIZE = 500;
+
+/**
+ * Persisted Run event stream (SPEC §§18, 19). Every event a client can observe is durable and
+ * numbered, so a dropped connection is recovered by replaying `?after=<sequence>` rather than by
+ * re-deriving Run state — losing the stream never changes the Run.
+ */
+export const RUN_EVENT_STORAGE_STATEMENTS: readonly string[] = [
+  `CREATE TABLE IF NOT EXISTS run_events (
+    business_id      text NOT NULL,
+    run_id           uuid NOT NULL,
+    sequence         bigint NOT NULL CHECK (sequence > 0),
+    event_type       text NOT NULL CHECK (length(event_type) > 0),
+    audience         text NOT NULL CHECK (audience IN ('participant', 'operator')),
+    payload          jsonb NOT NULL CHECK (jsonb_typeof(payload) = 'object'),
+    idempotency_key  text NOT NULL CHECK (length(idempotency_key) > 0),
+    occurred_at      timestamptz NOT NULL,
+    PRIMARY KEY (business_id, run_id, sequence),
+    UNIQUE (business_id, run_id, idempotency_key),
+    FOREIGN KEY (business_id, run_id) REFERENCES runs(business_id, id)
+  )`,
+  `CREATE OR REPLACE FUNCTION reject_run_event_change()
+    RETURNS trigger LANGUAGE plpgsql AS $$
+    BEGIN
+      RAISE EXCEPTION 'run_event_append_only';
+    END;
+    $$`,
+  "DROP TRIGGER IF EXISTS run_events_append_only ON run_events",
+  `CREATE TRIGGER run_events_append_only
+    BEFORE UPDATE OR DELETE ON run_events
+    FOR EACH ROW EXECUTE FUNCTION reject_run_event_change()`,
+];
+
+interface RunEventRow {
+  business_id: string;
+  run_id: string;
+  sequence: string | number;
+  event_type: string;
+  audience: RunEventAudience;
+  payload: Record<string, unknown>;
+  occurred_at: Date | string;
+}
+
+const RUN_EVENT_COLUMNS =
+  "business_id, run_id, sequence, event_type, audience, payload, occurred_at";
+
+function persistedRunEvent(row: RunEventRow): PersistedRunEvent {
+  return {
+    businessId: row.business_id,
+    runId: row.run_id,
+    sequence: Number(row.sequence),
+    eventType: row.event_type,
+    audience: row.audience,
+    payload: row.payload,
+    occurredAt: row.occurred_at instanceof Date ? row.occurred_at.toISOString() : row.occurred_at,
+  };
+}
+
+/** Append-only Run event log with a gapless per-Run sequence. */
+export class RunEventStore {
+  constructor(private readonly transactions: TransactionPort) {}
+
+  /**
+   * Appends one event. The Run row is locked while the next sequence is derived, so concurrent
+   * producers cannot mint the same cursor; a repeated `idempotencyKey` returns the recorded event
+   * unchanged instead of emitting a second copy.
+   */
+  async append(input: AppendRunEventInput): Promise<PersistedRunEvent> {
+    return this.transactions.withTransaction(async (transaction) => {
+      await transaction.query("SELECT id FROM runs WHERE business_id = $1 AND id = $2 FOR UPDATE", [
+        input.businessId,
+        input.runId,
+      ]);
+      const inserted = await transaction.query<RunEventRow>(
+        `INSERT INTO run_events (
+           business_id, run_id, sequence, event_type, audience, payload, idempotency_key, occurred_at
+         )
+         SELECT $1, $2,
+                COALESCE(
+                  (SELECT MAX(sequence) FROM run_events WHERE business_id = $1 AND run_id = $2),
+                  0
+                ) + 1,
+                $3, $4, $5::jsonb, $6, $7::timestamptz
+         ON CONFLICT (business_id, run_id, idempotency_key) DO NOTHING
+         RETURNING ${RUN_EVENT_COLUMNS}`,
+        [
+          input.businessId,
+          input.runId,
+          input.eventType,
+          input.audience,
+          JSON.stringify(input.payload),
+          input.idempotencyKey,
+          input.occurredAt,
+        ]
+      );
+      const row = inserted.rows[0];
+      if (row) return persistedRunEvent(row);
+
+      const existing = await transaction.query<RunEventRow>(
+        `SELECT ${RUN_EVENT_COLUMNS}
+           FROM run_events
+          WHERE business_id = $1 AND run_id = $2 AND idempotency_key = $3`,
+        [input.businessId, input.runId, input.idempotencyKey]
+      );
+      return persistedRunEvent(existing.rows[0]);
+    });
+  }
+
+  /** Events after `after` the reader is allowed to see, oldest first and bounded. */
+  async list(
+    businessId: string,
+    runId: string,
+    options: ListRunEventsOptions
+  ): Promise<readonly PersistedRunEvent[]> {
+    if (options.audiences.length === 0) return [];
+    return this.transactions.withTransaction(async (transaction) => {
+      const result = await transaction.query<RunEventRow>(
+        `SELECT ${RUN_EVENT_COLUMNS}
+           FROM run_events
+          WHERE business_id = $1
+            AND run_id = $2
+            AND sequence > $3
+            AND audience = ANY($4::text[])
+          ORDER BY sequence
+          LIMIT $5`,
+        [
+          businessId,
+          runId,
+          options.after,
+          options.audiences,
+          options.limit ?? DEFAULT_RUN_EVENT_PAGE_SIZE,
+        ]
+      );
+      return result.rows.map(persistedRunEvent);
+    });
+  }
+
+  /** Highest sequence recorded for a Run, or 0 when the stream is empty. */
+  async latestSequence(businessId: string, runId: string): Promise<number> {
+    return this.transactions.withTransaction(async (transaction) => {
+      const result = await transaction.query<{ sequence: string | number | null }>(
+        `SELECT MAX(sequence) AS sequence
+           FROM run_events
+          WHERE business_id = $1 AND run_id = $2`,
+        [businessId, runId]
+      );
+      return Number(result.rows[0]?.sequence ?? 0);
+    });
+  }
+}

--- a/packages/storage/src/runs/index.ts
+++ b/packages/storage/src/runs/index.ts
@@ -23,6 +23,17 @@ export type {
   PersistedConcurrencySlotStatus,
 } from "./concurrency-store";
 export { CONCURRENCY_STORAGE_STATEMENTS, ConcurrencyStore } from "./concurrency-store";
+export type {
+  AppendRunEventInput,
+  ListRunEventsOptions,
+  PersistedRunEvent,
+  RunEventAudience,
+} from "./events";
+export {
+  DEFAULT_RUN_EVENT_PAGE_SIZE,
+  RUN_EVENT_STORAGE_STATEMENTS,
+  RunEventStore,
+} from "./events";
 export { MemoryWaitStore } from "./memory-wait-store";
 export type {
   AppendAttemptInput,


### PR DESCRIPTION
> Stacked on #238 — review that first; this PR targets `feat/aw-032-033-run-governance`.

## Summary

- **AW-034 — persisted Run event stream.** Append-only, audience-scoped `run_events` table with a gapless per-Run sequence (`RunEventStore.append/list/latestSequence`), surfaced as `GET /api/v1/runs/:id/events?after=<sequence>` (SPEC §18). Reconnect resumes from the caller's cursor, so a dropped connection replays exactly the missed suffix — no gap, no duplicate — and a cursorless reconnect replays the whole log. Append-only is enforced by a trigger, not by convention.
- **AW-035 — recovery proofs.** A `SimulatedRunStore` that injects a crash either *before* a durable write (write lost, operation safely retryable) or *after* it (write committed, acknowledgement lost, blind retry must lose the CAS). Suites cover claim/lease/wait/reconciliation in `packages/run-kernel/src/resilience`, Run dispatch and outbox delivery in `apps/worker/src/recovery`, and stream reconnection in `apps/api/src/runs/stream-recovery.test.ts`.
- Recovery invariants proven: a dead worker's Run is reclaimed and re-dispatched; two dispatchers on one Run produce exactly one terminal commit; a duplicate wait signal resumes once (`duplicate` thereafter); redelivery after a lost acknowledgement records exactly one receipt; an ambiguous effect stays `needs_reconciliation` and only `applied` evidence settles it; a revoked grant never reaches `events.list`.
- Adds `apps/worker/vitest.config.ts` so the worker suite collects only `src/**/*.test.ts` — without it, `pnpm build` output in `dist/` was re-collected and failed as CJS.

Migration 9 (persisted Run event stream) is added to `apps/api/src/pg-migrations/index.ts`.

## Test plan

- `pnpm --filter @tulipfarm/run-kernel run test` — includes 9 new resilience tests (written RED against a missing `simulator.ts`, then implemented to green).
- `pnpm --filter @tulipfarm/worker run test` — 7 new recovery tests (4 Run dispatch, 3 event delivery).
- `pnpm --filter @tulipfarm/api run test` — 12 event-stream, 6 route, and 3 stream-recovery tests; `pnpm --filter @tulipfarm/storage run test` — 9 PGlite tests for `run_events` (sequence gaplessness, audience scoping, append-only trigger).
- Phase gate on the full stack: `pnpm exec biome check .` clean, `pnpm typecheck` 28/28, `pnpm build` 5/5, `turbo run test` 27/27.