### PR TITLE
feat(agent-runtime): add model routing, context assembly, and Skill resolution

### DIFF
--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -8,8 +8,16 @@
     "test": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit"
   },
+  "dependencies": {
+    "@tulipfarm/audit": "workspace:*",
+    "@tulipfarm/authz": "workspace:*",
+    "@tulipfarm/run-kernel": "workspace:*",
+    "@tulipfarm/schema": "workspace:*",
+    "@tulipfarm/tool-broker": "workspace:*"
+  },
   "devDependencies": {
     "@tulipfarm/tsconfig": "workspace:*",
+    "@types/node": "^26.1.1",
     "typescript": "^6.0.3"
   }
 }

--- a/packages/agent-runtime/src/context/index.ts
+++ b/packages/agent-runtime/src/context/index.ts
@@ -1,0 +1,21 @@
+export type {
+  AssembleContextInput,
+  ContextAssemblyErrorCode,
+  ContextAuthorization,
+  ContextCandidate,
+  ContextEntry,
+  ContextEntryKind,
+  ContextExclusion,
+  ContextExclusionReason,
+  ContextManifest,
+  ContextProvenance,
+  ContextTaint,
+} from "./manifest";
+export { assembleContext, ContextAssemblyError } from "./manifest";
+export type { InstructionPrecedence } from "./precedence";
+export {
+  INSTRUCTION_PRECEDENCE,
+  NON_COMPACTABLE_PRECEDENCE,
+  precedenceRank,
+  precedenceWithin,
+} from "./precedence";

--- a/packages/agent-runtime/src/context/manifest.test.ts
+++ b/packages/agent-runtime/src/context/manifest.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it } from "vitest";
+import { assembleContext, ContextAssemblyError, type ContextCandidate } from "./manifest";
+import { INSTRUCTION_PRECEDENCE } from "./precedence";
+
+function candidate(overrides: Partial<ContextCandidate> = {}): ContextCandidate {
+  return {
+    sourceId: "message-1",
+    kind: "message",
+    precedence: "user_request",
+    version: "1",
+    classification: "internal",
+    taint: "trusted",
+    authorization: { decision: "allow" },
+    tokens: 10,
+    digest: "sha256:message-1",
+    ...overrides,
+  };
+}
+
+const base = {
+  businessId: "biz-1",
+  runId: "run-1",
+  stateId: "state-1",
+  guardrailDigest: "sha256:guardrail",
+  bundleDigest: "sha256:bundle",
+  budgetTokens: 1_000,
+};
+
+describe("assembleContext", () => {
+  it("orders entries by the fixed instruction precedence, not by input order", () => {
+    const manifest = assembleContext({
+      ...base,
+      candidates: [
+        candidate({ sourceId: "web-1", kind: "knowledge", precedence: "untrusted_source" }),
+        candidate({ sourceId: "agent-1", kind: "instruction", precedence: "agent_instructions" }),
+        candidate({ sourceId: "safety", kind: "instruction", precedence: "platform_safety" }),
+        candidate({ sourceId: "user-1" }),
+      ],
+    });
+
+    expect(manifest.entries.map((entry) => entry.sourceId)).toEqual([
+      "safety",
+      "agent-1",
+      "user-1",
+      "web-1",
+    ]);
+    expect(INSTRUCTION_PRECEDENCE.indexOf("platform_safety")).toBe(0);
+    expect(INSTRUCTION_PRECEDENCE.at(-1)).toBe("untrusted_source");
+  });
+
+  it("excludes denied sources and records the denial reason", () => {
+    const manifest = assembleContext({
+      ...base,
+      candidates: [
+        candidate(),
+        candidate({
+          sourceId: "secret-doc",
+          kind: "knowledge",
+          authorization: { decision: "deny", reason: "acl_denied" },
+        }),
+      ],
+    });
+
+    expect(manifest.entries.map((entry) => entry.sourceId)).toEqual(["message-1"]);
+    expect(manifest.excluded).toEqual([{ sourceId: "secret-doc", reason: "acl_denied" }]);
+  });
+
+  it("keeps the transcript when a summary covers it", () => {
+    const manifest = assembleContext({
+      ...base,
+      candidates: [
+        candidate({ sourceId: "message-1" }),
+        candidate({ sourceId: "message-2", digest: "sha256:message-2" }),
+        candidate({
+          sourceId: "summary-1",
+          kind: "summary",
+          summarizes: ["message-1", "message-2"],
+          digest: "sha256:summary-1",
+        }),
+      ],
+    });
+
+    expect(manifest.entries.map((entry) => entry.sourceId)).toEqual([
+      "message-1",
+      "message-2",
+      "summary-1",
+    ]);
+  });
+
+  it("drops a summary whose sources are not all authorized", () => {
+    const manifest = assembleContext({
+      ...base,
+      candidates: [
+        candidate({ sourceId: "message-1" }),
+        candidate({
+          sourceId: "secret-doc",
+          kind: "knowledge",
+          authorization: { decision: "deny", reason: "acl_denied" },
+        }),
+        candidate({
+          sourceId: "summary-1",
+          kind: "summary",
+          summarizes: ["message-1", "secret-doc"],
+        }),
+      ],
+    });
+
+    expect(manifest.entries.map((entry) => entry.sourceId)).toEqual(["message-1"]);
+    expect(manifest.excluded).toContainEqual({
+      sourceId: "summary-1",
+      reason: "summary_source_unauthorized",
+    });
+  });
+
+  it("drops a summary referencing a source that is not in the manifest at all", () => {
+    const manifest = assembleContext({
+      ...base,
+      candidates: [candidate({ sourceId: "summary-1", kind: "summary", summarizes: ["ghost"] })],
+    });
+
+    expect(manifest.entries).toEqual([]);
+    expect(manifest.excluded).toEqual([
+      { sourceId: "summary-1", reason: "summary_source_unauthorized" },
+    ]);
+  });
+
+  it("makes a summary inherit the strictest taint and classification of its sources", () => {
+    const manifest = assembleContext({
+      ...base,
+      candidates: [
+        candidate({ sourceId: "message-1" }),
+        candidate({
+          sourceId: "web-1",
+          kind: "knowledge",
+          precedence: "untrusted_source",
+          taint: "untrusted",
+          classification: "restricted",
+        }),
+        candidate({
+          sourceId: "summary-1",
+          kind: "summary",
+          summarizes: ["message-1", "web-1"],
+          taint: "trusted",
+          classification: "internal",
+        }),
+      ],
+    });
+
+    const summary = manifest.entries.find((entry) => entry.sourceId === "summary-1");
+    expect(summary).toMatchObject({ taint: "untrusted", classification: "restricted" });
+  });
+
+  it("defaults to deny when authorization is absent", () => {
+    const manifest = assembleContext({
+      ...base,
+      candidates: [
+        {
+          ...candidate({ sourceId: "unchecked" }),
+          authorization: undefined as unknown as ContextCandidate["authorization"],
+        },
+      ],
+    });
+
+    expect(manifest.entries).toEqual([]);
+    expect(manifest.excluded).toEqual([{ sourceId: "unchecked", reason: "unauthorized" }]);
+  });
+
+  it("records guardrail, bundle, taint, and manifest digests", () => {
+    const manifest = assembleContext({
+      ...base,
+      candidates: [candidate(), candidate({ sourceId: "web-1", taint: "untrusted" })],
+    });
+
+    expect(manifest.guardrailDigest).toBe("sha256:guardrail");
+    expect(manifest.bundleDigest).toBe("sha256:bundle");
+    expect(manifest.taint).toBe("untrusted");
+    expect(manifest.digest).toMatch(/^[0-9a-f]{64}$/);
+    expect(assembleContext({ ...base, candidates: [candidate()] }).digest).not.toBe(
+      manifest.digest
+    );
+  });
+
+  it("never carries source content or reasoning into the manifest", () => {
+    const manifest = assembleContext({
+      ...base,
+      candidates: [
+        {
+          ...candidate(),
+          // A caller that smuggles content in must not see it reflected in the manifest.
+          content: "the private transcript",
+        } as ContextCandidate & { content: string },
+      ],
+    });
+
+    expect(JSON.stringify(manifest)).not.toContain("the private transcript");
+  });
+
+  it("compacts the lowest-precedence sources first when the token budget is tight", () => {
+    const manifest = assembleContext({
+      ...base,
+      budgetTokens: 25,
+      candidates: [
+        candidate({ sourceId: "safety", precedence: "platform_safety" }),
+        candidate({ sourceId: "user-1", precedence: "user_request" }),
+        candidate({ sourceId: "web-1", precedence: "untrusted_source", taint: "untrusted" }),
+      ],
+    });
+
+    expect(manifest.entries.map((entry) => entry.sourceId)).toEqual(["safety", "user-1"]);
+    expect(manifest.excluded).toEqual([{ sourceId: "web-1", reason: "context_budget" }]);
+    expect(manifest.totalTokens).toBe(20);
+  });
+
+  it("fails closed rather than dropping a platform safety instruction", () => {
+    expect(() =>
+      assembleContext({
+        ...base,
+        budgetTokens: 5,
+        candidates: [candidate({ sourceId: "safety", precedence: "platform_safety" })],
+      })
+    ).toThrow(new ContextAssemblyError("context_budget_exceeded"));
+  });
+
+  it("rejects a candidate that claims a precedence outside the fixed ladder", () => {
+    expect(() =>
+      assembleContext({
+        ...base,
+        candidates: [
+          candidate({
+            precedence: "override_everything" as unknown as ContextCandidate["precedence"],
+          }),
+        ],
+      })
+    ).toThrow(new ContextAssemblyError("unknown_precedence"));
+  });
+});

--- a/packages/agent-runtime/src/context/manifest.ts
+++ b/packages/agent-runtime/src/context/manifest.ts
@@ -1,0 +1,252 @@
+import { canonicalHash } from "@tulipfarm/schema";
+import {
+  type InstructionPrecedence,
+  NON_COMPACTABLE_PRECEDENCE,
+  precedenceRank,
+} from "./precedence";
+
+/**
+ * Context assembly (SPEC §10 step 3). Context is built only from authorized Messages,
+ * source-referenced summaries, confirmed Memory, permitted Knowledge, prior typed State outputs,
+ * and instructions. The manifest records sources, versions, classifications, taint, and the
+ * authorization decision behind every entry — and records no Message content, source text, or
+ * private chain-of-thought.
+ */
+
+export type ContextEntryKind =
+  | "message"
+  | "summary"
+  | "memory"
+  | "knowledge"
+  | "state_output"
+  | "instruction";
+
+export type ContextTaint = "trusted" | "untrusted";
+
+export interface ContextAuthorization {
+  readonly decision: "allow" | "deny";
+  readonly reason?: string;
+}
+
+export interface ContextProvenance {
+  readonly sourceRef: string;
+  readonly revision?: string;
+}
+
+/** One authorization-checked source offered to the Agent for this State. */
+export interface ContextCandidate {
+  readonly sourceId: string;
+  readonly kind: ContextEntryKind;
+  readonly precedence: InstructionPrecedence;
+  readonly version: string;
+  readonly classification: string;
+  readonly taint: ContextTaint;
+  readonly authorization: ContextAuthorization;
+  readonly tokens: number;
+  /** Digest of the referenced content. The content itself never enters the manifest. */
+  readonly digest: string;
+  readonly provenance?: ContextProvenance;
+  /** For `summary` entries: the source ids this summary was derived from. */
+  readonly summarizes?: readonly string[];
+}
+
+export interface ContextEntry {
+  readonly sourceId: string;
+  readonly kind: ContextEntryKind;
+  readonly precedence: InstructionPrecedence;
+  readonly version: string;
+  readonly classification: string;
+  readonly taint: ContextTaint;
+  readonly tokens: number;
+  readonly digest: string;
+  readonly provenance?: ContextProvenance;
+  readonly summarizes?: readonly string[];
+}
+
+export type ContextExclusionReason =
+  | "unauthorized"
+  | "summary_source_unauthorized"
+  | "context_budget"
+  | string;
+
+export interface ContextExclusion {
+  readonly sourceId: string;
+  readonly reason: ContextExclusionReason;
+}
+
+export interface ContextManifest {
+  readonly businessId: string;
+  readonly runId: string;
+  readonly stateId: string;
+  readonly entries: readonly ContextEntry[];
+  readonly excluded: readonly ContextExclusion[];
+  readonly totalTokens: number;
+  /** Strictest taint present; an untrusted source taints the whole Context. */
+  readonly taint: ContextTaint;
+  readonly guardrailDigest: string;
+  readonly bundleDigest: string;
+  readonly digest: string;
+}
+
+export interface AssembleContextInput {
+  readonly businessId: string;
+  readonly runId: string;
+  readonly stateId: string;
+  readonly candidates: readonly ContextCandidate[];
+  readonly guardrailDigest: string;
+  readonly bundleDigest: string;
+  readonly budgetTokens: number;
+}
+
+export type ContextAssemblyErrorCode =
+  | "context_budget_exceeded"
+  | "unknown_precedence"
+  | "missing_guardrail_digest";
+
+/** Assembly denial. Carries the reason code only — never a source, prompt, or Context payload. */
+export class ContextAssemblyError extends Error {
+  readonly name = "ContextAssemblyError";
+
+  constructor(readonly code: ContextAssemblyErrorCode) {
+    super(code);
+  }
+}
+
+/** Classification strength, weakest first. A summary inherits the strongest of its sources. */
+const CLASSIFICATION_RANK: Readonly<Record<string, number>> = {
+  public: 0,
+  internal: 1,
+  confidential: 2,
+  restricted: 3,
+};
+
+function strongestClassification(values: readonly string[]): string {
+  return values.reduce((strongest, value) =>
+    (CLASSIFICATION_RANK[value] ?? Number.MAX_SAFE_INTEGER) >
+    (CLASSIFICATION_RANK[strongest] ?? Number.MAX_SAFE_INTEGER)
+      ? value
+      : strongest
+  );
+}
+
+function toEntry(candidate: ContextCandidate): ContextEntry {
+  // Only the declared manifest fields are copied, so a caller cannot smuggle source content or
+  // reasoning into the recorded Context by adding extra properties to a candidate.
+  const entry: ContextEntry = {
+    sourceId: candidate.sourceId,
+    kind: candidate.kind,
+    precedence: candidate.precedence,
+    version: candidate.version,
+    classification: candidate.classification,
+    taint: candidate.taint,
+    tokens: candidate.tokens,
+    digest: candidate.digest,
+  };
+  return {
+    ...entry,
+    ...(candidate.provenance === undefined ? {} : { provenance: candidate.provenance }),
+    ...(candidate.summarizes === undefined ? {} : { summarizes: candidate.summarizes }),
+  };
+}
+
+/**
+ * Builds the Context manifest. A summary is additive evidence about the transcript, never a
+ * replacement for it and never a way around an ACL: a summary derived from a source the caller may
+ * not read is dropped, even though the summary text itself looks harmless.
+ */
+export function assembleContext(input: AssembleContextInput): ContextManifest {
+  if (input.guardrailDigest.length === 0) {
+    throw new ContextAssemblyError("missing_guardrail_digest");
+  }
+
+  const excluded: ContextExclusion[] = [];
+  const authorized: ContextCandidate[] = [];
+
+  for (const candidate of input.candidates) {
+    if (precedenceRank(candidate.precedence) === undefined) {
+      throw new ContextAssemblyError("unknown_precedence");
+    }
+    // Missing, stale, or unverifiable authorization denies (SPEC §12 default deny).
+    if (candidate.authorization?.decision !== "allow") {
+      excluded.push({
+        sourceId: candidate.sourceId,
+        reason: candidate.authorization?.reason ?? "unauthorized",
+      });
+      continue;
+    }
+    authorized.push(candidate);
+  }
+
+  const byId = new Map(authorized.map((candidate) => [candidate.sourceId, candidate]));
+  const retained: ContextCandidate[] = [];
+  for (const candidate of authorized) {
+    if (candidate.kind !== "summary") {
+      retained.push(candidate);
+      continue;
+    }
+    const sources = (candidate.summarizes ?? []).map((sourceId) => byId.get(sourceId));
+    if (sources.length === 0 || sources.some((source) => source === undefined)) {
+      excluded.push({ sourceId: candidate.sourceId, reason: "summary_source_unauthorized" });
+      continue;
+    }
+    const resolved = sources as ContextCandidate[];
+    retained.push({
+      ...candidate,
+      // The summary can never be less tainted or less classified than what it summarizes.
+      taint: resolved.some((source) => source.taint === "untrusted")
+        ? "untrusted"
+        : candidate.taint,
+      classification: strongestClassification([
+        candidate.classification,
+        ...resolved.map((source) => source.classification),
+      ]),
+    });
+  }
+
+  const ordered = retained
+    .map((candidate, index) => ({ candidate, index }))
+    .sort((left, right) => {
+      const rank =
+        (precedenceRank(left.candidate.precedence) as number) -
+        (precedenceRank(right.candidate.precedence) as number);
+      return rank !== 0 ? rank : left.index - right.index;
+    })
+    .map(({ candidate }) => candidate);
+
+  const kept: ContextCandidate[] = [];
+  let totalTokens = 0;
+  // Compaction drops from the lowest precedence upward; safety and Guardrail levels never drop.
+  for (const candidate of ordered) {
+    if (totalTokens + candidate.tokens <= input.budgetTokens) {
+      kept.push(candidate);
+      totalTokens += candidate.tokens;
+      continue;
+    }
+    if (NON_COMPACTABLE_PRECEDENCE.includes(candidate.precedence)) {
+      throw new ContextAssemblyError("context_budget_exceeded");
+    }
+    excluded.push({ sourceId: candidate.sourceId, reason: "context_budget" });
+  }
+
+  const entries = kept.map(toEntry);
+  const taint: ContextTaint = entries.some((entry) => entry.taint === "untrusted")
+    ? "untrusted"
+    : "trusted";
+
+  return Object.freeze({
+    businessId: input.businessId,
+    runId: input.runId,
+    stateId: input.stateId,
+    entries: Object.freeze(entries),
+    excluded: Object.freeze(excluded),
+    totalTokens,
+    taint,
+    guardrailDigest: input.guardrailDigest,
+    bundleDigest: input.bundleDigest,
+    digest: canonicalHash({
+      entries,
+      guardrailDigest: input.guardrailDigest,
+      bundleDigest: input.bundleDigest,
+    }),
+  });
+}

--- a/packages/agent-runtime/src/context/precedence.ts
+++ b/packages/agent-runtime/src/context/precedence.ts
@@ -1,0 +1,38 @@
+/**
+ * Fixed, observable instruction precedence (SPEC §10). Lower levels cannot override higher levels:
+ * a Skill cannot overrule the Agent, an explicit user request cannot overrule the active business
+ * Guardrail, and untrusted source content is data at the bottom of the ladder — never instruction.
+ */
+export const INSTRUCTION_PRECEDENCE = [
+  "platform_safety",
+  "business_guardrail",
+  "routine_instructions",
+  "agent_instructions",
+  "skill_instructions",
+  "user_request",
+  "untrusted_source",
+] as const;
+
+export type InstructionPrecedence = (typeof INSTRUCTION_PRECEDENCE)[number];
+
+/** Levels that carry the platform's own invariants and are never compacted away. */
+export const NON_COMPACTABLE_PRECEDENCE: readonly InstructionPrecedence[] = [
+  "platform_safety",
+  "business_guardrail",
+];
+
+const RANK: Readonly<Record<string, number>> = Object.fromEntries(
+  INSTRUCTION_PRECEDENCE.map((level, index) => [level, index])
+);
+
+export function precedenceRank(level: string): number | undefined {
+  return RANK[level];
+}
+
+/** True when `candidate` sits at or below `ceiling` and therefore cannot override it. */
+export function precedenceWithin(
+  candidate: InstructionPrecedence,
+  ceiling: InstructionPrecedence
+): boolean {
+  return RANK[candidate] >= RANK[ceiling];
+}

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -1,3 +1,5 @@
+export * from "./context";
+export * from "./models";
 export type {
   ModelInvocationRequest,
   ModelInvocationResult,
@@ -5,3 +7,4 @@ export type {
   ModelOutput,
   ModelPort,
 } from "./ports";
+export * from "./skills";

--- a/packages/agent-runtime/src/models/index.ts
+++ b/packages/agent-runtime/src/models/index.ts
@@ -1,0 +1,17 @@
+export type {
+  ModelProfileAttempt,
+  ModelProfileCatalog,
+  ModelProfileDenialReason,
+  ModelProfileSelection,
+  ModelRequirements,
+  RoutableModelProfile,
+} from "./profile";
+export { checkModelProfile, selectModelProfile } from "./profile";
+export type {
+  ModelInvocationScope,
+  ModelRouterOptions,
+  ModelRoutingErrorCode,
+} from "./router";
+export { ModelRouter, ModelRoutingError } from "./router";
+export type { ModelUsageEvent, ModelUsageOutcome, ModelUsageSink } from "./usage";
+export { InMemoryModelUsageSink, totalModelCostUsd, totalModelTokens } from "./usage";

--- a/packages/agent-runtime/src/models/profile.test.ts
+++ b/packages/agent-runtime/src/models/profile.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from "vitest";
+import {
+  type ModelProfileCatalog,
+  type ModelRequirements,
+  type RoutableModelProfile,
+  selectModelProfile,
+} from "./profile";
+
+function profile(overrides: Partial<RoutableModelProfile> = {}): RoutableModelProfile {
+  return {
+    profileId: "primary",
+    provider: "acme",
+    model: "acme-1",
+    reasoning: "high",
+    supports: { tools: true, structuredOutput: true, contextWindowTokens: 100_000 },
+    constraints: {
+      dataRetention: "zero_retention",
+      allowTraining: false,
+      residency: "eu",
+      maxCostUsd: 1,
+      maxTokens: 50_000,
+      maxLatencyMs: 5_000,
+    },
+    fallbacks: [],
+    allowCaching: true,
+    ...overrides,
+  };
+}
+
+function catalog(...profiles: readonly RoutableModelProfile[]): ModelProfileCatalog {
+  const byId = new Map(profiles.map((entry) => [entry.profileId, entry]));
+  return { get: (id) => byId.get(id) };
+}
+
+const requirements: ModelRequirements = {
+  needsTools: true,
+  needsStructuredOutput: true,
+  estimatedContextTokens: 10_000,
+  estimatedCostUsd: 0.5,
+  sensitive: false,
+  allowTraining: false,
+  residency: "eu",
+  dataRetention: "zero_retention",
+};
+
+describe("selectModelProfile", () => {
+  it("selects a profile that meets every capability, data, residency, and budget constraint", () => {
+    const selection = selectModelProfile("primary", requirements, catalog(profile()));
+
+    expect(selection).toMatchObject({
+      outcome: "selected",
+      profileId: "primary",
+      cacheAllowed: true,
+    });
+    if (selection.outcome !== "selected") throw new Error("expected selection");
+    expect(selection.chain.map((entry) => entry.profileId)).toEqual(["primary"]);
+  });
+
+  it("denies an unknown profile instead of inventing a default", () => {
+    expect(selectModelProfile("missing", requirements, catalog())).toEqual({
+      outcome: "denied",
+      profileId: "missing",
+      reason: "unknown_profile",
+      attempts: [{ profileId: "missing", reason: "unknown_profile" }],
+    });
+  });
+
+  it.each([
+    [
+      "tool support",
+      profile({ supports: { tools: false, structuredOutput: true, contextWindowTokens: 100_000 } }),
+      "tools_unsupported",
+    ],
+    [
+      "structured output",
+      profile({ supports: { tools: true, structuredOutput: false, contextWindowTokens: 100_000 } }),
+      "structured_output_unsupported",
+    ],
+    [
+      "context window",
+      profile({ supports: { tools: true, structuredOutput: true, contextWindowTokens: 1_000 } }),
+      "context_window_exceeded",
+    ],
+    [
+      "residency",
+      profile({ constraints: { residency: "us", dataRetention: "zero_retention" } }),
+      "residency_violation",
+    ],
+    [
+      "data retention",
+      profile({ constraints: { residency: "eu", dataRetention: "provider_default" } }),
+      "data_retention_violation",
+    ],
+    [
+      "training",
+      profile({
+        constraints: { residency: "eu", dataRetention: "zero_retention", allowTraining: true },
+      }),
+      "training_not_permitted",
+    ],
+    [
+      "cost budget",
+      profile({
+        constraints: { residency: "eu", dataRetention: "zero_retention", maxCostUsd: 0.1 },
+      }),
+      "cost_budget_exceeded",
+    ],
+    [
+      "token budget",
+      profile({
+        constraints: { residency: "eu", dataRetention: "zero_retention", maxTokens: 100 },
+      }),
+      "token_budget_exceeded",
+    ],
+  ])("denies on %s without falling back to a weaker profile", (_label, candidate, reason) => {
+    const selection = selectModelProfile("primary", requirements, catalog(candidate));
+
+    expect(selection).toMatchObject({ outcome: "denied", reason });
+  });
+
+  it("denies a latency ceiling above the requested maximum", () => {
+    const selection = selectModelProfile(
+      "primary",
+      { ...requirements, maxLatencyMs: 1_000 },
+      catalog(profile())
+    );
+
+    expect(selection).toMatchObject({ outcome: "denied", reason: "latency_budget_exceeded" });
+  });
+
+  it("denies a capability class the requester did not ask for", () => {
+    const selection = selectModelProfile(
+      "primary",
+      { ...requirements, requiredCapabilityClass: "vision" },
+      catalog(profile({ capabilityClass: "text" }))
+    );
+
+    expect(selection).toMatchObject({ outcome: "denied", reason: "capability_class_mismatch" });
+  });
+
+  it("keeps caching off for sensitive work even when the profile permits it", () => {
+    const selection = selectModelProfile(
+      "primary",
+      { ...requirements, sensitive: true },
+      catalog(profile({ allowCaching: true }))
+    );
+
+    expect(selection).toMatchObject({ outcome: "selected", cacheAllowed: false });
+  });
+
+  it("keeps only fallbacks that satisfy the same constraints, in declared order", () => {
+    const selection = selectModelProfile(
+      "primary",
+      requirements,
+      catalog(
+        profile({ fallbacks: ["weak", "peer"] }),
+        profile({
+          profileId: "weak",
+          supports: { tools: false, structuredOutput: true, contextWindowTokens: 100_000 },
+        }),
+        profile({ profileId: "peer", provider: "local", model: "llama" })
+      )
+    );
+
+    if (selection.outcome !== "selected") throw new Error("expected selection");
+    expect(selection.chain.map((entry) => entry.profileId)).toEqual(["primary", "peer"]);
+    expect(selection.rejectedFallbacks).toEqual([
+      { profileId: "weak", reason: "tools_unsupported" },
+    ]);
+  });
+
+  it("stops a fallback cycle instead of looping", () => {
+    const selection = selectModelProfile(
+      "primary",
+      requirements,
+      catalog(
+        profile({ fallbacks: ["peer"] }),
+        profile({ profileId: "peer", fallbacks: ["primary"] })
+      )
+    );
+
+    if (selection.outcome !== "selected") throw new Error("expected selection");
+    expect(selection.chain.map((entry) => entry.profileId)).toEqual(["primary", "peer"]);
+  });
+
+  it("denies a fallback the catalog does not publish", () => {
+    const selection = selectModelProfile(
+      "primary",
+      requirements,
+      catalog(profile({ fallbacks: ["ghost"] }))
+    );
+
+    if (selection.outcome !== "selected") throw new Error("expected selection");
+    expect(selection.rejectedFallbacks).toEqual([
+      { profileId: "ghost", reason: "unknown_profile" },
+    ]);
+  });
+});

--- a/packages/agent-runtime/src/models/profile.ts
+++ b/packages/agent-runtime/src/models/profile.ts
@@ -1,0 +1,195 @@
+import type { ModelDataRetention, ModelProfileSpec, ModelReasoningLevel } from "@tulipfarm/schema";
+
+/**
+ * ModelProfile routing (SPEC §17). Model use is guardrail-driven through Soul-authored
+ * ModelProfiles, never hard-coded in an Agent. A profile is usable only when it independently
+ * meets every capability, Tool, structured-output, context, data-handling, residency, and budget
+ * constraint of the request — and a fallback must meet exactly the same constraints, so degrading
+ * to a weaker model is a denial rather than a silent downgrade.
+ */
+
+/** A published ModelProfile, flattened to the fields routing depends on. */
+export interface RoutableModelProfile extends ModelProfileSpec {
+  readonly profileId: string;
+  readonly reasoning: ModelReasoningLevel;
+}
+
+export interface ModelProfileCatalog {
+  get(profileId: string): RoutableModelProfile | undefined;
+}
+
+/** What the caller needs from a model for this Run, derived from Guardrail, Agent, and Context. */
+export interface ModelRequirements {
+  readonly needsTools: boolean;
+  readonly needsStructuredOutput: boolean;
+  readonly estimatedContextTokens: number;
+  readonly estimatedCostUsd?: number;
+  /** Sensitive work keeps caching off regardless of what the profile permits (SPEC §17). */
+  readonly sensitive: boolean;
+  /** Whether the data may be used for provider training. Defaults to forbidden. */
+  readonly allowTraining?: boolean;
+  readonly residency?: string;
+  readonly dataRetention?: ModelDataRetention;
+  readonly maxLatencyMs?: number;
+  readonly requiredCapabilityClass?: string;
+}
+
+export type ModelProfileDenialReason =
+  | "unknown_profile"
+  | "tools_unsupported"
+  | "structured_output_unsupported"
+  | "context_window_exceeded"
+  | "residency_violation"
+  | "data_retention_violation"
+  | "training_not_permitted"
+  | "cost_budget_exceeded"
+  | "token_budget_exceeded"
+  | "latency_budget_exceeded"
+  | "capability_class_mismatch";
+
+export interface ModelProfileAttempt {
+  readonly profileId: string;
+  readonly reason: ModelProfileDenialReason;
+}
+
+export type ModelProfileSelection =
+  | {
+      readonly outcome: "selected";
+      readonly profileId: string;
+      /** Primary first, then every fallback that satisfies the same constraints, in order. */
+      readonly chain: readonly RoutableModelProfile[];
+      readonly cacheAllowed: boolean;
+      readonly rejectedFallbacks: readonly ModelProfileAttempt[];
+    }
+  | {
+      readonly outcome: "denied";
+      readonly profileId: string;
+      readonly reason: ModelProfileDenialReason;
+      readonly attempts: readonly ModelProfileAttempt[];
+    };
+
+/** Data retention strength, narrowest first. A profile may never retain more than requested. */
+const RETENTION_RANK: Readonly<Record<ModelDataRetention, number>> = {
+  none: 0,
+  zero_retention: 1,
+  provider_default: 2,
+};
+
+/**
+ * Checks one candidate against the request. Returns the first violated constraint so denial
+ * evidence names a cause rather than a generic rejection.
+ */
+export function checkModelProfile(
+  profile: RoutableModelProfile,
+  requirements: ModelRequirements
+): ModelProfileDenialReason | null {
+  if (requirements.needsTools && !profile.supports.tools) return "tools_unsupported";
+  if (requirements.needsStructuredOutput && !profile.supports.structuredOutput) {
+    return "structured_output_unsupported";
+  }
+  if (requirements.estimatedContextTokens > profile.supports.contextWindowTokens) {
+    return "context_window_exceeded";
+  }
+  if (
+    requirements.requiredCapabilityClass !== undefined &&
+    profile.capabilityClass !== requirements.requiredCapabilityClass
+  ) {
+    return "capability_class_mismatch";
+  }
+
+  const constraints = profile.constraints ?? {};
+  if (requirements.residency !== undefined && constraints.residency !== requirements.residency) {
+    return "residency_violation";
+  }
+  if (requirements.dataRetention !== undefined) {
+    const permitted = RETENTION_RANK[requirements.dataRetention];
+    const declared = constraints.dataRetention;
+    // An undeclared retention posture is unverifiable, not permissive.
+    if (declared === undefined || RETENTION_RANK[declared] > permitted) {
+      return "data_retention_violation";
+    }
+  }
+  if (constraints.allowTraining === true && requirements.allowTraining !== true) {
+    return "training_not_permitted";
+  }
+
+  const costCeiling = constraints.maxCostUsd ?? profile.budgets?.maxCostUsd;
+  if (
+    requirements.estimatedCostUsd !== undefined &&
+    costCeiling !== undefined &&
+    requirements.estimatedCostUsd > costCeiling
+  ) {
+    return "cost_budget_exceeded";
+  }
+  const tokenCeiling = constraints.maxTokens ?? profile.budgets?.maxTokens;
+  if (tokenCeiling !== undefined && requirements.estimatedContextTokens > tokenCeiling) {
+    return "token_budget_exceeded";
+  }
+  if (
+    requirements.maxLatencyMs !== undefined &&
+    (constraints.maxLatencyMs === undefined || constraints.maxLatencyMs > requirements.maxLatencyMs)
+  ) {
+    return "latency_budget_exceeded";
+  }
+  return null;
+}
+
+/**
+ * Resolves the named profile plus its ordered, constraint-equivalent fallback chain. The primary
+ * profile decides the outcome: a primary that fails any constraint denies outright instead of
+ * quietly routing to a fallback that would have been chosen for a weaker request.
+ */
+export function selectModelProfile(
+  profileId: string,
+  requirements: ModelRequirements,
+  catalog: ModelProfileCatalog
+): ModelProfileSelection {
+  const primary = catalog.get(profileId);
+  if (primary === undefined) {
+    const attempt: ModelProfileAttempt = { profileId, reason: "unknown_profile" };
+    return { outcome: "denied", profileId, reason: "unknown_profile", attempts: [attempt] };
+  }
+
+  const primaryViolation = checkModelProfile(primary, requirements);
+  if (primaryViolation !== null) {
+    return {
+      outcome: "denied",
+      profileId,
+      reason: primaryViolation,
+      attempts: [{ profileId, reason: primaryViolation }],
+    };
+  }
+
+  const chain: RoutableModelProfile[] = [primary];
+  const rejected: ModelProfileAttempt[] = [];
+  const seen = new Set<string>([primary.profileId]);
+  const queue = [...(primary.fallbacks ?? [])];
+
+  while (queue.length > 0) {
+    const candidateId = queue.shift() as string;
+    if (seen.has(candidateId)) continue;
+    seen.add(candidateId);
+
+    const candidate = catalog.get(candidateId);
+    if (candidate === undefined) {
+      rejected.push({ profileId: candidateId, reason: "unknown_profile" });
+      continue;
+    }
+    const violation = checkModelProfile(candidate, requirements);
+    if (violation !== null) {
+      rejected.push({ profileId: candidateId, reason: violation });
+      continue;
+    }
+    chain.push(candidate);
+    queue.push(...(candidate.fallbacks ?? []));
+  }
+
+  return {
+    outcome: "selected",
+    profileId,
+    chain: Object.freeze(chain),
+    // Sensitive caching is off by default and cannot be re-enabled by the profile (SPEC §17).
+    cacheAllowed: primary.allowCaching && !requirements.sensitive,
+    rejectedFallbacks: Object.freeze(rejected),
+  };
+}

--- a/packages/agent-runtime/src/models/router.test.ts
+++ b/packages/agent-runtime/src/models/router.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from "vitest";
+import type { ModelInvocationRequest, ModelInvocationResult, ModelPort } from "../ports";
+import type { ModelProfileCatalog, ModelRequirements, RoutableModelProfile } from "./profile";
+import { ModelRouter, ModelRoutingError } from "./router";
+import type { ModelUsageEvent, ModelUsageSink } from "./usage";
+
+function profile(overrides: Partial<RoutableModelProfile> = {}): RoutableModelProfile {
+  return {
+    profileId: "primary",
+    provider: "acme",
+    model: "acme-1",
+    reasoning: "high",
+    supports: { tools: true, structuredOutput: true, contextWindowTokens: 100_000 },
+    constraints: { dataRetention: "zero_retention", residency: "eu" },
+    fallbacks: [],
+    allowCaching: false,
+    ...overrides,
+  };
+}
+
+function catalog(...profiles: readonly RoutableModelProfile[]): ModelProfileCatalog {
+  const byId = new Map(profiles.map((entry) => [entry.profileId, entry]));
+  return { get: (id) => byId.get(id) };
+}
+
+const requirements: ModelRequirements = {
+  needsTools: true,
+  needsStructuredOutput: true,
+  estimatedContextTokens: 10,
+  sensitive: false,
+  residency: "eu",
+  dataRetention: "zero_retention",
+};
+
+const request: ModelInvocationRequest = {
+  requestId: "req-1",
+  modelProfileId: "primary",
+  messages: [{ role: "user", content: "the private transcript" }],
+};
+
+function recordingSink(): ModelUsageSink & { events: ModelUsageEvent[] } {
+  const events: ModelUsageEvent[] = [];
+  return {
+    events,
+    record: async (event) => {
+      events.push(event);
+    },
+  };
+}
+
+function port(result: Partial<ModelInvocationResult> = {}): ModelPort {
+  return {
+    invoke: async (input) => ({
+      requestId: input.requestId,
+      output: { kind: "text", text: "confidential-answer-body" },
+      usage: { inputTokens: 10, outputTokens: 5, costUsd: 0.01 },
+      ...result,
+    }),
+  };
+}
+
+function router(options: {
+  readonly providers: Readonly<Record<string, ModelPort>>;
+  readonly catalog: ModelProfileCatalog;
+  readonly sink: ModelUsageSink;
+  readonly latencies?: readonly number[];
+}) {
+  const ticks = [...(options.latencies ?? [])];
+  let now = 0;
+  return new ModelRouter({
+    catalog: options.catalog,
+    providers: options.providers,
+    usage: options.sink,
+    now: () => {
+      const value = now;
+      now += ticks.shift() ?? 0;
+      return new Date(value);
+    },
+  });
+}
+
+describe("ModelRouter", () => {
+  it("invokes the selected provider and persists usage, cost, and latency evidence", async () => {
+    const sink = recordingSink();
+    const result = await router({
+      providers: { acme: port() },
+      catalog: catalog(profile()),
+      sink,
+      latencies: [120],
+    }).invoke(request, requirements, { businessId: "biz-1", runId: "run-1", stateId: "state-1" });
+
+    expect(result.output).toEqual({ kind: "text", text: "confidential-answer-body" });
+    expect(sink.events).toHaveLength(1);
+    expect(sink.events[0]).toMatchObject({
+      businessId: "biz-1",
+      runId: "run-1",
+      stateId: "state-1",
+      profileId: "primary",
+      provider: "acme",
+      model: "acme-1",
+      attempt: 1,
+      outcome: "succeeded",
+      inputTokens: 10,
+      outputTokens: 5,
+      costUsd: 0.01,
+      latencyMs: 120,
+      cacheAllowed: false,
+    });
+  });
+
+  it("never records prompt, message, or output content in usage evidence", async () => {
+    const sink = recordingSink();
+    await router({
+      providers: { acme: port() },
+      catalog: catalog(profile()),
+      sink,
+    }).invoke(request, requirements, { businessId: "biz-1", runId: "run-1", stateId: "state-1" });
+
+    expect(JSON.stringify(sink.events)).not.toContain("the private transcript");
+    expect(JSON.stringify(sink.events)).not.toContain("confidential-answer-body");
+  });
+
+  it("routes a local OpenAI-compatible provider through the same interface", async () => {
+    const sink = recordingSink();
+    const result = await router({
+      providers: { openai_compatible: port() },
+      catalog: catalog(profile({ provider: "openai_compatible", model: "local-llama" })),
+      sink,
+    }).invoke(request, requirements, { businessId: "biz-1", runId: "run-1", stateId: "state-1" });
+
+    expect(result.output).toEqual({ kind: "text", text: "confidential-answer-body" });
+    expect(sink.events[0]).toMatchObject({ provider: "openai_compatible", model: "local-llama" });
+  });
+
+  it("falls back only to a constraint-equivalent profile and records both attempts", async () => {
+    const sink = recordingSink();
+    const failing: ModelPort = {
+      invoke: async () => {
+        throw new Error("provider outage");
+      },
+    };
+    const result = await router({
+      providers: { acme: failing, local: port() },
+      catalog: catalog(
+        profile({ fallbacks: ["peer", "weak"] }),
+        profile({ profileId: "peer", provider: "local", model: "local-1" }),
+        profile({
+          profileId: "weak",
+          provider: "local",
+          supports: { tools: false, structuredOutput: true, contextWindowTokens: 10 },
+        })
+      ),
+      sink,
+    }).invoke(request, requirements, { businessId: "biz-1", runId: "run-1", stateId: "state-1" });
+
+    expect(result.output).toEqual({ kind: "text", text: "confidential-answer-body" });
+    expect(sink.events.map((event) => [event.profileId, event.outcome])).toEqual([
+      ["primary", "provider_error"],
+      ["peer", "succeeded"],
+    ]);
+  });
+
+  it("denies when the profile fails a constraint instead of routing anyway", async () => {
+    const sink = recordingSink();
+    await expect(
+      router({
+        providers: { acme: port() },
+        catalog: catalog(profile({ constraints: { residency: "us" } })),
+        sink,
+      }).invoke(request, requirements, {
+        businessId: "biz-1",
+        runId: "run-1",
+        stateId: "state-1",
+      })
+    ).rejects.toThrow(new ModelRoutingError("residency_violation"));
+    expect(sink.events).toEqual([]);
+  });
+
+  it("denies when no adapter is registered for the profile's provider", async () => {
+    const sink = recordingSink();
+    await expect(
+      router({ providers: {}, catalog: catalog(profile()), sink }).invoke(request, requirements, {
+        businessId: "biz-1",
+        runId: "run-1",
+        stateId: "state-1",
+      })
+    ).rejects.toThrow(new ModelRoutingError("provider_unavailable"));
+    expect(sink.events).toHaveLength(1);
+    expect(sink.events[0]).toMatchObject({ profileId: "primary", outcome: "provider_unavailable" });
+  });
+
+  it("fails closed when actual usage exceeds the profile budget", async () => {
+    const sink = recordingSink();
+    await expect(
+      router({
+        providers: {
+          acme: port({ usage: { inputTokens: 10, outputTokens: 5, costUsd: 9.5 } }),
+        },
+        catalog: catalog(
+          profile({
+            constraints: { dataRetention: "zero_retention", residency: "eu", maxCostUsd: 1 },
+          })
+        ),
+        sink,
+      }).invoke(request, requirements, {
+        businessId: "biz-1",
+        runId: "run-1",
+        stateId: "state-1",
+      })
+    ).rejects.toThrow(new ModelRoutingError("budget_exceeded"));
+    expect(sink.events.at(-1)).toMatchObject({ outcome: "budget_exceeded", costUsd: 9.5 });
+  });
+
+  it("exhausts the chain rather than retrying a denied profile", async () => {
+    const sink = recordingSink();
+    const failing: ModelPort = {
+      invoke: async () => {
+        throw new Error("provider outage");
+      },
+    };
+    await expect(
+      router({ providers: { acme: failing }, catalog: catalog(profile()), sink }).invoke(
+        request,
+        requirements,
+        { businessId: "biz-1", runId: "run-1", stateId: "state-1" }
+      )
+    ).rejects.toThrow(new ModelRoutingError("fallback_exhausted"));
+    expect(sink.events).toHaveLength(1);
+  });
+});

--- a/packages/agent-runtime/src/models/router.ts
+++ b/packages/agent-runtime/src/models/router.ts
@@ -1,0 +1,171 @@
+import type { ModelInvocationRequest, ModelInvocationResult, ModelPort } from "../ports";
+import {
+  type ModelProfileCatalog,
+  type ModelProfileDenialReason,
+  type ModelRequirements,
+  type RoutableModelProfile,
+  selectModelProfile,
+} from "./profile";
+import type { ModelUsageEvent, ModelUsageSink } from "./usage";
+
+/**
+ * Provider-neutral model routing (SPEC §17). The router resolves a governed ModelProfile, invokes
+ * the registered provider adapter behind {@link ModelPort}, and persists usage/cost/latency
+ * evidence for every attempt. Fallback is a safe fallback only: the chain contains solely profiles
+ * that met the *same* constraints, so an outage never degrades data handling or capability.
+ */
+
+export type ModelRoutingErrorCode =
+  | ModelProfileDenialReason
+  | "provider_unavailable"
+  | "budget_exceeded"
+  | "fallback_exhausted";
+
+/** Routing denial. Carries the reason code only — never a prompt, Context, or provider payload. */
+export class ModelRoutingError extends Error {
+  readonly name = "ModelRoutingError";
+
+  constructor(readonly code: ModelRoutingErrorCode) {
+    super(code);
+  }
+}
+
+export interface ModelInvocationScope {
+  readonly businessId: string;
+  readonly runId: string;
+  readonly stateId: string;
+}
+
+export interface ModelRouterOptions {
+  readonly catalog: ModelProfileCatalog;
+  /** Provider adapters keyed by the ModelProfile `provider` value, registered at composition. */
+  readonly providers: Readonly<Record<string, ModelPort>>;
+  readonly usage: ModelUsageSink;
+  readonly now: () => Date;
+}
+
+function budgetViolation(
+  profile: RoutableModelProfile,
+  result: ModelInvocationResult,
+  latencyMs: number
+): "budget_exceeded" | "latency_exceeded" | null {
+  const constraints = profile.constraints ?? {};
+  const costCeiling = constraints.maxCostUsd ?? profile.budgets?.maxCostUsd;
+  const tokenCeiling = constraints.maxTokens ?? profile.budgets?.maxTokens;
+  const totalTokens = result.usage.inputTokens + result.usage.outputTokens;
+  const costUsd = result.usage.costUsd;
+  if (costCeiling !== undefined && costUsd !== undefined && costUsd > costCeiling) {
+    return "budget_exceeded";
+  }
+  if (tokenCeiling !== undefined && totalTokens > tokenCeiling) return "budget_exceeded";
+  if (constraints.maxLatencyMs !== undefined && latencyMs > constraints.maxLatencyMs) {
+    return "latency_exceeded";
+  }
+  return null;
+}
+
+export class ModelRouter {
+  constructor(private readonly options: ModelRouterOptions) {}
+
+  async invoke(
+    request: ModelInvocationRequest,
+    requirements: ModelRequirements,
+    scope: ModelInvocationScope
+  ): Promise<ModelInvocationResult> {
+    const selection = selectModelProfile(
+      request.modelProfileId,
+      requirements,
+      this.options.catalog
+    );
+    if (selection.outcome === "denied") throw new ModelRoutingError(selection.reason);
+
+    let attempt = 0;
+    for (const profile of selection.chain) {
+      attempt += 1;
+      const provider = this.options.providers[profile.provider];
+      const startedAt = this.options.now();
+
+      if (provider === undefined) {
+        await this.record(profile, scope, request, selection.cacheAllowed, attempt, {
+          outcome: "provider_unavailable",
+          latencyMs: 0,
+          occurredAt: startedAt,
+        });
+        continue;
+      }
+
+      let result: ModelInvocationResult;
+      try {
+        result = await provider.invoke({ ...request, modelProfileId: profile.profileId });
+      } catch {
+        const failedAt = this.options.now();
+        await this.record(profile, scope, request, selection.cacheAllowed, attempt, {
+          outcome: "provider_error",
+          latencyMs: failedAt.getTime() - startedAt.getTime(),
+          occurredAt: failedAt,
+        });
+        continue;
+      }
+
+      const finishedAt = this.options.now();
+      const latencyMs = finishedAt.getTime() - startedAt.getTime();
+      const violation = budgetViolation(profile, result, latencyMs);
+      await this.record(profile, scope, request, selection.cacheAllowed, attempt, {
+        outcome: violation ?? "succeeded",
+        latencyMs,
+        occurredAt: finishedAt,
+        usage: result.usage,
+        providerRequestId: result.providerRequestId,
+      });
+      // A blown budget is a durable failure, not a reason to try another model on the same budget.
+      if (violation === "budget_exceeded") throw new ModelRoutingError("budget_exceeded");
+      if (violation === "latency_exceeded") continue;
+      return result;
+    }
+
+    throw new ModelRoutingError(
+      attempt === 0 ? "provider_unavailable" : this.exhaustionCode(selection.chain)
+    );
+  }
+
+  private exhaustionCode(chain: readonly RoutableModelProfile[]): ModelRoutingErrorCode {
+    return chain.every((profile) => this.options.providers[profile.provider] === undefined)
+      ? "provider_unavailable"
+      : "fallback_exhausted";
+  }
+
+  private async record(
+    profile: RoutableModelProfile,
+    scope: ModelInvocationScope,
+    request: ModelInvocationRequest,
+    cacheAllowed: boolean,
+    attempt: number,
+    outcome: {
+      readonly outcome: ModelUsageEvent["outcome"];
+      readonly latencyMs: number;
+      readonly occurredAt: Date;
+      readonly usage?: ModelInvocationResult["usage"];
+      readonly providerRequestId?: string;
+    }
+  ): Promise<void> {
+    await this.options.usage.record({
+      requestId: request.requestId,
+      businessId: scope.businessId,
+      runId: scope.runId,
+      stateId: scope.stateId,
+      profileId: profile.profileId,
+      provider: profile.provider,
+      model: profile.model,
+      reasoning: profile.reasoning,
+      attempt,
+      outcome: outcome.outcome,
+      inputTokens: outcome.usage?.inputTokens ?? 0,
+      outputTokens: outcome.usage?.outputTokens ?? 0,
+      costUsd: outcome.usage?.costUsd ?? null,
+      latencyMs: outcome.latencyMs,
+      cacheAllowed,
+      providerRequestId: outcome.providerRequestId,
+      occurredAt: outcome.occurredAt,
+    });
+  }
+}

--- a/packages/agent-runtime/src/models/usage.ts
+++ b/packages/agent-runtime/src/models/usage.ts
@@ -1,0 +1,55 @@
+/**
+ * Model usage evidence (SPEC §10 step 7, §17). Every model attempt persists token, cost, latency,
+ * and routing facts so budgets and audits read the same durable record. Evidence carries no
+ * prompt, Message, Context, or model output content — protected contents travel as authorized
+ * Artifacts, never as inline evidence.
+ */
+
+export type ModelUsageOutcome =
+  | "succeeded"
+  | "provider_error"
+  | "provider_unavailable"
+  | "budget_exceeded"
+  | "latency_exceeded";
+
+export interface ModelUsageEvent {
+  readonly requestId: string;
+  readonly businessId: string;
+  readonly runId: string;
+  readonly stateId: string;
+  readonly profileId: string;
+  readonly provider: string;
+  readonly model: string;
+  readonly reasoning: string;
+  /** 1-based position in the fallback chain, so a retry is distinguishable from a fallback. */
+  readonly attempt: number;
+  readonly outcome: ModelUsageOutcome;
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly costUsd: number | null;
+  readonly latencyMs: number;
+  readonly cacheAllowed: boolean;
+  readonly providerRequestId?: string;
+  readonly occurredAt: Date;
+}
+
+export interface ModelUsageSink {
+  record(event: ModelUsageEvent): Promise<void>;
+}
+
+/** Collects usage in memory. Tests and warm caches only; never an authoritative ledger. */
+export class InMemoryModelUsageSink implements ModelUsageSink {
+  readonly events: ModelUsageEvent[] = [];
+
+  async record(event: ModelUsageEvent): Promise<void> {
+    this.events.push(event);
+  }
+}
+
+export function totalModelCostUsd(events: readonly ModelUsageEvent[]): number {
+  return events.reduce((total, event) => total + (event.costUsd ?? 0), 0);
+}
+
+export function totalModelTokens(events: readonly ModelUsageEvent[]): number {
+  return events.reduce((total, event) => total + event.inputTokens + event.outputTokens, 0);
+}

--- a/packages/agent-runtime/src/ports/model.ts
+++ b/packages/agent-runtime/src/ports/model.ts
@@ -34,6 +34,8 @@ export interface ModelInvocationResult {
   readonly usage: {
     readonly inputTokens: number;
     readonly outputTokens: number;
+    /** Provider-reported cost when the adapter can price the call; absent when unknown. */
+    readonly costUsd?: number;
   };
   readonly providerRequestId?: string;
 }

--- a/packages/agent-runtime/src/skills/index.ts
+++ b/packages/agent-runtime/src/skills/index.ts
@@ -1,0 +1,13 @@
+export type {
+  ResolvableSkill,
+  ResolvedSkill,
+  ResolveSkillsInput,
+  SkillCatalog,
+  SkillRef,
+  SkillResolution,
+  SkillResolutionDenialReason,
+  SkillScanStatus,
+  SkillSelectionReason,
+  SkillTrustPolicy,
+} from "./resolve";
+export { resolveSkills, skillRef } from "./resolve";

--- a/packages/agent-runtime/src/skills/resolve.test.ts
+++ b/packages/agent-runtime/src/skills/resolve.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from "vitest";
+import {
+  type ResolvableSkill,
+  resolveSkills,
+  type SkillCatalog,
+  type SkillTrustPolicy,
+} from "./resolve";
+
+function skill(overrides: Partial<ResolvableSkill> = {}): ResolvableSkill {
+  return {
+    skillId: "triage",
+    version: "1.0.0",
+    digest: "sha256:triage-1",
+    trustTier: "first_party",
+    scan: { status: "clean", scannedDigest: "sha256:triage-1" },
+    dependencies: [],
+    requiredToolAbilities: ["github.issue.read"],
+    contextTokens: 100,
+    ...overrides,
+  };
+}
+
+function catalog(...skills: readonly ResolvableSkill[]): SkillCatalog {
+  const byRef = new Map(skills.map((entry) => [`${entry.skillId}@${entry.version}`, entry]));
+  return { get: (skillId, version) => byRef.get(`${skillId}@${version}`) };
+}
+
+const trustPolicy: SkillTrustPolicy = {
+  allowedTiers: ["first_party", "business_authored"],
+  requireScanForTiers: ["business_authored", "third_party"],
+};
+
+const base = {
+  trustPolicy,
+  grantedToolAbilities: ["github.issue.read", "github.issue.comment"],
+  contextBudgetTokens: 1_000,
+};
+
+describe("resolveSkills", () => {
+  it("resolves multiple selections with exact versions, reasons, and context budget", () => {
+    const resolution = resolveSkills({
+      ...base,
+      selections: [
+        { skillId: "triage", version: "1.0.0" },
+        { skillId: "reply", version: "2.1.0" },
+      ],
+      catalog: catalog(skill(), skill({ skillId: "reply", version: "2.1.0", contextTokens: 50 })),
+    });
+
+    if (resolution.outcome !== "resolved") throw new Error(resolution.reason);
+    expect(
+      resolution.skills.map((entry) => [entry.skillId, entry.version, entry.selectionReason])
+    ).toEqual([
+      ["triage", "1.0.0", "requested"],
+      ["reply", "2.1.0", "requested"],
+    ]);
+    expect(resolution.contextTokens).toBe(150);
+  });
+
+  it("resolves exact dependency versions and records why each was selected", () => {
+    const resolution = resolveSkills({
+      ...base,
+      selections: [{ skillId: "triage", version: "1.0.0" }],
+      catalog: catalog(
+        skill({ dependencies: [{ skillId: "shared", version: "0.3.0" }] }),
+        skill({ skillId: "shared", version: "0.3.0", requiredToolAbilities: [] })
+      ),
+    });
+
+    if (resolution.outcome !== "resolved") throw new Error(resolution.reason);
+    expect(resolution.skills.map((entry) => [entry.skillId, entry.selectionReason])).toEqual([
+      ["triage", "requested"],
+      ["shared", "dependency"],
+    ]);
+    expect(resolution.skills[1]?.requiredBy).toEqual(["triage@1.0.0"]);
+  });
+
+  it("denies an unpublished Skill version rather than resolving a nearby one", () => {
+    expect(
+      resolveSkills({
+        ...base,
+        selections: [{ skillId: "triage", version: "9.9.9" }],
+        catalog: catalog(skill()),
+      })
+    ).toMatchObject({ outcome: "denied", reason: "unknown_skill", skillRef: "triage@9.9.9" });
+  });
+
+  it("reports a conflict when two versions of one Skill are pulled in", () => {
+    const resolution = resolveSkills({
+      ...base,
+      selections: [
+        { skillId: "triage", version: "1.0.0" },
+        { skillId: "reply", version: "2.1.0" },
+      ],
+      catalog: catalog(
+        skill(),
+        skill({
+          skillId: "reply",
+          version: "2.1.0",
+          dependencies: [{ skillId: "triage", version: "1.1.0" }],
+          requiredToolAbilities: [],
+        }),
+        skill({ version: "1.1.0", digest: "sha256:triage-2" })
+      ),
+    });
+
+    expect(resolution).toMatchObject({
+      outcome: "denied",
+      reason: "version_conflict",
+      skillRef: "triage@1.1.0",
+    });
+  });
+
+  it("stops a dependency cycle instead of looping", () => {
+    const resolution = resolveSkills({
+      ...base,
+      selections: [{ skillId: "triage", version: "1.0.0" }],
+      catalog: catalog(
+        skill({ dependencies: [{ skillId: "shared", version: "0.3.0" }] }),
+        skill({
+          skillId: "shared",
+          version: "0.3.0",
+          dependencies: [{ skillId: "triage", version: "1.0.0" }],
+          requiredToolAbilities: [],
+        })
+      ),
+    });
+
+    if (resolution.outcome !== "resolved") throw new Error(resolution.reason);
+    expect(resolution.skills).toHaveLength(2);
+  });
+
+  it("denies a trust tier the Guardrail does not allow", () => {
+    expect(
+      resolveSkills({
+        ...base,
+        selections: [{ skillId: "triage", version: "1.0.0" }],
+        catalog: catalog(skill({ trustTier: "third_party" })),
+      })
+    ).toMatchObject({ outcome: "denied", reason: "trust_tier_forbidden" });
+  });
+
+  it("denies a scannable tier whose executable content has not passed scanning", () => {
+    expect(
+      resolveSkills({
+        ...base,
+        selections: [{ skillId: "triage", version: "1.0.0" }],
+        catalog: catalog(skill({ trustTier: "business_authored", scan: { status: "pending" } })),
+      })
+    ).toMatchObject({ outcome: "denied", reason: "scan_required" });
+  });
+
+  it("denies when the scanned digest no longer matches the published content", () => {
+    expect(
+      resolveSkills({
+        ...base,
+        selections: [{ skillId: "triage", version: "1.0.0" }],
+        catalog: catalog(
+          skill({
+            trustTier: "business_authored",
+            scan: { status: "clean", scannedDigest: "sha256:stale" },
+          })
+        ),
+      })
+    ).toMatchObject({ outcome: "denied", reason: "scan_required" });
+  });
+
+  it("denies a Skill preflight that needs an ability the caller does not already hold", () => {
+    expect(
+      resolveSkills({
+        ...base,
+        selections: [{ skillId: "triage", version: "1.0.0" }],
+        catalog: catalog(skill({ requiredToolAbilities: ["github.repo.delete"] })),
+      })
+    ).toMatchObject({
+      outcome: "denied",
+      reason: "missing_tool_ability",
+      detail: "github.repo.delete",
+    });
+  });
+
+  it("never widens abilities beyond what the caller already holds", () => {
+    const resolution = resolveSkills({
+      ...base,
+      grantedToolAbilities: ["github.issue.read", "github.issue.comment"],
+      selections: [{ skillId: "triage", version: "1.0.0" }],
+      catalog: catalog(skill({ requiredToolAbilities: ["github.issue.read"] })),
+    });
+
+    if (resolution.outcome !== "resolved") throw new Error(resolution.reason);
+    expect(resolution.abilities).toEqual(["github.issue.read"]);
+    expect(resolution).not.toHaveProperty("grants");
+  });
+
+  it("denies when resolved Skills exceed the Context budget", () => {
+    expect(
+      resolveSkills({
+        ...base,
+        contextBudgetTokens: 120,
+        selections: [
+          { skillId: "triage", version: "1.0.0" },
+          { skillId: "reply", version: "2.1.0" },
+        ],
+        catalog: catalog(
+          skill(),
+          skill({ skillId: "reply", version: "2.1.0", requiredToolAbilities: [] })
+        ),
+      })
+    ).toMatchObject({ outcome: "denied", reason: "context_budget_exceeded" });
+  });
+});

--- a/packages/agent-runtime/src/skills/resolve.ts
+++ b/packages/agent-runtime/src/skills/resolve.ts
@@ -1,0 +1,176 @@
+import type { DefinitionTrustTier } from "@tulipfarm/schema";
+
+/**
+ * Skill resolution (SPEC §10). Multiple Skills may be selected for one Run, but exact versions,
+ * selection reasons, dependency resolution, conflicts, and Context budget are recorded. Trust
+ * tiers decide whether changed executable content must be scanned and approved first.
+ *
+ * A Skill declares the Tool abilities it needs; it never grants one. Preflight therefore only
+ * intersects the declaration with the abilities the caller already holds — a Skill that asks for
+ * more is denied, never elevated (SPEC invariant 3).
+ */
+
+export interface SkillRef {
+  readonly skillId: string;
+  readonly version: string;
+}
+
+export type SkillScanStatus = "clean" | "pending" | "rejected";
+
+export interface ResolvableSkill extends SkillRef {
+  readonly digest: string;
+  readonly trustTier: DefinitionTrustTier;
+  readonly scan: { readonly status: SkillScanStatus; readonly scannedDigest?: string };
+  readonly dependencies: readonly SkillRef[];
+  readonly requiredToolAbilities: readonly string[];
+  readonly contextTokens: number;
+}
+
+export interface SkillCatalog {
+  get(skillId: string, version: string): ResolvableSkill | undefined;
+}
+
+/** Guardrail-owned trust policy: which tiers may run, and which must carry a current clean scan. */
+export interface SkillTrustPolicy {
+  readonly allowedTiers: readonly DefinitionTrustTier[];
+  readonly requireScanForTiers: readonly DefinitionTrustTier[];
+}
+
+export type SkillSelectionReason = "requested" | "dependency";
+
+export interface ResolvedSkill extends SkillRef {
+  readonly digest: string;
+  readonly trustTier: DefinitionTrustTier;
+  readonly selectionReason: SkillSelectionReason;
+  readonly requiredBy: readonly string[];
+  readonly contextTokens: number;
+}
+
+export type SkillResolutionDenialReason =
+  | "unknown_skill"
+  | "version_conflict"
+  | "trust_tier_forbidden"
+  | "scan_required"
+  | "missing_tool_ability"
+  | "context_budget_exceeded";
+
+export type SkillResolution =
+  | {
+      readonly outcome: "resolved";
+      readonly skills: readonly ResolvedSkill[];
+      /** Intersection of declared needs with held abilities. Never a superset. */
+      readonly abilities: readonly string[];
+      readonly contextTokens: number;
+      /** Stable identity of this exact selection set, for evidence and replay comparison. */
+      readonly selectionKey: string;
+    }
+  | {
+      readonly outcome: "denied";
+      readonly reason: SkillResolutionDenialReason;
+      readonly skillRef: string;
+      readonly detail?: string;
+    };
+
+export interface ResolveSkillsInput {
+  readonly selections: readonly SkillRef[];
+  readonly catalog: SkillCatalog;
+  readonly trustPolicy: SkillTrustPolicy;
+  /** Tool abilities the invoking user/Agent intersection already holds. */
+  readonly grantedToolAbilities: readonly string[];
+  readonly contextBudgetTokens: number;
+}
+
+export function skillRef(ref: SkillRef): string {
+  return `${ref.skillId}@${ref.version}`;
+}
+
+function denied(
+  reason: SkillResolutionDenialReason,
+  ref: string,
+  detail?: string
+): SkillResolution {
+  return detail === undefined
+    ? { outcome: "denied", reason, skillRef: ref }
+    : { outcome: "denied", reason, skillRef: ref, detail };
+}
+
+export function resolveSkills(input: ResolveSkillsInput): SkillResolution {
+  const resolved = new Map<string, ResolvedSkill>();
+  const selectedVersions = new Map<string, string>();
+  const granted = new Set(input.grantedToolAbilities);
+  const abilities = new Set<string>();
+
+  const queue: { readonly ref: SkillRef; readonly requiredBy?: string }[] = input.selections.map(
+    (ref) => ({ ref })
+  );
+
+  while (queue.length > 0) {
+    const item = queue.shift() as { ref: SkillRef; requiredBy?: string };
+    const ref = skillRef(item.ref);
+
+    const pinned = selectedVersions.get(item.ref.skillId);
+    if (pinned !== undefined && pinned !== item.ref.version) {
+      // Two exact versions of one Skill is a conflict to report, not a silent "latest wins".
+      return denied("version_conflict", ref, `${item.ref.skillId}@${pinned}`);
+    }
+
+    const existing = resolved.get(ref);
+    if (existing !== undefined) {
+      if (item.requiredBy !== undefined && !existing.requiredBy.includes(item.requiredBy)) {
+        resolved.set(ref, {
+          ...existing,
+          requiredBy: [...existing.requiredBy, item.requiredBy],
+        });
+      }
+      continue;
+    }
+
+    const skill = input.catalog.get(item.ref.skillId, item.ref.version);
+    if (skill === undefined) return denied("unknown_skill", ref);
+
+    if (!input.trustPolicy.allowedTiers.includes(skill.trustTier)) {
+      return denied("trust_tier_forbidden", ref, skill.trustTier);
+    }
+    if (input.trustPolicy.requireScanForTiers.includes(skill.trustTier)) {
+      // Changed executable content invalidates its scan: the scan must name the current digest.
+      if (skill.scan.status !== "clean" || skill.scan.scannedDigest !== skill.digest) {
+        return denied("scan_required", ref, skill.scan.status);
+      }
+    }
+    if (skill.scan.status === "rejected") return denied("scan_required", ref, "rejected");
+
+    for (const ability of skill.requiredToolAbilities) {
+      if (!granted.has(ability)) return denied("missing_tool_ability", ref, ability);
+      abilities.add(ability);
+    }
+
+    selectedVersions.set(item.ref.skillId, item.ref.version);
+    resolved.set(ref, {
+      skillId: skill.skillId,
+      version: skill.version,
+      digest: skill.digest,
+      trustTier: skill.trustTier,
+      selectionReason: item.requiredBy === undefined ? "requested" : "dependency",
+      requiredBy: item.requiredBy === undefined ? [] : [item.requiredBy],
+      contextTokens: skill.contextTokens,
+    });
+
+    for (const dependency of skill.dependencies) {
+      queue.push({ ref: dependency, requiredBy: ref });
+    }
+  }
+
+  const skills = [...resolved.values()];
+  const contextTokens = skills.reduce((total, entry) => total + entry.contextTokens, 0);
+  if (contextTokens > input.contextBudgetTokens) {
+    return denied("context_budget_exceeded", skills.map(skillRef).join(","));
+  }
+
+  return {
+    outcome: "resolved",
+    skills: Object.freeze(skills),
+    abilities: Object.freeze([...abilities].sort()),
+    contextTokens,
+    selectionKey: skills.map(skillRef).sort().join("|"),
+  };
+}

--- a/packages/agent-runtime/tsconfig.json
+++ b/packages/agent-runtime/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "moduleResolution": "bundler",
     "module": "ESNext",
-    "noEmit": true
+    "noEmit": true,
+    "types": ["node"]
   },
   "include": ["src"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -416,10 +416,29 @@ importers:
         version: 6.0.3
 
   packages/agent-runtime:
+    dependencies:
+      '@tulipfarm/audit':
+        specifier: workspace:*
+        version: link:../audit
+      '@tulipfarm/authz':
+        specifier: workspace:*
+        version: link:../authz
+      '@tulipfarm/run-kernel':
+        specifier: workspace:*
+        version: link:../run-kernel
+      '@tulipfarm/schema':
+        specifier: workspace:*
+        version: link:../schema
+      '@tulipfarm/tool-broker':
+        specifier: workspace:*
+        version: link:../tool-broker
     devDependencies:
       '@tulipfarm/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      '@types/node':
+        specifier: ^26.1.1
+        version: 26.1.1
       typescript:
         specifier: ^6.0.3
         version: 6.0.3


### PR DESCRIPTION
## Summary

- **AW-046 — ModelProfile routing** (`src/models/`): profiles are selected only when they independently meet every capability, residency, retention, training, context, latency, and budget constraint. A fallback is kept only when it satisfies the *same* constraints, so degrading to a weaker or looser model is a denial, not a silent downgrade. Caching stays off for sensitive work regardless of what the profile permits. Usage/cost evidence is recorded per attempt with no prompt or output content.
- **AW-047 — Context assembly** (`src/context/`): fixed instruction precedence (platform safety → business guardrail → routine → agent → skill → user → untrusted source), default-deny on unauthorized sources, summaries that inherit the strictest taint/classification and are dropped when a summarized source is unauthorized, and compaction that drops lowest precedence first and refuses to drop safety or guardrail levels. Manifests record sources, versions, classifications, taint, and authorization — never content or reasoning.
- **AW-048 — Skill resolution** (`src/skills/`): exact versions only (no "latest wins"), version conflicts reported rather than resolved, trust tiers and current scans enforced (a scan must name the published digest), and declared Tool abilities intersected with what the caller already holds — a Skill that asks for more is denied, never elevated.

Also adds the workspace dependencies/`types` the package now needs and an optional provider-reported `costUsd` on `ModelInvocationResult`.

## Test plan

- `pnpm --filter @tulipfarm/agent-runtime exec vitest run` — 48 tests across 5 files (profile selection/denials, router fallback + evidence redaction, context precedence/compaction/summaries, Skill trust/scan/ability cases)
- `pnpm --filter @tulipfarm/agent-runtime typecheck`
- `pnpm exec biome check .`
- `pnpm exec tsx scripts/architecture-check.ts`