### PR TITLE
fix(cutover): make phase 14 review fail honest

### DIFF
--- a/apps/api/src/chat/routes.test.ts
+++ b/apps/api/src/chat/routes.test.ts
@@ -13,6 +13,7 @@ import { MemorySessionStore } from "../auth/session-store";
 import { createUser, type UserDoc, type UserRepo } from "../auth/users";
 import { ToolRegistry } from "../broker/tool-adapter";
 import { GuardrailsService } from "../guardrails";
+import { DEPLOYMENT_BUSINESS_ID } from "../identity/principal";
 import { MAX_HISTORY_TOKENS } from "../memory/limits";
 import { WorkingMemoryService } from "../memory/service";
 import {
@@ -21,6 +22,11 @@ import {
   type WorkingMemoryRepo,
 } from "../memory/working-memory";
 import { encodeCursor, type PaginatedResult } from "../pagination";
+import {
+  DurableInvocationGateway,
+  type DurableInvocationRecord,
+  type DurableInvocationStore,
+} from "../runtime/invocation-gateway";
 import type { ConversationDoc, ConversationRepo } from "./conversations";
 import type { MessageDoc, MessagePart, MessageRepo } from "./messages";
 import { MemoryPendingInteractionRepo } from "./pending-interactions";
@@ -331,6 +337,20 @@ class FakeTokenRepo implements TokenRepo {
   }
 }
 
+class FakeInvocationStore implements DurableInvocationStore {
+  readonly records: DurableInvocationRecord[] = [];
+  private readonly byKey = new Map<string, DurableInvocationRecord>();
+
+  async persist(record: DurableInvocationRecord) {
+    const key = `${record.businessId}:${record.source}:${record.idempotencyKey}`;
+    const existing = this.byKey.get(key);
+    if (existing) return { outcome: "duplicate" as const, runId: existing.runId };
+    this.records.push(record);
+    this.byKey.set(key, record);
+    return { outcome: "started" as const, runId: record.runId };
+  }
+}
+
 async function waitFor(predicate: () => boolean, ms = 500): Promise<void> {
   const start = Date.now();
   while (!predicate()) {
@@ -409,6 +429,7 @@ describe("chat routes", () => {
   let otherSid: string;
   let select: ReturnType<typeof vi.fn>;
   let llmService: LlmService;
+  let invocationStore: FakeInvocationStore;
 
   beforeEach(async () => {
     capturedPrompts.length = 0;
@@ -438,6 +459,7 @@ describe("chat routes", () => {
       return { model, modelId, tier: undefined, chain: [{ provider: "test", modelId }] };
     });
     llmService = { select, resolve } as unknown as LlmService;
+    invocationStore = new FakeInvocationStore();
 
     app = await buildApp({
       sessionStore: store,
@@ -449,6 +471,7 @@ describe("chat routes", () => {
       streamResumeRepo: streamRepo,
       streamHub,
       workingMemoryService: new WorkingMemoryService(workingMemoryRepo),
+      invocations: new DurableInvocationGateway({ store: invocationStore }),
     });
   });
 
@@ -458,9 +481,9 @@ describe("chat routes", () => {
 
   function post(
     payload: InjectOptions["payload"],
-    opts: { auth?: boolean; csrf?: boolean } = {}
+    opts: { auth?: boolean; csrf?: boolean; idempotencyKey?: string } = {}
   ): Promise<LightMyRequestResponse> {
-    const { auth = true, csrf = true } = opts;
+    const { auth = true, csrf = true, idempotencyKey } = opts;
     const cookies: Record<string, string> = {};
     const headers: Record<string, string> = {};
     if (auth) cookies[SESSION_COOKIE] = sid;
@@ -468,6 +491,7 @@ describe("chat routes", () => {
       cookies[CSRF_COOKIE] = TEST_CSRF;
       headers[CSRF_HEADER] = TEST_CSRF;
     }
+    if (idempotencyKey) headers["idempotency-key"] = idempotencyKey;
     return app.inject({ method: "POST", url: "/api/v1/chat", cookies, headers, payload });
   }
 
@@ -513,6 +537,26 @@ describe("chat routes", () => {
       );
       expect(res.headers["x-conversation-id"]).toBeDefined();
       expect(res.body).toContain("Hello");
+      expect(invocationStore.records).toEqual([
+        expect.objectContaining({
+          businessId: DEPLOYMENT_BUSINESS_ID,
+          initiator: { kind: "user", id: userId },
+          effectiveSubject: { kind: "user", id: userId },
+        }),
+      ]);
+    });
+
+    it("does not execute a duplicate idempotent invocation twice", async () => {
+      const payload = { message: userMsg("hi") };
+      const first = await post(payload, { idempotencyKey: "chat-request-1" });
+      const duplicate = await post(payload, { idempotencyKey: "chat-request-1" });
+
+      expect(first.statusCode).toBe(200);
+      expect(duplicate.statusCode).toBe(409);
+      expect(duplicate.json()).toEqual({ error: "duplicate chat invocation" });
+      expect(duplicate.headers["x-run-id"]).toBe(first.headers["x-run-id"]);
+      expect(invocationStore.records).toHaveLength(1);
+      expect(select).toHaveBeenCalledTimes(1);
     });
 
     // AC3 — unknown model id → 400, no assistant message persisted

--- a/apps/api/src/chat/routes.ts
+++ b/apps/api/src/chat/routes.ts
@@ -93,12 +93,22 @@ export function registerChatRoutes(
         tags: ["chat"],
         security: [{ sessionCookie: [] }, { bearerToken: [] }],
         body: ChatBodySchema,
-        response: { 400: ErrorSchema, 401: ErrorSchema, 404: ErrorSchema, 503: ErrorSchema },
+        response: {
+          400: ErrorSchema,
+          401: ErrorSchema,
+          404: ErrorSchema,
+          409: ErrorSchema,
+          503: ErrorSchema,
+        },
       },
     },
     async (req, reply) => {
       if (invocations) {
         const body = req.body as { agentId?: string };
+        const principal = req.principal;
+        if (!principal) {
+          return reply.code(401).send({ error: "unauthorized" });
+        }
         const idempotencyHeader = req.headers["idempotency-key"];
         const idempotencyKey =
           typeof idempotencyHeader === "string" && idempotencyHeader.length > 0
@@ -106,14 +116,20 @@ export function registerChatRoutes(
             : req.id;
         const result = await invocations.start({
           source: "chat",
-          businessId: "default",
-          initiator: { kind: "user", id: req.user?._id ?? "unknown" },
-          effectiveSubject: { kind: "user", id: req.user?._id ?? "unknown" },
+          businessId: principal.businessId,
+          initiator: { kind: principal.kind, id: principal.id },
+          effectiveSubject: { kind: principal.kind, id: principal.id },
           definitionRef: `published:agent:${body.agentId ?? "assistant"}`,
           payloadRef: `artifact:request:${req.id}`,
           idempotencyKey,
         });
+        // The chat response is hijacked for SSE below, so write this to the raw response as well as
+        // Fastify's header collection. Otherwise the durable Run identifier is lost at the wire.
         reply.header("X-Run-Id", result.runId);
+        reply.raw.setHeader("X-Run-Id", result.runId);
+        if (result.outcome === "duplicate") {
+          return reply.code(409).send({ error: "duplicate chat invocation" });
+        }
       }
       return runChatTurn(req, reply, turnCtx);
     }

--- a/apps/web/app/routes/_app.integrations._index.tsx
+++ b/apps/web/app/routes/_app.integrations._index.tsx
@@ -12,7 +12,6 @@ import { ErrorState } from "~/components/states";
 import { Button } from "~/components/ui/button";
 import { ApiError } from "~/lib/api";
 import {
-  connectIntegration,
   disconnectIntegration,
   type IntegrationSummary,
   listIntegrations,

--- a/apps/web/app/routes/_app.integrations.marketplace.tsx
+++ b/apps/web/app/routes/_app.integrations.marketplace.tsx
@@ -8,7 +8,6 @@ import {
   installIntegrations,
   type MarketplaceCatalog,
   marketplaceIntegrations,
-  type ScannedIntegration,
   type ScanResult,
   scanIntegrations,
 } from "~/lib/integrations";

--- a/apps/web/app/routes/setup.tsx
+++ b/apps/web/app/routes/setup.tsx
@@ -199,7 +199,7 @@ function LlmStep({ onNext }: { onNext: () => void }) {
   const [providers, setProviders] = useState<LlmProviderInfo[]>([]);
   const [providerId, setProviderId] = useState("anthropic");
   const [fieldValues, setFieldValues] = useState<Record<string, string>>({});
-  const [model, setModel] = useState(DEFAULT_MODEL["anthropic"] ?? "");
+  const [model, setModel] = useState(DEFAULT_MODEL.anthropic ?? "");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -241,7 +241,7 @@ function LlmStep({ onNext }: { onNext: () => void }) {
     setError(null);
     try {
       const filled = selected.fields.filter((f) => (fieldValues[f.key] ?? "").trim().length > 0);
-      await Promise.all(filled.map((f) => putSecret(f.key, fieldValues[f.key]!.trim())));
+      await Promise.all(filled.map((f) => putSecret(f.key, (fieldValues[f.key] ?? "").trim())));
       const entry = { provider: providerId, model: model.trim() };
       await putLlmConfig({
         tiers: {

--- a/apps/worker/test/e2e/github-jira-triage/harness.ts
+++ b/apps/worker/test/e2e/github-jira-triage/harness.ts
@@ -19,12 +19,7 @@ import {
   jiraEffectLabel,
   normalizeGitHubIssueEvent,
 } from "@tulipfarm/integrations";
-import {
-  type CompiledRoutine,
-  type CompiledState,
-  compileRoutine,
-  type IdentityCeiling,
-} from "@tulipfarm/run-kernel";
+import { type CompiledState, compileRoutine, type IdentityCeiling } from "@tulipfarm/run-kernel";
 import {
   type AccessGrantDefinition,
   ajv,
@@ -214,10 +209,6 @@ function record(value: unknown): Record<string, unknown> {
     throw new Error("expected an object");
   }
   return value as Record<string, unknown>;
-}
-
-function stringList(value: unknown): string[] {
-  return Array.isArray(value) ? value.map((entry) => String(entry)) : [];
 }
 
 /**

--- a/ops/cutover/review.ts
+++ b/ops/cutover/review.ts
@@ -45,7 +45,18 @@ export const PHASE_14_RESOLVED_MAJORS: readonly ReviewFinding[] = [
 export const PHASE_14_REVIEW: readonly ReviewSection[] = [
   {
     category: "Security",
-    findings: [],
+    findings: [
+      {
+        severity: "MAJOR",
+        summary: "Production Soul authoring bypasses the changeset validation gateway.",
+        disposition: "deferred",
+        evidence:
+          "apps/api/src/soul/agents/tools.ts; apps/api/src/soul/skills/tools.ts; " +
+          "apps/api/src/soul/resource-types/routes.ts",
+        reason:
+          "Each authoring surface must be migrated to the package Soul gateway before cutover.",
+      },
+    ],
     evidence: [
       "test/security/threat-model.test.ts",
       "scripts/legacy-removal.test.ts",
@@ -54,7 +65,26 @@ export const PHASE_14_REVIEW: readonly ReviewSection[] = [
   },
   {
     category: "Correctness",
-    findings: [],
+    findings: [
+      {
+        severity: "MAJOR",
+        summary: "Chat records a Run but executes the Turn inline without durable worker States.",
+        disposition: "deferred",
+        evidence: "apps/api/src/chat/routes.ts; apps/api/src/runtime/chat-run.ts",
+        reason:
+          "The request payload must become an Artifact and worker-owned State before inline " +
+          "execution can be removed.",
+      },
+      {
+        severity: "MAJOR",
+        summary: "Legacy API-owned jobs and direct Tool execution remain authoritative.",
+        disposition: "deferred",
+        evidence:
+          "apps/api/src/routines/jobs.ts; apps/api/src/routines/schedules.ts; " +
+          "apps/api/src/routines/action-executor.ts",
+        reason: "Routine scheduling and effects require migration to Run Kernel and Tool Broker.",
+      },
+    ],
     evidence: [
       "apps/api/src/runtime/invocation-gateway.test.ts",
       "apps/api/src/runtime/invocation-store.pg.test.ts",
@@ -62,7 +92,17 @@ export const PHASE_14_REVIEW: readonly ReviewSection[] = [
   },
   {
     category: "Performance",
-    findings: [],
+    findings: [
+      {
+        severity: "MAJOR",
+        summary: "The required scenario load and recovery targets have no measured load run.",
+        disposition: "deferred",
+        evidence: "test/performance/load-profile.test.ts",
+        reason:
+          "Current evidence exercises an in-memory admission contract and does not generate " +
+          "ingress, waits, fan-out, SSE, or provider load.",
+      },
+    ],
     evidence: [
       "test/performance/load-profile.test.ts",
       "packages/observability/src/backpressure.ts",
@@ -70,7 +110,17 @@ export const PHASE_14_REVIEW: readonly ReviewSection[] = [
   },
   {
     category: "Design",
-    findings: [],
+    findings: [
+      {
+        severity: "MAJOR",
+        summary: "Worker applications are libraries, not bootable authoritative processes.",
+        disposition: "deferred",
+        evidence: "apps/worker/src/index.ts; apps/integration-worker/src/index.ts",
+        reason:
+          "Both entrypoints need production dependency composition, lifecycle, health, and " +
+          "dispatch loops.",
+      },
+    ],
     evidence: ["ops/cutover/contract.ts", "scripts/cutover-contract.test.ts"],
   },
   {
@@ -85,7 +135,17 @@ export const PHASE_14_REVIEW: readonly ReviewSection[] = [
   },
   {
     category: "Testing",
-    findings: [],
+    findings: [
+      {
+        severity: "MAJOR",
+        summary: "Phase 14 verification evidence is self-declared rather than run-derived.",
+        disposition: "deferred",
+        evidence: "ops/verification/phase14.ts; scripts/phase14-verification.test.ts",
+        reason:
+          "The gate currently tests hard-coded passed values instead of signed or generated " +
+          "outputs from the required checks.",
+      },
+    ],
     evidence: [
       "pnpm test",
       "scripts/phase14-review.test.ts",
@@ -93,3 +153,9 @@ export const PHASE_14_REVIEW: readonly ReviewSection[] = [
     ],
   },
 ] as const;
+
+export const PHASE_14_RELEASE_READY = PHASE_14_REVIEW.every((section) =>
+  section.findings.every(
+    (finding) => finding.severity !== "MAJOR" || finding.disposition === "fixed"
+  )
+);

--- a/ops/cutover/spec-traceability.ts
+++ b/ops/cutover/spec-traceability.ts
@@ -1,8 +1,9 @@
 export interface TraceabilityEntry {
   id: string;
   requirement: string;
-  status: "met";
+  status: "met" | "blocked";
   evidence: readonly string[];
+  blocker?: string;
 }
 
 export const PHASE_14_TRACEABILITY: {
@@ -12,20 +13,187 @@ export const PHASE_14_TRACEABILITY: {
 } = {
   sections: [
     {
+      id: "1",
+      requirement: "Durable AI business harness summary",
+      status: "met",
+      evidence: ["docs/architecture/boundaries.md"],
+    },
+    {
+      id: "2",
+      requirement: "Current-state assessment and explicit adapt-or-replace decisions",
+      status: "met",
+      evidence: ["docs/architecture/legacy-inventory.md", "docs/architecture/decision-index.md"],
+    },
+    {
+      id: "3",
+      requirement: "Approved product goals",
+      status: "met",
+      evidence: ["docs/architecture/boundaries.md", "scripts/spec-traceability.test.ts"],
+    },
+    {
+      id: "4",
+      requirement: "Non-goals and deferred scope remain bounded",
+      status: "met",
+      evidence: ["docs/architecture/decision-index.md"],
+    },
+    {
+      id: "5",
+      requirement: "Release-blocking architectural invariants",
+      status: "blocked",
+      evidence: [
+        "docs/architecture/boundaries.md",
+        "apps/api/src/runtime/invocation-gateway.test.ts",
+      ],
+      blocker:
+        "Production Soul writes and Turn execution still bypass governed runtime boundaries.",
+    },
+    {
+      id: "6",
+      requirement: "System shape, package ownership, and dependency direction",
+      status: "met",
+      evidence: ["docs/architecture/dependency-rules.md", "scripts/lib/architecture-rules.test.ts"],
+    },
+    {
+      id: "7",
+      requirement: "Canonical authored and runtime domain model",
+      status: "met",
+      evidence: [
+        "packages/schema/src/definitions/contracts.test.ts",
+        "packages/storage/src/runs/run-store.pg.test.ts",
+      ],
+    },
+    {
+      id: "8",
+      requirement: "Soul changesets, publication, and immutable bundle loading",
+      status: "blocked",
+      evidence: [
+        "packages/soul/src/changeset.test.ts",
+        "packages/soul/src/publication.test.ts",
+        "packages/soul/src/soul-loader.test.ts",
+      ],
+      blocker: "Production authoring routes still write directly to the Soul filesystem and Git.",
+    },
+    {
+      id: "9",
+      requirement: "Durable Routine and Trigger model",
+      status: "blocked",
+      evidence: [
+        "packages/run-kernel/src/routine/compiler.test.ts",
+        "packages/run-kernel/src/triggers/scheduler.test.ts",
+        "apps/worker/test/e2e/github-jira-triage/triage.test.ts",
+      ],
+      blocker: "Legacy Routine pg-boss consumers still run inside the API process.",
+    },
+    {
+      id: "10",
+      requirement: "Bounded, durable Agent runtime",
+      status: "blocked",
+      evidence: [
+        "packages/agent-runtime/src/loop/loop.test.ts",
+        "apps/worker/src/agent-state.test.ts",
+      ],
+      blocker: "Chat executes its Agent loop in the API instead of through the durable worker.",
+    },
+    {
+      id: "11",
+      requirement: "Governed Tools, Guardrails, Approvals, and effects",
+      status: "blocked",
+      evidence: [
+        "packages/tool-broker/src/broker.test.ts",
+        "packages/tool-broker/src/approval-gate.test.ts",
+        "packages/tool-broker/src/effects/dispatch.test.ts",
+      ],
+      blocker: "Production Routine and ingress paths can execute Tools outside the Tool Broker.",
+    },
+    {
+      id: "12",
+      requirement: "Identity, authorization, and external principals",
+      status: "met",
+      evidence: [
+        "packages/authz/test/security-matrix/authorization-isolation.test.ts",
+        "apps/api/src/identity/routes.test.ts",
+      ],
+    },
+    {
+      id: "13",
+      requirement: "Secret Broker and strong production sandbox boundaries",
+      status: "met",
+      evidence: [
+        "packages/secrets/src/broker.test.ts",
+        "packages/sandbox/test/security/skill-boundary.security.test.ts",
+      ],
+    },
+    {
+      id: "14",
+      requirement: "ACL-first Knowledge and scoped confirmed Memory",
+      status: "blocked",
+      evidence: [
+        "packages/knowledge/test/security/leakage.test.ts",
+        "packages/memory/test/security/leakage.test.ts",
+      ],
+      blocker: "The governed Knowledge and Memory packages are not composed into production apps.",
+    },
+    {
+      id: "15",
+      requirement: "Governed Integrations and durable channels",
+      status: "blocked",
+      evidence: [
+        "packages/integrations/test/conformance/external-isolation.test.ts",
+        "packages/integrations/src/channels/security.test.ts",
+      ],
+      blocker: "The Integration Worker entrypoint has no production boot or dispatch loop.",
+    },
+    {
+      id: "16",
+      requirement: "Safe A2UI, resumable forms, and immutable Artifacts",
+      status: "met",
+      evidence: [
+        "packages/a2ui/src/action.test.ts",
+        "packages/a2ui/src/forms/service.test.ts",
+        "packages/run-kernel/src/artifacts.test.ts",
+      ],
+    },
+    {
+      id: "17",
+      requirement: "Constraint-preserving ModelProfile routing",
+      status: "met",
+      evidence: [
+        "packages/agent-runtime/src/models/profile.test.ts",
+        "packages/agent-runtime/src/models/router.test.ts",
+      ],
+    },
+    {
+      id: "18",
+      requirement: "Versioned HTTP, SSE, and event interfaces",
+      status: "met",
+      evidence: ["apps/api/src/openapi.test.ts", "apps/api/src/runs/events.test.ts"],
+    },
+    {
+      id: "19",
+      requirement: "PostgreSQL correctness and persistence constraints",
+      status: "met",
+      evidence: [
+        "packages/storage/src/runs/run-store.pg.test.ts",
+        "packages/storage/src/events/event-store.pg.test.ts",
+      ],
+    },
+    {
       id: "20",
       requirement: "Audit, retention, and compliance-oriented controls",
-      status: "met",
+      status: "blocked",
       evidence: [
         "packages/audit/src/verify.test.ts",
         "apps/docs/content/docs/security/control-evidence.mdx",
         "apps/docs/content/docs/security/privacy.mdx",
       ],
+      blocker: "The governed Audit package is not composed into production applications.",
     },
     {
       id: "21",
       requirement: "Permission-safe product and operational user experiences",
       status: "met",
       evidence: [
+        "apps/web/app/components/operations/operations-console.test.tsx",
         "apps/web/app/routes/_app.approvals.tsx",
         "apps/web/app/routes/_app.runs.$id.tsx",
         "apps/web/app/routes/_app.admin.guardrails.tsx",
@@ -34,12 +202,14 @@ export const PHASE_14_TRACEABILITY: {
     {
       id: "22",
       requirement: "Operations, observability, resilience, recovery, and load posture",
-      status: "met",
+      status: "blocked",
       evidence: [
         "packages/observability/src/resilience.test.ts",
         "test/performance/load-profile.test.ts",
         "ops/resilience/README.md",
       ],
+      blocker:
+        "Load evidence is an in-memory contract test rather than the required scenario load run.",
     },
     {
       id: "23",
@@ -60,22 +230,45 @@ export const PHASE_14_TRACEABILITY: {
     {
       id: "25",
       requirement: "Layered verification and production gates",
-      status: "met",
+      status: "blocked",
       evidence: [
         "scripts/phase14-review.test.ts",
         "scripts/legacy-removal.test.ts",
         "scripts/resilience-contract.test.ts",
       ],
+      blocker:
+        "Verification status is declared in constants and is not derived from recorded runs.",
     },
     {
       id: "26",
       requirement: "Ordered rebuild, unified cutover, and legacy removal",
-      status: "met",
+      status: "blocked",
       evidence: [
         "apps/api/src/runtime/invocation-gateway.test.ts",
         "scripts/cutover-contract.test.ts",
         "scripts/legacy-removal.test.ts",
       ],
+      blocker:
+        "Legacy behavior remains under renamed paths and separate workers are not authoritative.",
+    },
+    {
+      id: "27",
+      requirement: "Approved design decisions and rejected alternatives",
+      status: "met",
+      evidence: ["docs/architecture/decision-index.md"],
+    },
+    {
+      id: "28",
+      requirement: "No unresolved blocking architecture questions",
+      status: "blocked",
+      evidence: ["docs/architecture/decision-index.md"],
+      blocker: "Production composition and cutover ownership remain unresolved.",
+    },
+    {
+      id: "29",
+      requirement: "Specification approval and task-package contract",
+      status: "met",
+      evidence: ["docs/architecture/boundaries.md", "scripts/spec-traceability.test.ts"],
     },
   ],
   invariants: [
@@ -109,8 +302,9 @@ export const PHASE_14_TRACEABILITY: {
     {
       id: "I-05",
       requirement: "Every authored write uses the Soul changeset and validation gateway",
-      status: "met",
+      status: "blocked",
       evidence: ["packages/soul/src/changeset.test.ts", "packages/soul/src/publication.test.ts"],
+      blocker: "API Agent, Skill, Resource Type, and LLM configuration paths write Soul directly.",
     },
     {
       id: "I-06",
@@ -121,11 +315,12 @@ export const PHASE_14_TRACEABILITY: {
     {
       id: "I-07",
       requirement: "Every Turn and automation creates a durable Run and States",
-      status: "met",
+      status: "blocked",
       evidence: [
         "apps/api/src/runtime/invocation-gateway.test.ts",
         "apps/api/src/runtime/invocation-store.pg.test.ts",
       ],
+      blocker: "Chat creates a Run record but executes the Turn inline without durable States.",
     },
     {
       id: "I-08",
@@ -203,18 +398,20 @@ export const PHASE_14_TRACEABILITY: {
     {
       id: "C-01",
       requirement: "Every UI/API/Agent/import write reaches the Soul gateway",
-      status: "met",
+      status: "blocked",
       evidence: [
         "packages/soul/src/changeset.test.ts",
         "packages/soul/src/agent-publication.test.ts",
         "packages/soul/src/converters/legacy-definitions.test.ts",
       ],
+      blocker: "Production API authoring paths still mutate Soul files and Git directly.",
     },
     {
       id: "C-02",
       requirement: "Chat and every Trigger class create the same Run and State records",
-      status: "met",
+      status: "blocked",
       evidence: ["apps/api/src/runtime/invocation-gateway.test.ts"],
+      blocker: "The Chat gateway does not dispatch the Turn as worker-owned durable States.",
     },
     {
       id: "C-03",
@@ -243,11 +440,13 @@ export const PHASE_14_TRACEABILITY: {
     {
       id: "C-06",
       requirement: "Worker death during an approved side effect reaches reconciliation",
-      status: "met",
+      status: "blocked",
       evidence: [
         "apps/worker/src/run-dispatcher.test.ts",
         "packages/tool-broker/src/effects/reconcile.test.ts",
       ],
+      blocker:
+        "The Worker entrypoint exports components but does not boot an authoritative process.",
     },
     {
       id: "C-07",
@@ -268,8 +467,9 @@ export const PHASE_14_TRACEABILITY: {
     {
       id: "C-09",
       requirement: "Legacy routes and workers are removed as bypass paths",
-      status: "met",
+      status: "blocked",
       evidence: ["scripts/legacy-removal.test.ts", "apps/api/src/legacy-inventory.test.ts"],
+      blocker: "In-process jobs, direct Soul writes, and direct Tool execution remain in the API.",
     },
   ],
 };

--- a/packages/run-kernel/src/replay.test.ts
+++ b/packages/run-kernel/src/replay.test.ts
@@ -24,7 +24,7 @@ const states: routineSchema.RoutineState[] = [
     type: "agent",
     name: "Classify",
     agentRef: { name: "triage", version: "1.0.0" },
-    input: { issue: "${ input.issueId }" },
+    input: { issue: `\${ input.issueId }` },
     transition: "Label",
   },
   {
@@ -33,7 +33,7 @@ const states: routineSchema.RoutineState[] = [
     toolRef: { name: "github", version: "2.0.0" },
     action: "issues.addLabels",
     credentialRef: "github-app",
-    input: { label: "${ states.Classify.output.label }" },
+    input: { label: `\${ states.Classify.output.label }` },
     end: true,
   },
 ];

--- a/packages/run-kernel/src/resilience/recovery.test.ts
+++ b/packages/run-kernel/src/resilience/recovery.test.ts
@@ -92,7 +92,7 @@ describe("crash at the claim boundary", () => {
 
 describe("crash while holding a lease", () => {
   it("recovers an accepted Run once its lease expires", async () => {
-    const { store, leases } = leaseFixture();
+    const { leases } = leaseFixture();
     await leases.claim({
       businessId: BUSINESS_ID,
       runId: RUN_ID,

--- a/packages/run-kernel/src/resilience/simulator.ts
+++ b/packages/run-kernel/src/resilience/simulator.ts
@@ -224,7 +224,7 @@ export class SimulatedRunStore implements RunLeaseStore, RunResumeStore, Reconci
   async requeueWaitingRun(_businessId: string, runId: string): Promise<boolean> {
     this.guard("requeueWaitingRun", "before");
     const run = this.runs.get(runId);
-    if (!run || run.status !== "waiting") return false;
+    if (run?.status !== "waiting") return false;
     this.runs.set(runId, { ...run, status: "queued", version: run.version + 1 });
     this.requeues += 1;
     this.guard("requeueWaitingRun", "after");

--- a/packages/run-kernel/src/routine/compiler.test.ts
+++ b/packages/run-kernel/src/routine/compiler.test.ts
@@ -57,7 +57,7 @@ const label: routineSchema.RoutineState = {
   name: "Label",
   toolRef: { name: "github", version: "2.0.0" },
   action: "issues.addLabels",
-  input: { issue: "${ input.issueId }", label: "bug" },
+  input: { issue: `\${ input.issueId }`, label: "bug" },
   end: true,
 };
 

--- a/packages/run-kernel/src/simulate.test.ts
+++ b/packages/run-kernel/src/simulate.test.ts
@@ -37,7 +37,7 @@ const classify: routineSchema.RoutineState = {
   type: "agent",
   name: "Classify",
   agentRef: { name: "triage", version: "1.0.0" },
-  input: { issue: "${ input.issueId }" },
+  input: { issue: `\${ input.issueId }` },
   transition: "Label",
 };
 
@@ -47,14 +47,17 @@ const label: routineSchema.RoutineState = {
   toolRef: { name: "github", version: "2.0.0" },
   action: "issues.addLabels",
   credentialRef: "github-app",
-  input: { issue: "${ input.issueId }", label: "${ states.Classify.output.label }" },
+  input: {
+    issue: `\${ input.issueId }`,
+    label: `\${ states.Classify.output.label }`,
+  },
   end: true,
 };
 
 /** The same Tool State, but with no reference to an upstream State's output. */
 const standaloneLabel: routineSchema.RoutineState = {
   ...label,
-  input: { issue: "${ input.issueId }", label: "bug" },
+  input: { issue: `\${ input.issueId }`, label: "bug" },
 };
 
 const routine = compile([classify, label], "Classify");

--- a/scripts/phase14-review.test.ts
+++ b/scripts/phase14-review.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { PHASE_14_RESOLVED_MAJORS, PHASE_14_REVIEW } from "../ops/cutover/review";
+import {
+  PHASE_14_RELEASE_READY,
+  PHASE_14_RESOLVED_MAJORS,
+  PHASE_14_REVIEW,
+} from "../ops/cutover/review";
 
 const REQUIRED_CATEGORIES = [
   "Security",
@@ -16,19 +20,26 @@ describe("Phase 14 whole-rewrite review", () => {
     expect(PHASE_14_REVIEW.map((section) => section.category)).toEqual(REQUIRED_CATEGORIES);
   });
 
-  it("leaves no major finding and gives every minor a disposition", () => {
+  it("gives every finding a disposition and reason when deferred", () => {
     const findings = PHASE_14_REVIEW.flatMap((section) => section.findings);
-    expect(findings.filter((finding) => finding.severity === "MAJOR")).toEqual([]);
     expect(
-      findings
-        .filter((finding) => finding.severity === "MINOR")
-        .every((finding) => finding.disposition === "fixed" || finding.disposition === "deferred")
+      findings.every(
+        (finding) => finding.disposition === "fixed" || finding.disposition === "deferred"
+      )
     ).toBe(true);
     expect(
       findings
         .filter((finding) => finding.disposition === "deferred")
         .every((finding) => Boolean(finding.reason))
     ).toBe(true);
+  });
+
+  it("does not declare the release ready while a major remains deferred", () => {
+    const deferredMajors = PHASE_14_REVIEW.flatMap((section) => section.findings).filter(
+      (finding) => finding.severity === "MAJOR" && finding.disposition === "deferred"
+    );
+    expect(deferredMajors.length).toBeGreaterThan(0);
+    expect(PHASE_14_RELEASE_READY).toBe(false);
   });
 
   it("records every discovered major as fixed with evidence", () => {

--- a/scripts/spec-traceability.test.ts
+++ b/scripts/spec-traceability.test.ts
@@ -3,14 +3,14 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import { PHASE_14_TRACEABILITY } from "../ops/cutover/spec-traceability";
 
-const REQUIRED_SECTIONS = ["20", "21", "22", "23", "24", "25", "26"] as const;
+const REQUIRED_SECTIONS = Array.from({ length: 29 }, (_, index) => String(index + 1));
 
 describe("Phase 14 specification traceability", () => {
-  it("maps every numbered phase specification section", () => {
+  it("maps every numbered specification section", () => {
     expect(PHASE_14_TRACEABILITY.sections.map((entry) => entry.id)).toEqual(REQUIRED_SECTIONS);
   });
 
-  it("maps every invariant and cutover criterion without deferral", () => {
+  it("maps every invariant and cutover criterion without silent deferral", () => {
     expect(PHASE_14_TRACEABILITY.invariants.length).toBeGreaterThan(0);
     expect(PHASE_14_TRACEABILITY.cutoverCriteria.length).toBeGreaterThan(0);
     const entries = [
@@ -18,7 +18,12 @@ describe("Phase 14 specification traceability", () => {
       ...PHASE_14_TRACEABILITY.invariants,
       ...PHASE_14_TRACEABILITY.cutoverCriteria,
     ];
-    expect(entries.every((entry) => entry.status === "met")).toBe(true);
+    expect(entries.every((entry) => entry.status === "met" || entry.status === "blocked")).toBe(
+      true
+    );
+    expect(
+      entries.filter((entry) => entry.status === "blocked").every((entry) => Boolean(entry.blocker))
+    ).toBe(true);
     expect(entries.every((entry) => entry.evidence.length > 0)).toBe(true);
     expect(
       entries.every((entry) =>
@@ -28,5 +33,26 @@ describe("Phase 14 specification traceability", () => {
     expect(entries.some((entry) => entry.evidence.some((path) => path.includes("TASKS.md")))).toBe(
       false
     );
+  });
+
+  it("keeps known production cutover gaps release-blocking", () => {
+    const blocked = new Set(
+      [...PHASE_14_TRACEABILITY.invariants, ...PHASE_14_TRACEABILITY.cutoverCriteria]
+        .filter((entry) => entry.status === "blocked")
+        .map((entry) => entry.id)
+    );
+    expect(blocked).toEqual(new Set(["I-05", "I-07", "C-01", "C-02", "C-06", "C-09"]));
+  });
+
+  it("backs every normative runtime section with executable evidence", () => {
+    const runtimeSections = PHASE_14_TRACEABILITY.sections.filter((entry) => {
+      const id = Number(entry.id);
+      return id >= 5 && id <= 26;
+    });
+    expect(
+      runtimeSections.every((entry) =>
+        entry.evidence.some((path) => path.endsWith(".test.ts") || path.endsWith(".test.tsx"))
+      )
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- preserve authenticated business/principal identity on durable Chat invocations, expose the Run
  identifier over SSE, and reject duplicate idempotent requests before a second Turn executes
- expand Phase 14 traceability to all 29 SPEC sections and keep unresolved production cutover
  invariants explicitly release-blocking
- record the major worker, Soul gateway, Tool Broker, load-evidence, and verification gaps while
  cleaning the repository's existing Biome warnings

## Why

The Phase 14 review and traceability gates were reporting a release-ready state from isolated tests
and hard-coded evidence even though several production paths still bypass the governed runtime.
Chat also used an incorrect business/principal identity and re-executed duplicate idempotent
requests.

## Test plan

- [x] `pnpm lint` — 28/28 tasks, no warnings
- [x] `pnpm typecheck` — 28/28 tasks
- [x] `pnpm build` — 5/5 tasks
- [x] focused Chat, traceability, review, Run Kernel, and worker regressions
- [x] API suite with one worker — 182 files / 1,794 tests
- [x] remaining Turbo test graph — 26/26 tasks

## Verification note

The unconstrained API Vitest run still crashes two fork workers after 180/182 files without an
assertion failure. The complete API suite passes with `--maxWorkers=1`; the review records
run-derived verification and production composition as remaining release blockers.
