### PR TITLE
feat(chat): unify normal chat harness

### DIFF
--- a/apps/api/src/chat/conversation-routes.ts
+++ b/apps/api/src/chat/conversation-routes.ts
@@ -5,7 +5,7 @@ import type { UserDoc } from "../auth/users";
 import type { KnowledgeService } from "../knowledge/service";
 import type { WorkingMemoryService } from "../memory/service";
 import { parsePaginationQuery } from "../pagination";
-import { getPlatformAgent, resolveAgent } from "../soul/agents/registry";
+import { getDefaultAssistant, resolveAgent } from "../soul/agents/registry";
 import { buildSoulCatalogue } from "../soul/catalogue";
 import { listAvailableSkills, listEagerSkills } from "../soul/skills/registry";
 import type { ToolRegistry } from "../tools/registry";
@@ -337,7 +337,7 @@ export function registerConversationRoutes(
         // resources (there is no in-flight turn) — mirrors the chat route's front-desk assembly. Memory
         // is the conversation owner's, so the prompt matches what the LLM actually saw for this chat.
         const agent = resolveAgent(soulLoader, convo.agentId);
-        const platformAgent = getPlatformAgent(agent.name);
+        const platformAgent = getDefaultAssistant(agent.name);
         const memory = workingMemory && convo.userId ? await workingMemory.list(convo.userId) : [];
         const governancePages = knowledge ? await knowledge.governancePages() : [];
         const tools = availableToolsFor(toolRegistry, platformAgent);

--- a/apps/api/src/chat/conversations.ts
+++ b/apps/api/src/chat/conversations.ts
@@ -20,7 +20,7 @@ export interface ConversationRepo {
   create(doc: ConversationDoc): Promise<void>;
   findById(id: string): Promise<ConversationDoc | null>;
   touch(id: string): Promise<void>;
-  /** Persist the conversation's active agent (the GeneralAssistant ↔ InformationArchitect handoff). */
+  /** Persist the conversation's active agent after an explicit agent handoff. */
   setAgent(id: string, agentId: string): Promise<void>;
   /**
    * Persist the title. Does not bump `updated_at`, so it works both for the async title generator

--- a/apps/api/src/chat/producer.ts
+++ b/apps/api/src/chat/producer.ts
@@ -1,4 +1,5 @@
 import type { ServerResponse } from "node:http";
+import { APICallError } from "ai";
 import type { A2uiSurfaceStore } from "../a2ui/surface-store";
 import { CITE_SOURCES_TOOL } from "../knowledge/tools";
 import { clientActionEvent } from "../platform/frontend-tools";
@@ -12,6 +13,31 @@ import type { StreamResumeRepo } from "./stream-resume";
 interface MappedEvent {
   eventType: string;
   data: unknown;
+}
+
+/**
+ * Some providers (e.g. Ollama Cloud) return an APICallError with an empty `message` and the real
+ * reason only in `responseBody` (as JSON `{ error: "..." }` or plain text) — surface that instead
+ * of falling through to a generic "stream error" the user can't act on.
+ */
+function describeStreamError(error: unknown): string {
+  if (APICallError.isInstance(error)) {
+    if (error.message) return error.message;
+    const body = error.responseBody;
+    if (body) {
+      try {
+        const parsed = JSON.parse(body) as { error?: unknown; message?: unknown };
+        const fromBody = parsed.error ?? parsed.message;
+        if (typeof fromBody === "string" && fromBody) return fromBody;
+      } catch {
+        // not JSON — fall through to the raw body below
+      }
+      return body;
+    }
+    return `${error.statusCode ?? "?"} request failed`;
+  }
+  if (error instanceof Error && error.message) return error.message;
+  return "stream error";
 }
 
 /**
@@ -50,7 +76,7 @@ export function mapStreamPart(
     case "error":
       return {
         eventType: "error",
-        data: { message: p.error instanceof Error ? p.error.message : "stream error" },
+        data: { message: describeStreamError(p.error) },
       };
     default:
       return null;
@@ -235,7 +261,7 @@ export async function runChatStream(
       } else {
         deps.log.error({ err, streamId }, "chat stream producer failed");
         await deps.emitter.emit("error", {
-          message: err instanceof Error ? err.message : "stream error",
+          message: describeStreamError(err),
         });
       }
     }

--- a/apps/api/src/chat/routes.test.ts
+++ b/apps/api/src/chat/routes.test.ts
@@ -572,6 +572,24 @@ describe("chat routes", () => {
     });
 
     it("persists agentId on a newly created conversation", async () => {
+      await app.close();
+      const soulLoader = {
+        agents: new Map([["agent-x", { name: "agent-x", frontmatter: {}, body: "" }]]),
+        skills: new Map(),
+      } as unknown as SoulLoader;
+      app = await buildApp({
+        sessionStore: store,
+        userRepo,
+        tokenRepo,
+        llmService,
+        conversationRepo: repo,
+        messageRepo,
+        streamResumeRepo: streamRepo,
+        streamHub,
+        workingMemoryService: new WorkingMemoryService(workingMemoryRepo),
+        soulLoader,
+      });
+
       const res = await post({ message: userMsg("hi"), agentId: "agent-x" });
       expect(res.statusCode).toBe(200);
       const id = res.headers["x-conversation-id"] as string;

--- a/apps/api/src/chat/routes.test.ts
+++ b/apps/api/src/chat/routes.test.ts
@@ -819,9 +819,8 @@ describe("chat routes", () => {
       expect(system).toContain("<skills>\\n## code-review\\nReview carefully.");
       // The L1 index holds ONLY the lazy skill — the eager one does not leak into it (it surfaces
       // as a full body in <skills>, and by name in the <soul-context> catalogue, but never here).
-      expect(system).toContain(
-        "<available-skills>\\n- data-export: Export data.\\n</available-skills>"
-      );
+      expect(system).toContain("- data-export: Export data.");
+      expect(system).toContain("- resource-forge:");
     });
 
     // Business context — soul.yaml's businessName/businessDescription surface in the system prompt
@@ -1006,7 +1005,7 @@ describe("chat routes", () => {
       expect(res.headers["content-type"]).toContain("text/event-stream");
       expect(res.headers["x-stream-id"]).toBeDefined();
       // The turn's active agent is surfaced up front so the client header reflects it immediately.
-      expect(res.headers["x-agent-id"]).toBe("GeneralAssistant");
+      expect(res.headers["x-agent-id"]).toBeUndefined();
       expect(res.body).toMatch(/id: 1\nevent: text\ndata: /);
       expect(res.body).toContain("event: finish");
     });
@@ -1255,9 +1254,8 @@ describe("chat routes", () => {
     });
   });
 
-  // ── Same-turn agent handoff: the front desk calls transfer_to_agent, the loop switches the active
-  //    agent (persisting it) and the target continues in the SAME SSE stream; complete_task hands
-  //    control back to the GeneralAssistant. ──
+  // ── Same-turn agent handoff: a user-created agent can call transfer_to_agent and the loop switches
+  //    to a valid target in the same SSE stream. Normal chat never has a named platform agent. ──
   describe("POST /api/v1/chat (agent handoff / delegation)", () => {
     function registerControlTools(): ToolRegistry {
       const reg = new ToolRegistry();
@@ -1296,7 +1294,7 @@ describe("chat routes", () => {
       return reg;
     }
 
-    it("transfers GeneralAssistant → InformationArchitect in one turn and persists the active agent", async () => {
+    it("ignores a transfer to an agent that does not exist", async () => {
       await app.close();
       select.mockImplementation(() =>
         makeToolThenTextModel(
@@ -1304,10 +1302,10 @@ describe("chat routes", () => {
             {
               toolCallId: "c1",
               toolName: "transfer_to_agent",
-              args: { agentId: "InformationArchitect" },
+              args: { agentId: "missing-agent" },
             },
           ],
-          "Information Architect here — building it now."
+          "The default assistant stays active."
         )
       );
       app = await buildApp({
@@ -1329,21 +1327,14 @@ describe("chat routes", () => {
       await waitFor(() => streamRepo.rows.some((r) => r.eventType === "finish"), 2000);
 
       const types = streamRepo.rows.map((r) => r.eventType);
-      // The front desk's transfer tool-result AND the architect's follow-up text are on one stream,
-      // closed by exactly one finish.
+      // An unknown target cannot take over the conversation; the stream still closes once.
       expect(types.filter((t) => t === "finish")).toHaveLength(1);
       const toolResult = streamRepo.rows.find((r) => r.eventType === "tool-result");
       expect((toolResult?.data as { toolName: string }).toolName).toBe("transfer_to_agent");
-      const text = streamRepo.rows
-        .filter((r) => r.eventType === "text")
-        .map((r) => (r.data as { delta: string }).delta)
-        .join("");
-      expect(text).toContain("Information Architect here");
-      // The active agent is persisted as the architect (it did not complete_task this turn).
-      expect(repo.docs.get(convoId)?.agentId).toBe("InformationArchitect");
+      expect(repo.docs.get(convoId)?.agentId).toBeUndefined();
     });
 
-    it("complete_task hands control back to the GeneralAssistant", async () => {
+    it("does not persist an unknown agent on a new conversation", async () => {
       await app.close();
       select.mockImplementation(() =>
         makeToolThenTextModel(
@@ -1364,14 +1355,13 @@ describe("chat routes", () => {
         toolRegistry: registerControlTools(),
       });
 
-      const res = await post({ message: userMsg("that's all"), agentId: "InformationArchitect" });
+      const res = await post({ message: userMsg("that's all"), agentId: "missing-agent" });
       expect(res.statusCode).toBe(200);
       const convoId = res.headers["x-conversation-id"] as string;
       await waitFor(() => streamRepo.rows.some((r) => r.eventType === "finish"), 2000);
 
-      expect(repo.docs.get(convoId)?.agentId).toBe("GeneralAssistant");
-      // After complete_task the front desk streams a brief closing confirmation (the model's 2nd
-      // call), so the turn never ends on a silent tool result.
+      expect(repo.docs.get(convoId)?.agentId).toBeUndefined();
+      // Completion is a normal tool result; no second platform-agent turn is created.
       const closing = streamRepo.rows
         .filter((r) => r.eventType === "text")
         .map((r) => (r.data as { delta: string }).delta)
@@ -1384,8 +1374,7 @@ describe("chat routes", () => {
   // ── Sticky @mention hand-off: a mid-conversation `@agent` mention re-targets the active agent.
   //    Unlike the LLM-driven transfer_to_agent above, this is a deterministic, user-initiated switch
   //    keyed off body.agentId — the tagged agent takes over this turn and persists as the
-  //    conversation's agent until a different one is tagged. InformationArchitect/GeneralAssistant are
-  //    platform agents (always resolvable via getAgent), so no toolRegistry/soul setup is needed. ──
+  //    conversation's agent until a different one is tagged. Normal chat has no persisted agent id. ──
   describe("POST /api/v1/chat (sticky @mention hand-off)", () => {
     async function seedConvo(agentId?: string): Promise<string> {
       const id = randomUUID();
@@ -1403,56 +1392,35 @@ describe("chat routes", () => {
     const handoffs = () => streamRepo.rows.filter((r) => r.eventType === "agent-handoff");
     const finish = () => waitFor(() => streamRepo.rows.some((r) => r.eventType === "finish"), 2000);
 
-    it("routes the turn to the @mentioned agent, persists it, and emits an inline handoff marker", async () => {
-      const convoId = await seedConvo("GeneralAssistant");
+    it("ignores a mention of an agent that does not exist", async () => {
+      const convoId = await seedConvo();
       const res = await post({
         conversationId: convoId,
-        message: userMsg("@Information Architect build it"),
-        agentId: "InformationArchitect",
+        message: userMsg("@Missing Agent build it"),
+        agentId: "missing-agent",
       });
       expect(res.statusCode).toBe(200);
       await finish();
 
-      // The header reflects the switched agent immediately (X-Agent-Id), the switch persists, and a
-      // single agent-handoff event drives the client's inline marker + current-agent indicator.
-      expect(res.headers["x-agent-id"]).toBe("InformationArchitect");
-      expect(repo.docs.get(convoId)?.agentId).toBe("InformationArchitect");
+      expect(res.headers["x-agent-id"]).toBeUndefined();
+      expect(repo.docs.get(convoId)?.agentId).toBeUndefined();
       const hs = handoffs();
-      expect(hs).toHaveLength(1);
-      expect(hs[0]?.data).toMatchObject({ from: "GeneralAssistant", to: "InformationArchitect" });
+      expect(hs).toHaveLength(0);
     });
 
-    it("a turn with no @mention stays on the conversation's persisted agent (sticky)", async () => {
-      const convoId = await seedConvo("InformationArchitect");
+    it("a conversation with a removed agent resolves to normal chat", async () => {
+      const convoId = await seedConvo("removed-agent");
       const res = await post({ conversationId: convoId, message: userMsg("and the next bit") });
       expect(res.statusCode).toBe(200);
       await finish();
 
-      expect(res.headers["x-agent-id"]).toBe("InformationArchitect");
-      expect(repo.docs.get(convoId)?.agentId).toBe("InformationArchitect");
+      expect(res.headers["x-agent-id"]).toBeUndefined();
+      expect(repo.docs.get(convoId)?.agentId).toBe("removed-agent");
       expect(handoffs()).toHaveLength(0);
     });
 
-    it("re-tagging a different agent switches again", async () => {
-      const convoId = await seedConvo("InformationArchitect");
-      const res = await post({
-        conversationId: convoId,
-        message: userMsg("@General Assistant thanks"),
-        agentId: "GeneralAssistant",
-      });
-      expect(res.statusCode).toBe(200);
-      await finish();
-
-      expect(res.headers["x-agent-id"]).toBe("GeneralAssistant");
-      expect(repo.docs.get(convoId)?.agentId).toBe("GeneralAssistant");
-      expect(handoffs()[0]?.data).toMatchObject({
-        from: "InformationArchitect",
-        to: "GeneralAssistant",
-      });
-    });
-
     it("ignores an unknown @mention (no switch, no marker, no persist)", async () => {
-      const convoId = await seedConvo("GeneralAssistant");
+      const convoId = await seedConvo();
       const setAgentSpy = vi.spyOn(repo, "setAgent");
       const res = await post({
         conversationId: convoId,
@@ -1462,61 +1430,26 @@ describe("chat routes", () => {
       expect(res.statusCode).toBe(200);
       await finish();
 
-      expect(res.headers["x-agent-id"]).toBe("GeneralAssistant");
-      expect(repo.docs.get(convoId)?.agentId).toBe("GeneralAssistant");
+      expect(res.headers["x-agent-id"]).toBeUndefined();
+      expect(repo.docs.get(convoId)?.agentId).toBeUndefined();
       expect(handoffs()).toHaveLength(0);
       expect(setAgentSpy).not.toHaveBeenCalled();
     });
 
-    it("mentioning the already-active agent is a no-op (no marker, no persist)", async () => {
-      const convoId = await seedConvo("GeneralAssistant");
-      const setAgentSpy = vi.spyOn(repo, "setAgent");
-      const res = await post({
-        conversationId: convoId,
-        message: userMsg("@General Assistant still you"),
-        agentId: "GeneralAssistant",
-      });
-      expect(res.statusCode).toBe(200);
-      await finish();
-
-      expect(res.headers["x-agent-id"]).toBe("GeneralAssistant");
-      expect(handoffs()).toHaveLength(0);
-      expect(setAgentSpy).not.toHaveBeenCalled();
-    });
-
-    it("a legacy conversation (no persisted agent) mentioning the default agent is a no-op", async () => {
-      // convo.agentId === undefined (a row predating agent persistence): the effective agent is the
-      // GeneralAssistant, so tagging it must NOT spuriously switch/persist/emit a marker.
+    it("normal chat ignores an unknown mention without persisting an agent", async () => {
       const convoId = await seedConvo();
       const setAgentSpy = vi.spyOn(repo, "setAgent");
       const res = await post({
         conversationId: convoId,
-        message: userMsg("@General Assistant hi"),
-        agentId: "GeneralAssistant",
+        message: userMsg("@Missing Agent hi"),
+        agentId: "missing-agent",
       });
       expect(res.statusCode).toBe(200);
       await finish();
 
-      expect(res.headers["x-agent-id"]).toBe("GeneralAssistant");
+      expect(res.headers["x-agent-id"]).toBeUndefined();
       expect(handoffs()).toHaveLength(0);
       expect(setAgentSpy).not.toHaveBeenCalled();
-    });
-
-    it("a setAgent persistence failure is non-fatal — the turn still runs as the switched agent", async () => {
-      const convoId = await seedConvo("GeneralAssistant");
-      vi.spyOn(repo, "setAgent").mockRejectedValueOnce(new Error("db down"));
-      const res = await post({
-        conversationId: convoId,
-        message: userMsg("@Information Architect build it"),
-        agentId: "InformationArchitect",
-      });
-      expect(res.statusCode).toBe(200);
-      await finish();
-
-      // The in-memory switch survives a failed persist: the turn is served by the target agent and a
-      // finish closes the stream (no 500). Persistence simply didn't stick this time.
-      expect(res.headers["x-agent-id"]).toBe("InformationArchitect");
-      expect(streamRepo.rows.filter((r) => r.eventType === "finish")).toHaveLength(1);
     });
   });
 

--- a/apps/api/src/chat/system-prompt.test.ts
+++ b/apps/api/src/chat/system-prompt.test.ts
@@ -1,7 +1,7 @@
 import type { SoulAgent } from "@tulipfarm/soul";
 import { describe, expect, it } from "vitest";
 import { assembleSystemPrompt } from "../context/assemble";
-import { INFORMATION_ARCHITECT } from "../soul/agents/platform-agents";
+import { DEFAULT_ASSISTANT } from "../soul/agents/platform-agents";
 import type { SoulCatalogue } from "../soul/catalogue";
 import { assembleAgentSystemPrompt } from "./system-prompt";
 
@@ -57,7 +57,7 @@ describe("assembleAgentSystemPrompt", () => {
   it("merges the platform agent's forge skills into the available-skills index", () => {
     const withForge = assembleAgentSystemPrompt({
       agent,
-      platformAgent: INFORMATION_ARCHITECT,
+      platformAgent: DEFAULT_ASSISTANT,
       ...empty,
     });
     const withoutForge = assembleAgentSystemPrompt({ agent, platformAgent: undefined, ...empty });
@@ -68,10 +68,10 @@ describe("assembleAgentSystemPrompt", () => {
   it("threads the soul catalogue and tool index into their blocks; forge stays out of soul-context", () => {
     const out = assembleAgentSystemPrompt({
       agent,
-      platformAgent: INFORMATION_ARCHITECT,
+      platformAgent: DEFAULT_ASSISTANT,
       ...empty,
       soulCatalogue: {
-        agents: [{ name: "GeneralAssistant", description: "Front desk" }],
+        agents: [{ name: "support-agent", description: "Customer support" }],
         skills: [{ name: "catalogue-skill", description: "Repo skill" }],
         resourceTypes: [{ name: "invoice", description: "Billable items" }],
         routines: [],

--- a/apps/api/src/chat/turn-helpers.ts
+++ b/apps/api/src/chat/turn-helpers.ts
@@ -2,7 +2,7 @@ import type { ModelMessage } from "ai";
 import type { FastifyReply } from "fastify";
 import type { KnowledgeService } from "../knowledge/service";
 import { CITE_SOURCES_TOOL } from "../knowledge/tools";
-import { EXCLUSIVE_SOUL_WRITE_TOOLS, type PlatformAgent } from "../soul/agents/registry";
+import type { PlatformAgent } from "../soul/agents/registry";
 import type { ToolRegistry } from "../tools/registry";
 import {
   fromAssistantParts,
@@ -244,29 +244,22 @@ export function corsPassthrough(reply: FastifyReply): Record<string, string> {
 }
 
 // Per-agent tool scoping (shared by the chat turn's toolset build, its <available-tools> prompt
-// block, and the debug-context route): the Information Architect is filtered to its forge
-// allowlist; every other agent (the GeneralAssistant front desk + user soul agents) gets all
-// registered tools EXCEPT the IA-exclusive soul writes — so only the IA can author/edit soul
-// artifacts. `undefined` (no/empty registry) means no scoping — every registered tool is exposed.
+// block, and the debug-context route): a platform allowlist is applied when supplied; otherwise
+// every registered tool is exposed. The built-in assistant intentionally receives the full set.
 export function allowedToolNamesFor(
   toolRegistry: ToolRegistry | undefined,
   pa: PlatformAgent | undefined
 ): ReadonlySet<string> | undefined {
   if (!(toolRegistry && toolRegistry.getAll().length > 0)) return undefined;
   if (pa?.toolAllowlist) return new Set(pa.toolAllowlist);
-  return new Set(
-    toolRegistry
-      .getAll()
-      .map((t) => t.name)
-      .filter((n) => !EXCLUSIVE_SOUL_WRITE_TOOLS.has(n))
-  );
+  return undefined;
 }
 
 /**
  * Whether to instruct knowledge grounding + citation (and surface pinned pages) for an agent this
  * turn: a knowledge service must be wired AND `cite_sources` must be in the agent's scoped toolset
- * (so e.g. the Information Architect, which has no knowledge tools, is excluded). Centralizes the gate
- * the chat turn and the debug-context route otherwise duplicated.
+ * (so a future restricted platform agent can be excluded). Centralizes the gate the chat turn and
+ * the debug-context route otherwise duplicated.
  */
 export function canGroundKnowledge(
   knowledge: KnowledgeService | undefined,

--- a/apps/api/src/chat/turn.ts
+++ b/apps/api/src/chat/turn.ts
@@ -158,10 +158,14 @@ export async function prepareChatTurn(
   } else {
     const now = new Date();
     const requestedAgentId = body.agentId;
+    // Unknown agentId → normal chat (the composer only offers real agents); don't persist a
+    // dangling reference.
+    const validAgentId =
+      requestedAgentId && getAgent(soulLoader, requestedAgentId) ? requestedAgentId : undefined;
     convo = {
       _id: randomUUID(),
       userId: user._id,
-      agentId: requestedAgentId,
+      agentId: validAgentId,
       model: undefined,
       createdAt: now,
       updatedAt: now,
@@ -171,7 +175,7 @@ export async function prepareChatTurn(
     events?.emit(DOMAIN_EVENTS.CONVERSATION_CREATED, {
       conversationId: convo._id,
       actorId: user._id,
-      agentId: requestedAgentId,
+      agentId: validAgentId,
     });
     // Best-effort, off the turn's critical path: derive a title from the first message via the
     // quick tier and persist it asynchronously. The stream below is never blocked on this, and a
@@ -791,8 +795,10 @@ export async function runChatTurn(req: FastifyRequest, reply: FastifyReply, ctx:
   writeSseHeaders(reply.raw, {
     "X-Stream-Id": handle.streamId,
     "X-Message-Id": handle.replyMessageId,
-    // Only a user-selected Soul Agent is exposed to the client. Normal chat has no agent identity.
-    ...(prepared.convo.agentId ? { "X-Agent-Id": handle.agentName } : {}),
+    // Only a user-selected Soul Agent is exposed to the client. Normal chat has no agent identity —
+    // and a removed agent resolves back to normal chat, so key off the resolved agent, not the
+    // (possibly stale) persisted convo.agentId.
+    ...(prepared.agent.name !== DEFAULT_ASSISTANT_NAME ? { "X-Agent-Id": handle.agentName } : {}),
     ...corsPassthrough(reply),
   });
   reply.hijack();

--- a/apps/api/src/chat/turn.ts
+++ b/apps/api/src/chat/turn.ts
@@ -20,9 +20,9 @@ import {
   type ObservableStep,
 } from "../observability/capture";
 import {
-  GENERAL_ASSISTANT_NAME,
+  DEFAULT_ASSISTANT_NAME,
   getAgent,
-  getPlatformAgent,
+  getDefaultAssistant,
   resolveAgent,
 } from "../soul/agents/registry";
 import { buildSoulCatalogue } from "../soul/catalogue";
@@ -101,14 +101,14 @@ export interface PreparedTurn {
   isNew: boolean;
   userSwitch?: { from: string; to: string; reason: string };
   agent: ReturnType<typeof resolveAgent>;
-  platformAgent: ReturnType<typeof getPlatformAgent>;
+  platformAgent: ReturnType<typeof getDefaultAssistant>;
   resolved: ResolvedModel;
   resolvedModelId: string;
   messages: ModelMessage[];
   pending: Awaited<ReturnType<PendingInteractionRepo["findOpenByConversation"]>>;
   buildSystemFor: (
     a: ReturnType<typeof resolveAgent>,
-    pa: ReturnType<typeof getPlatformAgent>
+    pa: ReturnType<typeof getDefaultAssistant>
   ) => string;
 }
 
@@ -157,10 +157,11 @@ export async function prepareChatTurn(
     isNew = false;
   } else {
     const now = new Date();
+    const requestedAgentId = body.agentId;
     convo = {
       _id: randomUUID(),
       userId: user._id,
-      agentId: body.agentId,
+      agentId: requestedAgentId,
       model: undefined,
       createdAt: now,
       updatedAt: now,
@@ -170,7 +171,7 @@ export async function prepareChatTurn(
     events?.emit(DOMAIN_EVENTS.CONVERSATION_CREATED, {
       conversationId: convo._id,
       actorId: user._id,
-      agentId: body.agentId,
+      agentId: requestedAgentId,
     });
     // Best-effort, off the turn's critical path: derive a title from the first message via the
     // quick tier and persist it asynchronously. The stream below is never blocked on this, and a
@@ -190,11 +191,10 @@ export async function prepareChatTurn(
   //     body.agentId above, so no switch/marker there.) Surfaced to the client as the same
   //     `agent-handoff` event a transfer emits (see agentTurnStream).
   let userSwitch: { from: string; to: string; reason: string } | undefined;
-  // Compare against the EFFECTIVE current agent: a legacy row with no persisted agentId resolves
-  // to the GeneralAssistant, so tagging it must read as a no-op (not a spurious GA→GA switch).
-  const currentAgentId = convo.agentId ?? GENERAL_ASSISTANT_NAME;
+  // A conversation with no selected Agent is normal chat, not an implicit named Agent.
+  const currentAgentId = convo.agentId ?? DEFAULT_ASSISTANT_NAME;
   if (!isNew && body.agentId && body.agentId !== currentAgentId) {
-    const target = getAgent(soulLoader, body.agentId); // platform OR soul agent; undefined if unknown
+    const target = getAgent(soulLoader, body.agentId);
     if (target) {
       userSwitch = {
         from: currentAgentId,
@@ -252,11 +252,11 @@ export async function prepareChatTurn(
   const history = await messageRepo.listByConversation(convo._id, 1000);
   const messages: ModelMessage[] = [];
   const agent = resolveAgent(soulLoader, convo.agentId);
-  const platformAgent = getPlatformAgent(agent.name);
+  const platformAgent = getDefaultAssistant(agent.name);
   // Memory + governance + soul skills are conversation-scoped, so fetch once and reuse for both
-  // the front desk and any handoff target. `buildSystemFor` assembles a per-agent system prompt:
-  // the agent's body + its inbuilt forge skills (frontmatter only; bodies pulled on demand via
-  // load_skill). Only the Information Architect carries forge skills today.
+  // the built-in assistant and any handoff target. `buildSystemFor` assembles a per-agent system
+  // prompt: the agent's body + its inbuilt forge skills (frontmatter only; bodies pulled on demand
+  // via `load_skill`).
   const memoryList = workingMemory ? await workingMemory.list(user._id) : [];
   const governancePages = knowledge ? await knowledge.governancePages() : [];
   const soulAvailableSkills = listAvailableSkills(soulLoader);
@@ -502,7 +502,7 @@ export async function startChatTurn(
 
   // Same-turn agent loop (delegation): the active agent runs first; if it calls
   // `transfer_to_agent` the conversation's active agent switches (persisted) and the target
-  // continues IN THE SAME SSE stream; `complete_task` hands control back to the GeneralAssistant.
+  // continues in the same SSE stream.
   // Each agent gets its own streamText tool loop; we suppress the per-agent `finish` part and
   // emit exactly one synthetic finish after the chain ends.
   const MAX_HANDOFF_DEPTH = 4;
@@ -510,9 +510,6 @@ export async function startChatTurn(
     let activeAgent = agent;
     let activePlatform = platformAgent;
     let turnMessages = messages;
-    // Set once we've queued the GeneralAssistant's closing confirmation after a `complete_task`,
-    // so the next iteration runs that wrap-up turn and then ends.
-    let closingTurn = false;
 
     // Observability accumulators (best-effort, off the critical path). Each finished step emits an
     // LLM_STEP_FINISHED; totals roll up across steps + handoffs into one TURN_FINISHED at the end.
@@ -584,7 +581,7 @@ export async function startChatTurn(
           tools: turnTools,
           // The stop endpoint aborts this signal to halt generation mid-turn (see streamControllers).
           abortSignal: abortController.signal,
-          // Stop the agent's own loop at the step budget, or as soon as it hands off / completes —
+          // Stop the agent's own loop at the step budget, or as soon as it hands off —
           // so control returns to this loop without the agent rambling after the control tool.
           stopWhen: ({ steps }) => {
             if (steps.length >= MAX_TOOL_STEPS) return true;
@@ -592,7 +589,6 @@ export async function startChatTurn(
             return (last?.toolCalls ?? []).some(
               (c) =>
                 c.toolName === "transfer_to_agent" ||
-                c.toolName === "complete_task" ||
                 c.toolName === "ask_user" || // HITL: end the turn cleanly with the form rendered
                 c.toolName === "cite_sources" // terminal: cite_sources is the answer's last act —
               // stopping here prevents the model running another step that restates the whole answer
@@ -652,10 +648,7 @@ export async function startChatTurn(
           },
         });
 
-        let control:
-          | { type: "transfer"; target: string; reason?: string }
-          | { type: "complete"; summary?: string }
-          | undefined;
+        let control: { type: "transfer"; target: string; reason?: string } | undefined;
         // Set when this agent calls `ask_user`: the turn ends with the form rendered and a pending
         // interaction is persisted so the next request resumes with the user's answer.
         let pendingAsk:
@@ -678,24 +671,15 @@ export async function startChatTurn(
               };
             }
           }
-          if (
-            p.type === "tool-result" &&
-            (p.toolName === "transfer_to_agent" || p.toolName === "complete_task")
-          ) {
+          if (p.type === "tool-result" && p.toolName === "transfer_to_agent") {
             const full = fullResultCache.get(p.toolCallId as string);
             if (full?.success) {
               const data = full.data as Record<string, unknown>;
-              control =
-                p.toolName === "transfer_to_agent"
-                  ? {
-                      type: "transfer",
-                      target: String(data.agentId),
-                      reason: data.message ? String(data.message) : undefined,
-                    }
-                  : {
-                      type: "complete",
-                      summary: data.summary ? String(data.summary) : undefined,
-                    };
+              control = {
+                type: "transfer",
+                target: String(data.agentId),
+                reason: data.message ? String(data.message) : undefined,
+              };
             }
           }
           yield part;
@@ -724,12 +708,13 @@ export async function startChatTurn(
           emitTurnFinished("paused");
           break;
         }
-        if (closingTurn) break; // the GeneralAssistant's closing confirmation just streamed
-        if (control?.type === "transfer" && depth < MAX_HANDOFF_DEPTH - 1) {
+        const transferTarget =
+          control?.type === "transfer" ? getAgent(soulLoader, control.target) : undefined;
+        if (control?.type === "transfer" && transferTarget && depth < MAX_HANDOFF_DEPTH - 1) {
           const fromAgent = activeAgent.name;
-          await repo.setAgent(convo._id, control.target);
-          activeAgent = resolveAgent(soulLoader, control.target);
-          activePlatform = getPlatformAgent(activeAgent.name);
+          await repo.setAgent(convo._id, transferTarget.name);
+          activeAgent = transferTarget;
+          activePlatform = getDefaultAssistant(activeAgent.name);
           // Surface the live switch so the client's current-agent indicator follows the handoff.
           yield {
             type: "agent-handoff",
@@ -746,35 +731,6 @@ export async function startChatTurn(
             { role: "user", content: handoffUser },
           ];
           continue;
-        }
-        if (control?.type === "complete" && depth < MAX_HANDOFF_DEPTH - 1) {
-          // Control returns to the front desk, which streams a brief confirmation of what the
-          // specialist just did — otherwise the turn ends on a silent (collapsed) tool result.
-          const fromAgent = activeAgent.name;
-          await repo.setAgent(convo._id, GENERAL_ASSISTANT_NAME);
-          activeAgent = resolveAgent(soulLoader, GENERAL_ASSISTANT_NAME);
-          activePlatform = getPlatformAgent(activeAgent.name);
-          // Hand the indicator back to the front desk for the closing confirmation turn.
-          yield { type: "agent-handoff", from: fromAgent, to: activeAgent.name };
-          const summary = control.summary ?? "completed the requested work";
-          turnMessages = [
-            { role: "system", content: buildSystemFor(activeAgent, activePlatform) },
-            { role: "user", content: userContent },
-            {
-              role: "assistant",
-              content: `(Internal note — the Information Architect handled that and reported: ${summary})`,
-            },
-            {
-              role: "user",
-              content:
-                "In one short, friendly sentence, confirm what was just created or done, and suggest one relevant next step. Do not call any tools.",
-            },
-          ];
-          closingTurn = true;
-          continue;
-        }
-        if (control?.type === "complete") {
-          await repo.setAgent(convo._id, GENERAL_ASSISTANT_NAME);
         }
         break;
       }
@@ -835,9 +791,8 @@ export async function runChatTurn(req: FastifyRequest, reply: FastifyReply, ctx:
   writeSseHeaders(reply.raw, {
     "X-Stream-Id": handle.streamId,
     "X-Message-Id": handle.replyMessageId,
-    // The agent handling this turn (from the @mention / conversation) so the client's header
-    // indicator reflects it immediately; mid-turn handoffs then update it via agent-handoff events.
-    "X-Agent-Id": handle.agentName,
+    // Only a user-selected Soul Agent is exposed to the client. Normal chat has no agent identity.
+    ...(prepared.convo.agentId ? { "X-Agent-Id": handle.agentName } : {}),
     ...corsPassthrough(reply),
   });
   reply.hijack();

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -80,7 +80,6 @@ import { reconcileRoutineSchedules, registerRoutineCronWorker } from "./routines
 import { RoutineTriggerService, subscribeRoutineEventTriggers } from "./routines/trigger-service";
 import { bootstrapFromEnv } from "./setup/bootstrap";
 import { readSoulConfig, SOUL_GIT_CREDENTIAL_KEY } from "./setup/soul-config";
-import { PLATFORM_AGENTS } from "./soul/agents/platform-agents";
 import { BUILTIN_SKILLS } from "./soul/skills/builtin-skills";
 import { registerSoulSync } from "./soul-sync";
 import { buildToolRegistry } from "./tools/setup";
@@ -246,7 +245,6 @@ async function boot() {
         soulPath: process.env.SOUL_PATH,
         gitSync,
         builtinSkills: BUILTIN_SKILLS,
-        platformAgentNames: new Set(PLATFORM_AGENTS.map((a) => a.name)),
         triggerRoutine: (slug, inputs) =>
           routineTriggerService.trigger(slug, { type: "agent", payload: inputs ?? {} }),
         onRoutinesChanged: async () => {

--- a/apps/api/src/onboarding/catalog.ts
+++ b/apps/api/src/onboarding/catalog.ts
@@ -1,5 +1,5 @@
 /*
- * Static seed catalog for the Information Architect suggestion layer (ONBOARDING ONB-V1-002/003).
+ * Static seed catalog for the normal-chat suggestion layer (ONBOARDING ONB-V1-002/003).
  * Each entry is a candidate onboarding suggestion. `resources` is the match key: the resource
  * name(s) the suggestion would create — an entry is hidden once any of them already exists in the
  * soul (AC-V1-002). `label` is the chip text; `prompt` is the message seeded into chat on tap.

--- a/apps/api/src/onboarding/checklist.ts
+++ b/apps/api/src/onboarding/checklist.ts
@@ -9,7 +9,7 @@ import { evaluateRules } from "./rules";
  * contextual "recommended next" items come from the deterministic rule set in ./rules.
  *
  * Typed against a minimal soul slice (resources/skills/agents maps) so it is trivially testable with
- * a stub — mirrors suggestions.ts. The platform agents (GeneralAssistant / InformationArchitect)
+ * a stub — mirrors suggestions.ts. The built-in platform assistant
  * live in listAgents(), NOT in soulLoader.agents, so `agents.size > 0` correctly counts only
  * user-created soul agents.
  */

--- a/apps/api/src/onboarding/personalize.ts
+++ b/apps/api/src/onboarding/personalize.ts
@@ -60,7 +60,7 @@ export const PERSONALIZED_SCHEMA = {
 } as const;
 
 export const SYSTEM_PROMPT = [
-  "You are the Information Architect's onboarding guide for TulipFarm, an AI-native business",
+  "You are TulipFarm's onboarding guide for an AI-native business",
   "operating system. Given a business and what it has already built in its soul, propose the most",
   "useful next things to create.",
   "",

--- a/apps/api/src/onboarding/routes.ts
+++ b/apps/api/src/onboarding/routes.ts
@@ -9,7 +9,7 @@ import { getPersonalizedOnboarding } from "./personalize";
 import { deriveSuggestions } from "./suggestions";
 
 /*
- * Read-only HTTP surface for the onboarding / Information Architect layer (ONBOARDING ONB-V1).
+ * Read-only HTTP surface for the normal-chat onboarding layer (ONBOARDING ONB-V1).
  *
  * - `/suggestions` — the adaptive empty-state chips, derived from the soul resource set (a candidate
  *   is omitted once the resource it would create already exists). No persistence.

--- a/apps/api/src/onboarding/rules.ts
+++ b/apps/api/src/onboarding/rules.ts
@@ -4,7 +4,7 @@ import type { ChecklistSignals, Recommendation } from "./checklist";
  * Deterministic "recommended next" rules (ONBOARDING ONB-V1). Each rule is a predicate over the
  * current soul state plus a builder for its label + seeded chat prompt. Recommendations surface in
  * the checklist card once core steps progress; tapping one seeds a prompt down the existing
- * GeneralAssistant -> InformationArchitect build flow (identical to the suggestion chips). Pure and
+ * built-in assistant build flow (identical to the suggestion chips). Pure and
  * cheap — no LLM — so it can run on every checklist request. Adding a rule = one array entry.
  */
 

--- a/apps/api/src/platform/tools.test.ts
+++ b/apps/api/src/platform/tools.test.ts
@@ -469,17 +469,17 @@ describe("transferToAgentTool", () => {
     expect(res).toMatchObject({ success: false, error: { code: "not_found" } });
   });
 
-  it("accepts a code-defined platform agent (InformationArchitect) as a transfer target", async () => {
+  it("accepts the built-in platform assistant as a transfer target", async () => {
     const ctx: PlatformToolContext = {
-      platformAgentNames: new Set(["InformationArchitect"]),
+      platformAgentNames: new Set(["GeneralAssistant"]),
     };
     const res = await transferToAgentTool.handler(
-      { agentId: "InformationArchitect", message: "build an invoices resource" },
+      { agentId: "GeneralAssistant", message: "resume the default assistant" },
       ctx
     );
     expect(res).toMatchObject({
       success: true,
-      data: { agentId: "InformationArchitect", status: "transferred" },
+      data: { agentId: "GeneralAssistant", status: "transferred" },
     });
   });
 });

--- a/apps/api/src/platform/tools.ts
+++ b/apps/api/src/platform/tools.ts
@@ -439,7 +439,7 @@ const validateTransfer = ajv.compile(TRANSFER_TO_AGENT_SCHEMA);
 export const transferToAgentTool: PlatformTool = {
   name: "transfer_to_agent",
   description:
-    "Hand the conversation off to another agent (e.g. the InformationArchitect for any create/edit of a resource type, skill, or agent). The conversation's active agent switches and future turns are handled by the target until it completes. Validates that the target is a known platform or soul agent.",
+    "Hand the conversation off to another configured agent. The conversation's active agent switches and future turns are handled by the target. Validates that the target is a known platform or Soul agent.",
   mutating: false,
   inputSchema: TRANSFER_TO_AGENT_SCHEMA,
   handler: async (args, ctx) => {

--- a/apps/api/src/soul/agents/platform-agents.test.ts
+++ b/apps/api/src/soul/agents/platform-agents.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_ASSISTANT, DEFAULT_ASSISTANT_NAME, getDefaultAssistant } from "./platform-agents";
+
+describe("default chat harness", () => {
+  it("is an internal normal-chat identity rather than a selectable Soul agent", () => {
+    expect(DEFAULT_ASSISTANT.name).toBe(DEFAULT_ASSISTANT_NAME);
+    expect(getDefaultAssistant(DEFAULT_ASSISTANT_NAME)).toBe(DEFAULT_ASSISTANT);
+    expect(getDefaultAssistant("support-agent")).toBeUndefined();
+  });
+
+  it("combines TulipFarm's business-building role with execution discipline", () => {
+    expect(DEFAULT_ASSISTANT.body).toContain("## Building the system");
+    expect(DEFAULT_ASSISTANT.body).toContain("## Execution discipline");
+    expect(DEFAULT_ASSISTANT.body).toContain("Do not describe an action you could");
+    expect(DEFAULT_ASSISTANT.body).toContain("verify the result");
+    expect(DEFAULT_ASSISTANT.body).toContain("never invent a successful result");
+    expect(DEFAULT_ASSISTANT.body).toContain("Batch independent reads, searches, and lookups");
+    expect(DEFAULT_ASSISTANT.body).toContain("active autonomy and approval rules");
+  });
+});

--- a/apps/api/src/soul/agents/platform-agents.ts
+++ b/apps/api/src/soul/agents/platform-agents.ts
@@ -2,113 +2,46 @@ import type { SoulAgent } from "@tulipfarm/soul";
 import { FORGE_SKILL_NAMES } from "../skills/builtin-skills";
 
 /**
- * The two inbuilt platform agents (AGT-V1-007). These are code-defined — NOT AGENT.md on disk, NOT
- * loaded from the soul repo, NOT operator-editable. They are always present:
- *
- * - GeneralAssistant — the front desk. Read-only for soul mutations; answers questions, reads
- *   resources/knowledge, and DELEGATES any create/curate request to the Information Architect via
- *   `transfer_to_agent`. The default agent when none is selected.
- * - InformationArchitect — the single creation specialist. Owns the soul-CRUD tools, lazily loads
- *   the inbuilt forge skills (resource-forge / skill-forge / agent-forge / routine-forge /
- *   onboarding) via `load_skill`, does the writes itself, and returns control to the
- *   GeneralAssistant via `complete_task`.
- *
- * `toolAllowlist` (which tools the agent may actually call) is ENFORCED per-turn in the chat route
- * (Wave 2). `forgeSkills` are surfaced to the agent in `<available-skills>` and loadable via
- * `load_skill` (Wave 2). A SoulAgent (user-created) has neither — it gets flat ALLOW_ALL.
+ * The default chat harness. It is code-defined — not AGENT.md on disk, not loaded from the Soul
+ * repository, and not operator-editable. It owns both day-to-day work and Soul creation, so normal
+ * chat never needs a named platform-agent handoff.
  */
 export interface PlatformAgent extends SoulAgent {
-  /** Tool names this agent may call. `undefined` = all registered tools (flat ALLOW_ALL). */
+  /** Tool names this agent may call. Undefined means every registered tool. */
   toolAllowlist?: readonly string[];
   /** Inbuilt forge skill names surfaced to this agent and loadable via `load_skill`. */
   forgeSkills?: readonly string[];
 }
 
-/** Reserved PascalCase names so platform agents can never collide with kebab-case soul agents. */
-export const GENERAL_ASSISTANT_NAME = "GeneralAssistant";
-export const INFORMATION_ARCHITECT_NAME = "InformationArchitect";
+/** Internal identity for normal chat. It is never listed as an Agent or selectable in the UI. */
+export const DEFAULT_ASSISTANT_NAME = "__tulipfarm_default__";
 
-/**
- * Soul-write / control tools reserved for the Information Architect. They are stripped from every
- * agent that has NO `toolAllowlist` (the GeneralAssistant and user soul agents), so only the IA can
- * author or edit soul artifacts — "creation/curation routes to the Information Architect" (mirrors
- * the canary's exclusive-tool model). Agents WITH an allowlist (the IA) are filtered to that
- * allowlist instead, which is where these names are granted back.
- */
-export const EXCLUSIVE_SOUL_WRITE_TOOLS: ReadonlySet<string> = new Set([
-  "create_resource_type",
-  "resource_type_update",
-  "create_resource_hooks",
-  "resource_hooks_delete",
-  "agent_create",
-  "agent_update",
-  "agent_delete",
-  "skill_create",
-  "skill_update",
-  "skill_delete",
-  "skill_activate",
-  "routine_forge",
-  "complete_task",
-]);
-
-/**
- * The Information Architect's tool set: read the soul, author/edit resource types, skills, agents and
- * routines, load its forge skills, present interview UI, and signal completion back to the front desk.
- * It deliberately has NO `transfer_to_agent` (it never delegates — it only `complete_task`s back)
- * and NO resource-record or knowledge tools (those are day-to-day ops the front desk handles).
- */
-export const INFORMATION_ARCHITECT_TOOL_ALLOWLIST: readonly string[] = [
-  // Reads
-  "list_resource_types",
-  "resource_type_schema",
-  "agent_list",
-  "agent_get",
-  "skill_list",
-  "skill_get",
-  // Soul writes (resource types + hooks / agents / skills)
-  "create_resource_type",
-  "resource_type_update",
-  "create_resource_hooks",
-  "resource_hooks_get",
-  "resource_hooks_delete",
-  "agent_create",
-  "agent_update",
-  "agent_delete",
-  "skill_create",
-  "skill_update",
-  "skill_activate",
-  "skill_delete",
-  // Routines (author + smoke-test)
-  "routine_forge",
-  "trigger_routine",
-  // Forge skills (lazy load) + interview UI + validation
-  "load_skill",
-  "load_skill_reference",
-  "present_choices",
-  "compose_view",
-  "render_surface",
-  "update_surface",
-  "ask_user",
-  "get_client_context",
-  "navigate_to",
-  "prefill_form",
-  "invoke_action",
-  "validate_artifact",
-  // Working memory + completion signal back to the GeneralAssistant
-  "update_memory",
-  "delete_memory",
-  "complete_task",
-];
-
-const GENERAL_ASSISTANT_BODY = `## Identity
+const DEFAULT_ASSISTANT_BODY = `## Identity
 
 You are the assistant for TulipFarm — an AI-native business operating system that helps users manage
-their business data. You are the front desk: you answer everyday questions directly and route
-specialized work to the right place.
+their business data and build their business system. You handle both everyday work and Soul creation
+in this conversation.
 
 You are a helpful, knowledgeable business assistant. When users ask about something, focus on what
 you can actually do; if a request falls outside your capabilities, be honest rather than guessing.
 You get things done efficiently while being clear about what you're doing and why.
+
+## Execution discipline
+
+- When a tool can make progress or verify an answer, use it. Do not describe an action you could
+  take and leave it for a later turn.
+- Finish the requested outcome, not merely a plan, partial draft, or one intermediate operation.
+  Before saying creation or an update is complete, verify the result with the relevant read, list,
+  or status tool when one is available.
+- Base claims about business data, the Soul, and current system state on tool results or supplied
+  context. If a tool fails or required information is unavailable, say so plainly, try a sensible
+  alternative when available, and never invent a successful result.
+- Make the obvious safe interpretation and act when it does not materially change the outcome. Ask
+  one focused question only when the missing choice changes the record, artifact, or action.
+- Batch independent reads, searches, and lookups in the same response. Keep dependent work ordered:
+  inspect before changing, and verify after changing.
+- Respect the active autonomy and approval rules. Never bypass a required approval, and explain a
+  real blocker together with the most useful next step.
 
 ## Decision Framework
 
@@ -117,7 +50,6 @@ You get things done efficiently while being clear about what you're doing and wh
 - When creating or updating a record, infer sensible values for fields you can reasonably derive
   (title, description, category, status, priority) and act — don't list fields you could have filled
   and ask the user to confirm them.
-- When the user asks to "find" or "search", read the relevant resources with appropriate filters.
 - When showing results, offer relevant follow-up actions.
 - If an operation partially succeeds, report what worked and what didn't.
 - **When you need the user to pick between options** (yes/no, A vs B, any branching decision), call
@@ -129,68 +61,12 @@ You get things done efficiently while being clear about what you're doing and wh
 
 For anything structured — a list of records, a table, key metrics, a detail view, a chart, or a short
 form to collect input — call \`render_surface\` with a declarative A2UI spec instead of describing the
-data in prose. \`spec.root\` is a component node (or array) using Card, Row, Column, Grid, Heading,
-Text, Badge, Alert, Button, MetricCard, List, DetailView, DataTable, BarChart, LineChart, Form. Bind
-values with \`{ "path": "/key" }\` against \`dataModel\`, and attach \`action: { event, payload }\` to
-buttons for follow-ups. Keep a one-line text summary alongside the surface. To update a surface you
-already rendered (a changed metric, a refreshed table), call \`update_surface\` with a \`dataModel\`
-patch — only nodes you bound with \`{ path }\` will recompute and swap in place, so bind the values you
-expect to change rather than inlining them. To change a surface's STRUCTURE (different components), call
-\`render_surface\` again with the SAME \`surfaceId\` — it replaces that surface in place.
+data in prose. Keep a one-line text summary alongside the surface.
 
-## Knowing the user's view
+## Building the system
 
-Call \`get_client_context\` to see the route + page title the user currently has open, and ground your
-answer in it (e.g. the record they're viewing). After that read, you may act on their view:
-\`navigate_to\` (open an internal path), \`prefill_form\` (propose values into the form they have open for
-them to confirm — you never submit), or \`invoke_action\` (run a named action the page registered). These
-actions are refused until you've called \`get_client_context\`.
-
-## Routing
-
-You are the front desk. You answer everyday questions directly (greetings, "what can you do?", reads
-of resources/knowledge). For anything that **builds or edits the soul** — a resource type/schema, an
-agent, a skill, a routine (scheduled/triggered automation), or onboarding — you **transfer** the
-conversation to the Information Architect using \`transfer_to_agent\`. You are the only agent that can
-transfer. Note: *triggering* an existing routine is a day-to-day op you handle yourself
-(\`routine_picker\` + \`trigger_routine\`); only *authoring/editing* one transfers.
-
-### When to transfer to \`InformationArchitect\`
-
-Transfer **immediately on the first turn** when the user wants to create or edit any soul artifact.
-Pass a brief \`reason\`: what the user wants, nothing more. Do NOT ask clarifying questions first —
-the Information Architect runs its own interview.
-
-Soul-building triggers (transfer right away):
-- "create / build / set up / make a / I need a [X]" where X is a system or data model (ticket
-  system, CRM, leave tracker, helpdesk, inventory, hiring pipeline, project manager, custom
-  workflow, …).
-- "create a resource", "add a schema", "track [X]", "store [X]".
-- "create an agent", "create a skill".
-- "create a routine", "automate [X]", "every morning/when X happens do Y", "schedule [X]".
-- First-run onboarding ("set up my business").
-
-Example: "create an invoices resource" → \`transfer_to_agent\` to \`InformationArchitect\` with reason
-"User wants to create an invoices resource type."
-
-### What you handle yourself (do NOT transfer)
-
-- Greetings, capability questions, small talk.
-- Reading resources, schemas, knowledge.
-
-### If intent is genuinely ambiguous
-
-Only ask to clarify when a message has no actionable keyword at all (e.g. "hi", "help"). A
-noun-phrase request like "build a CRM" is NOT ambiguous — transfer.`;
-
-const INFORMATION_ARCHITECT_BODY = `# Information Architect
-
-You are the Information Architect. You own all soul-building: resource types, skills, agents, and
-routines. You were activated because the user wants to create or edit part of their system, or run
-onboarding. Do the work yourself — you do NOT transfer or delegate. You load **forge skills** for
-guidance and call the soul-CRUD tools directly.
-
-## Core principles
+For a resource type/schema, agent, skill, routine, or onboarding request, build it yourself. For
+creation work:
 
 - **Load the right forge skill before building.** Each artifact type has a forge skill listed in
   \`<available-skills>\`. Call \`load_skill\` with its name to load the full workflow, then follow it:
@@ -199,73 +75,31 @@ guidance and call the soul-CRUD tools directly.
   - \`load_skill("agent-forge")\` — to define an agent.
   - \`load_skill("routine-forge")\` — to author a scheduled/triggered automation (routine).
   - \`load_skill("onboarding")\` — to run guided first-time business setup.
-  Load only what you need, when you need it.
 - **Build one artifact at a time, in dependency order:** resources → skills → agents → routines. A
   schema must exist before an agent references it, and a tool/agent must exist before a routine calls it.
-- **You finish the session, not the forge skills.** Each forge produces one artifact and reports
-  back to you. Only you decide when the whole session is done and call \`complete_task\`.
 - Soul writes are direct and ungated — \`create_resource_type\` / \`skill_create\` / \`agent_create\`
-  commit immediately. There is no approval step for editing the soul.
-- **Preview structured artifacts with \`render_surface\`** (a declarative A2UI spec → rich tf-* UI) —
-  e.g. show a proposed schema as a DetailView/DataTable before or after writing it.
+  commit immediately. There is no approval step for editing the Soul.
+- **Preview structured artifacts with \`render_surface\`** before or after writing them when useful.
 - **Use \`present_choices\` for every branching decision** (yes/no, option A vs B, "do you want X?").
-  Never list options as plain-text bullet points — they are not interactive. \`present_choices\`
-  renders clickable cards the user can tap; plain prose requires free-text matching and stalls the
-  turn when the user types a short answer like "yes".
+  Never list options as plain-text bullet points — they are not interactive.
 
-## Entry
+If the Soul already has custom resource types or agents, acknowledge the existing setup and add to it.
+Generated artifacts are additive; never modify or remove existing ones unless the user asks.`;
 
-Branch on the request:
-- **Incremental** ("create an invoices resource", "add a support agent", "make a skill that…",
-  "automate a daily digest routine"): skip discovery. Load the matching forge skill, build that
-  single artifact, then \`complete_task\`.
-- **Onboarding** ("set up my business", "run onboarding"): \`load_skill("onboarding")\` and follow
-  its full discovery → plan → generate → review flow.
-
-If the soul already has custom resource types or agents, acknowledge the existing setup and add to
-it — generated artifacts are additive; never modify or remove existing ones unless the user asks.
-
-## Completion contract
-
-When the session's work is done, call \`complete_task\`:
-- **success:** \`{ status: "success", summary: "<what was built>", result: { resources?, skills?, agents? } }\`
-- **failed:** \`{ status: "failed", error: "<specific reason>" }\`
-- **cancelled:** \`{ status: "cancelled", summary: "User abandoned setup." }\`
-
-If the user sends a message clearly unrelated to building, ask once whether to abandon; on
-confirmation, \`complete_task\` with \`cancelled\`.`;
-
-/** The default front-desk agent — answers when no soul agent is selected. */
-export const GENERAL_ASSISTANT: PlatformAgent = {
-  name: GENERAL_ASSISTANT_NAME,
+/** Normal chat's built-in harness — answers and builds when no Soul agent is selected. */
+export const DEFAULT_ASSISTANT: PlatformAgent = {
+  name: DEFAULT_ASSISTANT_NAME,
   frontmatter: {
-    label: "General Assistant",
+    label: "TulipFarm Assistant",
     description:
-      "Front desk for TulipFarm — answers questions, reads resources and knowledge, and routes creation work to the Information Architect.",
-    model: "standard",
-  },
-  body: GENERAL_ASSISTANT_BODY,
-};
-
-/** The single creation specialist — builds soul artifacts via the inbuilt forge skills. */
-export const INFORMATION_ARCHITECT: PlatformAgent = {
-  name: INFORMATION_ARCHITECT_NAME,
-  frontmatter: {
-    label: "Information Architect",
-    description:
-      "Creation specialist — builds and edits resource types, skills, and agents and runs onboarding, using the inbuilt forge skills.",
+      "TulipFarm's built-in assistant — manages business work and builds resources, skills, agents, and routines.",
     model: "complex",
   },
-  body: INFORMATION_ARCHITECT_BODY,
+  body: DEFAULT_ASSISTANT_BODY,
   forgeSkills: FORGE_SKILL_NAMES,
-  toolAllowlist: INFORMATION_ARCHITECT_TOOL_ALLOWLIST,
 };
 
-/** All inbuilt platform agents, GeneralAssistant first. */
-export const PLATFORM_AGENTS: readonly PlatformAgent[] = [GENERAL_ASSISTANT, INFORMATION_ARCHITECT];
-
-/** Look up an inbuilt platform agent by exact (PascalCase) name. */
-export function getPlatformAgent(name: string | undefined): PlatformAgent | undefined {
-  if (!name) return undefined;
-  return PLATFORM_AGENTS.find((a) => a.name === name);
+/** Returns the default harness only for a normal-chat identity. */
+export function getDefaultAssistant(name: string | undefined): PlatformAgent | undefined {
+  return name === DEFAULT_ASSISTANT_NAME ? DEFAULT_ASSISTANT : undefined;
 }

--- a/apps/api/src/soul/agents/registry.test.ts
+++ b/apps/api/src/soul/agents/registry.test.ts
@@ -1,18 +1,9 @@
 import type { SoulAgent, SoulLoader } from "@tulipfarm/soul";
 import { describe, expect, it } from "vitest";
-import {
-  EXCLUSIVE_SOUL_WRITE_TOOLS,
-  GENERAL_ASSISTANT,
-  GENERAL_ASSISTANT_NAME,
-  getAgent,
-  INFORMATION_ARCHITECT,
-  INFORMATION_ARCHITECT_NAME,
-  listAgents,
-  resolveAgent,
-} from "./registry";
+import { DEFAULT_ASSISTANT, getAgent, listAgents, resolveAgent } from "./registry";
 
 function makeSoulLoader(agents: SoulAgent[] = []): SoulLoader {
-  return { agents: new Map(agents.map((a) => [a.name, a])) } as unknown as SoulLoader;
+  return { agents: new Map(agents.map((agent) => [agent.name, agent])) } as unknown as SoulLoader;
 }
 
 const PLANNER: SoulAgent = {
@@ -22,113 +13,24 @@ const PLANNER: SoulAgent = {
 };
 
 describe("agent registry", () => {
-  describe("GENERAL_ASSISTANT built-in", () => {
-    it("has the reserved PascalCase name, a label, and a non-empty body", () => {
-      expect(GENERAL_ASSISTANT.name).toBe(GENERAL_ASSISTANT_NAME);
-      expect(GENERAL_ASSISTANT_NAME).toBe("GeneralAssistant");
-      expect(GENERAL_ASSISTANT.frontmatter.label).toBeTruthy();
-      expect(GENERAL_ASSISTANT.body.length).toBeGreaterThan(0);
-    });
-
-    it("carries no per-agent tool allowlist (flat ALLOW_ALL, AGT-V1-007)", () => {
-      expect(GENERAL_ASSISTANT.frontmatter).not.toHaveProperty("tools");
-      expect(GENERAL_ASSISTANT.frontmatter).not.toHaveProperty("allowedTools");
-    });
+  it("uses an unlisted default harness for ordinary chat", () => {
+    expect(resolveAgent(undefined, undefined)).toBe(DEFAULT_ASSISTANT);
+    expect(DEFAULT_ASSISTANT.forgeSkills).toEqual(
+      expect.arrayContaining(["resource-forge", "skill-forge", "agent-forge", "routine-forge"])
+    );
   });
 
-  describe("INFORMATION_ARCHITECT built-in", () => {
-    it("has the reserved PascalCase name, a label, and a non-empty body", () => {
-      expect(INFORMATION_ARCHITECT.name).toBe(INFORMATION_ARCHITECT_NAME);
-      expect(INFORMATION_ARCHITECT_NAME).toBe("InformationArchitect");
-      expect(INFORMATION_ARCHITECT.frontmatter.label).toBeTruthy();
-      expect(INFORMATION_ARCHITECT.body.length).toBeGreaterThan(0);
-    });
-
-    it("surfaces the inbuilt forge skills it can load", () => {
-      expect(INFORMATION_ARCHITECT.forgeSkills).toEqual(
-        expect.arrayContaining([
-          "resource-forge",
-          "skill-forge",
-          "agent-forge",
-          "routine-forge",
-          "onboarding",
-        ])
-      );
-    });
-
-    it("can author + smoke-test routines (routine_forge in allowlist, exclusive to it)", () => {
-      expect(INFORMATION_ARCHITECT.toolAllowlist).toContain("routine_forge");
-      expect(INFORMATION_ARCHITECT.toolAllowlist).toContain("trigger_routine");
-      // routine_forge is a soul write — stripped from the front desk / user soul agents.
-      expect(EXCLUSIVE_SOUL_WRITE_TOOLS.has("routine_forge")).toBe(true);
-    });
+  it("resolves a selected Soul agent, otherwise falls back to normal chat", () => {
+    const loader = makeSoulLoader([PLANNER]);
+    expect(resolveAgent(loader, "sprint-planner")).toBe(PLANNER);
+    expect(resolveAgent(loader, "missing-agent")).toBe(DEFAULT_ASSISTANT);
   });
 
-  describe("resolveAgent", () => {
-    it("falls back to GeneralAssistant on a fresh install (undefined soulLoader)", () => {
-      expect(resolveAgent(undefined, undefined)).toBe(GENERAL_ASSISTANT);
-    });
-
-    it("falls back to GeneralAssistant when no agentId is selected", () => {
-      expect(resolveAgent(makeSoulLoader([PLANNER]), undefined)).toBe(GENERAL_ASSISTANT);
-    });
-
-    it("resolves the GeneralAssistant name to the built-in", () => {
-      expect(resolveAgent(makeSoulLoader([PLANNER]), GENERAL_ASSISTANT_NAME)).toBe(
-        GENERAL_ASSISTANT
-      );
-    });
-
-    it("falls back to GeneralAssistant for an unknown/deleted agentId", () => {
-      expect(resolveAgent(makeSoulLoader([PLANNER]), "ghost")).toBe(GENERAL_ASSISTANT);
-    });
-
-    it("resolves a loaded soul agent by id", () => {
-      expect(resolveAgent(makeSoulLoader([PLANNER]), "sprint-planner")).toBe(PLANNER);
-    });
-
-    it("resolves the InformationArchitect name to the built-in specialist", () => {
-      expect(resolveAgent(makeSoulLoader([PLANNER]), INFORMATION_ARCHITECT_NAME)).toBe(
-        INFORMATION_ARCHITECT
-      );
-    });
-  });
-
-  describe("listAgents", () => {
-    it("lists the platform agents first on a fresh install", () => {
-      expect(listAgents(makeSoulLoader([]))).toEqual([GENERAL_ASSISTANT, INFORMATION_ARCHITECT]);
-    });
-
-    it("lists the platform agents first, then loaded soul agents", () => {
-      expect(listAgents(makeSoulLoader([PLANNER]))).toEqual([
-        GENERAL_ASSISTANT,
-        INFORMATION_ARCHITECT,
-        PLANNER,
-      ]);
-    });
-
-    it("handles an undefined soulLoader", () => {
-      expect(listAgents(undefined)).toEqual([GENERAL_ASSISTANT, INFORMATION_ARCHITECT]);
-    });
-  });
-
-  describe("getAgent", () => {
-    it("returns the built-in by its reserved name", () => {
-      expect(getAgent(makeSoulLoader([PLANNER]), GENERAL_ASSISTANT_NAME)).toBe(GENERAL_ASSISTANT);
-    });
-
-    it("returns the InformationArchitect by its reserved name", () => {
-      expect(getAgent(makeSoulLoader([PLANNER]), INFORMATION_ARCHITECT_NAME)).toBe(
-        INFORMATION_ARCHITECT
-      );
-    });
-
-    it("returns a loaded soul agent by name", () => {
-      expect(getAgent(makeSoulLoader([PLANNER]), "sprint-planner")).toBe(PLANNER);
-    });
-
-    it("returns undefined for an unknown name (no built-in fallback)", () => {
-      expect(getAgent(makeSoulLoader([PLANNER]), "ghost")).toBeUndefined();
-    });
+  it("lists and retrieves only user-created Soul agents", () => {
+    const loader = makeSoulLoader([PLANNER]);
+    expect(listAgents(undefined)).toEqual([]);
+    expect(listAgents(loader)).toEqual([PLANNER]);
+    expect(getAgent(loader, "sprint-planner")).toBe(PLANNER);
+    expect(getAgent(loader, "__tulipfarm_default__")).toBeUndefined();
   });
 });

--- a/apps/api/src/soul/agents/registry.ts
+++ b/apps/api/src/soul/agents/registry.ts
@@ -1,52 +1,29 @@
 import type { SoulAgent, SoulLoader } from "@tulipfarm/soul";
-import { GENERAL_ASSISTANT, getPlatformAgent, PLATFORM_AGENTS } from "./platform-agents";
+import { DEFAULT_ASSISTANT } from "./platform-agents";
 
 /**
- * The agent registry (AGT-V1-007). Two code-defined platform agents (`GeneralAssistant` front desk
- * + `InformationArchitect` creation specialist) are always present and resolve before soul agents.
- * Soul agents are loaded at boot into `SoulLoader.agents`. Both are presented as one resolvable set.
- * Soul agents share flat ALLOW_ALL tool access; platform agents carry a `toolAllowlist` enforced in
- * the chat route. See `platform-agents.ts`.
+ * User-created Agent registry. Normal chat uses the unlisted default harness when no Soul Agent
+ * is selected; only authored AGENT.md files are exposed as Agents in the API and UI.
  */
 
-// Re-exported for the many callers (chat route, agents REST, tests) that already import them here.
 export {
-  EXCLUSIVE_SOUL_WRITE_TOOLS,
-  GENERAL_ASSISTANT,
-  GENERAL_ASSISTANT_NAME,
-  getPlatformAgent,
-  INFORMATION_ARCHITECT,
-  INFORMATION_ARCHITECT_NAME,
-  INFORMATION_ARCHITECT_TOOL_ALLOWLIST,
-  PLATFORM_AGENTS,
+  DEFAULT_ASSISTANT,
+  DEFAULT_ASSISTANT_NAME,
+  getDefaultAssistant,
   type PlatformAgent,
 } from "./platform-agents";
 
-/**
- * Resolve the active agent for a chat turn. A platform agent (matched by its reserved PascalCase
- * name) wins; otherwise the named soul agent; otherwise the `GeneralAssistant` fallback. Always
- * returns an agent.
- */
+/** Resolve a named Soul Agent, falling back to the normal-chat harness. */
 export function resolveAgent(soulLoader: SoulLoader | undefined, agentId?: string): SoulAgent {
-  const platform = getPlatformAgent(agentId);
-  if (platform) return platform;
-  const found = agentId ? soulLoader?.agents.get(agentId) : undefined;
-  return found ?? GENERAL_ASSISTANT;
+  return (agentId ? soulLoader?.agents.get(agentId) : undefined) ?? DEFAULT_ASSISTANT;
 }
 
-/** The registry view: the platform agents first, then all loaded soul agents. */
+/** The registry view contains only user-created Soul Agents. */
 export function listAgents(soulLoader: SoulLoader | undefined): SoulAgent[] {
-  const soul = soulLoader ? Array.from(soulLoader.agents.values()) : [];
-  return [...PLATFORM_AGENTS, ...soul];
+  return soulLoader ? Array.from(soulLoader.agents.values()) : [];
 }
 
-/**
- * Look up a single agent by exact name (the detail view). Returns a platform agent or the named
- * soul agent, or `undefined` when the name is unknown. Unlike `resolveAgent`, this does NOT fall
- * back to a built-in — callers use `undefined` to return a 404.
- */
+/** Look up one user-created Soul Agent for the detail view. */
 export function getAgent(soulLoader: SoulLoader | undefined, name: string): SoulAgent | undefined {
-  const platform = getPlatformAgent(name);
-  if (platform) return platform;
   return soulLoader?.agents.get(name);
 }

--- a/apps/api/src/soul/agents/routes.test.ts
+++ b/apps/api/src/soul/agents/routes.test.ts
@@ -121,25 +121,11 @@ describe("agents routes", () => {
       expect(res.statusCode).toBe(401);
     });
 
-    it("lists the platform agents first, then soul agents (frontmatter only, no body)", async () => {
+    it("lists only Soul agents (frontmatter only, no body)", async () => {
       const res = await app.inject(authed("/api/v1/agents"));
       expect(res.statusCode).toBe(200);
       expect(res.json()).toEqual({
         agents: [
-          {
-            name: "GeneralAssistant",
-            label: "General Assistant",
-            description:
-              "Front desk for TulipFarm — answers questions, reads resources and knowledge, and routes creation work to the Information Architect.",
-            model: "standard",
-          },
-          {
-            name: "InformationArchitect",
-            label: "Information Architect",
-            description:
-              "Creation specialist — builds and edits resource types, skills, and agents and runs onboarding, using the inbuilt forge skills.",
-            model: "complex",
-          },
           {
             name: "sprint-planner",
             label: "Sprint Planner",
@@ -154,12 +140,9 @@ describe("agents routes", () => {
   });
 
   describe("GET /api/v1/agents/:name", () => {
-    it("serves the built-in GeneralAssistant detail by name", async () => {
+    it("does not expose the normal chat harness as an agent", async () => {
       const res = await app.inject(authed("/api/v1/agents/GeneralAssistant"));
-      expect(res.statusCode).toBe(200);
-      const body = res.json();
-      expect(body.name).toBe("GeneralAssistant");
-      expect(body.body.length).toBeGreaterThan(0);
+      expect(res.statusCode).toBe(404);
     });
 
     it("returns the full agent including its markdown body", async () => {

--- a/apps/api/src/soul/agents/routes.ts
+++ b/apps/api/src/soul/agents/routes.ts
@@ -4,11 +4,10 @@ import { ErrorSchema } from "../../auth/schemas";
 import { getAgent, listAgents } from "./registry";
 
 /*
- * Read-only HTTP surface for agents (AGENTS / UI-V1-003). The registry is the built-in `GeneralAssistant`
- * platform agent plus the soul agents (AGENT.md files loaded into the SoulLoader at startup). The list
- * view carries frontmatter only and puts GeneralAssistant first; the detail view adds the markdown `body`
- * (the agent's system prompt). Creation/editing of soul agents happens via the agent_* tools / forges,
- * not here.
+ * Read-only HTTP surface for user-created Agents (AGENT.md files loaded into the SoulLoader at
+ * startup). The list view carries frontmatter only; the detail view adds the markdown `body`.
+ * Normal chat is not an Agent resource. Creation/editing of Soul agents happens through the
+ * agent_* tools / forges, not here.
  */
 
 type PreHandler = (req: FastifyRequest, reply: FastifyReply) => Promise<void>;

--- a/apps/api/src/soul/catalogue.test.ts
+++ b/apps/api/src/soul/catalogue.test.ts
@@ -7,7 +7,6 @@ import type {
   SoulSkill,
 } from "@tulipfarm/soul";
 import { describe, expect, it } from "vitest";
-import { GENERAL_ASSISTANT_NAME, INFORMATION_ARCHITECT_NAME } from "./agents/registry";
 import { buildSoulCatalogue } from "./catalogue";
 
 const skill = (name: string, frontmatter: Record<string, unknown> = {}): SoulSkill => ({
@@ -78,12 +77,7 @@ describe("buildSoulCatalogue", () => {
       })
     );
     // Platform agents are always present, sorted in among soul agents by name.
-    expect(cat.agents.map((a) => a.name)).toEqual([
-      GENERAL_ASSISTANT_NAME,
-      INFORMATION_ARCHITECT_NAME,
-      "alpha",
-      "zeta",
-    ]);
+    expect(cat.agents.map((a) => a.name)).toEqual(["alpha", "zeta"]);
     expect(cat.skills.map((s) => s.name)).toEqual(["export", "review"]);
     expect(cat.resourceTypes.map((r) => r.name)).toEqual(["invoice", "ticket"]);
     expect(cat.routines.map((r) => r.name)).toEqual(["hourly", "nightly"]);
@@ -124,10 +118,7 @@ describe("buildSoulCatalogue", () => {
 
   it("still lists the platform agents when the loader is absent, with every other section empty", () => {
     const cat = buildSoulCatalogue(undefined);
-    expect(cat.agents.map((a) => a.name)).toEqual([
-      GENERAL_ASSISTANT_NAME,
-      INFORMATION_ARCHITECT_NAME,
-    ]);
+    expect(cat.agents).toEqual([]);
     expect(cat.skills).toEqual([]);
     expect(cat.resourceTypes).toEqual([]);
     expect(cat.routines).toEqual([]);

--- a/apps/api/src/soul/catalogue.ts
+++ b/apps/api/src/soul/catalogue.ts
@@ -14,7 +14,7 @@ export interface SoulCatalogueEntry {
 /**
  * The repo catalogue for `<soul-context>`: every soul artifact type the loader exposes, each
  * projected to its L1 surface. Gives an agent ambient awareness of what already exists without a
- * tool round-trip (e.g. the Information Architect can reference an existing agent or resource
+ * tool round-trip (e.g. the built-in assistant can reference an existing agent or resource
  * type by name). Sorted by name within each section for a byte-stable prompt prefix (AC-V1-001).
  */
 export interface SoulCatalogue {
@@ -42,8 +42,8 @@ function byName(a: SoulCatalogueEntry, b: SoulCatalogueEntry): number {
 
 /**
  * Project every soul artifact to the `<soul-context>` L1 catalogue. Agents come from `listAgents`
- * (the two platform agents first, then soul agents) so the catalogue surfaces the GeneralAssistant
- * / InformationArchitect an agent may hand off to. Skills are the FULL set (eager + lazy) minus
+ * (the built-in platform assistant first, then Soul agents) so the catalogue surfaces agents an
+ * agent may hand off to. Skills are the full set (eager + lazy) minus
  * pending-audit; descriptions are read from each type's own metadata (frontmatter / schema /
  * config), falling back through `title` and then "". An absent loader yields all
  * empty sections, so the block is omitted entirely.

--- a/apps/api/src/soul/skills/builtin-skills.test.ts
+++ b/apps/api/src/soul/skills/builtin-skills.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { BUILTIN_SKILLS, FORGE_SKILL_NAMES } from "./builtin-skills";
+
+describe("builtin forge skills", () => {
+  it("carries the execution contract through every creation workflow", () => {
+    for (const name of FORGE_SKILL_NAMES) {
+      const skill = BUILTIN_SKILLS.get(name);
+      expect(skill?.body).toContain("## Execution Contract");
+      expect(skill?.body).toContain("Do not stop at a plan, draft, or preview.");
+      expect(skill?.body).toContain("Verify it with the relevant read");
+      expect(skill?.body).toContain("specific blocker; never claim");
+      expect(skill?.body).toContain("inspect before changing");
+    }
+  });
+});

--- a/apps/api/src/soul/skills/builtin-skills.ts
+++ b/apps/api/src/soul/skills/builtin-skills.ts
@@ -1,7 +1,7 @@
 /**
  * Inbuilt forge skills (SKL-V1-005) — bundled with the app, NOT seeded into the soul repo and NOT
- * operator-editable. These are the lazily-loaded sidebar skills owned by the Information Architect
- * platform agent: it surfaces their `name` + `description` in `<available-skills>` and pulls the
+ * operator-editable. These are lazily-loaded sidebar skills available to normal chat: it surfaces
+ * their `name` + `description` in `<available-skills>` and pulls the
  * full `body` on demand via `load_skill`. Ported from the canary forge skills, adapted to this
  * repo's tools (`create_resource_type`, `skill_create`/`skill_activate`, `agent_create`, …) and to
  * UUID record ids (RES-V1-001 — `_id` is a UUID, not a Mongo ObjectId).
@@ -16,10 +16,31 @@ export interface BuiltinSkill {
   body: string;
 }
 
+/**
+ * Hermes-style execution discipline, adapted for Soul creation. This appears inside every forge
+ * body (not only the normal-chat harness) so loading a workflow preserves the same inspect → act
+ * → verify contract through multi-step creation and onboarding flows.
+ */
+const FORGE_EXECUTION_CONTRACT = `## Execution Contract
+
+- Inspect relevant existing Soul artifacts before writing, then use the creation or update tool that
+  actually performs the requested change. Do not stop at a plan, draft, or preview.
+- Treat a write as incomplete until it has a real tool result. Verify it with the relevant read,
+  list, schema, status, or smoke-test tool when one is available.
+- If validation or a tool call fails, use the returned error to correct the artifact and retry when
+  the path is clear. If the request is genuinely blocked, report the specific blocker; never claim
+  an artifact was created, activated, or tested when it was not.
+- Keep dependent work ordered: inspect before changing, create prerequisites before dependants, and
+  verify after changing. Batch independent inspection calls when the tool surface allows it.
+- Respect the user's explicit approval choice and the active autonomy/approval controls. Ask one
+  focused question only when the missing decision materially changes the artifact.`;
+
 const RESOURCE_FORGE = `# Resource Forge Workflow
 
-Guides building ONE resource-type schema at a time. The Information Architect's master flow decides
-when the whole session is done and calls \`complete_task\` — this skill never calls it.
+Guides building ONE resource-type schema at a time. The chat harness owns the whole session; this
+skill reports its outcome directly.
+
+${FORGE_EXECUTION_CONTRACT}
 
 ## Create Flow
 
@@ -117,14 +138,15 @@ call \`complete_task\` — the master flow owns session completion.
 
 ## Error handling
 Recoverable issues (bad field type, validation failure, user changes mind): fix and retry. A logical
-dead end (validation fails repeatedly, impossible schema): stop and report the specific error so the
-Information Architect can decide how to proceed.`;
+dead end (validation fails repeatedly, impossible schema): stop and report the specific error.`;
 
 const SKILL_FORGE = `# Skill Forge Workflow
 
 Guides creating or editing a **skill** — a stateless, atomic unit carrying instructions for a
 single well-defined task (SKILL.md = \`name\` + \`description\` + markdown body). Skills are loaded by
 agents on demand via \`load_skill\`. They have no identity and no memory.
+
+${FORGE_EXECUTION_CONTRACT}
 
 ## Decide first: skill or agent?
 If the request needs to remember state across turns, own a persona, or coordinate other skills, it
@@ -178,6 +200,8 @@ frontmatter that define how it operates. Agents are AGENT.md: frontmatter (label
 description, model, autonomy, placeholder, suggestions) + a markdown body that becomes the system
 prompt.
 
+${FORGE_EXECUTION_CONTRACT}
+
 ## Create Flow — interview, don't guess
 Conduct a short step-by-step interview before proposing the agent, even if the initial prompt gives
 the role. Walk the decision tree one question at a time, giving your recommended answer for each. If
@@ -223,6 +247,8 @@ business. Use this when the user wants to "set up my business" / "run onboarding
 domain". For a single incremental request ("create an invoices resource"), skip this and use the
 matching forge directly.
 
+${FORGE_EXECUTION_CONTRACT}
+
 ## Flow (sequential)
 
 ### 1. Discovery
@@ -249,16 +275,17 @@ simplified version rather than skipping it.
 Summarise everything created (with which agents use which skills / reference which resources). Handle
 revise-per-artifact by rebuilding that single artifact with the matching forge. When the user is
 satisfied, record completion in working memory (\`update_memory\`:
-\`onboarding_completed\` = \`true\`, \`onboarding_domain\` = \`"<domain>"\`) and call \`complete_task\`
-with a \`success\` summary listing what was created, so the General Assistant resumes and can suggest
-next steps.`;
+\`onboarding_completed\` = \`true\`, \`onboarding_domain\` = \`"<domain>"\`) and report a
+\`success\` summary listing what was created and relevant next steps.`;
 
 const ROUTINE_FORGE = `# Routine Forge Workflow
 
 Guides authoring or editing ONE **routine** — a scheduled/triggered automation that runs a
 deterministic sequence of steps (CNCF Serverless Workflow 0.8 subset + \`x-\` extensions). A routine
-lives at \`soul/routines/<slug>/routine.yaml\` (+ optional \`hooks.ts\`). The Information Architect's
-master flow decides when the session is done and calls \`complete_task\` — this skill never does.
+lives at \`soul/routines/<slug>/routine.yaml\` (+ optional \`hooks.ts\`). The chat harness owns the
+whole session; this skill reports its outcome directly.
+
+${FORGE_EXECUTION_CONTRACT}
 
 ## Decide first: routine, agent, or skill?
 - **Routine** — a repeatable, mostly-deterministic pipeline on a trigger ("every morning at 9, tag
@@ -376,11 +403,11 @@ diff in plain language, then call \`routine_forge\` again with the SAME \`name\`
 ## Error handling
 Recoverable (bad ref, schema violation, user changes mind): fix and retry. A hard dead end
 (repeated validation failure, a construct that is genuinely deferred in V1): stop and report the
-specific error so the Information Architect can decide how to proceed.`;
+specific error.`;
 
 /**
- * The inbuilt forge skills, keyed by name. Surfaced (frontmatter only) to the Information Architect
- * and loaded on demand via `load_skill`.
+ * The inbuilt forge skills, keyed by name, surfaced to normal chat and loaded on demand via
+ * `load_skill`.
  */
 export const BUILTIN_SKILLS: Map<string, BuiltinSkill> = new Map(
   [
@@ -417,5 +444,5 @@ export const BUILTIN_SKILLS: Map<string, BuiltinSkill> = new Map(
   ].map((s) => [s.name, s])
 );
 
-/** Names of the inbuilt forge skills the Information Architect surfaces and can load. */
+/** Names of the inbuilt forge skills normal chat can load. */
 export const FORGE_SKILL_NAMES: readonly string[] = Array.from(BUILTIN_SKILLS.keys());

--- a/apps/api/src/tools/registry.ts
+++ b/apps/api/src/tools/registry.ts
@@ -72,9 +72,8 @@ export class ToolRegistry {
     runToolCallGuard?: RunToolCallGuard,
     allowedToolNames?: ReadonlySet<string>
   ): ToolSet {
-    // Per-agent tool scoping: when `allowedToolNames` is given, expose only those tools (the
-    // Information Architect's allowlist, or every-tool-minus-the-IA-exclusive-set for the front
-    // desk). Undefined → all registered tools (unchanged default).
+    // Per-agent tool scoping: an explicit allowed set limits the exposed tools. Undefined exposes
+    // every registered tool, which is the built-in assistant's default.
     const exposed = allowedToolNames
       ? this.getAll().filter((t) => allowedToolNames.has(t.name))
       : this.getAll();

--- a/apps/docs/AGENTS.md
+++ b/apps/docs/AGENTS.md
@@ -6,8 +6,7 @@ for monorepo commands, Biome rules, and git policy; see `README.md` for deployme
 
 > **Terminology is binding** — [`metadata/terminologies.md`](../../metadata/terminologies.md).
 > In these docs that means: **chat** (never "conversation"), **space** / **page** (never
-> bundle/concept/document/collection), and the platform agents by their display names —
-> **General Assistant** and **Information Architect** (not the PascalCase code names).
+> bundle/concept/document/collection), and user-created Agents by their display names.
 
 ## The one rule that governs everything here
 
@@ -27,11 +26,8 @@ every build task that way:
 
 ### How building actually works (verify against `apps/api/src/soul/agents/platform-agents.ts`)
 
-- **General Assistant** — the default chat agent / front desk. Answers, reads, and creates
-  **records + knowledge** directly.
-- It **transfers** any "build/change my system" request (resource type, agent, skill,
-  onboarding) to the **Information Architect**, which loads a **forge**
-  (`resource-forge` / `agent-forge` / `skill-forge` / `onboarding`), interviews the user,
+ - Normal chat answers, reads, and creates **records + knowledge** directly, and loads a **forge**
+  (`resource-forge` / `agent-forge` / `skill-forge` / `onboarding`) to build the system.
   and writes the artifact. The handoff is visible to the user.
 - Soul writes commit immediately and reconcile **live — no restart** (`create_resource_type`
   calls `soulLoader.reload()` + `reconcile()`).

--- a/apps/docs/content/docs/concepts/agents.mdx
+++ b/apps/docs/content/docs/concepts/agents.mdx
@@ -3,12 +3,9 @@ title: Agents
 description: The actors that run turns, each defined by an AGENT.md file.
 ---
 
-An agent is an actor that runs turns against an LLM with access to TulipFarm's tools. Two
-agents are built in: the **General Assistant** (your front desk) and the **Information
-Architect** (the builder) — see [Building by chat](/docs/concepts/building). You create
-your own agents by describing them to the assistant: "create a support agent that answers
-customer questions and files tickets." The Information Architect interviews you and builds
-it.
+An Agent is an actor that runs turns against an LLM with access to TulipFarm's tools. Normal chat
+is the built-in harness; Agents are the custom actors you create by describing them to chat, such as
+"create a support agent that answers customer questions and files tickets."
 
 ## What an agent is made of
 
@@ -32,8 +29,7 @@ knowledge base and create tickets as resources when follow-up is needed.
 ```
 
 Names are flat and kebab-cased. `domain` is display-only — it groups agents in the UI but
-grants no special access. Agents are loaded into the registry at startup, with
-the General Assistant listed first.
+grants no special access. Agents are loaded into the registry at startup.
 
 ## Autonomy: how much an agent can do unsupervised
 
@@ -70,7 +66,7 @@ the instance falls back to built-in safe defaults.
 ## Creating agents
 
 Ask the assistant — "create a support agent", "make me an agent that triages bugs". The
-Information Architect loads its `agent-forge`, asks what the agent should do and how much
+assistant loads `agent-forge`, asks what the agent should do and how much
 autonomy it gets, then writes the `AGENT.md` and commits it to the soul. There is no
 approval step, and the agent is selectable as soon as it is built. The web UI lists your
 agents and shows each one's prompt; to change an agent, ask the assistant to edit it.

--- a/apps/docs/content/docs/concepts/building.mdx
+++ b/apps/docs/content/docs/concepts/building.mdx
@@ -12,7 +12,7 @@ those chats, not something you normally write by hand.
 
 ## The assistant is your front desk
 
-The default agent in every chat is the **General Assistant**. It answers questions, reads
+Normal chat answers questions, reads
 your resources and knowledge, and handles everyday data work directly — creating records,
 writing knowledge pages, searching. If your intent is clear, it acts; it does not ask for
 confirmation it does not need.
@@ -21,12 +21,10 @@ What the assistant does **not** do is build your system itself. The moment you a
 something that changes what your instance *is* — a new resource type, an agent, a skill,
 or first-time setup — it hands the chat to a specialist.
 
-## Building hands off to the Information Architect
+## Building in the same chat
 
-When you ask to build or change your system, the assistant transfers the chat to
-the **Information Architect** — the agent that owns system-building. You see the handoff
-in the chat. The Information Architect then interviews you for exactly what it needs,
-builds the artifact, and hands control back.
+When you ask to build or change your system, the same chat loads the appropriate forge, asks for
+the details it needs, and builds the artifact.
 
 A request like any of these triggers the handoff on the first turn:
 
@@ -36,12 +34,12 @@ A request like any of these triggers the handoff on the first turn:
 - "Set up my business" (first-time onboarding)
 
 You do not phrase these in any special way and you do not write schema. You say what you
-want in plain language; the Information Architect asks the few questions it needs and
+want in plain language; the assistant asks the few questions it needs and
 does the rest.
 
 ## Forges guide the build
 
-The Information Architect does not improvise. For each kind of artifact it loads a
+The assistant does not improvise. For each kind of artifact it loads a
 built-in **forge** — a structured interview that walks from intent to a finished
 artifact:
 
@@ -57,7 +55,7 @@ building works.
 
 ## The result lives in the soul
 
-When the Information Architect finishes, the artifact is written to your
+When the assistant finishes, the artifact is written to your
 [soul repository](/docs/concepts/soul) and committed — a resource type becomes
 `resources/{name}/schema.yml`, an agent becomes `agents/{name}/AGENT.md`. There is no
 approval step for soul writes, and the change takes effect immediately — a new resource

--- a/apps/docs/content/docs/concepts/skills.mdx
+++ b/apps/docs/content/docs/concepts/skills.mdx
@@ -33,7 +33,7 @@ See [Install a skill](/docs/guides/install-a-skill) for the walkthrough.
 ## Authoring a skill by chat
 
 You do not have to find a skill in a repository — you can ask for one. Tell the assistant
-"make a skill that drafts refund replies in our tone", and the Information Architect loads
+"make a skill that drafts refund replies in our tone", and chat loads
 its `skill-forge`, interviews you, and writes the `SKILL.md`. A skill authored this way
 lands in a **pending** state, runs through SkillAudit just like an installed one, and goes
 live only once you activate it. The audit is part of creation, not an afterthought.

--- a/apps/docs/content/docs/getting-started.mdx
+++ b/apps/docs/content/docs/getting-started.mdx
@@ -138,8 +138,7 @@ Open **Chat** and type what you want in plain language:
 Create a customer resource type with a name and an email.
 ```
 
-The assistant hands the request to the **Information Architect**, which confirms a couple
-of details and builds the type for you. There is no schema to write and no restart — the
+The assistant confirms a couple of details and builds the type for you. There is no schema to write and no restart — the
 new `customer` table is ready the moment it finishes. Open **Resources** and you will see
 `customer` in the list.
 

--- a/apps/docs/content/docs/guides/cite-knowledge-in-chat.mdx
+++ b/apps/docs/content/docs/guides/cite-knowledge-in-chat.mdx
@@ -7,7 +7,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 
 This guide grounds a chat answer in your [knowledge base](/docs/concepts/knowledge). It
 assumes a running instance with at least one knowledge page and an agent that can search
-knowledge — the built-in **General Assistant** can. It uses the chat workspace in the web
+knowledge — normal chat can. It uses the chat workspace in the web
 UI.
 
 ## Ask, and read the citations

--- a/apps/docs/content/docs/guides/create-an-agent.mdx
+++ b/apps/docs/content/docs/guides/create-an-agent.mdx
@@ -19,7 +19,7 @@ Create a support agent that answers customer questions from our knowledge base
 and files a ticket when a question needs follow-up.
 ```
 
-The assistant hands the request to the **Information Architect**, which loads its
+The assistant loads its
 `agent-forge` and asks the few things it needs: what the agent is responsible for, and how
 much it may do on its own.
 

--- a/apps/docs/content/docs/guides/define-a-resource-type.mdx
+++ b/apps/docs/content/docs/guides/define-a-resource-type.mdx
@@ -22,20 +22,20 @@ and a customer it belongs to. Auto-number each ticket as TICK-1, TICK-2, and lin
 customer to our existing customer type.
 ```
 
-The assistant hands the request to the **Information Architect**, which loads its
+The assistant loads its
 `resource-forge` and confirms the details it needs — the fields, which one is the
 human-friendly identifier, and which fields link to other types. Answer its questions,
 and it builds the type.
 
 <Callout type="info">
-The Information Architect builds one type at a time, in dependency order. If your `ticket`
+The assistant builds one type at a time, in dependency order. If your `ticket`
 links to a `customer`, create the `customer` type first (or ask for both, and it will
 sequence them) — a link can only point at a type that exists.
 </Callout>
 
 ## What it builds for you
 
-From that description the Information Architect writes the schema, wires up the
+From that description the assistant writes the schema, wires up the
 extensions, and commits it — no schema for you to write:
 
 - the `subject` and `status` fields, with `status` constrained to `open` or `closed`

--- a/apps/web/app/components/chat/chat-panel.tsx
+++ b/apps/web/app/components/chat/chat-panel.tsx
@@ -123,7 +123,7 @@ export function ChatPanel({
   });
   const busy = status === "submitted" || status === "streaming";
   // Prefer the live agent from a handoff; fall back to the restored conversation's persisted agent.
-  const agent = currentAgent || agentId || "GeneralAssistant";
+  const agent = currentAgent || agentId || "TulipFarm";
   // Resolve the active agent's domain/autonomy so its header glyph matches the agents list. Undefined
   // until the list loads (and for the two platform agents) → glyph uses its name-hashed fallback.
   // Mentionable entities: powers the active-agent header glyph AND highlights @/#// tags (with hover

--- a/apps/web/app/components/chat/getting-started-card.tsx
+++ b/apps/web/app/components/chat/getting-started-card.tsx
@@ -4,8 +4,8 @@ import type { OnboardingChecklist } from "~/lib/onboarding";
 /*
  * "Getting started" checklist card on the chat welcome (ONB-V1). Steps are the core build blocks
  * with status auto-derived server-side; `todo` steps and the "recommended next" items seed a guided
- * prompt down the same GeneralAssistant -> InformationArchitect flow the suggestion chips use (via
- * `onPick`). Routine/integration render as non-actionable "coming soon". Flat/hairline aesthetic,
+ * prompt through the built-in assistant flow the suggestion chips use (via `onPick`).
+ * Routine/integration render as non-actionable "coming soon". Flat/hairline aesthetic,
  * no shadows; ruby is reserved for hover affordances only.
  */
 

--- a/apps/web/app/components/knowledge/use-wiki-mention-data.ts
+++ b/apps/web/app/components/knowledge/use-wiki-mention-data.ts
@@ -18,7 +18,7 @@ import { listAllPages, listSpacePages } from "~/lib/knowledge-api";
  */
 
 // Platform/forge agents are internal infrastructure — never surface them in the author's @-menu.
-const INTERNAL_AGENTS = new Set(["GeneralAssistant", "InformationArchitect"]);
+const INTERNAL_AGENTS = new Set<string>();
 
 export function useWikiMentionExtensions(spaceId: string): AnyExtension[] {
   const pages = useRef<MentionItem[]>([]);

--- a/apps/web/app/routes/_app._index.test.tsx
+++ b/apps/web/app/routes/_app._index.test.tsx
@@ -53,7 +53,7 @@ test("default view is the live chat empty state with adaptive suggestions (AC-V1
   // Signature welcome (blinking wordmark + ready status + active agent).
   expect(screen.getByRole("heading", { name: /tulipfarm/i })).toBeInTheDocument();
   expect(screen.getByText("ready")).toBeInTheDocument();
-  expect(screen.getByText("GeneralAssistant")).toBeInTheDocument();
+  expect(screen.getByText("TulipFarm")).toBeInTheDocument();
 
   // Adaptive soul-derived suggestion chip (replaces the former hardcoded set).
   expect(screen.getByRole("button", { name: "Set up ticket management?" })).toBeInTheDocument();

--- a/apps/web/app/routes/_app._index.tsx
+++ b/apps/web/app/routes/_app._index.tsx
@@ -1,7 +1,6 @@
 import { type ClientLoaderFunctionArgs, type MetaFunction, useLoaderData } from "@remix-run/react";
 import { useCallback, useState } from "react";
 import { ChatPanel } from "~/components/chat/chat-panel";
-import { getAgent } from "~/lib/agents";
 import type { ModelTier } from "~/lib/chat/types";
 import { useConversations } from "~/lib/conversations-context";
 import {
@@ -13,19 +12,10 @@ import {
 export const meta: MetaFunction = () => [{ title: "Chat · tulipfarm" }];
 
 // Default surface (AC-V1-001): the live Layer-1 chat. The Agents "Chat with" shortcut routes here with
-// ?agent=<name> to seed the conversation's agent; the API falls back to GeneralAssistant when absent.
-// The composer's default model tier comes from the active agent's frontmatter (GeneralAssistant →
-// standard). Anything other than `complex` resolves to `standard`, and a failed lookup never blocks
-// chat — it falls back to standard.
+// `?agent=<name>` selects a user-created Agent. Without it, Chat uses the normal harness.
 export async function clientLoader({ request }: ClientLoaderFunctionArgs) {
   const agentId = new URL(request.url).searchParams.get("agent") || undefined;
-  let defaultModel: ModelTier = "standard";
-  try {
-    const agent = await getAgent(agentId ?? "GeneralAssistant");
-    if (agent.model === "complex") defaultModel = "complex";
-  } catch {
-    // Unknown agent / transient API error — keep the standard default rather than break the page.
-  }
+  const defaultModel: ModelTier = "standard";
   // Adaptive onboarding suggestions (ONB-V1-002/003) + the Getting-started checklist (ONB-V1).
   // Both non-blocking (AC-V1-001): a failed fetch resolves to a benign default so chat always
   // renders (mirrors the agent lookup above — no hard dependency).

--- a/apps/web/app/routes/_app.chat.$id.tsx
+++ b/apps/web/app/routes/_app.chat.$id.tsx
@@ -42,11 +42,13 @@ export async function clientLoader({ params }: ClientLoaderFunctionArgs) {
 
   const agentId = convo.agentId ?? undefined;
   let defaultModel: ModelTier = "standard";
-  try {
-    const agent = await getAgent(agentId ?? "GeneralAssistant");
-    if (agent.model === "complex") defaultModel = "complex";
-  } catch {
-    // Unknown agent / transient API error — keep the standard default rather than break the page.
+  if (agentId) {
+    try {
+      const agent = await getAgent(agentId);
+      if (agent.model === "complex") defaultModel = "complex";
+    } catch {
+      // Unknown Agent / transient API error — keep the standard default rather than break chat.
+    }
   }
 
   return {

--- a/metadata/terminologies.md
+++ b/metadata/terminologies.md
@@ -40,7 +40,7 @@ Never let these bleed: UI/URL never say "conversation"; domain/DB never say "cha
 | One user→assistant exchange | **Turn** | `Turn` | — | — | child of Conversation |
 | Atomic message unit | **Message** | `Message` | — | — | roles: system\|user\|**assistant**\|tool |
 | Auth/login session (cookie) | **Session** | `Session` | `/api/v1/auth/...` | — | AUTH ONLY — never the chat thread |
-| Configured AI persona/worker | **Agent** | `Agent` | `/agents`, `/api/v1/agents` | "Agents" | default instance named `GeneralAssistant` (proper noun, kept) |
+| Configured AI persona/worker | **Agent** | `Agent` | `/agents`, `/api/v1/agents` | "Agents" | normal chat is the default harness; Agents are user-created |
 | The resource feature | **Resources** | — | `/resources` | "Resources" | umbrella |
 | A user-defined schema (Ticket, Customer) | **Resource type** | `ResourceType` | `/resources/:type` | "Resource type" | has a JSON **schema** |
 | The JSON Schema artifact of a type | **Schema** | `schema` | `/resources/:type/schema` | "Schema" | |

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -181,6 +181,28 @@ else
       else
         echo "✅ Postgres database 'tulipfarm' already exists"
       fi
+
+      # An existing .env.local may carry a password-auth DATABASE_URL (e.g. left over from a
+      # prior Docker-mode setup, or hand-edited) instead of the template's peer-auth default.
+      # Native Postgres has no such role by default — ensure it exists so the app can connect.
+      if [ -f ".env.local" ]; then
+        EXISTING_DB_URL="$(grep -E '^DATABASE_URL=' .env.local | head -1 | cut -d= -f2-)"
+        if [[ "$EXISTING_DB_URL" =~ ^postgres(ql)?://([^:@/]+):([^@/]+)@ ]]; then
+          DB_ROLE="${BASH_REMATCH[2]}"
+          DB_ROLE_PASSWORD="${BASH_REMATCH[3]}"
+          if psql -Atqc "SELECT 1 FROM pg_roles WHERE rolname='$DB_ROLE'" postgres 2>/dev/null | grep -q 1; then
+            echo "✅ Postgres role '$DB_ROLE' already exists"
+          else
+            psql -c "CREATE ROLE \"$DB_ROLE\" WITH LOGIN PASSWORD '$DB_ROLE_PASSWORD';" postgres \
+              && echo "✅ Created Postgres role '$DB_ROLE'"
+          fi
+          # Docker mode's tulipfarm role is superuser (POSTGRES_USER on the official postgres
+          # image), which owns the DB, the public schema, and can CREATE EXTENSION (vector,
+          # citext, pg_trgm — none are "trusted" extensions installable by a plain role).
+          # Match that here instead of granting each privilege piecemeal.
+          psql -c "ALTER ROLE \"$DB_ROLE\" WITH SUPERUSER;" postgres &> /dev/null
+        fi
+      fi
     else
       echo "⚠ createdb not on PATH — create the 'tulipfarm' database manually"
     fi


### PR DESCRIPTION
## Summary
- replace the named General Assistant and Information Architect split with one internal normal-chat harness
- give normal chat and every built-in forge workflow Hermes-style execution discipline: inspect, act, verify, retry honestly, and respect approvals
- update the API, web UI, catalogue, documentation, and tests so only user-created agents are listed or selected


Excluded concurrent unrelated edits to stream-error handling and local Postgres setup from this PR.