### PR TITLE
feat(skills): add catalog categories and update checks

### DIFF
--- a/apps/api/src/soul/skills/routes.test.ts
+++ b/apps/api/src/soul/skills/routes.test.ts
@@ -82,10 +82,11 @@ const skill = (name: string, description: string): SoulSkill => ({
 // marketplace.json (the curated-catalog manifest read by GET /api/v1/skills/marketplace).
 async function makeRemoteRepo(
   manifest?: unknown,
-  skillContent = "---\nname: demo-skill\ndescription: A demo skill.\n---\nDo the demo."
+  skillContent = "---\nname: demo-skill\ndescription: A demo skill.\n---\nDo the demo.",
+  category?: string
 ): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), "skill-remote-"));
-  const skillDir = join(dir, "skills", "demo-skill");
+  const skillDir = category ? join(dir, category, "demo-skill") : join(dir, "skills", "demo-skill");
   await mkdir(skillDir, { recursive: true });
   await writeFile(join(skillDir, "SKILL.md"), skillContent, "utf8");
   if (manifest !== undefined) {
@@ -827,6 +828,7 @@ describe("skills routes", () => {
             skillId: "demo-skill",
             name: "demo-skill",
             description: "Manifest description.",
+            category: "productivity",
             installs: 42,
             source: "tulipfarm/skills",
           },
@@ -853,6 +855,7 @@ describe("skills routes", () => {
           name: "demo-skill",
           skillId: "demo-skill",
           description: "A demo skill.",
+          category: "productivity",
           installs: 42,
           installed: false,
           updateAvailable: false,
@@ -876,6 +879,29 @@ describe("skills routes", () => {
         {
           name: "demo-skill",
           description: "A demo skill.",
+          installed: false,
+          updateAvailable: false,
+        },
+      ]);
+    });
+
+    it("derives category from the authoritative catalog directory", async () => {
+      const remote = await makeRemoteRepo(undefined, undefined, "productivity");
+      temps.push(remote);
+      process.env.MARKETPLACE_SOURCE = `file://${remote}`;
+
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/skills/marketplace",
+        cookies: auth(),
+        headers,
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json().skills).toEqual([
+        {
+          name: "demo-skill",
+          description: "A demo skill.",
+          category: "productivity",
           installed: false,
           updateAvailable: false,
         },
@@ -963,6 +989,133 @@ describe("skills routes", () => {
       expect(installed.statusCode).toBe(200);
       const lock = JSON.parse(await readFile(join(soulPath, "skills-lock.json"), "utf8"));
       expect(lock.skills["demo-skill"].sourceUrl).toBe(`file://${remote}`);
+    });
+  });
+
+  describe("GET /api/v1/skills/updates", () => {
+    afterEach(() => {
+      delete process.env.MARKETPLACE_SOURCE;
+    });
+
+    it("returns 401 without auth", async () => {
+      const res = await app.inject({ method: "GET", url: "/api/v1/skills/updates" });
+      expect(res.statusCode).toBe(401);
+    });
+
+    it("lists catalog drift and sends reinstall through audit and operator confirm", async () => {
+      const remote = await makeRemoteRepo({
+        version: 1,
+        skills: [
+          {
+            id: "tulipfarm/skills/productivity/demo-skill",
+            skillId: "demo-skill",
+            name: "demo-skill",
+            description: "A demo skill.",
+            category: "productivity",
+            installs: 42,
+            source: "tulipfarm/skills",
+          },
+        ],
+      });
+      temps.push(remote);
+      const source = `file://${remote}`;
+      process.env.MARKETPLACE_SOURCE = source;
+      soulLoader.skills.set("demo-skill", skill("demo-skill", "A demo skill."));
+      await writeFile(
+        join(soulPath, "skills-lock.json"),
+        JSON.stringify({
+          version: 1,
+          skills: {
+            "demo-skill": {
+              sourceUrl: source,
+              sourceType: "git",
+              hash: "0".repeat(64),
+            },
+          },
+        }),
+        "utf8"
+      );
+
+      const updates = await app.inject({
+        method: "GET",
+        url: "/api/v1/skills/updates",
+        cookies: auth(),
+        headers,
+      });
+      expect(updates.statusCode).toBe(200);
+      expect(updates.json().skills).toEqual([
+        {
+          name: "demo-skill",
+          skillId: "demo-skill",
+          description: "A demo skill.",
+          category: "productivity",
+          installs: 42,
+          installed: true,
+          updateAvailable: true,
+        },
+      ]);
+
+      const { scanId } = updates.json();
+      const blocked = await app.inject({
+        method: "POST",
+        url: "/api/v1/skills/install",
+        cookies: auth(),
+        headers,
+        payload: { scanId, names: ["demo-skill"] },
+      });
+      expect(blocked.statusCode).toBe(409);
+
+      buildAudit.mockResolvedValue({
+        riskRating: "low",
+        summary: "Benign.",
+        toolsReach: [],
+        findings: [],
+      });
+      await app.inject({
+        method: "POST",
+        url: "/api/v1/skills/audit",
+        cookies: auth(),
+        headers,
+        payload: { scanId, name: "demo-skill" },
+      });
+      const installed = await app.inject({
+        method: "POST",
+        url: "/api/v1/skills/install",
+        cookies: auth(),
+        headers,
+        payload: { scanId, names: ["demo-skill"] },
+      });
+      expect(installed.statusCode).toBe(200);
+    });
+
+    it("does not report a same-name Skill installed from another source", async () => {
+      const remote = await makeRemoteRepo();
+      temps.push(remote);
+      process.env.MARKETPLACE_SOURCE = `file://${remote}`;
+      soulLoader.skills.set("demo-skill", skill("demo-skill", "A demo skill."));
+      await writeFile(
+        join(soulPath, "skills-lock.json"),
+        JSON.stringify({
+          version: 1,
+          skills: {
+            "demo-skill": {
+              sourceUrl: "owner/other-catalog",
+              sourceType: "github",
+              hash: "0".repeat(64),
+            },
+          },
+        }),
+        "utf8"
+      );
+
+      const updates = await app.inject({
+        method: "GET",
+        url: "/api/v1/skills/updates",
+        cookies: auth(),
+        headers,
+      });
+      expect(updates.statusCode).toBe(200);
+      expect(updates.json().skills).toEqual([]);
     });
   });
 });

--- a/apps/api/src/soul/skills/routes.ts
+++ b/apps/api/src/soul/skills/routes.ts
@@ -41,6 +41,7 @@ const MAX_SCANS = 25;
 export interface DiscoveredSkill {
   name: string;
   description?: string;
+  category?: string;
   // Path of the SKILL.md relative to the repo root (recorded in skills-lock.json).
   skillPath: string;
   // Raw SKILL.md content (frontmatter + body), written verbatim on install.
@@ -109,6 +110,12 @@ function sourceType(source: string): "github" | "git" {
   return /github\.com|^[\w.-]+\/[\w.-]+$/.test(base) ? "github" : "git";
 }
 
+function categoryFromSkillPath(skillPath: string): string | undefined {
+  const parts = skillPath.split(/[\\/]/).slice(0, -2);
+  if (parts[0] === "skills") parts.shift();
+  return parts[0];
+}
+
 /**
  * Walk a directory tree for SKILL.md files and parse each into a DiscoveredSkill. Skips .git and
  * node_modules. Skills whose directory name is not a safe Skill identifier are dropped (that name
@@ -132,6 +139,7 @@ export async function discoverSkills(root: string): Promise<DiscoveredSkill[]> {
         out.push({
           name,
           description: asString(frontmatter.description),
+          category: categoryFromSkillPath(relative(root, full)),
           skillPath: relative(root, full),
           content,
         });
@@ -233,6 +241,7 @@ interface MarketplaceManifestEntry {
   skillId?: string;
   name?: string;
   description?: string;
+  category?: string;
   installs?: number;
 }
 
@@ -248,6 +257,7 @@ interface MarketplaceResponse {
     name: string;
     skillId?: string;
     description?: string;
+    category?: string;
     installs?: number;
     installed: boolean;
     updateAvailable: boolean;
@@ -258,7 +268,7 @@ interface MarketplaceResponse {
 // matching scan entry is still alive (pruning/cap can evict it independently).
 const marketplaceCache = new Map<
   string,
-  { scanId: string; expires: number; response: MarketplaceResponse }
+  { scanId: string; expires: number; manifest: Map<string, MarketplaceManifestEntry> }
 >();
 
 async function readManifest(dir: string): Promise<Map<string, MarketplaceManifestEntry>> {
@@ -280,12 +290,79 @@ async function readManifest(dir: string): Promise<Map<string, MarketplaceManifes
   return byName;
 }
 
+async function loadMarketplace(
+  gitSync: GitSyncService,
+  soulLoader: SoulLoader,
+  bundledSkills: ReadonlyMap<string, BundledSkill>,
+  disabledBundledSkills: ReadonlySet<string>
+): Promise<MarketplaceResponse> {
+  const source = marketplaceSource();
+  const now = Date.now();
+  const cached = marketplaceCache.get(source);
+  const cachedScan = cached ? scans.get(cached.scanId) : undefined;
+  if (cached && cached.expires > now && cachedScan) {
+    const lock = await readLock(gitSync.path);
+    return {
+      scanId: cached.scanId,
+      source,
+      skills: cachedScan.skills.map((skill) => {
+        const meta = cached.manifest.get(skill.name);
+        const status = installStatus(skill, lock, soulLoader, bundledSkills, disabledBundledSkills);
+        return {
+          name: skill.name,
+          skillId: asString(meta?.skillId),
+          description: skill.description ?? asString(meta?.description),
+          category: skill.category ?? asString(meta?.category),
+          installs: typeof meta?.installs === "number" ? meta.installs : undefined,
+          installed: status.installed,
+          updateAvailable: status.updateAvailable && lock.skills[skill.name]?.sourceUrl === source,
+        };
+      }),
+    };
+  }
+
+  let dir: string | undefined;
+  try {
+    const clone = await cloneToTemp(source);
+    dir = clone.dir;
+    const discovered = await discoverSkills(dir);
+    const manifest = await readManifest(dir);
+    const scanId = randomUUID();
+    pruneScans(now);
+    scans.set(scanId, {
+      source,
+      ref: clone.ref,
+      skills: discovered,
+      audited: new Set(),
+      expires: now + SCAN_TTL_MS,
+    });
+    marketplaceCache.set(source, {
+      scanId,
+      expires: now + SCAN_TTL_MS,
+      manifest,
+    });
+    return loadMarketplace(gitSync, soulLoader, bundledSkills, disabledBundledSkills);
+  } finally {
+    if (dir) await rm(dir, { recursive: true, force: true });
+  }
+}
+
 const SummaryProps = {
   name: { type: "string" },
   description: { type: "string" },
   provenance: { type: "string", enum: ["builtin", "marketplace", "user"] },
   source: { type: "string" },
   pendingAudit: { type: "boolean" },
+} as const;
+
+const MarketplaceSkillProps = {
+  name: { type: "string" },
+  skillId: { type: "string" },
+  description: { type: "string" },
+  category: { type: "string" },
+  installs: { type: "number" },
+  installed: { type: "boolean" },
+  updateAvailable: { type: "boolean" },
 } as const;
 
 export function registerSkillRoutes(
@@ -356,14 +433,7 @@ export function registerSkillRoutes(
                 items: {
                   type: "object",
                   required: ["name", "installed", "updateAvailable"],
-                  properties: {
-                    name: { type: "string" },
-                    skillId: { type: "string" },
-                    description: { type: "string" },
-                    installs: { type: "number" },
-                    installed: { type: "boolean" },
-                    updateAvailable: { type: "boolean" },
-                  },
+                  properties: MarketplaceSkillProps,
                 },
               },
             },
@@ -376,51 +446,64 @@ export function registerSkillRoutes(
     async (_req, reply) => {
       // The catalog clone creates server-side scan state, so never let intermediaries cache it.
       reply.header("cache-control", "no-store");
-      const source = marketplaceSource();
-      const now = Date.now();
-      const cached = marketplaceCache.get(source);
-      if (cached && cached.expires > now && scans.has(cached.scanId)) return cached.response;
-
-      let dir: string | undefined;
       try {
-        const clone = await cloneToTemp(source);
-        dir = clone.dir;
-        const discovered = await discoverSkills(dir);
-        const manifest = await readManifest(dir);
-        const lock = await readLock(gitSync.path);
-        const scanId = randomUUID();
-        pruneScans(now);
-        // A real scan entry so the existing audit → operator-confirm install flow (and its 409
-        // audit gate, AC-V1-003) applies to marketplace installs unchanged.
-        scans.set(scanId, {
-          source,
-          ref: clone.ref,
-          skills: discovered,
-          audited: new Set(),
-          expires: now + SCAN_TTL_MS,
-        });
-        const response: MarketplaceResponse = {
-          scanId,
-          source,
-          skills: discovered.map((s) => {
-            const meta = manifest.get(s.name);
-            return {
-              name: s.name,
-              skillId: asString(meta?.skillId),
-              description: s.description ?? asString(meta?.description),
-              installs: typeof meta?.installs === "number" ? meta.installs : undefined,
-              ...installStatus(s, lock, soulLoader, bundledSkills, disabledBundledSkills),
-            };
-          }),
-        };
-        marketplaceCache.set(source, { scanId, expires: now + SCAN_TTL_MS, response });
-        return response;
+        return await loadMarketplace(gitSync, soulLoader, bundledSkills, disabledBundledSkills);
       } catch (e) {
         return reply.code(502).send({
           error: `marketplace unavailable: ${e instanceof Error ? e.message : String(e)}`,
         });
-      } finally {
-        if (dir) await rm(dir, { recursive: true, force: true });
+      }
+    }
+  );
+
+  app.get(
+    "/api/v1/skills/updates",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description:
+          "List installed marketplace Skills whose locked content hash differs from the current catalog.",
+        tags: ["skills"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        response: {
+          200: {
+            type: "object",
+            required: ["scanId", "source", "skills"],
+            properties: {
+              scanId: { type: "string" },
+              source: { type: "string" },
+              skills: {
+                type: "array",
+                items: {
+                  type: "object",
+                  required: ["name", "installed", "updateAvailable"],
+                  properties: MarketplaceSkillProps,
+                },
+              },
+            },
+          },
+          401: ErrorSchema,
+          502: ErrorSchema,
+        },
+      },
+    },
+    async (_req, reply) => {
+      reply.header("cache-control", "no-store");
+      try {
+        const marketplace = await loadMarketplace(
+          gitSync,
+          soulLoader,
+          bundledSkills,
+          disabledBundledSkills
+        );
+        return {
+          ...marketplace,
+          skills: marketplace.skills.filter((skill) => skill.updateAvailable),
+        };
+      } catch (e) {
+        return reply.code(502).send({
+          error: `marketplace unavailable: ${e instanceof Error ? e.message : String(e)}`,
+        });
       }
     }
   );

--- a/apps/web/app/lib/skills.ts
+++ b/apps/web/app/lib/skills.ts
@@ -30,6 +30,7 @@ export type MarketplaceSkill = {
   name: string;
   skillId?: string;
   description?: string;
+  category?: string;
   installs?: number;
 } & SkillInstallStatus;
 
@@ -83,6 +84,10 @@ export async function installSkills(
 
 export async function marketplaceSkills(): Promise<MarketplaceCatalog> {
   return apiGet<MarketplaceCatalog>("/api/v1/skills/marketplace");
+}
+
+export async function skillUpdates(): Promise<MarketplaceCatalog> {
+  return apiGet<MarketplaceCatalog>("/api/v1/skills/updates");
 }
 
 export async function removeSkill(name: string): Promise<void> {

--- a/apps/web/app/routes/_app.skills.marketplace.tsx
+++ b/apps/web/app/routes/_app.skills.marketplace.tsx
@@ -116,6 +116,14 @@ export default function SkillsMarketplace() {
 
   const selectedNames = [...selected];
   const allAudited = selectedNames.length > 0 && selectedNames.every((n) => reports[n]);
+  const catalogGroups = new Map<string, MarketplaceCatalog["skills"]>();
+  for (const skill of catalog?.skills ?? []) {
+    const category = skill.category ?? "other";
+    const group = catalogGroups.get(category);
+    if (group) group.push(skill);
+    else catalogGroups.set(category, [skill]);
+  }
+  const updateCount = catalog?.skills.filter((skill) => skill.updateAvailable).length ?? 0;
 
   // Load one or more catalog skills into the select → audit → confirm pipeline (the audit gate runs
   // unchanged). Used by the per-row Install/Update buttons and the "Review all" button.
@@ -221,48 +229,67 @@ export default function SkillsMarketplace() {
                 <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">
                   official marketplace · {catalog.source}
                 </p>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  disabled={busy !== null}
-                  onClick={() => loadIntoPipeline(catalog.scanId, catalog.skills)}
-                >
-                  Review all ({catalog.skills.length})
-                </Button>
+                <div className="flex items-center gap-2">
+                  {updateCount > 0 ? (
+                    <span className="rounded-sm border border-primary px-2 py-1 text-xs uppercase tracking-[0.15em] text-primary">
+                      {updateCount} {updateCount === 1 ? "update" : "updates"} available
+                    </span>
+                  ) : null}
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={busy !== null}
+                    onClick={() => loadIntoPipeline(catalog.scanId, catalog.skills)}
+                  >
+                    Review all ({catalog.skills.length})
+                  </Button>
+                </div>
               </div>
-              {/* List scrolls within the panel so the page itself does not grow with the catalog. */}
-              <ul className="flex max-h-96 flex-col divide-y divide-border overflow-y-auto rounded-sm border border-border">
-                {catalog.skills.map((s) => (
-                  <li key={s.name} className="flex items-center gap-3 px-3 py-2">
-                    <span className="font-medium text-foreground">{s.name}</span>
-                    {s.description ? (
-                      <span className="min-w-0 flex-1 truncate text-muted-foreground">
-                        {s.description}
-                      </span>
-                    ) : (
-                      <span className="flex-1" />
-                    )}
-                    {s.installs !== undefined ? (
-                      <span className="shrink-0 text-xs text-muted-foreground">
-                        {s.installs} installs
-                      </span>
-                    ) : null}
-                    {s.installed && !s.updateAvailable ? (
-                      <InstallBadge installed updateAvailable={false} />
-                    ) : (
-                      <Button
-                        size="sm"
-                        variant={s.updateAvailable ? "default" : "outline"}
-                        className="shrink-0"
-                        disabled={busy !== null}
-                        onClick={() => loadIntoPipeline(catalog.scanId, [s])}
-                      >
-                        {s.updateAvailable ? "Update" : "Install"}
-                      </Button>
-                    )}
-                  </li>
+              {/* Groups scroll within the panel so the page itself does not grow with the catalog. */}
+              <div className="flex max-h-96 flex-col gap-3 overflow-y-auto rounded-sm border border-border p-3">
+                {[...catalogGroups].map(([category, skills]) => (
+                  <section key={category} aria-labelledby={`category-${category}`}>
+                    <h2
+                      id={`category-${category}`}
+                      className="mb-1 text-xs uppercase tracking-[0.2em] text-muted-foreground"
+                    >
+                      {category.replaceAll("-", " ")}
+                    </h2>
+                    <ul className="flex flex-col divide-y divide-border rounded-sm border border-border">
+                      {skills.map((s) => (
+                        <li key={s.name} className="flex items-center gap-3 px-3 py-2">
+                          <span className="font-medium text-foreground">{s.name}</span>
+                          {s.description ? (
+                            <span className="min-w-0 flex-1 truncate text-muted-foreground">
+                              {s.description}
+                            </span>
+                          ) : (
+                            <span className="flex-1" />
+                          )}
+                          {s.installs !== undefined ? (
+                            <span className="shrink-0 text-xs text-muted-foreground">
+                              {s.installs} installs
+                            </span>
+                          ) : null}
+                          {s.installed && !s.updateAvailable ? (
+                            <InstallBadge installed updateAvailable={false} />
+                          ) : (
+                            <Button
+                              size="sm"
+                              variant={s.updateAvailable ? "default" : "outline"}
+                              className="shrink-0"
+                              disabled={busy !== null}
+                              onClick={() => loadIntoPipeline(catalog.scanId, [s])}
+                            >
+                              {s.updateAvailable ? "Update" : "Install"}
+                            </Button>
+                          )}
+                        </li>
+                      ))}
+                    </ul>
+                  </section>
                 ))}
-              </ul>
+              </div>
               <p className="border-t border-border pt-4 text-xs uppercase tracking-[0.2em] text-muted-foreground">
                 or install from any git repo
               </p>

--- a/apps/web/app/routes/skills.marketplace.test.tsx
+++ b/apps/web/app/routes/skills.marketplace.test.tsx
@@ -115,18 +115,21 @@ test("catalog rows badge installed and update-available skills", async () => {
       {
         name: "fresh-skill",
         description: "Not yet installed.",
+        category: "productivity",
         installed: false,
         updateAvailable: false,
       },
       {
         name: "current-skill",
         description: "Installed, current.",
+        category: "productivity",
         installed: true,
         updateAvailable: false,
       },
       {
         name: "stale-skill",
         description: "Installed, stale.",
+        category: "engineering",
         installed: true,
         updateAvailable: true,
       },
@@ -138,6 +141,9 @@ test("catalog rows badge installed and update-available skills", async () => {
   expect(screen.getByText(/installed ✓/i)).toBeInTheDocument();
   expect(screen.getByRole("button", { name: /^Install$/ })).toBeInTheDocument();
   expect(screen.getByRole("button", { name: /^Update$/ })).toBeInTheDocument();
+  expect(screen.getByRole("heading", { name: "productivity" })).toBeInTheDocument();
+  expect(screen.getByRole("heading", { name: "engineering" })).toBeInTheDocument();
+  expect(screen.getByText("1 update available")).toBeInTheDocument();
 });
 
 test("per-row Install loads only that skill into the audit pipeline", async () => {

--- a/scripts/validate-skill-catalog.ts
+++ b/scripts/validate-skill-catalog.ts
@@ -1,0 +1,60 @@
+import { readdir, readFile } from "node:fs/promises";
+import { basename, dirname, join, relative, resolve } from "node:path";
+import { validateSkill } from "../packages/schema/src/skill-frontmatter";
+import { parseFrontmatter } from "../packages/soul/src/published-loader";
+
+async function skillFiles(root: string): Promise<string[]> {
+  const files: string[] = [];
+
+  async function walk(directory: string): Promise<void> {
+    const entries = await readdir(directory, { withFileTypes: true });
+    for (const entry of entries) {
+      const path = join(directory, entry.name);
+      if (entry.isDirectory() && !entry.name.startsWith(".") && entry.name !== "node_modules") {
+        await walk(path);
+      } else if (entry.isFile() && entry.name === "SKILL.md") {
+        files.push(path);
+      }
+    }
+  }
+
+  await walk(root);
+  return files.sort();
+}
+
+export async function validateSkillCatalog(root: string): Promise<string[]> {
+  const errors: string[] = [];
+  for (const path of await skillFiles(root)) {
+    const location = relative(root, path);
+    try {
+      const content = await readFile(path, "utf8");
+      const { frontmatter, body } = parseFrontmatter(content);
+      const result = validateSkill({
+        name: basename(dirname(path)),
+        frontmatter,
+        body,
+        content,
+      });
+      if (!result.valid) errors.push(`${location}: ${result.error}`);
+    } catch (error) {
+      errors.push(`${location}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+  return errors;
+}
+
+const catalogRoot = process.argv[2];
+if (!catalogRoot) {
+  console.error("Usage: pnpm exec tsx scripts/validate-skill-catalog.ts <catalog-root>");
+  process.exitCode = 2;
+} else {
+  const root = resolve(catalogRoot);
+  const files = await skillFiles(root);
+  const errors = await validateSkillCatalog(root);
+  if (errors.length > 0) {
+    for (const error of errors) console.error(error);
+    process.exitCode = 1;
+  } else {
+    console.log(`Validated ${files.length} Skills with @tulipfarm/schema.`);
+  }
+}


### PR DESCRIPTION
## Summary

- surface catalog categories and current update status through the Skills API
- group marketplace Skills by category and show an updates-available affordance
- expose the shared Step 4 validator for the public Skill catalog CI

The public catalog migration will follow in a dependent PR after this validator is available on
`main`.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm architecture:check`
- [x] API Skill route tests (36 passed)
- [x] web marketplace route tests (6 passed)
- [x] shared validator against all 88 catalog Skills
- [ ] `pnpm test` — repository's existing native Node/Vitest worker teardown crash reproduced
      after 181/182 API test files and 1821/1824 tests passed; no Step 2 assertion failed
