### PR TITLE
feat(agent-runtime): add bounded Agent loop, durable Turns, delegation, and eval gate

### DIFF
--- a/apps/api/src/conversations/service.test.ts
+++ b/apps/api/src/conversations/service.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from "vitest";
+import {
+  ConversationAccessError,
+  ConversationService,
+  type ConversationStore,
+  type PersistedMessage,
+  type PersistedTurn,
+  type RunLauncher,
+  type TurnGrant,
+} from "./service";
+
+const GRANT: TurnGrant = {
+  businessId: "biz-1",
+  principal: "user:u-1",
+  abilities: ["conversation.write"],
+};
+
+class FakeStore implements ConversationStore {
+  messages: PersistedMessage[] = [];
+  turns: PersistedTurn[] = [];
+
+  async findTurnByIdempotencyKey(
+    _businessId: string,
+    key: string
+  ): Promise<PersistedTurn | undefined> {
+    return this.turns.find((turn) => turn.idempotencyKey === key);
+  }
+
+  async findTurn(_businessId: string, turnId: string): Promise<PersistedTurn | undefined> {
+    return this.turns.find((turn) => turn.id === turnId);
+  }
+
+  async appendMessage(message: PersistedMessage): Promise<void> {
+    this.messages.push(message);
+  }
+
+  async saveTurn(turn: PersistedTurn): Promise<void> {
+    const index = this.turns.findIndex((existing) => existing.id === turn.id);
+    if (index === -1) this.turns.push(turn);
+    else this.turns[index] = turn;
+  }
+
+  async listMessages(
+    _businessId: string,
+    conversationId: string
+  ): Promise<readonly PersistedMessage[]> {
+    return this.messages.filter((message) => message.conversationId === conversationId);
+  }
+}
+
+class FakeLauncher implements RunLauncher {
+  starts: { turnId: string; attempt: number }[] = [];
+  failNext = false;
+
+  async start(input: { turnId: string; attempt: number }): Promise<{ runId: string }> {
+    if (this.failNext) {
+      this.failNext = false;
+      throw new Error("run kernel unavailable");
+    }
+    this.starts.push({ turnId: input.turnId, attempt: input.attempt });
+    return { runId: `run-${this.starts.length}` };
+  }
+}
+
+function service(
+  options: { grant?: TurnGrant | null; store?: FakeStore; runs?: FakeLauncher } = {}
+) {
+  const store = options.store ?? new FakeStore();
+  const runs = options.runs ?? new FakeLauncher();
+  let ids = 0;
+  const authorizeCalls: string[] = [];
+
+  const conversations = new ConversationService({
+    store,
+    runs,
+    authorize: async (action) => {
+      authorizeCalls.push(action);
+      return options.grant === undefined ? GRANT : options.grant;
+    },
+    newId: () => {
+      ids += 1;
+      return `id-${ids}`;
+    },
+    now: () => new Date("2026-07-25T10:00:00.000Z"),
+  });
+
+  return { conversations, store, runs, authorizeCalls };
+}
+
+const turnInput = {
+  businessId: "biz-1",
+  conversationId: "conv-1",
+  content: "summarize the incident",
+  idempotencyKey: "key-1",
+};
+
+describe("ConversationService", () => {
+  it("persists the user Message and Turn before the Run is started", async () => {
+    const { conversations, store, runs } = service();
+    const started = await conversations.startTurn(turnInput);
+
+    expect(store.messages).toHaveLength(1);
+    expect(store.messages[0]).toMatchObject({ role: "user", content: "summarize the incident" });
+    expect(runs.starts).toEqual([{ turnId: started.turnId, attempt: 1 }]);
+    expect(started).toMatchObject({ runId: "run-1", cursor: 0 });
+  });
+
+  it("returns the same Turn and Run for a replayed idempotency key", async () => {
+    const { conversations, store, runs } = service();
+    const first = await conversations.startTurn(turnInput);
+    const second = await conversations.startTurn(turnInput);
+
+    expect(second).toEqual(first);
+    expect(store.messages).toHaveLength(1);
+    expect(runs.starts).toHaveLength(1);
+  });
+
+  it("resumes a Turn whose Run never started, without duplicating the Message", async () => {
+    const runs = new FakeLauncher();
+    runs.failNext = true;
+    const { conversations, store } = service({ runs });
+
+    await expect(conversations.startTurn(turnInput)).rejects.toThrow("run kernel unavailable");
+    expect(store.turns[0]).toMatchObject({ status: "start_failed" });
+
+    const retried = await conversations.startTurn(turnInput);
+    expect(store.messages).toHaveLength(1);
+    expect(retried).toMatchObject({ runId: "run-1", turnId: store.turns[0]?.id });
+    expect(store.turns).toHaveLength(1);
+  });
+
+  it("retries the same Turn as a new attempt that supersedes the old Run", async () => {
+    const { conversations, store, runs } = service();
+    const started = await conversations.startTurn(turnInput);
+    const retried = await conversations.retryTurn({
+      businessId: "biz-1",
+      turnId: started.turnId,
+      mode: "same_turn",
+    });
+
+    expect(retried.turnId).toBe(started.turnId);
+    expect(retried.runId).toBe("run-2");
+    expect(runs.starts).toEqual([
+      { turnId: started.turnId, attempt: 1 },
+      { turnId: started.turnId, attempt: 2 },
+    ]);
+    expect(store.turns).toHaveLength(1);
+    expect(store.turns[0]).toMatchObject({ attempt: 2, supersededRunIds: ["run-1"] });
+  });
+
+  it("retries as a new Turn that replays the request without touching the original", async () => {
+    const { conversations, store } = service();
+    const started = await conversations.startTurn(turnInput);
+    const retried = await conversations.retryTurn({
+      businessId: "biz-1",
+      turnId: started.turnId,
+      mode: "new_turn",
+    });
+
+    expect(retried.turnId).not.toBe(started.turnId);
+    expect(store.turns).toHaveLength(2);
+    expect(store.turns[0]).toMatchObject({ attempt: 1, runId: "run-1" });
+    expect(store.messages).toHaveLength(2);
+    expect(store.messages[1]).toMatchObject({ role: "user", content: "summarize the incident" });
+  });
+
+  it("rechecks authorization on every Turn and persists nothing when it is denied", async () => {
+    const { conversations, store, runs, authorizeCalls } = service({ grant: null });
+
+    await expect(conversations.startTurn(turnInput)).rejects.toBeInstanceOf(
+      ConversationAccessError
+    );
+    expect(store.messages).toEqual([]);
+    expect(runs.starts).toEqual([]);
+    expect(authorizeCalls).toEqual(["start_turn"]);
+  });
+
+  it("rechecks authorization on reads", async () => {
+    const { conversations } = service({ grant: null });
+
+    await expect(
+      conversations.listMessages({ businessId: "biz-1", conversationId: "conv-1" })
+    ).rejects.toBeInstanceOf(ConversationAccessError);
+  });
+
+  it("hands a reconnecting reader the Turn's Run and its durable cursor", async () => {
+    const { conversations, store } = service();
+    const started = await conversations.startTurn(turnInput);
+    const turn = store.turns[0];
+    if (turn === undefined) throw new Error("turn missing");
+    await store.saveTurn({ ...turn, cursor: 7 });
+
+    expect(
+      await conversations.streamHandle({ businessId: "biz-1", turnId: started.turnId })
+    ).toEqual({ runId: "run-1", after: 7 });
+  });
+
+  it("refuses to stream a Turn the reader may not see", async () => {
+    const store = new FakeStore();
+    const authorized = service({ store });
+    const started = await authorized.conversations.startTurn(turnInput);
+    const denied = service({ store, grant: null });
+
+    await expect(
+      denied.conversations.streamHandle({ businessId: "biz-1", turnId: started.turnId })
+    ).rejects.toBeInstanceOf(ConversationAccessError);
+  });
+});

--- a/apps/api/src/conversations/service.ts
+++ b/apps/api/src/conversations/service.ts
@@ -1,0 +1,251 @@
+/**
+ * Governed Conversations and Turns (SPEC §10, §18).
+ *
+ * A Turn is durable before it is dispatched: the user Message and the Turn row are written first,
+ * then a Run is started for it. That ordering is what makes a lost response safe to retry — a
+ * replayed idempotency key resolves to the same Turn and Run instead of a second Message, and a
+ * Turn whose Run never started resumes rather than duplicating.
+ *
+ * Streaming is cursor-based: readers resume from the Turn's persisted cursor over the Run event
+ * stream, so a reconnect never replays or drops. Authorization is re-checked on every Turn and
+ * every read; nothing here caches a decision across calls.
+ */
+
+export type TurnStatus = "pending" | "running" | "start_failed" | "succeeded" | "failed";
+
+export interface PersistedMessage {
+  readonly id: string;
+  readonly businessId: string;
+  readonly conversationId: string;
+  readonly turnId: string;
+  readonly role: "user" | "assistant";
+  readonly content: string;
+  readonly createdAt: Date;
+}
+
+export interface PersistedTurn {
+  readonly id: string;
+  readonly businessId: string;
+  readonly conversationId: string;
+  readonly idempotencyKey: string;
+  readonly requestMessageId: string;
+  readonly status: TurnStatus;
+  readonly attempt: number;
+  readonly runId: string | null;
+  /** Run event sequence already delivered to readers; a reconnect resumes strictly after it. */
+  readonly cursor: number;
+  readonly supersededRunIds: readonly string[];
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+}
+
+export interface ConversationStore {
+  findTurnByIdempotencyKey(businessId: string, key: string): Promise<PersistedTurn | undefined>;
+  findTurn(businessId: string, turnId: string): Promise<PersistedTurn | undefined>;
+  appendMessage(message: PersistedMessage): Promise<void>;
+  saveTurn(turn: PersistedTurn): Promise<void>;
+  listMessages(businessId: string, conversationId: string): Promise<readonly PersistedMessage[]>;
+}
+
+export interface RunLauncher {
+  start(input: {
+    businessId: string;
+    conversationId: string;
+    turnId: string;
+    attempt: number;
+  }): Promise<{ runId: string }>;
+}
+
+export interface TurnGrant {
+  readonly businessId: string;
+  readonly principal: string;
+  readonly abilities: readonly string[];
+}
+
+export type ConversationAction = "start_turn" | "retry_turn" | "read_messages" | "read_stream";
+
+export class ConversationAccessError extends Error {
+  readonly name = "ConversationAccessError";
+
+  constructor(readonly action: ConversationAction) {
+    super(`conversation_access_denied:${action}`);
+  }
+}
+
+export interface ConversationServiceDeps {
+  readonly store: ConversationStore;
+  readonly runs: RunLauncher;
+  authorize(action: ConversationAction, businessId: string): Promise<TurnGrant | null>;
+  newId(): string;
+  now(): Date;
+}
+
+export interface StartTurnInput {
+  readonly businessId: string;
+  readonly conversationId: string;
+  readonly content: string;
+  readonly idempotencyKey: string;
+}
+
+export interface StartedTurn {
+  readonly turnId: string;
+  readonly runId: string;
+  readonly cursor: number;
+}
+
+export interface RetryTurnInput {
+  readonly businessId: string;
+  readonly turnId: string;
+  /** `same_turn` re-dispatches the existing Turn; `new_turn` replays the request as a fresh Turn. */
+  readonly mode: "same_turn" | "new_turn";
+}
+
+export class ConversationService {
+  constructor(private readonly deps: ConversationServiceDeps) {}
+
+  async startTurn(input: StartTurnInput): Promise<StartedTurn> {
+    await this.require("start_turn", input.businessId);
+
+    const existing = await this.deps.store.findTurnByIdempotencyKey(
+      input.businessId,
+      input.idempotencyKey
+    );
+    if (existing !== undefined) {
+      if (existing.runId !== null) {
+        return { turnId: existing.id, runId: existing.runId, cursor: existing.cursor };
+      }
+      // The Message is already durable; only the dispatch is missing.
+      return this.dispatch(existing, existing.attempt);
+    }
+
+    const now = this.deps.now();
+    const turnId = this.deps.newId();
+    const messageId = this.deps.newId();
+
+    await this.deps.store.appendMessage({
+      id: messageId,
+      businessId: input.businessId,
+      conversationId: input.conversationId,
+      turnId,
+      role: "user",
+      content: input.content,
+      createdAt: now,
+    });
+
+    const turn: PersistedTurn = {
+      id: turnId,
+      businessId: input.businessId,
+      conversationId: input.conversationId,
+      idempotencyKey: input.idempotencyKey,
+      requestMessageId: messageId,
+      status: "pending",
+      attempt: 1,
+      runId: null,
+      cursor: 0,
+      supersededRunIds: [],
+      createdAt: now,
+      updatedAt: now,
+    };
+    await this.deps.store.saveTurn(turn);
+
+    return this.dispatch(turn, 1);
+  }
+
+  async retryTurn(input: RetryTurnInput): Promise<StartedTurn> {
+    await this.require("retry_turn", input.businessId);
+    const turn = await this.load(input.businessId, input.turnId, "retry_turn");
+
+    if (input.mode === "same_turn") {
+      const superseded =
+        turn.runId === null ? turn.supersededRunIds : [...turn.supersededRunIds, turn.runId];
+      return this.dispatch(
+        {
+          ...turn,
+          attempt: turn.attempt + 1,
+          runId: null,
+          // A new attempt streams its own Run, so the reader's cursor restarts with it.
+          cursor: 0,
+          supersededRunIds: superseded,
+        },
+        turn.attempt + 1
+      );
+    }
+
+    const messages = await this.deps.store.listMessages(turn.businessId, turn.conversationId);
+    const request = messages.find((message) => message.id === turn.requestMessageId);
+    if (request === undefined) throw new ConversationAccessError("retry_turn");
+
+    return this.startTurn({
+      businessId: turn.businessId,
+      conversationId: turn.conversationId,
+      content: request.content,
+      idempotencyKey: `${turn.idempotencyKey}:retry:${this.deps.newId()}`,
+    });
+  }
+
+  async listMessages(input: {
+    businessId: string;
+    conversationId: string;
+  }): Promise<readonly PersistedMessage[]> {
+    await this.require("read_messages", input.businessId);
+    return this.deps.store.listMessages(input.businessId, input.conversationId);
+  }
+
+  /** Where a reconnecting reader should resume: the Turn's Run and its durable cursor. */
+  async streamHandle(input: {
+    businessId: string;
+    turnId: string;
+  }): Promise<{ runId: string; after: number }> {
+    await this.require("read_stream", input.businessId);
+    const turn = await this.load(input.businessId, input.turnId, "read_stream");
+    if (turn.runId === null) throw new ConversationAccessError("read_stream");
+    return { runId: turn.runId, after: turn.cursor };
+  }
+
+  private async dispatch(turn: PersistedTurn, attempt: number): Promise<StartedTurn> {
+    let runId: string;
+    try {
+      const started = await this.deps.runs.start({
+        businessId: turn.businessId,
+        conversationId: turn.conversationId,
+        turnId: turn.id,
+        attempt,
+      });
+      runId = started.runId;
+    } catch (error) {
+      // The Turn stays durable and resumable; only the dispatch failed.
+      await this.deps.store.saveTurn({
+        ...turn,
+        attempt,
+        status: "start_failed",
+        updatedAt: this.deps.now(),
+      });
+      throw error;
+    }
+
+    await this.deps.store.saveTurn({
+      ...turn,
+      attempt,
+      runId,
+      status: "running",
+      updatedAt: this.deps.now(),
+    });
+    return { turnId: turn.id, runId, cursor: turn.cursor };
+  }
+
+  private async require(action: ConversationAction, businessId: string): Promise<TurnGrant> {
+    const grant = await this.deps.authorize(action, businessId);
+    if (grant === null) throw new ConversationAccessError(action);
+    return grant;
+  }
+
+  private async load(
+    businessId: string,
+    turnId: string,
+    action: ConversationAction
+  ): Promise<PersistedTurn> {
+    const turn = await this.deps.store.findTurn(businessId, turnId);
+    if (turn === undefined) throw new ConversationAccessError(action);
+    return turn;
+  }
+}

--- a/apps/worker/AGENTS.md
+++ b/apps/worker/AGENTS.md
@@ -2,7 +2,9 @@
 
 `@tulipfarm/worker` — durable Run dispatch, Agent/Tool States, timers, reconciliation, and
 projections. Composition-only: this app wires published packages together and must not
-reimplement package-owned logic. **Scaffold today:** `src/index.ts` is `export {}`. tsconfig
+reimplement package-owned logic. Today: Run/event dispatchers, `src/agent-state.ts` (Agent State
+execution around the bounded Agent loop), and `src/conversation-turn.ts` (durable Turn
+completion). tsconfig
 extends `@tulipfarm/tsconfig/node.json`. See root `AGENTS.md` for commands/lint.
 
 May import: `schema`, `authz`, `audit`, `secrets`, `run-kernel`, `tool-broker`, `agent-runtime`,

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
+    "@tulipfarm/agent-runtime": "workspace:*",
     "@tulipfarm/run-kernel": "workspace:*",
     "@tulipfarm/storage": "workspace:*"
   },

--- a/apps/worker/src/agent-state.test.ts
+++ b/apps/worker/src/agent-state.test.ts
@@ -1,0 +1,125 @@
+import type { AgentLoopInput, AgentLoopOutcome } from "@tulipfarm/agent-runtime";
+import { RunTransitionError, type StateStatus } from "@tulipfarm/run-kernel";
+import { describe, expect, it } from "vitest";
+import { type AgentStateRequest, AgentStateRunner } from "./agent-state";
+
+const counters = { iterations: 1, toolCalls: 0, repairs: 0 };
+
+function request(from: StateStatus = "claimed"): AgentStateRequest {
+  return { businessId: "biz-1", runId: "run-1", stateKey: "state-1", from };
+}
+
+function runner(
+  outcome: AgentLoopOutcome | (() => Promise<AgentLoopOutcome>),
+  overrides: { waitId?: string } = {}
+) {
+  const transitions: { from: StateStatus; to: StateStatus }[] = [];
+  const waits: { approvalId: string }[] = [];
+  let loopRuns = 0;
+
+  const agentState = new AgentStateRunner({
+    loop: {
+      run: async () => {
+        loopRuns += 1;
+        return typeof outcome === "function" ? await outcome() : outcome;
+      },
+    },
+    transitions: {
+      transition: async (input) => {
+        transitions.push({ from: input.from, to: input.to });
+      },
+    },
+    waits: {
+      register: async (input) => {
+        waits.push({ approvalId: input.approvalId });
+        return { waitId: overrides.waitId ?? "wait-1" };
+      },
+    },
+    buildInput: async (): Promise<AgentLoopInput> => ({
+      businessId: "biz-1",
+      runId: "run-1",
+      stateId: "state-1",
+      modelProfileId: "primary",
+      contextDigest: "sha256:context",
+      guardrailDigest: "sha256:guardrail",
+      messages: [],
+      tools: [],
+      limits: { maxIterations: 4, maxToolCalls: 4, maxRepairAttempts: 2 },
+    }),
+  });
+
+  return {
+    agentState,
+    transitions,
+    waits,
+    get loopRuns() {
+      return loopRuns;
+    },
+  };
+}
+
+describe("AgentStateRunner", () => {
+  it("drives a completed loop through running to succeeded", async () => {
+    const harness = runner({ status: "completed", output: { label: "bug" }, ...counters });
+    const result = await harness.agentState.execute(request());
+
+    expect(harness.transitions).toEqual([
+      { from: "claimed", to: "running" },
+      { from: "running", to: "succeeded" },
+    ]);
+    expect(result).toMatchObject({ status: "succeeded", output: { label: "bug" } });
+  });
+
+  it("fails the State when the loop hits a durable limit", async () => {
+    const harness = runner({ status: "failed", reason: "iteration_limit", ...counters });
+    const result = await harness.agentState.execute(request());
+
+    expect(harness.transitions.at(-1)).toEqual({ from: "running", to: "failed" });
+    expect(result).toMatchObject({ status: "failed", reason: "iteration_limit" });
+  });
+
+  it("registers a durable wait and parks the State instead of finishing it", async () => {
+    const harness = runner({
+      status: "awaiting_approval",
+      approvalId: "appr-1",
+      callId: "call-1",
+      ...counters,
+    });
+    const result = await harness.agentState.execute(request());
+
+    expect(harness.waits).toEqual([{ approvalId: "appr-1" }]);
+    expect(harness.transitions.at(-1)).toEqual({ from: "running", to: "waiting" });
+    expect(result).toMatchObject({ status: "waiting", waitId: "wait-1" });
+  });
+
+  it("takes a cancelled loop through cancelling to cancelled", async () => {
+    const harness = runner({ status: "cancelled", ...counters });
+    const result = await harness.agentState.execute(request());
+
+    expect(harness.transitions).toEqual([
+      { from: "claimed", to: "running" },
+      { from: "running", to: "cancelling" },
+      { from: "cancelling", to: "cancelled" },
+    ]);
+    expect(result).toMatchObject({ status: "cancelled" });
+  });
+
+  it("marks the State for reconciliation when the loop throws mid-flight", async () => {
+    const harness = runner(async () => {
+      throw new Error("worker crashed");
+    });
+    const result = await harness.agentState.execute(request());
+
+    expect(harness.transitions.at(-1)).toEqual({ from: "running", to: "needs_reconciliation" });
+    expect(result).toMatchObject({ status: "needs_reconciliation" });
+  });
+
+  it("refuses to start from a terminal State status and never runs the loop", async () => {
+    const harness = runner({ status: "completed", output: null, ...counters });
+
+    await expect(harness.agentState.execute(request("succeeded"))).rejects.toBeInstanceOf(
+      RunTransitionError
+    );
+    expect(harness.loopRuns).toBe(0);
+  });
+});

--- a/apps/worker/src/agent-state.ts
+++ b/apps/worker/src/agent-state.ts
@@ -1,0 +1,118 @@
+import type { AgentLoopInput, AgentLoopOutcome } from "@tulipfarm/agent-runtime";
+import { assertStateTransition, type StateStatus } from "@tulipfarm/run-kernel";
+
+/**
+ * Agent State execution (SPEC §10). Composition only: the bounded loop lives in
+ * `@tulipfarm/agent-runtime` and the state machine in `@tulipfarm/run-kernel`; this file maps one
+ * to the other so an Agent State can only end in a status the kernel allows, and an Approval parks
+ * the State on a durable wait instead of blocking a worker.
+ */
+
+export interface AgentStateRequest {
+  readonly businessId: string;
+  readonly runId: string;
+  readonly stateKey: string;
+  readonly from: StateStatus;
+}
+
+export interface StateTransitionPort {
+  transition(input: {
+    businessId: string;
+    runId: string;
+    stateKey: string;
+    from: StateStatus;
+    to: StateStatus;
+    reason?: string;
+  }): Promise<void>;
+}
+
+export interface ApprovalWaitPort {
+  register(input: {
+    businessId: string;
+    runId: string;
+    stateKey: string;
+    approvalId: string;
+    callId: string;
+  }): Promise<{ waitId: string }>;
+}
+
+export interface AgentLoopRunner {
+  run(input: AgentLoopInput): Promise<AgentLoopOutcome>;
+}
+
+export interface AgentStateRunnerOptions {
+  readonly loop: AgentLoopRunner;
+  readonly transitions: StateTransitionPort;
+  readonly waits: ApprovalWaitPort;
+  buildInput(request: AgentStateRequest): Promise<AgentLoopInput>;
+}
+
+export type AgentStateResult =
+  | { readonly status: "succeeded"; readonly output: unknown }
+  | { readonly status: "failed"; readonly reason: string }
+  | { readonly status: "waiting"; readonly waitId: string; readonly approvalId: string }
+  | { readonly status: "cancelled" }
+  | { readonly status: "needs_reconciliation" };
+
+export class AgentStateRunner {
+  constructor(private readonly options: AgentStateRunnerOptions) {}
+
+  async execute(request: AgentStateRequest): Promise<AgentStateResult> {
+    // Fail before any model or Tool work if the State cannot legally start.
+    assertStateTransition(request.from, "running");
+    await this.move(request, request.from, "running");
+
+    let outcome: AgentLoopOutcome;
+    try {
+      outcome = await this.options.loop.run(await this.options.buildInput(request));
+    } catch {
+      // Effects may or may not have landed; reconciliation decides, not the worker.
+      await this.move(request, "running", "needs_reconciliation", "agent_loop_error");
+      return { status: "needs_reconciliation" };
+    }
+
+    switch (outcome.status) {
+      case "completed":
+        await this.move(request, "running", "succeeded");
+        return { status: "succeeded", output: outcome.output };
+
+      case "failed":
+        await this.move(request, "running", "failed", outcome.reason);
+        return { status: "failed", reason: outcome.reason };
+
+      case "awaiting_approval": {
+        const { waitId } = await this.options.waits.register({
+          businessId: request.businessId,
+          runId: request.runId,
+          stateKey: request.stateKey,
+          approvalId: outcome.approvalId,
+          callId: outcome.callId,
+        });
+        await this.move(request, "running", "waiting", "approval_required");
+        return { status: "waiting", waitId, approvalId: outcome.approvalId };
+      }
+
+      case "cancelled":
+        await this.move(request, "running", "cancelling", "cancelled");
+        await this.move(request, "cancelling", "cancelled");
+        return { status: "cancelled" };
+    }
+  }
+
+  private async move(
+    request: AgentStateRequest,
+    from: StateStatus,
+    to: StateStatus,
+    reason?: string
+  ): Promise<void> {
+    assertStateTransition(from, to);
+    await this.options.transitions.transition({
+      businessId: request.businessId,
+      runId: request.runId,
+      stateKey: request.stateKey,
+      from,
+      to,
+      ...(reason === undefined ? {} : { reason }),
+    });
+  }
+}

--- a/apps/worker/src/conversation-turn.test.ts
+++ b/apps/worker/src/conversation-turn.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import {
+  ConversationTurnCompleter,
+  type TurnCompletionRecord,
+  type TurnCompletionStore,
+} from "./conversation-turn";
+
+class FakeStore implements TurnCompletionStore {
+  records: TurnCompletionRecord[] = [];
+  appended: { turnId: string; attempt: number; content: string }[] = [];
+  completed: { turnId: string; attempt: number; status: string; cursor: number }[] = [];
+
+  async findCompletion(
+    _businessId: string,
+    turnId: string,
+    attempt: number
+  ): Promise<TurnCompletionRecord | undefined> {
+    return this.records.find((record) => record.turnId === turnId && record.attempt === attempt);
+  }
+
+  async appendAssistantMessage(input: {
+    businessId: string;
+    turnId: string;
+    attempt: number;
+    content: string;
+  }): Promise<{ messageId: string }> {
+    this.appended.push({ turnId: input.turnId, attempt: input.attempt, content: input.content });
+    return { messageId: `msg-${this.appended.length}` };
+  }
+
+  async completeTurn(input: {
+    businessId: string;
+    turnId: string;
+    attempt: number;
+    status: "succeeded" | "failed";
+    cursor: number;
+    messageId: string | null;
+  }): Promise<void> {
+    this.completed.push({
+      turnId: input.turnId,
+      attempt: input.attempt,
+      status: input.status,
+      cursor: input.cursor,
+    });
+    this.records.push({
+      turnId: input.turnId,
+      attempt: input.attempt,
+      status: input.status,
+      messageId: input.messageId,
+    });
+  }
+}
+
+const request = {
+  businessId: "biz-1",
+  conversationId: "conv-1",
+  turnId: "turn-1",
+  attempt: 1,
+  cursor: 12,
+};
+
+describe("ConversationTurnCompleter", () => {
+  it("appends the assistant Message and completes the Turn at the final cursor", async () => {
+    const store = new FakeStore();
+    const completer = new ConversationTurnCompleter({ store });
+
+    const result = await completer.complete({
+      ...request,
+      outcome: { status: "succeeded", text: "here is the summary" },
+    });
+
+    expect(store.appended).toEqual([
+      { turnId: "turn-1", attempt: 1, content: "here is the summary" },
+    ]);
+    expect(store.completed).toEqual([
+      { turnId: "turn-1", attempt: 1, status: "succeeded", cursor: 12 },
+    ]);
+    expect(result).toMatchObject({ status: "succeeded", messageId: "msg-1" });
+  });
+
+  it("is idempotent when the same attempt is redelivered after a crash", async () => {
+    const store = new FakeStore();
+    const completer = new ConversationTurnCompleter({ store });
+    const input = { ...request, outcome: { status: "succeeded" as const, text: "done" } };
+
+    const first = await completer.complete(input);
+    const second = await completer.complete(input);
+
+    expect(second).toEqual(first);
+    expect(store.appended).toHaveLength(1);
+    expect(store.completed).toHaveLength(1);
+  });
+
+  it("fails the Turn without inventing an assistant Message", async () => {
+    const store = new FakeStore();
+    const completer = new ConversationTurnCompleter({ store });
+
+    const result = await completer.complete({
+      ...request,
+      outcome: { status: "failed", reason: "iteration_limit" },
+    });
+
+    expect(store.appended).toEqual([]);
+    expect(store.completed).toEqual([
+      { turnId: "turn-1", attempt: 1, status: "failed", cursor: 12 },
+    ]);
+    expect(result).toMatchObject({ status: "failed", reason: "iteration_limit" });
+  });
+
+  it("leaves a waiting Turn open so the Approval can resume it", async () => {
+    const store = new FakeStore();
+    const completer = new ConversationTurnCompleter({ store });
+
+    const result = await completer.complete({
+      ...request,
+      outcome: { status: "waiting", waitId: "wait-1" },
+    });
+
+    expect(store.appended).toEqual([]);
+    expect(store.completed).toEqual([]);
+    expect(result).toMatchObject({ status: "waiting", waitId: "wait-1" });
+  });
+
+  it("treats a superseded attempt as stale and does not overwrite the newer one", async () => {
+    const store = new FakeStore();
+    const completer = new ConversationTurnCompleter({ store });
+
+    await completer.complete({
+      ...request,
+      attempt: 2,
+      outcome: { status: "succeeded", text: "attempt two" },
+    });
+    const stale = await completer.complete({
+      ...request,
+      attempt: 1,
+      outcome: { status: "succeeded", text: "attempt one" },
+      latestAttempt: 2,
+    });
+
+    expect(stale).toMatchObject({ status: "stale" });
+    expect(store.appended).toEqual([{ turnId: "turn-1", attempt: 2, content: "attempt two" }]);
+  });
+});

--- a/apps/worker/src/conversation-turn.ts
+++ b/apps/worker/src/conversation-turn.ts
@@ -1,0 +1,123 @@
+/**
+ * Turn completion (SPEC §10, §18). The Run finished; this writes the durable result the reader
+ * will see. Completion is keyed by `(turnId, attempt)` so a redelivered job cannot post a second
+ * assistant Message, and an attempt the user already superseded by retrying is dropped as stale
+ * instead of overwriting the newer one.
+ */
+
+export type TurnCompletionStatus = "succeeded" | "failed";
+
+export interface TurnCompletionRecord {
+  readonly turnId: string;
+  readonly attempt: number;
+  readonly status: TurnCompletionStatus;
+  readonly messageId: string | null;
+}
+
+export interface TurnCompletionStore {
+  findCompletion(
+    businessId: string,
+    turnId: string,
+    attempt: number
+  ): Promise<TurnCompletionRecord | undefined>;
+  appendAssistantMessage(input: {
+    businessId: string;
+    conversationId: string;
+    turnId: string;
+    attempt: number;
+    content: string;
+  }): Promise<{ messageId: string }>;
+  completeTurn(input: {
+    businessId: string;
+    turnId: string;
+    attempt: number;
+    status: TurnCompletionStatus;
+    cursor: number;
+    messageId: string | null;
+  }): Promise<void>;
+}
+
+export type TurnOutcome =
+  | { readonly status: "succeeded"; readonly text: string }
+  | { readonly status: "failed"; readonly reason: string }
+  | { readonly status: "waiting"; readonly waitId: string };
+
+export interface CompleteTurnInput {
+  readonly businessId: string;
+  readonly conversationId: string;
+  readonly turnId: string;
+  readonly attempt: number;
+  /** Last Run event sequence for this attempt; readers resume strictly after it. */
+  readonly cursor: number;
+  readonly outcome: TurnOutcome;
+  /** Highest attempt the Turn has; a lower attempt arriving late is stale. */
+  readonly latestAttempt?: number;
+}
+
+export type CompleteTurnResult =
+  | { readonly status: "succeeded"; readonly messageId: string }
+  | { readonly status: "failed"; readonly reason: string }
+  | { readonly status: "waiting"; readonly waitId: string }
+  | { readonly status: "stale" };
+
+export interface ConversationTurnCompleterOptions {
+  readonly store: TurnCompletionStore;
+}
+
+export class ConversationTurnCompleter {
+  constructor(private readonly options: ConversationTurnCompleterOptions) {}
+
+  async complete(input: CompleteTurnInput): Promise<CompleteTurnResult> {
+    if (input.latestAttempt !== undefined && input.latestAttempt > input.attempt) {
+      return { status: "stale" };
+    }
+
+    if (input.outcome.status === "waiting") {
+      // The Turn is parked on a durable wait; resuming it will complete it later.
+      return { status: "waiting", waitId: input.outcome.waitId };
+    }
+
+    const existing = await this.options.store.findCompletion(
+      input.businessId,
+      input.turnId,
+      input.attempt
+    );
+    if (existing !== undefined) {
+      return existing.status === "succeeded"
+        ? { status: "succeeded", messageId: existing.messageId ?? "" }
+        : {
+            status: "failed",
+            reason: input.outcome.status === "failed" ? input.outcome.reason : "",
+          };
+    }
+
+    if (input.outcome.status === "failed") {
+      await this.options.store.completeTurn({
+        businessId: input.businessId,
+        turnId: input.turnId,
+        attempt: input.attempt,
+        status: "failed",
+        cursor: input.cursor,
+        messageId: null,
+      });
+      return { status: "failed", reason: input.outcome.reason };
+    }
+
+    const { messageId } = await this.options.store.appendAssistantMessage({
+      businessId: input.businessId,
+      conversationId: input.conversationId,
+      turnId: input.turnId,
+      attempt: input.attempt,
+      content: input.outcome.text,
+    });
+    await this.options.store.completeTurn({
+      businessId: input.businessId,
+      turnId: input.turnId,
+      attempt: input.attempt,
+      status: "succeeded",
+      cursor: input.cursor,
+      messageId,
+    });
+    return { status: "succeeded", messageId };
+  }
+}

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,4 +1,23 @@
 export {
+  type AgentLoopRunner,
+  type AgentStateRequest,
+  type AgentStateResult,
+  AgentStateRunner,
+  type AgentStateRunnerOptions,
+  type ApprovalWaitPort,
+  type StateTransitionPort,
+} from "./agent-state";
+export {
+  type CompleteTurnInput,
+  type CompleteTurnResult,
+  ConversationTurnCompleter,
+  type ConversationTurnCompleterOptions,
+  type TurnCompletionRecord,
+  type TurnCompletionStatus,
+  type TurnCompletionStore,
+  type TurnOutcome,
+} from "./conversation-turn";
+export {
   type DispatchBatchResult,
   EventOutboxDispatcher,
   type EventOutboxDispatcherOptions,

--- a/packages/agent-runtime/AGENTS.md
+++ b/packages/agent-runtime/AGENTS.md
@@ -1,10 +1,21 @@
 # Agent Runtime — Agent Conventions
 
 `@tulipfarm/agent-runtime` — Context assembly, iterative model/tool loop, model profiles,
-compaction, budgets, and delegation orchestration. **Today:** `src/ports/model.ts` defines the
-provider-neutral model invocation boundary. tsconfig extends `@tulipfarm/tsconfig/base.json`.
-See root `AGENTS.md` for
-commands/lint.
+compaction, budgets, and delegation orchestration. tsconfig extends
+`@tulipfarm/tsconfig/base.json`. See root `AGENTS.md` for commands/lint.
+
+## Layout
+
+| Path | What |
+| --- | --- |
+| `src/ports/model.ts` | Provider-neutral model invocation boundary. |
+| `src/models/` | ModelProfile routing, constraint-equivalent fallback chains, usage/cost evidence. |
+| `src/context/` | Instruction precedence, Context assembly, compaction, manifests. |
+| `src/skills/` | Skill resolution: exact versions, trust tiers, scanning, ability intersection. |
+| `src/loop/` | Bounded durable Tool loop + checkpoints; the broker is the only effect path. |
+| `src/delegation/` | Helper Agents as child Runs: read-only start, narrowing, detach, Artifacts. |
+| `src/evals/` | Versioned eval suites and the publication activation gate. |
+| `test/security/` | Adversarial injection / non-amplification corpus. |
 
 May import: `@tulipfarm/schema`, `@tulipfarm/authz`, `@tulipfarm/audit`,
 `@tulipfarm/run-kernel`, `@tulipfarm/tool-broker`, `@tulipfarm/knowledge`, `@tulipfarm/memory`,

--- a/packages/agent-runtime/src/delegation/delegate.test.ts
+++ b/packages/agent-runtime/src/delegation/delegate.test.ts
@@ -1,0 +1,212 @@
+import {
+  type ChildAuthority,
+  type ChildLink,
+  type ChildLinkStore,
+  ChildRunError,
+  ChildRunManager,
+} from "@tulipfarm/run-kernel";
+import { describe, expect, it } from "vitest";
+import { DelegationCoordinator, type DelegationError, type DelegationRequest } from "./delegate";
+
+class FakeChildLinkStore implements ChildLinkStore {
+  links: ChildLink[] = [];
+
+  async link(input: {
+    parentRunId: string;
+    childRunId: string;
+    authority: ChildAuthority;
+    createdAt: string;
+  }): Promise<ChildLink> {
+    const link: ChildLink = {
+      parentRunId: input.parentRunId,
+      childRunId: input.childRunId,
+      authority: input.authority,
+      detachedAt: null,
+      createdAt: input.createdAt,
+    };
+    this.links.push(link);
+    return link;
+  }
+
+  async detach(
+    _businessId: string,
+    parentRunId: string,
+    childRunId: string,
+    detachedAt: string
+  ): Promise<boolean> {
+    const index = this.links.findIndex(
+      (link) => link.parentRunId === parentRunId && link.childRunId === childRunId
+    );
+    const existing = this.links[index];
+    if (existing === undefined || existing.detachedAt !== null) return false;
+    this.links[index] = { ...existing, detachedAt };
+    return true;
+  }
+
+  async listChildren(_businessId: string, parentRunId: string): Promise<readonly ChildLink[]> {
+    return this.links.filter((link) => link.parentRunId === parentRunId);
+  }
+}
+
+const PARENT_AUTHORITY: ChildAuthority = {
+  tools: ["github.issue.read", "github.issue.comment", "knowledge.search"],
+  classifications: ["internal", "confidential"],
+  limits: { toolCalls: 20, costUsd: 5 },
+};
+
+const READ_ONLY_TOOLS = new Set(["github.issue.read", "knowledge.search"]);
+
+function coordinator(options: { maxDepth?: number } = {}) {
+  const store = new FakeChildLinkStore();
+  const delegation = new DelegationCoordinator({
+    children: new ChildRunManager(store),
+    tools: { isReadOnly: (name: string) => READ_ONLY_TOOLS.has(name) },
+    policy: { maxDepth: options.maxDepth ?? 2 },
+  });
+  return { delegation, store };
+}
+
+function request(overrides: Partial<DelegationRequest> = {}): DelegationRequest {
+  return {
+    businessId: "biz-1",
+    parentRunId: "run-parent",
+    childRunId: "run-child",
+    parent: {
+      authority: PARENT_AUTHORITY,
+      depth: 0,
+      deadlineAt: "2026-07-25T11:00:00.000Z",
+    },
+    requested: {},
+    now: "2026-07-25T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("DelegationCoordinator", () => {
+  it("starts a helper read-only, dropping the parent's effect-bearing Tools", async () => {
+    const { delegation } = coordinator();
+    const helper = await delegation.delegate(request());
+
+    expect(helper.authority.tools).toEqual(["github.issue.read", "knowledge.search"]);
+    expect(helper.mode).toBe("read_only");
+    expect(helper.depth).toBe(1);
+  });
+
+  it("grants an effect-bearing Tool only when the helper explicitly asks and the parent holds it", async () => {
+    const { delegation } = coordinator();
+    const helper = await delegation.delegate(
+      request({
+        requested: { mode: "read_write", tools: ["github.issue.comment"] },
+      })
+    );
+
+    expect(helper.authority.tools).toEqual(["github.issue.comment"]);
+    expect(helper.mode).toBe("read_write");
+  });
+
+  it("denies a Tool the parent never held", async () => {
+    const { delegation, store } = coordinator();
+
+    await expect(
+      delegation.delegate(
+        request({ requested: { mode: "read_write", tools: ["github.repo.delete"] } })
+      )
+    ).rejects.toBeInstanceOf(ChildRunError);
+    expect(store.links).toEqual([]);
+  });
+
+  it("denies a budget above the parent's ceiling", async () => {
+    const { delegation } = coordinator();
+
+    await expect(
+      delegation.delegate(request({ requested: { limits: { costUsd: 50 } } }))
+    ).rejects.toBeInstanceOf(ChildRunError);
+  });
+
+  it("denies a classification the parent cannot see", async () => {
+    const { delegation } = coordinator();
+
+    await expect(
+      delegation.delegate(request({ requested: { classifications: ["restricted"] } }))
+    ).rejects.toBeInstanceOf(ChildRunError);
+  });
+
+  it("denies a deadline later than the parent's and keeps an earlier one", async () => {
+    const { delegation, store } = coordinator();
+
+    await expect(
+      delegation.delegate(request({ requested: { deadlineAt: "2026-07-25T23:00:00.000Z" } }))
+    ).rejects.toMatchObject({ code: "deadline_amplification" });
+    expect(store.links).toEqual([]);
+
+    const helper = await delegation.delegate(
+      request({ requested: { deadlineAt: "2026-07-25T10:30:00.000Z" } })
+    );
+    expect(helper.deadlineAt).toBe("2026-07-25T10:30:00.000Z");
+  });
+
+  it("refuses to delegate past the configured depth", async () => {
+    const { delegation, store } = coordinator({ maxDepth: 1 });
+
+    await expect(
+      delegation.delegate(request({ parent: { ...request().parent, depth: 1 } }))
+    ).rejects.toMatchObject({ code: "depth_limit_exceeded" });
+    expect(store.links).toEqual([]);
+  });
+
+  it("propagates cancellation to attached helpers only", async () => {
+    const { delegation } = coordinator();
+    await delegation.delegate(request());
+    await delegation.delegate(request({ childRunId: "run-child-2" }));
+    await delegation.detach({
+      businessId: "biz-1",
+      parentRunId: "run-parent",
+      childRunId: "run-child-2",
+      now: "2026-07-25T10:05:00.000Z",
+    });
+
+    expect(await delegation.cancellationTargets("biz-1", "run-parent")).toEqual(["run-child"]);
+  });
+
+  it("accepts a helper Artifact only when it matches the declared schema", async () => {
+    const { delegation } = coordinator();
+    const schema = {
+      type: "object",
+      required: ["summary"],
+      properties: { summary: { type: "string" } },
+    };
+
+    const accepted = delegation.acceptArtifact({
+      childRunId: "run-child",
+      schemaRef: "helper.summary.v1",
+      schema,
+      value: { summary: "no regressions found" },
+    });
+    expect(accepted).toMatchObject({
+      outcome: "accepted",
+      artifact: { childRunId: "run-child", schemaRef: "helper.summary.v1" },
+    });
+
+    expect(
+      delegation.acceptArtifact({
+        childRunId: "run-child",
+        schemaRef: "helper.summary.v1",
+        schema,
+        value: { summary: 42 },
+      })
+    ).toMatchObject({ outcome: "rejected", reason: "artifact_schema_mismatch" });
+  });
+
+  it("records the narrowed authority on the durable link, not the requested one", async () => {
+    const { delegation, store } = coordinator();
+    await delegation.delegate(request({ requested: { limits: { toolCalls: 3 } } }));
+
+    expect(store.links[0]?.authority).toMatchObject({
+      tools: ["github.issue.read", "knowledge.search"],
+      limits: { toolCalls: 3, costUsd: 5 },
+    });
+  });
+});
+
+// Type-only guard: the error union stays a closed set of reason codes.
+const _codes: DelegationError["code"][] = ["depth_limit_exceeded", "deadline_amplification"];

--- a/packages/agent-runtime/src/delegation/delegate.ts
+++ b/packages/agent-runtime/src/delegation/delegate.ts
@@ -1,0 +1,167 @@
+import type {
+  ChildAuthority,
+  ChildLink,
+  ChildRunManager,
+  RequestedChildAuthority,
+} from "@tulipfarm/run-kernel";
+import { ajv, canonicalHash } from "@tulipfarm/schema";
+
+/**
+ * Agent delegation (SPEC §10). A helper Agent is a child Run, so it inherits the kernel's
+ * non-amplification rules for Tools, classifications, and limits. This module adds the Agent-level
+ * defaults on top: a helper starts read-only, its deadline and depth may only narrow, cancellation
+ * reaches attached helpers only, and a helper reports back through a schema-validated Artifact
+ * rather than free-form text the parent would have to trust.
+ */
+
+export type DelegationMode = "read_only" | "read_write";
+
+export interface DelegationParentContext {
+  readonly authority: ChildAuthority;
+  readonly depth: number;
+  readonly deadlineAt: string;
+}
+
+export interface RequestedDelegation extends RequestedChildAuthority {
+  readonly mode?: DelegationMode;
+  readonly deadlineAt?: string;
+}
+
+export interface DelegationRequest {
+  readonly businessId: string;
+  readonly parentRunId: string;
+  readonly childRunId: string;
+  readonly parent: DelegationParentContext;
+  readonly requested: RequestedDelegation;
+  readonly now: string;
+}
+
+export interface DelegatedHelper {
+  readonly childRunId: string;
+  readonly authority: ChildAuthority;
+  readonly mode: DelegationMode;
+  readonly depth: number;
+  readonly deadlineAt: string;
+  readonly link: ChildLink;
+}
+
+export type DelegationErrorCode = "depth_limit_exceeded" | "deadline_amplification";
+
+/** Delegation denial carrying the reason code and offending field only. */
+export class DelegationError extends Error {
+  readonly name = "DelegationError";
+
+  constructor(
+    readonly code: DelegationErrorCode,
+    readonly field = ""
+  ) {
+    super(`${code}${field ? `:${field}` : ""}`);
+  }
+}
+
+export interface HelperArtifact {
+  readonly childRunId: string;
+  readonly schemaRef: string;
+  readonly value: unknown;
+  readonly digest: string;
+}
+
+export type ArtifactAcceptance =
+  | { readonly outcome: "accepted"; readonly artifact: HelperArtifact }
+  | { readonly outcome: "rejected"; readonly reason: "artifact_schema_mismatch" };
+
+/** Which Tools carry no effect; the broker catalog is the source of truth behind it. */
+export interface ReadOnlyToolOracle {
+  isReadOnly(toolName: string): boolean;
+}
+
+export interface DelegationCoordinatorOptions {
+  readonly children: ChildRunManager;
+  readonly tools: ReadOnlyToolOracle;
+  readonly policy: { readonly maxDepth: number };
+}
+
+export class DelegationCoordinator {
+  constructor(private readonly options: DelegationCoordinatorOptions) {}
+
+  async delegate(request: DelegationRequest): Promise<DelegatedHelper> {
+    const depth = request.parent.depth + 1;
+    if (depth > this.options.policy.maxDepth) {
+      throw new DelegationError("depth_limit_exceeded", "depth");
+    }
+
+    const deadlineAt = request.requested.deadlineAt ?? request.parent.deadlineAt;
+    if (Date.parse(deadlineAt) > Date.parse(request.parent.deadlineAt)) {
+      throw new DelegationError("deadline_amplification", "deadlineAt");
+    }
+
+    const mode = request.requested.mode ?? "read_only";
+    // A helper that did not ask for effects never gets them, even though the parent holds them.
+    const tools =
+      mode === "read_only"
+        ? (request.requested.tools ?? request.parent.authority.tools).filter((tool) =>
+            this.options.tools.isReadOnly(tool)
+          )
+        : request.requested.tools;
+
+    const link = await this.options.children.spawn({
+      businessId: request.businessId,
+      parentRunId: request.parentRunId,
+      childRunId: request.childRunId,
+      parentAuthority: request.parent.authority,
+      requestedAuthority: {
+        ...(tools === undefined ? {} : { tools }),
+        ...(request.requested.classifications === undefined
+          ? {}
+          : { classifications: request.requested.classifications }),
+        ...(request.requested.limits === undefined ? {} : { limits: request.requested.limits }),
+      },
+      now: request.now,
+    });
+
+    return {
+      childRunId: request.childRunId,
+      authority: link.authority,
+      mode,
+      depth,
+      deadlineAt,
+      link,
+    };
+  }
+
+  /** Explicit detach: the helper outlives parent cancellation from this point on. */
+  async detach(input: {
+    businessId: string;
+    parentRunId: string;
+    childRunId: string;
+    now: string;
+  }): Promise<boolean> {
+    return this.options.children.detach(input);
+  }
+
+  async cancellationTargets(businessId: string, parentRunId: string): Promise<readonly string[]> {
+    const attached = await this.options.children.listAttached(businessId, parentRunId);
+    return attached.map((link) => link.childRunId);
+  }
+
+  acceptArtifact(input: {
+    childRunId: string;
+    schemaRef: string;
+    schema: Readonly<Record<string, unknown>>;
+    value: unknown;
+  }): ArtifactAcceptance {
+    const validate = ajv.compile(input.schema);
+    if (!validate(input.value)) {
+      return { outcome: "rejected", reason: "artifact_schema_mismatch" };
+    }
+    return {
+      outcome: "accepted",
+      artifact: {
+        childRunId: input.childRunId,
+        schemaRef: input.schemaRef,
+        value: input.value,
+        digest: canonicalHash({ schemaRef: input.schemaRef, value: input.value }),
+      },
+    };
+  }
+}

--- a/packages/agent-runtime/src/delegation/index.ts
+++ b/packages/agent-runtime/src/delegation/index.ts
@@ -1,0 +1,13 @@
+export type {
+  ArtifactAcceptance,
+  DelegatedHelper,
+  DelegationCoordinatorOptions,
+  DelegationErrorCode,
+  DelegationMode,
+  DelegationParentContext,
+  DelegationRequest,
+  HelperArtifact,
+  ReadOnlyToolOracle,
+  RequestedDelegation,
+} from "./delegate";
+export { DelegationCoordinator, DelegationError } from "./delegate";

--- a/packages/agent-runtime/src/evals/index.ts
+++ b/packages/agent-runtime/src/evals/index.ts
@@ -1,0 +1,12 @@
+export type {
+  ActivationBlockReason,
+  ActivationVerdict,
+  EvalCase,
+  EvalCaseResult,
+  EvalException,
+  EvalReport,
+  EvalSeverity,
+  EvaluateActivationInput,
+  RunEvalSuiteInput,
+} from "./suite";
+export { evaluateActivation, runEvalSuite } from "./suite";

--- a/packages/agent-runtime/src/evals/suite.test.ts
+++ b/packages/agent-runtime/src/evals/suite.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it } from "vitest";
+import {
+  type EvalCase,
+  type EvalCaseResult,
+  type EvalReport,
+  evaluateActivation,
+  runEvalSuite,
+} from "./suite";
+
+function evalCase(overrides: Partial<EvalCase> = {}): EvalCase {
+  return {
+    caseId: "triage-1",
+    version: "1.0.0",
+    severity: "blocking",
+    input: { prompt: "classify this ticket" },
+    expected: { label: "bug" },
+    ...overrides,
+  };
+}
+
+function result(caseId: string, passed: boolean, version = "1.0.0"): EvalCaseResult {
+  return { caseId, version, severity: "blocking", passed };
+}
+
+function report(overrides: Partial<EvalReport> = {}): EvalReport {
+  return {
+    agentId: "triage-agent",
+    agentVersion: "2.0.0",
+    suiteVersion: "1.0.0",
+    results: [result("triage-1", true)],
+    passed: 1,
+    failed: 0,
+    digest: "digest",
+    ...overrides,
+  };
+}
+
+const NOW = new Date("2026-07-25T10:00:00.000Z");
+
+describe("runEvalSuite", () => {
+  it("records a pass/fail per versioned case and a digest of the whole run", async () => {
+    const suiteReport = await runEvalSuite({
+      agentId: "triage-agent",
+      agentVersion: "2.0.0",
+      suiteVersion: "1.0.0",
+      cases: [evalCase(), evalCase({ caseId: "triage-2", expected: { label: "question" } })],
+      execute: async (testCase) =>
+        testCase.caseId === "triage-1" ? { label: "bug" } : { label: "bug" },
+    });
+
+    expect(suiteReport.results).toEqual([
+      { caseId: "triage-1", version: "1.0.0", severity: "blocking", passed: true },
+      { caseId: "triage-2", version: "1.0.0", severity: "blocking", passed: false },
+    ]);
+    expect(suiteReport).toMatchObject({ passed: 1, failed: 1 });
+    expect(suiteReport.digest).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("counts an execution error as a failed case rather than aborting the suite", async () => {
+    const suiteReport = await runEvalSuite({
+      agentId: "triage-agent",
+      agentVersion: "2.0.0",
+      suiteVersion: "1.0.0",
+      cases: [evalCase(), evalCase({ caseId: "triage-2" })],
+      execute: async (testCase) => {
+        if (testCase.caseId === "triage-1") throw new Error("model unavailable");
+        return { label: "bug" };
+      },
+    });
+
+    expect(suiteReport.results.map((entry) => entry.passed)).toEqual([false, true]);
+  });
+
+  it("gives the same digest for the same results and a different one when a case changes", async () => {
+    const run = (expected: unknown) =>
+      runEvalSuite({
+        agentId: "triage-agent",
+        agentVersion: "2.0.0",
+        suiteVersion: "1.0.0",
+        cases: [evalCase({ expected })],
+        execute: async () => ({ label: "bug" }),
+      });
+
+    const first = await run({ label: "bug" });
+    const second = await run({ label: "bug" });
+    const third = await run({ label: "question" });
+
+    expect(first.digest).toBe(second.digest);
+    expect(third.digest).not.toBe(first.digest);
+  });
+});
+
+describe("evaluateActivation", () => {
+  it("activates an action-capable Agent whose blocking cases all pass", () => {
+    expect(evaluateActivation({ report: report(), actionCapable: true, now: NOW })).toMatchObject({
+      decision: "allowed",
+    });
+  });
+
+  it("blocks an action-capable Agent on a regression against the baseline", () => {
+    const verdict = evaluateActivation({
+      report: report({ results: [result("triage-1", false)], passed: 0, failed: 1 }),
+      baseline: report(),
+      actionCapable: true,
+      now: NOW,
+    });
+
+    expect(verdict).toMatchObject({ decision: "blocked", reason: "eval_regression" });
+    expect(verdict.decision === "blocked" && verdict.regressedCaseIds).toEqual(["triage-1"]);
+  });
+
+  it("blocks a failing blocking case even with no baseline to regress against", () => {
+    expect(
+      evaluateActivation({
+        report: report({ results: [result("triage-1", false)], passed: 0, failed: 1 }),
+        actionCapable: true,
+        now: NOW,
+      })
+    ).toMatchObject({ decision: "blocked", reason: "blocking_case_failed" });
+  });
+
+  it("does not block on an advisory case", () => {
+    expect(
+      evaluateActivation({
+        report: report({
+          results: [{ caseId: "style-1", version: "1.0.0", severity: "advisory", passed: false }],
+          passed: 0,
+          failed: 1,
+        }),
+        actionCapable: true,
+        now: NOW,
+      })
+    ).toMatchObject({ decision: "allowed" });
+  });
+
+  it("allows a read-only Agent to publish while its blocking case fails", () => {
+    expect(
+      evaluateActivation({
+        report: report({ results: [result("triage-1", false)], passed: 0, failed: 1 }),
+        baseline: report(),
+        actionCapable: false,
+        now: NOW,
+      })
+    ).toMatchObject({ decision: "allowed" });
+  });
+
+  it("allows a regression covered by a scoped, unexpired, audited admin exception", () => {
+    const verdict = evaluateActivation({
+      report: report({ results: [result("triage-1", false)], passed: 0, failed: 1 }),
+      baseline: report(),
+      actionCapable: true,
+      now: NOW,
+      exception: {
+        exceptionId: "exc-1",
+        agentId: "triage-agent",
+        caseIds: ["triage-1"],
+        grantedBy: "user:admin-1",
+        grantedByRole: "admin",
+        expiresAt: "2026-07-26T10:00:00.000Z",
+        auditEventId: "audit-1",
+        reason: "known upstream flake, fix tracked",
+      },
+    });
+
+    expect(verdict).toMatchObject({ decision: "allowed", exceptionId: "exc-1" });
+  });
+
+  it("rejects an expired exception", () => {
+    expect(
+      evaluateActivation({
+        report: report({ results: [result("triage-1", false)], passed: 0, failed: 1 }),
+        baseline: report(),
+        actionCapable: true,
+        now: NOW,
+        exception: {
+          exceptionId: "exc-1",
+          agentId: "triage-agent",
+          caseIds: ["triage-1"],
+          grantedBy: "user:admin-1",
+          grantedByRole: "admin",
+          expiresAt: "2026-07-24T10:00:00.000Z",
+          auditEventId: "audit-1",
+          reason: "stale",
+        },
+      })
+    ).toMatchObject({ decision: "blocked", reason: "eval_regression" });
+  });
+
+  it("rejects an exception scoped to another Agent or another case", () => {
+    const base = {
+      report: report({ results: [result("triage-1", false)], passed: 0, failed: 1 }),
+      baseline: report(),
+      actionCapable: true,
+      now: NOW,
+    };
+    const exception = {
+      exceptionId: "exc-1",
+      agentId: "triage-agent",
+      caseIds: ["triage-1"],
+      grantedBy: "user:admin-1",
+      grantedByRole: "admin" as const,
+      expiresAt: "2026-07-26T10:00:00.000Z",
+      auditEventId: "audit-1",
+      reason: "scoped",
+    };
+
+    expect(
+      evaluateActivation({ ...base, exception: { ...exception, agentId: "other-agent" } })
+    ).toMatchObject({ decision: "blocked" });
+    expect(
+      evaluateActivation({ ...base, exception: { ...exception, caseIds: ["triage-2"] } })
+    ).toMatchObject({ decision: "blocked" });
+  });
+
+  it("rejects an unaudited or non-admin exception", () => {
+    const base = {
+      report: report({ results: [result("triage-1", false)], passed: 0, failed: 1 }),
+      baseline: report(),
+      actionCapable: true,
+      now: NOW,
+    };
+    const exception = {
+      exceptionId: "exc-1",
+      agentId: "triage-agent",
+      caseIds: ["triage-1"],
+      grantedBy: "user:admin-1",
+      grantedByRole: "admin" as const,
+      expiresAt: "2026-07-26T10:00:00.000Z",
+      auditEventId: "audit-1",
+      reason: "scoped",
+    };
+
+    expect(
+      evaluateActivation({
+        ...base,
+        exception: { ...exception, grantedByRole: "member" as unknown as "admin" },
+      })
+    ).toMatchObject({ decision: "blocked" });
+    expect(
+      evaluateActivation({ ...base, exception: { ...exception, auditEventId: "" } })
+    ).toMatchObject({ decision: "blocked" });
+  });
+
+  it("blocks when the report was produced against a different Agent version", () => {
+    expect(
+      evaluateActivation({
+        report: report({ agentVersion: "1.9.0" }),
+        actionCapable: true,
+        now: NOW,
+        publishingVersion: "2.0.0",
+      })
+    ).toMatchObject({ decision: "blocked", reason: "stale_eval_report" });
+  });
+});

--- a/packages/agent-runtime/src/evals/suite.ts
+++ b/packages/agent-runtime/src/evals/suite.ts
@@ -1,0 +1,178 @@
+import { canonicalHash } from "@tulipfarm/schema";
+
+/**
+ * Agent eval suite and activation gate (SPEC §10). Publishing an action-capable Agent is gated on
+ * evidence, not intent: every blocking case must pass, and a case that used to pass and now fails
+ * blocks activation. The only way past a regression is a named admin exception that is scoped to
+ * this Agent and these cases, expires, and points at its own audit event — so the bypass is itself
+ * a durable, reviewable fact rather than a flag someone can leave on.
+ */
+
+export type EvalSeverity = "blocking" | "advisory";
+
+export interface EvalCase {
+  readonly caseId: string;
+  /** Cases are versioned: changing expectations produces a new version, never a silent edit. */
+  readonly version: string;
+  readonly severity: EvalSeverity;
+  readonly input: unknown;
+  readonly expected: unknown;
+}
+
+export interface EvalCaseResult {
+  readonly caseId: string;
+  readonly version: string;
+  readonly severity: EvalSeverity;
+  readonly passed: boolean;
+}
+
+export interface EvalReport {
+  readonly agentId: string;
+  readonly agentVersion: string;
+  readonly suiteVersion: string;
+  readonly results: readonly EvalCaseResult[];
+  readonly passed: number;
+  readonly failed: number;
+  readonly digest: string;
+}
+
+export interface RunEvalSuiteInput {
+  readonly agentId: string;
+  readonly agentVersion: string;
+  readonly suiteVersion: string;
+  readonly cases: readonly EvalCase[];
+  execute(testCase: EvalCase): Promise<unknown>;
+  /** Defaults to canonical-digest equality against `expected`. */
+  matches?(testCase: EvalCase, actual: unknown): boolean;
+}
+
+export async function runEvalSuite(input: RunEvalSuiteInput): Promise<EvalReport> {
+  const matches =
+    input.matches ??
+    ((testCase: EvalCase, actual: unknown) =>
+      canonicalHash(testCase.expected) === canonicalHash(actual));
+
+  const results: EvalCaseResult[] = [];
+  for (const testCase of input.cases) {
+    let passed: boolean;
+    try {
+      passed = matches(testCase, await input.execute(testCase));
+    } catch {
+      // An Agent that cannot answer a case has not passed it.
+      passed = false;
+    }
+    results.push({
+      caseId: testCase.caseId,
+      version: testCase.version,
+      severity: testCase.severity,
+      passed,
+    });
+  }
+
+  return {
+    agentId: input.agentId,
+    agentVersion: input.agentVersion,
+    suiteVersion: input.suiteVersion,
+    results,
+    passed: results.filter((entry) => entry.passed).length,
+    failed: results.filter((entry) => !entry.passed).length,
+    digest: canonicalHash({
+      agentId: input.agentId,
+      agentVersion: input.agentVersion,
+      suiteVersion: input.suiteVersion,
+      cases: input.cases.map((testCase) => ({
+        caseId: testCase.caseId,
+        version: testCase.version,
+        expected: testCase.expected,
+      })),
+      results,
+    }),
+  };
+}
+
+/** Named, expiring, audited admin permission to activate over a specific regression. */
+export interface EvalException {
+  readonly exceptionId: string;
+  readonly agentId: string;
+  readonly caseIds: readonly string[];
+  readonly grantedBy: string;
+  readonly grantedByRole: "admin";
+  readonly expiresAt: string;
+  readonly auditEventId: string;
+  readonly reason: string;
+}
+
+export type ActivationBlockReason =
+  | "eval_regression"
+  | "blocking_case_failed"
+  | "stale_eval_report";
+
+export type ActivationVerdict =
+  | { readonly decision: "allowed"; readonly exceptionId?: string }
+  | {
+      readonly decision: "blocked";
+      readonly reason: ActivationBlockReason;
+      readonly regressedCaseIds: readonly string[];
+      readonly failedCaseIds: readonly string[];
+    };
+
+export interface EvaluateActivationInput {
+  readonly report: EvalReport;
+  readonly baseline?: EvalReport;
+  readonly actionCapable: boolean;
+  readonly now: Date;
+  /** Version being published; a report for a different version is stale evidence. */
+  readonly publishingVersion?: string;
+  readonly exception?: EvalException;
+}
+
+export function evaluateActivation(input: EvaluateActivationInput): ActivationVerdict {
+  if (
+    input.publishingVersion !== undefined &&
+    input.publishingVersion !== input.report.agentVersion
+  ) {
+    return blocked("stale_eval_report", [], []);
+  }
+
+  const failed = input.report.results.filter(
+    (entry) => !entry.passed && entry.severity === "blocking"
+  );
+  if (failed.length === 0) return { decision: "allowed" };
+
+  // A read-only Agent cannot act on a wrong answer, so its evals inform rather than gate.
+  if (!input.actionCapable) return { decision: "allowed" };
+
+  const baselinePassed = new Set(
+    (input.baseline?.results ?? []).filter((entry) => entry.passed).map((entry) => entry.caseId)
+  );
+  const regressed = failed.filter((entry) => baselinePassed.has(entry.caseId));
+  const failedCaseIds = failed.map((entry) => entry.caseId);
+  const regressedCaseIds = regressed.map((entry) => entry.caseId);
+
+  if (regressed.length === 0) {
+    return blocked("blocking_case_failed", regressedCaseIds, failedCaseIds);
+  }
+
+  const exception = input.exception;
+  const covered =
+    exception !== undefined &&
+    exception.agentId === input.report.agentId &&
+    exception.grantedByRole === "admin" &&
+    exception.auditEventId !== "" &&
+    exception.grantedBy !== "" &&
+    Date.parse(exception.expiresAt) > input.now.getTime() &&
+    failedCaseIds.every((caseId) => exception.caseIds.includes(caseId));
+
+  if (covered && exception !== undefined) {
+    return { decision: "allowed", exceptionId: exception.exceptionId };
+  }
+  return blocked("eval_regression", regressedCaseIds, failedCaseIds);
+}
+
+function blocked(
+  reason: ActivationBlockReason,
+  regressedCaseIds: readonly string[],
+  failedCaseIds: readonly string[]
+): ActivationVerdict {
+  return { decision: "blocked", reason, regressedCaseIds, failedCaseIds };
+}

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -1,4 +1,7 @@
 export * from "./context";
+export * from "./delegation";
+export * from "./evals";
+export * from "./loop";
 export * from "./models";
 export type {
   ModelInvocationRequest,

--- a/packages/agent-runtime/src/loop/checkpoint.ts
+++ b/packages/agent-runtime/src/loop/checkpoint.ts
@@ -1,0 +1,30 @@
+/**
+ * Durable loop counters (SPEC §10). Limits are only real if they survive a crash: a resumed Agent
+ * State continues from the persisted counters instead of restarting its iteration, Tool-call, and
+ * repair budgets from zero.
+ */
+export interface AgentLoopCheckpoint {
+  readonly businessId: string;
+  readonly runId: string;
+  readonly stateId: string;
+  readonly iterations: number;
+  readonly toolCalls: number;
+  readonly repairs: number;
+}
+
+export interface LoopCheckpointStore {
+  load(runId: string, stateId: string): Promise<AgentLoopCheckpoint | undefined>;
+  save(checkpoint: AgentLoopCheckpoint): Promise<void>;
+}
+
+export class InMemoryLoopCheckpointStore implements LoopCheckpointStore {
+  private readonly checkpoints = new Map<string, AgentLoopCheckpoint>();
+
+  async load(runId: string, stateId: string): Promise<AgentLoopCheckpoint | undefined> {
+    return this.checkpoints.get(`${runId}/${stateId}`);
+  }
+
+  async save(checkpoint: AgentLoopCheckpoint): Promise<void> {
+    this.checkpoints.set(`${checkpoint.runId}/${checkpoint.stateId}`, checkpoint);
+  }
+}

--- a/packages/agent-runtime/src/loop/index.ts
+++ b/packages/agent-runtime/src/loop/index.ts
@@ -1,0 +1,18 @@
+export type { AgentLoopCheckpoint, LoopCheckpointStore } from "./checkpoint";
+export { InMemoryLoopCheckpointStore } from "./checkpoint";
+export type {
+  AgentLoopBudgetPort,
+  AgentLoopDependencies,
+  AgentLoopEvent,
+  AgentLoopEventSink,
+  AgentLoopEventType,
+  AgentLoopFailureReason,
+  AgentLoopInput,
+  AgentLoopLimits,
+  AgentLoopOutcome,
+  ExposedTool,
+  ToolDispatchPort,
+  ToolDispatchRequest,
+  ToolDispatchResult,
+} from "./loop";
+export { AgentLoop } from "./loop";

--- a/packages/agent-runtime/src/loop/loop.test.ts
+++ b/packages/agent-runtime/src/loop/loop.test.ts
@@ -1,0 +1,357 @@
+import { describe, expect, it } from "vitest";
+import type { ModelInvocationResult, ModelPort } from "../ports";
+import { InMemoryLoopCheckpointStore } from "./checkpoint";
+import {
+  AgentLoop,
+  type AgentLoopEvent,
+  type AgentLoopInput,
+  type ToolDispatchPort,
+  type ToolDispatchResult,
+} from "./loop";
+
+function textResult(text: string): ModelInvocationResult {
+  return {
+    requestId: "req",
+    output: { kind: "text", text },
+    usage: { inputTokens: 5, outputTokens: 5 },
+  };
+}
+
+function toolCallResult(
+  calls: readonly { callId: string; name: string; arguments: unknown }[]
+): ModelInvocationResult {
+  return {
+    requestId: "req",
+    output: { kind: "tool_calls", calls },
+    usage: { inputTokens: 5, outputTokens: 5 },
+  };
+}
+
+function scriptedModel(...results: readonly ModelInvocationResult[]): ModelPort & {
+  requests: number;
+} {
+  const queue = [...results];
+  const port = {
+    requests: 0,
+    invoke: async () => {
+      port.requests += 1;
+      const next = queue.shift();
+      if (next === undefined) throw new Error("model called more times than scripted");
+      return next;
+    },
+  };
+  return port;
+}
+
+function dispatcher(...results: readonly ToolDispatchResult[]): ToolDispatchPort & {
+  calls: { name: string; arguments: unknown }[];
+} {
+  const queue = [...results];
+  const port = {
+    calls: [] as { name: string; arguments: unknown }[],
+    dispatch: async (call: { name: string; arguments: unknown }) => {
+      port.calls.push({ name: call.name, arguments: call.arguments });
+      return queue.shift() ?? { status: "succeeded" as const, callId: "call-1", output: {} };
+    },
+  };
+  return port;
+}
+
+function input(overrides: Partial<AgentLoopInput> = {}): AgentLoopInput {
+  return {
+    businessId: "biz-1",
+    runId: "run-1",
+    stateId: "state-1",
+    modelProfileId: "primary",
+    contextDigest: "sha256:context",
+    guardrailDigest: "sha256:guardrail",
+    messages: [{ role: "user", content: "triage the issue" }],
+    tools: [{ name: "github.issue.comment", inputSchema: { type: "object", required: ["body"] } }],
+    limits: { maxIterations: 5, maxToolCalls: 3, maxRepairAttempts: 2 },
+    ...overrides,
+  };
+}
+
+function collector() {
+  const events: AgentLoopEvent[] = [];
+  return {
+    events,
+    sink: {
+      append: async (event: AgentLoopEvent) => {
+        events.push(event);
+      },
+    },
+  };
+}
+
+function loop(options: {
+  model: ModelPort;
+  tools?: ToolDispatchPort;
+  checkpoints?: InMemoryLoopCheckpointStore;
+  events?: { append: (event: AgentLoopEvent) => Promise<void> };
+  budget?: { consume: (input: { key: string; amount: number }) => Promise<{ outcome: string }> };
+  cancelled?: () => Promise<boolean>;
+}) {
+  return new AgentLoop({
+    model: options.model,
+    tools: options.tools ?? dispatcher(),
+    checkpoints: options.checkpoints ?? new InMemoryLoopCheckpointStore(),
+    events: options.events ?? collector().sink,
+    budget: options.budget ?? { consume: async () => ({ outcome: "allowed" }) },
+    isCancelled: options.cancelled ?? (async () => false),
+  });
+}
+
+describe("AgentLoop", () => {
+  it("returns the model answer without dispatching a Tool", async () => {
+    const tools = dispatcher();
+    const outcome = await loop({ model: scriptedModel(textResult("done")), tools }).run(input());
+
+    expect(outcome).toMatchObject({ status: "completed", iterations: 1, toolCalls: 0 });
+    expect(tools.calls).toEqual([]);
+  });
+
+  it("routes every Tool call through the broker dispatcher and feeds results back", async () => {
+    const tools = dispatcher({ status: "succeeded", callId: "call-1", output: { ok: true } });
+    const outcome = await loop({
+      model: scriptedModel(
+        toolCallResult([
+          { callId: "call-1", name: "github.issue.comment", arguments: { body: "hi" } },
+        ]),
+        textResult("commented")
+      ),
+      tools,
+    }).run(input());
+
+    expect(tools.calls).toEqual([{ name: "github.issue.comment", arguments: { body: "hi" } }]);
+    expect(outcome).toMatchObject({ status: "completed", toolCalls: 1, iterations: 2 });
+  });
+
+  it("feeds a denial back as data and never retries the denied call itself", async () => {
+    const tools = dispatcher({
+      status: "denied",
+      callId: "call-1",
+      reason: "authorization_denied",
+    });
+    const outcome = await loop({
+      model: scriptedModel(
+        toolCallResult([
+          { callId: "call-1", name: "github.issue.comment", arguments: { body: "hi" } },
+        ]),
+        textResult("cannot do that")
+      ),
+      tools,
+    }).run(input());
+
+    expect(tools.calls).toHaveLength(1);
+    expect(outcome).toMatchObject({ status: "completed" });
+  });
+
+  it("repairs a malformed Tool call within the repair budget", async () => {
+    const tools = dispatcher(
+      { status: "invalid_arguments", callId: "call-1", reason: "invalid_arguments" },
+      { status: "succeeded", callId: "call-2", output: {} }
+    );
+    const outcome = await loop({
+      model: scriptedModel(
+        toolCallResult([{ callId: "call-1", name: "github.issue.comment", arguments: {} }]),
+        toolCallResult([
+          { callId: "call-2", name: "github.issue.comment", arguments: { body: "hi" } },
+        ]),
+        textResult("fixed")
+      ),
+      tools,
+    }).run(input());
+
+    expect(outcome).toMatchObject({ status: "completed", repairs: 1 });
+  });
+
+  it("fails closed once the repair budget is spent", async () => {
+    const tools = dispatcher(
+      { status: "invalid_arguments", callId: "call-1", reason: "invalid_arguments" },
+      { status: "invalid_arguments", callId: "call-2", reason: "invalid_arguments" },
+      { status: "invalid_arguments", callId: "call-3", reason: "invalid_arguments" }
+    );
+    const outcome = await loop({
+      model: scriptedModel(
+        toolCallResult([{ callId: "call-1", name: "github.issue.comment", arguments: {} }]),
+        toolCallResult([{ callId: "call-2", name: "github.issue.comment", arguments: {} }]),
+        toolCallResult([{ callId: "call-3", name: "github.issue.comment", arguments: {} }])
+      ),
+      tools,
+    }).run(input());
+
+    expect(outcome).toMatchObject({ status: "failed", reason: "repair_budget_exhausted" });
+  });
+
+  it("normalizes a provider that omits or repeats a call id", async () => {
+    const tools = dispatcher({ status: "succeeded", callId: "call-1", output: {} });
+    const outcome = await loop({
+      model: scriptedModel(
+        toolCallResult([
+          { callId: "", name: "github.issue.comment", arguments: { body: "a" } },
+          { callId: "", name: "github.issue.comment", arguments: { body: "b" } },
+        ]),
+        textResult("done")
+      ),
+      tools,
+    }).run(input());
+
+    expect(tools.calls).toHaveLength(2);
+    expect(outcome).toMatchObject({ status: "completed", toolCalls: 2 });
+  });
+
+  it("denies a Tool the caller never exposed to the model", async () => {
+    const tools = dispatcher();
+    const outcome = await loop({
+      model: scriptedModel(
+        toolCallResult([{ callId: "call-1", name: "shell.exec", arguments: {} }]),
+        textResult("ok")
+      ),
+      tools,
+    }).run(input());
+
+    expect(tools.calls).toEqual([]);
+    expect(outcome).toMatchObject({ status: "completed" });
+  });
+
+  it("stops at the iteration limit instead of looping forever", async () => {
+    const outcome = await loop({
+      model: scriptedModel(
+        toolCallResult([{ callId: "c1", name: "github.issue.comment", arguments: { body: "1" } }]),
+        toolCallResult([{ callId: "c2", name: "github.issue.comment", arguments: { body: "2" } }])
+      ),
+      tools: dispatcher(
+        { status: "succeeded", callId: "c1", output: {} },
+        { status: "succeeded", callId: "c2", output: {} }
+      ),
+    }).run(input({ limits: { maxIterations: 2, maxToolCalls: 9, maxRepairAttempts: 2 } }));
+
+    expect(outcome).toMatchObject({ status: "failed", reason: "iteration_limit" });
+  });
+
+  it("stops at the Tool-call limit", async () => {
+    const outcome = await loop({
+      model: scriptedModel(
+        toolCallResult([{ callId: "c1", name: "github.issue.comment", arguments: { body: "1" } }]),
+        toolCallResult([{ callId: "c2", name: "github.issue.comment", arguments: { body: "2" } }])
+      ),
+      tools: dispatcher(
+        { status: "succeeded", callId: "c1", output: {} },
+        { status: "succeeded", callId: "c2", output: {} }
+      ),
+    }).run(input({ limits: { maxIterations: 9, maxToolCalls: 1, maxRepairAttempts: 2 } }));
+
+    expect(outcome).toMatchObject({ status: "failed", reason: "tool_call_limit" });
+  });
+
+  it("stops when the durable budget is exhausted", async () => {
+    const outcome = await loop({
+      model: scriptedModel(textResult("done")),
+      budget: { consume: async () => ({ outcome: "exhausted" }) },
+    }).run(input());
+
+    expect(outcome).toMatchObject({ status: "failed", reason: "budget_exhausted" });
+  });
+
+  it("yields cancellation before calling the model again", async () => {
+    const model = scriptedModel(
+      toolCallResult([{ callId: "c1", name: "github.issue.comment", arguments: { body: "1" } }])
+    );
+    let checks = 0;
+    const outcome = await loop({
+      model,
+      tools: dispatcher({ status: "succeeded", callId: "c1", output: {} }),
+      cancelled: async () => {
+        checks += 1;
+        return checks > 1;
+      },
+    }).run(input());
+
+    expect(outcome).toMatchObject({ status: "cancelled" });
+    expect(model.requests).toBe(1);
+  });
+
+  it("yields a durable wait when a Tool call needs Approval", async () => {
+    const outcome = await loop({
+      model: scriptedModel(
+        toolCallResult([{ callId: "c1", name: "github.issue.comment", arguments: { body: "1" } }])
+      ),
+      tools: dispatcher({ status: "awaiting_approval", callId: "c1", approvalId: "appr-1" }),
+    }).run(input());
+
+    expect(outcome).toMatchObject({ status: "awaiting_approval", approvalId: "appr-1" });
+  });
+
+  it("AJV-validates structured output and repairs an invalid one", async () => {
+    const outcome = await loop({
+      model: scriptedModel(
+        {
+          requestId: "req",
+          output: { kind: "structured", value: { label: 5 } },
+          usage: { inputTokens: 1, outputTokens: 1 },
+        },
+        {
+          requestId: "req",
+          output: { kind: "structured", value: { label: "bug" } },
+          usage: { inputTokens: 1, outputTokens: 1 },
+        }
+      ),
+    }).run(
+      input({
+        outputSchema: {
+          type: "object",
+          required: ["label"],
+          properties: { label: { type: "string" } },
+        },
+      })
+    );
+
+    expect(outcome).toMatchObject({ status: "completed", output: { label: "bug" }, repairs: 1 });
+  });
+
+  it("resumes from the persisted checkpoint after a crash rather than restarting limits", async () => {
+    const checkpoints = new InMemoryLoopCheckpointStore();
+    await checkpoints.save({
+      businessId: "biz-1",
+      runId: "run-1",
+      stateId: "state-1",
+      iterations: 2,
+      toolCalls: 2,
+      repairs: 0,
+    });
+
+    const outcome = await loop({
+      model: scriptedModel(
+        toolCallResult([{ callId: "c1", name: "github.issue.comment", arguments: { body: "1" } }])
+      ),
+      tools: dispatcher({ status: "succeeded", callId: "c1", output: {} }),
+      checkpoints,
+    }).run(input({ limits: { maxIterations: 9, maxToolCalls: 2, maxRepairAttempts: 2 } }));
+
+    expect(outcome).toMatchObject({ status: "failed", reason: "tool_call_limit" });
+  });
+
+  it("emits durable, content-free loop events for stream recovery", async () => {
+    const events = collector();
+    await loop({
+      model: scriptedModel(
+        toolCallResult([
+          { callId: "c1", name: "github.issue.comment", arguments: { body: "s3cret" } },
+        ]),
+        textResult("done")
+      ),
+      tools: dispatcher({ status: "succeeded", callId: "c1", output: {} }),
+      events: events.sink,
+    }).run(input());
+
+    expect(events.events.map((event) => event.type)).toEqual([
+      "iteration_started",
+      "tool_call_dispatched",
+      "iteration_started",
+      "completed",
+    ]);
+    expect(events.events.map((event) => event.sequence)).toEqual([1, 2, 3, 4]);
+    expect(JSON.stringify(events.events)).not.toContain("s3cret");
+  });
+});

--- a/packages/agent-runtime/src/loop/loop.ts
+++ b/packages/agent-runtime/src/loop/loop.ts
@@ -1,0 +1,389 @@
+import { ajv } from "@tulipfarm/schema";
+import type { ModelInvocationRequest, ModelMessage, ModelPort } from "../ports";
+import type { AgentLoopCheckpoint, LoopCheckpointStore } from "./checkpoint";
+
+/**
+ * Bounded, durable Agent Tool loop (SPEC §10).
+ *
+ * Invariants this file exists to hold:
+ * - The Tool broker is the only effect path. The loop never executes a Tool, and a Tool the caller
+ *   did not expose is refused here rather than handed to the broker.
+ * - Model output is untrusted data. Denials, malformed calls, and schema-invalid structured output
+ *   come back as transcript content, never as control flow the model can widen.
+ * - Every loop, Tool-call, repair, and budget limit is checked against durable counters, so a
+ *   resumed State cannot buy itself a fresh budget by crashing.
+ */
+
+export interface AgentLoopLimits {
+  readonly maxIterations: number;
+  readonly maxToolCalls: number;
+  readonly maxRepairAttempts: number;
+}
+
+export interface ExposedTool {
+  readonly name: string;
+  readonly description?: string;
+  readonly inputSchema: Readonly<Record<string, unknown>>;
+}
+
+export interface AgentLoopInput {
+  readonly businessId: string;
+  readonly runId: string;
+  readonly stateId: string;
+  readonly modelProfileId: string;
+  /** Digest of the Context manifest the messages were assembled from. */
+  readonly contextDigest: string;
+  readonly guardrailDigest: string;
+  readonly messages: readonly ModelMessage[];
+  readonly tools: readonly ExposedTool[];
+  readonly limits: AgentLoopLimits;
+  readonly outputSchema?: Readonly<Record<string, unknown>>;
+}
+
+export interface ToolDispatchRequest {
+  readonly businessId: string;
+  readonly runId: string;
+  readonly stateId: string;
+  readonly callId: string;
+  readonly name: string;
+  readonly arguments: unknown;
+}
+
+export type ToolDispatchResult =
+  | { readonly status: "succeeded"; readonly callId: string; readonly output: unknown }
+  | { readonly status: "denied"; readonly callId: string; readonly reason: string }
+  | { readonly status: "invalid_arguments"; readonly callId: string; readonly reason: string }
+  | { readonly status: "failed"; readonly callId: string; readonly reason: string }
+  | {
+      readonly status: "awaiting_approval";
+      readonly callId: string;
+      readonly approvalId: string;
+    };
+
+/** The broker-backed effect boundary. Authorization, validation, and effects all live behind it. */
+export interface ToolDispatchPort {
+  dispatch(request: ToolDispatchRequest): Promise<ToolDispatchResult>;
+}
+
+export type AgentLoopEventType =
+  | "iteration_started"
+  | "tool_call_dispatched"
+  | "tool_call_rejected"
+  | "awaiting_approval"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
+/**
+ * Persisted, content-free loop event. Consumers stream by `sequence`, so a reconnecting client
+ * resumes from its cursor instead of replaying the model.
+ */
+export interface AgentLoopEvent {
+  readonly sequence: number;
+  readonly businessId: string;
+  readonly runId: string;
+  readonly stateId: string;
+  readonly type: AgentLoopEventType;
+  readonly iteration: number;
+  readonly toolName?: string;
+  readonly callId?: string;
+  readonly outcome?: string;
+  readonly occurredAt: string;
+}
+
+export interface AgentLoopEventSink {
+  append(event: AgentLoopEvent): Promise<void>;
+}
+
+/** Structural view of the Run kernel budget manager: charge before use, fail closed. */
+export interface AgentLoopBudgetPort {
+  consume(input: { key: string; amount: number }): Promise<{ outcome: string }>;
+}
+
+export type AgentLoopFailureReason =
+  | "iteration_limit"
+  | "tool_call_limit"
+  | "repair_budget_exhausted"
+  | "budget_exhausted"
+  | "model_error";
+
+export type AgentLoopOutcome =
+  | {
+      readonly status: "completed";
+      readonly output: unknown;
+      readonly iterations: number;
+      readonly toolCalls: number;
+      readonly repairs: number;
+    }
+  | {
+      readonly status: "failed";
+      readonly reason: AgentLoopFailureReason;
+      readonly iterations: number;
+      readonly toolCalls: number;
+      readonly repairs: number;
+    }
+  | {
+      readonly status: "awaiting_approval";
+      readonly approvalId: string;
+      readonly callId: string;
+      readonly iterations: number;
+      readonly toolCalls: number;
+      readonly repairs: number;
+    }
+  | {
+      readonly status: "cancelled";
+      readonly iterations: number;
+      readonly toolCalls: number;
+      readonly repairs: number;
+    };
+
+export interface AgentLoopDependencies {
+  readonly model: ModelPort;
+  readonly tools: ToolDispatchPort;
+  readonly checkpoints: LoopCheckpointStore;
+  readonly events: AgentLoopEventSink;
+  readonly budget: AgentLoopBudgetPort;
+  isCancelled(): Promise<boolean>;
+  now?(): Date;
+}
+
+const ITERATION_BUDGET_KEY = "agent_loop_iterations";
+const TOKEN_BUDGET_KEY = "agent_loop_tokens";
+
+type CompiledValidator = ReturnType<typeof ajv.compile>;
+
+export class AgentLoop {
+  constructor(private readonly deps: AgentLoopDependencies) {}
+
+  async run(input: AgentLoopInput): Promise<AgentLoopOutcome> {
+    const resumed = await this.deps.checkpoints.load(input.runId, input.stateId);
+    const counters = {
+      iterations: resumed?.iterations ?? 0,
+      toolCalls: resumed?.toolCalls ?? 0,
+      repairs: resumed?.repairs ?? 0,
+    };
+
+    const exposed = new Map(input.tools.map((tool) => [tool.name, tool]));
+    const validate = input.outputSchema === undefined ? undefined : ajv.compile(input.outputSchema);
+    const messages: ModelMessage[] = [...input.messages];
+    let sequence = 0;
+
+    const emit = async (
+      type: AgentLoopEventType,
+      extra: Partial<Pick<AgentLoopEvent, "toolName" | "callId" | "outcome">> = {}
+    ): Promise<void> => {
+      sequence += 1;
+      await this.deps.events.append({
+        sequence,
+        businessId: input.businessId,
+        runId: input.runId,
+        stateId: input.stateId,
+        type,
+        iteration: counters.iterations,
+        occurredAt: (this.deps.now?.() ?? new Date()).toISOString(),
+        ...extra,
+      });
+    };
+
+    const checkpoint = async (): Promise<void> => {
+      const next: AgentLoopCheckpoint = {
+        businessId: input.businessId,
+        runId: input.runId,
+        stateId: input.stateId,
+        ...counters,
+      };
+      await this.deps.checkpoints.save(next);
+    };
+
+    const finish = async (
+      outcome: AgentLoopOutcome,
+      type: AgentLoopEventType
+    ): Promise<AgentLoopOutcome> => {
+      await checkpoint();
+      await emit(type);
+      return outcome;
+    };
+
+    for (;;) {
+      if (await this.deps.isCancelled()) {
+        return finish({ status: "cancelled", ...counters }, "cancelled");
+      }
+
+      if (counters.iterations + 1 > input.limits.maxIterations) {
+        return finish({ status: "failed", reason: "iteration_limit", ...counters }, "failed");
+      }
+
+      const iterationBudget = await this.deps.budget.consume({
+        key: ITERATION_BUDGET_KEY,
+        amount: 1,
+      });
+      if (iterationBudget.outcome === "exhausted") {
+        return finish({ status: "failed", reason: "budget_exhausted", ...counters }, "failed");
+      }
+
+      counters.iterations += 1;
+      await emit("iteration_started");
+
+      const request: ModelInvocationRequest = {
+        requestId: `${input.runId}:${input.stateId}:${counters.iterations}`,
+        modelProfileId: input.modelProfileId,
+        messages,
+        tools: input.tools,
+        ...(input.outputSchema === undefined ? {} : { outputSchema: input.outputSchema }),
+      };
+
+      let result: Awaited<ReturnType<ModelPort["invoke"]>>;
+      try {
+        result = await this.deps.model.invoke(request);
+      } catch {
+        return finish({ status: "failed", reason: "model_error", ...counters }, "failed");
+      }
+
+      const tokenBudget = await this.deps.budget.consume({
+        key: TOKEN_BUDGET_KEY,
+        amount: result.usage.inputTokens + result.usage.outputTokens,
+      });
+      if (tokenBudget.outcome === "exhausted") {
+        return finish({ status: "failed", reason: "budget_exhausted", ...counters }, "failed");
+      }
+
+      if (result.output.kind === "tool_calls") {
+        const calls = normalizeCalls(result.output.calls, counters.iterations);
+        let approval: { approvalId: string; callId: string } | undefined;
+
+        for (const call of calls) {
+          const tool = exposed.get(call.name);
+          if (tool === undefined) {
+            // A Tool the caller never exposed is refused here; the broker never sees it.
+            messages.push(toolMessage(call.callId, { error: "tool_not_available" }));
+            await emit("tool_call_rejected", {
+              toolName: call.name,
+              callId: call.callId,
+              outcome: "tool_not_available",
+            });
+            continue;
+          }
+
+          if (counters.toolCalls + 1 > input.limits.maxToolCalls) {
+            return finish({ status: "failed", reason: "tool_call_limit", ...counters }, "failed");
+          }
+
+          const dispatched = await this.deps.tools.dispatch({
+            businessId: input.businessId,
+            runId: input.runId,
+            stateId: input.stateId,
+            callId: call.callId,
+            name: call.name,
+            arguments: call.arguments,
+          });
+          counters.toolCalls += 1;
+          await emit("tool_call_dispatched", {
+            toolName: call.name,
+            callId: call.callId,
+            outcome: dispatched.status,
+          });
+
+          if (dispatched.status === "awaiting_approval") {
+            approval = { approvalId: dispatched.approvalId, callId: call.callId };
+            break;
+          }
+
+          if (dispatched.status === "invalid_arguments") {
+            counters.repairs += 1;
+            if (counters.repairs > input.limits.maxRepairAttempts) {
+              return finish(
+                { status: "failed", reason: "repair_budget_exhausted", ...counters },
+                "failed"
+              );
+            }
+            messages.push(
+              toolMessage(call.callId, { error: "invalid_arguments", detail: dispatched.reason })
+            );
+            continue;
+          }
+
+          if (dispatched.status === "succeeded") {
+            messages.push(toolMessage(call.callId, { output: dispatched.output }));
+            continue;
+          }
+
+          // Denied and failed calls are data the model must reason about, not a retry signal.
+          messages.push(
+            toolMessage(call.callId, { error: dispatched.status, detail: dispatched.reason })
+          );
+        }
+
+        await checkpoint();
+
+        if (approval !== undefined) {
+          return finish(
+            { status: "awaiting_approval", ...approval, ...counters },
+            "awaiting_approval"
+          );
+        }
+        continue;
+      }
+
+      if (validate !== undefined) {
+        const value =
+          result.output.kind === "structured" ? result.output.value : parseJson(result.output.text);
+        if (validate(value)) {
+          return finish({ status: "completed", output: value, ...counters }, "completed");
+        }
+
+        counters.repairs += 1;
+        if (counters.repairs > input.limits.maxRepairAttempts) {
+          return finish(
+            { status: "failed", reason: "repair_budget_exhausted", ...counters },
+            "failed"
+          );
+        }
+        messages.push({
+          role: "user",
+          content: JSON.stringify({
+            error: "structured_output_invalid",
+            detail: errorText(validate),
+          }),
+        });
+        await checkpoint();
+        continue;
+      }
+
+      const output = result.output.kind === "structured" ? result.output.value : result.output.text;
+      return finish({ status: "completed", output, ...counters }, "completed");
+    }
+  }
+}
+
+function normalizeCalls(
+  calls: readonly { readonly callId: string; readonly name: string; readonly arguments: unknown }[],
+  iteration: number
+): readonly { callId: string; name: string; arguments: unknown }[] {
+  // Providers sometimes omit or repeat call ids; correlation must stay unambiguous regardless.
+  const seen = new Set<string>();
+  return calls.map((call, index) => {
+    const candidate = call.callId.trim();
+    const callId =
+      candidate === "" || seen.has(candidate) ? `call-${iteration}-${index + 1}` : candidate;
+    seen.add(callId);
+    return { callId, name: call.name, arguments: call.arguments };
+  });
+}
+
+function toolMessage(callId: string, payload: Record<string, unknown>): ModelMessage {
+  return { role: "tool", content: JSON.stringify({ callId, ...payload }) };
+}
+
+function parseJson(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+function errorText(validate: CompiledValidator): string {
+  return (validate.errors ?? [])
+    .map((error) => `${error.instancePath || "/"} ${error.message ?? "invalid"}`)
+    .join("; ");
+}

--- a/packages/agent-runtime/test/security/adversarial.test.ts
+++ b/packages/agent-runtime/test/security/adversarial.test.ts
@@ -1,0 +1,515 @@
+import { ChildRunError, ChildRunManager } from "@tulipfarm/run-kernel";
+import { describe, expect, it } from "vitest";
+import {
+  assembleContext,
+  type ContextCandidate,
+  DelegationCoordinator,
+  evaluateActivation,
+  InMemoryLoopCheckpointStore,
+  type ModelInvocationResult,
+  type ModelProfileCatalog,
+  type ModelRequirements,
+  type RoutableModelProfile,
+  resolveSkills,
+  selectModelProfile,
+  type ToolDispatchResult,
+} from "../../src";
+import { FakeChildLinkStore, loopHarness, TOOL_NAME } from "./harness";
+
+/**
+ * Adversarial corpus (SPEC §10, §17, invariants 1-3). Every case here is an attempt to widen
+ * authority, launder untrusted content into instructions, or escape a durable limit through the
+ * model. The assertions are on the runtime's decisions, not on prompt wording — a prompt fix
+ * cannot make any of these pass.
+ */
+
+describe("prompt injection cannot outrank governed instructions", () => {
+  function candidate(overrides: Partial<ContextCandidate> = {}): ContextCandidate {
+    return {
+      sourceId: "safety",
+      kind: "instruction",
+      precedence: "platform_safety",
+      version: "1",
+      classification: "internal",
+      taint: "trusted",
+      authorization: { decision: "allow" },
+      tokens: 10,
+      digest: "sha256:safety",
+      ...overrides,
+    };
+  }
+
+  const injected = candidate({
+    sourceId: "ticket-body",
+    kind: "knowledge",
+    precedence: "untrusted_source",
+    taint: "untrusted",
+    digest: "sha256:ticket",
+    tokens: 10,
+  });
+
+  it("keeps an untrusted source below every governed instruction level", () => {
+    const manifest = assembleContext({
+      businessId: "biz-1",
+      runId: "run-1",
+      stateId: "state-1",
+      candidates: [
+        injected,
+        candidate(),
+        candidate({ sourceId: "guard", precedence: "business_guardrail" }),
+      ],
+      guardrailDigest: "sha256:guardrail",
+      bundleDigest: "sha256:bundle",
+      budgetTokens: 1_000,
+    });
+
+    expect(manifest.entries.map((entry) => entry.precedence)).toEqual([
+      "platform_safety",
+      "business_guardrail",
+      "untrusted_source",
+    ]);
+    expect(manifest.taint).toBe("untrusted");
+  });
+
+  it("drops untrusted content before safety instructions when the budget is tight", () => {
+    const manifest = assembleContext({
+      businessId: "biz-1",
+      runId: "run-1",
+      stateId: "state-1",
+      candidates: [injected, candidate()],
+      guardrailDigest: "sha256:guardrail",
+      bundleDigest: "sha256:bundle",
+      budgetTokens: 10,
+    });
+
+    expect(manifest.entries.map((entry) => entry.sourceId)).toEqual(["safety"]);
+    expect(manifest.excluded).toEqual([{ sourceId: "ticket-body", reason: "context_budget" }]);
+  });
+
+  it("refuses to admit a source the caller was not authorized to read", () => {
+    const manifest = assembleContext({
+      businessId: "biz-1",
+      runId: "run-1",
+      stateId: "state-1",
+      candidates: [
+        candidate(),
+        candidate({
+          sourceId: "other-tenant-doc",
+          kind: "knowledge",
+          precedence: "untrusted_source",
+          authorization: { decision: "deny", reason: "not_authorized" },
+        }),
+      ],
+      guardrailDigest: "sha256:guardrail",
+      bundleDigest: "sha256:bundle",
+      budgetTokens: 1_000,
+    });
+
+    expect(manifest.entries.map((entry) => entry.sourceId)).toEqual(["safety"]);
+    expect(manifest.excluded).toEqual([{ sourceId: "other-tenant-doc", reason: "not_authorized" }]);
+  });
+
+  it("drops a summary that launders an unauthorized source", () => {
+    const manifest = assembleContext({
+      businessId: "biz-1",
+      runId: "run-1",
+      stateId: "state-1",
+      candidates: [
+        candidate({
+          sourceId: "denied-doc",
+          kind: "knowledge",
+          precedence: "untrusted_source",
+          authorization: { decision: "deny" },
+        }),
+        candidate({
+          sourceId: "summary-1",
+          kind: "summary",
+          precedence: "untrusted_source",
+          summarizes: ["denied-doc"],
+        }),
+      ],
+      guardrailDigest: "sha256:guardrail",
+      bundleDigest: "sha256:bundle",
+      budgetTokens: 1_000,
+    });
+
+    expect(manifest.entries).toEqual([]);
+    expect(manifest.excluded).toContainEqual({
+      sourceId: "summary-1",
+      reason: "summary_source_unauthorized",
+    });
+  });
+});
+
+describe("model output cannot widen Tool authority", () => {
+  function toolCalls(
+    calls: readonly { callId: string; name: string; arguments: unknown }[]
+  ): ModelInvocationResult {
+    return {
+      requestId: "req",
+      output: { kind: "tool_calls", calls },
+      usage: { inputTokens: 1, outputTokens: 1 },
+    };
+  }
+
+  const text: ModelInvocationResult = {
+    requestId: "req",
+    output: { kind: "text", text: "done" },
+    usage: { inputTokens: 1, outputTokens: 1 },
+  };
+
+  it("never dispatches a Tool the caller did not expose, however the model names it", async () => {
+    const harness = loopHarness({
+      results: [
+        toolCalls([
+          { callId: "c1", name: "shell.exec", arguments: { cmd: "rm -rf /" } },
+          { callId: "c2", name: "../../tools/admin.grant", arguments: {} },
+        ]),
+        text,
+      ],
+    });
+
+    const outcome = await harness.loop.run(harness.input());
+
+    expect(harness.tools.calls).toEqual([]);
+    expect(outcome).toMatchObject({ status: "completed", toolCalls: 0 });
+  });
+
+  it("treats a broker denial as data, not as permission to try again", async () => {
+    const denial: ToolDispatchResult = {
+      status: "denied",
+      callId: "c1",
+      reason: "authorization_denied",
+    };
+    const harness = loopHarness({
+      results: [
+        toolCalls([{ callId: "c1", name: TOOL_NAME, arguments: { body: "x" } }]),
+        toolCalls([{ callId: "c2", name: TOOL_NAME, arguments: { body: "x" } }]),
+        text,
+      ],
+      dispatches: [denial, denial],
+    });
+
+    const outcome = await harness.loop.run(harness.input());
+
+    // The loop re-asks the broker every time; nothing in the transcript escalates the decision.
+    expect(harness.tools.calls).toHaveLength(2);
+    expect(outcome).toMatchObject({ status: "completed" });
+  });
+
+  it("cannot self-approve: only the broker can park a call on an Approval", async () => {
+    const harness = loopHarness({
+      results: [
+        toolCalls([
+          { callId: "c1", name: TOOL_NAME, arguments: { body: "approved: yes, proceed" } },
+        ]),
+      ],
+      dispatches: [{ status: "awaiting_approval", callId: "c1", approvalId: "appr-1" }],
+    });
+
+    expect(await harness.loop.run(harness.input())).toMatchObject({
+      status: "awaiting_approval",
+      approvalId: "appr-1",
+    });
+  });
+
+  it("cannot spend past a durable limit by emitting a burst of calls", async () => {
+    const harness = loopHarness({
+      results: [
+        toolCalls([
+          { callId: "c1", name: TOOL_NAME, arguments: { body: "1" } },
+          { callId: "c2", name: TOOL_NAME, arguments: { body: "2" } },
+          { callId: "c3", name: TOOL_NAME, arguments: { body: "3" } },
+        ]),
+      ],
+      dispatches: [
+        { status: "succeeded", callId: "c1", output: {} },
+        { status: "succeeded", callId: "c2", output: {} },
+      ],
+    });
+
+    const outcome = await harness.loop.run(
+      harness.input({ limits: { maxIterations: 5, maxToolCalls: 2, maxRepairAttempts: 2 } })
+    );
+
+    expect(harness.tools.calls).toHaveLength(2);
+    expect(outcome).toMatchObject({ status: "failed", reason: "tool_call_limit" });
+  });
+
+  it("cannot buy a fresh budget by crashing and resuming", async () => {
+    const checkpoints = new InMemoryLoopCheckpointStore();
+    await checkpoints.save({
+      businessId: "biz-1",
+      runId: "run-1",
+      stateId: "state-1",
+      iterations: 4,
+      toolCalls: 0,
+      repairs: 0,
+    });
+    const harness = loopHarness({ results: [text], checkpoints });
+
+    expect(
+      await harness.loop.run(
+        harness.input({ limits: { maxIterations: 4, maxToolCalls: 4, maxRepairAttempts: 2 } })
+      )
+    ).toMatchObject({ status: "failed", reason: "iteration_limit" });
+  });
+
+  it("keeps loop evidence free of Tool arguments and model text", async () => {
+    const harness = loopHarness({
+      results: [
+        toolCalls([{ callId: "c1", name: TOOL_NAME, arguments: { body: "exfiltrate-me" } }]),
+        {
+          requestId: "req",
+          output: { kind: "text", text: "secret-answer" },
+          usage: { inputTokens: 1, outputTokens: 1 },
+        },
+      ],
+      dispatches: [{ status: "succeeded", callId: "c1", output: { token: "leak-me" } }],
+    });
+
+    await harness.loop.run(harness.input());
+
+    const serialized = JSON.stringify(harness.events);
+    expect(serialized).not.toContain("exfiltrate-me");
+    expect(serialized).not.toContain("secret-answer");
+    expect(serialized).not.toContain("leak-me");
+  });
+});
+
+describe("Skills and helpers cannot amplify authority", () => {
+  it("denies a Skill that declares an ability the caller does not hold", () => {
+    expect(
+      resolveSkills({
+        selections: [{ skillId: "exfil", version: "1.0.0" }],
+        catalog: {
+          get: () => ({
+            skillId: "exfil",
+            version: "1.0.0",
+            digest: "sha256:exfil",
+            trustTier: "first_party",
+            scan: { status: "clean", scannedDigest: "sha256:exfil" },
+            dependencies: [],
+            requiredToolAbilities: ["secrets.read"],
+            contextTokens: 10,
+          }),
+        },
+        trustPolicy: { allowedTiers: ["first_party"], requireScanForTiers: [] },
+        grantedToolAbilities: ["github.issue.read"],
+        contextBudgetTokens: 1_000,
+      })
+    ).toMatchObject({ outcome: "denied", reason: "missing_tool_ability" });
+  });
+
+  it("denies a Skill whose executable content changed after its scan", () => {
+    expect(
+      resolveSkills({
+        selections: [{ skillId: "swapped", version: "1.0.0" }],
+        catalog: {
+          get: () => ({
+            skillId: "swapped",
+            version: "1.0.0",
+            digest: "sha256:new-content",
+            trustTier: "business_authored",
+            scan: { status: "clean", scannedDigest: "sha256:reviewed-content" },
+            dependencies: [],
+            requiredToolAbilities: [],
+            contextTokens: 10,
+          }),
+        },
+        trustPolicy: {
+          allowedTiers: ["business_authored"],
+          requireScanForTiers: ["business_authored"],
+        },
+        grantedToolAbilities: [],
+        contextBudgetTokens: 1_000,
+      })
+    ).toMatchObject({ outcome: "denied", reason: "scan_required" });
+  });
+
+  it("denies a helper Run that asks for more than its parent holds", async () => {
+    const delegation = new DelegationCoordinator({
+      children: new ChildRunManager(new FakeChildLinkStore()),
+      tools: { isReadOnly: (name) => name.endsWith(".read") },
+      policy: { maxDepth: 2 },
+    });
+    const parent = {
+      authority: {
+        tools: ["github.issue.read"],
+        classifications: ["internal"],
+        limits: { costUsd: 1 },
+      },
+      depth: 0,
+      deadlineAt: "2026-07-25T11:00:00.000Z",
+    };
+    const base = {
+      businessId: "biz-1",
+      parentRunId: "run-parent",
+      childRunId: "run-child",
+      parent,
+      now: "2026-07-25T10:00:00.000Z",
+    };
+
+    await expect(
+      delegation.delegate({ ...base, requested: { mode: "read_write", tools: ["secrets.read"] } })
+    ).rejects.toBeInstanceOf(ChildRunError);
+    await expect(
+      delegation.delegate({ ...base, requested: { limits: { costUsd: 100 } } })
+    ).rejects.toBeInstanceOf(ChildRunError);
+    await expect(
+      delegation.delegate({ ...base, requested: { classifications: ["restricted"] } })
+    ).rejects.toBeInstanceOf(ChildRunError);
+    await expect(
+      delegation.delegate({
+        ...base,
+        requested: { deadlineAt: "2026-07-30T00:00:00.000Z" },
+      })
+    ).rejects.toMatchObject({ code: "deadline_amplification" });
+  });
+
+  it("starts a helper read-only even when the parent could write", async () => {
+    const delegation = new DelegationCoordinator({
+      children: new ChildRunManager(new FakeChildLinkStore()),
+      tools: { isReadOnly: (name) => name.endsWith(".read") },
+      policy: { maxDepth: 2 },
+    });
+
+    const helper = await delegation.delegate({
+      businessId: "biz-1",
+      parentRunId: "run-parent",
+      childRunId: "run-child",
+      parent: {
+        authority: {
+          tools: ["github.issue.read", "github.issue.comment"],
+          classifications: ["internal"],
+          limits: {},
+        },
+        depth: 0,
+        deadlineAt: "2026-07-25T11:00:00.000Z",
+      },
+      requested: {},
+      now: "2026-07-25T10:00:00.000Z",
+    });
+
+    expect(helper.authority.tools).toEqual(["github.issue.read"]);
+  });
+});
+
+describe("routing and publication cannot be talked down", () => {
+  function profile(overrides: Partial<RoutableModelProfile> = {}): RoutableModelProfile {
+    return {
+      profileId: "primary",
+      provider: "acme",
+      model: "acme-1",
+      reasoning: "high",
+      supports: { tools: true, structuredOutput: true, contextWindowTokens: 100_000 },
+      constraints: {
+        dataRetention: "zero_retention",
+        allowTraining: false,
+        residency: "eu",
+        maxCostUsd: 1,
+        maxTokens: 50_000,
+        maxLatencyMs: 5_000,
+      },
+      fallbacks: [],
+      allowCaching: true,
+      ...overrides,
+    };
+  }
+
+  const requirements: ModelRequirements = {
+    needsTools: true,
+    needsStructuredOutput: true,
+    estimatedContextTokens: 10_000,
+    estimatedCostUsd: 0.5,
+    sensitive: false,
+    allowTraining: false,
+    residency: "eu",
+    dataRetention: "zero_retention",
+  };
+
+  it("refuses a fallback that relaxes residency or retention", () => {
+    const catalog: ModelProfileCatalog = {
+      get: (id) =>
+        id === "primary"
+          ? profile({ fallbacks: ["cheap-us"] })
+          : id === "cheap-us"
+            ? profile({
+                profileId: "cheap-us",
+                constraints: {
+                  dataRetention: "provider_default",
+                  allowTraining: true,
+                  residency: "us",
+                  maxCostUsd: 1,
+                  maxTokens: 50_000,
+                  maxLatencyMs: 5_000,
+                },
+              })
+            : undefined,
+    };
+
+    const selection = selectModelProfile("primary", requirements, catalog);
+    if (selection.outcome !== "selected") throw new Error("expected selection");
+    expect(selection.chain.map((entry) => entry.profileId)).toEqual(["primary"]);
+    expect(selection.rejectedFallbacks.map((entry) => entry.profileId)).toEqual(["cheap-us"]);
+  });
+
+  it("keeps caching off for sensitive work regardless of the profile", () => {
+    const selection = selectModelProfile(
+      "primary",
+      { ...requirements, sensitive: true },
+      { get: () => profile() }
+    );
+
+    expect(selection).toMatchObject({ outcome: "selected", cacheAllowed: false });
+  });
+
+  it("refuses to activate an action-capable Agent on a forged eval exception", () => {
+    const report = {
+      agentId: "triage-agent",
+      agentVersion: "2.0.0",
+      suiteVersion: "1.0.0",
+      results: [
+        { caseId: "safety-1", version: "1.0.0", severity: "blocking" as const, passed: false },
+      ],
+      passed: 0,
+      failed: 1,
+      digest: "digest",
+    };
+    const baseline = {
+      ...report,
+      results: [
+        { caseId: "safety-1", version: "1.0.0", severity: "blocking" as const, passed: true },
+      ],
+      passed: 1,
+      failed: 0,
+    };
+    const exception = {
+      exceptionId: "exc-1",
+      agentId: "triage-agent",
+      caseIds: ["safety-1"],
+      grantedBy: "user:admin-1",
+      grantedByRole: "admin" as const,
+      expiresAt: "2026-07-26T10:00:00.000Z",
+      auditEventId: "audit-1",
+      reason: "temporary",
+    };
+    const now = new Date("2026-07-25T10:00:00.000Z");
+
+    for (const forged of [
+      { ...exception, agentId: "another-agent" },
+      { ...exception, caseIds: ["unrelated-case"] },
+      { ...exception, expiresAt: "2026-07-24T10:00:00.000Z" },
+      { ...exception, auditEventId: "" },
+      { ...exception, grantedBy: "" },
+    ]) {
+      expect(
+        evaluateActivation({ report, baseline, actionCapable: true, now, exception: forged })
+      ).toMatchObject({ decision: "blocked" });
+    }
+
+    expect(
+      evaluateActivation({ report, baseline, actionCapable: true, now, exception })
+    ).toMatchObject({ decision: "allowed", exceptionId: "exc-1" });
+  });
+});

--- a/packages/agent-runtime/test/security/harness.ts
+++ b/packages/agent-runtime/test/security/harness.ts
@@ -1,0 +1,102 @@
+import type { ChildAuthority, ChildLink, ChildLinkStore } from "@tulipfarm/run-kernel";
+import {
+  AgentLoop,
+  type AgentLoopEvent,
+  type AgentLoopInput,
+  InMemoryLoopCheckpointStore,
+  type ModelInvocationResult,
+  type ToolDispatchResult,
+} from "../../src";
+
+export const TOOL_NAME = "github.issue.comment";
+
+/** Scripted model + broker so each adversarial case states only what it is attacking. */
+export function loopHarness(options: {
+  results: readonly ModelInvocationResult[];
+  dispatches?: readonly ToolDispatchResult[];
+  checkpoints?: InMemoryLoopCheckpointStore;
+}) {
+  const results = [...options.results];
+  const dispatches = [...(options.dispatches ?? [])];
+  const calls: { name: string; arguments: unknown }[] = [];
+  const events: AgentLoopEvent[] = [];
+
+  const loop = new AgentLoop({
+    model: {
+      invoke: async () => {
+        const next = results.shift();
+        if (next === undefined) throw new Error("model called more times than scripted");
+        return next;
+      },
+    },
+    tools: {
+      dispatch: async (call) => {
+        calls.push({ name: call.name, arguments: call.arguments });
+        return dispatches.shift() ?? { status: "succeeded", callId: call.callId, output: {} };
+      },
+    },
+    checkpoints: options.checkpoints ?? new InMemoryLoopCheckpointStore(),
+    events: {
+      append: async (event) => {
+        events.push(event);
+      },
+    },
+    budget: { consume: async () => ({ outcome: "allowed" }) },
+    isCancelled: async () => false,
+  });
+
+  const input = (overrides: Partial<AgentLoopInput> = {}): AgentLoopInput => ({
+    businessId: "biz-1",
+    runId: "run-1",
+    stateId: "state-1",
+    modelProfileId: "primary",
+    contextDigest: "sha256:context",
+    guardrailDigest: "sha256:guardrail",
+    messages: [{ role: "user", content: "handle the ticket" }],
+    tools: [{ name: TOOL_NAME, inputSchema: { type: "object", required: ["body"] } }],
+    limits: { maxIterations: 5, maxToolCalls: 5, maxRepairAttempts: 2 },
+    ...overrides,
+  });
+
+  return { loop, calls, events, input, tools: { calls } };
+}
+
+export class FakeChildLinkStore implements ChildLinkStore {
+  links: ChildLink[] = [];
+
+  async link(input: {
+    parentRunId: string;
+    childRunId: string;
+    authority: ChildAuthority;
+    createdAt: string;
+  }): Promise<ChildLink> {
+    const link: ChildLink = {
+      parentRunId: input.parentRunId,
+      childRunId: input.childRunId,
+      authority: input.authority,
+      detachedAt: null,
+      createdAt: input.createdAt,
+    };
+    this.links.push(link);
+    return link;
+  }
+
+  async detach(
+    _businessId: string,
+    parentRunId: string,
+    childRunId: string,
+    detachedAt: string
+  ): Promise<boolean> {
+    const index = this.links.findIndex(
+      (link) => link.parentRunId === parentRunId && link.childRunId === childRunId
+    );
+    const existing = this.links[index];
+    if (existing === undefined || existing.detachedAt !== null) return false;
+    this.links[index] = { ...existing, detachedAt };
+    return true;
+  }
+
+  async listChildren(_businessId: string, parentRunId: string): Promise<readonly ChildLink[]> {
+    return this.links.filter((link) => link.parentRunId === parentRunId);
+  }
+}

--- a/packages/agent-runtime/tsconfig.json
+++ b/packages/agent-runtime/tsconfig.json
@@ -6,5 +6,5 @@
     "noEmit": true,
     "types": ["node"]
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }

--- a/packages/soul/src/agent-publication.test.ts
+++ b/packages/soul/src/agent-publication.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import {
+  AgentPublicationError,
+  type AgentPublicationRequest,
+  publishAgentVersion,
+} from "./agent-publication";
+
+function request(overrides: Partial<AgentPublicationRequest> = {}): AgentPublicationRequest {
+  return {
+    agentId: "triage-agent",
+    version: "2.0.0",
+    actionCapable: true,
+    activation: { decision: "allowed" },
+    evalReportDigest: "a".repeat(64),
+    publishedBy: "user:admin-1",
+    ...overrides,
+  };
+}
+
+describe("publishAgentVersion", () => {
+  it("publishes an action-capable Agent whose activation gate allowed it", () => {
+    expect(publishAgentVersion(request())).toMatchObject({
+      status: "published",
+      agentId: "triage-agent",
+      version: "2.0.0",
+      evalReportDigest: "a".repeat(64),
+    });
+  });
+
+  it("refuses to publish an action-capable Agent the gate blocked", () => {
+    expect(() =>
+      publishAgentVersion(
+        request({
+          activation: {
+            decision: "blocked",
+            reason: "eval_regression",
+            regressedCaseIds: ["triage-1"],
+            failedCaseIds: ["triage-1"],
+          },
+        })
+      )
+    ).toThrow(AgentPublicationError);
+  });
+
+  it("records the admin exception that carried a blocked run past the gate", () => {
+    expect(
+      publishAgentVersion(request({ activation: { decision: "allowed", exceptionId: "exc-1" } }))
+    ).toMatchObject({ status: "published", exceptionId: "exc-1" });
+  });
+
+  it("requires eval evidence for an action-capable Agent", () => {
+    expect(() => publishAgentVersion(request({ evalReportDigest: undefined }))).toThrow(
+      AgentPublicationError
+    );
+  });
+
+  it("publishes a read-only Agent without an eval report", () => {
+    expect(
+      publishAgentVersion(
+        request({ actionCapable: false, evalReportDigest: undefined, activation: undefined })
+      )
+    ).toMatchObject({ status: "published" });
+  });
+
+  it("refuses an action-capable Agent with no activation verdict at all", () => {
+    expect(() => publishAgentVersion(request({ activation: undefined }))).toThrow(
+      AgentPublicationError
+    );
+  });
+
+  it("carries the reason code without leaking case content", () => {
+    try {
+      publishAgentVersion(
+        request({
+          activation: {
+            decision: "blocked",
+            reason: "blocking_case_failed",
+            regressedCaseIds: [],
+            failedCaseIds: ["triage-1"],
+          },
+        })
+      );
+      throw new Error("expected publication to be refused");
+    } catch (error) {
+      expect(error).toBeInstanceOf(AgentPublicationError);
+      expect((error as AgentPublicationError).code).toBe("activation_blocked");
+      expect((error as AgentPublicationError).message).toBe(
+        "activation_blocked:blocking_case_failed"
+      );
+    }
+  });
+});

--- a/packages/soul/src/agent-publication.ts
+++ b/packages/soul/src/agent-publication.ts
@@ -1,0 +1,84 @@
+/**
+ * Agent version publication gate (SPEC §10).
+ *
+ * An action-capable Agent may only be published with eval evidence and an activation verdict that
+ * allowed it. The verdict is produced by `@tulipfarm/agent-runtime`, but this package must not
+ * import it (see `docs/architecture/dependency-rules.md`), so the verdict shape is declared here
+ * structurally: the runtime's `ActivationVerdict` satisfies it, and the gate stays a pure function
+ * of the evidence handed to it.
+ */
+
+export interface ActivationAllowed {
+  readonly decision: "allowed";
+  readonly exceptionId?: string;
+}
+
+export interface ActivationBlocked {
+  readonly decision: "blocked";
+  readonly reason: string;
+  readonly regressedCaseIds: readonly string[];
+  readonly failedCaseIds: readonly string[];
+}
+
+export type AgentActivationVerdict = ActivationAllowed | ActivationBlocked;
+
+export type AgentPublicationErrorCode = "activation_blocked" | "eval_evidence_missing";
+
+/** Publication denial carrying the reason code only — never eval inputs or model output. */
+export class AgentPublicationError extends Error {
+  readonly name = "AgentPublicationError";
+
+  constructor(
+    readonly code: AgentPublicationErrorCode,
+    readonly detail = ""
+  ) {
+    super(`${code}${detail ? `:${detail}` : ""}`);
+  }
+}
+
+export interface AgentPublicationRequest {
+  readonly agentId: string;
+  readonly version: string;
+  /** True when the Agent may call effect-bearing Tools; read-only Agents are gated more loosely. */
+  readonly actionCapable: boolean;
+  readonly activation?: AgentActivationVerdict;
+  readonly evalReportDigest?: string;
+  readonly publishedBy: string;
+}
+
+export interface PublishedAgentVersion {
+  readonly status: "published";
+  readonly agentId: string;
+  readonly version: string;
+  readonly actionCapable: boolean;
+  readonly evalReportDigest: string | null;
+  readonly exceptionId: string | null;
+  readonly publishedBy: string;
+}
+
+export function publishAgentVersion(request: AgentPublicationRequest): PublishedAgentVersion {
+  if (request.actionCapable) {
+    if (request.activation === undefined) {
+      throw new AgentPublicationError("eval_evidence_missing", "activation");
+    }
+    if (request.evalReportDigest === undefined) {
+      throw new AgentPublicationError("eval_evidence_missing", "evalReportDigest");
+    }
+    if (request.activation.decision === "blocked") {
+      throw new AgentPublicationError("activation_blocked", request.activation.reason);
+    }
+  }
+
+  const exceptionId =
+    request.activation?.decision === "allowed" ? (request.activation.exceptionId ?? null) : null;
+
+  return {
+    status: "published",
+    agentId: request.agentId,
+    version: request.version,
+    actionCapable: request.actionCapable,
+    evalReportDigest: request.evalReportDigest ?? null,
+    exceptionId,
+    publishedBy: request.publishedBy,
+  };
+}

--- a/packages/soul/src/index.ts
+++ b/packages/soul/src/index.ts
@@ -1,4 +1,13 @@
 export type {
+  ActivationAllowed,
+  ActivationBlocked,
+  AgentActivationVerdict,
+  AgentPublicationErrorCode,
+  AgentPublicationRequest,
+  PublishedAgentVersion,
+} from "./agent-publication";
+export { AgentPublicationError, publishAgentVersion } from "./agent-publication";
+export type {
   BundleDefinition,
   BundleErrorCode,
   BundleSignature,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -383,6 +383,9 @@ importers:
 
   apps/worker:
     dependencies:
+      '@tulipfarm/agent-runtime':
+        specifier: workspace:*
+        version: link:../../packages/agent-runtime
       '@tulipfarm/run-kernel':
         specifier: workspace:*
         version: link:../../packages/run-kernel


### PR DESCRIPTION
> Stacked on #242 — review that one first; this PR's base retargets to `main` once it merges.

## Summary

- **AW-049 — bounded durable Tool loop** (`packages/agent-runtime/src/loop/`, `apps/worker/src/agent-state.ts`): iteration/Tool-call/repair counters are checkpointed, so a resumed State continues its budgets rather than restarting them. The broker is the only effect path — an unexposed Tool is refused before dispatch, denials and malformed calls return as transcript data, provider call-id quirks are normalized, and only a broker `awaiting_approval` parks the State on a durable wait. Structured output is AJV-validated with a bounded repair budget. Loop events are content-free and sequenced for stream recovery.
- **AW-050 — durable Conversations and Turns** (`apps/api/src/conversations/`, `apps/worker/src/conversation-turn.ts`): Message and Turn are persisted before the Run is started, so a replayed idempotency key returns the same Turn and Run, a Turn whose Run never started resumes without duplicating the Message, and retry supports both same-Turn (new attempt, prior Run superseded) and new-Turn semantics. Readers resume from the Turn's durable cursor; authorization is re-checked on every Turn and every read. Turn completion is idempotent per `(turnId, attempt)` and drops stale superseded attempts.
- **AW-051 — delegation** (`packages/agent-runtime/src/delegation/`): helpers are child Runs that start read-only, may only narrow Tools, classifications, limits, deadline, and depth, detach explicitly to survive parent cancellation, and report back through schema-validated Artifacts.
- **AW-052 — eval gate** (`packages/agent-runtime/src/evals/`, `packages/soul/src/agent-publication.ts`): versioned eval cases, activation blocked on any failing blocking case or regression for action-capable Agents, and the only bypass is an exception scoped to that Agent and those cases, expiring, admin-granted, and audit-linked. The soul-side publication gate declares the verdict shape structurally so no `soul ↔ agent-runtime` import edge is introduced.
- **AW-053 — adversarial corpus** (`packages/agent-runtime/test/security/`): injection cannot outrank governed instructions or launder unauthorized sources through summaries; model output cannot reach an unexposed Tool, self-approve, burst past a Tool-call limit, or buy a fresh budget by crashing; Skills and helpers cannot amplify authority; fallbacks cannot relax residency/retention; forged eval exceptions cannot activate an Agent.

Scope note: HTTP/OpenAPI exposure of Conversations stays with AW-066 — this PR lands the durable service and its ports only.

## Test plan

- `pnpm --filter @tulipfarm/agent-runtime exec vitest run` — 103 tests (incl. 17 adversarial cases)
- `pnpm --filter @tulipfarm/worker exec vitest run` — 24 tests
- `pnpm --filter @tulipfarm/soul exec vitest run` — 183 tests
- `pnpm --filter @tulipfarm/api exec vitest run` — Conversation service suite green with the rest of the app
- `pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm build` at the repo root
- `pnpm exec tsx scripts/architecture-check.ts` — no forbidden imports or cycles