### PR TITLE
feat(skills): add Skill frontmatter validation

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -68,6 +68,7 @@ import { PgDurableInvocationStore } from "./runtime/invocation-store";
 import { bootstrapFromEnv } from "./setup/bootstrap";
 import { readSoulConfig, SOUL_GIT_CREDENTIAL_KEY } from "./setup/soul-config";
 import { BUILTIN_SKILLS } from "./soul/skills/builtin-skills";
+import { loadBundledSkills } from "./soul/skills/bundled";
 import { registerSoulSync } from "./soul-sync";
 import { buildToolRegistry } from "./tools/setup";
 
@@ -119,6 +120,7 @@ async function boot() {
 
     const soulLoader = new SoulLoader(soulPath, console);
     await soulLoader.load();
+    await loadBundledSkills(console);
 
     // Per-type resource tables can't be created lazily (no `db.collection(type)`):
     // materialise them for every loaded soul type before serving.

--- a/apps/api/src/soul/skills/builtin-skills.ts
+++ b/apps/api/src/soul/skills/builtin-skills.ts
@@ -160,7 +160,7 @@ Call \`skill_list\` to show existing skills (avoid duplicates, anchor naming). C
 task this skill performs and which agents will use it.
 
 ### Step 2 — Identity
-- **name**: kebab-case, \`^[a-z][a-z0-9-]*$\`, equal to the skill's directory name.
+- **name**: \`^[a-z0-9][a-z0-9._-]*$\` (maximum 64 characters), equal to the skill's directory name.
 - **description**: one sentence written as a trigger condition for an LLM reader — specific tool
   names, 3–5 task types, synonyms, and action verbs. A vague description never fires; this is the #1
   reason skills don't activate.
@@ -180,10 +180,11 @@ Scope any autonomy narrowly. Skills inform, they don't override the agent's judg
 ### Step 5 — Validate, preview, write
 1. If \`validate_artifact\` is available, validate the assembled SKILL.md first.
 2. Present the draft concisely (name + description + a short body summary) and ask for approval.
-3. On approval call \`skill_create\` with \`name\`, \`body\`, and \`frontmatter\` ({ description,
-   tags?, requires? }). This commits the skill in a **pending-audit** state and runs the SkillAudit
-   reviewer, returning a safety report. (If no LLM is configured the tool returns \`audit_required\`
-   — tell the user to configure a provider, then retry.)
+3. On approval call \`skill_create\` with \`name\`, \`body\`, and \`frontmatter\` ({ name,
+   description, tags?, requires? }). The frontmatter name must equal the Skill name. This commits
+   the Skill in a **pending-audit** state and runs the SkillAudit reviewer, returning a safety
+   report. (If no LLM is configured the tool returns \`audit_required\` — tell the user to configure
+   a provider, then retry.)
 4. Show the user the audit's risk rating + summary. The audit is **advisory** — the operator still
    confirms. On confirmation, call \`skill_activate\` with the \`name\` to make the skill live.
 5. Confirm in one line: "the \`<name>\` skill is now live". Do NOT call \`complete_task\` — the

--- a/apps/api/src/soul/skills/bundled.test.ts
+++ b/apps/api/src/soul/skills/bundled.test.ts
@@ -1,0 +1,87 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import type { Logger } from "@tulipfarm/soul";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { bundledSkillsDir, loadBundledSkills } from "./bundled";
+
+const temporaryDirectories: string[] = [];
+const originalOverride = process.env.BUNDLED_SKILLS_DIR;
+
+async function makeTree(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "bundled-skills-"));
+  temporaryDirectories.push(root);
+
+  const valid = join(root, "core", "valid-skill");
+  const invalid = join(root, "core", "invalid-skill");
+  await mkdir(valid, { recursive: true });
+  await mkdir(invalid, { recursive: true });
+  await writeFile(
+    join(valid, "SKILL.md"),
+    "---\nname: valid-skill\ndescription: A valid bundled Skill.\n---\nFollow the steps.",
+    "utf8"
+  );
+  await writeFile(
+    join(invalid, "SKILL.md"),
+    "---\nname: invalid-skill\n---\nMissing a description.",
+    "utf8"
+  );
+  return root;
+}
+
+function makeLogger(): Logger {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+afterEach(async () => {
+  if (originalOverride === undefined) {
+    delete process.env.BUNDLED_SKILLS_DIR;
+  } else {
+    process.env.BUNDLED_SKILLS_DIR = originalOverride;
+  }
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true }))
+  );
+});
+
+describe("bundledSkillsDir", () => {
+  it("uses an explicit BUNDLED_SKILLS_DIR override", () => {
+    process.env.BUNDLED_SKILLS_DIR = "./test-skills";
+    expect(bundledSkillsDir()).toBe(resolve("./test-skills"));
+  });
+});
+
+describe("loadBundledSkills", () => {
+  it("loads valid Skills and skips malformed Skills without throwing", async () => {
+    const root = await makeTree();
+    const logger = makeLogger();
+
+    const skills = await loadBundledSkills(logger, root);
+
+    expect([...skills.keys()]).toEqual(["valid-skill"]);
+    expect(skills.get("valid-skill")).toMatchObject({
+      name: "valid-skill",
+      frontmatter: {
+        name: "valid-skill",
+        description: "A valid bundled Skill.",
+      },
+      body: "Follow the steps.",
+    });
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Bundled Skill "invalid-skill" skipped')
+    );
+  });
+
+  it("returns an empty map when the bundled tree does not exist", async () => {
+    const logger = makeLogger();
+    const skills = await loadBundledSkills(logger, "/path/that/does/not/exist");
+    expect(skills.size).toBe(0);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/soul/skills/bundled.ts
+++ b/apps/api/src/soul/skills/bundled.ts
@@ -1,0 +1,85 @@
+import { type Dirent, existsSync } from "node:fs";
+import { readdir, readFile } from "node:fs/promises";
+import { basename, join, resolve } from "node:path";
+import { validateSkill } from "@tulipfarm/schema";
+import { type Logger, parseFrontmatter, type SoulSkill } from "@tulipfarm/soul";
+
+const IMAGE_SKILLS_DIR = "/app/skills";
+const REPO_SKILLS_DIR = resolve(__dirname, "../../../../../skills");
+
+export function bundledSkillsDir(): string {
+  const override = process.env.BUNDLED_SKILLS_DIR?.trim();
+  if (override) return resolve(override);
+  if (existsSync(IMAGE_SKILLS_DIR)) return IMAGE_SKILLS_DIR;
+  return REPO_SKILLS_DIR;
+}
+
+function isNotFound(error: unknown): boolean {
+  return (
+    error instanceof Error && "code" in error && (error as NodeJS.ErrnoException).code === "ENOENT"
+  );
+}
+
+/**
+ * Load and validate the future bundled Skill tree without activating it.
+ *
+ * Step 1 will consume the returned map as an overlay. Step 4 calls this at boot only to ensure
+ * malformed bundled Skills are logged and skipped rather than taking down the server.
+ */
+export async function loadBundledSkills(
+  logger: Logger,
+  root = bundledSkillsDir()
+): Promise<Map<string, SoulSkill>> {
+  const skills = new Map<string, SoulSkill>();
+
+  async function walk(directory: string): Promise<void> {
+    let entries: Dirent[];
+    try {
+      entries = await readdir(directory, { withFileTypes: true });
+    } catch (error) {
+      if (!isNotFound(error)) {
+        logger.error(
+          `Bundled Skills: cannot read "${directory}": ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        );
+      }
+      return;
+    }
+
+    entries.sort((left, right) => left.name.localeCompare(right.name));
+    for (const entry of entries) {
+      const path = join(directory, entry.name);
+      if (entry.isDirectory()) {
+        await walk(path);
+        continue;
+      }
+      if (!entry.isFile() || entry.name !== "SKILL.md") continue;
+
+      const name = basename(directory);
+      try {
+        const content = await readFile(path, "utf8");
+        const { frontmatter, body } = parseFrontmatter(content);
+        const validation = validateSkill({ name, frontmatter, body, content });
+        if (!validation.valid) {
+          logger.error(`Bundled Skill "${name}" skipped: ${validation.error}`);
+          continue;
+        }
+        if (skills.has(name)) {
+          logger.error(`Bundled Skill "${name}" skipped: duplicate Skill name`);
+          continue;
+        }
+        skills.set(name, { name, frontmatter: validation.frontmatter, body });
+      } catch (error) {
+        logger.error(
+          `Bundled Skill "${name}" skipped: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        );
+      }
+    }
+  }
+
+  await walk(root);
+  return skills;
+}

--- a/apps/api/src/soul/skills/routes.test.ts
+++ b/apps/api/src/soul/skills/routes.test.ts
@@ -79,15 +79,14 @@ const skill = (name: string, description: string): SoulSkill => ({
 // Build a throwaway local git repo containing one installable skill — `git clone <path>` reads it
 // offline, so the scan flow is exercised without any network. Optionally writes a root
 // marketplace.json (the curated-catalog manifest read by GET /api/v1/skills/marketplace).
-async function makeRemoteRepo(manifest?: unknown): Promise<string> {
+async function makeRemoteRepo(
+  manifest?: unknown,
+  skillContent = "---\nname: demo-skill\ndescription: A demo skill.\n---\nDo the demo."
+): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), "skill-remote-"));
   const skillDir = join(dir, "skills", "demo-skill");
   await mkdir(skillDir, { recursive: true });
-  await writeFile(
-    join(skillDir, "SKILL.md"),
-    "---\nname: demo-skill\ndescription: A demo skill.\n---\nDo the demo.",
-    "utf8"
-  );
+  await writeFile(join(skillDir, "SKILL.md"), skillContent, "utf8");
   if (manifest !== undefined) {
     await writeFile(join(dir, "marketplace.json"), JSON.stringify(manifest), "utf8");
   }
@@ -540,6 +539,143 @@ describe("skills routes", () => {
       expect(installRes.statusCode).toBe(409);
       expect(withSync).not.toHaveBeenCalled();
       await expect(access(join(soulPath, "skills", "demo-skill", "SKILL.md"))).rejects.toThrow();
+    });
+
+    it("refuses a malformed audited Skill at install and writes nothing", async () => {
+      const remote = await makeRemoteRepo(
+        undefined,
+        "---\nname: demo-skill\n---\nMissing the required description."
+      );
+      temps.push(remote);
+      const scanRes = await app.inject({
+        method: "POST",
+        url: "/api/v1/skills/scan",
+        cookies: auth(),
+        headers,
+        payload: { source: `file://${remote}` },
+      });
+      const { scanId } = scanRes.json();
+      buildAudit.mockResolvedValue({
+        riskRating: "low",
+        summary: "No issue found.",
+        toolsReach: [],
+        findings: [],
+      });
+      await app.inject({
+        method: "POST",
+        url: "/api/v1/skills/audit",
+        cookies: auth(),
+        headers,
+        payload: { scanId, name: "demo-skill" },
+      });
+
+      const installRes = await app.inject({
+        method: "POST",
+        url: "/api/v1/skills/install",
+        cookies: auth(),
+        headers,
+        payload: { scanId, names: ["demo-skill"] },
+      });
+
+      expect(installRes.statusCode).toBe(400);
+      expect(installRes.json().error).toMatch(/invalid Skill.*description/);
+      expect(withSync).not.toHaveBeenCalled();
+      expect(reload).not.toHaveBeenCalled();
+      await expect(access(join(soulPath, "skills", "demo-skill", "SKILL.md"))).rejects.toThrow();
+    });
+
+    it("validates every selected Skill before an atomic multi-Skill install", async () => {
+      const remote = await makeRemoteRepo();
+      temps.push(remote);
+      const invalidDir = join(remote, "skills", "invalid-skill");
+      await mkdir(invalidDir, { recursive: true });
+      await writeFile(
+        join(invalidDir, "SKILL.md"),
+        "---\nname: invalid-skill\n---\nMissing the required description.",
+        "utf8"
+      );
+      const git = (args: string[]) => execFileP("git", args, { cwd: remote });
+      await git(["add", "-A"]);
+      await git(["commit", "-q", "-m", "add invalid skill"]);
+
+      const scanRes = await app.inject({
+        method: "POST",
+        url: "/api/v1/skills/scan",
+        cookies: auth(),
+        headers,
+        payload: { source: `file://${remote}` },
+      });
+      const { scanId } = scanRes.json();
+      buildAudit.mockResolvedValue({
+        riskRating: "low",
+        summary: "No issue found.",
+        toolsReach: [],
+        findings: [],
+      });
+      for (const name of ["demo-skill", "invalid-skill"]) {
+        await app.inject({
+          method: "POST",
+          url: "/api/v1/skills/audit",
+          cookies: auth(),
+          headers,
+          payload: { scanId, name },
+        });
+      }
+
+      const installRes = await app.inject({
+        method: "POST",
+        url: "/api/v1/skills/install",
+        cookies: auth(),
+        headers,
+        payload: { scanId, names: ["demo-skill", "invalid-skill"] },
+      });
+
+      expect(installRes.statusCode).toBe(400);
+      expect(withSync).not.toHaveBeenCalled();
+      expect(reload).not.toHaveBeenCalled();
+      await expect(access(join(soulPath, "skills", "demo-skill", "SKILL.md"))).rejects.toThrow();
+      await expect(access(join(soulPath, "skills", "invalid-skill", "SKILL.md"))).rejects.toThrow();
+    });
+
+    it("measures the exact raw marketplace file when enforcing the size limit", async () => {
+      const oversized =
+        "---\nname: demo-skill\ndescription: A demo skill.\n" +
+        `${"# padding\n".repeat(12_000)}---\nDo the demo.`;
+      const remote = await makeRemoteRepo(undefined, oversized);
+      temps.push(remote);
+      const scanRes = await app.inject({
+        method: "POST",
+        url: "/api/v1/skills/scan",
+        cookies: auth(),
+        headers,
+        payload: { source: `file://${remote}` },
+      });
+      const { scanId } = scanRes.json();
+      buildAudit.mockResolvedValue({
+        riskRating: "low",
+        summary: "No issue found.",
+        toolsReach: [],
+        findings: [],
+      });
+      await app.inject({
+        method: "POST",
+        url: "/api/v1/skills/audit",
+        cookies: auth(),
+        headers,
+        payload: { scanId, name: "demo-skill" },
+      });
+
+      const installRes = await app.inject({
+        method: "POST",
+        url: "/api/v1/skills/install",
+        cookies: auth(),
+        headers,
+        payload: { scanId, names: ["demo-skill"] },
+      });
+
+      expect(installRes.statusCode).toBe(400);
+      expect(installRes.json().error).toMatch(/100,000 characters/);
+      expect(withSync).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/soul/skills/routes.ts
+++ b/apps/api/src/soul/skills/routes.ts
@@ -5,10 +5,14 @@ import { tmpdir } from "node:os";
 import { basename, dirname, join, relative } from "node:path";
 import { promisify } from "node:util";
 import type { LlmService } from "@tulipfarm/llm";
-import { LlmNotConfiguredError } from "@tulipfarm/schema";
-import type { GitSyncService, SoulLoader, SoulSkill } from "@tulipfarm/soul";
+import { LlmNotConfiguredError, validateSkill } from "@tulipfarm/schema";
+import {
+  type GitSyncService,
+  parseFrontmatter,
+  type SoulLoader,
+  type SoulSkill,
+} from "@tulipfarm/soul";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
-import { parse as parseYaml } from "yaml";
 import type { ActivityService } from "../../activity/service";
 import { ErrorSchema } from "../../auth/schemas";
 import { buildAudit, SKILL_AUDIT_REPORT_SCHEMA } from "./audit";
@@ -27,7 +31,7 @@ const execFileP = promisify(execFile);
 
 type PreHandler = (req: FastifyRequest, reply: FastifyReply) => Promise<void>;
 
-const NAME_RE = /^[a-z][a-z0-9-]*$/;
+const NAME_RE = /^[a-z0-9][a-z0-9._-]{0,63}$/;
 const SCAN_TTL_MS = 10 * 60 * 1000;
 const CLONE_TIMEOUT_MS = 60_000;
 const MAX_SCANS = 25;
@@ -71,13 +75,6 @@ function asString(v: unknown): string | undefined {
   return typeof v === "string" && v.length > 0 ? v : undefined;
 }
 
-function parseFrontmatter(content: string): { frontmatter: Record<string, unknown>; body: string } {
-  const match = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
-  if (!match) return { frontmatter: {}, body: content.trim() };
-  const frontmatter = (parseYaml(match[1]) ?? {}) as Record<string, unknown>;
-  return { frontmatter, body: match[2].trim() };
-}
-
 // A source may carry an optional "#<ref>" suffix (branch or tag name — not a commit SHA) so
 // pre-merge branches can be scanned and tested: "owner/repo#my-branch". No "#" ⇒ default branch.
 function splitSourceRef(source: string): { base: string; ref?: string } {
@@ -112,7 +109,7 @@ function sourceType(source: string): "github" | "git" {
 
 /**
  * Walk a directory tree for SKILL.md files and parse each into a DiscoveredSkill. Skips .git and
- * node_modules. Skills whose resolved name is not a safe kebab-case identifier are dropped (the name
+ * node_modules. Skills whose directory name is not a safe Skill identifier are dropped (that name
  * becomes a soul directory on install, so it must not allow path traversal). Exported for testing.
  */
 export async function discoverSkills(root: string): Promise<DiscoveredSkill[]> {
@@ -128,7 +125,7 @@ export async function discoverSkills(root: string): Promise<DiscoveredSkill[]> {
       } else if (entry.name === "SKILL.md") {
         const content = await readFile(full, "utf8");
         const { frontmatter } = parseFrontmatter(content);
-        const name = asString(frontmatter.name) ?? basename(dirname(full));
+        const name = basename(dirname(full));
         if (!NAME_RE.test(name)) continue;
         out.push({
           name,
@@ -672,6 +669,21 @@ export function registerSkillRoutes(
         return reply
           .code(409)
           .send({ error: `audit required before install: ${unaudited.join(", ")}` });
+
+      for (const skill of chosen as DiscoveredSkill[]) {
+        const { frontmatter, body } = parseFrontmatter(skill.content);
+        const validation = validateSkill({
+          name: skill.name,
+          frontmatter,
+          body,
+          content: skill.content,
+        });
+        if (!validation.valid) {
+          return reply
+            .code(400)
+            .send({ error: `invalid Skill "${skill.name}": ${validation.error}` });
+        }
+      }
 
       const installed: string[] = [];
       for (const skill of chosen as DiscoveredSkill[]) {

--- a/apps/api/src/soul/skills/tools.test.ts
+++ b/apps/api/src/soul/skills/tools.test.ts
@@ -28,6 +28,10 @@ const FAKE_REPORT = {
   findings: [],
 };
 
+function frontmatter(name: string, fields: Record<string, unknown> = {}): Record<string, unknown> {
+  return { name, description: `Instructions for ${name}.`, ...fields };
+}
+
 function makeGitSync(soulPath = "/fake/soul"): GitSyncService {
   return {
     path: soulPath,
@@ -81,7 +85,11 @@ describe("skill_create", () => {
   it("writes SKILL.md with _pendingAudit marker, commits, reloads, returns auditReport", async () => {
     const ctx = makeCtx([], makeLlmService());
     const res = await createTool.handler(
-      { name: "code-review", body: "Review code carefully." },
+      {
+        name: "code-review",
+        body: "Review code carefully.",
+        frontmatter: frontmatter("code-review"),
+      },
       ctx
     );
 
@@ -89,7 +97,7 @@ describe("skill_create", () => {
       success: true,
       data: {
         name: "code-review",
-        frontmatter: {},
+        frontmatter: frontmatter("code-review"),
         body: "Review code carefully.",
         auditReport: FAKE_REPORT,
       },
@@ -109,7 +117,11 @@ describe("skill_create", () => {
   it("includes user frontmatter in SKILL.md alongside _pendingAudit", async () => {
     const ctx = makeCtx([], makeLlmService());
     const res = await createTool.handler(
-      { name: "planner", body: "Plan tasks.", frontmatter: { tags: ["planning"] } },
+      {
+        name: "planner",
+        body: "Plan tasks.",
+        frontmatter: frontmatter("planner", { tags: ["planning"] }),
+      },
       ctx
     );
 
@@ -121,40 +133,55 @@ describe("skill_create", () => {
     expect(content).toContain("Plan tasks.");
     // Returned frontmatter excludes _pendingAudit (internal marker not surfaced to caller).
     const data = (res as { success: true; data: { frontmatter: unknown } }).data;
-    expect(data.frontmatter).toEqual({ tags: ["planning"] });
+    expect(data.frontmatter).toEqual(frontmatter("planner", { tags: ["planning"] }));
   });
 
   it("returns audit_required if llmService absent from context", async () => {
     const ctx = makeCtx();
-    const res = await createTool.handler({ name: "code-review", body: "body" }, ctx);
+    const res = await createTool.handler(
+      { name: "code-review", body: "body", frontmatter: frontmatter("code-review") },
+      ctx
+    );
     expect(res).toMatchObject({ success: false, error: { code: "audit_required" } });
     expect(mkdir).not.toHaveBeenCalled();
   });
 
   it("returns audit_required if LlmNotConfiguredError thrown by llmService.select", async () => {
     const ctx = makeCtx([], makeLlmService(false));
-    const res = await createTool.handler({ name: "code-review", body: "body" }, ctx);
+    const res = await createTool.handler(
+      { name: "code-review", body: "body", frontmatter: frontmatter("code-review") },
+      ctx
+    );
     expect(res).toMatchObject({ success: false, error: { code: "audit_required" } });
     expect(mkdir).not.toHaveBeenCalled();
   });
 
   it("returns validation_error for invalid name (uppercase)", async () => {
     const ctx = makeCtx([], makeLlmService());
-    const res = await createTool.handler({ name: "CodeReview", body: "body" }, ctx);
+    const res = await createTool.handler(
+      { name: "CodeReview", body: "body", frontmatter: frontmatter("CodeReview") },
+      ctx
+    );
     expect(res).toMatchObject({ success: false, error: { code: "validation_error" } });
     expect(ctx.gitSync.withSync).not.toHaveBeenCalled();
   });
 
-  it("returns validation_error for name starting with digit", async () => {
+  it("accepts a schema-valid name starting with a digit", async () => {
     const ctx = makeCtx([], makeLlmService());
-    const res = await createTool.handler({ name: "1skill", body: "body" }, ctx);
-    expect(res).toMatchObject({ success: false, error: { code: "validation_error" } });
+    const res = await createTool.handler(
+      { name: "1skill", body: "body", frontmatter: frontmatter("1skill") },
+      ctx
+    );
+    expect(res).toMatchObject({ success: true, data: { name: "1skill" } });
   });
 
   it("returns validation_error if skill dir already exists", async () => {
     vi.mocked(existsSync).mockReturnValue(true);
     const ctx = makeCtx([], makeLlmService());
-    const res = await createTool.handler({ name: "code-review", body: "body" }, ctx);
+    const res = await createTool.handler(
+      { name: "code-review", body: "body", frontmatter: frontmatter("code-review") },
+      ctx
+    );
     expect(res).toMatchObject({
       success: false,
       error: { code: "validation_error", message: expect.stringContaining("already exists") },
@@ -167,6 +194,52 @@ describe("skill_create", () => {
     const res = await createTool.handler({ name: "skill-x" }, ctx);
     expect(res).toMatchObject({ success: false, error: { code: "validation_error" } });
   });
+
+  it("requires caller-authored name and description frontmatter", async () => {
+    const ctx = makeCtx([], makeLlmService());
+    const res = await createTool.handler(
+      { name: "skill-x", body: "Body.", frontmatter: { name: "skill-x" } },
+      ctx
+    );
+    expect(res).toMatchObject({ success: false, error: { code: "validation_error" } });
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+
+  it("rejects reserved frontmatter before selecting an audit model or writing", async () => {
+    const llmService = makeLlmService();
+    const ctx = makeCtx([], llmService);
+    const res = await createTool.handler(
+      {
+        name: "skill-x",
+        body: "Body.",
+        frontmatter: frontmatter("skill-x", { _pendingAudit: false }),
+      },
+      ctx
+    );
+    expect(res).toMatchObject({
+      success: false,
+      error: { code: "validation_error", message: expect.stringContaining("_pendingAudit") },
+    });
+    expect(llmService.select).not.toHaveBeenCalled();
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+
+  it("rejects a final serialized file over 100,000 characters", async () => {
+    const ctx = makeCtx([], makeLlmService());
+    const res = await createTool.handler(
+      {
+        name: "skill-x",
+        body: "x".repeat(100_000),
+        frontmatter: frontmatter("skill-x"),
+      },
+      ctx
+    );
+    expect(res).toMatchObject({
+      success: false,
+      error: { code: "validation_error", message: expect.stringContaining("100,000") },
+    });
+    expect(writeFile).not.toHaveBeenCalled();
+  });
 });
 
 // ── skill_activate ────────────────────────────────────────────────────────────
@@ -178,7 +251,7 @@ describe("skill_activate", () => {
 
   const pendingSkill: SoulSkill = {
     name: "code-review",
-    frontmatter: { _pendingAudit: true, tags: ["review"] },
+    frontmatter: frontmatter("code-review", { _pendingAudit: true, tags: ["review"] }),
     body: "Review code.",
   };
 
@@ -195,7 +268,9 @@ describe("skill_activate", () => {
   });
 
   it("returns validation_error if skill is already active (no _pendingAudit)", async () => {
-    const ctx = makeCtx([{ name: "code-review", frontmatter: {}, body: "body" }]);
+    const ctx = makeCtx([
+      { name: "code-review", frontmatter: frontmatter("code-review"), body: "body" },
+    ]);
     const res = await activateTool.handler({ name: "code-review" }, ctx);
     expect(res).toMatchObject({
       success: false,
@@ -215,6 +290,19 @@ describe("skill_activate", () => {
     const res = await activateTool.handler({}, ctx);
     expect(res).toMatchObject({ success: false, error: { code: "validation_error" } });
   });
+
+  it("refuses to activate malformed legacy frontmatter", async () => {
+    const ctx = makeCtx([
+      {
+        name: "code-review",
+        frontmatter: { name: "code-review", _pendingAudit: true },
+        body: "Body.",
+      },
+    ]);
+    const res = await activateTool.handler({ name: "code-review" }, ctx);
+    expect(res).toMatchObject({ success: false, error: { code: "validation_error" } });
+    expect(writeFile).not.toHaveBeenCalled();
+  });
 });
 
 // ── skill_update ──────────────────────────────────────────────────────────────
@@ -222,7 +310,7 @@ describe("skill_activate", () => {
 describe("skill_update", () => {
   const existingSkill: SoulSkill = {
     name: "code-review",
-    frontmatter: { tags: ["review"] },
+    frontmatter: frontmatter("code-review", { tags: ["review"] }),
     body: "Old body.",
   };
 
@@ -236,7 +324,11 @@ describe("skill_update", () => {
 
     expect(res).toMatchObject({
       success: true,
-      data: { name: "code-review", frontmatter: { tags: ["review"] }, body: "New body." },
+      data: {
+        name: "code-review",
+        frontmatter: frontmatter("code-review", { tags: ["review"] }),
+        body: "New body.",
+      },
     });
     expect(writeFile).toHaveBeenCalledWith(
       expect.stringContaining("SKILL.md"),
@@ -250,7 +342,10 @@ describe("skill_update", () => {
   it("updates frontmatter only, preserves existing body", async () => {
     const ctx = makeCtx([existingSkill]);
     const res = await updateTool.handler(
-      { name: "code-review", frontmatter: { tags: ["review", "security"] } },
+      {
+        name: "code-review",
+        frontmatter: frontmatter("code-review", { tags: ["review", "security"] }),
+      },
       ctx
     );
 
@@ -258,7 +353,7 @@ describe("skill_update", () => {
       success: true,
       data: {
         name: "code-review",
-        frontmatter: { tags: ["review", "security"] },
+        frontmatter: frontmatter("code-review", { tags: ["review", "security"] }),
         body: "Old body.",
       },
     });
@@ -267,14 +362,64 @@ describe("skill_update", () => {
   it("updates both body and frontmatter", async () => {
     const ctx = makeCtx([existingSkill]);
     const res = await updateTool.handler(
-      { name: "code-review", body: "New.", frontmatter: { version: "2" } },
+      {
+        name: "code-review",
+        body: "New.",
+        frontmatter: frontmatter("code-review", { version: "2" }),
+      },
       ctx
     );
 
     expect(res).toMatchObject({
       success: true,
-      data: { name: "code-review", frontmatter: { version: "2" }, body: "New." },
+      data: {
+        name: "code-review",
+        frontmatter: frontmatter("code-review", { version: "2" }),
+        body: "New.",
+      },
     });
+  });
+
+  it("preserves a server-set pending audit marker without returning it as public frontmatter", async () => {
+    const pending: SoulSkill = {
+      name: "code-review",
+      frontmatter: frontmatter("code-review", { _pendingAudit: true }),
+      body: "Old body.",
+    };
+    const ctx = makeCtx([pending]);
+
+    const res = await updateTool.handler(
+      {
+        name: "code-review",
+        frontmatter: frontmatter("code-review", { version: "2" }),
+      },
+      ctx
+    );
+
+    expect(res).toMatchObject({
+      success: true,
+      data: {
+        frontmatter: frontmatter("code-review", { version: "2" }),
+      },
+    });
+    const content = vi.mocked(writeFile).mock.calls[0][1] as string;
+    expect(content).toContain("_pendingAudit: true");
+  });
+
+  it("rejects caller attempts to set the pending audit marker", async () => {
+    const ctx = makeCtx([existingSkill]);
+    const res = await updateTool.handler(
+      {
+        name: "code-review",
+        frontmatter: frontmatter("code-review", { _pendingAudit: true }),
+      },
+      ctx
+    );
+    expect(res).toMatchObject({
+      success: false,
+      error: { code: "validation_error", message: expect.stringContaining("_pendingAudit") },
+    });
+    expect(writeFile).not.toHaveBeenCalled();
   });
 
   it("returns not_found for unknown skill", async () => {

--- a/apps/api/src/soul/skills/tools.ts
+++ b/apps/api/src/soul/skills/tools.ts
@@ -2,13 +2,16 @@ import { existsSync } from "node:fs";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { LlmService } from "@tulipfarm/llm";
-import { ajv, LlmNotConfiguredError } from "@tulipfarm/schema";
+import {
+  ajv,
+  LlmNotConfiguredError,
+  SkillFrontmatterSchema,
+  serializeSkill,
+  validateSkill,
+} from "@tulipfarm/schema";
 import type { GitSyncService, SoulLoader } from "@tulipfarm/soul";
-import { stringify } from "yaml";
 import { err, ok, type ToolCallResult } from "../../tools/types.js";
 import { buildAudit } from "./audit.js";
-
-const NAME_RE = /^[a-z][a-z0-9-]*$/;
 
 export interface SkillToolContext {
   gitSync: GitSyncService;
@@ -34,27 +37,45 @@ function firstError(validate: ReturnType<typeof ajv.compile>): string {
   return `${e.instancePath || "(root)"} ${e.message ?? "is invalid"}`.trim();
 }
 
-function serializeSkill(frontmatter: Record<string, unknown>, body: string): string {
-  if (Object.keys(frontmatter).length === 0) return body;
-  return `---\n${stringify(frontmatter)}---\n${body}`;
+const PUBLIC_FRONTMATTER_SCHEMA = {
+  ...SkillFrontmatterSchema,
+  properties: {
+    name: SkillFrontmatterSchema.properties.name,
+    description: SkillFrontmatterSchema.properties.description,
+    eager: SkillFrontmatterSchema.properties.eager,
+    category: SkillFrontmatterSchema.properties.category,
+    version: SkillFrontmatterSchema.properties.version,
+    author: SkillFrontmatterSchema.properties.author,
+    license: SkillFrontmatterSchema.properties.license,
+  },
+} as const;
+
+function publicFrontmatter(frontmatter: Record<string, unknown>): {
+  frontmatter: Record<string, unknown>;
+  pendingAudit: boolean;
+} {
+  const { _pendingAudit: pendingAudit, ...publicFields } = frontmatter;
+  return { frontmatter: publicFields, pendingAudit: pendingAudit === true };
 }
 
 // ── skill_create ──────────────────────────────────────────────────────────────
 
 const CREATE_SCHEMA = {
   type: "object",
-  required: ["name", "body"],
+  required: ["name", "body", "frontmatter"],
   additionalProperties: false,
   properties: {
     name: {
       type: "string",
       minLength: 1,
-      description: "Skill name (kebab-case, e.g. 'code-review'). Becomes the soul directory name.",
+      description:
+        "Skill name using lowercase letters, numbers, dots, underscores, or hyphens. Becomes the soul directory name.",
     },
     body: { type: "string", description: "Markdown skill body (instructions/content)." },
     frontmatter: {
-      type: "object",
-      description: "Optional YAML frontmatter fields (arbitrary key-value pairs).",
+      ...PUBLIC_FRONTMATTER_SCHEMA,
+      description:
+        "YAML frontmatter. name must match the Skill name and description is required. Unknown benign fields are allowed; underscore-prefixed and authority-grant fields are forbidden.",
     },
   },
 } as const;
@@ -69,17 +90,16 @@ const skillCreate: SkillTool = {
   inputSchema: CREATE_SCHEMA,
   handler: async (args, ctx) => {
     if (!validateCreate(args)) return err("validation_error", firstError(validateCreate));
-    const {
-      name,
-      body,
-      frontmatter = {},
-    } = args as {
+    const { name, body, frontmatter } = args as {
       name: string;
       body: string;
-      frontmatter?: Record<string, unknown>;
+      frontmatter: Record<string, unknown>;
     };
 
-    if (!NAME_RE.test(name)) return err("validation_error", "invalid skill name");
+    const pendingFm = { ...frontmatter, _pendingAudit: true };
+    const content = serializeSkill(pendingFm, body);
+    const validation = validateSkill({ name, frontmatter, body, content });
+    if (!validation.valid) return err("validation_error", validation.error);
 
     const skillDir = join(ctx.gitSync.path, "skills", name);
     if (existsSync(skillDir)) return err("validation_error", "skill already exists");
@@ -105,10 +125,9 @@ const skillCreate: SkillTool = {
     }
 
     // Write with _pendingAudit marker so the skill is committed but inactive until operator confirms.
-    const pendingFm = { ...frontmatter, _pendingAudit: true };
     try {
       await mkdir(skillDir, { recursive: true });
-      await writeFile(join(skillDir, "SKILL.md"), serializeSkill(pendingFm, body), "utf8");
+      await writeFile(join(skillDir, "SKILL.md"), content, "utf8");
     } catch (e) {
       return err("internal_error", reason(e));
     }
@@ -130,8 +149,7 @@ const skillCreate: SkillTool = {
     try {
       auditReport = await buildAudit(model, {
         name,
-        description:
-          typeof frontmatter.description === "string" ? frontmatter.description : undefined,
+        description: validation.frontmatter.description,
         body,
       });
     } catch (e) {
@@ -155,9 +173,9 @@ const UPDATE_SCHEMA = {
     name: { type: "string", minLength: 1, description: "Skill name to update." },
     body: { type: "string", description: "New markdown body (replaces existing)." },
     frontmatter: {
-      type: "object",
+      ...PUBLIC_FRONTMATTER_SCHEMA,
       description:
-        "New frontmatter (replaces existing). Omit to keep current. At least one of body or frontmatter must be provided.",
+        "New complete frontmatter (replaces existing). name and description are required. Omit to keep current. At least one of body or frontmatter must be provided.",
     },
   },
 } as const;
@@ -183,12 +201,17 @@ const skillUpdate: SkillTool = {
     const existing = ctx.soulLoader.skills.get(name);
     if (!existing) return err("not_found", `skill not found: ${name}`);
 
+    const existingPublic = publicFrontmatter(existing.frontmatter);
     const newBody = body ?? existing.body;
-    const newFm = frontmatter ?? existing.frontmatter;
+    const newFm = frontmatter ?? existingPublic.frontmatter;
+    const persistedFm = existingPublic.pendingAudit ? { ...newFm, _pendingAudit: true } : newFm;
+    const content = serializeSkill(persistedFm, newBody);
+    const validation = validateSkill({ name, frontmatter: newFm, body: newBody, content });
+    if (!validation.valid) return err("validation_error", validation.error);
 
     const skillFile = join(ctx.gitSync.path, "skills", name, "SKILL.md");
     try {
-      await writeFile(skillFile, serializeSkill(newFm, newBody), "utf8");
+      await writeFile(skillFile, content, "utf8");
     } catch (e) {
       return err("internal_error", reason(e));
     }
@@ -205,7 +228,7 @@ const skillUpdate: SkillTool = {
       return err("internal_error", reason(e));
     }
 
-    return ok({ name, frontmatter: newFm, body: newBody });
+    return ok({ name, frontmatter: validation.frontmatter, body: newBody });
   },
 };
 
@@ -339,9 +362,18 @@ const skillActivate: SkillTool = {
     }
 
     const { _pendingAudit: _removed, ...activeFm } = skill.frontmatter;
+    const content = serializeSkill(activeFm, skill.body);
+    const validation = validateSkill({
+      name,
+      frontmatter: activeFm,
+      body: skill.body,
+      content,
+    });
+    if (!validation.valid) return err("validation_error", validation.error);
+
     const skillFile = join(ctx.gitSync.path, "skills", name, "SKILL.md");
     try {
-      await writeFile(skillFile, serializeSkill(activeFm, skill.body), "utf8");
+      await writeFile(skillFile, content, "utf8");
     } catch (e) {
       return err("internal_error", reason(e));
     }

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -66,6 +66,16 @@ export {
   RoutineDefinitionSchema,
   validateRoutineDefinition,
 } from "./routine";
+export type {
+  SkillFrontmatter,
+  SkillValidationInput,
+  SkillValidationResult,
+} from "./skill-frontmatter";
+export {
+  SkillFrontmatterSchema,
+  serializeSkill,
+  validateSkill,
+} from "./skill-frontmatter";
 export type { CounterFn } from "./transforms";
 export {
   applyTransforms,

--- a/packages/schema/src/skill-frontmatter.test.ts
+++ b/packages/schema/src/skill-frontmatter.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { SKILL_FORBIDDEN_GRANT_KEYS } from "./definitions/skill";
+import { serializeSkill, validateSkill } from "./skill-frontmatter";
+
+const VALID_FRONTMATTER = {
+  name: "code-review",
+  description: "Review code for correctness.",
+};
+
+function validate(
+  frontmatter: Record<string, unknown> = VALID_FRONTMATTER,
+  body = "Follow the review procedure.",
+  content = serializeSkill(frontmatter, body),
+  name = "code-review"
+) {
+  return validateSkill({ name, frontmatter, body, content });
+}
+
+describe("validateSkill", () => {
+  it.each([
+    ["uppercase", "Foo"],
+    ["leading hyphen", "-bad"],
+    ["65 characters", "a".repeat(65)],
+  ])("rejects an invalid name: %s", (_label, name) => {
+    expect(validate({ ...VALID_FRONTMATTER, name }, "Body.", undefined, name)).toMatchObject({
+      valid: false,
+    });
+  });
+
+  it("accepts the name length and character boundaries", () => {
+    const name = `1.${"a".repeat(61)}_`;
+    expect(name).toHaveLength(64);
+    expect(validate({ ...VALID_FRONTMATTER, name }, "Body.", undefined, name)).toMatchObject({
+      valid: true,
+    });
+  });
+
+  it("accepts a 1024-character description and rejects 1025 characters", () => {
+    expect(validate({ ...VALID_FRONTMATTER, description: "d".repeat(1024) })).toMatchObject({
+      valid: true,
+    });
+    expect(validate({ ...VALID_FRONTMATTER, description: "d".repeat(1025) })).toMatchObject({
+      valid: false,
+    });
+  });
+
+  it("rejects an empty or whitespace-only body", () => {
+    expect(validate(VALID_FRONTMATTER, " \n\t")).toEqual({
+      valid: false,
+      error: "SKILL.md body must not be empty",
+    });
+  });
+
+  it("accepts exactly 100,000 characters and rejects 100,001", () => {
+    expect(validate(VALID_FRONTMATTER, "Body.", "x".repeat(100_000))).toMatchObject({
+      valid: true,
+    });
+    expect(validate(VALID_FRONTMATTER, "Body.", "x".repeat(100_001))).toEqual({
+      valid: false,
+      error: "SKILL.md content exceeds 100,000 characters",
+    });
+  });
+
+  it("rejects a frontmatter name that differs from the directory name", () => {
+    expect(validate({ ...VALID_FRONTMATTER, name: "other-skill" })).toEqual({
+      valid: false,
+      error: 'frontmatter.name must equal the Skill directory name "code-review"',
+    });
+  });
+
+  it("rejects agent-supplied _pendingAudit and nested underscore-prefixed keys", () => {
+    expect(validate({ ...VALID_FRONTMATTER, _pendingAudit: true })).toEqual({
+      valid: false,
+      error: "frontmatter._pendingAudit is reserved for server use",
+    });
+    expect(
+      validate({
+        ...VALID_FRONTMATTER,
+        metadata: { settings: [{ _serverOnly: true }] },
+      })
+    ).toEqual({
+      valid: false,
+      error: "frontmatter.metadata.settings[0]._serverOnly is reserved for server use",
+    });
+  });
+
+  it.each(SKILL_FORBIDDEN_GRANT_KEYS)("rejects grant-shaped key %s", (key) => {
+    expect(validate({ ...VALID_FRONTMATTER, [key]: ["tool"] })).toMatchObject({
+      valid: false,
+      error: expect.stringContaining(`frontmatter.${key}`),
+    });
+  });
+
+  it("rejects nested grant-shaped keys", () => {
+    expect(
+      validate({
+        ...VALID_FRONTMATTER,
+        metadata: { authority: { permissions: ["write"] } },
+      })
+    ).toEqual({
+      valid: false,
+      error:
+        "frontmatter.metadata.authority.permissions is forbidden because a Skill cannot grant authority",
+    });
+  });
+
+  it("accepts unknown benign keys for forward compatibility", () => {
+    const result = validate({
+      ...VALID_FRONTMATTER,
+      platforms: ["macos", "linux"],
+      metadata: { tags: ["review"], config: [{ key: "review.depth", default: "normal" }] },
+    });
+    expect(result).toMatchObject({ valid: true });
+  });
+});

--- a/packages/schema/src/skill-frontmatter.ts
+++ b/packages/schema/src/skill-frontmatter.ts
@@ -1,0 +1,140 @@
+import { stringify } from "yaml";
+import { ajv } from "./ajv";
+import { SKILL_FORBIDDEN_GRANT_KEYS } from "./definitions/skill";
+
+const MAX_SKILL_CONTENT_CHARS = 100_000;
+
+export const SkillFrontmatterSchema = {
+  type: "object",
+  required: ["name", "description"],
+  additionalProperties: true,
+  properties: {
+    name: {
+      type: "string",
+      maxLength: 64,
+      pattern: "^[a-z0-9][a-z0-9._-]*$",
+    },
+    description: { type: "string", minLength: 1, maxLength: 1024 },
+    eager: { type: "boolean" },
+    category: {
+      type: "string",
+      maxLength: 64,
+      pattern: "^[a-z0-9][a-z0-9._-]*$",
+    },
+    version: { type: "string" },
+    author: { type: "string" },
+    license: { type: "string" },
+    _pendingAudit: { type: "boolean" },
+  },
+} as const;
+
+export interface SkillFrontmatter {
+  name: string;
+  description: string;
+  eager?: boolean;
+  category?: string;
+  version?: string;
+  author?: string;
+  license?: string;
+  _pendingAudit?: boolean;
+  [key: string]: unknown;
+}
+
+export interface SkillValidationInput {
+  name: string;
+  frontmatter: unknown;
+  body: string;
+  /** Exact raw or would-be-written SKILL.md content used for the character limit. */
+  content: string;
+}
+
+export type SkillValidationResult =
+  | { valid: true; frontmatter: SkillFrontmatter }
+  | { valid: false; error: string };
+
+const checkFrontmatter = ajv.compile(SkillFrontmatterSchema);
+const forbiddenGrantKeys = new Set<string>(SKILL_FORBIDDEN_GRANT_KEYS);
+
+function firstSchemaError(): string {
+  const error = checkFrontmatter.errors?.[0];
+  if (!error) return "invalid Skill frontmatter";
+  return `${error.instancePath || "(root)"} ${error.message ?? "is invalid"}`.trim();
+}
+
+function reservedKeyError(
+  value: unknown,
+  path = "frontmatter",
+  seen = new Set<object>()
+): string | undefined {
+  if (value === null || typeof value !== "object") return undefined;
+  if (seen.has(value)) return undefined;
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    for (const [index, item] of value.entries()) {
+      const error = reservedKeyError(item, `${path}[${index}]`, seen);
+      if (error) return error;
+    }
+    return undefined;
+  }
+
+  for (const key of Object.getOwnPropertyNames(value)) {
+    const keyPath = `${path}.${key}`;
+    if (key.startsWith("_")) {
+      return `${keyPath} is reserved for server use`;
+    }
+    if (forbiddenGrantKeys.has(key)) {
+      return `${keyPath} is forbidden because a Skill cannot grant authority`;
+    }
+    const error = reservedKeyError((value as Record<string, unknown>)[key], keyPath, seen);
+    if (error) return error;
+  }
+  return undefined;
+}
+
+/**
+ * Validate a SKILL.md candidate at a write boundary without throwing.
+ *
+ * `content` must be the exact raw or serialized value the caller will write. Keeping it explicit
+ * prevents raw marketplace files with large comments or whitespace from bypassing the size limit
+ * through parse-and-reserialize normalization.
+ */
+export function validateSkill(input: SkillValidationInput): SkillValidationResult {
+  if (!checkFrontmatter(input.frontmatter)) {
+    return { valid: false, error: firstSchemaError() };
+  }
+
+  const frontmatter = input.frontmatter as SkillFrontmatter;
+  if (frontmatter.name !== input.name) {
+    return {
+      valid: false,
+      error: `frontmatter.name must equal the Skill directory name "${input.name}"`,
+    };
+  }
+
+  const keyError = reservedKeyError(frontmatter);
+  if (keyError) return { valid: false, error: keyError };
+
+  if (input.body.trim().length === 0) {
+    return { valid: false, error: "SKILL.md body must not be empty" };
+  }
+
+  if (input.content.length > MAX_SKILL_CONTENT_CHARS) {
+    return {
+      valid: false,
+      error: `SKILL.md content exceeds ${MAX_SKILL_CONTENT_CHARS.toLocaleString("en-US")} characters`,
+    };
+  }
+
+  return { valid: true, frontmatter };
+}
+
+/**
+ * Serialize a validated Skill consistently for soul write boundaries.
+ *
+ * Internal server fields may be present in `frontmatter`; callers validate the public frontmatter
+ * separately and pass this exact result back to `validateSkill` for content-size enforcement.
+ */
+export function serializeSkill(frontmatter: Record<string, unknown>, body: string): string {
+  return `---\n${stringify(frontmatter)}---\n${body}`;
+}

--- a/packages/soul/src/index.ts
+++ b/packages/soul/src/index.ts
@@ -85,7 +85,7 @@ export {
   SoulPublicationCoordinator,
   SoulPublicationError,
 } from "./publication";
-export { SoulLoader } from "./published-loader";
+export { parseFrontmatter, SoulLoader } from "./published-loader";
 export type { SoulSemanticIssue, SoulSemanticIssueCode } from "./refs";
 export { SoulSemanticValidationError } from "./refs";
 export { validateSoulSemantics } from "./semantic";

--- a/packages/soul/src/published-loader.ts
+++ b/packages/soul/src/published-loader.ts
@@ -16,7 +16,10 @@ import type {
 
 const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/;
 
-function parseFrontmatter(content: string): { frontmatter: Record<string, unknown>; body: string } {
+export function parseFrontmatter(content: string): {
+  frontmatter: Record<string, unknown>;
+  body: string;
+} {
   const match = FRONTMATTER_RE.exec(content);
   if (!match) return { frontmatter: {}, body: content.trim() };
   const frontmatter = (parseYaml(match[1]) ?? {}) as Record<string, unknown>;


### PR DESCRIPTION
## Summary

- add the shared Skill frontmatter schema and non-throwing validator, including exact size limits and recursive reserved-key protection
- enforce validation across Skill authoring, activation, marketplace installation, and bundled-Skill boot discovery
- add boundary, malformed-input, marker-preservation, and atomic-install coverage for the Step 4 acceptance criteria

## Why

Step 4 establishes the write-time Skill contract required before the remaining handoff steps can safely create or install Skills. Unknown benign metadata remains forward-compatible, while server-owned and grant-like keys are rejected at any nesting depth.

## User impact

Invalid Skills are rejected before filesystem mutation or activation. Marketplace installs preflight every selected Skill atomically, and pending-audit state remains server-controlled.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm architecture:check`
- [x] `git diff --check`