### PR TITLE
feat(operations): add API and responsive shell foundation

### DIFF
--- a/apps/api/src/admin/routes.test.ts
+++ b/apps/api/src/admin/routes.test.ts
@@ -1,0 +1,241 @@
+import Fastify from "fastify";
+import { describe, expect, it, vi } from "vitest";
+import {
+  type OperationalApiDeps,
+  type OperationalPermission,
+  registerOperationalRoutes,
+} from "./routes";
+
+const run = {
+  id: "run-1",
+  routineId: "routine-1",
+  routineVersion: "3",
+  status: "attention_required" as const,
+  version: 7,
+  createdAt: "2026-07-26T00:00:00.000Z",
+  startedAt: "2026-07-26T00:00:01.000Z",
+  finishedAt: null,
+  states: [],
+  effects: [],
+  waits: [],
+  guardrailDecisions: [],
+  lineage: [],
+  costs: { amountUsd: 0.12, modelTokens: 900 },
+};
+
+function deps(overrides: Partial<OperationalApiDeps> = {}): OperationalApiDeps {
+  const permissions: OperationalPermission[] = [
+    "runs:read",
+    "runs:control",
+    "operations:read",
+    "guardrails:read",
+    "guardrails:write",
+    "agents:write",
+    "approvals:read",
+    "approvals:decide",
+    "roles:read",
+    "roles:write",
+    "operations:control",
+  ];
+  return {
+    authorize: async () => ({
+      businessId: "business-1",
+      principalId: "user-1",
+      permissions,
+    }),
+    listRuns: async () => ({ items: [run], nextCursor: null }),
+    getRun: async () => run,
+    commandRun: async (_grant, input) => ({
+      commandId: `command-${input.action}`,
+      runId: input.runId,
+      status: "accepted" as const,
+    }),
+    getOperations: async () => ({
+      health: [],
+      incidents: [],
+      quarantine: [],
+      killSwitches: [],
+      audit: [],
+      recovery: { supportBundleAvailable: true, lastBackupAt: null },
+    }),
+    getGuardrails: async () => ({ revision: "guardrail-7", items: [] }),
+    proposeGuardrailChangeset: async () => ({
+      changesetId: "changeset-1",
+      status: "validated" as const,
+    }),
+    proposeAgentChangeset: async () => ({
+      changesetId: "changeset-agent-1",
+      candidateVersion: "4",
+      status: "awaiting_approval" as const,
+    }),
+    getInbox: async () => ({ items: [] }),
+    decideApproval: async () => ({
+      approvalId: "approval-1",
+      status: "pending" as const,
+      decisions: 1,
+      requiredDecisions: 2,
+    }),
+    getRoles: async () => ({ revision: "roles-1", items: [] }),
+    proposeRoleChangeset: async () => ({
+      changesetId: "changeset-role-1",
+      status: "awaiting_approval" as const,
+    }),
+    commandOperation: async () => ({
+      commandId: "operation-1",
+      status: "accepted" as const,
+    }),
+    ...overrides,
+  };
+}
+
+async function harness(overrides: Partial<OperationalApiDeps> = {}) {
+  const app = Fastify();
+  registerOperationalRoutes(app, deps(overrides), async () => undefined);
+  await app.ready();
+  return app;
+}
+
+describe("operational API", () => {
+  it("returns an authorized Run read model and documents the browser endpoints", async () => {
+    const app = await harness();
+    const response = await app.inject({ method: "GET", url: "/api/v1/runs/run-1" });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ run });
+    await app.close();
+  });
+
+  it("fails closed with a safe versioned envelope", async () => {
+    const app = await harness({ authorize: vi.fn(async () => null) });
+    const response = await app.inject({ method: "GET", url: "/api/v1/admin/operations" });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json()).toMatchObject({
+      error: {
+        version: "1",
+        code: "forbidden",
+        retryable: false,
+      },
+    });
+    expect(JSON.stringify(response.json())).not.toContain("business-1");
+    await app.close();
+  });
+
+  it("requires an idempotency key and delegates Run commands without changing intent", async () => {
+    const commandRun = vi.fn(async (_grant, input) => ({
+      commandId: "command-1",
+      runId: input.runId,
+      status: "accepted" as const,
+    }));
+    const app = await harness({ commandRun });
+
+    const missing = await app.inject({
+      method: "POST",
+      url: "/api/v1/runs/run-1/cancel",
+      payload: { expectedVersion: 7, reason: "operator request" },
+    });
+    expect(missing.statusCode).toBe(400);
+
+    const accepted = await app.inject({
+      method: "POST",
+      url: "/api/v1/runs/run-1/cancel",
+      headers: { "idempotency-key": "cancel-run-1-v7" },
+      payload: { expectedVersion: 7, reason: "operator request" },
+    });
+    expect(accepted.statusCode).toBe(202);
+    expect(commandRun).toHaveBeenCalledWith(expect.objectContaining({ principalId: "user-1" }), {
+      action: "cancel",
+      expectedVersion: 7,
+      idempotencyKey: "cancel-run-1-v7",
+      reason: "operator request",
+      runId: "run-1",
+    });
+    await app.close();
+  });
+
+  it("sends Guardrail edits only through the Soul changeset authority", async () => {
+    const proposeGuardrailChangeset = vi.fn(async () => ({
+      changesetId: "changeset-1",
+      status: "awaiting_approval" as const,
+    }));
+    const app = await harness({ proposeGuardrailChangeset });
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/v1/guardrails/changesets",
+      headers: { "idempotency-key": "guardrail-change-1" },
+      payload: {
+        baseRevision: "guardrail-7",
+        changes: [{ op: "replace", path: "/items/0/enabled", value: false }],
+      },
+    });
+
+    expect(response.statusCode).toBe(202);
+    expect(proposeGuardrailChangeset).toHaveBeenCalledWith(
+      expect.objectContaining({ principalId: "user-1" }),
+      expect.objectContaining({
+        baseRevision: "guardrail-7",
+        idempotencyKey: "guardrail-change-1",
+      })
+    );
+    await app.close();
+  });
+
+  it("sends exact Agent candidates through the Soul publication authority", async () => {
+    const proposeAgentChangeset = vi.fn(async () => ({
+      changesetId: "changeset-agent-1",
+      candidateVersion: "4",
+      status: "awaiting_approval" as const,
+    }));
+    const app = await harness({ proposeAgentChangeset });
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/v1/agents/support/changesets",
+      headers: { "idempotency-key": "publish-support-v4" },
+      payload: {
+        baseVersion: "3",
+        candidateVersion: "4",
+        patch: { description: "Updated support Agent" },
+      },
+    });
+
+    expect(response.statusCode).toBe(202);
+    expect(proposeAgentChangeset).toHaveBeenCalledWith(
+      expect.objectContaining({ principalId: "user-1" }),
+      expect.objectContaining({
+        agentId: "support",
+        candidateVersion: "4",
+        idempotencyKey: "publish-support-v4",
+      })
+    );
+    await app.close();
+  });
+
+  it("records a decision for the exact Approval without accepting changed intent", async () => {
+    const decideApproval = vi.fn(async () => ({
+      approvalId: "approval-1",
+      status: "pending" as const,
+      decisions: 1,
+      requiredDecisions: 2,
+    }));
+    const app = await harness({ decideApproval });
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/v1/approvals/approval-1/decisions",
+      headers: { "idempotency-key": "approval-1-user-1-approve" },
+      payload: { decision: "approved", comment: "Reviewed exact target" },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(decideApproval).toHaveBeenCalledWith(
+      expect.objectContaining({ principalId: "user-1" }),
+      {
+        approvalId: "approval-1",
+        comment: "Reviewed exact target",
+        decision: "approved",
+        idempotencyKey: "approval-1-user-1-approve",
+      }
+    );
+    expect(response.json()).toMatchObject({ status: "pending", requiredDecisions: 2 });
+    await app.close();
+  });
+});

--- a/apps/api/src/admin/routes.test.ts
+++ b/apps/api/src/admin/routes.test.ts
@@ -1,5 +1,6 @@
 import Fastify from "fastify";
 import { describe, expect, it, vi } from "vitest";
+import type { RateLimiter } from "../rate-limit";
 import {
   type OperationalApiDeps,
   type OperationalPermission,
@@ -88,9 +89,9 @@ function deps(overrides: Partial<OperationalApiDeps> = {}): OperationalApiDeps {
   };
 }
 
-async function harness(overrides: Partial<OperationalApiDeps> = {}) {
+async function harness(overrides: Partial<OperationalApiDeps> = {}, rateLimiter?: RateLimiter) {
   const app = Fastify();
-  registerOperationalRoutes(app, deps(overrides), async () => undefined);
+  registerOperationalRoutes(app, deps(overrides), async () => undefined, rateLimiter);
   await app.ready();
   return app;
 }
@@ -118,6 +119,30 @@ describe("operational API", () => {
       },
     });
     expect(JSON.stringify(response.json())).not.toContain("business-1");
+    await app.close();
+  });
+
+  it("rate-limits operational reads before authorization", async () => {
+    const authorize = vi.fn(async () => ({
+      businessId: "business-1",
+      principalId: "user-1",
+      permissions: ["operations:read"] as OperationalPermission[],
+    }));
+    const rateLimiter: RateLimiter = {
+      check: vi.fn(async () => ({
+        allowed: false,
+        limit: 120,
+        remaining: 0,
+        resetAt: Date.now() + 60_000,
+      })),
+    };
+    const app = await harness({ authorize }, rateLimiter);
+
+    const response = await app.inject({ method: "GET", url: "/api/v1/admin/operations" });
+
+    expect(response.statusCode).toBe(429);
+    expect(response.json()).toEqual({ error: "rate_limit_exceeded" });
+    expect(authorize).not.toHaveBeenCalled();
     await app.close();
   });
 

--- a/apps/api/src/admin/routes.ts
+++ b/apps/api/src/admin/routes.ts
@@ -1,0 +1,917 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+
+type PreHandler = (req: FastifyRequest, reply: FastifyReply) => Promise<void>;
+
+export type OperationalPermission =
+  | "runs:read"
+  | "runs:control"
+  | "operations:read"
+  | "guardrails:read"
+  | "guardrails:write"
+  | "agents:write"
+  | "approvals:read"
+  | "approvals:decide"
+  | "roles:read"
+  | "roles:write"
+  | "operations:control";
+
+export interface OperationalGrant {
+  readonly businessId: string;
+  readonly principalId: string;
+  readonly permissions: readonly OperationalPermission[];
+}
+
+export interface RunStateReadModel {
+  readonly key: string;
+  readonly status: string;
+  readonly attempts: number;
+  readonly input?: unknown;
+  readonly output?: unknown;
+  readonly errorEvidenceRef?: string;
+}
+
+export interface RunReadModel {
+  readonly id: string;
+  readonly routineId: string;
+  readonly routineVersion: string;
+  readonly status: string;
+  readonly version: number;
+  readonly createdAt: string;
+  readonly startedAt: string | null;
+  readonly finishedAt: string | null;
+  readonly states: readonly RunStateReadModel[];
+  readonly effects: readonly Record<string, unknown>[];
+  readonly waits: readonly Record<string, unknown>[];
+  readonly guardrailDecisions: readonly Record<string, unknown>[];
+  readonly lineage: readonly Record<string, unknown>[];
+  readonly costs: { readonly amountUsd: number; readonly modelTokens: number };
+}
+
+export type RunCommandAction = "pause" | "resume" | "cancel" | "retry" | "reconcile";
+
+export interface RunCommandInput {
+  readonly action: RunCommandAction;
+  readonly runId: string;
+  readonly expectedVersion: number;
+  readonly reason: string;
+  readonly idempotencyKey: string;
+}
+
+export interface OperationsReadModel {
+  readonly health: readonly Record<string, unknown>[];
+  readonly incidents: readonly Record<string, unknown>[];
+  readonly quarantine: readonly Record<string, unknown>[];
+  readonly killSwitches: readonly Record<string, unknown>[];
+  readonly audit: readonly Record<string, unknown>[];
+  readonly recovery: {
+    readonly supportBundleAvailable: boolean;
+    readonly lastBackupAt: string | null;
+  };
+}
+
+export interface GuardrailsReadModel {
+  readonly revision: string;
+  readonly items: readonly Record<string, unknown>[];
+}
+
+export interface GuardrailChangesetInput {
+  readonly baseRevision: string;
+  readonly changes: readonly {
+    readonly op: "add" | "remove" | "replace";
+    readonly path: string;
+    readonly value?: unknown;
+  }[];
+  readonly idempotencyKey: string;
+}
+
+export interface AgentChangesetInput {
+  readonly agentId: string;
+  readonly baseVersion: string;
+  readonly candidateVersion: string;
+  readonly patch: Record<string, unknown>;
+  readonly idempotencyKey: string;
+}
+
+export interface InboxItemReadModel {
+  readonly id: string;
+  readonly kind: "approval" | "human_task" | "form" | "access_request";
+  readonly title: string;
+  readonly status: string;
+  readonly risk: "low" | "medium" | "high";
+  readonly intentDigest?: string;
+  readonly guardrailRevision?: string;
+  readonly target?: string;
+  readonly destination?: string;
+  readonly fields?: readonly string[];
+  readonly expiresAt?: string;
+  readonly decisions: number;
+  readonly requiredDecisions: number;
+  readonly canDecide: boolean;
+  readonly denialReason?: string;
+}
+
+export interface ApprovalDecisionInput {
+  readonly approvalId: string;
+  readonly decision: "approved" | "denied";
+  readonly comment?: string;
+  readonly idempotencyKey: string;
+}
+
+export interface RolesReadModel {
+  readonly revision: string;
+  readonly items: readonly {
+    readonly id: string;
+    readonly name: string;
+    readonly principalKinds: readonly string[];
+    readonly grants: readonly string[];
+    readonly conditions: readonly string[];
+  }[];
+}
+
+export interface OperationalApiDeps {
+  authorize(req: FastifyRequest): Promise<OperationalGrant | null>;
+  listRuns(
+    grant: OperationalGrant,
+    options: { cursor?: string; limit: number }
+  ): Promise<{ items: readonly RunReadModel[]; nextCursor: string | null }>;
+  getRun(grant: OperationalGrant, runId: string): Promise<RunReadModel | null>;
+  commandRun(
+    grant: OperationalGrant,
+    input: RunCommandInput
+  ): Promise<{ commandId: string; runId: string; status: "accepted" | "duplicate" }>;
+  getOperations(grant: OperationalGrant): Promise<OperationsReadModel>;
+  getGuardrails(grant: OperationalGrant): Promise<GuardrailsReadModel>;
+  proposeGuardrailChangeset(
+    grant: OperationalGrant,
+    input: GuardrailChangesetInput
+  ): Promise<{
+    changesetId: string;
+    status: "validated" | "awaiting_approval" | "published";
+  }>;
+  proposeAgentChangeset(
+    grant: OperationalGrant,
+    input: AgentChangesetInput
+  ): Promise<{
+    changesetId: string;
+    candidateVersion: string;
+    status: "validated" | "awaiting_approval" | "published";
+  }>;
+  getInbox(grant: OperationalGrant): Promise<{ items: readonly InboxItemReadModel[] }>;
+  decideApproval(
+    grant: OperationalGrant,
+    input: ApprovalDecisionInput
+  ): Promise<{
+    approvalId: string;
+    status: "pending" | "approved" | "denied";
+    decisions: number;
+    requiredDecisions: number;
+  }>;
+  getRoles(grant: OperationalGrant): Promise<RolesReadModel>;
+  proposeRoleChangeset(
+    grant: OperationalGrant,
+    input: {
+      baseRevision: string;
+      role: Record<string, unknown>;
+      idempotencyKey: string;
+    }
+  ): Promise<{
+    changesetId: string;
+    status: "validated" | "awaiting_approval" | "published";
+  }>;
+  commandOperation(
+    grant: OperationalGrant,
+    input: {
+      action: "support-bundle.create" | "kill-switch.set" | "quarantine.resolve" | "recovery.start";
+      parameters: Record<string, unknown>;
+      idempotencyKey: string;
+    }
+  ): Promise<{ commandId: string; status: "accepted" | "duplicate" }>;
+}
+
+const security: { [securityLabel: string]: readonly string[] }[] = [
+  { sessionCookie: [] },
+  { bearerToken: [] },
+];
+const idParams = {
+  type: "object",
+  additionalProperties: false,
+  required: ["id"],
+  properties: { id: { type: "string", minLength: 1 } },
+} as const;
+const errorSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["error"],
+  properties: {
+    error: {
+      type: "object",
+      additionalProperties: false,
+      required: ["version", "code", "message", "correlationId", "retryable"],
+      properties: {
+        version: { type: "string", const: "1" },
+        code: { type: "string" },
+        message: { type: "string" },
+        correlationId: { type: "string" },
+        retryable: { type: "boolean" },
+      },
+    },
+  },
+} as const;
+
+function fail(
+  reply: FastifyReply,
+  request: FastifyRequest,
+  status: 400 | 403 | 404 | 409,
+  code: string,
+  message: string,
+  retryable = false
+) {
+  return reply.code(status).send({
+    error: {
+      version: "1",
+      code,
+      message,
+      correlationId: request.id,
+      retryable,
+    },
+  });
+}
+
+async function requireGrant(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  deps: OperationalApiDeps,
+  permission: OperationalPermission
+): Promise<OperationalGrant | null> {
+  const grant = await deps.authorize(request);
+  if (!grant?.permissions.includes(permission)) {
+    fail(reply, request, 403, "forbidden", "You do not have access to this operation.");
+    return null;
+  }
+  return grant;
+}
+
+function idempotencyKey(request: FastifyRequest): string | null {
+  const raw = request.headers["idempotency-key"];
+  if (Array.isArray(raw)) return raw[0] ?? null;
+  return typeof raw === "string" && raw.length > 0 ? raw : null;
+}
+
+const runSchema = {
+  type: "object",
+  additionalProperties: true,
+  required: [
+    "id",
+    "routineId",
+    "routineVersion",
+    "status",
+    "version",
+    "createdAt",
+    "startedAt",
+    "finishedAt",
+    "states",
+    "effects",
+    "waits",
+    "guardrailDecisions",
+    "lineage",
+    "costs",
+  ],
+  properties: {
+    id: { type: "string" },
+    routineId: { type: "string" },
+    routineVersion: { type: "string" },
+    status: { type: "string" },
+    version: { type: "integer" },
+    createdAt: { type: "string" },
+    startedAt: { type: ["string", "null"] },
+    finishedAt: { type: ["string", "null"] },
+    states: { type: "array", items: { type: "object", additionalProperties: true } },
+    effects: { type: "array", items: { type: "object", additionalProperties: true } },
+    waits: { type: "array", items: { type: "object", additionalProperties: true } },
+    guardrailDecisions: {
+      type: "array",
+      items: { type: "object", additionalProperties: true },
+    },
+    lineage: { type: "array", items: { type: "object", additionalProperties: true } },
+    costs: {
+      type: "object",
+      required: ["amountUsd", "modelTokens"],
+      properties: { amountUsd: { type: "number" }, modelTokens: { type: "number" } },
+    },
+  },
+} as const;
+
+export function registerOperationalRoutes(
+  app: FastifyInstance,
+  deps: OperationalApiDeps,
+  requireAuth: PreHandler
+): void {
+  app.get(
+    "/api/v1/runs",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description: "List authorized Run read models for the operational browser UI.",
+        tags: ["runs"],
+        security,
+        querystring: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            cursor: { type: "string" },
+            limit: { type: "integer", minimum: 1, maximum: 100, default: 50 },
+          },
+        },
+        response: {
+          200: {
+            type: "object",
+            required: ["items", "nextCursor"],
+            properties: {
+              items: { type: "array", items: runSchema },
+              nextCursor: { type: ["string", "null"] },
+            },
+          },
+          403: errorSchema,
+        },
+      },
+    },
+    async (request, reply) => {
+      const grant = await requireGrant(request, reply, deps, "runs:read");
+      if (!grant) return;
+      const query = request.query as { cursor?: string; limit?: number };
+      return deps.listRuns(grant, { cursor: query.cursor, limit: query.limit ?? 50 });
+    }
+  );
+
+  app.get(
+    "/api/v1/runs/:id",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description:
+          "Get an authorized Run inspector read model with States, effects, waits, costs, " +
+          "Guardrail decisions, and lineage.",
+        tags: ["runs"],
+        security,
+        params: idParams,
+        response: {
+          200: {
+            type: "object",
+            required: ["run"],
+            properties: { run: runSchema },
+          },
+          403: errorSchema,
+          404: errorSchema,
+        },
+      },
+    },
+    async (request, reply) => {
+      const grant = await requireGrant(request, reply, deps, "runs:read");
+      if (!grant) return;
+      const { id } = request.params as { id: string };
+      const run = await deps.getRun(grant, id);
+      if (!run) return fail(reply, request, 404, "run_not_found", "Run not found.");
+      return { run };
+    }
+  );
+
+  for (const action of ["pause", "resume", "cancel", "retry", "reconcile"] as const) {
+    app.post(
+      `/api/v1/runs/:id/${action}`,
+      {
+        preHandler: requireAuth,
+        schema: {
+          description:
+            `Request a server-authorized ${action} command for one Run. ` +
+            "The browser supplies presentation intent only; the Run authority validates it.",
+          tags: ["runs"],
+          security,
+          params: idParams,
+          headers: {
+            type: "object",
+            properties: { "idempotency-key": { type: "string", minLength: 1, maxLength: 200 } },
+          },
+          body: {
+            type: "object",
+            additionalProperties: false,
+            required: ["expectedVersion", "reason"],
+            properties: {
+              expectedVersion: { type: "integer", minimum: 0 },
+              reason: { type: "string", minLength: 1, maxLength: 500 },
+            },
+          },
+          response: {
+            202: {
+              type: "object",
+              required: ["commandId", "runId", "status"],
+              properties: {
+                commandId: { type: "string" },
+                runId: { type: "string" },
+                status: { type: "string", enum: ["accepted", "duplicate"] },
+              },
+            },
+            400: errorSchema,
+            403: errorSchema,
+            404: errorSchema,
+            409: errorSchema,
+          },
+        },
+      },
+      async (request, reply) => {
+        const grant = await requireGrant(request, reply, deps, "runs:control");
+        if (!grant) return;
+        const key = idempotencyKey(request);
+        if (!key) {
+          return fail(
+            reply,
+            request,
+            400,
+            "idempotency_key_required",
+            "An Idempotency-Key header is required."
+          );
+        }
+        const { id } = request.params as { id: string };
+        const body = request.body as { expectedVersion: number; reason: string };
+        const result = await deps.commandRun(grant, {
+          action,
+          runId: id,
+          expectedVersion: body.expectedVersion,
+          reason: body.reason,
+          idempotencyKey: key,
+        });
+        return reply.code(202).send(result);
+      }
+    );
+  }
+
+  app.get(
+    "/api/v1/admin/operations",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description:
+          "Authorized, redacted operations read model: health, incidents, quarantine, kill " +
+          "switches, audit summaries, and recovery posture.",
+        tags: ["admin"],
+        security,
+        response: {
+          200: { type: "object", additionalProperties: true },
+          403: errorSchema,
+        },
+      },
+    },
+    async (request, reply) => {
+      const grant = await requireGrant(request, reply, deps, "operations:read");
+      if (!grant) return;
+      return deps.getOperations(grant);
+    }
+  );
+
+  app.get(
+    "/api/v1/guardrails",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description: "Get the authorized Guardrail administration read model.",
+        tags: ["guardrails"],
+        security,
+        response: {
+          200: {
+            type: "object",
+            required: ["revision", "items"],
+            properties: {
+              revision: { type: "string" },
+              items: { type: "array", items: { type: "object", additionalProperties: true } },
+            },
+          },
+          403: errorSchema,
+        },
+      },
+    },
+    async (request, reply) => {
+      const grant = await requireGrant(request, reply, deps, "guardrails:read");
+      if (!grant) return;
+      return deps.getGuardrails(grant);
+    }
+  );
+
+  app.post(
+    "/api/v1/guardrails/changesets",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description:
+          "Propose a Guardrail change through the Soul changeset validation, Approval, and " +
+          "publication authority. This endpoint never writes Guardrails directly.",
+        tags: ["guardrails", "soul"],
+        security,
+        headers: {
+          type: "object",
+          properties: { "idempotency-key": { type: "string", minLength: 1, maxLength: 200 } },
+        },
+        body: {
+          type: "object",
+          additionalProperties: false,
+          required: ["baseRevision", "changes"],
+          properties: {
+            baseRevision: { type: "string", minLength: 1 },
+            changes: {
+              type: "array",
+              minItems: 1,
+              items: {
+                type: "object",
+                additionalProperties: false,
+                required: ["op", "path"],
+                properties: {
+                  op: { type: "string", enum: ["add", "remove", "replace"] },
+                  path: { type: "string", minLength: 1 },
+                  value: {},
+                },
+              },
+            },
+          },
+        },
+        response: {
+          202: {
+            type: "object",
+            required: ["changesetId", "status"],
+            properties: {
+              changesetId: { type: "string" },
+              status: {
+                type: "string",
+                enum: ["validated", "awaiting_approval", "published"],
+              },
+            },
+          },
+          400: errorSchema,
+          403: errorSchema,
+          409: errorSchema,
+        },
+      },
+    },
+    async (request, reply) => {
+      const grant = await requireGrant(request, reply, deps, "guardrails:write");
+      if (!grant) return;
+      const key = idempotencyKey(request);
+      if (!key) {
+        return fail(
+          reply,
+          request,
+          400,
+          "idempotency_key_required",
+          "An Idempotency-Key header is required."
+        );
+      }
+      const body = request.body as Omit<GuardrailChangesetInput, "idempotencyKey">;
+      const result = await deps.proposeGuardrailChangeset(grant, {
+        ...body,
+        idempotencyKey: key,
+      });
+      return reply.code(202).send(result);
+    }
+  );
+
+  app.post(
+    "/api/v1/agents/:id/changesets",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description:
+          "Propose an exact Agent candidate through the Soul validation, evaluation, Approval, " +
+          "and publication authority. The browser cannot publish or write Agent files directly.",
+        tags: ["agents", "soul"],
+        security,
+        params: idParams,
+        headers: {
+          type: "object",
+          properties: { "idempotency-key": { type: "string", minLength: 1, maxLength: 200 } },
+        },
+        body: {
+          type: "object",
+          additionalProperties: false,
+          required: ["baseVersion", "candidateVersion", "patch"],
+          properties: {
+            baseVersion: { type: "string", minLength: 1 },
+            candidateVersion: { type: "string", minLength: 1 },
+            patch: { type: "object", additionalProperties: true },
+          },
+        },
+        response: {
+          202: {
+            type: "object",
+            required: ["changesetId", "candidateVersion", "status"],
+            properties: {
+              changesetId: { type: "string" },
+              candidateVersion: { type: "string" },
+              status: {
+                type: "string",
+                enum: ["validated", "awaiting_approval", "published"],
+              },
+            },
+          },
+          400: errorSchema,
+          403: errorSchema,
+          409: errorSchema,
+        },
+      },
+    },
+    async (request, reply) => {
+      const grant = await requireGrant(request, reply, deps, "agents:write");
+      if (!grant) return;
+      const key = idempotencyKey(request);
+      if (!key) {
+        return fail(
+          reply,
+          request,
+          400,
+          "idempotency_key_required",
+          "An Idempotency-Key header is required."
+        );
+      }
+      const { id } = request.params as { id: string };
+      const body = request.body as Omit<AgentChangesetInput, "agentId" | "idempotencyKey">;
+      const result = await deps.proposeAgentChangeset(grant, {
+        ...body,
+        agentId: id,
+        idempotencyKey: key,
+      });
+      return reply.code(202).send(result);
+    }
+  );
+
+  app.get(
+    "/api/v1/inbox",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description:
+          "Unified authorized inbox for Approvals, human tasks, form waits, and access requests. " +
+          "Form content and protected intent payloads remain on their owning data planes.",
+        tags: ["approvals"],
+        security,
+        response: {
+          200: {
+            type: "object",
+            required: ["items"],
+            properties: {
+              items: {
+                type: "array",
+                items: { type: "object", additionalProperties: true },
+              },
+            },
+          },
+          403: errorSchema,
+        },
+      },
+    },
+    async (request, reply) => {
+      const grant = await requireGrant(request, reply, deps, "approvals:read");
+      if (!grant) return;
+      return deps.getInbox(grant);
+    }
+  );
+
+  app.post(
+    "/api/v1/approvals/:id/decisions",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description:
+          "Record one server-authorized decision for the exact persisted Approval binding. " +
+          "The request cannot replace the intent, target, destination, or Guardrail revision.",
+        tags: ["approvals"],
+        security,
+        params: idParams,
+        headers: {
+          type: "object",
+          properties: { "idempotency-key": { type: "string", minLength: 1, maxLength: 200 } },
+        },
+        body: {
+          type: "object",
+          additionalProperties: false,
+          required: ["decision"],
+          properties: {
+            decision: { type: "string", enum: ["approved", "denied"] },
+            comment: { type: "string", maxLength: 1000 },
+          },
+        },
+        response: {
+          200: {
+            type: "object",
+            required: ["approvalId", "status", "decisions", "requiredDecisions"],
+            properties: {
+              approvalId: { type: "string" },
+              status: { type: "string", enum: ["pending", "approved", "denied"] },
+              decisions: { type: "integer" },
+              requiredDecisions: { type: "integer" },
+            },
+          },
+          400: errorSchema,
+          403: errorSchema,
+          404: errorSchema,
+          409: errorSchema,
+        },
+      },
+    },
+    async (request, reply) => {
+      const grant = await requireGrant(request, reply, deps, "approvals:decide");
+      if (!grant) return;
+      const key = idempotencyKey(request);
+      if (!key) {
+        return fail(
+          reply,
+          request,
+          400,
+          "idempotency_key_required",
+          "An Idempotency-Key header is required."
+        );
+      }
+      const { id } = request.params as { id: string };
+      const body = request.body as {
+        decision: "approved" | "denied";
+        comment?: string;
+      };
+      return deps.decideApproval(grant, {
+        approvalId: id,
+        decision: body.decision,
+        comment: body.comment,
+        idempotencyKey: key,
+      });
+    }
+  );
+
+  app.get(
+    "/api/v1/roles",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description: "Get authorized custom Role summaries and scoped grants.",
+        tags: ["roles"],
+        security,
+        response: {
+          200: {
+            type: "object",
+            required: ["revision", "items"],
+            properties: {
+              revision: { type: "string" },
+              items: { type: "array", items: { type: "object", additionalProperties: true } },
+            },
+          },
+          403: errorSchema,
+        },
+      },
+    },
+    async (request, reply) => {
+      const grant = await requireGrant(request, reply, deps, "roles:read");
+      if (!grant) return;
+      return deps.getRoles(grant);
+    }
+  );
+
+  app.post(
+    "/api/v1/roles/changesets",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description:
+          "Propose a custom Role through the Soul changeset authority. The route cannot assign " +
+          "or broaden authority directly.",
+        tags: ["roles", "soul"],
+        security,
+        headers: {
+          type: "object",
+          properties: { "idempotency-key": { type: "string", minLength: 1, maxLength: 200 } },
+        },
+        body: {
+          type: "object",
+          additionalProperties: false,
+          required: ["baseRevision", "role"],
+          properties: {
+            baseRevision: { type: "string", minLength: 1 },
+            role: { type: "object", additionalProperties: true },
+          },
+        },
+        response: {
+          202: {
+            type: "object",
+            required: ["changesetId", "status"],
+            properties: {
+              changesetId: { type: "string" },
+              status: {
+                type: "string",
+                enum: ["validated", "awaiting_approval", "published"],
+              },
+            },
+          },
+          400: errorSchema,
+          403: errorSchema,
+          409: errorSchema,
+        },
+      },
+    },
+    async (request, reply) => {
+      const grant = await requireGrant(request, reply, deps, "roles:write");
+      if (!grant) return;
+      const key = idempotencyKey(request);
+      if (!key) {
+        return fail(
+          reply,
+          request,
+          400,
+          "idempotency_key_required",
+          "An Idempotency-Key header is required."
+        );
+      }
+      const body = request.body as {
+        baseRevision: string;
+        role: Record<string, unknown>;
+      };
+      const result = await deps.proposeRoleChangeset(grant, {
+        ...body,
+        idempotencyKey: key,
+      });
+      return reply.code(202).send(result);
+    }
+  );
+
+  app.post(
+    "/api/v1/admin/operations/:action",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description:
+          "Request an audited operational command. The operations authority reauthorizes the " +
+          "target and never accepts protected payloads from the browser.",
+        tags: ["admin"],
+        security,
+        params: {
+          type: "object",
+          additionalProperties: false,
+          required: ["action"],
+          properties: {
+            action: {
+              type: "string",
+              enum: [
+                "support-bundle.create",
+                "kill-switch.set",
+                "quarantine.resolve",
+                "recovery.start",
+              ],
+            },
+          },
+        },
+        headers: {
+          type: "object",
+          properties: { "idempotency-key": { type: "string", minLength: 1, maxLength: 500 } },
+        },
+        body: {
+          type: "object",
+          additionalProperties: false,
+          required: ["input"],
+          properties: { input: { type: "object", additionalProperties: true } },
+        },
+        response: {
+          202: {
+            type: "object",
+            required: ["commandId", "status"],
+            properties: {
+              commandId: { type: "string" },
+              status: { type: "string", enum: ["accepted", "duplicate"] },
+            },
+          },
+          400: errorSchema,
+          403: errorSchema,
+          409: errorSchema,
+        },
+      },
+    },
+    async (request, reply) => {
+      const grant = await requireGrant(request, reply, deps, "operations:control");
+      if (!grant) return;
+      const key = idempotencyKey(request);
+      if (!key) {
+        return fail(
+          reply,
+          request,
+          400,
+          "idempotency_key_required",
+          "An Idempotency-Key header is required."
+        );
+      }
+      const { action } = request.params as {
+        action:
+          | "support-bundle.create"
+          | "kill-switch.set"
+          | "quarantine.resolve"
+          | "recovery.start";
+      };
+      const { input } = request.body as { input: Record<string, unknown> };
+      const result = await deps.commandOperation(grant, {
+        action,
+        parameters: input,
+        idempotencyKey: key,
+      });
+      return reply.code(202).send(result);
+    }
+  );
+}

--- a/apps/api/src/admin/routes.ts
+++ b/apps/api/src/admin/routes.ts
@@ -1,4 +1,5 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { makeRateLimitHook, type RateLimiter } from "../rate-limit";
 
 type PreHandler = (req: FastifyRequest, reply: FastifyReply) => Promise<void>;
 
@@ -304,12 +305,18 @@ const runSchema = {
 export function registerOperationalRoutes(
   app: FastifyInstance,
   deps: OperationalApiDeps,
-  requireAuth: PreHandler
+  requireAuth: PreHandler,
+  rateLimiter?: RateLimiter
 ): void {
+  const rateLimitHook = rateLimiter
+    ? makeRateLimitHook(rateLimiter, (request) => `rl:operations:${request.ip}`, 120, 60_000)
+    : undefined;
+  const limitedAuth: PreHandler[] = rateLimitHook ? [rateLimitHook, requireAuth] : [requireAuth];
+
   app.get(
     "/api/v1/runs",
     {
-      preHandler: requireAuth,
+      preHandler: limitedAuth,
       schema: {
         description: "List authorized Run read models for the operational browser UI.",
         tags: ["runs"],
@@ -346,7 +353,7 @@ export function registerOperationalRoutes(
   app.get(
     "/api/v1/runs/:id",
     {
-      preHandler: requireAuth,
+      preHandler: limitedAuth,
       schema: {
         description:
           "Get an authorized Run inspector read model with States, effects, waits, costs, " +
@@ -379,7 +386,7 @@ export function registerOperationalRoutes(
     app.post(
       `/api/v1/runs/:id/${action}`,
       {
-        preHandler: requireAuth,
+        preHandler: limitedAuth,
         schema: {
           description:
             `Request a server-authorized ${action} command for one Run. ` +
@@ -447,7 +454,7 @@ export function registerOperationalRoutes(
   app.get(
     "/api/v1/admin/operations",
     {
-      preHandler: requireAuth,
+      preHandler: limitedAuth,
       schema: {
         description:
           "Authorized, redacted operations read model: health, incidents, quarantine, kill " +
@@ -470,7 +477,7 @@ export function registerOperationalRoutes(
   app.get(
     "/api/v1/guardrails",
     {
-      preHandler: requireAuth,
+      preHandler: limitedAuth,
       schema: {
         description: "Get the authorized Guardrail administration read model.",
         tags: ["guardrails"],
@@ -498,7 +505,7 @@ export function registerOperationalRoutes(
   app.post(
     "/api/v1/guardrails/changesets",
     {
-      preHandler: requireAuth,
+      preHandler: limitedAuth,
       schema: {
         description:
           "Propose a Guardrail change through the Soul changeset validation, Approval, and " +
@@ -574,7 +581,7 @@ export function registerOperationalRoutes(
   app.post(
     "/api/v1/agents/:id/changesets",
     {
-      preHandler: requireAuth,
+      preHandler: limitedAuth,
       schema: {
         description:
           "Propose an exact Agent candidate through the Soul validation, evaluation, Approval, " +
@@ -642,7 +649,7 @@ export function registerOperationalRoutes(
   app.get(
     "/api/v1/inbox",
     {
-      preHandler: requireAuth,
+      preHandler: limitedAuth,
       schema: {
         description:
           "Unified authorized inbox for Approvals, human tasks, form waits, and access requests. " +
@@ -674,7 +681,7 @@ export function registerOperationalRoutes(
   app.post(
     "/api/v1/approvals/:id/decisions",
     {
-      preHandler: requireAuth,
+      preHandler: limitedAuth,
       schema: {
         description:
           "Record one server-authorized decision for the exact persisted Approval binding. " +
@@ -743,7 +750,7 @@ export function registerOperationalRoutes(
   app.get(
     "/api/v1/roles",
     {
-      preHandler: requireAuth,
+      preHandler: limitedAuth,
       schema: {
         description: "Get authorized custom Role summaries and scoped grants.",
         tags: ["roles"],
@@ -771,7 +778,7 @@ export function registerOperationalRoutes(
   app.post(
     "/api/v1/roles/changesets",
     {
-      preHandler: requireAuth,
+      preHandler: limitedAuth,
       schema: {
         description:
           "Propose a custom Role through the Soul changeset authority. The route cannot assign " +
@@ -837,7 +844,7 @@ export function registerOperationalRoutes(
   app.post(
     "/api/v1/admin/operations/:action",
     {
-      preHandler: requireAuth,
+      preHandler: limitedAuth,
       schema: {
         description:
           "Request an audited operational command. The operations authority reauthorizes the " +

--- a/apps/api/src/admin/runtime.test.ts
+++ b/apps/api/src/admin/runtime.test.ts
@@ -1,0 +1,125 @@
+import type { FastifyRequest } from "fastify";
+import { describe, expect, it, vi } from "vitest";
+import { createRuntimeOperationalApi } from "./runtime";
+
+const principal = {
+  id: "user-1",
+  kind: "user" as const,
+  businessId: "tulipfarm-local",
+  credential: "session" as const,
+  authMethods: ["password"] as const,
+  authenticatedAt: new Date(),
+  userId: "user-1",
+  role: "admin" as const,
+};
+
+function request() {
+  return { principal } as unknown as FastifyRequest;
+}
+
+function runtime() {
+  const decide = vi.fn(() => true);
+  const enqueueWake = vi.fn(async () => undefined);
+  const listPending = vi.fn(() => [
+    {
+      approvalId: "approval-tool",
+      toolCallId: "call-1",
+      toolName: "send_email",
+      args: { recipient: "customer@example.com", body: "private" },
+      expiresAt: "2026-07-26T10:00:00.000Z",
+      createdAt: "2026-07-26T09:00:00.000Z",
+    },
+  ]);
+  const activity = {
+    list: vi.fn(async () => ({
+      items: [
+        {
+          _id: "activity-1",
+          category: "integration",
+          action: "sync.failed",
+          actorType: "system" as const,
+          actorId: null,
+          targetType: "integration",
+          targetId: "crm",
+          summary: "CRM sync failed",
+          status: "error" as const,
+          metadata: { token: "must-not-leak" },
+          createdAt: new Date("2026-07-26T08:00:00.000Z"),
+        },
+      ],
+      nextCursor: null,
+    })),
+  };
+  const approvals = {
+    listPending: vi.fn(async () => []),
+    findById: vi.fn(async () => null),
+    settle: vi.fn(async () => undefined),
+  };
+  const api = createRuntimeOperationalApi({
+    activity,
+    approvals,
+    approvalRegistry: { decide, listPending },
+    enqueueWake,
+    guardrailsConfig: () => ({ input: { enabled: true } }),
+  });
+  return { api, decide, enqueueWake };
+}
+
+describe("runtime operational API", () => {
+  it("authorizes admin reads and Approval decisions without granting unavailable controls", async () => {
+    const { api } = runtime();
+    const grant = await api.authorize(request());
+
+    expect(grant?.permissions).toContain("operations:read");
+    expect(grant?.permissions).toContain("approvals:decide");
+    expect(grant?.permissions).not.toContain("operations:control");
+    expect(grant?.permissions).not.toContain("runs:control");
+  });
+
+  it("projects redacted Operations and Inbox models from live services", async () => {
+    const { api } = runtime();
+    const grant = await api.authorize(request());
+    if (!grant) throw new Error("expected an admin grant");
+
+    const operations = await api.getOperations(grant);
+    expect(operations.health).toEqual([{ component: "api", status: "ok" }]);
+    expect(operations.incidents).toEqual([
+      expect.objectContaining({ id: "activity-1", summary: "CRM sync failed" }),
+    ]);
+    expect(JSON.stringify(operations)).not.toContain("must-not-leak");
+
+    const inbox = await api.getInbox(grant);
+    expect(inbox.items).toEqual([
+      expect.objectContaining({
+        id: "approval-tool",
+        kind: "approval",
+        target: "send_email",
+        fields: ["body", "recipient"],
+        canDecide: true,
+      }),
+    ]);
+    expect(inbox.items[0]?.intentDigest).toMatch(/^[a-f0-9]{64}$/);
+    expect(JSON.stringify(inbox)).not.toContain("customer@example.com");
+    expect(JSON.stringify(inbox)).not.toContain("private");
+  });
+
+  it("settles a live Tool Approval through its owning registry", async () => {
+    const { api, decide } = runtime();
+    const grant = await api.authorize(request());
+    if (!grant) throw new Error("expected an admin grant");
+
+    await expect(
+      api.decideApproval(grant, {
+        approvalId: "approval-tool",
+        decision: "approved",
+        idempotencyKey: "decision-1",
+      })
+    ).resolves.toEqual({
+      approvalId: "approval-tool",
+      status: "approved",
+      decisions: 1,
+      requiredDecisions: 1,
+    });
+    expect(decide).toHaveBeenCalledWith("approval-tool", "approved");
+  });
+});

--- a/apps/api/src/admin/runtime.ts
+++ b/apps/api/src/admin/runtime.ts
@@ -1,0 +1,238 @@
+import { createHash } from "node:crypto";
+import type { FastifyRequest } from "fastify";
+import type { ActivityService } from "../activity/service";
+import type { ApprovalsRepo } from "../approvals/repo";
+import type { ApprovalRegistry } from "../chat/approvals";
+import type {
+  ApprovalDecisionInput,
+  InboxItemReadModel,
+  OperationalApiDeps,
+  OperationalGrant,
+  OperationalPermission,
+} from "./routes";
+
+type RuntimeOperationalDeps = {
+  activity: Pick<ActivityService, "list">;
+  approvals: Pick<ApprovalsRepo, "findById" | "listPending" | "settle">;
+  approvalRegistry: Pick<ApprovalRegistry, "decide" | "listPending">;
+  enqueueWake(job: {
+    runId: string;
+    reason: "approval";
+    token: string;
+    decision: "approved" | "denied";
+  }): Promise<void>;
+  guardrailsConfig(): unknown;
+};
+
+const ADMIN_PERMISSIONS: readonly OperationalPermission[] = [
+  "runs:read",
+  "operations:read",
+  "guardrails:read",
+  "approvals:read",
+  "approvals:decide",
+  "roles:read",
+];
+
+function digest(value: unknown): string {
+  return createHash("sha256").update(JSON.stringify(value)).digest("hex");
+}
+
+function unavailable(): never {
+  throw new Error("operational control is not available from this runtime");
+}
+
+function safeActivity(item: Awaited<ReturnType<ActivityService["list"]>>["items"][number]) {
+  return {
+    id: item._id,
+    category: item.category,
+    action: item.action,
+    actorType: item.actorType,
+    targetType: item.targetType,
+    targetId: item.targetId,
+    summary: item.summary,
+    status: item.status,
+    createdAt: item.createdAt.toISOString(),
+  };
+}
+
+function toolApproval(
+  item: ReturnType<ApprovalRegistry["listPending"]>[number]
+): InboxItemReadModel {
+  const args =
+    typeof item.args === "object" && item.args !== null
+      ? (item.args as Record<string, unknown>)
+      : {};
+  return {
+    id: item.approvalId,
+    kind: "approval",
+    title: `Approve ${item.toolName}`,
+    status: "pending",
+    risk: "medium",
+    intentDigest: digest({
+      toolCallId: item.toolCallId,
+      toolName: item.toolName,
+      args: item.args,
+    }),
+    target: item.toolName,
+    fields: Object.keys(args).sort(),
+    expiresAt: item.expiresAt,
+    decisions: 0,
+    requiredDecisions: 1,
+    canDecide: true,
+  };
+}
+
+function routineApproval(
+  row: Awaited<ReturnType<ApprovalsRepo["listPending"]>>[number]
+): InboxItemReadModel {
+  const payload =
+    typeof row.payload === "object" && row.payload !== null
+      ? (row.payload as Record<string, unknown>)
+      : {};
+  const routineSlug = typeof payload.routineSlug === "string" ? payload.routineSlug : "Routine";
+  const stateName = typeof payload.stateName === "string" ? payload.stateName : "human task";
+  const runId = typeof payload.runId === "string" ? payload.runId : undefined;
+  return {
+    id: row.id,
+    kind: "approval",
+    title: `${routineSlug}: ${stateName}`,
+    status: row.status,
+    risk: "medium",
+    intentDigest: digest({
+      approvalId: row.id,
+      routineSlug,
+      runId,
+      stateName,
+    }),
+    target: runId,
+    expiresAt: row.expiresAt.toISOString(),
+    decisions: 0,
+    requiredDecisions: 1,
+    canDecide: true,
+  };
+}
+
+export function createRuntimeOperationalApi(deps: RuntimeOperationalDeps): OperationalApiDeps {
+  const decisions = new Map<
+    string,
+    {
+      approvalId: string;
+      status: "approved" | "denied";
+      decisions: number;
+      requiredDecisions: number;
+    }
+  >();
+
+  return {
+    async authorize(request: FastifyRequest): Promise<OperationalGrant | null> {
+      const principal = request.principal;
+      if (principal?.kind !== "user" || principal.role !== "admin") return null;
+      return {
+        businessId: principal.businessId,
+        principalId: principal.id,
+        permissions: ADMIN_PERMISSIONS,
+      };
+    },
+
+    async listRuns() {
+      return { items: [], nextCursor: null };
+    },
+
+    async getRun() {
+      return null;
+    },
+
+    async commandRun() {
+      return unavailable();
+    },
+
+    async getOperations() {
+      const activity = await deps.activity.list({ limit: 50 });
+      const audit = activity.items.map(safeActivity);
+      return {
+        health: [{ component: "api", status: "ok" }],
+        incidents: audit.filter((item) => item.status === "error"),
+        quarantine: [],
+        killSwitches:
+          process.env.HOOKS_DISABLED === "true"
+            ? [{ id: "hooks", status: "enabled", scope: "all hooks" }]
+            : [],
+        audit,
+        recovery: { supportBundleAvailable: false, lastBackupAt: null },
+      };
+    },
+
+    async getGuardrails() {
+      const config = deps.guardrailsConfig();
+      const items =
+        typeof config === "object" && config !== null
+          ? Object.entries(config).map(([name, policy]) => ({ name, policy }))
+          : [];
+      return { revision: digest(config), items };
+    },
+
+    async proposeGuardrailChangeset() {
+      return unavailable();
+    },
+
+    async proposeAgentChangeset() {
+      return unavailable();
+    },
+
+    async getInbox() {
+      const [toolCalls, routineRows] = await Promise.all([
+        Promise.resolve(deps.approvalRegistry.listPending()),
+        deps.approvals.listPending("routine_state"),
+      ]);
+      return {
+        items: [...toolCalls.map(toolApproval), ...routineRows.map(routineApproval)],
+      };
+    },
+
+    async decideApproval(_grant, input: ApprovalDecisionInput) {
+      const cached = decisions.get(input.idempotencyKey);
+      if (cached) return cached;
+
+      const resolved = deps.approvalRegistry.decide(input.approvalId, input.decision);
+      if (!resolved) {
+        const row = await deps.approvals.findById(input.approvalId);
+        const payload =
+          typeof row?.payload === "object" && row.payload !== null
+            ? (row.payload as Record<string, unknown>)
+            : {};
+        const runId = typeof payload.runId === "string" ? payload.runId : undefined;
+        if (row?.kind !== "routine_state" || row.status !== "pending" || !runId) {
+          throw new Error("Approval not found or already resolved.");
+        }
+        await deps.approvals.settle(input.approvalId, input.decision);
+        await deps.enqueueWake({
+          runId,
+          reason: "approval",
+          token: `approval:${input.approvalId}`,
+          decision: input.decision,
+        });
+      }
+
+      const result = {
+        approvalId: input.approvalId,
+        status: input.decision,
+        decisions: 1,
+        requiredDecisions: 1,
+      };
+      decisions.set(input.idempotencyKey, result);
+      return result;
+    },
+
+    async getRoles() {
+      return { revision: digest([]), items: [] };
+    },
+
+    async proposeRoleChangeset() {
+      return unavailable();
+    },
+
+    async commandOperation() {
+      return unavailable();
+    },
+  };
+}

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -14,6 +14,7 @@ import Fastify from "fastify";
 import type { A2uiSurfaceStore } from "./a2ui/surface-store";
 import { registerActivityRoutes } from "./activity/routes";
 import type { ActivityService } from "./activity/service";
+import { type OperationalApiDeps, registerOperationalRoutes } from "./admin/routes";
 import type { ApprovalsRepo } from "./approvals/repo";
 import { registerApprovalRoutes } from "./approvals/routes";
 import type { TokenRepo } from "./auth/api-tokens";
@@ -118,6 +119,8 @@ export interface AppOptions {
   hookIngress?: HookIngressDeps;
   /** System routes overrides (update-check fetch injection for tests). */
   systemRoutes?: SystemRoutesDeps;
+  /** Authorized Phase 9 browser read models and server-side command authorities. */
+  operationalApi?: OperationalApiDeps;
 }
 
 export async function buildApp(opts: AppOptions = {}) {
@@ -171,7 +174,13 @@ export async function buildApp(opts: AppOptions = {}) {
     // Without explicit methods the preflight rejects PUT/DELETE — the write verbs the SPA uses for
     // secrets, resources, and config. Custom headers (CSRF echo + optimistic-concurrency If-Match).
     methods: ["GET", "HEAD", "POST", "PUT", "DELETE", "OPTIONS"],
-    allowedHeaders: ["Content-Type", "Authorization", "x-csrf-token", "If-Match"],
+    allowedHeaders: [
+      "Content-Type",
+      "Authorization",
+      "x-csrf-token",
+      "If-Match",
+      "Idempotency-Key",
+    ],
     // The chat SSE response carries these; the browser can only read them cross-origin if exposed.
     // X-Message-Id is the just-streamed reply's persisted id, so the client can attach feedback to it.
     exposedHeaders: ["X-Conversation-Id", "X-Stream-Id", "X-Message-Id", "X-Agent-Id"],
@@ -450,6 +459,9 @@ export async function buildApp(opts: AppOptions = {}) {
     }
     if (opts.runReplay) {
       registerRunReplayRoutes(app, opts.runReplay, requireAuth, opts.rateLimiter);
+    }
+    if (opts.operationalApi) {
+      registerOperationalRoutes(app, opts.operationalApi, requireAuth);
     }
     if (opts.feedbackRepo) {
       registerFeedbackRoutes(app, opts.feedbackRepo, requireAuth);

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -461,7 +461,7 @@ export async function buildApp(opts: AppOptions = {}) {
       registerRunReplayRoutes(app, opts.runReplay, requireAuth, opts.rateLimiter);
     }
     if (opts.operationalApi) {
-      registerOperationalRoutes(app, opts.operationalApi, requireAuth);
+      registerOperationalRoutes(app, opts.operationalApi, requireAuth, opts.rateLimiter);
     }
     if (opts.feedbackRepo) {
       registerFeedbackRoutes(app, opts.feedbackRepo, requireAuth);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -14,6 +14,7 @@ import { PgA2uiSurfaceStore } from "./a2ui/surface-store";
 import { subscribeActivityLogging } from "./activity/events";
 import { PgActivityRepo } from "./activity/repo";
 import { ActivityService } from "./activity/service";
+import { createRuntimeOperationalApi } from "./admin/runtime";
 import { buildApp } from "./app";
 import { ApprovalsRepo } from "./approvals/repo";
 import { PgTokenRepo } from "./auth/api-tokens";
@@ -327,6 +328,13 @@ async function boot() {
       activityService,
       observabilityService,
       observabilityConfig: obsConfig,
+      operationalApi: createRuntimeOperationalApi({
+        activity: activityService,
+        approvals: approvalsRepo,
+        approvalRegistry,
+        enqueueWake: (job) => routineEnqueuers.enqueueWake(job),
+        guardrailsConfig: () => soulLoader.guardrailsConfig,
+      }),
       routines: {
         registry: routineRegistry,
         runs: routineRuns,

--- a/apps/api/src/onboarding/personalize.test.ts
+++ b/apps/api/src/onboarding/personalize.test.ts
@@ -124,6 +124,30 @@ describe("getPersonalizedOnboarding", () => {
     expect(generateObject).toHaveBeenCalledOnce(); // served from cache
   });
 
+  it("repairs a complete fenced JSON response from providers without structured outputs", async () => {
+    generateObject.mockResolvedValue({ object: VALID });
+
+    const result = await getPersonalizedOnboarding(
+      soul({ businessDescription: "an online store" }),
+      {
+        llmService,
+        kvService: new KvService(new FakeKvRepo()),
+      }
+    );
+
+    expect(result).toEqual(VALID);
+    const options = generateObject.mock.calls[0][0] as {
+      experimental_repairText?: (input: { text: string; error: Error }) => Promise<string | null>;
+    };
+    expect(options.experimental_repairText).toBeTypeOf("function");
+    await expect(
+      options.experimental_repairText?.({
+        text: `\`\`\`json\n${JSON.stringify(VALID)}\n\`\`\``,
+        error: new Error("JSON parse failed"),
+      })
+    ).resolves.toBe(JSON.stringify(VALID));
+  });
+
   it("returns null when the LLM output is malformed / the call fails (static fallback)", async () => {
     generateObject.mockResolvedValue({ object: { suggestions: "nope" } });
     const kvService = new KvService(new FakeKvRepo());

--- a/apps/api/src/onboarding/personalize.ts
+++ b/apps/api/src/onboarding/personalize.ts
@@ -75,6 +75,7 @@ export const SYSTEM_PROMPT = [
   '- `label`: short chip text, question style (e.g. "Set up ticket management?").',
   '- `prompt`: the chat message that seeds the build flow (e.g. "Help me set up ticket management.").',
   "",
+  "Return raw JSON only. Do not wrap the response in Markdown or a code fence.",
   "Never propose something that already exists in the soul. Be specific to the business domain.",
 ].join("\n");
 
@@ -104,6 +105,11 @@ export function buildStateKey(businessDescription: string, state: SoulState): st
   return `suggestions:${hash}`;
 }
 
+async function repairFencedJson({ text }: { text: string }): Promise<string | null> {
+  const match = /^\s*```(?:json)?\s*\n([\s\S]*?)\n```\s*$/i.exec(text);
+  return match?.[1]?.trim() ?? null;
+}
+
 /** Run the LLM call and return a validated {@link Personalized}. Throws on malformed output. */
 export async function generatePersonalized(
   model: LlmModel,
@@ -112,6 +118,7 @@ export async function generatePersonalized(
   const { object } = await generateObject({
     model,
     schema: jsonSchema<Personalized>(PERSONALIZED_SCHEMA),
+    experimental_repairText: repairFencedJson,
     system: SYSTEM_PROMPT,
     prompt: [
       `Business name: ${ctx.businessName ?? "(unnamed)"}`,

--- a/apps/api/src/soul/agents/routes.ts
+++ b/apps/api/src/soul/agents/routes.ts
@@ -25,6 +25,13 @@ function asStringArray(v: unknown): string[] | undefined {
   return arr.length > 0 ? arr : undefined;
 }
 
+function asNumberRecord(v: unknown): Record<string, number> {
+  if (typeof v !== "object" || v === null || Array.isArray(v)) return {};
+  return Object.fromEntries(
+    Object.entries(v).filter((entry): entry is [string, number] => typeof entry[1] === "number")
+  );
+}
+
 function asAutonomy(v: unknown): Autonomy | undefined {
   return typeof v === "string" && (AUTONOMY_VALUES as readonly string[]).includes(v)
     ? (v as Autonomy)
@@ -45,11 +52,48 @@ function toSummary(agent: SoulAgent) {
 
 function toDetail(agent: SoulAgent) {
   const f = agent.frontmatter;
+  const version = asString(f.version);
+  const candidateVersion = asString(f.candidateVersion);
+  const evaluationStatus = asString(f.evaluationStatus);
+  const publicationStatus = asString(f.publicationStatus);
+  const governance =
+    version && candidateVersion
+      ? {
+          version,
+          roles: asStringArray(f.roles) ?? [],
+          skills: asStringArray(f.skills) ?? [],
+          tools: asStringArray(f.tools) ?? [],
+          modelProfile: asString(f.modelProfile) ?? asString(f.model) ?? "default",
+          limits: asNumberRecord(f.limits),
+          evaluation: {
+            status:
+              evaluationStatus &&
+              ["pending", "passed", "failed", "stale"].includes(evaluationStatus)
+                ? evaluationStatus
+                : "pending",
+            suite: asString(f.evaluationSuite) ?? "not configured",
+            passedAt: asString(f.evaluationPassedAt),
+          },
+          publication: {
+            candidateVersion,
+            status:
+              publicationStatus &&
+              ["draft", "validated", "awaiting_approval", "published", "blocked"].includes(
+                publicationStatus
+              )
+                ? publicationStatus
+                : "draft",
+            canPublish: f.canPublish === true,
+            reason: asString(f.publicationReason),
+          },
+        }
+      : undefined;
   return {
     ...toSummary(agent),
     placeholder: asStringArray(f.placeholder),
     suggestions: asStringArray(f.suggestions),
     body: agent.body,
+    governance,
   };
 }
 
@@ -118,6 +162,7 @@ export function registerAgentRoutes(
               placeholder: { type: "array", items: { type: "string" } },
               suggestions: { type: "array", items: { type: "string" } },
               body: { type: "string" },
+              governance: { type: "object", additionalProperties: true },
             },
           },
           401: ErrorSchema,

--- a/apps/web/app/components/admin/role-changeset-form.test.tsx
+++ b/apps/web/app/components/admin/role-changeset-form.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { RoleChangesetForm } from "./role-changeset-form";
+
+describe("RoleChangesetForm", () => {
+  it("proposes a custom Role through the governed changeset boundary", async () => {
+    const user = userEvent.setup();
+    const onPropose = vi.fn().mockResolvedValue(undefined);
+    render(<RoleChangesetForm onPropose={onPropose} />);
+
+    await user.type(screen.getByLabelText("Role ID"), "incident-commander");
+    await user.type(screen.getByLabelText("Role name"), "Incident commander");
+    await user.type(screen.getByLabelText("Principal kinds"), "user, agent");
+    await user.type(screen.getByLabelText("Grants"), "runs:read, runs:reconcile");
+    await user.click(screen.getByRole("button", { name: "Propose Role" }));
+
+    expect(onPropose).toHaveBeenCalledWith({
+      id: "incident-commander",
+      name: "Incident commander",
+      principalKinds: ["user", "agent"],
+      grants: ["runs:read", "runs:reconcile"],
+      conditions: [],
+    });
+    expect(screen.getByText("Role changeset proposed.")).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/components/admin/role-changeset-form.tsx
+++ b/apps/web/app/components/admin/role-changeset-form.tsx
@@ -1,0 +1,98 @@
+import type { FormEvent } from "react";
+import { useState } from "react";
+
+type RoleCandidate = {
+  id: string;
+  name: string;
+  principalKinds: string[];
+  grants: string[];
+  conditions: string[];
+};
+
+type RoleChangesetFormProps = {
+  onPropose: (role: RoleCandidate) => Promise<void>;
+};
+
+function commaSeparated(value: string): string[] {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+export function RoleChangesetForm({ onPropose }: RoleChangesetFormProps) {
+  const [status, setStatus] = useState<"idle" | "submitting" | "proposed" | "failed">("idle");
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const form = event.currentTarget;
+    setStatus("submitting");
+    const data = new FormData(form);
+
+    try {
+      await onPropose({
+        id: String(data.get("id") ?? "").trim(),
+        name: String(data.get("name") ?? "").trim(),
+        principalKinds: commaSeparated(String(data.get("principalKinds") ?? "")),
+        grants: commaSeparated(String(data.get("grants") ?? "")),
+        conditions: [],
+      });
+      setStatus("proposed");
+      form.reset();
+    } catch {
+      setStatus("failed");
+    }
+  }
+
+  return (
+    <form
+      className="grid gap-3 border border-border bg-card p-3 sm:grid-cols-2"
+      onSubmit={handleSubmit}
+    >
+      <h2 className="text-sm font-semibold sm:col-span-2">Propose a custom Role</h2>
+      <label className="grid gap-1 text-xs">
+        Role ID
+        <input className="border border-border bg-background px-2 py-1.5" name="id" required />
+      </label>
+      <label className="grid gap-1 text-xs">
+        Role name
+        <input className="border border-border bg-background px-2 py-1.5" name="name" required />
+      </label>
+      <label className="grid gap-1 text-xs">
+        Principal kinds
+        <input
+          className="border border-border bg-background px-2 py-1.5"
+          name="principalKinds"
+          placeholder="user, agent"
+          required
+        />
+      </label>
+      <label className="grid gap-1 text-xs">
+        Grants
+        <input
+          className="border border-border bg-background px-2 py-1.5"
+          name="grants"
+          placeholder="runs:read, runs:reconcile"
+          required
+        />
+      </label>
+      <div className="flex items-center gap-3 sm:col-span-2">
+        <button
+          className="border border-border px-3 py-1.5 text-xs font-medium"
+          disabled={status === "submitting"}
+          type="submit"
+        >
+          {status === "submitting" ? "Proposing…" : "Propose Role"}
+        </button>
+        {status === "proposed" ? (
+          <p className="text-xs text-muted-foreground">Role changeset proposed.</p>
+        ) : null}
+        {status === "failed" ? (
+          <p className="text-xs text-destructive" role="alert">
+            Role proposal failed.
+          </p>
+        ) : null}
+      </div>
+    </form>
+  );
+}

--- a/apps/web/app/components/agents/governance-card.test.tsx
+++ b/apps/web/app/components/agents/governance-card.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { AgentGovernanceCard } from "./governance-card";
+
+const governance = {
+  version: "3",
+  roles: ["support-reader"],
+  skills: ["triage"],
+  tools: ["github.issue.read"],
+  modelProfile: "balanced",
+  limits: { turns: 20, toolCalls: 8 },
+  evaluation: { status: "passed" as const, suite: "support-v2", passedAt: "2026-07-26" },
+  publication: {
+    candidateVersion: "4",
+    status: "validated" as const,
+    canPublish: true,
+  },
+};
+
+describe("AgentGovernanceCard", () => {
+  it("shows exact candidate and governed publication evidence", async () => {
+    const onPublish = vi.fn();
+    const user = userEvent.setup();
+    render(<AgentGovernanceCard governance={governance} onPublish={onPublish} />);
+
+    expect(screen.getByText("candidate 4")).toBeInTheDocument();
+    expect(screen.getByText(/support-v2/)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Propose version 4" }));
+    expect(onPublish).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks stale or failed candidates as presentation", () => {
+    render(
+      <AgentGovernanceCard
+        governance={{
+          ...governance,
+          evaluation: { ...governance.evaluation, status: "stale" },
+          publication: {
+            candidateVersion: "4",
+            status: "blocked",
+            canPublish: false,
+            reason: "Evaluation is stale",
+          },
+        }}
+        onPublish={vi.fn()}
+      />
+    );
+    expect(screen.getByRole("button", { name: "Propose version 4" })).toBeDisabled();
+    expect(screen.getByText("Evaluation is stale")).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/components/agents/governance-card.tsx
+++ b/apps/web/app/components/agents/governance-card.tsx
@@ -1,0 +1,95 @@
+import type { AgentGovernance } from "~/lib/agents";
+
+function Values({ values }: { values: readonly string[] }) {
+  if (values.length === 0) return <span className="text-muted-foreground">none</span>;
+  return (
+    <span className="flex flex-wrap gap-1">
+      {values.map((value) => (
+        <span key={value} className="rounded-sm border border-border px-1.5 py-0.5">
+          {value}
+        </span>
+      ))}
+    </span>
+  );
+}
+
+export function AgentGovernanceCard({
+  governance,
+  busy = false,
+  result,
+  onPublish,
+}: {
+  governance: AgentGovernance;
+  busy?: boolean;
+  result?: string;
+  onPublish: () => void;
+}) {
+  const candidate = governance.publication.candidateVersion;
+  return (
+    <section className="border border-border bg-card" aria-labelledby="agent-governance-title">
+      <div className="flex flex-wrap items-center gap-2 border-b border-border px-3 py-2">
+        <h2 id="agent-governance-title" className="text-xs font-medium uppercase tracking-[0.2em]">
+          Governance
+        </h2>
+        <span className="text-xs text-muted-foreground">version {governance.version}</span>
+        <span className="ml-auto text-xs text-primary">candidate {candidate}</span>
+      </div>
+      <dl className="grid gap-3 px-3 py-3 text-xs sm:grid-cols-2">
+        <div>
+          <dt className="mb-1 text-muted-foreground">Roles</dt>
+          <dd>
+            <Values values={governance.roles} />
+          </dd>
+        </div>
+        <div>
+          <dt className="mb-1 text-muted-foreground">Skills</dt>
+          <dd>
+            <Values values={governance.skills} />
+          </dd>
+        </div>
+        <div>
+          <dt className="mb-1 text-muted-foreground">Tools</dt>
+          <dd>
+            <Values values={governance.tools} />
+          </dd>
+        </div>
+        <div>
+          <dt className="mb-1 text-muted-foreground">Model profile</dt>
+          <dd>{governance.modelProfile}</dd>
+        </div>
+        <div>
+          <dt className="mb-1 text-muted-foreground">Limits</dt>
+          <dd>
+            {Object.entries(governance.limits)
+              .map(([key, value]) => `${key}: ${value}`)
+              .join(" · ")}
+          </dd>
+        </div>
+        <div>
+          <dt className="mb-1 text-muted-foreground">Evaluation</dt>
+          <dd>
+            {governance.evaluation.status} · {governance.evaluation.suite}
+          </dd>
+        </div>
+      </dl>
+      <div className="flex flex-wrap items-center gap-2 border-t border-border px-3 py-2">
+        <span className="text-xs text-muted-foreground">
+          {governance.publication.reason ?? governance.publication.status}
+        </span>
+        {result ? (
+          <span role="status" className="text-xs text-primary">
+            {result}
+          </span>
+        ) : null}
+        <button
+          type="button"
+          disabled={!governance.publication.canPublish || busy}
+          onClick={onPublish}
+          className="ml-auto rounded-sm bg-primary px-2 py-1 text-xs text-primary-foreground disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {busy ? "Proposing…" : `Propose version ${candidate}`}
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/app/components/app-sidebar.test.tsx
+++ b/apps/web/app/components/app-sidebar.test.tsx
@@ -44,7 +44,7 @@ test("renders the V1 sidebar sections (no standalone Chat item)", () => {
     "Resources",
     "Agents",
     "Routines",
-    "Approvals",
+    "Inbox",
     "Knowledge",
     "Integrations",
     "Settings",
@@ -65,13 +65,13 @@ test("does not render an Apps section (AC-V1-003)", () => {
   expect(screen.queryByText("Apps")).not.toBeInTheDocument();
 });
 
-test("renders no Approvals badge when there are no pending approvals", () => {
+test("renders no Inbox badge when there are no pending approvals", () => {
   render(<Stub initialEntries={["/"]} />);
-  const approvalsLink = screen.getByRole("link", { name: /approvals/i });
+  const approvalsLink = screen.getByRole("link", { name: /inbox/i });
   expect(within(approvalsLink).queryByText(/^\d+$/)).toBeNull();
 });
 
-test("renders the live Approvals badge count from context", () => {
+test("renders the live Inbox badge count from context", () => {
   useApprovals.mockReturnValue({
     approvals: [],
     count: 2,
@@ -80,7 +80,7 @@ test("renders the live Approvals badge count from context", () => {
     refresh: vi.fn(),
   });
   render(<Stub initialEntries={["/"]} />);
-  const approvalsLink = screen.getByRole("link", { name: /approvals/i });
+  const approvalsLink = screen.getByRole("link", { name: /inbox/i });
   expect(within(approvalsLink).getByText("2")).toBeInTheDocument();
 });
 

--- a/apps/web/app/components/app-sidebar.test.tsx
+++ b/apps/web/app/components/app-sidebar.test.tsx
@@ -199,3 +199,29 @@ test("collapsing the sidebar hides labels and persists the choice", async () => 
   expect(screen.queryByText("Resources")).not.toBeInTheDocument();
   expect(localStorage.getItem("sidebar-collapsed")).toBe("true");
 });
+
+test("mobile drawer closes on Escape and restores focus to its opener", async () => {
+  window.matchMedia = vi.fn().mockReturnValue({
+    matches: false,
+    media: "(min-width: 768px)",
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  });
+  const user = userEvent.setup();
+  render(<Stub initialEntries={["/"]} />);
+  const opener = screen.getByRole("button", { name: "Open navigation" });
+
+  await user.click(opener);
+  expect(screen.getByRole("complementary")).toHaveAttribute("aria-hidden", "false");
+  await user.keyboard("{Escape}");
+
+  expect(screen.getByRole("complementary", { hidden: true })).toHaveAttribute(
+    "aria-hidden",
+    "true"
+  );
+  expect(opener).toHaveFocus();
+});

--- a/apps/web/app/components/app-sidebar.tsx
+++ b/apps/web/app/components/app-sidebar.tsx
@@ -217,7 +217,12 @@ export function AppSidebar({ forceCollapsed = false }: { forceCollapsed?: boolea
   // Desktop-first so the nav is never hidden from AT before the media query resolves.
   const [isDesktop, setIsDesktop] = useState(true);
   const navRef = useRef<HTMLElement>(null);
+  const openerRef = useRef<HTMLButtonElement>(null);
   const close = () => setOpen(false);
+  const closeAndRestore = () => {
+    setOpen(false);
+    queueMicrotask(() => openerRef.current?.focus());
+  };
 
   // Collapse only applies on desktop; the mobile drawer always shows full labels. `forceCollapsed`
   // (set under /knowledge, which has its own tree rail) rails the nav without touching the persisted
@@ -241,6 +246,7 @@ export function AppSidebar({ forceCollapsed = false }: { forceCollapsed?: boolea
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
         setOpen(false);
+        queueMicrotask(() => openerRef.current?.focus());
       }
     };
     document.addEventListener("keydown", onKey);
@@ -261,6 +267,7 @@ export function AppSidebar({ forceCollapsed = false }: { forceCollapsed?: boolea
       {/* Mobile top bar with hamburger (hidden ≥ md). */}
       <header className="bg-sidebar text-sidebar-foreground border-sidebar-border flex h-12 items-center gap-2 border-b px-2 md:hidden">
         <button
+          ref={openerRef}
           type="button"
           aria-label="Open navigation"
           aria-expanded={open}
@@ -279,7 +286,7 @@ export function AppSidebar({ forceCollapsed = false }: { forceCollapsed?: boolea
         <button
           type="button"
           aria-label="Close navigation"
-          onClick={close}
+          onClick={closeAndRestore}
           className="fixed inset-0 z-40 bg-foreground/20 md:hidden"
         />
       ) : null}
@@ -322,7 +329,7 @@ export function AppSidebar({ forceCollapsed = false }: { forceCollapsed?: boolea
           <button
             type="button"
             aria-label="Close navigation"
-            onClick={close}
+            onClick={closeAndRestore}
             className="hover:bg-sidebar-accent/50 rounded-sm p-1.5 md:hidden"
           >
             <X className="size-5" />

--- a/apps/web/app/components/chat/chat-panel.tsx
+++ b/apps/web/app/components/chat/chat-panel.tsx
@@ -1,5 +1,6 @@
 import { Link } from "@remix-run/react";
 import { AgentGlyph } from "~/components/agent-glyph";
+import { ConnectionStatus } from "~/components/shell/states";
 import type { Autonomy } from "~/lib/agents";
 import type { ChatMessage, ModelTier } from "~/lib/chat/types";
 import { useChatStream } from "~/lib/chat/use-chat-stream";
@@ -116,6 +117,7 @@ export function ChatPanel({
     regenerate,
     sendFeedback,
     sendA2uiAgent,
+    connectionState,
   } = useChatStream({
     initialConversationId,
     initialMessages,
@@ -207,6 +209,11 @@ export function ChatPanel({
             </>
           ) : null}
         </p>
+      ) : null}
+      {connectionState === "reconnecting" ? (
+        <div className="mx-auto w-full max-w-3xl px-6 pb-2">
+          <ConnectionStatus state="reconnecting" />
+        </div>
       ) : null}
       <Composer
         busy={busy}

--- a/apps/web/app/components/inbox/inbox-item.test.tsx
+++ b/apps/web/app/components/inbox/inbox-item.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { InboxItem } from "./inbox-item";
+
+const item = {
+  id: "approval-1",
+  kind: "approval" as const,
+  title: "Create GitHub issue",
+  status: "pending",
+  risk: "high" as const,
+  intentDigest: "sha256:intent",
+  guardrailRevision: "gr-7",
+  target: "acme/repo",
+  destination: "github.com/acme/repo",
+  fields: ["title", "body"],
+  expiresAt: "2026-07-26T12:00:00Z",
+  decisions: 1,
+  requiredDecisions: 2,
+  canDecide: true,
+};
+
+describe("InboxItem", () => {
+  it("shows exact intent, destination, risk, expiry, fields, and four-eyes state", () => {
+    render(<InboxItem item={item} onDecision={vi.fn()} />);
+    expect(screen.getByText("sha256:intent")).toBeInTheDocument();
+    expect(screen.getByText("github.com/acme/repo")).toBeInTheDocument();
+    expect(screen.getByText("title, body")).toBeInTheDocument();
+    expect(screen.getByText("1 / 2 decisions")).toBeInTheDocument();
+  });
+
+  it("cannot self-approve when the server read model denies it", async () => {
+    const user = userEvent.setup();
+    const onDecision = vi.fn();
+    render(
+      <InboxItem
+        item={{ ...item, canDecide: false, denialReason: "Proposer cannot approve" }}
+        onDecision={onDecision}
+      />
+    );
+    expect(screen.getByRole("button", { name: "Approve" })).toBeDisabled();
+    await user.click(screen.getByRole("button", { name: "Approve" }));
+    expect(onDecision).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/components/inbox/inbox-item.tsx
+++ b/apps/web/app/components/inbox/inbox-item.tsx
@@ -1,0 +1,68 @@
+import type { InboxItemModel } from "~/lib/inbox";
+
+function Row({ label, value }: { label: string; value?: string }) {
+  if (!value) return null;
+  return (
+    <div className="grid grid-cols-[7rem_1fr] gap-2">
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="min-w-0 break-all">{value}</dd>
+    </div>
+  );
+}
+
+export function InboxItem({
+  item,
+  busy = false,
+  onDecision,
+}: {
+  item: InboxItemModel;
+  busy?: boolean;
+  onDecision: (decision: "approved" | "denied") => void;
+}) {
+  const isApproval = item.kind === "approval";
+  return (
+    <article className="border border-border bg-card">
+      <header className="flex flex-wrap items-center gap-2 border-b border-border px-3 py-2">
+        <span className="text-xs uppercase tracking-[0.2em] text-muted-foreground">
+          {item.kind.replace("_", " ")}
+        </span>
+        <h2 className="text-sm font-medium">{item.title}</h2>
+        <span className="ml-auto text-xs">
+          {item.risk} risk · {item.status}
+        </span>
+      </header>
+      <dl className="flex flex-col gap-2 px-3 py-3 text-xs">
+        <Row label="Intent" value={item.intentDigest} />
+        <Row label="Guardrail" value={item.guardrailRevision} />
+        <Row label="Target" value={item.target} />
+        <Row label="Destination" value={item.destination} />
+        <Row label="Fields" value={item.fields?.join(", ")} />
+        <Row label="Expires" value={item.expiresAt} />
+        <Row label="Four-eyes" value={`${item.decisions} / ${item.requiredDecisions} decisions`} />
+      </dl>
+      {isApproval ? (
+        <footer className="flex items-center gap-2 border-t border-border px-3 py-2">
+          {item.denialReason ? (
+            <span className="text-xs text-muted-foreground">{item.denialReason}</span>
+          ) : null}
+          <button
+            type="button"
+            disabled={!item.canDecide || busy}
+            onClick={() => onDecision("denied")}
+            className="ml-auto rounded-sm border border-destructive px-2 py-1 text-xs text-destructive disabled:opacity-50"
+          >
+            Deny
+          </button>
+          <button
+            type="button"
+            disabled={!item.canDecide || busy}
+            onClick={() => onDecision("approved")}
+            className="rounded-sm bg-primary px-2 py-1 text-xs text-primary-foreground disabled:opacity-50"
+          >
+            Approve
+          </button>
+        </footer>
+      ) : null}
+    </article>
+  );
+}

--- a/apps/web/app/components/operations/operations-console.test.tsx
+++ b/apps/web/app/components/operations/operations-console.test.tsx
@@ -1,0 +1,111 @@
+import { createRemixStub } from "@remix-run/testing";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { OperationsModel } from "~/lib/operations";
+import { OperationsConsole } from "./operations-console";
+
+const model = {
+  health: [{ component: "worker", status: "degraded" }],
+  incidents: [
+    {
+      id: "incident-1",
+      severity: "high",
+      title: "Queue stalled",
+      createdAt: "2026-07-26T00:00:00Z",
+    },
+  ],
+  quarantine: [{ id: "quarantine-1", reason: "ambiguous effect" }],
+  killSwitches: [{ id: "all-mutations", enabled: false }],
+  audit: [
+    {
+      id: "audit-1",
+      action: "run.cancel",
+      actorType: "user",
+      targetType: "run",
+      targetId: "0f5a23e8-42d7-7556-88d4-b544f361718b",
+      summary: "Cancelled a stalled Run",
+      status: "ok",
+      createdAt: "2026-07-26T00:00:00Z",
+      secret: "must-not-render",
+    },
+  ],
+  recovery: { supportBundleAvailable: true, lastBackupAt: "2026-07-26T00:00:00Z" },
+};
+
+function renderConsole(consoleModel: OperationsModel, onCommand = vi.fn()) {
+  const Stub = createRemixStub([
+    {
+      path: "/",
+      Component: () => <OperationsConsole model={consoleModel} onCommand={onCommand} />,
+    },
+    { path: "/settings/activities", Component: () => null },
+  ]);
+  return render(<Stub initialEntries={["/"]} />);
+}
+
+describe("OperationsConsole", () => {
+  it("renders structured operational summaries without raw JSON or protected fields", () => {
+    renderConsole(model);
+    expect(screen.getByRole("heading", { name: "Queue stalled" })).toBeInTheDocument();
+    expect(screen.getByText("worker")).toBeInTheDocument();
+    expect(screen.getByText("Degraded")).toBeInTheDocument();
+    expect(screen.getByText("High")).toBeInTheDocument();
+    expect(screen.getByRole("table", { name: "Audit and lineage events" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Event" })).toBeInTheDocument();
+    expect(screen.getByText("Cancelled a stalled Run")).toBeInTheDocument();
+    expect(screen.getByTitle("0f5a23e8-42d7-7556-88d4-b544f361718b")).toHaveTextContent("0f5a23e8");
+    expect(screen.queryByText(/"component":/)).not.toBeInTheDocument();
+    expect(screen.queryByText("must-not-render")).not.toBeInTheDocument();
+  });
+
+  it("uses compact, descriptive empty states", () => {
+    renderConsole({
+      health: [],
+      incidents: [],
+      quarantine: [],
+      killSwitches: [],
+      audit: [],
+      recovery: { supportBundleAvailable: false, lastBackupAt: null },
+    });
+    expect(screen.getByText("No active incidents")).toBeInTheDocument();
+    expect(screen.getByText("No quarantined items")).toBeInTheDocument();
+    expect(screen.getByText("No kill switches enabled")).toBeInTheDocument();
+    expect(screen.getByText("No audit events recorded")).toBeInTheDocument();
+    expect(screen.getByText("No backup reported")).toBeInTheDocument();
+  });
+
+  it("filters audit events using the rendered summary fields", async () => {
+    const user = userEvent.setup();
+    renderConsole({
+      ...model,
+      audit: [
+        ...model.audit,
+        {
+          id: "audit-2",
+          action: "job.run",
+          actorType: "system",
+          targetType: "job",
+          targetId: "connector-sync",
+          summary: "Connector sync ran",
+          status: "ok",
+          createdAt: "2026-07-26T01:00:00Z",
+        },
+      ],
+    });
+
+    await user.type(screen.getByRole("searchbox", { name: "Filter audit events" }), "connector");
+    expect(screen.getByText("Connector sync ran")).toBeInTheDocument();
+    expect(screen.queryByText("Cancelled a stalled Run")).not.toBeInTheDocument();
+    expect(screen.getByText("Showing 1 of 2 events")).toBeInTheDocument();
+  });
+
+  it("previews support bundle creation before invoking server recovery authority", async () => {
+    const user = userEvent.setup();
+    const onCommand = vi.fn();
+    renderConsole(model, onCommand);
+    await user.click(screen.getByRole("button", { name: "Create support bundle" }));
+    await user.click(screen.getByRole("button", { name: "Confirm Create Support Bundle" }));
+    expect(onCommand).toHaveBeenCalledWith("support-bundle.create", {});
+  });
+});

--- a/apps/web/app/components/operations/operations-console.tsx
+++ b/apps/web/app/components/operations/operations-console.tsx
@@ -1,0 +1,503 @@
+import { Link } from "@remix-run/react";
+import {
+  Activity,
+  AlertTriangle,
+  Ban,
+  CheckCircle2,
+  DatabaseBackup,
+  Search,
+  ShieldAlert,
+} from "lucide-react";
+import { type ReactNode, useState } from "react";
+import { DestructivePreview } from "~/components/shell/states";
+import type { OperationsModel } from "~/lib/operations";
+import { formatIso } from "~/lib/schema";
+import { cn } from "~/lib/utils";
+
+export type OperationAction =
+  | "support-bundle.create"
+  | "kill-switch.set"
+  | "quarantine.resolve"
+  | "recovery.start";
+
+type OperationalItem = Record<string, unknown>;
+
+function text(item: OperationalItem, ...keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = item[key];
+    if (typeof value === "string" && value.trim().length > 0) return value;
+  }
+  return undefined;
+}
+
+function humanize(value: string): string {
+  const words = value.replaceAll(/[._-]+/g, " ");
+  return `${words.charAt(0).toUpperCase()}${words.slice(1)}`;
+}
+
+function itemKey(item: OperationalItem, index: number): string {
+  return text(item, "id", "component", "name") ?? `item-${index}`;
+}
+
+function statusValue(item: OperationalItem, fallback: string): string {
+  const status = text(item, "status", "severity");
+  if (status) return status;
+  if (typeof item.enabled === "boolean") return item.enabled ? "enabled" : "disabled";
+  return fallback;
+}
+
+function statusTone(status: string): "positive" | "warning" | "danger" | "neutral" {
+  const normalized = status.toLowerCase();
+  if (/critical|error|failed|high|blocked|enabled/.test(normalized)) return "danger";
+  if (/degraded|warning|medium|pending|quarantined/.test(normalized)) return "warning";
+  if (/ok|healthy|resolved|disabled|success|low/.test(normalized)) return "positive";
+  return "neutral";
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const tone = statusTone(status);
+  return (
+    <span
+      className={cn(
+        "inline-flex shrink-0 items-center rounded-sm border px-1.5 py-0.5 text-[0.625rem] font-medium uppercase tracking-wide",
+        tone === "positive" && "border-emerald-500/30 bg-emerald-500/10 text-emerald-500",
+        tone === "warning" && "border-amber-500/30 bg-amber-500/10 text-amber-500",
+        tone === "danger" && "border-destructive/40 bg-destructive/10 text-destructive",
+        tone === "neutral" && "border-border bg-muted text-muted-foreground"
+      )}
+    >
+      {humanize(status)}
+    </span>
+  );
+}
+
+function Section({
+  title,
+  icon,
+  count,
+  children,
+}: {
+  title: string;
+  icon: ReactNode;
+  count?: number;
+  children: ReactNode;
+}) {
+  return (
+    <section className="min-w-0 border border-border bg-card">
+      <header className="flex items-center gap-2 border-b border-border px-3 py-2.5">
+        <span className="text-muted-foreground">{icon}</span>
+        <h2 className="text-xs font-medium uppercase tracking-[0.18em]">{title}</h2>
+        {count === undefined ? null : (
+          <span className="ml-auto text-[0.625rem] tabular-nums text-muted-foreground">
+            {count}
+          </span>
+        )}
+      </header>
+      {children}
+    </section>
+  );
+}
+
+function EmptyPanel({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex min-h-16 items-center gap-2 px-3 py-3 text-xs text-muted-foreground">
+      <CheckCircle2 aria-hidden="true" className="size-3.5 text-emerald-500" />
+      <span>{children}</span>
+    </div>
+  );
+}
+
+function HealthPanel({ items }: { items: readonly OperationalItem[] }) {
+  return (
+    <Section
+      title="Health"
+      count={items.length}
+      icon={<Activity aria-hidden="true" className="size-3.5" />}
+    >
+      {items.length === 0 ? (
+        <EmptyPanel>No health checks reported</EmptyPanel>
+      ) : (
+        <ul className="divide-y divide-border">
+          {items.map((item, index) => {
+            const component = text(item, "component", "name", "id") ?? "Unknown component";
+            const status = statusValue(item, "unknown");
+            return (
+              <li
+                key={itemKey(item, index)}
+                className="flex min-h-12 items-center gap-3 px-3 py-2 text-xs"
+              >
+                <span className="min-w-0 flex-1 truncate font-medium" title={component}>
+                  {component}
+                </span>
+                <StatusBadge status={status} />
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </Section>
+  );
+}
+
+function IncidentsPanel({ items }: { items: readonly OperationalItem[] }) {
+  return (
+    <Section
+      title="Incidents"
+      count={items.length}
+      icon={<AlertTriangle aria-hidden="true" className="size-3.5" />}
+    >
+      {items.length === 0 ? (
+        <EmptyPanel>No active incidents</EmptyPanel>
+      ) : (
+        <ul className="divide-y divide-border">
+          {items.map((item, index) => {
+            const title = text(item, "title", "summary", "action", "id") ?? `Incident ${index + 1}`;
+            const detail = text(item, "summary", "reason");
+            const severity = statusValue(item, "open");
+            const createdAt = text(item, "createdAt");
+            return (
+              <li key={itemKey(item, index)} className="px-3 py-2.5">
+                <div className="flex min-w-0 items-start gap-2">
+                  <div className="min-w-0 flex-1">
+                    <h3 className="truncate text-xs font-medium" title={title}>
+                      {title}
+                    </h3>
+                    {detail && detail !== title ? (
+                      <p className="mt-1 line-clamp-2 text-[0.6875rem] text-muted-foreground">
+                        {detail}
+                      </p>
+                    ) : null}
+                    {createdAt ? (
+                      <time
+                        dateTime={createdAt}
+                        className="mt-1 block text-[0.625rem] text-muted-foreground"
+                      >
+                        {formatIso(createdAt)}
+                      </time>
+                    ) : null}
+                  </div>
+                  <StatusBadge status={severity} />
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </Section>
+  );
+}
+
+function QuarantinePanel({ items }: { items: readonly OperationalItem[] }) {
+  return (
+    <Section
+      title="Quarantine"
+      count={items.length}
+      icon={<ShieldAlert aria-hidden="true" className="size-3.5" />}
+    >
+      {items.length === 0 ? (
+        <EmptyPanel>No quarantined items</EmptyPanel>
+      ) : (
+        <ul className="divide-y divide-border">
+          {items.map((item, index) => {
+            const id = text(item, "title", "name", "id") ?? `Item ${index + 1}`;
+            const reason = text(item, "reason", "summary") ?? "Reason not provided";
+            return (
+              <li key={itemKey(item, index)} className="flex items-start gap-3 px-3 py-2.5">
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-xs font-medium" title={id}>
+                    {id}
+                  </p>
+                  <p className="mt-1 line-clamp-2 text-[0.6875rem] text-muted-foreground">
+                    {reason}
+                  </p>
+                </div>
+                <StatusBadge status={statusValue(item, "quarantined")} />
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </Section>
+  );
+}
+
+function KillSwitchesPanel({ items }: { items: readonly OperationalItem[] }) {
+  return (
+    <Section
+      title="Kill switches"
+      count={items.length}
+      icon={<Ban aria-hidden="true" className="size-3.5" />}
+    >
+      {items.length === 0 ? (
+        <EmptyPanel>No kill switches enabled</EmptyPanel>
+      ) : (
+        <ul className="divide-y divide-border">
+          {items.map((item, index) => {
+            const id = text(item, "name", "id") ?? `Switch ${index + 1}`;
+            const scope = text(item, "scope", "summary");
+            return (
+              <li key={itemKey(item, index)} className="flex min-h-12 items-center gap-3 px-3 py-2">
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-xs font-medium" title={id}>
+                    {humanize(id)}
+                  </p>
+                  {scope ? (
+                    <p className="mt-0.5 truncate text-[0.625rem] text-muted-foreground">{scope}</p>
+                  ) : null}
+                </div>
+                <StatusBadge status={statusValue(item, "unknown")} />
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </Section>
+  );
+}
+
+function compactIdentifier(value: string): string {
+  if (value.length <= 18) return value;
+  return `${value.slice(0, 8)}…${value.slice(-4)}`;
+}
+
+const AUDIT_PREVIEW_LIMIT = 8;
+const AUDIT_SEARCH_KEYS = [
+  "action",
+  "event",
+  "summary",
+  "title",
+  "actorName",
+  "actorType",
+  "targetType",
+  "targetId",
+  "target",
+  "status",
+] as const;
+
+function matchesAuditQuery(item: OperationalItem, query: string): boolean {
+  if (!query) return true;
+  return AUDIT_SEARCH_KEYS.some((key) => text(item, key)?.toLowerCase().includes(query));
+}
+
+function AuditTable({ items }: { items: readonly OperationalItem[] }) {
+  const [query, setQuery] = useState("");
+  const normalizedQuery = query.trim().toLowerCase();
+  const matchingItems = items.filter((item) => matchesAuditQuery(item, normalizedQuery));
+  const visibleItems = matchingItems.slice(0, AUDIT_PREVIEW_LIMIT);
+
+  return (
+    <Section
+      title="Recent operational activity"
+      count={items.length}
+      icon={<ShieldAlert aria-hidden="true" className="size-3.5" />}
+    >
+      {items.length === 0 ? (
+        <EmptyPanel>No audit events recorded</EmptyPanel>
+      ) : (
+        <>
+          <div className="flex flex-wrap items-center gap-2 border-b border-border px-3 py-2">
+            <label className="relative min-w-48 flex-1 sm:max-w-xs">
+              <span className="sr-only">Filter audit events</span>
+              <Search
+                aria-hidden="true"
+                className="pointer-events-none absolute left-2 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground"
+              />
+              <input
+                type="search"
+                value={query}
+                onChange={(event) => setQuery(event.currentTarget.value)}
+                placeholder="Filter recent activity"
+                className="h-8 w-full rounded-sm border border-border bg-background pl-7 pr-2 text-xs outline-none placeholder:text-muted-foreground focus:border-ring"
+              />
+            </label>
+            <span className="text-[0.625rem] text-muted-foreground">
+              Showing {visibleItems.length} of {items.length} events
+            </span>
+            <Link
+              to="/settings/activities"
+              className="ml-auto text-xs text-primary underline-offset-2 hover:underline"
+            >
+              View all activities
+            </Link>
+          </div>
+          {visibleItems.length === 0 ? (
+            <div className="px-3 py-4 text-xs text-muted-foreground">
+              No matching operational activity
+            </div>
+          ) : (
+            <div className="max-w-full overflow-x-auto">
+              <table
+                aria-label="Audit and lineage events"
+                className="w-full min-w-[46rem] text-left"
+              >
+                <thead>
+                  <tr className="border-b border-border text-[0.625rem] uppercase tracking-wider text-muted-foreground">
+                    <th className="w-[42%] px-3 py-2 font-medium">Event</th>
+                    <th className="px-3 py-2 font-medium">Actor</th>
+                    <th className="px-3 py-2 font-medium">Target</th>
+                    <th className="px-3 py-2 font-medium">Status</th>
+                    <th className="px-3 py-2 text-right font-medium">Time</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border">
+                  {visibleItems.map((item, index) => {
+                    const action = text(item, "action", "event") ?? "Activity";
+                    const summary = text(item, "summary", "title") ?? humanize(action);
+                    const actor = text(item, "actorName", "actorType", "actorId") ?? "system";
+                    const targetType = text(item, "targetType");
+                    const targetId = text(item, "targetId", "target");
+                    const status = statusValue(item, "recorded");
+                    const createdAt = text(item, "createdAt");
+                    return (
+                      <tr key={itemKey(item, index)} className="align-top">
+                        <td className="px-3 py-2.5">
+                          <p className="max-w-xl text-xs font-medium">{summary}</p>
+                          <p className="mt-0.5 text-[0.625rem] text-muted-foreground">
+                            {humanize(action)}
+                          </p>
+                        </td>
+                        <td className="px-3 py-2.5 text-xs">{humanize(actor)}</td>
+                        <td className="px-3 py-2.5 text-xs">
+                          {targetType ? (
+                            <span className="block text-[0.625rem] text-muted-foreground">
+                              {humanize(targetType)}
+                            </span>
+                          ) : null}
+                          {targetId ? (
+                            <code
+                              title={targetId}
+                              className="block max-w-36 truncate text-[0.6875rem] text-foreground"
+                            >
+                              {compactIdentifier(targetId)}
+                            </code>
+                          ) : (
+                            <span className="text-muted-foreground">—</span>
+                          )}
+                        </td>
+                        <td className="px-3 py-2.5">
+                          <StatusBadge status={status} />
+                        </td>
+                        <td className="whitespace-nowrap px-3 py-2.5 text-right text-[0.6875rem] text-muted-foreground">
+                          {createdAt ? (
+                            <time dateTime={createdAt}>{formatIso(createdAt)}</time>
+                          ) : (
+                            "—"
+                          )}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </>
+      )}
+    </Section>
+  );
+}
+
+function attentionItems(model: OperationsModel): number {
+  const unhealthy = model.health.filter(
+    (item) => statusTone(statusValue(item, "unknown")) !== "positive"
+  ).length;
+  const activeKillSwitches = model.killSwitches.filter(
+    (item) => statusTone(statusValue(item, "unknown")) !== "positive"
+  ).length;
+  return unhealthy + model.incidents.length + model.quarantine.length + activeKillSwitches;
+}
+
+export function OperationsConsole({
+  model,
+  busy = false,
+  onCommand,
+}: {
+  model: OperationsModel;
+  busy?: boolean;
+  onCommand: (action: OperationAction, input: Record<string, unknown>) => void;
+}) {
+  const [previewSupport, setPreviewSupport] = useState(false);
+  const attentionCount = attentionItems(model);
+
+  return (
+    <div className="flex min-w-0 flex-col gap-4">
+      <header className="flex flex-wrap items-start gap-3">
+        <div className="min-w-0">
+          <h1 className="text-lg font-semibold">Operations</h1>
+          <p className="mt-0.5 max-w-2xl text-xs text-muted-foreground">
+            Authorized operational summaries. Protected payloads remain redacted.
+          </p>
+          <p
+            role="status"
+            className={cn(
+              "mt-2 inline-flex items-center gap-1.5 text-xs",
+              attentionCount > 0 ? "text-amber-500" : "text-emerald-500"
+            )}
+          >
+            {attentionCount > 0 ? (
+              <AlertTriangle aria-hidden="true" className="size-3.5" />
+            ) : (
+              <CheckCircle2 aria-hidden="true" className="size-3.5" />
+            )}
+            {attentionCount > 0
+              ? `${attentionCount} item${attentionCount === 1 ? "" : "s"} need attention`
+              : "All reported systems operational"}
+          </p>
+        </div>
+        {model.recovery.supportBundleAvailable ? (
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => setPreviewSupport(true)}
+            className="ml-auto rounded-sm border border-border px-2.5 py-1.5 text-xs hover:bg-muted disabled:opacity-60"
+          >
+            Create support bundle
+          </button>
+        ) : null}
+      </header>
+
+      {previewSupport ? (
+        <DestructivePreview
+          action="Create Support Bundle"
+          target="redacted operational diagnostics"
+          destination="authorized support bundle Artifact"
+          reversibility="Bundle creation is audited; the immutable Artifact can expire by retention"
+          busy={busy}
+          onCancel={() => setPreviewSupport(false)}
+          onConfirm={() => {
+            setPreviewSupport(false);
+            onCommand("support-bundle.create", {});
+          }}
+        />
+      ) : null}
+
+      <div className="grid min-w-0 gap-4 sm:grid-cols-2">
+        <HealthPanel items={model.health} />
+        <IncidentsPanel items={model.incidents} />
+        <QuarantinePanel items={model.quarantine} />
+        <KillSwitchesPanel items={model.killSwitches} />
+      </div>
+
+      <AuditTable items={model.audit} />
+
+      <Section title="Recovery" icon={<DatabaseBackup aria-hidden="true" className="size-3.5" />}>
+        <div className="flex flex-wrap items-center gap-x-6 gap-y-2 px-3 py-3 text-xs">
+          <div>
+            <span className="text-muted-foreground">Last backup</span>
+            <p className="mt-0.5 font-medium">
+              {model.recovery.lastBackupAt
+                ? formatIso(model.recovery.lastBackupAt)
+                : "No backup reported"}
+            </p>
+          </div>
+          <div>
+            <span className="text-muted-foreground">Support bundle</span>
+            <p className="mt-0.5 font-medium">
+              {model.recovery.supportBundleAvailable ? "Available" : "Unavailable"}
+            </p>
+          </div>
+        </div>
+      </Section>
+    </div>
+  );
+}

--- a/apps/web/app/components/runs/run-inspector.test.tsx
+++ b/apps/web/app/components/runs/run-inspector.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { RunInspector } from "./run-inspector";
+
+const run = {
+  id: "run-1",
+  routineId: "triage",
+  routineVersion: "3",
+  status: "attention_required",
+  version: 7,
+  createdAt: "2026-07-26T00:00:00Z",
+  startedAt: "2026-07-26T00:00:01Z",
+  finishedAt: null,
+  states: [{ key: "classify", status: "succeeded", attempts: 1, output: { label: "bug" } }],
+  effects: [{ id: "effect-1", status: "ambiguous", target: "github.repository/acme/repo" }],
+  waits: [{ kind: "approval", status: "open" }],
+  guardrailDecisions: [{ decision: "allow", revision: "gr-7" }],
+  lineage: [{ relation: "replay", sourceRunId: "run-0" }],
+  costs: { amountUsd: 0.12, modelTokens: 900 },
+};
+
+describe("RunInspector", () => {
+  it("renders the authorized Run evidence model", () => {
+    render(<RunInspector run={run} onCommand={vi.fn()} />);
+    expect(screen.getByText("classify")).toBeInTheDocument();
+    expect(screen.getByText(/effect-1/)).toBeInTheDocument();
+    expect(screen.getByText(/approval/)).toBeInTheDocument();
+    expect(screen.getByText(/gr-7/)).toBeInTheDocument();
+    expect(screen.getByText(/\$0\.1200/)).toBeInTheDocument();
+  });
+
+  it("previews destructive commands before delegating them", async () => {
+    const user = userEvent.setup();
+    const onCommand = vi.fn();
+    render(<RunInspector run={run} onCommand={onCommand} />);
+    await user.click(screen.getByRole("button", { name: "Cancel Run" }));
+    expect(screen.getAllByText("run-1")).toHaveLength(2);
+    await user.click(screen.getByRole("button", { name: "Confirm Cancel Run" }));
+    expect(onCommand).toHaveBeenCalledWith("cancel");
+  });
+});

--- a/apps/web/app/components/runs/run-inspector.tsx
+++ b/apps/web/app/components/runs/run-inspector.tsx
@@ -1,0 +1,115 @@
+import { useState } from "react";
+import { DestructivePreview } from "~/components/shell/states";
+import type { OperationalRun, RunCommandAction } from "~/lib/operations";
+
+function EvidenceList({
+  title,
+  items,
+}: {
+  title: string;
+  items: readonly Record<string, unknown>[];
+}) {
+  return (
+    <section className="border border-border bg-card">
+      <h2 className="border-b border-border px-3 py-2 text-xs font-medium uppercase tracking-[0.2em]">
+        {title}
+      </h2>
+      {items.length === 0 ? (
+        <p className="px-3 py-3 text-xs text-muted-foreground">none</p>
+      ) : (
+        <ul className="divide-y divide-border">
+          {items.map((item, index) => (
+            <li key={`${title}-${index}`} className="overflow-x-auto px-3 py-2">
+              <code className="text-xs">{JSON.stringify(item)}</code>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+export function RunInspector({
+  run,
+  busy = false,
+  onCommand,
+}: {
+  run: OperationalRun;
+  busy?: boolean;
+  onCommand: (action: RunCommandAction) => void;
+}) {
+  const [preview, setPreview] = useState<RunCommandAction>();
+  return (
+    <div className="flex flex-col gap-4">
+      <header className="flex flex-wrap items-center gap-2 border-b border-border pb-3">
+        <span className="rounded-sm border border-border px-2 py-1 text-xs">{run.status}</span>
+        <code className="text-xs text-muted-foreground">{run.id}</code>
+        <span className="text-xs text-muted-foreground">
+          {run.routineId}@{run.routineVersion}
+        </span>
+        <span className="ml-auto text-xs tabular-nums">
+          ${run.costs.amountUsd.toFixed(4)} · {run.costs.modelTokens} tokens
+        </span>
+      </header>
+
+      <div className="flex flex-wrap gap-2">
+        {(["pause", "resume", "retry", "reconcile"] as const).map((action) => (
+          <button
+            key={action}
+            type="button"
+            disabled={busy}
+            onClick={() => onCommand(action)}
+            className="rounded-sm border border-border px-2 py-1 text-xs capitalize"
+          >
+            {action}
+          </button>
+        ))}
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() => setPreview("cancel")}
+          className="rounded-sm border border-destructive px-2 py-1 text-xs text-destructive"
+        >
+          Cancel Run
+        </button>
+      </div>
+
+      {preview === "cancel" ? (
+        <DestructivePreview
+          action="Cancel Run"
+          target={run.id}
+          destination="TulipFarm Run authority"
+          reversibility="New work stops; ambiguous effects still require reconciliation"
+          busy={busy}
+          onCancel={() => setPreview(undefined)}
+          onConfirm={() => {
+            setPreview(undefined);
+            onCommand("cancel");
+          }}
+        />
+      ) : null}
+
+      <section className="border border-border bg-card">
+        <h2 className="border-b border-border px-3 py-2 text-xs font-medium uppercase tracking-[0.2em]">
+          States
+        </h2>
+        <ol className="divide-y divide-border">
+          {run.states.map((state) => (
+            <li key={state.key} className="grid gap-2 px-3 py-2 text-xs sm:grid-cols-4">
+              <strong>{state.key}</strong>
+              <span>{state.status}</span>
+              <span>{state.attempts} attempts</span>
+              <code className="overflow-x-auto">{JSON.stringify(state.output ?? null)}</code>
+            </li>
+          ))}
+        </ol>
+      </section>
+      <div className="grid gap-4 lg:grid-cols-2">
+        <EvidenceList title="Effects" items={run.effects} />
+        <EvidenceList title="Waits" items={run.waits} />
+        <EvidenceList title="Guardrail decisions" items={run.guardrailDecisions} />
+        <EvidenceList title="Lineage" items={run.lineage} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/components/shell/states.test.tsx
+++ b/apps/web/app/components/shell/states.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ConnectionStatus, DestructivePreview, PermissionDeniedState } from "./states";
+
+describe("shell state primitives", () => {
+  it("announces reconnect state without exposing transport details", () => {
+    render(<ConnectionStatus state="reconnecting" attempt={2} />);
+    expect(screen.getByRole("status")).toHaveTextContent("Reconnecting");
+    expect(screen.getByRole("status")).not.toHaveTextContent("token");
+  });
+
+  it("presents exact destructive target and requires server action confirmation", () => {
+    const onConfirm = vi.fn();
+    render(
+      <DestructivePreview
+        action="Cancel Run"
+        target="run-1"
+        destination="TulipFarm Run authority"
+        reversibility="Cannot undo in-flight provider effects"
+        onConfirm={onConfirm}
+      />
+    );
+    expect(screen.getByText("run-1")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Confirm Cancel Run" })).toBeInTheDocument();
+  });
+
+  it("renders safe permission denial with correlation evidence", () => {
+    render(<PermissionDeniedState correlationId="req-safe-1" />);
+    expect(screen.getByText(/req-safe-1/)).toBeInTheDocument();
+    expect(screen.queryByText(/stack/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/app/components/shell/states.tsx
+++ b/apps/web/app/components/shell/states.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useState } from "react";
+import { cn } from "~/lib/utils";
+
+export type ConnectionState = "online" | "offline" | "reconnecting";
+
+export function ConnectionStatus({ state, attempt }: { state: ConnectionState; attempt?: number }) {
+  const copy =
+    state === "online"
+      ? "Connected"
+      : state === "offline"
+        ? "Offline. Changes are not being sent."
+        : `Reconnecting${attempt ? ` · attempt ${attempt}` : ""}`;
+  return (
+    <p
+      role="status"
+      aria-live="polite"
+      className={cn("text-xs text-muted-foreground", state === "offline" && "text-destructive")}
+    >
+      {copy}
+    </p>
+  );
+}
+
+export function GlobalConnectionStatus() {
+  const [state, setState] = useState<ConnectionState>(() =>
+    typeof navigator === "undefined" || navigator.onLine ? "online" : "offline"
+  );
+
+  useEffect(() => {
+    const online = () => setState("reconnecting");
+    const offline = () => setState("offline");
+    window.addEventListener("online", online);
+    window.addEventListener("offline", offline);
+    return () => {
+      window.removeEventListener("online", online);
+      window.removeEventListener("offline", offline);
+    };
+  }, []);
+
+  if (state === "online") return null;
+  return (
+    <div className="fixed bottom-3 right-3 z-50 border border-border bg-card px-3 py-2">
+      <ConnectionStatus state={state} />
+    </div>
+  );
+}
+
+export function LoadingState({ label = "Loading" }: { label?: string }) {
+  return (
+    <p role="status" aria-live="polite" className="text-sm text-muted-foreground">
+      {label}…
+    </p>
+  );
+}
+
+export function PermissionDeniedState({ correlationId }: { correlationId?: string }) {
+  return (
+    <section role="alert" className="border border-border bg-card px-4 py-3">
+      <p className="text-sm font-medium">Permission denied</p>
+      <p className="mt-1 text-xs text-muted-foreground">
+        This view is not available to your current role.
+        {correlationId ? ` Reference: ${correlationId}.` : ""}
+      </p>
+    </section>
+  );
+}
+
+export function DestructivePreview({
+  action,
+  target,
+  destination,
+  reversibility,
+  busy = false,
+  onConfirm,
+  onCancel,
+}: {
+  action: string;
+  target: string;
+  destination: string;
+  reversibility: string;
+  busy?: boolean;
+  onConfirm: () => void;
+  onCancel?: () => void;
+}) {
+  return (
+    <section
+      aria-labelledby="destructive-preview-title"
+      className="border border-destructive/40 bg-card"
+    >
+      <h2
+        id="destructive-preview-title"
+        className="border-b border-border px-3 py-2 text-xs font-medium uppercase tracking-[0.2em]"
+      >
+        Confirm {action}
+      </h2>
+      <dl className="grid grid-cols-[7rem_1fr] gap-x-3 gap-y-2 px-3 py-3 text-xs">
+        <dt className="text-muted-foreground">Target</dt>
+        <dd>{target}</dd>
+        <dt className="text-muted-foreground">Destination</dt>
+        <dd>{destination}</dd>
+        <dt className="text-muted-foreground">Reversibility</dt>
+        <dd>{reversibility}</dd>
+      </dl>
+      <div className="flex justify-end gap-2 border-t border-border px-3 py-2">
+        {onCancel ? (
+          <button
+            type="button"
+            className="rounded-sm border border-border px-2 py-1 text-xs"
+            onClick={onCancel}
+          >
+            Cancel
+          </button>
+        ) : null}
+        <button
+          type="button"
+          disabled={busy}
+          className="rounded-sm bg-destructive px-2 py-1 text-xs text-destructive-foreground disabled:opacity-60"
+          onClick={onConfirm}
+        >
+          Confirm {action}
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/app/lib/admin.ts
+++ b/apps/web/app/lib/admin.ts
@@ -1,0 +1,61 @@
+import { apiCommand, apiGet } from "./api";
+
+export type GuardrailItem = {
+  id: string;
+  name?: string;
+  enabled?: boolean;
+  effect?: string;
+  scope?: string;
+};
+
+export type GuardrailsModel = {
+  revision: string;
+  items: GuardrailItem[];
+};
+
+export function getGuardrails(): Promise<GuardrailsModel> {
+  return apiGet<GuardrailsModel>("/api/v1/guardrails");
+}
+
+export function proposeGuardrailToggle(
+  model: GuardrailsModel,
+  item: GuardrailItem,
+  enabled: boolean
+): Promise<{ changesetId: string; status: string }> {
+  const index = model.items.findIndex((candidate) => candidate.id === item.id);
+  return apiCommand(
+    "/api/v1/guardrails/changesets",
+    {
+      baseRevision: model.revision,
+      changes: [{ op: "replace", path: `/items/${index}/enabled`, value: enabled }],
+    },
+    `guardrail-${model.revision}-${item.id}-${enabled}`
+  );
+}
+
+export type RolesModel = {
+  revision: string;
+  items: Array<{
+    id: string;
+    name: string;
+    principalKinds: string[];
+    grants: string[];
+    conditions: string[];
+  }>;
+};
+
+export function getRoles(): Promise<RolesModel> {
+  return apiGet<RolesModel>("/api/v1/roles");
+}
+
+export function proposeRole(
+  model: RolesModel,
+  role: Record<string, unknown>
+): Promise<{ changesetId: string; status: string }> {
+  const id = typeof role.id === "string" ? role.id : "new";
+  return apiCommand(
+    "/api/v1/roles/changesets",
+    { baseRevision: model.revision, role },
+    `role-${model.revision}-${id}`
+  );
+}

--- a/apps/web/app/lib/agents.ts
+++ b/apps/web/app/lib/agents.ts
@@ -1,4 +1,4 @@
-import { apiGet } from "./api";
+import { apiCommand, apiGet } from "./api";
 
 /*
  * Read-only client for the agents API (AGENTS / UI-V1-003). Agents are AGENT.md files in the soul
@@ -21,6 +21,27 @@ export type AgentDetail = AgentSummary & {
   placeholder?: string[];
   suggestions?: string[];
   body: string;
+  governance?: AgentGovernance;
+};
+
+export type AgentGovernance = {
+  version: string;
+  roles: string[];
+  skills: string[];
+  tools: string[];
+  modelProfile: string;
+  limits: Record<string, number>;
+  evaluation: {
+    status: "pending" | "passed" | "failed" | "stale";
+    suite: string;
+    passedAt?: string;
+  };
+  publication: {
+    candidateVersion: string;
+    status: "draft" | "validated" | "awaiting_approval" | "published" | "blocked";
+    canPublish: boolean;
+    reason?: string;
+  };
 };
 
 export async function listAgents(): Promise<AgentSummary[]> {
@@ -30,4 +51,20 @@ export async function listAgents(): Promise<AgentSummary[]> {
 
 export async function getAgent(name: string): Promise<AgentDetail> {
   return apiGet<AgentDetail>(`/api/v1/agents/${encodeURIComponent(name)}`);
+}
+
+export async function proposeAgentCandidate(
+  name: string,
+  governance: AgentGovernance
+): Promise<{ changesetId: string; candidateVersion: string; status: string }> {
+  const candidate = governance.publication.candidateVersion;
+  return apiCommand(
+    `/api/v1/agents/${encodeURIComponent(name)}/changesets`,
+    {
+      baseVersion: governance.version,
+      candidateVersion: candidate,
+      patch: {},
+    },
+    `agent-${name}-${candidate}`
+  );
 }

--- a/apps/web/app/lib/api.ts
+++ b/apps/web/app/lib/api.ts
@@ -71,6 +71,24 @@ export async function apiWrite<T>(
   return (await res.json()) as T;
 }
 
+/** A retry-safe server command. The server remains authoritative and deduplicates by this key. */
+export async function apiCommand<T>(
+  path: string,
+  body: unknown,
+  idempotencyKey: string
+): Promise<T> {
+  const headers = mutationHeaders();
+  headers["Idempotency-Key"] = idempotencyKey;
+  const res = await fetch(`${API_BASE}${path}`, {
+    method: "POST",
+    credentials: "include",
+    headers,
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw await readError(res);
+  return (await res.json()) as T;
+}
+
 // Like apiWrite (cookie-first auth, CSRF echo, optional If-Match) but for endpoints that return
 // 204 No Content — sends a JSON body and parses nothing, so it returns void.
 export async function apiSend(
@@ -147,8 +165,19 @@ export async function readError(res: Response): Promise<ApiError> {
   let message = res.statusText || `request failed (${res.status})`;
   let path: string | undefined;
   try {
-    const body = (await res.json()) as { error?: unknown; path?: unknown };
+    const body = (await res.json()) as {
+      error?: unknown;
+      path?: unknown;
+    };
     if (typeof body.error === "string") message = body.error;
+    if (
+      typeof body.error === "object" &&
+      body.error !== null &&
+      "message" in body.error &&
+      typeof body.error.message === "string"
+    ) {
+      message = body.error.message;
+    }
     if (typeof body.path === "string" && body.path.length > 0) path = body.path;
   } catch {
     // non-JSON body — keep the status-text fallback

--- a/apps/web/app/lib/chat/sse-client.test.ts
+++ b/apps/web/app/lib/chat/sse-client.test.ts
@@ -1,5 +1,19 @@
-import { expect, test } from "vitest";
-import { parseSseFrames } from "~/lib/chat/sse-client";
+import { afterEach, expect, test, vi } from "vitest";
+import { parseSseFrames, postChat } from "~/lib/chat/sse-client";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function streamResponse(frames: string, headers: Record<string, string> = {}) {
+  const body = new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(frames));
+      controller.close();
+    },
+  });
+  return new Response(body, { status: 200, headers });
+}
 
 test("parses a single frame with the spec spacing (space after the colon)", () => {
   const { frames, rest } = parseSseFrames('id: 1\nevent: text\ndata: {"delta":"hi"}\n\n');
@@ -69,4 +83,38 @@ test("ignores empty/whitespace-only frames and a frame whose data is invalid JSO
 test("defaults seq to 0 when no id line is present but event+data are", () => {
   const { frames } = parseSseFrames('event: text\ndata: {"delta":"x"}\n\n');
   expect(frames).toEqual([{ seq: 0, type: "text", data: { delta: "x" } }]);
+});
+
+test("recovers a dropped stream from the persisted cursor without duplicating events", async () => {
+  const fetchMock = vi
+    .fn()
+    .mockResolvedValueOnce(
+      streamResponse('id: 1\nevent: text\ndata: {"delta":"hello"}\n\n', {
+        "X-Stream-Id": "stream-1",
+      })
+    )
+    .mockResolvedValueOnce(
+      streamResponse(
+        'id: 1\nevent: text\ndata: {"delta":"hello"}\n\n' +
+          'id: 2\nevent: finish\ndata: {"reason":"stop"}\n\n'
+      )
+    );
+  vi.stubGlobal("fetch", fetchMock);
+  const events: string[] = [];
+  const states: string[] = [];
+
+  await postChat(
+    { message: { role: "user", content: "hello" } },
+    {
+      onEvent: (event) => events.push(event.type),
+      onConnectionState: (state) => states.push(state),
+    }
+  );
+
+  expect(events).toEqual(["text", "finish"]);
+  expect(states).toEqual(["reconnecting", "online"]);
+  expect(fetchMock.mock.calls[1]?.[0]).toContain("/api/v1/chat/streams/stream-1");
+  expect(fetchMock.mock.calls[1]?.[1]).toMatchObject({
+    headers: expect.objectContaining({ "Last-Event-ID": "1" }),
+  });
 });

--- a/apps/web/app/lib/chat/sse-client.ts
+++ b/apps/web/app/lib/chat/sse-client.ts
@@ -115,6 +115,7 @@ export type PostChatHandlers = {
   signal?: AbortSignal;
   onEvent: (event: ChatEvent) => void;
   onMeta?: (meta: ChatStreamMeta) => void;
+  onConnectionState?: (state: "online" | "reconnecting") => void;
 };
 
 // Best-effort `{ error }` extraction so a failed POST throws the same ApiError shape as the rest of
@@ -134,7 +135,7 @@ async function readChatError(res: Response): Promise<ApiError> {
 // `X-Conversation-Id`/`X-Stream-Id` headers via `onMeta`, then streams typed events to `onEvent`,
 // stopping at the first terminal event (finish/error) or when the reader is exhausted.
 export async function postChat(body: ChatRequestBody, handlers: PostChatHandlers): Promise<void> {
-  const { signal, onEvent, onMeta } = handlers;
+  const { signal, onMeta } = handlers;
   const res = await fetch(`${API_BASE}/api/v1/chat`, {
     method: "POST",
     credentials: "include",
@@ -145,17 +146,52 @@ export async function postChat(body: ChatRequestBody, handlers: PostChatHandlers
 
   if (!res.ok) throw await readChatError(res);
 
+  const streamId = res.headers.get("X-Stream-Id") ?? undefined;
   onMeta?.({
     conversationId: res.headers.get("X-Conversation-Id") ?? undefined,
-    streamId: res.headers.get("X-Stream-Id") ?? undefined,
+    streamId,
     messageId: res.headers.get("X-Message-Id") ?? undefined,
     agentId: res.headers.get("X-Agent-Id") ?? undefined,
   });
 
-  if (!res.body) return;
-  const reader = res.body.getReader();
+  let outcome = await consumeSse(res, handlers, 0);
+  if (outcome.terminal || !streamId) return;
+
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    handlers.onConnectionState?.("reconnecting");
+    const headers = mutationHeaders();
+    delete headers["Content-Type"];
+    headers.Accept = "text/event-stream";
+    headers["Last-Event-ID"] = String(outcome.lastSequence);
+    const resumed = await fetch(
+      `${API_BASE}/api/v1/chat/streams/${encodeURIComponent(streamId)}?lastEventId=${outcome.lastSequence}`,
+      {
+        method: "GET",
+        credentials: "include",
+        headers,
+        signal,
+      }
+    );
+    if (!resumed.ok) throw await readChatError(resumed);
+    outcome = await consumeSse(resumed, handlers, outcome.lastSequence);
+    if (outcome.terminal) {
+      handlers.onConnectionState?.("online");
+      return;
+    }
+  }
+  throw new ApiError(503, "The stream could not be recovered from its persisted cursor.");
+}
+
+async function consumeSse(
+  response: Response,
+  handlers: PostChatHandlers,
+  afterSequence: number
+): Promise<{ terminal: boolean; lastSequence: number }> {
+  if (!response.body) return { terminal: false, lastSequence: afterSequence };
+  const reader = response.body.getReader();
   const decoder = new TextDecoder();
   let buffer = "";
+  let lastSequence = afterSequence;
 
   while (true) {
     const { value, done } = await reader.read();
@@ -166,15 +202,18 @@ export async function postChat(body: ChatRequestBody, handlers: PostChatHandlers
     buffer = rest;
 
     for (const frame of frames) {
+      if (frame.seq <= lastSequence) continue;
+      lastSequence = frame.seq;
       const event = toChatEvent(frame);
       if (!event) continue;
-      onEvent(event);
+      handlers.onEvent(event);
       if (TERMINAL_EVENT_TYPES.has(event.type)) {
         await reader.cancel();
-        return;
+        return { terminal: true, lastSequence };
       }
     }
   }
+  return { terminal: false, lastSequence };
 }
 
 // Stop an in-flight chat stream server-side: aborts the LLM so generation halts. Reuses the shared

--- a/apps/web/app/lib/chat/use-chat-stream.ts
+++ b/apps/web/app/lib/chat/use-chat-stream.ts
@@ -8,7 +8,7 @@
  */
 
 import { type NavigateFunction, useNavigate } from "@remix-run/react";
-import { useCallback, useReducer, useRef } from "react";
+import { useCallback, useReducer, useRef, useState } from "react";
 import { invokeClientAction, prefillForm } from "~/lib/chat/action-registry";
 import {
   appendUserMessage,
@@ -192,6 +192,7 @@ function reducer(state: ChatState, action: ChatAction): ChatState {
 
 export function useChatStream(opts?: UseChatStreamOptions) {
   const [state, dispatch] = useReducer(reducer, opts, seedState);
+  const [connectionState, setConnectionState] = useState<"online" | "reconnecting">("online");
   // Latest conversation id + state + last send options, read inside callbacks without re-subscribing.
   const conversationIdRef = useRef<string | undefined>(opts?.initialConversationId);
   const stateRef = useRef(state);
@@ -246,6 +247,7 @@ export function useChatStream(opts?: UseChatStreamOptions) {
             if (event.type === "finish")
               onConversationChangeRef.current?.(conversationIdRef.current);
           },
+          onConnectionState: setConnectionState,
         }
       );
     } catch (err) {
@@ -340,6 +342,7 @@ export function useChatStream(opts?: UseChatStreamOptions) {
     currentAgent: state.currentAgent,
     conversationId: state.conversationId,
     error: state.error,
+    connectionState,
     send,
     stop,
     approve,

--- a/apps/web/app/lib/inbox.ts
+++ b/apps/web/app/lib/inbox.ts
@@ -1,0 +1,40 @@
+import { apiCommand, apiGet } from "./api";
+
+export type InboxItemModel = {
+  id: string;
+  kind: "approval" | "human_task" | "form" | "access_request";
+  title: string;
+  status: string;
+  risk: "low" | "medium" | "high";
+  intentDigest?: string;
+  guardrailRevision?: string;
+  target?: string;
+  destination?: string;
+  fields?: string[];
+  expiresAt?: string;
+  decisions: number;
+  requiredDecisions: number;
+  canDecide: boolean;
+  denialReason?: string;
+};
+
+export async function getInbox(): Promise<InboxItemModel[]> {
+  return (await apiGet<{ items: InboxItemModel[] }>("/api/v1/inbox")).items;
+}
+
+export function decideApproval(
+  item: InboxItemModel,
+  decision: "approved" | "denied",
+  comment?: string
+): Promise<{
+  approvalId: string;
+  status: "pending" | "approved" | "denied";
+  decisions: number;
+  requiredDecisions: number;
+}> {
+  return apiCommand(
+    `/api/v1/approvals/${encodeURIComponent(item.id)}/decisions`,
+    { decision, comment },
+    `${item.id}-${decision}-${item.decisions}`
+  );
+}

--- a/apps/web/app/lib/nav.ts
+++ b/apps/web/app/lib/nav.ts
@@ -2,11 +2,12 @@ import {
   BookOpen,
   Bot,
   Boxes,
-  CheckCheck,
+  Inbox,
   type LucideIcon,
   Plug,
   Puzzle,
   Settings,
+  ShieldAlert,
   Workflow,
 } from "lucide-react";
 import type { BadgeKey } from "~/lib/badges";
@@ -32,14 +33,15 @@ export const navItems: NavItem[] = [
   { to: "/skills", label: "Skills", icon: Puzzle, group: "Workspace" },
   { to: "/routines", label: "Routines", icon: Workflow, group: "Workspace" },
   {
-    to: "/approvals",
-    label: "Approvals",
-    icon: CheckCheck,
+    to: "/inbox",
+    label: "Inbox",
+    icon: Inbox,
     group: "Workspace",
     badgeKey: "approvals",
   },
   { to: "/knowledge", label: "Knowledge", icon: BookOpen, group: "Workspace" },
   { to: "/integrations", label: "Integrations", icon: Plug, group: "System" },
+  { to: "/operations", label: "Operations", icon: ShieldAlert, group: "System" },
   { to: "/settings", label: "Settings", icon: Settings, group: "System" },
 ];
 

--- a/apps/web/app/lib/operations.ts
+++ b/apps/web/app/lib/operations.ts
@@ -1,0 +1,67 @@
+import { apiCommand, apiGet } from "./api";
+
+export type RunCommandAction = "pause" | "resume" | "cancel" | "retry" | "reconcile";
+
+export type OperationalRun = {
+  id: string;
+  routineId: string;
+  routineVersion: string;
+  status: string;
+  version: number;
+  createdAt: string;
+  startedAt: string | null;
+  finishedAt: string | null;
+  states: Array<{
+    key: string;
+    status: string;
+    attempts: number;
+    input?: unknown;
+    output?: unknown;
+    errorEvidenceRef?: string;
+  }>;
+  effects: Array<Record<string, unknown>>;
+  waits: Array<Record<string, unknown>>;
+  guardrailDecisions: Array<Record<string, unknown>>;
+  lineage: Array<Record<string, unknown>>;
+  costs: { amountUsd: number; modelTokens: number };
+};
+
+export async function getOperationalRun(id: string): Promise<OperationalRun> {
+  return (await apiGet<{ run: OperationalRun }>(`/api/v1/runs/${encodeURIComponent(id)}`)).run;
+}
+
+export function commandRun(
+  run: OperationalRun,
+  action: RunCommandAction,
+  reason: string
+): Promise<{ commandId: string; runId: string; status: string }> {
+  return apiCommand(
+    `/api/v1/runs/${encodeURIComponent(run.id)}/${action}`,
+    { expectedVersion: run.version, reason },
+    `${action}-${run.id}-v${run.version}`
+  );
+}
+
+export type OperationsModel = {
+  health: Array<Record<string, unknown>>;
+  incidents: Array<Record<string, unknown>>;
+  quarantine: Array<Record<string, unknown>>;
+  killSwitches: Array<Record<string, unknown>>;
+  audit: Array<Record<string, unknown>>;
+  recovery: { supportBundleAvailable: boolean; lastBackupAt: string | null };
+};
+
+export function getOperations(): Promise<OperationsModel> {
+  return apiGet<OperationsModel>("/api/v1/admin/operations");
+}
+
+export function commandOperation(
+  action: string,
+  input: Record<string, unknown>
+): Promise<{ commandId: string; status: string }> {
+  return apiCommand(
+    `/api/v1/admin/operations/${encodeURIComponent(action)}`,
+    { input },
+    `operation-${action}-${JSON.stringify(input)}`
+  );
+}

--- a/apps/web/app/routes/_app.admin.guardrails.tsx
+++ b/apps/web/app/routes/_app.admin.guardrails.tsx
@@ -1,0 +1,49 @@
+import { useLoaderData, useRevalidator } from "@remix-run/react";
+import { useState } from "react";
+import { getGuardrails, proposeGuardrailToggle } from "~/lib/admin";
+
+export async function clientLoader() {
+  return { model: await getGuardrails() };
+}
+
+export default function GuardrailAdminRoute() {
+  const { model } = useLoaderData<typeof clientLoader>();
+  const revalidator = useRevalidator();
+  const [busy, setBusy] = useState<string>();
+  return (
+    <div className="mx-auto flex max-w-4xl flex-col gap-4 px-4 py-6 sm:px-6">
+      <header>
+        <h1 className="text-lg font-semibold">Guardrails</h1>
+        <p className="text-xs text-muted-foreground">
+          Revision {model.revision}. Changes are Soul changesets and may require Approval.
+        </p>
+      </header>
+      <ul className="divide-y divide-border border border-border bg-card">
+        {model.items.map((item) => (
+          <li key={item.id} className="flex flex-wrap items-center gap-3 px-3 py-3 text-xs">
+            <span className="font-medium">{item.name ?? item.id}</span>
+            <span className="text-muted-foreground">
+              {item.effect ?? "configured"} · {item.scope ?? "all"}
+            </span>
+            <button
+              type="button"
+              disabled={busy === item.id}
+              onClick={async () => {
+                setBusy(item.id);
+                try {
+                  await proposeGuardrailToggle(model, item, item.enabled === false);
+                  revalidator.revalidate();
+                } finally {
+                  setBusy(undefined);
+                }
+              }}
+              className="ml-auto rounded-sm border border-border px-2 py-1"
+            >
+              {item.enabled === false ? "Enable" : "Disable"}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/app/routes/_app.admin.roles.tsx
+++ b/apps/web/app/routes/_app.admin.roles.tsx
@@ -1,0 +1,35 @@
+import { useLoaderData } from "@remix-run/react";
+import { RoleChangesetForm } from "~/components/admin/role-changeset-form";
+import { getRoles, proposeRole } from "~/lib/admin";
+
+export async function clientLoader() {
+  return { model: await getRoles() };
+}
+
+export default function RoleAdminRoute() {
+  const { model } = useLoaderData<typeof clientLoader>();
+  return (
+    <div className="mx-auto flex max-w-4xl flex-col gap-4 px-4 py-6 sm:px-6">
+      <header>
+        <h1 className="text-lg font-semibold">Roles</h1>
+        <p className="text-xs text-muted-foreground">
+          Revision {model.revision}. Role changes use governed Soul changesets.
+        </p>
+      </header>
+      <RoleChangesetForm
+        onPropose={async (role) => {
+          await proposeRole(model, role);
+        }}
+      />
+      <ul className="divide-y divide-border border border-border bg-card">
+        {model.items.map((role) => (
+          <li key={role.id} className="grid gap-2 px-3 py-3 text-xs sm:grid-cols-3">
+            <strong>{role.name}</strong>
+            <span>{role.principalKinds.join(", ")}</span>
+            <span className="text-muted-foreground">{role.grants.join(", ")}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/app/routes/_app.agents.$name.tsx
+++ b/apps/web/app/routes/_app.agents.$name.tsx
@@ -5,12 +5,14 @@ import {
   useNavigate,
   useRouteError,
 } from "@remix-run/react";
+import { useState } from "react";
 import { AgentGlyph } from "~/components/agent-glyph";
+import { AgentGovernanceCard } from "~/components/agents/governance-card";
 import { MarkdownView } from "~/components/markdown-view";
 import { ResourcePanel } from "~/components/resource-panel";
 import { ErrorState, NotFoundState } from "~/components/states";
 import { Button } from "~/components/ui/button";
-import { getAgent } from "~/lib/agents";
+import { getAgent, proposeAgentCandidate } from "~/lib/agents";
 import { ApiError } from "~/lib/api";
 
 export const meta: MetaFunction = () => [{ title: "Agents · tulipfarm" }];
@@ -35,6 +37,8 @@ function MetaRow({ label, value }: { label: string; value?: string }) {
 export default function AgentDetail() {
   const { agent } = useLoaderData<typeof clientLoader>();
   const navigate = useNavigate();
+  const [publishing, setPublishing] = useState(false);
+  const [publishResult, setPublishResult] = useState<string>();
   const display = agent.label ?? agent.name;
   const hasMeta = Boolean(agent.label || agent.domain || agent.model || agent.autonomy);
 
@@ -68,6 +72,28 @@ export default function AgentDetail() {
           <MetaRow label="model" value={agent.model} />
           <MetaRow label="autonomy" value={agent.autonomy} />
         </dl>
+      ) : null}
+
+      {agent.governance ? (
+        <AgentGovernanceCard
+          governance={agent.governance}
+          busy={publishing}
+          result={publishResult}
+          onPublish={async () => {
+            const governance = agent.governance;
+            if (!governance) return;
+            setPublishing(true);
+            setPublishResult(undefined);
+            try {
+              const result = await proposeAgentCandidate(agent.name, governance);
+              setPublishResult(`${result.status} · ${result.changesetId}`);
+            } catch (error) {
+              setPublishResult(error instanceof Error ? error.message : "Publication failed");
+            } finally {
+              setPublishing(false);
+            }
+          }}
+        />
       ) : null}
 
       <div className="border-t border-border pt-4">

--- a/apps/web/app/routes/_app.audit.tsx
+++ b/apps/web/app/routes/_app.audit.tsx
@@ -1,0 +1,1 @@
+export { clientLoader, default } from "./_app.operations";

--- a/apps/web/app/routes/_app.health.tsx
+++ b/apps/web/app/routes/_app.health.tsx
@@ -1,0 +1,1 @@
+export { clientLoader, default } from "./_app.operations";

--- a/apps/web/app/routes/_app.inbox.tsx
+++ b/apps/web/app/routes/_app.inbox.tsx
@@ -1,0 +1,63 @@
+import { useLoaderData, useRevalidator, useRouteError } from "@remix-run/react";
+import { useState } from "react";
+import { EmptyState } from "~/components/empty-state";
+import { InboxItem } from "~/components/inbox/inbox-item";
+import { ErrorState } from "~/components/states";
+import { ApiError } from "~/lib/api";
+import { decideApproval, getInbox } from "~/lib/inbox";
+
+export async function clientLoader() {
+  return { items: await getInbox() };
+}
+
+export default function InboxRoute() {
+  const { items } = useLoaderData<typeof clientLoader>();
+  const revalidator = useRevalidator();
+  const [busyId, setBusyId] = useState<string>();
+  if (items.length === 0) {
+    return (
+      <EmptyState
+        section="inbox"
+        title="Inbox"
+        hint="No Approvals, human tasks, form waits, or access requests need attention."
+      />
+    );
+  }
+  return (
+    <div className="mx-auto flex max-w-4xl flex-col gap-4 px-4 py-6 sm:px-6">
+      <header>
+        <h1 className="text-lg font-semibold">Inbox</h1>
+        <p className="text-xs text-muted-foreground">
+          Exact server-authorized decisions and waiting work.
+        </p>
+      </header>
+      {items.map((item) => (
+        <InboxItem
+          key={item.id}
+          item={item}
+          busy={busyId === item.id}
+          onDecision={async (decision) => {
+            setBusyId(item.id);
+            try {
+              await decideApproval(item, decision);
+              revalidator.revalidate();
+            } finally {
+              setBusyId(undefined);
+            }
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+  return (
+    <ErrorState
+      section="inbox"
+      status={error instanceof ApiError ? error.status : undefined}
+      message={error instanceof Error ? error.message : undefined}
+    />
+  );
+}

--- a/apps/web/app/routes/_app.incidents.tsx
+++ b/apps/web/app/routes/_app.incidents.tsx
@@ -1,0 +1,1 @@
+export { clientLoader, default } from "./_app.operations";

--- a/apps/web/app/routes/_app.operations.tsx
+++ b/apps/web/app/routes/_app.operations.tsx
@@ -1,0 +1,31 @@
+import { useLoaderData, useRevalidator } from "@remix-run/react";
+import { useState } from "react";
+import {
+  type OperationAction,
+  OperationsConsole,
+} from "~/components/operations/operations-console";
+import { commandOperation, getOperations } from "~/lib/operations";
+
+export async function clientLoader() {
+  return { model: await getOperations() };
+}
+
+export default function OperationsRoute() {
+  const { model } = useLoaderData<typeof clientLoader>();
+  const revalidator = useRevalidator();
+  const [busy, setBusy] = useState(false);
+  async function command(action: OperationAction, input: Record<string, unknown>) {
+    setBusy(true);
+    try {
+      await commandOperation(action, input);
+      revalidator.revalidate();
+    } finally {
+      setBusy(false);
+    }
+  }
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-6 sm:px-6">
+      <OperationsConsole model={model} busy={busy} onCommand={command} />
+    </div>
+  );
+}

--- a/apps/web/app/routes/_app.recovery.tsx
+++ b/apps/web/app/routes/_app.recovery.tsx
@@ -1,0 +1,1 @@
+export { clientLoader, default } from "./_app.operations";

--- a/apps/web/app/routes/_app.runs.$id.tsx
+++ b/apps/web/app/routes/_app.runs.$id.tsx
@@ -1,0 +1,78 @@
+import {
+  type ClientLoaderFunctionArgs,
+  useLoaderData,
+  useRevalidator,
+  useRouteError,
+} from "@remix-run/react";
+import { useEffect, useState } from "react";
+import { RunInspector } from "~/components/runs/run-inspector";
+import { ConnectionStatus } from "~/components/shell/states";
+import { ErrorState } from "~/components/states";
+import { API_BASE, ApiError } from "~/lib/api";
+import { commandRun, getOperationalRun, type RunCommandAction } from "~/lib/operations";
+
+export async function clientLoader({ params }: ClientLoaderFunctionArgs) {
+  if (!params.id) throw new ApiError(404, "Run not found");
+  return { run: await getOperationalRun(params.id) };
+}
+
+export default function OperationalRunRoute() {
+  const { run } = useLoaderData<typeof clientLoader>();
+  const revalidator = useRevalidator();
+  const [busy, setBusy] = useState(false);
+  const [connection, setConnection] = useState<"online" | "reconnecting">("online");
+
+  useEffect(() => {
+    if (["succeeded", "failed", "cancelled"].includes(run.status)) return;
+    const key = `run-cursor:${run.id}`;
+    const after = sessionStorage.getItem(key) ?? "0";
+    const source = new EventSource(
+      `${API_BASE}/api/v1/runs/${encodeURIComponent(run.id)}/events?after=${after}`,
+      { withCredentials: true }
+    );
+    const onEvent = (event: MessageEvent) => {
+      if (event.lastEventId) sessionStorage.setItem(key, event.lastEventId);
+      setConnection("online");
+      revalidator.revalidate();
+    };
+    for (const eventType of [
+      "state.completed",
+      "effect.updated",
+      "run.waiting",
+      "run.attention_required",
+      "stream.closed",
+    ]) {
+      source.addEventListener(eventType, onEvent);
+    }
+    source.onerror = () => setConnection("reconnecting");
+    return () => source.close();
+  }, [revalidator, run.id, run.status]);
+
+  async function submit(action: RunCommandAction) {
+    setBusy(true);
+    try {
+      await commandRun(run, action, `Operator requested ${action} from the Run inspector`);
+      revalidator.revalidate();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto flex max-w-6xl flex-col gap-4 px-4 py-6 sm:px-6">
+      {connection === "reconnecting" ? <ConnectionStatus state="reconnecting" /> : null}
+      <RunInspector run={run} busy={busy} onCommand={submit} />
+    </div>
+  );
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+  return (
+    <ErrorState
+      section="runs"
+      status={error instanceof ApiError ? error.status : undefined}
+      message={error instanceof Error ? error.message : undefined}
+    />
+  );
+}

--- a/apps/web/app/routes/_app.tsx
+++ b/apps/web/app/routes/_app.tsx
@@ -1,5 +1,6 @@
 import { Outlet, redirect, useLocation } from "@remix-run/react";
 import { AppSidebar } from "~/components/app-sidebar";
+import { GlobalConnectionStatus } from "~/components/shell/states";
 import { ApiError, getSession } from "~/lib/api";
 import { ApprovalsProvider } from "~/lib/approvals-context";
 import { ConversationsProvider } from "~/lib/conversations-context";
@@ -36,10 +37,21 @@ export default function AppLayout() {
         {/* Desktop shell is capped to the viewport (h-svh + overflow-hidden) so the sidebar nav and
             the main panel each scroll internally instead of growing the whole page. */}
         <div className="md:flex md:h-svh md:overflow-hidden">
+          <a
+            href="#main-content"
+            className="fixed left-2 top-2 z-[100] -translate-y-16 bg-background px-3 py-2 text-sm focus:translate-y-0"
+          >
+            Skip to main content
+          </a>
           <AppSidebar forceCollapsed={collapseRail} />
-          <main className="min-h-[calc(100svh-3rem)] flex-1 overflow-auto md:h-svh md:min-h-0">
+          <main
+            id="main-content"
+            tabIndex={-1}
+            className="min-h-[calc(100svh-3rem)] flex-1 overflow-auto md:h-svh md:min-h-0"
+          >
             <Outlet />
           </main>
+          <GlobalConnectionStatus />
         </div>
       </ConversationsProvider>
     </ApprovalsProvider>


### PR DESCRIPTION
## Summary

- add AW-066 authorized operational read models, idempotent command routes, OpenAPI schemas, and fail-closed runtime adapters
- add AW-067A responsive shell primitives for navigation focus recovery, safe states, reconnect status, destructive previews, and structured API errors
- expose governed Agent metadata and repair exact Markdown-fenced onboarding JSON from providers without structured output support

## Test plan

- [x] API focused tests: 4 files, 21 tests
- [x] Shell focused tests: 2 files, 15 tests
- [x] Root typecheck
- [x] Root lint and build in the Phase 9 combined gate
- [x] Diff conflict/whitespace check