### PR TITLE
feat(ui): add responsive Phase 9 operational surfaces

### DIFF
--- a/apps/web/app/components/admin/role-changeset-form.test.tsx
+++ b/apps/web/app/components/admin/role-changeset-form.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { RoleChangesetForm } from "./role-changeset-form";
+
+describe("RoleChangesetForm", () => {
+  it("proposes a custom Role through the governed changeset boundary", async () => {
+    const user = userEvent.setup();
+    const onPropose = vi.fn().mockResolvedValue(undefined);
+    render(<RoleChangesetForm onPropose={onPropose} />);
+
+    await user.type(screen.getByLabelText("Role ID"), "incident-commander");
+    await user.type(screen.getByLabelText("Role name"), "Incident commander");
+    await user.type(screen.getByLabelText("Principal kinds"), "user, agent");
+    await user.type(screen.getByLabelText("Grants"), "runs:read, runs:reconcile");
+    await user.click(screen.getByRole("button", { name: "Propose Role" }));
+
+    expect(onPropose).toHaveBeenCalledWith({
+      id: "incident-commander",
+      name: "Incident commander",
+      principalKinds: ["user", "agent"],
+      grants: ["runs:read", "runs:reconcile"],
+      conditions: [],
+    });
+    expect(screen.getByText("Role changeset proposed.")).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/components/admin/role-changeset-form.tsx
+++ b/apps/web/app/components/admin/role-changeset-form.tsx
@@ -1,0 +1,98 @@
+import type { FormEvent } from "react";
+import { useState } from "react";
+
+type RoleCandidate = {
+  id: string;
+  name: string;
+  principalKinds: string[];
+  grants: string[];
+  conditions: string[];
+};
+
+type RoleChangesetFormProps = {
+  onPropose: (role: RoleCandidate) => Promise<void>;
+};
+
+function commaSeparated(value: string): string[] {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+export function RoleChangesetForm({ onPropose }: RoleChangesetFormProps) {
+  const [status, setStatus] = useState<"idle" | "submitting" | "proposed" | "failed">("idle");
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const form = event.currentTarget;
+    setStatus("submitting");
+    const data = new FormData(form);
+
+    try {
+      await onPropose({
+        id: String(data.get("id") ?? "").trim(),
+        name: String(data.get("name") ?? "").trim(),
+        principalKinds: commaSeparated(String(data.get("principalKinds") ?? "")),
+        grants: commaSeparated(String(data.get("grants") ?? "")),
+        conditions: [],
+      });
+      setStatus("proposed");
+      form.reset();
+    } catch {
+      setStatus("failed");
+    }
+  }
+
+  return (
+    <form
+      className="grid gap-3 border border-border bg-card p-3 sm:grid-cols-2"
+      onSubmit={handleSubmit}
+    >
+      <h2 className="text-sm font-semibold sm:col-span-2">Propose a custom Role</h2>
+      <label className="grid gap-1 text-xs">
+        Role ID
+        <input className="border border-border bg-background px-2 py-1.5" name="id" required />
+      </label>
+      <label className="grid gap-1 text-xs">
+        Role name
+        <input className="border border-border bg-background px-2 py-1.5" name="name" required />
+      </label>
+      <label className="grid gap-1 text-xs">
+        Principal kinds
+        <input
+          className="border border-border bg-background px-2 py-1.5"
+          name="principalKinds"
+          placeholder="user, agent"
+          required
+        />
+      </label>
+      <label className="grid gap-1 text-xs">
+        Grants
+        <input
+          className="border border-border bg-background px-2 py-1.5"
+          name="grants"
+          placeholder="runs:read, runs:reconcile"
+          required
+        />
+      </label>
+      <div className="flex items-center gap-3 sm:col-span-2">
+        <button
+          className="border border-border px-3 py-1.5 text-xs font-medium"
+          disabled={status === "submitting"}
+          type="submit"
+        >
+          {status === "submitting" ? "Proposing…" : "Propose Role"}
+        </button>
+        {status === "proposed" ? (
+          <p className="text-xs text-muted-foreground">Role changeset proposed.</p>
+        ) : null}
+        {status === "failed" ? (
+          <p className="text-xs text-destructive" role="alert">
+            Role proposal failed.
+          </p>
+        ) : null}
+      </div>
+    </form>
+  );
+}

--- a/apps/web/app/components/agents/governance-card.test.tsx
+++ b/apps/web/app/components/agents/governance-card.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { AgentGovernanceCard } from "./governance-card";
+
+const governance = {
+  version: "3",
+  roles: ["support-reader"],
+  skills: ["triage"],
+  tools: ["github.issue.read"],
+  modelProfile: "balanced",
+  limits: { turns: 20, toolCalls: 8 },
+  evaluation: { status: "passed" as const, suite: "support-v2", passedAt: "2026-07-26" },
+  publication: {
+    candidateVersion: "4",
+    status: "validated" as const,
+    canPublish: true,
+  },
+};
+
+describe("AgentGovernanceCard", () => {
+  it("shows exact candidate and governed publication evidence", async () => {
+    const onPublish = vi.fn();
+    const user = userEvent.setup();
+    render(<AgentGovernanceCard governance={governance} onPublish={onPublish} />);
+
+    expect(screen.getByText("candidate 4")).toBeInTheDocument();
+    expect(screen.getByText(/support-v2/)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Propose version 4" }));
+    expect(onPublish).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks stale or failed candidates as presentation", () => {
+    render(
+      <AgentGovernanceCard
+        governance={{
+          ...governance,
+          evaluation: { ...governance.evaluation, status: "stale" },
+          publication: {
+            candidateVersion: "4",
+            status: "blocked",
+            canPublish: false,
+            reason: "Evaluation is stale",
+          },
+        }}
+        onPublish={vi.fn()}
+      />
+    );
+    expect(screen.getByRole("button", { name: "Propose version 4" })).toBeDisabled();
+    expect(screen.getByText("Evaluation is stale")).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/components/agents/governance-card.tsx
+++ b/apps/web/app/components/agents/governance-card.tsx
@@ -1,0 +1,95 @@
+import type { AgentGovernance } from "~/lib/agents";
+
+function Values({ values }: { values: readonly string[] }) {
+  if (values.length === 0) return <span className="text-muted-foreground">none</span>;
+  return (
+    <span className="flex flex-wrap gap-1">
+      {values.map((value) => (
+        <span key={value} className="rounded-sm border border-border px-1.5 py-0.5">
+          {value}
+        </span>
+      ))}
+    </span>
+  );
+}
+
+export function AgentGovernanceCard({
+  governance,
+  busy = false,
+  result,
+  onPublish,
+}: {
+  governance: AgentGovernance;
+  busy?: boolean;
+  result?: string;
+  onPublish: () => void;
+}) {
+  const candidate = governance.publication.candidateVersion;
+  return (
+    <section className="border border-border bg-card" aria-labelledby="agent-governance-title">
+      <div className="flex flex-wrap items-center gap-2 border-b border-border px-3 py-2">
+        <h2 id="agent-governance-title" className="text-xs font-medium uppercase tracking-[0.2em]">
+          Governance
+        </h2>
+        <span className="text-xs text-muted-foreground">version {governance.version}</span>
+        <span className="ml-auto text-xs text-primary">candidate {candidate}</span>
+      </div>
+      <dl className="grid gap-3 px-3 py-3 text-xs sm:grid-cols-2">
+        <div>
+          <dt className="mb-1 text-muted-foreground">Roles</dt>
+          <dd>
+            <Values values={governance.roles} />
+          </dd>
+        </div>
+        <div>
+          <dt className="mb-1 text-muted-foreground">Skills</dt>
+          <dd>
+            <Values values={governance.skills} />
+          </dd>
+        </div>
+        <div>
+          <dt className="mb-1 text-muted-foreground">Tools</dt>
+          <dd>
+            <Values values={governance.tools} />
+          </dd>
+        </div>
+        <div>
+          <dt className="mb-1 text-muted-foreground">Model profile</dt>
+          <dd>{governance.modelProfile}</dd>
+        </div>
+        <div>
+          <dt className="mb-1 text-muted-foreground">Limits</dt>
+          <dd>
+            {Object.entries(governance.limits)
+              .map(([key, value]) => `${key}: ${value}`)
+              .join(" · ")}
+          </dd>
+        </div>
+        <div>
+          <dt className="mb-1 text-muted-foreground">Evaluation</dt>
+          <dd>
+            {governance.evaluation.status} · {governance.evaluation.suite}
+          </dd>
+        </div>
+      </dl>
+      <div className="flex flex-wrap items-center gap-2 border-t border-border px-3 py-2">
+        <span className="text-xs text-muted-foreground">
+          {governance.publication.reason ?? governance.publication.status}
+        </span>
+        {result ? (
+          <span role="status" className="text-xs text-primary">
+            {result}
+          </span>
+        ) : null}
+        <button
+          type="button"
+          disabled={!governance.publication.canPublish || busy}
+          onClick={onPublish}
+          className="ml-auto rounded-sm bg-primary px-2 py-1 text-xs text-primary-foreground disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {busy ? "Proposing…" : `Propose version ${candidate}`}
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/app/components/app-sidebar.test.tsx
+++ b/apps/web/app/components/app-sidebar.test.tsx
@@ -44,7 +44,7 @@ test("renders the V1 sidebar sections (no standalone Chat item)", () => {
     "Resources",
     "Agents",
     "Routines",
-    "Approvals",
+    "Inbox",
     "Knowledge",
     "Integrations",
     "Settings",
@@ -65,13 +65,13 @@ test("does not render an Apps section (AC-V1-003)", () => {
   expect(screen.queryByText("Apps")).not.toBeInTheDocument();
 });
 
-test("renders no Approvals badge when there are no pending approvals", () => {
+test("renders no Inbox badge when there are no pending approvals", () => {
   render(<Stub initialEntries={["/"]} />);
-  const approvalsLink = screen.getByRole("link", { name: /approvals/i });
+  const approvalsLink = screen.getByRole("link", { name: /inbox/i });
   expect(within(approvalsLink).queryByText(/^\d+$/)).toBeNull();
 });
 
-test("renders the live Approvals badge count from context", () => {
+test("renders the live Inbox badge count from context", () => {
   useApprovals.mockReturnValue({
     approvals: [],
     count: 2,
@@ -80,7 +80,7 @@ test("renders the live Approvals badge count from context", () => {
     refresh: vi.fn(),
   });
   render(<Stub initialEntries={["/"]} />);
-  const approvalsLink = screen.getByRole("link", { name: /approvals/i });
+  const approvalsLink = screen.getByRole("link", { name: /inbox/i });
   expect(within(approvalsLink).getByText("2")).toBeInTheDocument();
 });
 

--- a/apps/web/app/components/chat/chat-panel.tsx
+++ b/apps/web/app/components/chat/chat-panel.tsx
@@ -1,5 +1,6 @@
 import { Link } from "@remix-run/react";
 import { AgentGlyph } from "~/components/agent-glyph";
+import { ConnectionStatus } from "~/components/shell/states";
 import type { Autonomy } from "~/lib/agents";
 import type { ChatMessage, ModelTier } from "~/lib/chat/types";
 import { useChatStream } from "~/lib/chat/use-chat-stream";
@@ -116,6 +117,7 @@ export function ChatPanel({
     regenerate,
     sendFeedback,
     sendA2uiAgent,
+    connectionState,
   } = useChatStream({
     initialConversationId,
     initialMessages,
@@ -207,6 +209,11 @@ export function ChatPanel({
             </>
           ) : null}
         </p>
+      ) : null}
+      {connectionState === "reconnecting" ? (
+        <div className="mx-auto w-full max-w-3xl px-6 pb-2">
+          <ConnectionStatus state="reconnecting" />
+        </div>
       ) : null}
       <Composer
         busy={busy}

--- a/apps/web/app/components/inbox/inbox-item.test.tsx
+++ b/apps/web/app/components/inbox/inbox-item.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { InboxItem } from "./inbox-item";
+
+const item = {
+  id: "approval-1",
+  kind: "approval" as const,
+  title: "Create GitHub issue",
+  status: "pending",
+  risk: "high" as const,
+  intentDigest: "sha256:intent",
+  guardrailRevision: "gr-7",
+  target: "acme/repo",
+  destination: "github.com/acme/repo",
+  fields: ["title", "body"],
+  expiresAt: "2026-07-26T12:00:00Z",
+  decisions: 1,
+  requiredDecisions: 2,
+  canDecide: true,
+};
+
+describe("InboxItem", () => {
+  it("shows exact intent, destination, risk, expiry, fields, and four-eyes state", () => {
+    render(<InboxItem item={item} onDecision={vi.fn()} />);
+    expect(screen.getByText("sha256:intent")).toBeInTheDocument();
+    expect(screen.getByText("github.com/acme/repo")).toBeInTheDocument();
+    expect(screen.getByText("title, body")).toBeInTheDocument();
+    expect(screen.getByText("1 / 2 decisions")).toBeInTheDocument();
+  });
+
+  it("cannot self-approve when the server read model denies it", async () => {
+    const user = userEvent.setup();
+    const onDecision = vi.fn();
+    render(
+      <InboxItem
+        item={{ ...item, canDecide: false, denialReason: "Proposer cannot approve" }}
+        onDecision={onDecision}
+      />
+    );
+    expect(screen.getByRole("button", { name: "Approve" })).toBeDisabled();
+    await user.click(screen.getByRole("button", { name: "Approve" }));
+    expect(onDecision).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/components/inbox/inbox-item.tsx
+++ b/apps/web/app/components/inbox/inbox-item.tsx
@@ -1,0 +1,68 @@
+import type { InboxItemModel } from "~/lib/inbox";
+
+function Row({ label, value }: { label: string; value?: string }) {
+  if (!value) return null;
+  return (
+    <div className="grid grid-cols-[7rem_1fr] gap-2">
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="min-w-0 break-all">{value}</dd>
+    </div>
+  );
+}
+
+export function InboxItem({
+  item,
+  busy = false,
+  onDecision,
+}: {
+  item: InboxItemModel;
+  busy?: boolean;
+  onDecision: (decision: "approved" | "denied") => void;
+}) {
+  const isApproval = item.kind === "approval";
+  return (
+    <article className="border border-border bg-card">
+      <header className="flex flex-wrap items-center gap-2 border-b border-border px-3 py-2">
+        <span className="text-xs uppercase tracking-[0.2em] text-muted-foreground">
+          {item.kind.replace("_", " ")}
+        </span>
+        <h2 className="text-sm font-medium">{item.title}</h2>
+        <span className="ml-auto text-xs">
+          {item.risk} risk · {item.status}
+        </span>
+      </header>
+      <dl className="flex flex-col gap-2 px-3 py-3 text-xs">
+        <Row label="Intent" value={item.intentDigest} />
+        <Row label="Guardrail" value={item.guardrailRevision} />
+        <Row label="Target" value={item.target} />
+        <Row label="Destination" value={item.destination} />
+        <Row label="Fields" value={item.fields?.join(", ")} />
+        <Row label="Expires" value={item.expiresAt} />
+        <Row label="Four-eyes" value={`${item.decisions} / ${item.requiredDecisions} decisions`} />
+      </dl>
+      {isApproval ? (
+        <footer className="flex items-center gap-2 border-t border-border px-3 py-2">
+          {item.denialReason ? (
+            <span className="text-xs text-muted-foreground">{item.denialReason}</span>
+          ) : null}
+          <button
+            type="button"
+            disabled={!item.canDecide || busy}
+            onClick={() => onDecision("denied")}
+            className="ml-auto rounded-sm border border-destructive px-2 py-1 text-xs text-destructive disabled:opacity-50"
+          >
+            Deny
+          </button>
+          <button
+            type="button"
+            disabled={!item.canDecide || busy}
+            onClick={() => onDecision("approved")}
+            className="rounded-sm bg-primary px-2 py-1 text-xs text-primary-foreground disabled:opacity-50"
+          >
+            Approve
+          </button>
+        </footer>
+      ) : null}
+    </article>
+  );
+}

--- a/apps/web/app/components/operations/operations-console.test.tsx
+++ b/apps/web/app/components/operations/operations-console.test.tsx
@@ -1,0 +1,111 @@
+import { createRemixStub } from "@remix-run/testing";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { OperationsModel } from "~/lib/operations";
+import { OperationsConsole } from "./operations-console";
+
+const model = {
+  health: [{ component: "worker", status: "degraded" }],
+  incidents: [
+    {
+      id: "incident-1",
+      severity: "high",
+      title: "Queue stalled",
+      createdAt: "2026-07-26T00:00:00Z",
+    },
+  ],
+  quarantine: [{ id: "quarantine-1", reason: "ambiguous effect" }],
+  killSwitches: [{ id: "all-mutations", enabled: false }],
+  audit: [
+    {
+      id: "audit-1",
+      action: "run.cancel",
+      actorType: "user",
+      targetType: "run",
+      targetId: "0f5a23e8-42d7-7556-88d4-b544f361718b",
+      summary: "Cancelled a stalled Run",
+      status: "ok",
+      createdAt: "2026-07-26T00:00:00Z",
+      secret: "must-not-render",
+    },
+  ],
+  recovery: { supportBundleAvailable: true, lastBackupAt: "2026-07-26T00:00:00Z" },
+};
+
+function renderConsole(consoleModel: OperationsModel, onCommand = vi.fn()) {
+  const Stub = createRemixStub([
+    {
+      path: "/",
+      Component: () => <OperationsConsole model={consoleModel} onCommand={onCommand} />,
+    },
+    { path: "/settings/activities", Component: () => null },
+  ]);
+  return render(<Stub initialEntries={["/"]} />);
+}
+
+describe("OperationsConsole", () => {
+  it("renders structured operational summaries without raw JSON or protected fields", () => {
+    renderConsole(model);
+    expect(screen.getByRole("heading", { name: "Queue stalled" })).toBeInTheDocument();
+    expect(screen.getByText("worker")).toBeInTheDocument();
+    expect(screen.getByText("Degraded")).toBeInTheDocument();
+    expect(screen.getByText("High")).toBeInTheDocument();
+    expect(screen.getByRole("table", { name: "Audit and lineage events" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Event" })).toBeInTheDocument();
+    expect(screen.getByText("Cancelled a stalled Run")).toBeInTheDocument();
+    expect(screen.getByTitle("0f5a23e8-42d7-7556-88d4-b544f361718b")).toHaveTextContent("0f5a23e8");
+    expect(screen.queryByText(/"component":/)).not.toBeInTheDocument();
+    expect(screen.queryByText("must-not-render")).not.toBeInTheDocument();
+  });
+
+  it("uses compact, descriptive empty states", () => {
+    renderConsole({
+      health: [],
+      incidents: [],
+      quarantine: [],
+      killSwitches: [],
+      audit: [],
+      recovery: { supportBundleAvailable: false, lastBackupAt: null },
+    });
+    expect(screen.getByText("No active incidents")).toBeInTheDocument();
+    expect(screen.getByText("No quarantined items")).toBeInTheDocument();
+    expect(screen.getByText("No kill switches enabled")).toBeInTheDocument();
+    expect(screen.getByText("No audit events recorded")).toBeInTheDocument();
+    expect(screen.getByText("No backup reported")).toBeInTheDocument();
+  });
+
+  it("filters audit events using the rendered summary fields", async () => {
+    const user = userEvent.setup();
+    renderConsole({
+      ...model,
+      audit: [
+        ...model.audit,
+        {
+          id: "audit-2",
+          action: "job.run",
+          actorType: "system",
+          targetType: "job",
+          targetId: "connector-sync",
+          summary: "Connector sync ran",
+          status: "ok",
+          createdAt: "2026-07-26T01:00:00Z",
+        },
+      ],
+    });
+
+    await user.type(screen.getByRole("searchbox", { name: "Filter audit events" }), "connector");
+    expect(screen.getByText("Connector sync ran")).toBeInTheDocument();
+    expect(screen.queryByText("Cancelled a stalled Run")).not.toBeInTheDocument();
+    expect(screen.getByText("Showing 1 of 2 events")).toBeInTheDocument();
+  });
+
+  it("previews support bundle creation before invoking server recovery authority", async () => {
+    const user = userEvent.setup();
+    const onCommand = vi.fn();
+    renderConsole(model, onCommand);
+    await user.click(screen.getByRole("button", { name: "Create support bundle" }));
+    await user.click(screen.getByRole("button", { name: "Confirm Create Support Bundle" }));
+    expect(onCommand).toHaveBeenCalledWith("support-bundle.create", {});
+  });
+});

--- a/apps/web/app/components/operations/operations-console.tsx
+++ b/apps/web/app/components/operations/operations-console.tsx
@@ -1,0 +1,503 @@
+import { Link } from "@remix-run/react";
+import {
+  Activity,
+  AlertTriangle,
+  Ban,
+  CheckCircle2,
+  DatabaseBackup,
+  Search,
+  ShieldAlert,
+} from "lucide-react";
+import { type ReactNode, useState } from "react";
+import { DestructivePreview } from "~/components/shell/states";
+import type { OperationsModel } from "~/lib/operations";
+import { formatIso } from "~/lib/schema";
+import { cn } from "~/lib/utils";
+
+export type OperationAction =
+  | "support-bundle.create"
+  | "kill-switch.set"
+  | "quarantine.resolve"
+  | "recovery.start";
+
+type OperationalItem = Record<string, unknown>;
+
+function text(item: OperationalItem, ...keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = item[key];
+    if (typeof value === "string" && value.trim().length > 0) return value;
+  }
+  return undefined;
+}
+
+function humanize(value: string): string {
+  const words = value.replaceAll(/[._-]+/g, " ");
+  return `${words.charAt(0).toUpperCase()}${words.slice(1)}`;
+}
+
+function itemKey(item: OperationalItem, index: number): string {
+  return text(item, "id", "component", "name") ?? `item-${index}`;
+}
+
+function statusValue(item: OperationalItem, fallback: string): string {
+  const status = text(item, "status", "severity");
+  if (status) return status;
+  if (typeof item.enabled === "boolean") return item.enabled ? "enabled" : "disabled";
+  return fallback;
+}
+
+function statusTone(status: string): "positive" | "warning" | "danger" | "neutral" {
+  const normalized = status.toLowerCase();
+  if (/critical|error|failed|high|blocked|enabled/.test(normalized)) return "danger";
+  if (/degraded|warning|medium|pending|quarantined/.test(normalized)) return "warning";
+  if (/ok|healthy|resolved|disabled|success|low/.test(normalized)) return "positive";
+  return "neutral";
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const tone = statusTone(status);
+  return (
+    <span
+      className={cn(
+        "inline-flex shrink-0 items-center rounded-sm border px-1.5 py-0.5 text-[0.625rem] font-medium uppercase tracking-wide",
+        tone === "positive" && "border-emerald-500/30 bg-emerald-500/10 text-emerald-500",
+        tone === "warning" && "border-amber-500/30 bg-amber-500/10 text-amber-500",
+        tone === "danger" && "border-destructive/40 bg-destructive/10 text-destructive",
+        tone === "neutral" && "border-border bg-muted text-muted-foreground"
+      )}
+    >
+      {humanize(status)}
+    </span>
+  );
+}
+
+function Section({
+  title,
+  icon,
+  count,
+  children,
+}: {
+  title: string;
+  icon: ReactNode;
+  count?: number;
+  children: ReactNode;
+}) {
+  return (
+    <section className="min-w-0 border border-border bg-card">
+      <header className="flex items-center gap-2 border-b border-border px-3 py-2.5">
+        <span className="text-muted-foreground">{icon}</span>
+        <h2 className="text-xs font-medium uppercase tracking-[0.18em]">{title}</h2>
+        {count === undefined ? null : (
+          <span className="ml-auto text-[0.625rem] tabular-nums text-muted-foreground">
+            {count}
+          </span>
+        )}
+      </header>
+      {children}
+    </section>
+  );
+}
+
+function EmptyPanel({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex min-h-16 items-center gap-2 px-3 py-3 text-xs text-muted-foreground">
+      <CheckCircle2 aria-hidden="true" className="size-3.5 text-emerald-500" />
+      <span>{children}</span>
+    </div>
+  );
+}
+
+function HealthPanel({ items }: { items: readonly OperationalItem[] }) {
+  return (
+    <Section
+      title="Health"
+      count={items.length}
+      icon={<Activity aria-hidden="true" className="size-3.5" />}
+    >
+      {items.length === 0 ? (
+        <EmptyPanel>No health checks reported</EmptyPanel>
+      ) : (
+        <ul className="divide-y divide-border">
+          {items.map((item, index) => {
+            const component = text(item, "component", "name", "id") ?? "Unknown component";
+            const status = statusValue(item, "unknown");
+            return (
+              <li
+                key={itemKey(item, index)}
+                className="flex min-h-12 items-center gap-3 px-3 py-2 text-xs"
+              >
+                <span className="min-w-0 flex-1 truncate font-medium" title={component}>
+                  {component}
+                </span>
+                <StatusBadge status={status} />
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </Section>
+  );
+}
+
+function IncidentsPanel({ items }: { items: readonly OperationalItem[] }) {
+  return (
+    <Section
+      title="Incidents"
+      count={items.length}
+      icon={<AlertTriangle aria-hidden="true" className="size-3.5" />}
+    >
+      {items.length === 0 ? (
+        <EmptyPanel>No active incidents</EmptyPanel>
+      ) : (
+        <ul className="divide-y divide-border">
+          {items.map((item, index) => {
+            const title = text(item, "title", "summary", "action", "id") ?? `Incident ${index + 1}`;
+            const detail = text(item, "summary", "reason");
+            const severity = statusValue(item, "open");
+            const createdAt = text(item, "createdAt");
+            return (
+              <li key={itemKey(item, index)} className="px-3 py-2.5">
+                <div className="flex min-w-0 items-start gap-2">
+                  <div className="min-w-0 flex-1">
+                    <h3 className="truncate text-xs font-medium" title={title}>
+                      {title}
+                    </h3>
+                    {detail && detail !== title ? (
+                      <p className="mt-1 line-clamp-2 text-[0.6875rem] text-muted-foreground">
+                        {detail}
+                      </p>
+                    ) : null}
+                    {createdAt ? (
+                      <time
+                        dateTime={createdAt}
+                        className="mt-1 block text-[0.625rem] text-muted-foreground"
+                      >
+                        {formatIso(createdAt)}
+                      </time>
+                    ) : null}
+                  </div>
+                  <StatusBadge status={severity} />
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </Section>
+  );
+}
+
+function QuarantinePanel({ items }: { items: readonly OperationalItem[] }) {
+  return (
+    <Section
+      title="Quarantine"
+      count={items.length}
+      icon={<ShieldAlert aria-hidden="true" className="size-3.5" />}
+    >
+      {items.length === 0 ? (
+        <EmptyPanel>No quarantined items</EmptyPanel>
+      ) : (
+        <ul className="divide-y divide-border">
+          {items.map((item, index) => {
+            const id = text(item, "title", "name", "id") ?? `Item ${index + 1}`;
+            const reason = text(item, "reason", "summary") ?? "Reason not provided";
+            return (
+              <li key={itemKey(item, index)} className="flex items-start gap-3 px-3 py-2.5">
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-xs font-medium" title={id}>
+                    {id}
+                  </p>
+                  <p className="mt-1 line-clamp-2 text-[0.6875rem] text-muted-foreground">
+                    {reason}
+                  </p>
+                </div>
+                <StatusBadge status={statusValue(item, "quarantined")} />
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </Section>
+  );
+}
+
+function KillSwitchesPanel({ items }: { items: readonly OperationalItem[] }) {
+  return (
+    <Section
+      title="Kill switches"
+      count={items.length}
+      icon={<Ban aria-hidden="true" className="size-3.5" />}
+    >
+      {items.length === 0 ? (
+        <EmptyPanel>No kill switches enabled</EmptyPanel>
+      ) : (
+        <ul className="divide-y divide-border">
+          {items.map((item, index) => {
+            const id = text(item, "name", "id") ?? `Switch ${index + 1}`;
+            const scope = text(item, "scope", "summary");
+            return (
+              <li key={itemKey(item, index)} className="flex min-h-12 items-center gap-3 px-3 py-2">
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-xs font-medium" title={id}>
+                    {humanize(id)}
+                  </p>
+                  {scope ? (
+                    <p className="mt-0.5 truncate text-[0.625rem] text-muted-foreground">{scope}</p>
+                  ) : null}
+                </div>
+                <StatusBadge status={statusValue(item, "unknown")} />
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </Section>
+  );
+}
+
+function compactIdentifier(value: string): string {
+  if (value.length <= 18) return value;
+  return `${value.slice(0, 8)}…${value.slice(-4)}`;
+}
+
+const AUDIT_PREVIEW_LIMIT = 8;
+const AUDIT_SEARCH_KEYS = [
+  "action",
+  "event",
+  "summary",
+  "title",
+  "actorName",
+  "actorType",
+  "targetType",
+  "targetId",
+  "target",
+  "status",
+] as const;
+
+function matchesAuditQuery(item: OperationalItem, query: string): boolean {
+  if (!query) return true;
+  return AUDIT_SEARCH_KEYS.some((key) => text(item, key)?.toLowerCase().includes(query));
+}
+
+function AuditTable({ items }: { items: readonly OperationalItem[] }) {
+  const [query, setQuery] = useState("");
+  const normalizedQuery = query.trim().toLowerCase();
+  const matchingItems = items.filter((item) => matchesAuditQuery(item, normalizedQuery));
+  const visibleItems = matchingItems.slice(0, AUDIT_PREVIEW_LIMIT);
+
+  return (
+    <Section
+      title="Recent operational activity"
+      count={items.length}
+      icon={<ShieldAlert aria-hidden="true" className="size-3.5" />}
+    >
+      {items.length === 0 ? (
+        <EmptyPanel>No audit events recorded</EmptyPanel>
+      ) : (
+        <>
+          <div className="flex flex-wrap items-center gap-2 border-b border-border px-3 py-2">
+            <label className="relative min-w-48 flex-1 sm:max-w-xs">
+              <span className="sr-only">Filter audit events</span>
+              <Search
+                aria-hidden="true"
+                className="pointer-events-none absolute left-2 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground"
+              />
+              <input
+                type="search"
+                value={query}
+                onChange={(event) => setQuery(event.currentTarget.value)}
+                placeholder="Filter recent activity"
+                className="h-8 w-full rounded-sm border border-border bg-background pl-7 pr-2 text-xs outline-none placeholder:text-muted-foreground focus:border-ring"
+              />
+            </label>
+            <span className="text-[0.625rem] text-muted-foreground">
+              Showing {visibleItems.length} of {items.length} events
+            </span>
+            <Link
+              to="/settings/activities"
+              className="ml-auto text-xs text-primary underline-offset-2 hover:underline"
+            >
+              View all activities
+            </Link>
+          </div>
+          {visibleItems.length === 0 ? (
+            <div className="px-3 py-4 text-xs text-muted-foreground">
+              No matching operational activity
+            </div>
+          ) : (
+            <div className="max-w-full overflow-x-auto">
+              <table
+                aria-label="Audit and lineage events"
+                className="w-full min-w-[46rem] text-left"
+              >
+                <thead>
+                  <tr className="border-b border-border text-[0.625rem] uppercase tracking-wider text-muted-foreground">
+                    <th className="w-[42%] px-3 py-2 font-medium">Event</th>
+                    <th className="px-3 py-2 font-medium">Actor</th>
+                    <th className="px-3 py-2 font-medium">Target</th>
+                    <th className="px-3 py-2 font-medium">Status</th>
+                    <th className="px-3 py-2 text-right font-medium">Time</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border">
+                  {visibleItems.map((item, index) => {
+                    const action = text(item, "action", "event") ?? "Activity";
+                    const summary = text(item, "summary", "title") ?? humanize(action);
+                    const actor = text(item, "actorName", "actorType", "actorId") ?? "system";
+                    const targetType = text(item, "targetType");
+                    const targetId = text(item, "targetId", "target");
+                    const status = statusValue(item, "recorded");
+                    const createdAt = text(item, "createdAt");
+                    return (
+                      <tr key={itemKey(item, index)} className="align-top">
+                        <td className="px-3 py-2.5">
+                          <p className="max-w-xl text-xs font-medium">{summary}</p>
+                          <p className="mt-0.5 text-[0.625rem] text-muted-foreground">
+                            {humanize(action)}
+                          </p>
+                        </td>
+                        <td className="px-3 py-2.5 text-xs">{humanize(actor)}</td>
+                        <td className="px-3 py-2.5 text-xs">
+                          {targetType ? (
+                            <span className="block text-[0.625rem] text-muted-foreground">
+                              {humanize(targetType)}
+                            </span>
+                          ) : null}
+                          {targetId ? (
+                            <code
+                              title={targetId}
+                              className="block max-w-36 truncate text-[0.6875rem] text-foreground"
+                            >
+                              {compactIdentifier(targetId)}
+                            </code>
+                          ) : (
+                            <span className="text-muted-foreground">—</span>
+                          )}
+                        </td>
+                        <td className="px-3 py-2.5">
+                          <StatusBadge status={status} />
+                        </td>
+                        <td className="whitespace-nowrap px-3 py-2.5 text-right text-[0.6875rem] text-muted-foreground">
+                          {createdAt ? (
+                            <time dateTime={createdAt}>{formatIso(createdAt)}</time>
+                          ) : (
+                            "—"
+                          )}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </>
+      )}
+    </Section>
+  );
+}
+
+function attentionItems(model: OperationsModel): number {
+  const unhealthy = model.health.filter(
+    (item) => statusTone(statusValue(item, "unknown")) !== "positive"
+  ).length;
+  const activeKillSwitches = model.killSwitches.filter(
+    (item) => statusTone(statusValue(item, "unknown")) !== "positive"
+  ).length;
+  return unhealthy + model.incidents.length + model.quarantine.length + activeKillSwitches;
+}
+
+export function OperationsConsole({
+  model,
+  busy = false,
+  onCommand,
+}: {
+  model: OperationsModel;
+  busy?: boolean;
+  onCommand: (action: OperationAction, input: Record<string, unknown>) => void;
+}) {
+  const [previewSupport, setPreviewSupport] = useState(false);
+  const attentionCount = attentionItems(model);
+
+  return (
+    <div className="flex min-w-0 flex-col gap-4">
+      <header className="flex flex-wrap items-start gap-3">
+        <div className="min-w-0">
+          <h1 className="text-lg font-semibold">Operations</h1>
+          <p className="mt-0.5 max-w-2xl text-xs text-muted-foreground">
+            Authorized operational summaries. Protected payloads remain redacted.
+          </p>
+          <p
+            role="status"
+            className={cn(
+              "mt-2 inline-flex items-center gap-1.5 text-xs",
+              attentionCount > 0 ? "text-amber-500" : "text-emerald-500"
+            )}
+          >
+            {attentionCount > 0 ? (
+              <AlertTriangle aria-hidden="true" className="size-3.5" />
+            ) : (
+              <CheckCircle2 aria-hidden="true" className="size-3.5" />
+            )}
+            {attentionCount > 0
+              ? `${attentionCount} item${attentionCount === 1 ? "" : "s"} need attention`
+              : "All reported systems operational"}
+          </p>
+        </div>
+        {model.recovery.supportBundleAvailable ? (
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => setPreviewSupport(true)}
+            className="ml-auto rounded-sm border border-border px-2.5 py-1.5 text-xs hover:bg-muted disabled:opacity-60"
+          >
+            Create support bundle
+          </button>
+        ) : null}
+      </header>
+
+      {previewSupport ? (
+        <DestructivePreview
+          action="Create Support Bundle"
+          target="redacted operational diagnostics"
+          destination="authorized support bundle Artifact"
+          reversibility="Bundle creation is audited; the immutable Artifact can expire by retention"
+          busy={busy}
+          onCancel={() => setPreviewSupport(false)}
+          onConfirm={() => {
+            setPreviewSupport(false);
+            onCommand("support-bundle.create", {});
+          }}
+        />
+      ) : null}
+
+      <div className="grid min-w-0 gap-4 sm:grid-cols-2">
+        <HealthPanel items={model.health} />
+        <IncidentsPanel items={model.incidents} />
+        <QuarantinePanel items={model.quarantine} />
+        <KillSwitchesPanel items={model.killSwitches} />
+      </div>
+
+      <AuditTable items={model.audit} />
+
+      <Section title="Recovery" icon={<DatabaseBackup aria-hidden="true" className="size-3.5" />}>
+        <div className="flex flex-wrap items-center gap-x-6 gap-y-2 px-3 py-3 text-xs">
+          <div>
+            <span className="text-muted-foreground">Last backup</span>
+            <p className="mt-0.5 font-medium">
+              {model.recovery.lastBackupAt
+                ? formatIso(model.recovery.lastBackupAt)
+                : "No backup reported"}
+            </p>
+          </div>
+          <div>
+            <span className="text-muted-foreground">Support bundle</span>
+            <p className="mt-0.5 font-medium">
+              {model.recovery.supportBundleAvailable ? "Available" : "Unavailable"}
+            </p>
+          </div>
+        </div>
+      </Section>
+    </div>
+  );
+}

--- a/apps/web/app/components/runs/run-inspector.test.tsx
+++ b/apps/web/app/components/runs/run-inspector.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { RunInspector } from "./run-inspector";
+
+const run = {
+  id: "run-1",
+  routineId: "triage",
+  routineVersion: "3",
+  status: "attention_required",
+  version: 7,
+  createdAt: "2026-07-26T00:00:00Z",
+  startedAt: "2026-07-26T00:00:01Z",
+  finishedAt: null,
+  states: [{ key: "classify", status: "succeeded", attempts: 1, output: { label: "bug" } }],
+  effects: [{ id: "effect-1", status: "ambiguous", target: "github.repository/acme/repo" }],
+  waits: [{ kind: "approval", status: "open" }],
+  guardrailDecisions: [{ decision: "allow", revision: "gr-7" }],
+  lineage: [{ relation: "replay", sourceRunId: "run-0" }],
+  costs: { amountUsd: 0.12, modelTokens: 900 },
+};
+
+describe("RunInspector", () => {
+  it("renders the authorized Run evidence model", () => {
+    render(<RunInspector run={run} onCommand={vi.fn()} />);
+    expect(screen.getByText("classify")).toBeInTheDocument();
+    expect(screen.getByText(/effect-1/)).toBeInTheDocument();
+    expect(screen.getByText(/approval/)).toBeInTheDocument();
+    expect(screen.getByText(/gr-7/)).toBeInTheDocument();
+    expect(screen.getByText(/\$0\.1200/)).toBeInTheDocument();
+  });
+
+  it("previews destructive commands before delegating them", async () => {
+    const user = userEvent.setup();
+    const onCommand = vi.fn();
+    render(<RunInspector run={run} onCommand={onCommand} />);
+    await user.click(screen.getByRole("button", { name: "Cancel Run" }));
+    expect(screen.getAllByText("run-1")).toHaveLength(2);
+    await user.click(screen.getByRole("button", { name: "Confirm Cancel Run" }));
+    expect(onCommand).toHaveBeenCalledWith("cancel");
+  });
+});

--- a/apps/web/app/components/runs/run-inspector.tsx
+++ b/apps/web/app/components/runs/run-inspector.tsx
@@ -1,0 +1,115 @@
+import { useState } from "react";
+import { DestructivePreview } from "~/components/shell/states";
+import type { OperationalRun, RunCommandAction } from "~/lib/operations";
+
+function EvidenceList({
+  title,
+  items,
+}: {
+  title: string;
+  items: readonly Record<string, unknown>[];
+}) {
+  return (
+    <section className="border border-border bg-card">
+      <h2 className="border-b border-border px-3 py-2 text-xs font-medium uppercase tracking-[0.2em]">
+        {title}
+      </h2>
+      {items.length === 0 ? (
+        <p className="px-3 py-3 text-xs text-muted-foreground">none</p>
+      ) : (
+        <ul className="divide-y divide-border">
+          {items.map((item, index) => (
+            <li key={`${title}-${index}`} className="overflow-x-auto px-3 py-2">
+              <code className="text-xs">{JSON.stringify(item)}</code>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+export function RunInspector({
+  run,
+  busy = false,
+  onCommand,
+}: {
+  run: OperationalRun;
+  busy?: boolean;
+  onCommand: (action: RunCommandAction) => void;
+}) {
+  const [preview, setPreview] = useState<RunCommandAction>();
+  return (
+    <div className="flex flex-col gap-4">
+      <header className="flex flex-wrap items-center gap-2 border-b border-border pb-3">
+        <span className="rounded-sm border border-border px-2 py-1 text-xs">{run.status}</span>
+        <code className="text-xs text-muted-foreground">{run.id}</code>
+        <span className="text-xs text-muted-foreground">
+          {run.routineId}@{run.routineVersion}
+        </span>
+        <span className="ml-auto text-xs tabular-nums">
+          ${run.costs.amountUsd.toFixed(4)} · {run.costs.modelTokens} tokens
+        </span>
+      </header>
+
+      <div className="flex flex-wrap gap-2">
+        {(["pause", "resume", "retry", "reconcile"] as const).map((action) => (
+          <button
+            key={action}
+            type="button"
+            disabled={busy}
+            onClick={() => onCommand(action)}
+            className="rounded-sm border border-border px-2 py-1 text-xs capitalize"
+          >
+            {action}
+          </button>
+        ))}
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() => setPreview("cancel")}
+          className="rounded-sm border border-destructive px-2 py-1 text-xs text-destructive"
+        >
+          Cancel Run
+        </button>
+      </div>
+
+      {preview === "cancel" ? (
+        <DestructivePreview
+          action="Cancel Run"
+          target={run.id}
+          destination="TulipFarm Run authority"
+          reversibility="New work stops; ambiguous effects still require reconciliation"
+          busy={busy}
+          onCancel={() => setPreview(undefined)}
+          onConfirm={() => {
+            setPreview(undefined);
+            onCommand("cancel");
+          }}
+        />
+      ) : null}
+
+      <section className="border border-border bg-card">
+        <h2 className="border-b border-border px-3 py-2 text-xs font-medium uppercase tracking-[0.2em]">
+          States
+        </h2>
+        <ol className="divide-y divide-border">
+          {run.states.map((state) => (
+            <li key={state.key} className="grid gap-2 px-3 py-2 text-xs sm:grid-cols-4">
+              <strong>{state.key}</strong>
+              <span>{state.status}</span>
+              <span>{state.attempts} attempts</span>
+              <code className="overflow-x-auto">{JSON.stringify(state.output ?? null)}</code>
+            </li>
+          ))}
+        </ol>
+      </section>
+      <div className="grid gap-4 lg:grid-cols-2">
+        <EvidenceList title="Effects" items={run.effects} />
+        <EvidenceList title="Waits" items={run.waits} />
+        <EvidenceList title="Guardrail decisions" items={run.guardrailDecisions} />
+        <EvidenceList title="Lineage" items={run.lineage} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/lib/admin.ts
+++ b/apps/web/app/lib/admin.ts
@@ -1,0 +1,61 @@
+import { apiCommand, apiGet } from "./api";
+
+export type GuardrailItem = {
+  id: string;
+  name?: string;
+  enabled?: boolean;
+  effect?: string;
+  scope?: string;
+};
+
+export type GuardrailsModel = {
+  revision: string;
+  items: GuardrailItem[];
+};
+
+export function getGuardrails(): Promise<GuardrailsModel> {
+  return apiGet<GuardrailsModel>("/api/v1/guardrails");
+}
+
+export function proposeGuardrailToggle(
+  model: GuardrailsModel,
+  item: GuardrailItem,
+  enabled: boolean
+): Promise<{ changesetId: string; status: string }> {
+  const index = model.items.findIndex((candidate) => candidate.id === item.id);
+  return apiCommand(
+    "/api/v1/guardrails/changesets",
+    {
+      baseRevision: model.revision,
+      changes: [{ op: "replace", path: `/items/${index}/enabled`, value: enabled }],
+    },
+    `guardrail-${model.revision}-${item.id}-${enabled}`
+  );
+}
+
+export type RolesModel = {
+  revision: string;
+  items: Array<{
+    id: string;
+    name: string;
+    principalKinds: string[];
+    grants: string[];
+    conditions: string[];
+  }>;
+};
+
+export function getRoles(): Promise<RolesModel> {
+  return apiGet<RolesModel>("/api/v1/roles");
+}
+
+export function proposeRole(
+  model: RolesModel,
+  role: Record<string, unknown>
+): Promise<{ changesetId: string; status: string }> {
+  const id = typeof role.id === "string" ? role.id : "new";
+  return apiCommand(
+    "/api/v1/roles/changesets",
+    { baseRevision: model.revision, role },
+    `role-${model.revision}-${id}`
+  );
+}

--- a/apps/web/app/lib/agents.ts
+++ b/apps/web/app/lib/agents.ts
@@ -1,4 +1,4 @@
-import { apiGet } from "./api";
+import { apiCommand, apiGet } from "./api";
 
 /*
  * Read-only client for the agents API (AGENTS / UI-V1-003). Agents are AGENT.md files in the soul
@@ -21,6 +21,27 @@ export type AgentDetail = AgentSummary & {
   placeholder?: string[];
   suggestions?: string[];
   body: string;
+  governance?: AgentGovernance;
+};
+
+export type AgentGovernance = {
+  version: string;
+  roles: string[];
+  skills: string[];
+  tools: string[];
+  modelProfile: string;
+  limits: Record<string, number>;
+  evaluation: {
+    status: "pending" | "passed" | "failed" | "stale";
+    suite: string;
+    passedAt?: string;
+  };
+  publication: {
+    candidateVersion: string;
+    status: "draft" | "validated" | "awaiting_approval" | "published" | "blocked";
+    canPublish: boolean;
+    reason?: string;
+  };
 };
 
 export async function listAgents(): Promise<AgentSummary[]> {
@@ -30,4 +51,20 @@ export async function listAgents(): Promise<AgentSummary[]> {
 
 export async function getAgent(name: string): Promise<AgentDetail> {
   return apiGet<AgentDetail>(`/api/v1/agents/${encodeURIComponent(name)}`);
+}
+
+export async function proposeAgentCandidate(
+  name: string,
+  governance: AgentGovernance
+): Promise<{ changesetId: string; candidateVersion: string; status: string }> {
+  const candidate = governance.publication.candidateVersion;
+  return apiCommand(
+    `/api/v1/agents/${encodeURIComponent(name)}/changesets`,
+    {
+      baseVersion: governance.version,
+      candidateVersion: candidate,
+      patch: {},
+    },
+    `agent-${name}-${candidate}`
+  );
 }

--- a/apps/web/app/lib/chat/sse-client.test.ts
+++ b/apps/web/app/lib/chat/sse-client.test.ts
@@ -1,5 +1,19 @@
-import { expect, test } from "vitest";
-import { parseSseFrames } from "~/lib/chat/sse-client";
+import { afterEach, expect, test, vi } from "vitest";
+import { parseSseFrames, postChat } from "~/lib/chat/sse-client";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function streamResponse(frames: string, headers: Record<string, string> = {}) {
+  const body = new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(frames));
+      controller.close();
+    },
+  });
+  return new Response(body, { status: 200, headers });
+}
 
 test("parses a single frame with the spec spacing (space after the colon)", () => {
   const { frames, rest } = parseSseFrames('id: 1\nevent: text\ndata: {"delta":"hi"}\n\n');
@@ -69,4 +83,38 @@ test("ignores empty/whitespace-only frames and a frame whose data is invalid JSO
 test("defaults seq to 0 when no id line is present but event+data are", () => {
   const { frames } = parseSseFrames('event: text\ndata: {"delta":"x"}\n\n');
   expect(frames).toEqual([{ seq: 0, type: "text", data: { delta: "x" } }]);
+});
+
+test("recovers a dropped stream from the persisted cursor without duplicating events", async () => {
+  const fetchMock = vi
+    .fn()
+    .mockResolvedValueOnce(
+      streamResponse('id: 1\nevent: text\ndata: {"delta":"hello"}\n\n', {
+        "X-Stream-Id": "stream-1",
+      })
+    )
+    .mockResolvedValueOnce(
+      streamResponse(
+        'id: 1\nevent: text\ndata: {"delta":"hello"}\n\n' +
+          'id: 2\nevent: finish\ndata: {"reason":"stop"}\n\n'
+      )
+    );
+  vi.stubGlobal("fetch", fetchMock);
+  const events: string[] = [];
+  const states: string[] = [];
+
+  await postChat(
+    { message: { role: "user", content: "hello" } },
+    {
+      onEvent: (event) => events.push(event.type),
+      onConnectionState: (state) => states.push(state),
+    }
+  );
+
+  expect(events).toEqual(["text", "finish"]);
+  expect(states).toEqual(["reconnecting", "online"]);
+  expect(fetchMock.mock.calls[1]?.[0]).toContain("/api/v1/chat/streams/stream-1");
+  expect(fetchMock.mock.calls[1]?.[1]).toMatchObject({
+    headers: expect.objectContaining({ "Last-Event-ID": "1" }),
+  });
 });

--- a/apps/web/app/lib/chat/sse-client.ts
+++ b/apps/web/app/lib/chat/sse-client.ts
@@ -115,6 +115,7 @@ export type PostChatHandlers = {
   signal?: AbortSignal;
   onEvent: (event: ChatEvent) => void;
   onMeta?: (meta: ChatStreamMeta) => void;
+  onConnectionState?: (state: "online" | "reconnecting") => void;
 };
 
 // Best-effort `{ error }` extraction so a failed POST throws the same ApiError shape as the rest of
@@ -134,7 +135,7 @@ async function readChatError(res: Response): Promise<ApiError> {
 // `X-Conversation-Id`/`X-Stream-Id` headers via `onMeta`, then streams typed events to `onEvent`,
 // stopping at the first terminal event (finish/error) or when the reader is exhausted.
 export async function postChat(body: ChatRequestBody, handlers: PostChatHandlers): Promise<void> {
-  const { signal, onEvent, onMeta } = handlers;
+  const { signal, onMeta } = handlers;
   const res = await fetch(`${API_BASE}/api/v1/chat`, {
     method: "POST",
     credentials: "include",
@@ -145,17 +146,52 @@ export async function postChat(body: ChatRequestBody, handlers: PostChatHandlers
 
   if (!res.ok) throw await readChatError(res);
 
+  const streamId = res.headers.get("X-Stream-Id") ?? undefined;
   onMeta?.({
     conversationId: res.headers.get("X-Conversation-Id") ?? undefined,
-    streamId: res.headers.get("X-Stream-Id") ?? undefined,
+    streamId,
     messageId: res.headers.get("X-Message-Id") ?? undefined,
     agentId: res.headers.get("X-Agent-Id") ?? undefined,
   });
 
-  if (!res.body) return;
-  const reader = res.body.getReader();
+  let outcome = await consumeSse(res, handlers, 0);
+  if (outcome.terminal || !streamId) return;
+
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    handlers.onConnectionState?.("reconnecting");
+    const headers = mutationHeaders();
+    delete headers["Content-Type"];
+    headers.Accept = "text/event-stream";
+    headers["Last-Event-ID"] = String(outcome.lastSequence);
+    const resumed = await fetch(
+      `${API_BASE}/api/v1/chat/streams/${encodeURIComponent(streamId)}?lastEventId=${outcome.lastSequence}`,
+      {
+        method: "GET",
+        credentials: "include",
+        headers,
+        signal,
+      }
+    );
+    if (!resumed.ok) throw await readChatError(resumed);
+    outcome = await consumeSse(resumed, handlers, outcome.lastSequence);
+    if (outcome.terminal) {
+      handlers.onConnectionState?.("online");
+      return;
+    }
+  }
+  throw new ApiError(503, "The stream could not be recovered from its persisted cursor.");
+}
+
+async function consumeSse(
+  response: Response,
+  handlers: PostChatHandlers,
+  afterSequence: number
+): Promise<{ terminal: boolean; lastSequence: number }> {
+  if (!response.body) return { terminal: false, lastSequence: afterSequence };
+  const reader = response.body.getReader();
   const decoder = new TextDecoder();
   let buffer = "";
+  let lastSequence = afterSequence;
 
   while (true) {
     const { value, done } = await reader.read();
@@ -166,15 +202,18 @@ export async function postChat(body: ChatRequestBody, handlers: PostChatHandlers
     buffer = rest;
 
     for (const frame of frames) {
+      if (frame.seq <= lastSequence) continue;
+      lastSequence = frame.seq;
       const event = toChatEvent(frame);
       if (!event) continue;
-      onEvent(event);
+      handlers.onEvent(event);
       if (TERMINAL_EVENT_TYPES.has(event.type)) {
         await reader.cancel();
-        return;
+        return { terminal: true, lastSequence };
       }
     }
   }
+  return { terminal: false, lastSequence };
 }
 
 // Stop an in-flight chat stream server-side: aborts the LLM so generation halts. Reuses the shared

--- a/apps/web/app/lib/chat/use-chat-stream.ts
+++ b/apps/web/app/lib/chat/use-chat-stream.ts
@@ -8,7 +8,7 @@
  */
 
 import { type NavigateFunction, useNavigate } from "@remix-run/react";
-import { useCallback, useReducer, useRef } from "react";
+import { useCallback, useReducer, useRef, useState } from "react";
 import { invokeClientAction, prefillForm } from "~/lib/chat/action-registry";
 import {
   appendUserMessage,
@@ -192,6 +192,7 @@ function reducer(state: ChatState, action: ChatAction): ChatState {
 
 export function useChatStream(opts?: UseChatStreamOptions) {
   const [state, dispatch] = useReducer(reducer, opts, seedState);
+  const [connectionState, setConnectionState] = useState<"online" | "reconnecting">("online");
   // Latest conversation id + state + last send options, read inside callbacks without re-subscribing.
   const conversationIdRef = useRef<string | undefined>(opts?.initialConversationId);
   const stateRef = useRef(state);
@@ -246,6 +247,7 @@ export function useChatStream(opts?: UseChatStreamOptions) {
             if (event.type === "finish")
               onConversationChangeRef.current?.(conversationIdRef.current);
           },
+          onConnectionState: setConnectionState,
         }
       );
     } catch (err) {
@@ -340,6 +342,7 @@ export function useChatStream(opts?: UseChatStreamOptions) {
     currentAgent: state.currentAgent,
     conversationId: state.conversationId,
     error: state.error,
+    connectionState,
     send,
     stop,
     approve,

--- a/apps/web/app/lib/inbox.ts
+++ b/apps/web/app/lib/inbox.ts
@@ -1,0 +1,40 @@
+import { apiCommand, apiGet } from "./api";
+
+export type InboxItemModel = {
+  id: string;
+  kind: "approval" | "human_task" | "form" | "access_request";
+  title: string;
+  status: string;
+  risk: "low" | "medium" | "high";
+  intentDigest?: string;
+  guardrailRevision?: string;
+  target?: string;
+  destination?: string;
+  fields?: string[];
+  expiresAt?: string;
+  decisions: number;
+  requiredDecisions: number;
+  canDecide: boolean;
+  denialReason?: string;
+};
+
+export async function getInbox(): Promise<InboxItemModel[]> {
+  return (await apiGet<{ items: InboxItemModel[] }>("/api/v1/inbox")).items;
+}
+
+export function decideApproval(
+  item: InboxItemModel,
+  decision: "approved" | "denied",
+  comment?: string
+): Promise<{
+  approvalId: string;
+  status: "pending" | "approved" | "denied";
+  decisions: number;
+  requiredDecisions: number;
+}> {
+  return apiCommand(
+    `/api/v1/approvals/${encodeURIComponent(item.id)}/decisions`,
+    { decision, comment },
+    `${item.id}-${decision}-${item.decisions}`
+  );
+}

--- a/apps/web/app/lib/nav.ts
+++ b/apps/web/app/lib/nav.ts
@@ -2,11 +2,12 @@ import {
   BookOpen,
   Bot,
   Boxes,
-  CheckCheck,
+  Inbox,
   type LucideIcon,
   Plug,
   Puzzle,
   Settings,
+  ShieldAlert,
   Workflow,
 } from "lucide-react";
 import type { BadgeKey } from "~/lib/badges";
@@ -32,14 +33,15 @@ export const navItems: NavItem[] = [
   { to: "/skills", label: "Skills", icon: Puzzle, group: "Workspace" },
   { to: "/routines", label: "Routines", icon: Workflow, group: "Workspace" },
   {
-    to: "/approvals",
-    label: "Approvals",
-    icon: CheckCheck,
+    to: "/inbox",
+    label: "Inbox",
+    icon: Inbox,
     group: "Workspace",
     badgeKey: "approvals",
   },
   { to: "/knowledge", label: "Knowledge", icon: BookOpen, group: "Workspace" },
   { to: "/integrations", label: "Integrations", icon: Plug, group: "System" },
+  { to: "/operations", label: "Operations", icon: ShieldAlert, group: "System" },
   { to: "/settings", label: "Settings", icon: Settings, group: "System" },
 ];
 

--- a/apps/web/app/lib/operations.ts
+++ b/apps/web/app/lib/operations.ts
@@ -1,0 +1,67 @@
+import { apiCommand, apiGet } from "./api";
+
+export type RunCommandAction = "pause" | "resume" | "cancel" | "retry" | "reconcile";
+
+export type OperationalRun = {
+  id: string;
+  routineId: string;
+  routineVersion: string;
+  status: string;
+  version: number;
+  createdAt: string;
+  startedAt: string | null;
+  finishedAt: string | null;
+  states: Array<{
+    key: string;
+    status: string;
+    attempts: number;
+    input?: unknown;
+    output?: unknown;
+    errorEvidenceRef?: string;
+  }>;
+  effects: Array<Record<string, unknown>>;
+  waits: Array<Record<string, unknown>>;
+  guardrailDecisions: Array<Record<string, unknown>>;
+  lineage: Array<Record<string, unknown>>;
+  costs: { amountUsd: number; modelTokens: number };
+};
+
+export async function getOperationalRun(id: string): Promise<OperationalRun> {
+  return (await apiGet<{ run: OperationalRun }>(`/api/v1/runs/${encodeURIComponent(id)}`)).run;
+}
+
+export function commandRun(
+  run: OperationalRun,
+  action: RunCommandAction,
+  reason: string
+): Promise<{ commandId: string; runId: string; status: string }> {
+  return apiCommand(
+    `/api/v1/runs/${encodeURIComponent(run.id)}/${action}`,
+    { expectedVersion: run.version, reason },
+    `${action}-${run.id}-v${run.version}`
+  );
+}
+
+export type OperationsModel = {
+  health: Array<Record<string, unknown>>;
+  incidents: Array<Record<string, unknown>>;
+  quarantine: Array<Record<string, unknown>>;
+  killSwitches: Array<Record<string, unknown>>;
+  audit: Array<Record<string, unknown>>;
+  recovery: { supportBundleAvailable: boolean; lastBackupAt: string | null };
+};
+
+export function getOperations(): Promise<OperationsModel> {
+  return apiGet<OperationsModel>("/api/v1/admin/operations");
+}
+
+export function commandOperation(
+  action: string,
+  input: Record<string, unknown>
+): Promise<{ commandId: string; status: string }> {
+  return apiCommand(
+    `/api/v1/admin/operations/${encodeURIComponent(action)}`,
+    { input },
+    `operation-${action}-${JSON.stringify(input)}`
+  );
+}

--- a/apps/web/app/routes/_app.admin.guardrails.tsx
+++ b/apps/web/app/routes/_app.admin.guardrails.tsx
@@ -1,0 +1,49 @@
+import { useLoaderData, useRevalidator } from "@remix-run/react";
+import { useState } from "react";
+import { getGuardrails, proposeGuardrailToggle } from "~/lib/admin";
+
+export async function clientLoader() {
+  return { model: await getGuardrails() };
+}
+
+export default function GuardrailAdminRoute() {
+  const { model } = useLoaderData<typeof clientLoader>();
+  const revalidator = useRevalidator();
+  const [busy, setBusy] = useState<string>();
+  return (
+    <div className="mx-auto flex max-w-4xl flex-col gap-4 px-4 py-6 sm:px-6">
+      <header>
+        <h1 className="text-lg font-semibold">Guardrails</h1>
+        <p className="text-xs text-muted-foreground">
+          Revision {model.revision}. Changes are Soul changesets and may require Approval.
+        </p>
+      </header>
+      <ul className="divide-y divide-border border border-border bg-card">
+        {model.items.map((item) => (
+          <li key={item.id} className="flex flex-wrap items-center gap-3 px-3 py-3 text-xs">
+            <span className="font-medium">{item.name ?? item.id}</span>
+            <span className="text-muted-foreground">
+              {item.effect ?? "configured"} · {item.scope ?? "all"}
+            </span>
+            <button
+              type="button"
+              disabled={busy === item.id}
+              onClick={async () => {
+                setBusy(item.id);
+                try {
+                  await proposeGuardrailToggle(model, item, item.enabled === false);
+                  revalidator.revalidate();
+                } finally {
+                  setBusy(undefined);
+                }
+              }}
+              className="ml-auto rounded-sm border border-border px-2 py-1"
+            >
+              {item.enabled === false ? "Enable" : "Disable"}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/app/routes/_app.admin.roles.tsx
+++ b/apps/web/app/routes/_app.admin.roles.tsx
@@ -1,0 +1,35 @@
+import { useLoaderData } from "@remix-run/react";
+import { RoleChangesetForm } from "~/components/admin/role-changeset-form";
+import { getRoles, proposeRole } from "~/lib/admin";
+
+export async function clientLoader() {
+  return { model: await getRoles() };
+}
+
+export default function RoleAdminRoute() {
+  const { model } = useLoaderData<typeof clientLoader>();
+  return (
+    <div className="mx-auto flex max-w-4xl flex-col gap-4 px-4 py-6 sm:px-6">
+      <header>
+        <h1 className="text-lg font-semibold">Roles</h1>
+        <p className="text-xs text-muted-foreground">
+          Revision {model.revision}. Role changes use governed Soul changesets.
+        </p>
+      </header>
+      <RoleChangesetForm
+        onPropose={async (role) => {
+          await proposeRole(model, role);
+        }}
+      />
+      <ul className="divide-y divide-border border border-border bg-card">
+        {model.items.map((role) => (
+          <li key={role.id} className="grid gap-2 px-3 py-3 text-xs sm:grid-cols-3">
+            <strong>{role.name}</strong>
+            <span>{role.principalKinds.join(", ")}</span>
+            <span className="text-muted-foreground">{role.grants.join(", ")}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/app/routes/_app.agents.$name.tsx
+++ b/apps/web/app/routes/_app.agents.$name.tsx
@@ -5,12 +5,14 @@ import {
   useNavigate,
   useRouteError,
 } from "@remix-run/react";
+import { useState } from "react";
 import { AgentGlyph } from "~/components/agent-glyph";
+import { AgentGovernanceCard } from "~/components/agents/governance-card";
 import { MarkdownView } from "~/components/markdown-view";
 import { ResourcePanel } from "~/components/resource-panel";
 import { ErrorState, NotFoundState } from "~/components/states";
 import { Button } from "~/components/ui/button";
-import { getAgent } from "~/lib/agents";
+import { getAgent, proposeAgentCandidate } from "~/lib/agents";
 import { ApiError } from "~/lib/api";
 
 export const meta: MetaFunction = () => [{ title: "Agents · tulipfarm" }];
@@ -35,6 +37,8 @@ function MetaRow({ label, value }: { label: string; value?: string }) {
 export default function AgentDetail() {
   const { agent } = useLoaderData<typeof clientLoader>();
   const navigate = useNavigate();
+  const [publishing, setPublishing] = useState(false);
+  const [publishResult, setPublishResult] = useState<string>();
   const display = agent.label ?? agent.name;
   const hasMeta = Boolean(agent.label || agent.domain || agent.model || agent.autonomy);
 
@@ -68,6 +72,28 @@ export default function AgentDetail() {
           <MetaRow label="model" value={agent.model} />
           <MetaRow label="autonomy" value={agent.autonomy} />
         </dl>
+      ) : null}
+
+      {agent.governance ? (
+        <AgentGovernanceCard
+          governance={agent.governance}
+          busy={publishing}
+          result={publishResult}
+          onPublish={async () => {
+            const governance = agent.governance;
+            if (!governance) return;
+            setPublishing(true);
+            setPublishResult(undefined);
+            try {
+              const result = await proposeAgentCandidate(agent.name, governance);
+              setPublishResult(`${result.status} · ${result.changesetId}`);
+            } catch (error) {
+              setPublishResult(error instanceof Error ? error.message : "Publication failed");
+            } finally {
+              setPublishing(false);
+            }
+          }}
+        />
       ) : null}
 
       <div className="border-t border-border pt-4">

--- a/apps/web/app/routes/_app.audit.tsx
+++ b/apps/web/app/routes/_app.audit.tsx
@@ -1,0 +1,1 @@
+export { clientLoader, default } from "./_app.operations";

--- a/apps/web/app/routes/_app.health.tsx
+++ b/apps/web/app/routes/_app.health.tsx
@@ -1,0 +1,1 @@
+export { clientLoader, default } from "./_app.operations";

--- a/apps/web/app/routes/_app.inbox.tsx
+++ b/apps/web/app/routes/_app.inbox.tsx
@@ -1,0 +1,63 @@
+import { useLoaderData, useRevalidator, useRouteError } from "@remix-run/react";
+import { useState } from "react";
+import { EmptyState } from "~/components/empty-state";
+import { InboxItem } from "~/components/inbox/inbox-item";
+import { ErrorState } from "~/components/states";
+import { ApiError } from "~/lib/api";
+import { decideApproval, getInbox } from "~/lib/inbox";
+
+export async function clientLoader() {
+  return { items: await getInbox() };
+}
+
+export default function InboxRoute() {
+  const { items } = useLoaderData<typeof clientLoader>();
+  const revalidator = useRevalidator();
+  const [busyId, setBusyId] = useState<string>();
+  if (items.length === 0) {
+    return (
+      <EmptyState
+        section="inbox"
+        title="Inbox"
+        hint="No Approvals, human tasks, form waits, or access requests need attention."
+      />
+    );
+  }
+  return (
+    <div className="mx-auto flex max-w-4xl flex-col gap-4 px-4 py-6 sm:px-6">
+      <header>
+        <h1 className="text-lg font-semibold">Inbox</h1>
+        <p className="text-xs text-muted-foreground">
+          Exact server-authorized decisions and waiting work.
+        </p>
+      </header>
+      {items.map((item) => (
+        <InboxItem
+          key={item.id}
+          item={item}
+          busy={busyId === item.id}
+          onDecision={async (decision) => {
+            setBusyId(item.id);
+            try {
+              await decideApproval(item, decision);
+              revalidator.revalidate();
+            } finally {
+              setBusyId(undefined);
+            }
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+  return (
+    <ErrorState
+      section="inbox"
+      status={error instanceof ApiError ? error.status : undefined}
+      message={error instanceof Error ? error.message : undefined}
+    />
+  );
+}

--- a/apps/web/app/routes/_app.incidents.tsx
+++ b/apps/web/app/routes/_app.incidents.tsx
@@ -1,0 +1,1 @@
+export { clientLoader, default } from "./_app.operations";

--- a/apps/web/app/routes/_app.operations.tsx
+++ b/apps/web/app/routes/_app.operations.tsx
@@ -1,0 +1,31 @@
+import { useLoaderData, useRevalidator } from "@remix-run/react";
+import { useState } from "react";
+import {
+  type OperationAction,
+  OperationsConsole,
+} from "~/components/operations/operations-console";
+import { commandOperation, getOperations } from "~/lib/operations";
+
+export async function clientLoader() {
+  return { model: await getOperations() };
+}
+
+export default function OperationsRoute() {
+  const { model } = useLoaderData<typeof clientLoader>();
+  const revalidator = useRevalidator();
+  const [busy, setBusy] = useState(false);
+  async function command(action: OperationAction, input: Record<string, unknown>) {
+    setBusy(true);
+    try {
+      await commandOperation(action, input);
+      revalidator.revalidate();
+    } finally {
+      setBusy(false);
+    }
+  }
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-6 sm:px-6">
+      <OperationsConsole model={model} busy={busy} onCommand={command} />
+    </div>
+  );
+}

--- a/apps/web/app/routes/_app.recovery.tsx
+++ b/apps/web/app/routes/_app.recovery.tsx
@@ -1,0 +1,1 @@
+export { clientLoader, default } from "./_app.operations";

--- a/apps/web/app/routes/_app.runs.$id.tsx
+++ b/apps/web/app/routes/_app.runs.$id.tsx
@@ -1,0 +1,78 @@
+import {
+  type ClientLoaderFunctionArgs,
+  useLoaderData,
+  useRevalidator,
+  useRouteError,
+} from "@remix-run/react";
+import { useEffect, useState } from "react";
+import { RunInspector } from "~/components/runs/run-inspector";
+import { ConnectionStatus } from "~/components/shell/states";
+import { ErrorState } from "~/components/states";
+import { API_BASE, ApiError } from "~/lib/api";
+import { commandRun, getOperationalRun, type RunCommandAction } from "~/lib/operations";
+
+export async function clientLoader({ params }: ClientLoaderFunctionArgs) {
+  if (!params.id) throw new ApiError(404, "Run not found");
+  return { run: await getOperationalRun(params.id) };
+}
+
+export default function OperationalRunRoute() {
+  const { run } = useLoaderData<typeof clientLoader>();
+  const revalidator = useRevalidator();
+  const [busy, setBusy] = useState(false);
+  const [connection, setConnection] = useState<"online" | "reconnecting">("online");
+
+  useEffect(() => {
+    if (["succeeded", "failed", "cancelled"].includes(run.status)) return;
+    const key = `run-cursor:${run.id}`;
+    const after = sessionStorage.getItem(key) ?? "0";
+    const source = new EventSource(
+      `${API_BASE}/api/v1/runs/${encodeURIComponent(run.id)}/events?after=${after}`,
+      { withCredentials: true }
+    );
+    const onEvent = (event: MessageEvent) => {
+      if (event.lastEventId) sessionStorage.setItem(key, event.lastEventId);
+      setConnection("online");
+      revalidator.revalidate();
+    };
+    for (const eventType of [
+      "state.completed",
+      "effect.updated",
+      "run.waiting",
+      "run.attention_required",
+      "stream.closed",
+    ]) {
+      source.addEventListener(eventType, onEvent);
+    }
+    source.onerror = () => setConnection("reconnecting");
+    return () => source.close();
+  }, [revalidator, run.id, run.status]);
+
+  async function submit(action: RunCommandAction) {
+    setBusy(true);
+    try {
+      await commandRun(run, action, `Operator requested ${action} from the Run inspector`);
+      revalidator.revalidate();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto flex max-w-6xl flex-col gap-4 px-4 py-6 sm:px-6">
+      {connection === "reconnecting" ? <ConnectionStatus state="reconnecting" /> : null}
+      <RunInspector run={run} busy={busy} onCommand={submit} />
+    </div>
+  );
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+  return (
+    <ErrorState
+      section="runs"
+      status={error instanceof ApiError ? error.status : undefined}
+      message={error instanceof Error ? error.message : undefined}
+    />
+  );
+}


### PR DESCRIPTION
## Summary

- build AW-067B Agent governance, AW-067 durable Chat recovery, AW-068 Run inspection, AW-069 Inbox/Guardrail/role administration, and AW-070 operations/recovery surfaces
- add Inbox and Operations navigation while keeping Operations as the active operator workspace and Activities as the full historical event log
- present health, incidents, quarantine, kill switches, and recent operational activity as responsive structured UI with redaction, filtering, compact identifiers, and safe empty states

Depends on #249 and is intentionally based on feat/phase-9-api-shell.

## Test plan

- [x] Web suite: 73 files, 464 tests
- [x] Root lint
- [x] Root typecheck
- [x] Root build
- [x] Phase API suite: 181 files, 1,799 tests with reduced worker concurrency
- [x] Diff conflict/whitespace check