### PR TITLE
feat(tool-broker): add effect ledger and dispatch controls

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -27,6 +27,7 @@
     "@tulipfarm/secrets": "workspace:*",
     "@tulipfarm/soul": "workspace:*",
     "@tulipfarm/storage": "workspace:*",
+    "@tulipfarm/tool-broker": "workspace:*",
     "ai": "^7.0.2",
     "dotenv": "^17.4.2",
     "fastify": "^5.8.5",

--- a/apps/api/src/pg-migrations/index.ts
+++ b/apps/api/src/pg-migrations/index.ts
@@ -8,6 +8,7 @@ import {
   RUN_STORAGE_STATEMENTS,
   WAIT_STORAGE_STATEMENTS,
 } from "@tulipfarm/storage";
+import { EFFECT_STORAGE_STATEMENTS } from "@tulipfarm/tool-broker";
 import type { Queryable } from "../db";
 
 export interface PgMigration {
@@ -502,6 +503,15 @@ export const PG_MIGRATIONS: PgMigration[] = [
     description: "persisted Run event stream",
     up: async (q) => {
       for (const sql of RUN_EVENT_STORAGE_STATEMENTS) {
+        await q.query(sql);
+      }
+    },
+  },
+  {
+    version: 10,
+    description: "durable Tool intents and effect ledger",
+    up: async (q) => {
+      for (const sql of EFFECT_STORAGE_STATEMENTS) {
         await q.query(sql);
       }
     },

--- a/packages/tool-broker/package.json
+++ b/packages/tool-broker/package.json
@@ -8,8 +8,16 @@
     "test": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit"
   },
+  "dependencies": {
+    "@tulipfarm/authz": "workspace:*",
+    "@tulipfarm/schema": "workspace:*",
+    "@tulipfarm/secrets": "workspace:*",
+    "@tulipfarm/storage": "workspace:*"
+  },
   "devDependencies": {
+    "@electric-sql/pglite": "^0.5.3",
     "@tulipfarm/tsconfig": "workspace:*",
+    "@types/node": "^26.1.1",
     "typescript": "^6.0.3"
   }
 }

--- a/packages/tool-broker/src/approval-gate.test.ts
+++ b/packages/tool-broker/src/approval-gate.test.ts
@@ -1,0 +1,262 @@
+import type { AccessGrant, AuthorityLayer, DlpRule, GuardrailRule } from "@tulipfarm/authz";
+import { InMemoryApprovalRepo } from "@tulipfarm/storage";
+import { beforeEach, describe, expect, it } from "vitest";
+import { ToolApprovalDecisions, ToolApprovalGate, ToolApprovalGateError } from "./approval-gate";
+import type { ToolAuthorizationContext } from "./authorize";
+import { ToolBroker } from "./broker";
+import { ToolCatalog } from "./catalog";
+import type { ReserveEffectInput } from "./effects";
+import { MemoryEffectStore } from "./effects";
+import type { ToolIntent } from "./intent";
+import { makeContract } from "./test-fixtures";
+
+const BUSINESS_ID = "business-1";
+const APPROVAL_ID = "approval-1";
+const NOW = new Date("2026-07-25T00:00:00.000Z");
+
+const definition = makeContract({
+  riskClass: "medium",
+  mutating: true,
+  requiredActions: ["issue.label"],
+  requiredResources: ["issue"],
+  dataClasses: ["internal"],
+  allowedDestinations: ["github.com"],
+});
+
+function intent(overrides: Partial<ToolIntent> = {}): ToolIntent {
+  return {
+    intentId: "intent-1",
+    businessId: BUSINESS_ID,
+    runId: "11111111-1111-4111-8111-111111111111",
+    stateId: "label",
+    toolId: definition.spec.toolId,
+    toolVersion: definition.spec.toolVersion,
+    action: definition.spec.action,
+    targetRefs: [{ type: "issue", id: "issue-42" }],
+    arguments: { label: "triaged" },
+    destination: "github.com",
+    credentialRef: "secret://github",
+    idempotencyKey: "effect-key",
+    ...overrides,
+  };
+}
+
+function authorization(guardrailRevision = "guardrail-v3"): ToolAuthorizationContext {
+  const grant: AccessGrant = {
+    action: "issue.label",
+    resourceType: "issue",
+    recordSelector: "issue-42",
+    destination: "github.com",
+    effect: "allow",
+  };
+  const authorityLayers: AuthorityLayer[] = ["user", "agent", "run", "tool", "credential"].map(
+    (name) => ({ name, grants: [grant] })
+  );
+  const guardrailRules: GuardrailRule[] = [
+    {
+      id: "approval",
+      effect: "require_approval",
+      action: "issue.label",
+      resourceType: "issue",
+      recordSelector: "issue-42",
+      destination: "github.com",
+    },
+  ];
+  const dlpRules: DlpRule[] = [{ dataClass: "internal", allowedDestinations: ["github.com"] }];
+  return { authorityLayers, guardrailRules, dlpRules, guardrailRevision };
+}
+
+describe("ToolApprovalGate", () => {
+  let approvals: InMemoryApprovalRepo;
+  let effects: MemoryEffectStore;
+  let gate: ToolApprovalGate;
+  let awaiting: ReturnType<ToolBroker["authorize"]>;
+
+  beforeEach(() => {
+    approvals = new InMemoryApprovalRepo();
+    effects = new MemoryEffectStore();
+    const broker = new ToolBroker(ToolCatalog.load([definition]));
+    gate = new ToolApprovalGate(approvals, effects);
+    awaiting = broker.authorize(intent(), authorization());
+    expect(awaiting.outcome).toBe("awaiting_approval");
+  });
+
+  it("persists an exact readable Approval request", async () => {
+    if (awaiting.outcome !== "awaiting_approval") throw new Error("expected Approval");
+
+    const created = await gate.request(awaiting, {
+      approvalId: APPROVAL_ID,
+      evidenceHashes: ["artifact-input-a"],
+      preview: "Add label to one GitHub issue",
+      riskSummary: "External mutation",
+      allowedApproverRoles: ["operations_approver"],
+      proposerPrincipalId: "user-proposer",
+      performerPrincipalId: "user-performer",
+      agentPrincipalId: "agent-1",
+      expiresAt: new Date("2026-07-25T01:00:00.000Z"),
+      createdAt: NOW,
+    });
+
+    expect(created).toMatchObject({
+      approvalId: APPROVAL_ID,
+      binding: {
+        intentDigest: awaiting.intentDigest,
+        guardrailRevision: "guardrail-v3",
+      },
+      preview: "Add label to one GitHub issue",
+      decisions: [],
+    });
+  });
+
+  it("consumes one qualified decision before reserving the effect", async () => {
+    if (awaiting.outcome !== "awaiting_approval") throw new Error("expected Approval");
+    await request();
+    await approvals.appendDecision(BUSINESS_ID, APPROVAL_ID, {
+      approverPrincipalId: "user-approver",
+      approverRoles: ["operations_approver"],
+      outcome: "approved",
+      decidedAt: NOW,
+    });
+
+    const reserved = await gate.consumeAndReserve({
+      businessId: BUSINESS_ID,
+      approvalId: APPROVAL_ID,
+      intent: awaiting.intent,
+      evidenceHashes: ["artifact-input-a"],
+      guardrailRevision: "guardrail-v3",
+      effect: effectInput(),
+      at: NOW,
+    });
+
+    expect(reserved.effect).toMatchObject({ approvalId: APPROVAL_ID, state: "authorized" });
+    await expect(
+      gate.consumeAndReserve({
+        businessId: BUSINESS_ID,
+        approvalId: APPROVAL_ID,
+        intent: awaiting.intent,
+        evidenceHashes: ["artifact-input-a"],
+        guardrailRevision: "guardrail-v3",
+        effect: effectInput(),
+        at: NOW,
+      })
+    ).rejects.toThrow(new ToolApprovalGateError("already_used", APPROVAL_ID));
+  });
+
+  it.each([
+    [
+      "changed intent",
+      intent({ destination: "other.example" }),
+      ["artifact-input-a"],
+      "guardrail-v3",
+    ],
+    ["changed evidence", intent(), ["artifact-input-b"], "guardrail-v3"],
+    ["changed Guardrail", intent(), ["artifact-input-a"], "guardrail-v4"],
+  ])("denies %s substitution", async (_case, presentedIntent, evidenceHashes, revision) => {
+    await request();
+    await approvals.appendDecision(BUSINESS_ID, APPROVAL_ID, {
+      approverPrincipalId: "user-approver",
+      approverRoles: ["operations_approver"],
+      outcome: "approved",
+      decidedAt: NOW,
+    });
+
+    await expect(
+      gate.consumeAndReserve({
+        businessId: BUSINESS_ID,
+        approvalId: APPROVAL_ID,
+        intent: presentedIntent,
+        evidenceHashes,
+        guardrailRevision: revision,
+        effect: effectInput(),
+        at: NOW,
+      })
+    ).rejects.toThrow(new ToolApprovalGateError("binding_mismatch", APPROVAL_ID));
+  });
+
+  it("denies self-approval, expiry, and cancellation through the durable record", async () => {
+    await request();
+    await expect(
+      approvals.appendDecision(BUSINESS_ID, APPROVAL_ID, {
+        approverPrincipalId: "user-proposer",
+        approverRoles: ["operations_approver"],
+        outcome: "approved",
+        decidedAt: NOW,
+      })
+    ).rejects.toThrow();
+    await approvals.revoke(BUSINESS_ID, APPROVAL_ID, NOW);
+    await expect(
+      gate.consumeAndReserve({
+        businessId: BUSINESS_ID,
+        approvalId: APPROVAL_ID,
+        intent: intent(),
+        evidenceHashes: ["artifact-input-a"],
+        guardrailRevision: "guardrail-v3",
+        effect: effectInput(),
+        at: NOW,
+      })
+    ).rejects.toThrow(new ToolApprovalGateError("revoked", APPROVAL_ID));
+  });
+
+  it("keeps the API decision seam qualified and expiry-aware", async () => {
+    await request();
+    const decisions = new ToolApprovalDecisions(approvals);
+    expect(await decisions.listPending(BUSINESS_ID, NOW)).toHaveLength(1);
+    await expect(
+      decisions.decide(
+        BUSINESS_ID,
+        APPROVAL_ID,
+        {
+          principalId: "user-proposer",
+          businessId: BUSINESS_ID,
+          roles: ["operations_approver"],
+        },
+        "approved",
+        NOW
+      )
+    ).rejects.toThrow();
+    expect(await decisions.listPending(BUSINESS_ID, new Date("2026-07-25T01:00:00.000Z"))).toEqual(
+      []
+    );
+    await expect(
+      gate.consumeAndReserve({
+        businessId: BUSINESS_ID,
+        approvalId: APPROVAL_ID,
+        intent: intent(),
+        evidenceHashes: ["artifact-input-a"],
+        guardrailRevision: "guardrail-v3",
+        effect: effectInput(),
+        at: new Date("2026-07-25T01:00:00.000Z"),
+      })
+    ).rejects.toThrow(new ToolApprovalGateError("expired", APPROVAL_ID));
+  });
+
+  async function request() {
+    if (awaiting.outcome !== "awaiting_approval") throw new Error("expected Approval");
+    return gate.request(awaiting, {
+      approvalId: APPROVAL_ID,
+      evidenceHashes: ["artifact-input-a"],
+      preview: "Add label to one GitHub issue",
+      riskSummary: "External mutation",
+      allowedApproverRoles: ["operations_approver"],
+      proposerPrincipalId: "user-proposer",
+      performerPrincipalId: "user-performer",
+      expiresAt: new Date("2026-07-25T01:00:00.000Z"),
+      createdAt: NOW,
+    });
+  }
+
+  function effectInput(): Omit<
+    ReserveEffectInput,
+    "intent" | "intentDigest" | "guardrailRevision" | "approvalId"
+  > {
+    return {
+      effectId: "22222222-2222-4222-8222-222222222222",
+      businessId: BUSINESS_ID,
+      runId: "11111111-1111-4111-8111-111111111111",
+      stateId: "label",
+      logicalEffectOrdinal: 1,
+      idempotencyKey: "effect-key",
+      createdAt: NOW.toISOString(),
+    };
+  }
+});

--- a/packages/tool-broker/src/approval-gate.ts
+++ b/packages/tool-broker/src/approval-gate.ts
@@ -1,0 +1,162 @@
+import {
+  type ApprovalApprover,
+  assertApproverEligible,
+  computeApprovalBinding,
+} from "@tulipfarm/authz";
+import {
+  type ApprovalDecisionEntry,
+  type ApprovalGrantRecord,
+  type ApprovalRepo,
+  ApprovalStoreError,
+  type ApprovalStoreErrorCode,
+} from "@tulipfarm/storage";
+import type { ToolBrokerOutcome } from "./broker";
+import type { EffectStore, ReserveEffectInput, ReserveEffectResult } from "./effects";
+import type { ToolIntent } from "./intent";
+
+type AwaitingApprovalOutcome = Extract<ToolBrokerOutcome, { outcome: "awaiting_approval" }>;
+
+export type ToolApprovalGateErrorCode =
+  | ApprovalStoreErrorCode
+  | "invalid_approval_outcome"
+  | "binding_mismatch";
+
+export class ToolApprovalGateError extends Error {
+  constructor(
+    readonly code: ToolApprovalGateErrorCode,
+    readonly approvalId: string
+  ) {
+    super(`${code}:${approvalId}`);
+    this.name = "ToolApprovalGateError";
+  }
+}
+
+export interface ToolApprovalRequest {
+  readonly approvalId: string;
+  readonly evidenceHashes: readonly string[];
+  readonly preview: string;
+  readonly riskSummary: string;
+  readonly allowedApproverRoles: readonly string[];
+  readonly proposerPrincipalId: string;
+  readonly performerPrincipalId?: string;
+  readonly agentPrincipalId?: string;
+  readonly expiresAt: Date;
+  readonly createdAt: Date;
+}
+
+export interface ConsumeApprovedEffectInput {
+  readonly businessId: string;
+  readonly approvalId: string;
+  readonly intent: ToolIntent;
+  readonly evidenceHashes: readonly string[];
+  readonly guardrailRevision: string;
+  readonly effect: Omit<
+    ReserveEffectInput,
+    "intent" | "intentDigest" | "guardrailRevision" | "approvalId"
+  >;
+  readonly at: Date;
+}
+
+function translate(error: unknown, approvalId: string): never {
+  if (error instanceof ApprovalStoreError) {
+    throw new ToolApprovalGateError(error.code, approvalId);
+  }
+  throw error;
+}
+
+function binding(intent: ToolIntent, evidenceHashes: readonly string[], guardrailRevision: string) {
+  return computeApprovalBinding({ intent, evidenceHashes, guardrailRevision });
+}
+
+export class ToolApprovalGate {
+  constructor(
+    private readonly approvals: ApprovalRepo,
+    private readonly effects: EffectStore
+  ) {}
+
+  async request(
+    outcome: AwaitingApprovalOutcome,
+    request: ToolApprovalRequest
+  ): Promise<ApprovalGrantRecord> {
+    const exactBinding = binding(outcome.intent, request.evidenceHashes, outcome.guardrailRevision);
+    if (exactBinding.intentDigest !== outcome.intentDigest) {
+      throw new ToolApprovalGateError("binding_mismatch", request.approvalId);
+    }
+    try {
+      return await this.approvals.create({
+        approvalId: request.approvalId,
+        businessId: outcome.intent.businessId,
+        binding: exactBinding,
+        risk: outcome.risk.level,
+        allowedApproverRoles: request.allowedApproverRoles,
+        proposerPrincipalId: request.proposerPrincipalId,
+        performerPrincipalId: request.performerPrincipalId,
+        agentPrincipalId: request.agentPrincipalId,
+        preview: request.preview,
+        riskSummary: request.riskSummary,
+        expiresAt: request.expiresAt,
+        createdAt: request.createdAt,
+      });
+    } catch (error) {
+      return translate(error, request.approvalId);
+    }
+  }
+
+  async consumeAndReserve(input: ConsumeApprovedEffectInput): Promise<ReserveEffectResult> {
+    if (
+      input.intent.businessId !== input.businessId ||
+      input.intent.idempotencyKey !== input.effect.idempotencyKey
+    ) {
+      throw new ToolApprovalGateError("binding_mismatch", input.approvalId);
+    }
+    const exactBinding = binding(input.intent, input.evidenceHashes, input.guardrailRevision);
+    try {
+      await this.approvals.consume(input.businessId, input.approvalId, exactBinding, input.at);
+    } catch (error) {
+      return translate(error, input.approvalId);
+    }
+    return this.effects.reserve({
+      ...input.effect,
+      intent: input.intent,
+      intentDigest: exactBinding.intentDigest,
+      guardrailRevision: input.guardrailRevision,
+      approvalId: input.approvalId,
+    });
+  }
+}
+
+export class ToolApprovalDecisions {
+  constructor(private readonly approvals: ApprovalRepo) {}
+
+  async listPending(businessId: string, now: Date = new Date()): Promise<ApprovalGrantRecord[]> {
+    return (await this.approvals.list(businessId)).filter(
+      (record) =>
+        record.consumedAt === undefined &&
+        record.revokedAt === undefined &&
+        record.expiresAt > now &&
+        !record.decisions.some((decision) => decision.outcome === "denied")
+    );
+  }
+
+  async decide(
+    businessId: string,
+    approvalId: string,
+    approver: ApprovalApprover,
+    outcome: ApprovalDecisionEntry["outcome"],
+    decidedAt: Date
+  ): Promise<ApprovalGrantRecord> {
+    const record = await this.approvals.get(businessId, approvalId);
+    if (record === undefined) throw new ToolApprovalGateError("not_found", approvalId);
+    try {
+      assertApproverEligible(record, approver, decidedAt);
+      return await this.approvals.appendDecision(businessId, approvalId, {
+        approverPrincipalId: approver.principalId,
+        approverRoles: approver.roles,
+        outcome,
+        decidedAt,
+      });
+    } catch (error) {
+      return translate(error, approvalId);
+    }
+  }
+}

--- a/packages/tool-broker/src/authorize.ts
+++ b/packages/tool-broker/src/authorize.ts
@@ -1,0 +1,99 @@
+import {
+  type AuthorityLayer,
+  checkDlpBoundary,
+  type DlpRule,
+  decideEffectivePermission,
+  evaluateGuardrail,
+  type GuardrailRule,
+} from "@tulipfarm/authz";
+import type { PublishedToolContract } from "./contract";
+import type { ToolIntent } from "./intent";
+import type { ToolRiskContext } from "./risk";
+
+export interface ToolAuthorizationContext extends ToolRiskContext {
+  readonly authorityLayers: readonly AuthorityLayer[];
+  readonly guardrailRules: readonly GuardrailRule[];
+  readonly dlpRules: readonly DlpRule[];
+  readonly guardrailRevision: string;
+  readonly autonomy?:
+    | "answer_only"
+    | "propose_actions"
+    | "execute_low_risk"
+    | "execute_policy_authorized";
+  readonly audience?: string;
+  readonly secretDetected?: boolean;
+  readonly now?: Date;
+}
+
+export type ToolAuthorizationDenialReason =
+  | "authorization_denied"
+  | "guardrail_denied"
+  | "dlp_denied"
+  | "destination_denied"
+  | "missing_guardrail_revision";
+
+export type ToolPolicyOutcome =
+  | { readonly outcome: "authorized" }
+  | { readonly outcome: "awaiting_approval" }
+  | { readonly outcome: "denied"; readonly reason: ToolAuthorizationDenialReason };
+
+function protectedRequests(intent: ToolIntent, contract: PublishedToolContract) {
+  const actions = contract.requiredActions.length > 0 ? contract.requiredActions : [intent.action];
+  const targets =
+    intent.targetRefs.length > 0
+      ? intent.targetRefs
+      : contract.requiredResources.map((type) => ({ type, id: undefined }));
+  const resolvedTargets =
+    targets.length > 0 ? targets : [{ type: "Tool", id: contract.toolId as string | undefined }];
+  return actions.flatMap((action) =>
+    resolvedTargets.map((target) => ({
+      action,
+      resourceType: target.type,
+      recordId: target.id,
+      dataClass: contract.dataClasses[0],
+      destination: intent.destination,
+    }))
+  );
+}
+
+export function authorizeToolIntent(
+  intent: ToolIntent,
+  contract: PublishedToolContract,
+  context: ToolAuthorizationContext
+): ToolPolicyOutcome {
+  if (context.guardrailRevision.length === 0) {
+    return { outcome: "denied", reason: "missing_guardrail_revision" };
+  }
+  if (
+    intent.destination !== undefined &&
+    !contract.allowedDestinations.includes(intent.destination)
+  ) {
+    return { outcome: "denied", reason: "destination_denied" };
+  }
+
+  let approvalRequired = false;
+  for (const request of protectedRequests(intent, contract)) {
+    const authz = decideEffectivePermission(context.authorityLayers, request, context.now);
+    if (!authz.allowed) return { outcome: "denied", reason: "authorization_denied" };
+    const guardrail = evaluateGuardrail(context.guardrailRules, {
+      ...request,
+      recordCount: context.recordCount,
+      taint: context.taint,
+      autonomy: context.autonomy,
+      audience: context.audience,
+    });
+    if (guardrail.effect === "deny") {
+      return { outcome: "denied", reason: "guardrail_denied" };
+    }
+    approvalRequired ||= guardrail.effect === "require_approval";
+  }
+
+  const dlp = checkDlpBoundary(context.dlpRules, {
+    dataClasses: contract.dataClasses,
+    destination: intent.destination,
+    audience: context.audience,
+    secretDetected: context.secretDetected,
+  });
+  if (dlp.effect === "deny") return { outcome: "denied", reason: "dlp_denied" };
+  return approvalRequired ? { outcome: "awaiting_approval" } : { outcome: "authorized" };
+}

--- a/packages/tool-broker/src/broker.test.ts
+++ b/packages/tool-broker/src/broker.test.ts
@@ -1,0 +1,198 @@
+import type { AccessGrant, AuthorityLayer, DlpRule, GuardrailRule } from "@tulipfarm/authz";
+import type { ToolContractDefinition } from "@tulipfarm/schema";
+import { describe, expect, it } from "vitest";
+import type { ToolAuthorizationContext } from "./authorize";
+import { ToolBroker } from "./broker";
+import { ToolCatalog } from "./catalog";
+
+const contract: ToolContractDefinition = {
+  apiVersion: "tulipfarm.ai/v1",
+  kind: "ToolContract",
+  metadata: {
+    id: "33333333-3333-4333-8333-333333333333",
+    slug: "github-issue-label",
+    schemaVersion: 1,
+    authoredVersion: 1,
+    lifecycle: "active",
+    publishedDigest: "a".repeat(64),
+  },
+  spec: {
+    toolId: "github.issue.label",
+    toolVersion: "1.0.0",
+    action: "issue.label",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["label"],
+      properties: { label: { type: "string" } },
+    },
+    outputSchema: { type: "object" },
+    riskClass: "medium",
+    mutating: true,
+    requiredActions: ["issue.label"],
+    requiredResources: ["issue"],
+    dataClasses: ["internal"],
+    allowedDestinations: ["github.com"],
+    idempotency: { strategy: "provider" },
+    dryRun: false,
+    adapter: { kind: "integration", ref: "github" },
+  },
+};
+
+const grant: AccessGrant = {
+  action: "issue.label",
+  resourceType: "issue",
+  recordSelector: "issue-42",
+  destination: "github.com",
+  effect: "allow",
+};
+
+const authorityLayers: AuthorityLayer[] = [
+  { name: "user", grants: [grant] },
+  { name: "agent", grants: [grant] },
+  { name: "run", grants: [grant] },
+  { name: "tool", grants: [grant] },
+  { name: "credential", grants: [grant] },
+];
+
+const guardrailRules: GuardrailRule[] = [
+  {
+    id: "tool-allow",
+    effect: "allow",
+    action: "issue.label",
+    resourceType: "issue",
+    recordSelector: "issue-42",
+    destination: "github.com",
+    maxAutonomy: "execute_policy_authorized",
+    maxTaint: "trusted",
+  },
+];
+
+const dlpRules: DlpRule[] = [{ dataClass: "internal", allowedDestinations: ["github.com"] }];
+
+function context(overrides: Partial<ToolAuthorizationContext> = {}): ToolAuthorizationContext {
+  return {
+    authorityLayers,
+    guardrailRules,
+    dlpRules,
+    guardrailRevision: "guardrail-v3",
+    autonomy: "execute_low_risk",
+    taint: "trusted",
+    ...overrides,
+  };
+}
+
+function intent(overrides: Record<string, unknown> = {}) {
+  return {
+    intentId: "intent-1",
+    businessId: "business-1",
+    runId: "run-1",
+    stateId: "state-1",
+    toolId: "github.issue.label",
+    toolVersion: "1.0.0",
+    action: "issue.label",
+    targetRefs: [{ type: "issue", id: "issue-42" }],
+    arguments: { label: "triaged" },
+    destination: "github.com",
+    credentialRef: "secret://github",
+    idempotencyKey: "effect-1",
+    ...overrides,
+  };
+}
+
+describe("ToolBroker authorization", () => {
+  const broker = new ToolBroker(ToolCatalog.load([contract]));
+
+  it("normalizes, validates, and authorizes without dispatching", () => {
+    const outcome = broker.authorize(intent(), context());
+
+    expect(outcome).toMatchObject({
+      outcome: "authorized",
+      intent: {
+        toolId: "github.issue.label",
+        toolVersion: "1.0.0",
+        destination: "github.com",
+        credentialRef: "secret://github",
+      },
+      risk: { level: "medium" },
+      guardrailRevision: "guardrail-v3",
+    });
+    expect(outcome.intentDigest).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("binds target, destination, and Credential reference into the stable digest", () => {
+    const original = broker.authorize(intent(), context());
+    const changedTarget = broker.authorize(
+      intent({ targetRefs: [{ type: "issue", id: "issue-43" }] }),
+      context({
+        authorityLayers: authorityLayers.map((layer) => ({
+          ...layer,
+          grants: [{ ...grant, recordSelector: "*" }],
+        })),
+        guardrailRules: [{ ...guardrailRules[0], recordSelector: "*" }],
+      })
+    );
+    const changedDestination = broker.authorize(
+      intent({ destination: "github.example" }),
+      context({
+        authorityLayers: authorityLayers.map((layer) => ({
+          ...layer,
+          grants: [{ ...grant, destination: "github.example" }],
+        })),
+        guardrailRules: [{ ...guardrailRules[0], destination: "github.example" }],
+        dlpRules: [{ dataClass: "internal", allowedDestinations: ["github.example"] }],
+      })
+    );
+    const changedCredential = broker.authorize(
+      intent({ credentialRef: "secret://github-next" }),
+      context()
+    );
+
+    expect(
+      new Set([
+        original.intentDigest,
+        changedTarget.intentDigest,
+        changedDestination.intentDigest,
+        changedCredential.intentDigest,
+      ]).size
+    ).toBe(4);
+  });
+
+  it("denies invalid input and never exposes an adapter dispatch method", () => {
+    const outcome = broker.authorize(intent({ arguments: { label: 42 } }), context());
+
+    expect(outcome).toMatchObject({ outcome: "denied", reason: "invalid_arguments" });
+    expect("dispatch" in broker).toBe(false);
+  });
+
+  it.each([
+    [
+      "authorization",
+      context({ authorityLayers: [{ name: "user", grants: [] }] }),
+      "authorization_denied",
+    ],
+    [
+      "Guardrail",
+      context({ guardrailRules: [{ ...guardrailRules[0], effect: "deny" }] }),
+      "guardrail_denied",
+    ],
+    ["DLP", context({ dlpRules: [] }), "dlp_denied"],
+  ])("fails closed when %s denies", (_boundary, authContext, reason) => {
+    expect(broker.authorize(intent(), authContext)).toMatchObject({
+      outcome: "denied",
+      reason,
+    });
+  });
+
+  it("returns an Approval outcome when the Guardrail requires one", () => {
+    const outcome = broker.authorize(
+      intent(),
+      context({ guardrailRules: [{ ...guardrailRules[0], effect: "require_approval" }] })
+    );
+
+    expect(outcome).toMatchObject({
+      outcome: "awaiting_approval",
+      guardrailRevision: "guardrail-v3",
+    });
+  });
+});

--- a/packages/tool-broker/src/broker.ts
+++ b/packages/tool-broker/src/broker.ts
@@ -1,0 +1,69 @@
+import { ajv } from "@tulipfarm/schema";
+import {
+  authorizeToolIntent,
+  type ToolAuthorizationContext,
+  type ToolAuthorizationDenialReason,
+} from "./authorize";
+import type { ToolCatalog } from "./catalog";
+import type { PublishedToolContract } from "./contract";
+import { intentDigest, normalizeToolIntent, type ToolIntent } from "./intent";
+import { assessToolRisk, type ToolRiskAssessment } from "./risk";
+
+export type ToolBrokerDenialReason =
+  | ToolAuthorizationDenialReason
+  | "invalid_intent"
+  | "invalid_arguments"
+  | "unknown_contract"
+  | "contract_mismatch";
+
+interface ToolBrokerOutcomeBase {
+  readonly intent: ToolIntent;
+  readonly intentDigest: string;
+  readonly risk: ToolRiskAssessment;
+  readonly guardrailRevision: string;
+  readonly contract: PublishedToolContract;
+}
+
+export type ToolBrokerOutcome =
+  | (ToolBrokerOutcomeBase & { readonly outcome: "authorized" })
+  | (ToolBrokerOutcomeBase & { readonly outcome: "awaiting_approval" })
+  | (Partial<ToolBrokerOutcomeBase> & {
+      readonly outcome: "denied";
+      readonly reason: ToolBrokerDenialReason;
+    });
+
+export class ToolBroker {
+  constructor(private readonly catalog: ToolCatalog) {}
+
+  authorize(input: unknown, context: ToolAuthorizationContext): ToolBrokerOutcome {
+    let intent: ToolIntent;
+    try {
+      intent = normalizeToolIntent(input);
+    } catch {
+      return { outcome: "denied", reason: "invalid_intent" };
+    }
+
+    const contract = this.catalog.get(intent.toolId, intent.toolVersion);
+    if (contract === undefined) return { outcome: "denied", reason: "unknown_contract" };
+    const digest = intentDigest(intent);
+    const risk = assessToolRisk(contract, context);
+    const base = {
+      intent,
+      intentDigest: digest,
+      risk,
+      guardrailRevision: context.guardrailRevision,
+      contract,
+    };
+    if (contract.action !== intent.action) {
+      return { ...base, outcome: "denied", reason: "contract_mismatch" };
+    }
+    const validateArguments = ajv.compile(contract.inputSchema);
+    if (!validateArguments(intent.arguments)) {
+      return { ...base, outcome: "denied", reason: "invalid_arguments" };
+    }
+
+    const policy = authorizeToolIntent(intent, contract, context);
+    if (policy.outcome === "denied") return { ...base, ...policy };
+    return { ...base, outcome: policy.outcome };
+  }
+}

--- a/packages/tool-broker/src/catalog.test.ts
+++ b/packages/tool-broker/src/catalog.test.ts
@@ -1,0 +1,91 @@
+import type { ToolContractDefinition } from "@tulipfarm/schema";
+import { describe, expect, it } from "vitest";
+import { ToolCatalog, ToolCatalogError } from "./catalog";
+
+function contract(
+  toolId: string,
+  toolVersion: string,
+  overrides: Partial<ToolContractDefinition["spec"]> = {}
+): ToolContractDefinition {
+  return {
+    apiVersion: "tulipfarm.ai/v1",
+    kind: "ToolContract",
+    metadata: {
+      id: crypto.randomUUID(),
+      slug: toolId.replaceAll(".", "-"),
+      schemaVersion: 1,
+      authoredVersion: 1,
+      lifecycle: "active",
+      publishedDigest: "a".repeat(64),
+    },
+    spec: {
+      toolId,
+      toolVersion,
+      action: "read",
+      inputSchema: { type: "object" },
+      outputSchema: { type: "object" },
+      riskClass: "low",
+      mutating: false,
+      dryRun: false,
+      idempotency: { strategy: "none" },
+      adapter: { kind: "native", ref: toolId },
+      ...overrides,
+    },
+  };
+}
+
+describe("ToolCatalog", () => {
+  it("loads immutable contracts pinned by Tool id and version", () => {
+    const catalog = ToolCatalog.load([
+      contract("github.issue.get", "1.0.0"),
+      contract("github.issue.get", "2.0.0"),
+    ]);
+
+    expect(catalog.get("github.issue.get", "1.0.0")?.toolVersion).toBe("1.0.0");
+    expect(catalog.get("github.issue.get", "2.0.0")?.toolVersion).toBe("2.0.0");
+    const requiredActions = catalog.get("github.issue.get", "1.0.0")?.requiredActions;
+    expect(() => Reflect.apply(Array.prototype.push, requiredActions, ["write"])).toThrow();
+  });
+
+  it("rejects unpublished and duplicate pinned contracts", () => {
+    const unpublished = contract("github.issue.get", "1.0.0");
+    delete unpublished.metadata.publishedDigest;
+
+    expect(() => ToolCatalog.load([unpublished])).toThrow(
+      new ToolCatalogError("contract_not_published", "github.issue.get@1.0.0")
+    );
+    expect(() =>
+      ToolCatalog.load([
+        contract("github.issue.get", "1.0.0"),
+        contract("github.issue.get", "1.0.0"),
+      ])
+    ).toThrow(new ToolCatalogError("duplicate_contract", "github.issue.get@1.0.0"));
+  });
+
+  it("exposes no Tool when the allowlist is absent or empty", () => {
+    const catalog = ToolCatalog.load([contract("github.issue.get", "1.0.0")]);
+
+    expect(catalog.authorized()).toEqual([]);
+    expect(catalog.authorized(new Set())).toEqual([]);
+  });
+
+  it("searches only the authorized set and leaks no hidden metadata", () => {
+    const catalog = ToolCatalog.load([
+      contract("github.issue.get", "1.0.0", {
+        action: "read issue",
+        requiredActions: ["issues:read"],
+      }),
+      contract("payroll.salary.export", "1.0.0", {
+        action: "export hidden salaries",
+        dataClasses: ["restricted"],
+      }),
+    ]);
+    const allowlist = new Set(["github.issue.get@1.0.0"]);
+
+    expect(catalog.search("issue", allowlist)).toEqual([
+      expect.objectContaining({ toolId: "github.issue.get", toolVersion: "1.0.0" }),
+    ]);
+    expect(catalog.search("salary restricted export", allowlist)).toEqual([]);
+    expect(catalog.search("", allowlist)).toEqual([]);
+  });
+});

--- a/packages/tool-broker/src/catalog.ts
+++ b/packages/tool-broker/src/catalog.ts
@@ -1,0 +1,55 @@
+import type { ToolContractDefinition } from "@tulipfarm/schema";
+import {
+  type PublishedToolContract,
+  publishToolContract,
+  type ToolContractRef,
+  toolContractRef,
+} from "./contract";
+import { searchToolContracts, type ToolCatalogEntry } from "./search";
+
+export type ToolCatalogErrorCode = "contract_not_published" | "duplicate_contract";
+
+export class ToolCatalogError extends Error {
+  constructor(
+    readonly code: ToolCatalogErrorCode,
+    readonly contractRef: ToolContractRef
+  ) {
+    super(`${code}:${contractRef}`);
+    this.name = "ToolCatalogError";
+  }
+}
+
+export class ToolCatalog {
+  private constructor(
+    private readonly contracts: ReadonlyMap<ToolContractRef, PublishedToolContract>
+  ) {}
+
+  static load(definitions: readonly ToolContractDefinition[]): ToolCatalog {
+    const contracts = new Map<ToolContractRef, PublishedToolContract>();
+    for (const definition of definitions) {
+      const ref = toolContractRef(definition.spec.toolId, definition.spec.toolVersion);
+      if (contracts.has(ref)) throw new ToolCatalogError("duplicate_contract", ref);
+      try {
+        contracts.set(ref, publishToolContract(definition));
+      } catch {
+        throw new ToolCatalogError("contract_not_published", ref);
+      }
+    }
+    return new ToolCatalog(contracts);
+  }
+
+  get(toolId: string, toolVersion: string): PublishedToolContract | undefined {
+    return this.contracts.get(toolContractRef(toolId, toolVersion));
+  }
+
+  authorized(allowlist?: ReadonlySet<string>): PublishedToolContract[] {
+    if (allowlist === undefined || allowlist.size === 0) return [];
+    return [...this.contracts]
+      .filter(([ref]) => allowlist.has(ref))
+      .map(([, contract]) => contract);
+  }
+
+  search(query: string, allowlist?: ReadonlySet<string>): ToolCatalogEntry[] {
+    return searchToolContracts(this.authorized(allowlist), query);
+  }
+}

--- a/packages/tool-broker/src/contract.ts
+++ b/packages/tool-broker/src/contract.ts
@@ -1,0 +1,57 @@
+import type { ToolContractDefinition, ToolContractSpec } from "@tulipfarm/schema";
+
+export interface PublishedToolContract
+  extends Omit<
+    ToolContractSpec,
+    "requiredActions" | "requiredResources" | "dataClasses" | "allowedDestinations"
+  > {
+  readonly definitionId: string;
+  readonly authoredVersion: number;
+  readonly publishedDigest: string;
+  readonly requiredActions: readonly string[];
+  readonly requiredResources: readonly string[];
+  readonly dataClasses: readonly string[];
+  readonly allowedDestinations: readonly string[];
+}
+
+export type ToolContractRef = `${string}@${string}`;
+
+export function toolContractRef(toolId: string, toolVersion: string): ToolContractRef {
+  return `${toolId}@${toolVersion}`;
+}
+
+function freezeSchema(schema: Record<string, unknown>): Readonly<Record<string, unknown>> {
+  return Object.freeze(structuredClone(schema));
+}
+
+export function publishToolContract(definition: ToolContractDefinition): PublishedToolContract {
+  const digest = definition.metadata.publishedDigest;
+  const ref = toolContractRef(definition.spec.toolId, definition.spec.toolVersion);
+  if (
+    digest === undefined ||
+    (definition.metadata.lifecycle !== "published" && definition.metadata.lifecycle !== "active")
+  ) {
+    throw new Error(`contract_not_published:${ref}`);
+  }
+
+  const spec = definition.spec;
+  return Object.freeze({
+    ...spec,
+    definitionId: definition.metadata.id,
+    authoredVersion: definition.metadata.authoredVersion,
+    publishedDigest: digest,
+    inputSchema: freezeSchema(spec.inputSchema),
+    outputSchema: freezeSchema(spec.outputSchema),
+    errorSchema: spec.errorSchema === undefined ? undefined : freezeSchema(spec.errorSchema),
+    requiredActions: Object.freeze([...(spec.requiredActions ?? [])]),
+    requiredResources: Object.freeze([...(spec.requiredResources ?? [])]),
+    dataClasses: Object.freeze([...(spec.dataClasses ?? [])]),
+    allowedDestinations: Object.freeze([...(spec.allowedDestinations ?? [])]),
+    idempotency: Object.freeze({ ...spec.idempotency }),
+    timeout: spec.timeout === undefined ? undefined : Object.freeze({ ...spec.timeout }),
+    retry: spec.retry === undefined ? undefined : Object.freeze({ ...spec.retry }),
+    compensation:
+      spec.compensation === undefined ? undefined : Object.freeze({ ...spec.compensation }),
+    adapter: Object.freeze({ ...spec.adapter }),
+  });
+}

--- a/packages/tool-broker/src/credential-dispatch.test.ts
+++ b/packages/tool-broker/src/credential-dispatch.test.ts
@@ -1,0 +1,156 @@
+import { inMemorySecretProvider, SecretBroker, SecretLeakError } from "@tulipfarm/secrets";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ToolCatalog } from "./catalog";
+import { CredentialDispatcher } from "./credential-dispatch";
+import {
+  AdapterDispatchError,
+  EffectDispatcher,
+  EffectLedger,
+  type EffectRecord,
+  MemoryEffectStore,
+  type ReserveEffectInput,
+  type ToolAdapter,
+} from "./effects";
+import { makeContract } from "./test-fixtures";
+
+const BUSINESS_ID = "business-1";
+const EFFECT_ID = "22222222-2222-4222-8222-222222222222";
+const SECRET_REF = "secret://github";
+const OLD_SECRET = "github-old-secret";
+const ROTATED_SECRET = "github-rotated-secret";
+
+const definition = makeContract({
+  mutating: true,
+  riskClass: "medium",
+  idempotency: { strategy: "provider" },
+  retry: { maxAttempts: 2, safeToRetry: true },
+  outputSchema: {
+    type: "object",
+    additionalProperties: false,
+    required: ["providerId"],
+    properties: { providerId: { type: "string" } },
+  },
+});
+
+function reservation(): ReserveEffectInput {
+  return {
+    effectId: EFFECT_ID,
+    businessId: BUSINESS_ID,
+    runId: "11111111-1111-4111-8111-111111111111",
+    stateId: "label",
+    logicalEffectOrdinal: 1,
+    idempotencyKey: "effect-key",
+    intentDigest: "a".repeat(64),
+    intent: {
+      intentId: "intent-1",
+      businessId: BUSINESS_ID,
+      runId: "11111111-1111-4111-8111-111111111111",
+      stateId: "label",
+      toolId: definition.spec.toolId,
+      toolVersion: definition.spec.toolVersion,
+      action: definition.spec.action,
+      targetRefs: [{ type: "issue", id: "issue-42" }],
+      arguments: { label: "triaged" },
+      destination: "github.com",
+      credentialRef: SECRET_REF,
+      idempotencyKey: "effect-key",
+    },
+    guardrailRevision: "guardrail-v3",
+    approvalId: "approval-1",
+    createdAt: "2026-07-25T00:00:00.000Z",
+  };
+}
+
+describe("CredentialDispatcher", () => {
+  let store: MemoryEffectStore;
+  let provider: ReturnType<typeof inMemorySecretProvider>;
+  let reauthorize: ReturnType<typeof vi.fn<(effect: EffectRecord) => Promise<boolean>>>;
+  let credentialDispatcher: CredentialDispatcher;
+
+  beforeEach(async () => {
+    store = new MemoryEffectStore();
+    await new EffectLedger(store).reserve(reservation());
+    provider = inMemorySecretProvider({ [SECRET_REF]: OLD_SECRET });
+    reauthorize = vi.fn<(effect: EffectRecord) => Promise<boolean>>(async () => true);
+    const secrets = new SecretBroker({
+      provider,
+      authorizer: { authorize: async () => ({ allowed: true, maxUses: 1 }) },
+    });
+    credentialDispatcher = new CredentialDispatcher({ secrets, reauthorize });
+  });
+
+  it("leases the current Credential only inside the adapter callback", async () => {
+    provider.set(SECRET_REF, ROTATED_SECRET);
+    const adapter: ToolAdapter = {
+      dispatch: vi.fn(async (_request, credential) => {
+        expect(credential).toBe(ROTATED_SECRET);
+        return { providerId: "external-42" };
+      }),
+    };
+
+    await dispatcher(adapter).dispatch(BUSINESS_ID, EFFECT_ID);
+
+    expect(reauthorize).toHaveBeenCalledTimes(1);
+    expect(JSON.stringify(await store.list(BUSINESS_ID))).not.toContain(ROTATED_SECRET);
+    expect(JSON.stringify(await store.listAttempts(BUSINESS_ID, EFFECT_ID))).not.toContain(
+      ROTATED_SECRET
+    );
+  });
+
+  it("reauthorizes and leases fresh on every retry attempt", async () => {
+    let calls = 0;
+    const adapter: ToolAdapter = {
+      dispatch: vi.fn(async (_request, credential) => {
+        calls += 1;
+        if (calls === 1) {
+          provider.set(SECRET_REF, ROTATED_SECRET);
+          throw new AdapterDispatchError("before_dispatch", "transport_unavailable", true);
+        }
+        expect(credential).toBe(ROTATED_SECRET);
+        return { providerId: "external-42" };
+      }),
+    };
+
+    await dispatcher(adapter).dispatch(BUSINESS_ID, EFFECT_ID);
+
+    expect(reauthorize).toHaveBeenCalledTimes(2);
+  });
+
+  it("denies when final authorization is no longer current", async () => {
+    reauthorize.mockResolvedValue(false);
+    const adapter: ToolAdapter = {
+      dispatch: vi.fn(async () => ({ providerId: "must-not-run" })),
+    };
+
+    await expect(dispatcher(adapter).dispatch(BUSINESS_ID, EFFECT_ID)).rejects.toThrow();
+    expect(adapter.dispatch).not.toHaveBeenCalled();
+  });
+
+  it("blocks plaintext in adapter results and persists no plaintext", async () => {
+    const adapter: ToolAdapter = {
+      dispatch: vi.fn(async (_request, credential) => ({ providerId: credential })),
+    };
+
+    const error = await dispatcher(adapter)
+      .dispatch(BUSINESS_ID, EFFECT_ID)
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).not.toBeInstanceOf(SecretLeakError);
+    expect(JSON.stringify(await store.list(BUSINESS_ID))).not.toContain(OLD_SECRET);
+    expect(JSON.stringify(await store.listAttempts(BUSINESS_ID, EFFECT_ID))).not.toContain(
+      OLD_SECRET
+    );
+  });
+
+  function dispatcher(adapter: ToolAdapter) {
+    return new EffectDispatcher({
+      store,
+      catalog: ToolCatalog.load([definition]),
+      adapters: new Map([["github", adapter]]),
+      credentialDispatcher,
+      wait: async () => undefined,
+      now: () => "2026-07-25T00:00:01.000Z",
+    });
+  }
+});

--- a/packages/tool-broker/src/credential-dispatch.ts
+++ b/packages/tool-broker/src/credential-dispatch.ts
@@ -1,0 +1,66 @@
+import { type SecretBroker, SecretLeakError, SecretLeaseDeniedError } from "@tulipfarm/secrets";
+import {
+  AdapterDispatchError,
+  type EffectRecord,
+  type ToolAdapter,
+  type ToolAdapterRequest,
+} from "./effects";
+
+export interface CredentialDispatcherDeps {
+  readonly secrets: SecretBroker;
+  readonly reauthorize: (effect: EffectRecord) => Promise<boolean> | boolean;
+}
+
+export class CredentialDispatcher {
+  constructor(private readonly deps: CredentialDispatcherDeps) {}
+
+  async dispatch(
+    effect: EffectRecord,
+    adapter: ToolAdapter,
+    request: ToolAdapterRequest
+  ): Promise<unknown> {
+    const secretRef = effect.intent.credentialRef;
+    if (secretRef === undefined) return adapter.dispatch(request);
+
+    let authorized = false;
+    try {
+      authorized = await this.deps.reauthorize(effect);
+    } catch {
+      authorized = false;
+    }
+    if (!authorized) {
+      throw new AdapterDispatchError("before_dispatch", "authorization_revoked", false);
+    }
+
+    try {
+      const lease = await this.deps.secrets.lease({
+        scope: {
+          secretRef,
+          toolId: effect.intent.toolId,
+          targetId: effect.intent.targetRefs[0]?.id,
+          runId: effect.runId,
+          stateId: effect.stateId,
+          purpose: effect.intent.action,
+        },
+        maxUses: 1,
+      });
+      return await lease.use((credential) => adapter.dispatch(request, credential));
+    } catch (error) {
+      if (error instanceof AdapterDispatchError) {
+        throw new AdapterDispatchError(
+          error.phase,
+          "adapter_error",
+          error.retryable,
+          error.providerRequestId
+        );
+      }
+      if (error instanceof SecretLeakError) {
+        throw new AdapterDispatchError("after_dispatch", "credential_output_blocked", false);
+      }
+      if (error instanceof SecretLeaseDeniedError) {
+        throw new AdapterDispatchError("before_dispatch", "credential_denied", false);
+      }
+      throw new AdapterDispatchError("after_dispatch", "credential_dispatch_failed", false);
+    }
+  }
+}

--- a/packages/tool-broker/src/effects/compensate.ts
+++ b/packages/tool-broker/src/effects/compensate.ts
@@ -1,0 +1,96 @@
+import type { ToolAuthorizationContext } from "../authorize";
+import type { ToolBroker } from "../broker";
+import type { ToolCatalog } from "../catalog";
+import type { ToolIntent } from "../intent";
+import { EffectLedgerError, type ReserveEffectResult } from "./model";
+import type { EffectStore } from "./store";
+
+export type CompensationErrorCode =
+  | "original_effect_not_found"
+  | "original_effect_not_confirmed"
+  | "compensation_not_declared"
+  | "compensation_intent_mismatch"
+  | "compensation_denied";
+
+export class CompensationError extends Error {
+  constructor(
+    readonly code: CompensationErrorCode,
+    readonly effectId: string
+  ) {
+    super(`${code}:${effectId}`);
+    this.name = "CompensationError";
+  }
+}
+
+export interface AuthorizeCompensationInput {
+  readonly originalEffectId: string;
+  readonly effectId: string;
+  readonly logicalEffectOrdinal: number;
+  readonly intent: ToolIntent;
+  readonly authorization: ToolAuthorizationContext;
+  readonly createdAt: string;
+  readonly approvalId?: string;
+}
+
+export interface EffectCompensatorDeps {
+  readonly store: EffectStore;
+  readonly broker: ToolBroker;
+  readonly catalog: ToolCatalog;
+}
+
+export class EffectCompensator {
+  constructor(private readonly deps: EffectCompensatorDeps) {}
+
+  async authorizeAndReserve(input: AuthorizeCompensationInput): Promise<ReserveEffectResult> {
+    const original = await this.deps.store.get(input.intent.businessId, input.originalEffectId);
+    if (original === undefined) {
+      throw new CompensationError("original_effect_not_found", input.originalEffectId);
+    }
+    if (original.state !== "confirmed") {
+      throw new CompensationError("original_effect_not_confirmed", input.originalEffectId);
+    }
+    const originalContract = this.deps.catalog.get(
+      original.intent.toolId,
+      original.intent.toolVersion
+    );
+    const operation = originalContract?.compensation?.operation;
+    if (operation === undefined) {
+      throw new CompensationError("compensation_not_declared", input.originalEffectId);
+    }
+    if (
+      input.intent.businessId !== original.businessId ||
+      input.intent.runId !== original.runId ||
+      input.intent.action !== operation
+    ) {
+      throw new CompensationError("compensation_intent_mismatch", input.originalEffectId);
+    }
+
+    const authorization = this.deps.broker.authorize(input.intent, input.authorization);
+    if (authorization.outcome !== "authorized") {
+      throw new CompensationError("compensation_denied", input.originalEffectId);
+    }
+    try {
+      return await this.deps.store.reserveCompensation(
+        {
+          effectId: input.effectId,
+          businessId: original.businessId,
+          runId: original.runId,
+          stateId: original.stateId,
+          logicalEffectOrdinal: input.logicalEffectOrdinal,
+          idempotencyKey: authorization.intent.idempotencyKey,
+          intentDigest: authorization.intentDigest,
+          intent: authorization.intent,
+          guardrailRevision: authorization.guardrailRevision,
+          approvalId: input.approvalId,
+          createdAt: input.createdAt,
+        },
+        original.effectId
+      );
+    } catch (error) {
+      if (error instanceof EffectLedgerError && error.code === "effect_state_conflict") {
+        throw new CompensationError("original_effect_not_confirmed", input.originalEffectId);
+      }
+      throw error;
+    }
+  }
+}

--- a/packages/tool-broker/src/effects/dispatch.test.ts
+++ b/packages/tool-broker/src/effects/dispatch.test.ts
@@ -1,0 +1,153 @@
+import type { ToolContractDefinition } from "@tulipfarm/schema";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ToolCatalog } from "../catalog";
+import {
+  AdapterDispatchError,
+  EffectDispatcher,
+  type ToolAdapter,
+  ToolDispatchError,
+} from "./dispatch";
+import type { ReserveEffectInput } from "./model";
+import { EffectLedger, MemoryEffectStore } from "./store";
+
+const BUSINESS_ID = "business-1";
+const EFFECT_ID = "22222222-2222-4222-8222-222222222222";
+
+const definition: ToolContractDefinition = {
+  apiVersion: "tulipfarm.ai/v1",
+  kind: "ToolContract",
+  metadata: {
+    id: "33333333-3333-4333-8333-333333333333",
+    slug: "github-issue-label",
+    schemaVersion: 1,
+    authoredVersion: 1,
+    lifecycle: "active",
+    publishedDigest: "a".repeat(64),
+  },
+  spec: {
+    toolId: "github.issue.label",
+    toolVersion: "1.0.0",
+    action: "issue.label",
+    inputSchema: { type: "object" },
+    outputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["providerId"],
+      properties: { providerId: { type: "string" } },
+    },
+    riskClass: "medium",
+    mutating: true,
+    dataClasses: ["internal"],
+    allowedDestinations: ["github.com"],
+    idempotency: { strategy: "provider" },
+    retry: { maxAttempts: 3, safeToRetry: true },
+    dryRun: false,
+    adapter: { kind: "integration", ref: "github" },
+  },
+};
+
+function reservation(): ReserveEffectInput {
+  return {
+    effectId: EFFECT_ID,
+    businessId: BUSINESS_ID,
+    runId: "11111111-1111-4111-8111-111111111111",
+    stateId: "label",
+    logicalEffectOrdinal: 1,
+    idempotencyKey: "stable-effect-key",
+    intentDigest: "a".repeat(64),
+    intent: {
+      intentId: "intent-1",
+      businessId: BUSINESS_ID,
+      runId: "11111111-1111-4111-8111-111111111111",
+      stateId: "label",
+      toolId: "github.issue.label",
+      toolVersion: "1.0.0",
+      action: "issue.label",
+      targetRefs: [{ type: "issue", id: "issue-42" }],
+      arguments: { label: "triaged" },
+      destination: "github.com",
+      credentialRef: "secret://github",
+      idempotencyKey: "stable-effect-key",
+    },
+    guardrailRevision: "guardrail-v3",
+    createdAt: "2026-07-25T00:00:00.000Z",
+  };
+}
+
+describe("EffectDispatcher", () => {
+  let store: MemoryEffectStore;
+
+  beforeEach(async () => {
+    store = new MemoryEffectStore();
+    await new EffectLedger(store).reserve(reservation());
+  });
+
+  it("dispatches only after the effect and attempt are durable", async () => {
+    const adapter: ToolAdapter = {
+      dispatch: vi.fn(async (request) => {
+        expect(await store.get(BUSINESS_ID, EFFECT_ID)).toMatchObject({ state: "dispatched" });
+        expect(await store.listAttempts(BUSINESS_ID, EFFECT_ID)).toHaveLength(1);
+        expect(request.idempotencyKey).toBe("stable-effect-key");
+        return { providerId: "external-42" };
+      }),
+    };
+
+    const result = await dispatcher(adapter).dispatch(BUSINESS_ID, EFFECT_ID);
+
+    expect(result).toEqual({ providerId: "external-42" });
+    expect(await store.get(BUSINESS_ID, EFFECT_ID)).toMatchObject({ state: "confirmed" });
+  });
+
+  it("retries a classified pre-dispatch failure with the same stable key and backoff", async () => {
+    const keys: string[] = [];
+    const adapter: ToolAdapter = {
+      dispatch: vi.fn(async (request) => {
+        keys.push(request.idempotencyKey);
+        if (keys.length === 1) {
+          throw new AdapterDispatchError("before_dispatch", "transport_unavailable", true);
+        }
+        return { providerId: "external-42" };
+      }),
+    };
+    const wait = vi.fn(async () => undefined);
+
+    await dispatcher(adapter, wait).dispatch(BUSINESS_ID, EFFECT_ID);
+
+    expect(keys).toEqual(["stable-effect-key", "stable-effect-key"]);
+    expect(wait).toHaveBeenCalledWith(100);
+    expect(await store.listAttempts(BUSINESS_ID, EFFECT_ID)).toHaveLength(2);
+  });
+
+  it("marks an uncertain mutation ambiguous and never blindly retries", async () => {
+    const adapter: ToolAdapter = {
+      dispatch: vi.fn(async () => {
+        throw new AdapterDispatchError("after_dispatch", "provider_timeout", true, "request-42");
+      }),
+    };
+
+    await expect(dispatcher(adapter).dispatch(BUSINESS_ID, EFFECT_ID)).rejects.toThrow(
+      new ToolDispatchError("ambiguous", EFFECT_ID)
+    );
+    expect(adapter.dispatch).toHaveBeenCalledTimes(1);
+    expect(await store.get(BUSINESS_ID, EFFECT_ID)).toMatchObject({ state: "ambiguous" });
+  });
+
+  it("validates provider output before confirming the effect", async () => {
+    const adapter: ToolAdapter = { dispatch: vi.fn(async () => ({ providerId: 42 })) };
+
+    await expect(dispatcher(adapter).dispatch(BUSINESS_ID, EFFECT_ID)).rejects.toThrow(
+      new ToolDispatchError("invalid_output", EFFECT_ID)
+    );
+    expect(await store.get(BUSINESS_ID, EFFECT_ID)).toMatchObject({ state: "failed" });
+  });
+
+  function dispatcher(adapter: ToolAdapter, wait?: (delayMs: number) => Promise<void>) {
+    return new EffectDispatcher({
+      store,
+      catalog: ToolCatalog.load([definition]),
+      adapters: new Map([["github", adapter]]),
+      wait,
+      now: () => "2026-07-25T00:00:01.000Z",
+    });
+  }
+});

--- a/packages/tool-broker/src/effects/dispatch.ts
+++ b/packages/tool-broker/src/effects/dispatch.ts
@@ -1,0 +1,164 @@
+import { ajv, canonicalHash } from "@tulipfarm/schema";
+import type { ToolCatalog } from "../catalog";
+import type { CredentialDispatcher } from "../credential-dispatch";
+import type { ToolIntent } from "../intent";
+import { mayRetry, retryDelayMs } from "./retry";
+import type { EffectStore } from "./store";
+
+export type DispatchPhase = "before_dispatch" | "after_dispatch";
+
+export class AdapterDispatchError extends Error {
+  constructor(
+    readonly phase: DispatchPhase,
+    readonly code: string,
+    readonly retryable: boolean,
+    readonly providerRequestId?: string
+  ) {
+    super(code);
+    this.name = "AdapterDispatchError";
+  }
+}
+
+export interface ToolAdapterRequest {
+  readonly intent: ToolIntent;
+  readonly idempotencyKey: string;
+  readonly attempt: number;
+  readonly timeoutMs?: number;
+}
+
+export interface ToolAdapter {
+  dispatch(request: ToolAdapterRequest, credential?: string): Promise<unknown>;
+}
+
+export type ToolDispatchErrorCode =
+  | "effect_not_found"
+  | "contract_not_found"
+  | "adapter_not_found"
+  | "dispatch_failed"
+  | "ambiguous"
+  | "invalid_output";
+
+export class ToolDispatchError extends Error {
+  constructor(
+    readonly code: ToolDispatchErrorCode,
+    readonly effectId: string
+  ) {
+    super(`${code}:${effectId}`);
+    this.name = "ToolDispatchError";
+  }
+}
+
+export interface EffectDispatcherDeps {
+  readonly store: EffectStore;
+  readonly catalog: ToolCatalog;
+  readonly adapters: ReadonlyMap<string, ToolAdapter>;
+  readonly credentialDispatcher?: CredentialDispatcher;
+  readonly wait?: (delayMs: number) => Promise<void>;
+  readonly now?: () => string;
+}
+
+function classifyError(error: unknown, mutating: boolean): AdapterDispatchError {
+  if (error instanceof AdapterDispatchError) return error;
+  return new AdapterDispatchError(
+    mutating ? "after_dispatch" : "before_dispatch",
+    "adapter_error",
+    false
+  );
+}
+
+async function withTimeout(
+  operation: Promise<unknown>,
+  timeoutMs: number | undefined
+): Promise<unknown> {
+  if (timeoutMs === undefined || timeoutMs <= 0) return operation;
+  return Promise.race([
+    operation,
+    new Promise<never>((_resolve, reject) => {
+      setTimeout(
+        () => reject(new AdapterDispatchError("after_dispatch", "provider_timeout", true)),
+        timeoutMs
+      );
+    }),
+  ]);
+}
+
+export class EffectDispatcher {
+  private readonly wait: (delayMs: number) => Promise<void>;
+  private readonly now: () => string;
+
+  constructor(private readonly deps: EffectDispatcherDeps) {
+    this.wait = deps.wait ?? (() => Promise.resolve());
+    this.now = deps.now ?? (() => new Date().toISOString());
+  }
+
+  async dispatch(businessId: string, effectId: string): Promise<unknown> {
+    const effect = await this.deps.store.get(businessId, effectId);
+    if (effect === undefined) throw new ToolDispatchError("effect_not_found", effectId);
+    const contract = this.deps.catalog.get(effect.intent.toolId, effect.intent.toolVersion);
+    if (contract === undefined) throw new ToolDispatchError("contract_not_found", effectId);
+    const adapter = this.deps.adapters.get(contract.adapter.ref);
+    if (adapter === undefined) throw new ToolDispatchError("adapter_not_found", effectId);
+    const validateOutput = ajv.compile(contract.outputSchema);
+
+    let attemptNumber = 0;
+    while (true) {
+      const attempt = await this.deps.store.beginAttempt(businessId, effectId, this.now());
+      attemptNumber = attempt.attempt;
+      try {
+        const request = {
+          intent: effect.intent,
+          idempotencyKey: effect.idempotencyKey,
+          attempt: attemptNumber,
+          timeoutMs: contract.timeout?.wallClockMs,
+        };
+        const output = await withTimeout(
+          this.deps.credentialDispatcher === undefined
+            ? adapter.dispatch(request)
+            : this.deps.credentialDispatcher.dispatch(effect, adapter, request),
+          contract.timeout?.wallClockMs
+        );
+        if (!validateOutput(output)) {
+          await this.deps.store.finishAttempt({
+            businessId,
+            effectId,
+            attempt: attemptNumber,
+            attemptState: "failed",
+            effectState: "failed",
+            errorCode: "invalid_output",
+            finishedAt: this.now(),
+          });
+          throw new ToolDispatchError("invalid_output", effectId);
+        }
+        await this.deps.store.finishAttempt({
+          businessId,
+          effectId,
+          attempt: attemptNumber,
+          attemptState: "confirmed",
+          effectState: "confirmed",
+          outputDigest: canonicalHash(output),
+          finishedAt: this.now(),
+        });
+        return output;
+      } catch (thrown) {
+        if (thrown instanceof ToolDispatchError) throw thrown;
+        const error = classifyError(thrown, contract.mutating);
+        const ambiguous = error.phase === "after_dispatch" && contract.mutating;
+        const retry =
+          error.retryable && mayRetry(contract, attemptNumber, error.phase) && !ambiguous;
+        await this.deps.store.finishAttempt({
+          businessId,
+          effectId,
+          attempt: attemptNumber,
+          attemptState: ambiguous ? "ambiguous" : "failed",
+          effectState: ambiguous ? "ambiguous" : retry ? "authorized" : "failed",
+          providerRequestId: error.providerRequestId,
+          errorCode: error.code,
+          finishedAt: this.now(),
+        });
+        if (ambiguous) throw new ToolDispatchError("ambiguous", effectId);
+        if (!retry) throw new ToolDispatchError("dispatch_failed", effectId);
+        await this.wait(retryDelayMs(attemptNumber));
+      }
+    }
+  }
+}

--- a/packages/tool-broker/src/effects/index.ts
+++ b/packages/tool-broker/src/effects/index.ts
@@ -1,0 +1,7 @@
+export * from "./compensate";
+export * from "./dispatch";
+export * from "./jobs";
+export * from "./model";
+export * from "./reconcile";
+export * from "./retry";
+export * from "./store";

--- a/packages/tool-broker/src/effects/jobs.ts
+++ b/packages/tool-broker/src/effects/jobs.ts
@@ -1,0 +1,26 @@
+import type { EffectReconciler, ReconciliationResult } from "./reconcile";
+import type { EffectStore } from "./store";
+
+export interface ReconciliationJobResult {
+  readonly effectId: string;
+  readonly result: ReconciliationResult;
+}
+
+export async function runReconciliationJobs(
+  store: EffectStore,
+  reconciler: EffectReconciler,
+  businessId: string,
+  limit: number
+): Promise<ReconciliationJobResult[]> {
+  const candidates = (await store.list(businessId))
+    .filter((effect) => effect.state === "ambiguous" || effect.state === "reconciliation_required")
+    .slice(0, Math.max(0, limit));
+  const results: ReconciliationJobResult[] = [];
+  for (const effect of candidates) {
+    results.push({
+      effectId: effect.effectId,
+      result: await reconciler.reconcile(businessId, effect.effectId),
+    });
+  }
+  return results;
+}

--- a/packages/tool-broker/src/effects/model.ts
+++ b/packages/tool-broker/src/effects/model.ts
@@ -1,0 +1,101 @@
+import type { ToolIntent } from "../intent";
+
+export type EffectState =
+  | "proposed"
+  | "denied"
+  | "awaiting_approval"
+  | "authorized"
+  | "dispatched"
+  | "confirmed"
+  | "failed"
+  | "ambiguous"
+  | "compensating"
+  | "compensated"
+  | "reconciliation_required";
+
+export interface EffectRecord {
+  readonly effectId: string;
+  readonly businessId: string;
+  readonly runId: string;
+  readonly stateId: string;
+  readonly logicalEffectOrdinal: number;
+  readonly idempotencyKey: string;
+  readonly intentDigest: string;
+  readonly intent: ToolIntent;
+  readonly guardrailRevision: string;
+  readonly approvalId?: string;
+  readonly state: EffectState;
+  readonly parentEffectId?: string;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+}
+
+export interface ReserveEffectInput {
+  readonly effectId: string;
+  readonly businessId: string;
+  readonly runId: string;
+  readonly stateId: string;
+  readonly logicalEffectOrdinal: number;
+  readonly idempotencyKey: string;
+  readonly intentDigest: string;
+  readonly intent: ToolIntent;
+  readonly guardrailRevision: string;
+  readonly approvalId?: string;
+  readonly parentEffectId?: string;
+  readonly createdAt: string;
+}
+
+export interface ReserveEffectResult {
+  readonly outcome: "created" | "duplicate";
+  readonly effect: EffectRecord;
+}
+
+export type EffectAttemptState = "prepared" | "dispatched" | "confirmed" | "failed" | "ambiguous";
+
+export interface EffectAttempt {
+  readonly businessId: string;
+  readonly effectId: string;
+  readonly attempt: number;
+  readonly state: EffectAttemptState;
+  readonly providerRequestId?: string;
+  readonly outputDigest?: string;
+  readonly errorCode?: string;
+  readonly startedAt: string;
+  readonly finishedAt?: string;
+}
+
+export interface FinishEffectAttemptInput {
+  readonly businessId: string;
+  readonly effectId: string;
+  readonly attempt: number;
+  readonly attemptState: Exclude<EffectAttemptState, "prepared" | "dispatched">;
+  readonly effectState: EffectState;
+  readonly providerRequestId?: string;
+  readonly outputDigest?: string;
+  readonly errorCode?: string;
+  readonly finishedAt: string;
+}
+
+export interface TransitionEffectInput {
+  readonly businessId: string;
+  readonly effectId: string;
+  readonly expectedStates: readonly EffectState[];
+  readonly state: EffectState;
+  readonly updatedAt: string;
+}
+
+export type EffectLedgerErrorCode =
+  | "idempotency_digest_mismatch"
+  | "effect_not_found"
+  | "effect_state_conflict"
+  | "attempt_not_found";
+
+export class EffectLedgerError extends Error {
+  constructor(
+    readonly code: EffectLedgerErrorCode,
+    readonly reference: string
+  ) {
+    super(`${code}:${reference}`);
+    this.name = "EffectLedgerError";
+  }
+}

--- a/packages/tool-broker/src/effects/reconcile.test.ts
+++ b/packages/tool-broker/src/effects/reconcile.test.ts
@@ -1,0 +1,221 @@
+import type { AccessGrant, AuthorityLayer, DlpRule, GuardrailRule } from "@tulipfarm/authz";
+import type { ToolContractDefinition } from "@tulipfarm/schema";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ToolAuthorizationContext } from "../authorize";
+import { ToolBroker } from "../broker";
+import { ToolCatalog } from "../catalog";
+import { EffectCompensator } from "./compensate";
+import type { ReserveEffectInput } from "./model";
+import { EffectReconciler, type ToolReconciliationAdapter } from "./reconcile";
+import { EffectLedger, MemoryEffectStore } from "./store";
+
+const BUSINESS_ID = "business-1";
+const EFFECT_ID = "22222222-2222-4222-8222-222222222222";
+
+const originalDefinition: ToolContractDefinition = {
+  apiVersion: "tulipfarm.ai/v1",
+  kind: "ToolContract",
+  metadata: {
+    id: "33333333-3333-4333-8333-333333333333",
+    slug: "github-issue-label",
+    schemaVersion: 1,
+    authoredVersion: 1,
+    lifecycle: "active",
+    publishedDigest: "a".repeat(64),
+  },
+  spec: {
+    toolId: "github.issue.label",
+    toolVersion: "1.0.0",
+    action: "issue.label",
+    inputSchema: { type: "object" },
+    outputSchema: { type: "object" },
+    riskClass: "medium",
+    mutating: true,
+    requiredActions: ["issue.label"],
+    requiredResources: ["issue"],
+    dataClasses: ["internal"],
+    allowedDestinations: ["github.com"],
+    idempotency: { strategy: "provider" },
+    retry: { maxAttempts: 1, safeToRetry: false },
+    compensation: { operation: "issue.unlabel", reconciliation: "issue.lookup-label" },
+    dryRun: false,
+    adapter: { kind: "integration", ref: "github" },
+  },
+};
+
+const compensationDefinition: ToolContractDefinition = {
+  ...originalDefinition,
+  metadata: {
+    ...originalDefinition.metadata,
+    id: "44444444-4444-4444-8444-444444444444",
+    slug: "github-issue-unlabel",
+  },
+  spec: {
+    ...originalDefinition.spec,
+    toolId: "github.issue.unlabel",
+    action: "issue.unlabel",
+    requiredActions: ["issue.unlabel"],
+    compensation: undefined,
+  },
+};
+
+function reservation(): ReserveEffectInput {
+  return {
+    effectId: EFFECT_ID,
+    businessId: BUSINESS_ID,
+    runId: "11111111-1111-4111-8111-111111111111",
+    stateId: "label",
+    logicalEffectOrdinal: 1,
+    idempotencyKey: "stable-effect-key",
+    intentDigest: "a".repeat(64),
+    intent: {
+      intentId: "intent-1",
+      businessId: BUSINESS_ID,
+      runId: "11111111-1111-4111-8111-111111111111",
+      stateId: "label",
+      toolId: "github.issue.label",
+      toolVersion: "1.0.0",
+      action: "issue.label",
+      targetRefs: [{ type: "issue", id: "issue-42" }],
+      arguments: { label: "triaged" },
+      destination: "github.com",
+      idempotencyKey: "stable-effect-key",
+    },
+    guardrailRevision: "guardrail-v3",
+    createdAt: "2026-07-25T00:00:00.000Z",
+  };
+}
+
+describe("EffectReconciler", () => {
+  let store: MemoryEffectStore;
+  let catalog: ToolCatalog;
+
+  beforeEach(async () => {
+    store = new MemoryEffectStore();
+    catalog = ToolCatalog.load([originalDefinition, compensationDefinition]);
+    await new EffectLedger(store).reserve(reservation());
+    await store.transition({
+      businessId: BUSINESS_ID,
+      effectId: EFFECT_ID,
+      expectedStates: ["authorized"],
+      state: "ambiguous",
+      updatedAt: "2026-07-25T00:00:01.000Z",
+    });
+  });
+
+  it("runs the declared lookup and confirms applied effects", async () => {
+    const adapter: ToolReconciliationAdapter = {
+      reconcile: vi.fn(async (request) => {
+        expect(request.operation).toBe("issue.lookup-label");
+        return { outcome: "confirmed" as const, evidenceRef: "artifact://lookup-1" };
+      }),
+    };
+
+    const result = await reconciler(adapter).reconcile(BUSINESS_ID, EFFECT_ID);
+
+    expect(result).toEqual({ outcome: "confirmed", evidenceRef: "artifact://lookup-1" });
+    expect(await store.get(BUSINESS_ID, EFFECT_ID)).toMatchObject({ state: "confirmed" });
+  });
+
+  it("keeps an unresolved outcome visible for operator attention", async () => {
+    const adapter: ToolReconciliationAdapter = {
+      reconcile: vi.fn(async () => ({
+        outcome: "ambiguous" as const,
+        evidenceRef: "artifact://lookup-2",
+      })),
+    };
+
+    const result = await reconciler(adapter).reconcile(BUSINESS_ID, EFFECT_ID);
+
+    expect(result).toMatchObject({ outcome: "attention_required" });
+    expect(await store.get(BUSINESS_ID, EFFECT_ID)).toMatchObject({
+      state: "reconciliation_required",
+    });
+  });
+
+  function reconciler(adapter: ToolReconciliationAdapter) {
+    return new EffectReconciler({
+      store,
+      catalog,
+      adapters: new Map([["github", adapter]]),
+      now: () => "2026-07-25T00:00:02.000Z",
+    });
+  }
+});
+
+describe("EffectCompensator", () => {
+  it("creates a newly authorized effect with lineage to the original", async () => {
+    const store = new MemoryEffectStore();
+    const catalog = ToolCatalog.load([originalDefinition, compensationDefinition]);
+    await new EffectLedger(store).reserve(reservation());
+    await store.transition({
+      businessId: BUSINESS_ID,
+      effectId: EFFECT_ID,
+      expectedStates: ["authorized"],
+      state: "confirmed",
+      updatedAt: "2026-07-25T00:00:01.000Z",
+    });
+    const compensator = new EffectCompensator({
+      store,
+      broker: new ToolBroker(catalog),
+      catalog,
+    });
+
+    const result = await compensator.authorizeAndReserve({
+      originalEffectId: EFFECT_ID,
+      effectId: "55555555-5555-4555-8555-555555555555",
+      logicalEffectOrdinal: 2,
+      intent: {
+        ...reservation().intent,
+        intentId: "intent-2",
+        toolId: "github.issue.unlabel",
+        action: "issue.unlabel",
+        idempotencyKey: "compensate-stable-effect-key",
+      },
+      authorization: authorizationContext(),
+      createdAt: "2026-07-25T00:00:02.000Z",
+    });
+
+    expect(result).toMatchObject({
+      outcome: "created",
+      effect: {
+        parentEffectId: EFFECT_ID,
+        state: "authorized",
+        idempotencyKey: "compensate-stable-effect-key",
+      },
+    });
+    expect(await store.get(BUSINESS_ID, EFFECT_ID)).toMatchObject({ state: "compensating" });
+  });
+});
+
+function authorizationContext(): ToolAuthorizationContext {
+  const grant: AccessGrant = {
+    action: "issue.unlabel",
+    resourceType: "issue",
+    recordSelector: "issue-42",
+    destination: "github.com",
+    effect: "allow",
+  };
+  const authorityLayers: AuthorityLayer[] = ["user", "agent", "run", "tool", "credential"].map(
+    (name) => ({ name, grants: [grant] })
+  );
+  const guardrailRules: GuardrailRule[] = [
+    {
+      id: "compensate",
+      effect: "allow",
+      action: "issue.unlabel",
+      resourceType: "issue",
+      recordSelector: "issue-42",
+      destination: "github.com",
+    },
+  ];
+  const dlpRules: DlpRule[] = [{ dataClass: "internal", allowedDestinations: ["github.com"] }];
+  return {
+    authorityLayers,
+    guardrailRules,
+    dlpRules,
+    guardrailRevision: "guardrail-v4",
+    taint: "trusted",
+    autonomy: "execute_policy_authorized",
+  };
+}

--- a/packages/tool-broker/src/effects/reconcile.ts
+++ b/packages/tool-broker/src/effects/reconcile.ts
@@ -1,0 +1,106 @@
+import type { ToolCatalog } from "../catalog";
+import type { ToolIntent } from "../intent";
+import type { EffectStore } from "./store";
+
+export interface ToolReconciliationRequest {
+  readonly intent: ToolIntent;
+  readonly idempotencyKey: string;
+  readonly operation: string;
+}
+
+export type ToolReconciliationOutcome =
+  | { readonly outcome: "confirmed"; readonly evidenceRef: string }
+  | { readonly outcome: "not_applied"; readonly evidenceRef: string }
+  | { readonly outcome: "ambiguous"; readonly evidenceRef: string };
+
+export interface ToolReconciliationAdapter {
+  reconcile(request: ToolReconciliationRequest): Promise<ToolReconciliationOutcome>;
+}
+
+export type ReconciliationResult =
+  | { readonly outcome: "confirmed"; readonly evidenceRef: string }
+  | { readonly outcome: "not_applied"; readonly evidenceRef: string }
+  | {
+      readonly outcome: "attention_required";
+      readonly reason: "still_ambiguous" | "lookup_unavailable" | "lookup_failed";
+      readonly evidenceRef?: string;
+    };
+
+export interface EffectReconcilerDeps {
+  readonly store: EffectStore;
+  readonly catalog: ToolCatalog;
+  readonly adapters: ReadonlyMap<string, ToolReconciliationAdapter>;
+  readonly now?: () => string;
+}
+
+export class EffectReconciler {
+  private readonly now: () => string;
+
+  constructor(private readonly deps: EffectReconcilerDeps) {
+    this.now = deps.now ?? (() => new Date().toISOString());
+  }
+
+  async reconcile(businessId: string, effectId: string): Promise<ReconciliationResult> {
+    const effect = await this.deps.store.get(businessId, effectId);
+    if (effect === undefined) {
+      return { outcome: "attention_required", reason: "lookup_unavailable" };
+    }
+    const contract = this.deps.catalog.get(effect.intent.toolId, effect.intent.toolVersion);
+    const operation = contract?.compensation?.reconciliation;
+    const adapter =
+      contract === undefined ? undefined : this.deps.adapters.get(contract.adapter.ref);
+    if (operation === undefined || adapter === undefined) {
+      await this.requireAttention(businessId, effectId);
+      return { outcome: "attention_required", reason: "lookup_unavailable" };
+    }
+
+    let result: ToolReconciliationOutcome;
+    try {
+      result = await adapter.reconcile({
+        intent: effect.intent,
+        idempotencyKey: effect.idempotencyKey,
+        operation,
+      });
+    } catch {
+      await this.requireAttention(businessId, effectId);
+      return { outcome: "attention_required", reason: "lookup_failed" };
+    }
+
+    if (result.outcome === "confirmed") {
+      await this.deps.store.transition({
+        businessId,
+        effectId,
+        expectedStates: ["ambiguous", "reconciliation_required"],
+        state: "confirmed",
+        updatedAt: this.now(),
+      });
+      return result;
+    }
+    if (result.outcome === "not_applied") {
+      await this.deps.store.transition({
+        businessId,
+        effectId,
+        expectedStates: ["ambiguous", "reconciliation_required"],
+        state: "failed",
+        updatedAt: this.now(),
+      });
+      return result;
+    }
+    await this.requireAttention(businessId, effectId);
+    return {
+      outcome: "attention_required",
+      reason: "still_ambiguous",
+      evidenceRef: result.evidenceRef,
+    };
+  }
+
+  private async requireAttention(businessId: string, effectId: string): Promise<void> {
+    await this.deps.store.transition({
+      businessId,
+      effectId,
+      expectedStates: ["ambiguous", "reconciliation_required"],
+      state: "reconciliation_required",
+      updatedAt: this.now(),
+    });
+  }
+}

--- a/packages/tool-broker/src/effects/retry.ts
+++ b/packages/tool-broker/src/effects/retry.ts
@@ -1,0 +1,21 @@
+import type { PublishedToolContract } from "../contract";
+
+export function retryDelayMs(attempt: number): number {
+  return Math.min(30_000, 100 * 2 ** Math.max(0, attempt - 1));
+}
+
+export function maxDispatchAttempts(contract: PublishedToolContract): number {
+  return Math.max(1, contract.retry?.maxAttempts ?? 1);
+}
+
+export function mayRetry(
+  contract: PublishedToolContract,
+  attempt: number,
+  phase: "before_dispatch" | "after_dispatch"
+): boolean {
+  if (attempt >= maxDispatchAttempts(contract) || contract.retry?.safeToRetry !== true) {
+    return false;
+  }
+  if (phase === "after_dispatch" && contract.mutating) return false;
+  return true;
+}

--- a/packages/tool-broker/src/effects/store.test.ts
+++ b/packages/tool-broker/src/effects/store.test.ts
@@ -1,0 +1,108 @@
+import { PGlite } from "@electric-sql/pglite";
+import type { TransactionPort } from "@tulipfarm/storage";
+import { beforeEach, describe, expect, it } from "vitest";
+import { EffectLedgerError, type ReserveEffectInput } from "./model";
+import { EFFECT_STORAGE_STATEMENTS, EffectLedger, MemoryEffectStore, PgEffectStore } from "./store";
+
+const BUSINESS_ID = "business-1";
+const RUN_ID = "11111111-1111-4111-8111-111111111111";
+const EFFECT_ID = "22222222-2222-4222-8222-222222222222";
+
+function input(overrides: Partial<ReserveEffectInput> = {}): ReserveEffectInput {
+  return {
+    effectId: EFFECT_ID,
+    businessId: BUSINESS_ID,
+    runId: RUN_ID,
+    stateId: "label",
+    logicalEffectOrdinal: 1,
+    idempotencyKey: "effect-key-1",
+    intentDigest: "a".repeat(64),
+    intent: {
+      intentId: "intent-1",
+      businessId: BUSINESS_ID,
+      runId: RUN_ID,
+      stateId: "label",
+      toolId: "github.issue.label",
+      toolVersion: "1.0.0",
+      action: "issue.label",
+      targetRefs: [{ type: "issue", id: "issue-42" }],
+      arguments: { label: "triaged" },
+      destination: "github.com",
+      credentialRef: "secret://github",
+      idempotencyKey: "effect-key-1",
+    },
+    guardrailRevision: "guardrail-v3",
+    approvalId: "approval-1",
+    createdAt: "2026-07-25T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("MemoryEffectStore", () => {
+  it("persists the authorized intent and evidence before returning", async () => {
+    const ledger = new EffectLedger(new MemoryEffectStore());
+
+    const result = await ledger.reserve(input());
+
+    expect(result).toMatchObject({
+      outcome: "created",
+      effect: {
+        state: "authorized",
+        intentDigest: "a".repeat(64),
+        guardrailRevision: "guardrail-v3",
+        approvalId: "approval-1",
+        intent: { credentialRef: "secret://github" },
+      },
+    });
+  });
+
+  it("deduplicates concurrent matching keys into one durable intent", async () => {
+    const store = new MemoryEffectStore();
+    const ledger = new EffectLedger(store);
+
+    const results = await Promise.all(
+      Array.from({ length: 20 }, () => ledger.reserve(input({ effectId: crypto.randomUUID() })))
+    );
+
+    expect(results.filter((result) => result.outcome === "created")).toHaveLength(1);
+    expect(new Set(results.map((result) => result.effect.effectId))).toHaveLength(1);
+    expect(await store.list(BUSINESS_ID)).toHaveLength(1);
+  });
+
+  it("denies reuse of a key for a different intent digest", async () => {
+    const ledger = new EffectLedger(new MemoryEffectStore());
+    await ledger.reserve(input());
+
+    await expect(
+      ledger.reserve(input({ effectId: crypto.randomUUID(), intentDigest: "b".repeat(64) }))
+    ).rejects.toThrow(new EffectLedgerError("idempotency_digest_mismatch", "effect-key-1"));
+  });
+});
+
+describe("PgEffectStore", () => {
+  let database: PGlite;
+  let store: PgEffectStore;
+
+  beforeEach(async () => {
+    database = new PGlite();
+    for (const statement of EFFECT_STORAGE_STATEMENTS) await database.query(statement);
+    const transactions: TransactionPort = {
+      withTransaction: (operation) => database.transaction(operation),
+    };
+    store = new PgEffectStore(transactions);
+  });
+
+  it("enforces one matching intent per business idempotency key", async () => {
+    const ledger = new EffectLedger(store);
+    const [first, duplicate] = await Promise.all([
+      ledger.reserve(input()),
+      ledger.reserve(input({ effectId: crypto.randomUUID() })),
+    ]);
+
+    expect(new Set([first.outcome, duplicate.outcome])).toEqual(new Set(["created", "duplicate"]));
+    expect(first.effect.effectId).toBe(duplicate.effect.effectId);
+    await expect(
+      ledger.reserve(input({ effectId: crypto.randomUUID(), intentDigest: "c".repeat(64) }))
+    ).rejects.toThrow(EffectLedgerError);
+  });
+});

--- a/packages/tool-broker/src/effects/store.ts
+++ b/packages/tool-broker/src/effects/store.ts
@@ -1,0 +1,566 @@
+import type { Queryable, TransactionPort } from "@tulipfarm/storage";
+import type { ToolIntent } from "../intent";
+import {
+  type EffectAttempt,
+  EffectLedgerError,
+  type EffectRecord,
+  type FinishEffectAttemptInput,
+  type ReserveEffectInput,
+  type ReserveEffectResult,
+  type TransitionEffectInput,
+} from "./model";
+
+export const EFFECT_STORAGE_STATEMENTS: readonly string[] = [
+  `CREATE TABLE IF NOT EXISTS tool_intents (
+    business_id        text NOT NULL,
+    intent_id          text NOT NULL,
+    run_id             uuid NOT NULL,
+    state_id           text NOT NULL,
+    idempotency_key    text NOT NULL,
+    intent_digest      text NOT NULL CHECK (intent_digest ~ '^[a-f0-9]{64}$'),
+    normalized_intent  jsonb NOT NULL CHECK (jsonb_typeof(normalized_intent) = 'object'),
+    created_at         timestamptz NOT NULL,
+    PRIMARY KEY (business_id, intent_id),
+    UNIQUE (business_id, idempotency_key)
+  )`,
+  `CREATE TABLE IF NOT EXISTS effect_records (
+    business_id            text NOT NULL,
+    effect_id              uuid NOT NULL,
+    intent_id              text NOT NULL,
+    run_id                 uuid NOT NULL,
+    state_id               text NOT NULL,
+    logical_effect_ordinal integer NOT NULL CHECK (logical_effect_ordinal >= 0),
+    idempotency_key        text NOT NULL,
+    intent_digest          text NOT NULL CHECK (intent_digest ~ '^[a-f0-9]{64}$'),
+    guardrail_revision     text NOT NULL,
+    approval_id            text,
+    state                  text NOT NULL CHECK (state IN (
+      'proposed', 'denied', 'awaiting_approval', 'authorized', 'dispatched', 'confirmed',
+      'failed', 'ambiguous', 'compensating', 'compensated', 'reconciliation_required'
+    )),
+    parent_effect_id       uuid,
+    created_at             timestamptz NOT NULL,
+    updated_at             timestamptz NOT NULL,
+    PRIMARY KEY (business_id, effect_id),
+    UNIQUE (business_id, idempotency_key),
+    UNIQUE (business_id, run_id, state_id, logical_effect_ordinal),
+    FOREIGN KEY (business_id, intent_id) REFERENCES tool_intents(business_id, intent_id),
+    FOREIGN KEY (business_id, parent_effect_id)
+      REFERENCES effect_records(business_id, effect_id)
+  )`,
+  `CREATE INDEX IF NOT EXISTS effect_records_reconciliation_idx
+    ON effect_records (business_id, state, updated_at)
+    WHERE state IN ('ambiguous', 'reconciliation_required')`,
+  `CREATE TABLE IF NOT EXISTS effect_attempts (
+    business_id        text NOT NULL,
+    effect_id          uuid NOT NULL,
+    attempt            integer NOT NULL CHECK (attempt > 0),
+    state              text NOT NULL CHECK (
+      state IN ('prepared', 'dispatched', 'confirmed', 'failed', 'ambiguous')
+    ),
+    provider_request_id text,
+    output_digest      text CHECK (output_digest IS NULL OR output_digest ~ '^[a-f0-9]{64}$'),
+    error_code         text,
+    started_at         timestamptz NOT NULL,
+    finished_at        timestamptz,
+    PRIMARY KEY (business_id, effect_id, attempt),
+    FOREIGN KEY (business_id, effect_id)
+      REFERENCES effect_records(business_id, effect_id)
+  )`,
+];
+
+export interface EffectStore {
+  reserve(input: ReserveEffectInput): Promise<ReserveEffectResult>;
+  reserveCompensation(
+    input: ReserveEffectInput,
+    parentEffectId: string
+  ): Promise<ReserveEffectResult>;
+  get(businessId: string, effectId: string): Promise<EffectRecord | undefined>;
+  list(businessId: string): Promise<EffectRecord[]>;
+  transition(input: TransitionEffectInput): Promise<EffectRecord>;
+  beginAttempt(businessId: string, effectId: string, startedAt: string): Promise<EffectAttempt>;
+  finishAttempt(input: FinishEffectAttemptInput): Promise<EffectRecord>;
+  listAttempts(businessId: string, effectId: string): Promise<EffectAttempt[]>;
+}
+
+function freezeIntent(intent: ToolIntent): ToolIntent {
+  return Object.freeze({
+    ...structuredClone(intent),
+    targetRefs: Object.freeze(intent.targetRefs.map((target) => Object.freeze({ ...target }))),
+  });
+}
+
+function effect(input: ReserveEffectInput): EffectRecord {
+  return Object.freeze({
+    ...input,
+    intent: freezeIntent(input.intent),
+    state: "authorized",
+    updatedAt: input.createdAt,
+  });
+}
+
+export class MemoryEffectStore implements EffectStore {
+  private readonly records = new Map<string, EffectRecord>();
+  private readonly attempts = new Map<string, EffectAttempt[]>();
+
+  private key(businessId: string, idempotencyKey: string): string {
+    return `${businessId}\u0000${idempotencyKey}`;
+  }
+
+  async reserve(input: ReserveEffectInput): Promise<ReserveEffectResult> {
+    const key = this.key(input.businessId, input.idempotencyKey);
+    const existing = this.records.get(key);
+    if (existing !== undefined) {
+      if (existing.intentDigest !== input.intentDigest) {
+        throw new EffectLedgerError("idempotency_digest_mismatch", input.idempotencyKey);
+      }
+      return { outcome: "duplicate", effect: existing };
+    }
+    const created = effect(input);
+    this.records.set(key, created);
+    return { outcome: "created", effect: created };
+  }
+
+  async reserveCompensation(
+    input: ReserveEffectInput,
+    parentEffectId: string
+  ): Promise<ReserveEffectResult> {
+    const parent = await this.get(input.businessId, parentEffectId);
+    if (parent === undefined) throw new EffectLedgerError("effect_not_found", parentEffectId);
+    if (parent.state !== "confirmed") {
+      throw new EffectLedgerError("effect_state_conflict", parentEffectId);
+    }
+    const result = await this.reserve({ ...input, parentEffectId });
+    const parentKey = this.key(input.businessId, parent.idempotencyKey);
+    this.records.set(
+      parentKey,
+      Object.freeze({ ...parent, state: "compensating", updatedAt: input.createdAt })
+    );
+    return result;
+  }
+
+  async get(businessId: string, effectId: string): Promise<EffectRecord | undefined> {
+    return [...this.records.values()].find(
+      (record) => record.businessId === businessId && record.effectId === effectId
+    );
+  }
+
+  async list(businessId: string): Promise<EffectRecord[]> {
+    return [...this.records.values()].filter((record) => record.businessId === businessId);
+  }
+
+  async transition(input: TransitionEffectInput): Promise<EffectRecord> {
+    const record = await this.get(input.businessId, input.effectId);
+    if (record === undefined) throw new EffectLedgerError("effect_not_found", input.effectId);
+    if (!input.expectedStates.includes(record.state)) {
+      throw new EffectLedgerError("effect_state_conflict", input.effectId);
+    }
+    const updated = Object.freeze({
+      ...record,
+      state: input.state,
+      updatedAt: input.updatedAt,
+    });
+    this.records.set(this.key(input.businessId, record.idempotencyKey), updated);
+    return updated;
+  }
+
+  async beginAttempt(
+    businessId: string,
+    effectId: string,
+    startedAt: string
+  ): Promise<EffectAttempt> {
+    const record = await this.get(businessId, effectId);
+    if (record === undefined) throw new EffectLedgerError("effect_not_found", effectId);
+    if (record.state !== "authorized") {
+      throw new EffectLedgerError("effect_state_conflict", effectId);
+    }
+    const key = this.key(businessId, record.idempotencyKey);
+    this.records.set(key, Object.freeze({ ...record, state: "dispatched", updatedAt: startedAt }));
+    const existing = this.attempts.get(key) ?? [];
+    const attempt = Object.freeze({
+      businessId,
+      effectId,
+      attempt: existing.length + 1,
+      state: "dispatched" as const,
+      startedAt,
+    });
+    this.attempts.set(key, [...existing, attempt]);
+    return attempt;
+  }
+
+  async finishAttempt(input: FinishEffectAttemptInput): Promise<EffectRecord> {
+    const record = await this.get(input.businessId, input.effectId);
+    if (record === undefined) throw new EffectLedgerError("effect_not_found", input.effectId);
+    const key = this.key(input.businessId, record.idempotencyKey);
+    const attempts = this.attempts.get(key) ?? [];
+    const index = attempts.findIndex((attempt) => attempt.attempt === input.attempt);
+    if (index < 0) throw new EffectLedgerError("attempt_not_found", String(input.attempt));
+    const completed = Object.freeze({
+      ...attempts[index],
+      state: input.attemptState,
+      providerRequestId: input.providerRequestId,
+      outputDigest: input.outputDigest,
+      errorCode: input.errorCode,
+      finishedAt: input.finishedAt,
+    });
+    this.attempts.set(
+      key,
+      attempts.map((attempt, attemptIndex) => (attemptIndex === index ? completed : attempt))
+    );
+    const updated = Object.freeze({
+      ...record,
+      state: input.effectState,
+      updatedAt: input.finishedAt,
+    });
+    this.records.set(key, updated);
+    return updated;
+  }
+
+  async listAttempts(businessId: string, effectId: string): Promise<EffectAttempt[]> {
+    const record = await this.get(businessId, effectId);
+    if (record === undefined) return [];
+    return [...(this.attempts.get(this.key(businessId, record.idempotencyKey)) ?? [])];
+  }
+}
+
+interface EffectRow {
+  effect_id: string;
+  business_id: string;
+  run_id: string;
+  state_id: string;
+  logical_effect_ordinal: number;
+  idempotency_key: string;
+  intent_digest: string;
+  normalized_intent: ToolIntent;
+  guardrail_revision: string;
+  approval_id: string | null;
+  state: EffectRecord["state"];
+  parent_effect_id: string | null;
+  created_at: string | Date;
+  updated_at: string | Date;
+}
+
+interface EffectAttemptRow {
+  business_id: string;
+  effect_id: string;
+  attempt: number;
+  state: EffectAttempt["state"];
+  provider_request_id: string | null;
+  output_digest: string | null;
+  error_code: string | null;
+  started_at: string | Date;
+  finished_at: string | Date | null;
+}
+
+function iso(value: string | Date): string {
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+function fromRow(row: EffectRow): EffectRecord {
+  return Object.freeze({
+    effectId: row.effect_id,
+    businessId: row.business_id,
+    runId: row.run_id,
+    stateId: row.state_id,
+    logicalEffectOrdinal: row.logical_effect_ordinal,
+    idempotencyKey: row.idempotency_key,
+    intentDigest: row.intent_digest,
+    intent: freezeIntent(row.normalized_intent),
+    guardrailRevision: row.guardrail_revision,
+    approvalId: row.approval_id ?? undefined,
+    state: row.state,
+    parentEffectId: row.parent_effect_id ?? undefined,
+    createdAt: iso(row.created_at),
+    updatedAt: iso(row.updated_at),
+  });
+}
+
+function attemptFromRow(row: EffectAttemptRow): EffectAttempt {
+  return Object.freeze({
+    businessId: row.business_id,
+    effectId: row.effect_id,
+    attempt: row.attempt,
+    state: row.state,
+    providerRequestId: row.provider_request_id ?? undefined,
+    outputDigest: row.output_digest ?? undefined,
+    errorCode: row.error_code ?? undefined,
+    startedAt: iso(row.started_at),
+    finishedAt: row.finished_at === null ? undefined : iso(row.finished_at),
+  });
+}
+
+async function findByKey(
+  queryable: Queryable,
+  businessId: string,
+  idempotencyKey: string
+): Promise<EffectRecord | undefined> {
+  const result = await queryable.query<EffectRow>(
+    `SELECT effects.*, intents.normalized_intent
+       FROM effect_records effects
+       JOIN tool_intents intents
+         ON intents.business_id = effects.business_id AND intents.intent_id = effects.intent_id
+      WHERE effects.business_id = $1 AND effects.idempotency_key = $2`,
+    [businessId, idempotencyKey]
+  );
+  return result.rows[0] === undefined ? undefined : fromRow(result.rows[0]);
+}
+
+export class PgEffectStore implements EffectStore {
+  constructor(private readonly transactions: TransactionPort) {}
+
+  reserve(input: ReserveEffectInput): Promise<ReserveEffectResult> {
+    return this.transactions.withTransaction((transaction) =>
+      this.reserveWithin(transaction, input)
+    );
+  }
+
+  reserveCompensation(
+    input: ReserveEffectInput,
+    parentEffectId: string
+  ): Promise<ReserveEffectResult> {
+    return this.transactions.withTransaction(async (transaction) => {
+      const parent = await transaction.query<{ state: EffectRecord["state"] }>(
+        `SELECT state FROM effect_records
+          WHERE business_id = $1 AND effect_id = $2 FOR UPDATE`,
+        [input.businessId, parentEffectId]
+      );
+      if (parent.rows[0] === undefined) {
+        throw new EffectLedgerError("effect_not_found", parentEffectId);
+      }
+      if (parent.rows[0].state !== "confirmed") {
+        throw new EffectLedgerError("effect_state_conflict", parentEffectId);
+      }
+      const result = await this.reserveWithin(transaction, { ...input, parentEffectId });
+      await transaction.query(
+        `UPDATE effect_records SET state = 'compensating', updated_at = $3
+          WHERE business_id = $1 AND effect_id = $2`,
+        [input.businessId, parentEffectId, input.createdAt]
+      );
+      return result;
+    });
+  }
+
+  private async reserveWithin(
+    transaction: Queryable,
+    input: ReserveEffectInput
+  ): Promise<ReserveEffectResult> {
+    await transaction.query(
+      `INSERT INTO tool_intents (
+           business_id, intent_id, run_id, state_id, idempotency_key, intent_digest,
+           normalized_intent, created_at
+         ) VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8)
+         ON CONFLICT (business_id, idempotency_key) DO NOTHING`,
+      [
+        input.businessId,
+        input.intent.intentId,
+        input.runId,
+        input.stateId,
+        input.idempotencyKey,
+        input.intentDigest,
+        JSON.stringify(input.intent),
+        input.createdAt,
+      ]
+    );
+    const intents = await transaction.query<{ intent_id: string; intent_digest: string }>(
+      `SELECT intent_id, intent_digest FROM tool_intents
+          WHERE business_id = $1 AND idempotency_key = $2 FOR UPDATE`,
+      [input.businessId, input.idempotencyKey]
+    );
+    const reservedIntent = intents.rows[0];
+    if (reservedIntent === undefined) {
+      throw new EffectLedgerError("effect_not_found", input.idempotencyKey);
+    }
+    if (reservedIntent.intent_digest !== input.intentDigest) {
+      throw new EffectLedgerError("idempotency_digest_mismatch", input.idempotencyKey);
+    }
+
+    const inserted = await transaction.query<{ effect_id: string }>(
+      `INSERT INTO effect_records (
+           business_id, effect_id, intent_id, run_id, state_id, logical_effect_ordinal,
+           idempotency_key, intent_digest, guardrail_revision, approval_id, state,
+           parent_effect_id, created_at, updated_at
+         ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, 'authorized', $11, $12, $12)
+         ON CONFLICT (business_id, idempotency_key) DO NOTHING
+         RETURNING effect_id`,
+      [
+        input.businessId,
+        input.effectId,
+        reservedIntent.intent_id,
+        input.runId,
+        input.stateId,
+        input.logicalEffectOrdinal,
+        input.idempotencyKey,
+        input.intentDigest,
+        input.guardrailRevision,
+        input.approvalId ?? null,
+        input.parentEffectId ?? null,
+        input.createdAt,
+      ]
+    );
+    const stored = await findByKey(transaction, input.businessId, input.idempotencyKey);
+    if (stored === undefined) {
+      throw new EffectLedgerError("effect_not_found", input.idempotencyKey);
+    }
+    if (stored.intentDigest !== input.intentDigest) {
+      throw new EffectLedgerError("idempotency_digest_mismatch", input.idempotencyKey);
+    }
+    return { outcome: inserted.rows.length === 1 ? "created" : "duplicate", effect: stored };
+  }
+
+  get(businessId: string, effectId: string): Promise<EffectRecord | undefined> {
+    return this.transactions.withTransaction(async (transaction) => {
+      const result = await transaction.query<EffectRow>(
+        `SELECT effects.*, intents.normalized_intent
+           FROM effect_records effects
+           JOIN tool_intents intents
+             ON intents.business_id = effects.business_id AND intents.intent_id = effects.intent_id
+          WHERE effects.business_id = $1 AND effects.effect_id = $2`,
+        [businessId, effectId]
+      );
+      return result.rows[0] === undefined ? undefined : fromRow(result.rows[0]);
+    });
+  }
+
+  list(businessId: string): Promise<EffectRecord[]> {
+    return this.transactions.withTransaction(async (transaction) => {
+      const result = await transaction.query<EffectRow>(
+        `SELECT effects.*, intents.normalized_intent
+           FROM effect_records effects
+           JOIN tool_intents intents
+             ON intents.business_id = effects.business_id AND intents.intent_id = effects.intent_id
+          WHERE effects.business_id = $1 ORDER BY effects.created_at, effects.effect_id`,
+        [businessId]
+      );
+      return result.rows.map(fromRow);
+    });
+  }
+
+  transition(input: TransitionEffectInput): Promise<EffectRecord> {
+    return this.transactions.withTransaction(async (transaction) => {
+      const updated = await transaction.query(
+        `UPDATE effect_records SET state = $3, updated_at = $4
+          WHERE business_id = $1 AND effect_id = $2 AND state = ANY($5::text[])
+          RETURNING effect_id`,
+        [input.businessId, input.effectId, input.state, input.updatedAt, [...input.expectedStates]]
+      );
+      if (updated.rows.length !== 1) {
+        const existing = await this.findById(transaction, input.businessId, input.effectId);
+        throw new EffectLedgerError(
+          existing === undefined ? "effect_not_found" : "effect_state_conflict",
+          input.effectId
+        );
+      }
+      const effect = await this.findById(transaction, input.businessId, input.effectId);
+      if (effect === undefined) throw new EffectLedgerError("effect_not_found", input.effectId);
+      return effect;
+    });
+  }
+
+  beginAttempt(businessId: string, effectId: string, startedAt: string): Promise<EffectAttempt> {
+    return this.transactions.withTransaction(async (transaction) => {
+      const current = await transaction.query<{ state: EffectRecord["state"] }>(
+        `SELECT state FROM effect_records
+          WHERE business_id = $1 AND effect_id = $2 FOR UPDATE`,
+        [businessId, effectId]
+      );
+      if (current.rows[0] === undefined) {
+        throw new EffectLedgerError("effect_not_found", effectId);
+      }
+      if (current.rows[0].state !== "authorized") {
+        throw new EffectLedgerError("effect_state_conflict", effectId);
+      }
+      const number = await transaction.query<{ attempt: number }>(
+        `SELECT COALESCE(MAX(attempt), 0) + 1 AS attempt FROM effect_attempts
+          WHERE business_id = $1 AND effect_id = $2`,
+        [businessId, effectId]
+      );
+      const attemptNumber = Number(number.rows[0]?.attempt ?? 1);
+      const inserted = await transaction.query<EffectAttemptRow>(
+        `INSERT INTO effect_attempts (
+           business_id, effect_id, attempt, state, started_at
+         ) VALUES ($1, $2, $3, 'dispatched', $4)
+         RETURNING *`,
+        [businessId, effectId, attemptNumber, startedAt]
+      );
+      await transaction.query(
+        `UPDATE effect_records SET state = 'dispatched', updated_at = $3
+          WHERE business_id = $1 AND effect_id = $2`,
+        [businessId, effectId, startedAt]
+      );
+      const attempt = inserted.rows[0];
+      if (attempt === undefined) {
+        throw new EffectLedgerError("attempt_not_found", String(attemptNumber));
+      }
+      return attemptFromRow(attempt);
+    });
+  }
+
+  finishAttempt(input: FinishEffectAttemptInput): Promise<EffectRecord> {
+    return this.transactions.withTransaction(async (transaction) => {
+      const completed = await transaction.query(
+        `UPDATE effect_attempts
+            SET state = $4, provider_request_id = $5, output_digest = $6,
+                error_code = $7, finished_at = $8
+          WHERE business_id = $1 AND effect_id = $2 AND attempt = $3
+            AND state = 'dispatched'
+          RETURNING attempt`,
+        [
+          input.businessId,
+          input.effectId,
+          input.attempt,
+          input.attemptState,
+          input.providerRequestId ?? null,
+          input.outputDigest ?? null,
+          input.errorCode ?? null,
+          input.finishedAt,
+        ]
+      );
+      if (completed.rows.length !== 1) {
+        throw new EffectLedgerError("attempt_not_found", String(input.attempt));
+      }
+      await transaction.query(
+        `UPDATE effect_records SET state = $3, updated_at = $4
+          WHERE business_id = $1 AND effect_id = $2`,
+        [input.businessId, input.effectId, input.effectState, input.finishedAt]
+      );
+      const updated = await this.findById(transaction, input.businessId, input.effectId);
+      if (updated === undefined) throw new EffectLedgerError("effect_not_found", input.effectId);
+      return updated;
+    });
+  }
+
+  listAttempts(businessId: string, effectId: string): Promise<EffectAttempt[]> {
+    return this.transactions.withTransaction(async (transaction) => {
+      const result = await transaction.query<EffectAttemptRow>(
+        `SELECT * FROM effect_attempts
+          WHERE business_id = $1 AND effect_id = $2 ORDER BY attempt`,
+        [businessId, effectId]
+      );
+      return result.rows.map(attemptFromRow);
+    });
+  }
+
+  private async findById(
+    queryable: Queryable,
+    businessId: string,
+    effectId: string
+  ): Promise<EffectRecord | undefined> {
+    const result = await queryable.query<EffectRow>(
+      `SELECT effects.*, intents.normalized_intent
+         FROM effect_records effects
+         JOIN tool_intents intents
+           ON intents.business_id = effects.business_id AND intents.intent_id = effects.intent_id
+        WHERE effects.business_id = $1 AND effects.effect_id = $2`,
+      [businessId, effectId]
+    );
+    return result.rows[0] === undefined ? undefined : fromRow(result.rows[0]);
+  }
+}
+
+export class EffectLedger {
+  constructor(private readonly store: EffectStore) {}
+
+  reserve(input: ReserveEffectInput): Promise<ReserveEffectResult> {
+    return this.store.reserve(input);
+  }
+}

--- a/packages/tool-broker/src/index.ts
+++ b/packages/tool-broker/src/index.ts
@@ -1,1 +1,10 @@
-export {};
+export * from "./approval-gate";
+export * from "./authorize";
+export * from "./broker";
+export * from "./catalog";
+export * from "./contract";
+export * from "./credential-dispatch";
+export * from "./effects";
+export * from "./intent";
+export * from "./risk";
+export * from "./search";

--- a/packages/tool-broker/src/intent.ts
+++ b/packages/tool-broker/src/intent.ts
@@ -1,0 +1,102 @@
+import { canonicalHash } from "@tulipfarm/schema";
+
+export interface ToolTargetRef {
+  readonly type: string;
+  readonly id: string;
+}
+
+export interface ToolIntent {
+  readonly intentId: string;
+  readonly businessId: string;
+  readonly runId: string;
+  readonly stateId: string;
+  readonly toolId: string;
+  readonly toolVersion: string;
+  readonly action: string;
+  readonly targetRefs: readonly ToolTargetRef[];
+  readonly arguments: unknown;
+  readonly destination?: string;
+  readonly credentialRef?: string;
+  readonly idempotencyKey: string;
+}
+
+export type ToolIntentErrorCode =
+  | "invalid_intent"
+  | "invalid_arguments"
+  | "unknown_contract"
+  | "contract_mismatch";
+
+export class ToolIntentError extends Error {
+  constructor(readonly code: ToolIntentErrorCode) {
+    super(code);
+    this.name = "ToolIntentError";
+  }
+}
+
+function record(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function optionalString(value: unknown): value is string | undefined {
+  return value === undefined || nonEmptyString(value);
+}
+
+export function normalizeToolIntent(input: unknown): ToolIntent {
+  if (
+    !record(input) ||
+    !nonEmptyString(input.intentId) ||
+    !nonEmptyString(input.businessId) ||
+    !nonEmptyString(input.runId) ||
+    !nonEmptyString(input.stateId) ||
+    !nonEmptyString(input.toolId) ||
+    !nonEmptyString(input.toolVersion) ||
+    !nonEmptyString(input.action) ||
+    !Array.isArray(input.targetRefs) ||
+    !optionalString(input.destination) ||
+    !optionalString(input.credentialRef) ||
+    !nonEmptyString(input.idempotencyKey)
+  ) {
+    throw new ToolIntentError("invalid_intent");
+  }
+
+  const targetRefs: ToolTargetRef[] = [];
+  for (const target of input.targetRefs) {
+    if (!record(target) || !nonEmptyString(target.type) || !nonEmptyString(target.id)) {
+      throw new ToolIntentError("invalid_intent");
+    }
+    targetRefs.push(Object.freeze({ type: target.type, id: target.id }));
+  }
+
+  const intent = {
+    intentId: input.intentId,
+    businessId: input.businessId,
+    runId: input.runId,
+    stateId: input.stateId,
+    toolId: input.toolId,
+    toolVersion: input.toolVersion,
+    action: input.action,
+    targetRefs: Object.freeze(targetRefs),
+    arguments: structuredClone(input.arguments),
+    destination: input.destination,
+    credentialRef: input.credentialRef,
+    idempotencyKey: input.idempotencyKey,
+  };
+  intentDigest(intent);
+  return Object.freeze(intent);
+}
+
+export function intentDigest(intent: ToolIntent): string {
+  return canonicalHash({
+    toolId: intent.toolId,
+    toolVersion: intent.toolVersion,
+    action: intent.action,
+    targetRefs: intent.targetRefs,
+    arguments: intent.arguments,
+    destination: intent.destination ?? null,
+    credentialRef: intent.credentialRef ?? null,
+  });
+}

--- a/packages/tool-broker/src/risk.ts
+++ b/packages/tool-broker/src/risk.ts
@@ -1,0 +1,40 @@
+import type { PublishedToolContract } from "./contract";
+
+export type ToolRiskLevel = "low" | "medium" | "high";
+
+export interface ToolRiskContext {
+  readonly taint?: "trusted" | "untrusted";
+  readonly recordCount?: number;
+  readonly unusualCost?: boolean;
+  readonly irreversible?: boolean;
+}
+
+export interface ToolRiskAssessment {
+  readonly level: ToolRiskLevel;
+  readonly reasons: readonly string[];
+}
+
+const RANK: Readonly<Record<ToolRiskLevel, number>> = { low: 0, medium: 1, high: 2 };
+
+export function assessToolRisk(
+  contract: PublishedToolContract,
+  context: ToolRiskContext
+): ToolRiskAssessment {
+  let rank = RANK[contract.riskClass];
+  const reasons = new Set<string>([`contract_${contract.riskClass}`]);
+  if (contract.mutating && context.taint === "untrusted") {
+    rank = Math.max(rank, RANK.high);
+    reasons.add("untrusted_mutation");
+  }
+  if (context.irreversible) {
+    rank = Math.max(rank, RANK.high);
+    reasons.add("irreversible");
+  }
+  if (context.unusualCost || (context.recordCount !== undefined && context.recordCount > 100)) {
+    rank = Math.max(rank, RANK.high);
+    reasons.add("unusual_scope");
+  }
+  const level = (Object.entries(RANK).find(([, value]) => value === rank)?.[0] ??
+    "high") as ToolRiskLevel;
+  return Object.freeze({ level, reasons: Object.freeze([...reasons].sort()) });
+}

--- a/packages/tool-broker/src/search.ts
+++ b/packages/tool-broker/src/search.ts
@@ -1,0 +1,62 @@
+import type { PublishedToolContract } from "./contract";
+
+export interface ToolCatalogEntry {
+  readonly toolId: string;
+  readonly toolVersion: string;
+  readonly action: string;
+  readonly riskClass: PublishedToolContract["riskClass"];
+  readonly mutating: boolean;
+  readonly requiredActions: readonly string[];
+  readonly requiredResources: readonly string[];
+  readonly dataClasses: readonly string[];
+  readonly allowedDestinations: readonly string[];
+}
+
+function entry(contract: PublishedToolContract): ToolCatalogEntry {
+  return Object.freeze({
+    toolId: contract.toolId,
+    toolVersion: contract.toolVersion,
+    action: contract.action,
+    riskClass: contract.riskClass,
+    mutating: contract.mutating,
+    requiredActions: contract.requiredActions,
+    requiredResources: contract.requiredResources,
+    dataClasses: contract.dataClasses,
+    allowedDestinations: contract.allowedDestinations,
+  });
+}
+
+function searchableText(contract: PublishedToolContract): string {
+  return [
+    contract.toolId,
+    contract.action,
+    ...contract.requiredActions,
+    ...contract.requiredResources,
+    ...contract.dataClasses,
+    ...contract.allowedDestinations,
+  ]
+    .join(" ")
+    .toLocaleLowerCase();
+}
+
+export function searchToolContracts(
+  authorizedContracts: readonly PublishedToolContract[],
+  query: string
+): ToolCatalogEntry[] {
+  const terms = query
+    .toLocaleLowerCase()
+    .split(/\s+/u)
+    .filter((term) => term.length > 0);
+  if (terms.length === 0) return [];
+
+  return authorizedContracts
+    .filter((contract) => {
+      const text = searchableText(contract);
+      return terms.every((term) => text.includes(term));
+    })
+    .sort((left, right) => {
+      const byId = left.toolId.localeCompare(right.toolId);
+      return byId === 0 ? left.toolVersion.localeCompare(right.toolVersion) : byId;
+    })
+    .map(entry);
+}

--- a/packages/tool-broker/src/test-fixtures.ts
+++ b/packages/tool-broker/src/test-fixtures.ts
@@ -1,0 +1,29 @@
+import type { ToolContractDefinition, ToolContractSpec } from "@tulipfarm/schema";
+
+export function makeContract(overrides: Partial<ToolContractSpec> = {}): ToolContractDefinition {
+  return {
+    apiVersion: "tulipfarm.ai/v1",
+    kind: "ToolContract",
+    metadata: {
+      id: "33333333-3333-4333-8333-333333333333",
+      slug: "github-issue-label",
+      schemaVersion: 1,
+      authoredVersion: 1,
+      lifecycle: "active",
+      publishedDigest: "a".repeat(64),
+    },
+    spec: {
+      toolId: "github.issue.label",
+      toolVersion: "1.0.0",
+      action: "issue.label",
+      inputSchema: { type: "object" },
+      outputSchema: { type: "object" },
+      riskClass: "low",
+      mutating: false,
+      idempotency: { strategy: "none" },
+      dryRun: false,
+      adapter: { kind: "native", ref: "github" },
+      ...overrides,
+    },
+  };
+}

--- a/packages/tool-broker/test/security/broker-effect.security.test.ts
+++ b/packages/tool-broker/test/security/broker-effect.security.test.ts
@@ -1,0 +1,286 @@
+import type { AccessGrant, AuthorityLayer, DlpRule, GuardrailRule } from "@tulipfarm/authz";
+import { inMemorySecretProvider, SecretBroker } from "@tulipfarm/secrets";
+import { InMemoryApprovalRepo } from "@tulipfarm/storage";
+import { describe, expect, it, vi } from "vitest";
+import {
+  AdapterDispatchError,
+  CredentialDispatcher,
+  EffectDispatcher,
+  type EffectRecord,
+  type EffectStore,
+  MemoryEffectStore,
+  type ToolAdapter,
+  ToolApprovalDecisions,
+  ToolApprovalGate,
+  ToolApprovalGateError,
+  type ToolAuthorizationContext,
+  ToolBroker,
+  type ToolBrokerOutcome,
+  ToolCatalog,
+  type ToolIntent,
+} from "../../src";
+import { makeContract } from "../../src/test-fixtures";
+
+const BUSINESS_ID = "business-security";
+const RUN_ID = "11111111-1111-4111-8111-111111111111";
+const EFFECT_ID = "22222222-2222-4222-8222-222222222222";
+const NOW = new Date("2026-07-25T00:00:00.000Z");
+const SECRET_REF = "secret://security";
+const SECRET = "plaintext-must-never-persist";
+
+const definition = makeContract({
+  mutating: true,
+  riskClass: "medium",
+  requiredActions: ["issue.label"],
+  requiredResources: ["issue"],
+  dataClasses: ["internal"],
+  allowedDestinations: ["github.com"],
+  idempotency: { strategy: "provider" },
+  retry: { maxAttempts: 3, safeToRetry: true },
+  outputSchema: {
+    type: "object",
+    additionalProperties: false,
+    required: ["providerId"],
+    properties: { providerId: { type: "string" } },
+  },
+});
+
+function intent(overrides: Partial<ToolIntent> = {}): ToolIntent {
+  return {
+    intentId: "intent-security-1",
+    businessId: BUSINESS_ID,
+    runId: RUN_ID,
+    stateId: "state-security-1",
+    toolId: definition.spec.toolId,
+    toolVersion: definition.spec.toolVersion,
+    action: definition.spec.action,
+    targetRefs: [{ type: "issue", id: "issue-42" }],
+    arguments: { label: "triaged" },
+    destination: "github.com",
+    credentialRef: SECRET_REF,
+    idempotencyKey: "security-effect-key",
+    ...overrides,
+  };
+}
+
+function authorization(effect: GuardrailRule["effect"] = "allow"): ToolAuthorizationContext {
+  const grant: AccessGrant = {
+    action: "issue.label",
+    resourceType: "issue",
+    recordSelector: "issue-42",
+    destination: "github.com",
+    effect: "allow",
+  };
+  const authorityLayers: AuthorityLayer[] = ["user", "agent", "run", "tool", "credential"].map(
+    (name) => ({ name, grants: [grant] })
+  );
+  const guardrailRules: GuardrailRule[] = [
+    {
+      id: "security-rule",
+      effect,
+      action: "issue.label",
+      resourceType: "issue",
+      recordSelector: "issue-42",
+      destination: "github.com",
+    },
+  ];
+  const dlpRules: DlpRule[] = [{ dataClass: "internal", allowedDestinations: ["github.com"] }];
+  return {
+    authorityLayers,
+    guardrailRules,
+    dlpRules,
+    guardrailRevision: "guardrail-security-v1",
+    taint: "trusted",
+    autonomy: "execute_policy_authorized",
+  };
+}
+
+function authorized(
+  broker: ToolBroker,
+  presentedIntent: ToolIntent = intent()
+): Extract<ToolBrokerOutcome, { outcome: "authorized" }> {
+  const outcome = broker.authorize(presentedIntent, authorization());
+  if (outcome.outcome !== "authorized") throw new Error("expected authorized outcome");
+  return outcome;
+}
+
+async function reserveAuthorized(
+  store: EffectStore,
+  outcome: Extract<ToolBrokerOutcome, { outcome: "authorized" }>
+): Promise<EffectRecord> {
+  const result = await store.reserve({
+    effectId: EFFECT_ID,
+    businessId: outcome.intent.businessId,
+    runId: outcome.intent.runId,
+    stateId: outcome.intent.stateId,
+    logicalEffectOrdinal: 1,
+    idempotencyKey: outcome.intent.idempotencyKey,
+    intentDigest: outcome.intentDigest,
+    intent: outcome.intent,
+    guardrailRevision: outcome.guardrailRevision,
+    createdAt: NOW.toISOString(),
+  });
+  return result.effect;
+}
+
+describe("Tool Broker and effect threat boundary", () => {
+  it("denies forged Approval substitution and one-use replay before adapter dispatch", async () => {
+    const catalog = ToolCatalog.load([definition]);
+    const broker = new ToolBroker(catalog);
+    const awaiting = broker.authorize(intent(), authorization("require_approval"));
+    if (awaiting.outcome !== "awaiting_approval") throw new Error("expected Approval");
+    const approvals = new InMemoryApprovalRepo();
+    const effects = new MemoryEffectStore();
+    const gate = new ToolApprovalGate(approvals, effects);
+    await gate.request(awaiting, {
+      approvalId: "approval-security-1",
+      evidenceHashes: ["artifact-evidence-1"],
+      preview: "Label one issue",
+      riskSummary: "External mutation",
+      allowedApproverRoles: ["security_approver"],
+      proposerPrincipalId: "user-proposer",
+      performerPrincipalId: "user-performer",
+      agentPrincipalId: "agent-security",
+      expiresAt: new Date("2026-07-25T01:00:00.000Z"),
+      createdAt: NOW,
+    });
+    await new ToolApprovalDecisions(approvals).decide(
+      BUSINESS_ID,
+      "approval-security-1",
+      {
+        principalId: "user-approver",
+        businessId: BUSINESS_ID,
+        roles: ["security_approver"],
+      },
+      "approved",
+      NOW
+    );
+
+    await expect(
+      gate.consumeAndReserve({
+        businessId: BUSINESS_ID,
+        approvalId: "approval-security-1",
+        intent: { ...awaiting.intent, arguments: { label: "forged" } },
+        evidenceHashes: ["artifact-evidence-1"],
+        guardrailRevision: awaiting.guardrailRevision,
+        effect: {
+          effectId: EFFECT_ID,
+          businessId: BUSINESS_ID,
+          runId: RUN_ID,
+          stateId: "state-security-1",
+          logicalEffectOrdinal: 1,
+          idempotencyKey: awaiting.intent.idempotencyKey,
+          createdAt: NOW.toISOString(),
+        },
+        at: NOW,
+      })
+    ).rejects.toEqual(new ToolApprovalGateError("binding_mismatch", "approval-security-1"));
+    expect(await effects.list(BUSINESS_ID)).toEqual([]);
+
+    const approvedEffect = {
+      effectId: EFFECT_ID,
+      businessId: BUSINESS_ID,
+      runId: RUN_ID,
+      stateId: "state-security-1",
+      logicalEffectOrdinal: 1,
+      idempotencyKey: awaiting.intent.idempotencyKey,
+      createdAt: NOW.toISOString(),
+    };
+    await gate.consumeAndReserve({
+      businessId: BUSINESS_ID,
+      approvalId: "approval-security-1",
+      intent: awaiting.intent,
+      evidenceHashes: ["artifact-evidence-1"],
+      guardrailRevision: awaiting.guardrailRevision,
+      effect: approvedEffect,
+      at: NOW,
+    });
+    await expect(
+      gate.consumeAndReserve({
+        businessId: BUSINESS_ID,
+        approvalId: "approval-security-1",
+        intent: awaiting.intent,
+        evidenceHashes: ["artifact-evidence-1"],
+        guardrailRevision: awaiting.guardrailRevision,
+        effect: approvedEffect,
+        at: NOW,
+      })
+    ).rejects.toMatchObject({ code: "already_used" });
+    expect(await effects.list(BUSINESS_ID)).toHaveLength(1);
+    expect("dispatch" in broker).toBe(false);
+  });
+
+  it("redacts Credential exfiltration from errors and durable effect lineage", async () => {
+    const catalog = ToolCatalog.load([definition]);
+    const broker = new ToolBroker(catalog);
+    const store = new MemoryEffectStore();
+    await reserveAuthorized(store, authorized(broker));
+    const secrets = new SecretBroker({
+      provider: inMemorySecretProvider({ [SECRET_REF]: SECRET }),
+      authorizer: { authorize: async () => ({ allowed: true, maxUses: 1 }) },
+    });
+    const adapter: ToolAdapter = {
+      dispatch: vi.fn(async (_request, credential) => {
+        throw new Error(`provider rejected ${credential}`);
+      }),
+    };
+    const dispatcher = new EffectDispatcher({
+      store,
+      catalog,
+      adapters: new Map([["github", adapter]]),
+      credentialDispatcher: new CredentialDispatcher({
+        secrets,
+        reauthorize: async () => true,
+      }),
+      now: () => "2026-07-25T00:00:01.000Z",
+    });
+
+    const error = await dispatcher
+      .dispatch(BUSINESS_ID, EFFECT_ID)
+      .catch((caught: unknown) => caught);
+
+    expect(String(error)).not.toContain(SECRET);
+    expect(JSON.stringify(await store.list(BUSINESS_ID))).not.toContain(SECRET);
+    expect(JSON.stringify(await store.listAttempts(BUSINESS_ID, EFFECT_ID))).not.toContain(SECRET);
+  });
+
+  it("records an ambiguous cancellation once with complete Run/State/provider lineage", async () => {
+    const catalog = ToolCatalog.load([definition]);
+    const broker = new ToolBroker(catalog);
+    const store = new MemoryEffectStore();
+    await reserveAuthorized(store, authorized(broker));
+    const adapter: ToolAdapter = {
+      dispatch: vi.fn(async () => {
+        throw new AdapterDispatchError("after_dispatch", "cancelled", true, "provider-request-1");
+      }),
+    };
+
+    await expect(
+      new EffectDispatcher({
+        store,
+        catalog,
+        adapters: new Map([["github", adapter]]),
+        now: () => "2026-07-25T00:00:02.000Z",
+      }).dispatch(BUSINESS_ID, EFFECT_ID)
+    ).rejects.toMatchObject({ code: "ambiguous" });
+
+    expect(adapter.dispatch).toHaveBeenCalledOnce();
+    expect(await store.get(BUSINESS_ID, EFFECT_ID)).toMatchObject({
+      effectId: EFFECT_ID,
+      businessId: BUSINESS_ID,
+      runId: RUN_ID,
+      stateId: "state-security-1",
+      state: "ambiguous",
+      intent: { intentId: "intent-security-1" },
+    });
+    expect(await store.listAttempts(BUSINESS_ID, EFFECT_ID)).toEqual([
+      expect.objectContaining({
+        effectId: EFFECT_ID,
+        attempt: 1,
+        state: "ambiguous",
+        providerRequestId: "provider-request-1",
+        errorCode: "cancelled",
+      }),
+    ]);
+  });
+});

--- a/packages/tool-broker/tsconfig.json
+++ b/packages/tool-broker/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "moduleResolution": "bundler",
     "module": "ESNext",
-    "noEmit": true
+    "noEmit": true,
+    "types": ["node"]
   },
   "include": ["src"]
 }

--- a/packages/tool-broker/vitest.config.ts
+++ b/packages/tool-broker/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    // PGlite boots a WASM Postgres instance before the effect-store integration test. Under the
+    // package-wide coverage job, startup can exceed Vitest's 10s default while workers compete
+    // for CPU. Match storage's bounded CI ceiling so slow initialization is not treated as a hang.
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       '@tulipfarm/storage':
         specifier: workspace:*
         version: link:../../packages/storage
+      '@tulipfarm/tool-broker':
+        specifier: workspace:*
+        version: link:../../packages/tool-broker
       ai:
         specifier: ^7.0.2
         version: 7.0.2(zod@4.4.3)
@@ -748,10 +751,29 @@ importers:
         version: 6.0.3
 
   packages/tool-broker:
+    dependencies:
+      '@tulipfarm/authz':
+        specifier: workspace:*
+        version: link:../authz
+      '@tulipfarm/schema':
+        specifier: workspace:*
+        version: link:../schema
+      '@tulipfarm/secrets':
+        specifier: workspace:*
+        version: link:../secrets
+      '@tulipfarm/storage':
+        specifier: workspace:*
+        version: link:../storage
     devDependencies:
+      '@electric-sql/pglite':
+        specifier: ^0.5.3
+        version: 0.5.3
       '@tulipfarm/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      '@types/node':
+        specifier: ^26.1.1
+        version: 26.1.1
       typescript:
         specifier: ^6.0.3
         version: 6.0.3


### PR DESCRIPTION
## Summary

- add versioned Tool contracts, fail-closed catalog search, canonical intent authorization, and risk decisions
- persist intent/effect/attempt records before dispatch with idempotency, retry, reconciliation, and compensation controls
- bind exact one-use Approval decisions and dispatch-time Credential leases, with adversarial security coverage

## Known integration gap

- AW-023 is marked done but currently exports only `InMemoryApprovalRepo`; no PostgreSQL adapter exists. The Tool Broker exact-Approval gate and API-facing decision seam are included, but production API composition remains blocked on that missing durable adapter.

## Test plan

- [x] `pnpm --dir packages/tool-broker test` (36 tests)
- [x] `pnpm --filter @tulipfarm/tool-broker --filter @tulipfarm/sandbox --filter @tulipfarm/api test`
- [x] `pnpm test -- --maxWorkers=4`
- [x] `pnpm architecture:check`
- [x] `pnpm architecture:test`
- [x] `pnpm lint`
- [x] `pnpm run typecheck`
- [x] `pnpm build`
- [x] `git diff --check`