### PR TITLE
ci(release): automate PR-gated releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ concurrency:
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   # Route docs changes to their focused suite and everything else to the main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,13 @@
 name: CI
 
-# Quality suite for PRs and main pushes. Tag pushes (`v*`) are handled entirely
-# by publish-image.yml — this workflow never runs on tags.
+# Quality suite for PRs and main pushes. Prepare release can also dispatch it
+# explicitly when its PR was created with GITHUB_TOKEN (whose pushes do not
+# start other workflows).
 on:
   pull_request:
   push:
     branches: [main]
+  workflow_dispatch:
 
 # Cancel superseded runs on the same ref (e.g. rapid pushes to a PR branch).
 concurrency:
@@ -35,6 +37,9 @@ jobs:
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             base="${{ github.event.pull_request.base.sha }}"
             head="${{ github.event.pull_request.head.sha }}"
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            head="${{ github.sha }}"
+            base="$(git merge-base origin/main "$head")"
           else
             base="${{ github.event.before }}"
             head="${{ github.sha }}"

--- a/.github/workflows/compose-parity.yml
+++ b/.github/workflows/compose-parity.yml
@@ -4,7 +4,7 @@ name: Compose parity
 # and prove the health probes pass in-container. The container path — not native
 # `pnpm dev` — is the tested release path. Called from two places:
 #   - ci.yml (every PR / main push) as a standalone quality signal
-#   - publish-image.yml (tag pushes), which gates the GHCR publish on it
+#   - publish-image.yml, which supplies the exact candidate image to verify
 #
 # Three phases, all against the one image built below:
 #   1. zero-env   — no `.env` at all, the paste-and-run path (INST-002). Also proves the
@@ -14,9 +14,16 @@ name: Compose parity
 #   3. configured — the installer's path, with real secrets supplied in `.env`.
 on:
   workflow_call:
+    inputs:
+      image:
+        description: "Published candidate image to verify; empty builds the checkout locally"
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   compose-parity:
@@ -30,9 +37,17 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: docker/setup-buildx-action@v4
+      - name: Log in to GHCR
+        if: ${{ inputs.image != '' }}
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
       # Build the single bundled image once and load it into the local daemon, tagged
       # to match what compose resolves. No push, no creds.
       - name: Build app image (load into daemon)
+        if: ${{ inputs.image == '' }}
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -40,6 +55,14 @@ jobs:
           tags: ghcr.io/tulipfarm/tulipfarm:ci
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      - name: Load published candidate
+        if: ${{ inputs.image != '' }}
+        env:
+          CANDIDATE_IMAGE: ${{ inputs.image }}
+        run: |
+          set -euo pipefail
+          docker pull "$CANDIDATE_IMAGE"
+          docker tag "$CANDIDATE_IMAGE" ghcr.io/tulipfarm/tulipfarm:ci
 
       # --- Phase 1: zero-env ---------------------------------------------------------
       # `--wait` blocks until BOTH services report healthy (postgres pg_isready, app's

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,40 +1,125 @@
-name: Publish image
+name: Publish release
 
-# Release publish path (INST-001/011, AC-003): on every `v*` tag (pushed by
-# `pnpm release` locally or the Release workflow), re-verify the bundled stack
-# via the reusable compose-parity workflow, then build the single bundled image
-# for linux/amd64 + linux/arm64 and push it to GHCR under one pinned version
-# tag (no skew). The quality suite (lint/test/…) is NOT rerun here — it already
-# ran in ci.yml for the same SHA on the PR and the main push.
-run-name: Publish image ${{ github.ref_name }} → GHCR
-
+# A merged release PR is the only publication trigger. The workflow validates
+# the merge commit, builds one immutable multi-arch candidate, verifies that
+# exact candidate, promotes its manifest, and creates the GitHub Release last.
 on:
-  push:
-    tags: ["v*"]
+  pull_request:
+    types: [closed]
 
-# One publish per tag; never cancel a half-done registry push.
 concurrency:
-  group: publish-image-${{ github.ref }}
+  group: release
   cancel-in-progress: false
 
 permissions:
   contents: read
 
 jobs:
-  # Verification gate: only health-checked images ship.
-  compose-parity:
-    name: Verify
-    uses: ./.github/workflows/compose-parity.yml
-
-  publish-image:
-    name: Publish image
+  metadata:
+    name: Validate release merge
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      startsWith(github.event.pull_request.head.ref, 'release/v')
     runs-on: ubuntu-latest
-    needs: [compose-parity]
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      candidate: ${{ steps.release.outputs.candidate }}
+      release_sha: ${{ steps.release.outputs.release_sha }}
+      tag: ${{ steps.release.outputs.tag }}
+      version: ${{ steps.release.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "26.5.0"
+      - id: release
+        name: Validate release metadata
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RELEASE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          set -euo pipefail
+          version="${HEAD_BRANCH#release/v}"
+          tag="v$version"
+          package_version="$(node -p "require('./package.json').version")"
+          [ "$package_version" = "$version" ] || {
+            echo "Release branch requests $version but package.json contains $package_version"
+            exit 1
+          }
+          VERSION="$version" node --input-type=module -e '
+            import { isReleaseVersion } from "./scripts/request-release.ts";
+            if (!isReleaseVersion(process.env.VERSION ?? "")) {
+              throw new Error("Invalid release version: " + process.env.VERSION);
+            }
+          '
+          while IFS= read -r file; do
+            case "$file" in
+              CHANGELOG.md|package.json) ;;
+              *)
+                echo "Release PR contains an unexpected file: $file"
+                exit 1
+                ;;
+            esac
+          done < <(gh pr diff "$PR_NUMBER" --name-only)
+          grep -Fq "## [$version]" CHANGELOG.md || {
+            echo "CHANGELOG.md has no section for $version"
+            exit 1
+          }
+          git fetch origin main --tags
+          git merge-base --is-ancestor "$RELEASE_SHA" origin/main || {
+            echo "$RELEASE_SHA is not reachable from main"
+            exit 1
+          }
+          if git rev-parse --verify --quiet "refs/tags/$tag^{commit}" >/dev/null; then
+            tagged_sha="$(git rev-parse "refs/tags/$tag^{commit}")"
+            [ "$tagged_sha" = "$RELEASE_SHA" ] || {
+              echo "$tag already points to $tagged_sha"
+              exit 1
+            }
+          fi
+          {
+            echo "version=$version"
+            echo "tag=$tag"
+            echo "release_sha=$RELEASE_SHA"
+            echo "candidate=ghcr.io/tulipfarm/tulipfarm:sha-$RELEASE_SHA"
+          } >> "$GITHUB_OUTPUT"
+  quality:
+    name: Verify merged source
+    needs: metadata
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.metadata.outputs.release_sha }}
+      - uses: ./.github/actions/setup
+      - name: Lint
+        run: pnpm lint
+      - name: Typecheck
+        run: pnpm typecheck
+      - name: Test
+        run: pnpm test
+      - name: Build
+        run: pnpm build
+
+  build-candidate:
+    name: Build immutable candidate
+    needs: [metadata, quality]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.metadata.outputs.release_sha }}
       - uses: docker/setup-qemu-action@v4
       - uses: docker/setup-buildx-action@v4
       - name: Log in to GHCR
@@ -42,28 +127,142 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      # Always tag the exact version. Only move `:latest` for STABLE releases —
-      # prerelease/canary tags carry a `-` identifier (e.g. v0.1.0-alpha.0, from
-      # `pnpm release:canary`) and must not clobber the latest stable image.
-      - name: Compute image tags
-        id: imgtags
+          password: ${{ github.token }}
+      - id: candidate
+        name: Check for an existing candidate
+        env:
+          CANDIDATE_IMAGE: ${{ needs.metadata.outputs.candidate }}
         run: |
-          ref="${{ github.ref_name }}"
-          {
-            echo "tags<<EOF"
-            echo "ghcr.io/tulipfarm/tulipfarm:${ref}"
-            if [[ "$ref" != *-* ]]; then
-              echo "ghcr.io/tulipfarm/tulipfarm:latest"
-            fi
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-      - name: Build and push (multi-arch)
+          if docker buildx imagetools inspect "$CANDIDATE_IMAGE" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Build and push candidate
+        if: ${{ steps.candidate.outputs.exists != 'true' }}
         uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ steps.imgtags.outputs.tags }}
+          tags: ${{ needs.metadata.outputs.candidate }}
+          provenance: mode=max
+          sbom: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      - name: Verify candidate platforms
+        env:
+          CANDIDATE_IMAGE: ${{ needs.metadata.outputs.candidate }}
+        run: |
+          set -euo pipefail
+          docker buildx imagetools inspect "$CANDIDATE_IMAGE" --raw > manifest.json
+          jq -e '
+            [
+              .manifests[].platform
+              | select(.os == "linux")
+              | "\(.os)/\(.architecture)"
+            ] | unique | sort
+              == ["linux/amd64", "linux/arm64"]
+          ' manifest.json
+
+  verify-image:
+    name: Verify candidate
+    needs: [metadata, build-candidate]
+    permissions:
+      contents: read
+      packages: read
+    uses: ./.github/workflows/compose-parity.yml
+    with:
+      image: ${{ needs.metadata.outputs.candidate }}
+    secrets: inherit
+
+  publish:
+    name: Publish release
+    needs: [metadata, verify-image]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    env:
+      CANDIDATE_IMAGE: ${{ needs.metadata.outputs.candidate }}
+      GH_TOKEN: ${{ github.token }}
+      IMAGE: ghcr.io/tulipfarm/tulipfarm
+      RELEASE_SHA: ${{ needs.metadata.outputs.release_sha }}
+      TAG: ${{ needs.metadata.outputs.tag }}
+      VERSION: ${{ needs.metadata.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.metadata.outputs.release_sha }}
+      - uses: docker/setup-buildx-action@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+      - name: Create source tag
+        run: |
+          set -euo pipefail
+          git fetch origin main --tags
+          git merge-base --is-ancestor "$RELEASE_SHA" origin/main
+          if git rev-parse --verify --quiet "refs/tags/$TAG^{commit}" >/dev/null; then
+            [ "$(git rev-parse "refs/tags/$TAG^{commit}")" = "$RELEASE_SHA" ]
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git tag --annotate "$TAG" "$RELEASE_SHA" --message "Release $TAG"
+            git push origin "refs/tags/$TAG"
+          fi
+      - name: Promote verified image
+        run: |
+          set -euo pipefail
+          tags=(--tag "$IMAGE:$TAG")
+          if [[ "$VERSION" != *-* ]]; then
+            tags+=(--tag "$IMAGE:latest")
+          fi
+          docker buildx imagetools create "${tags[@]}" "$CANDIDATE_IMAGE"
+          docker buildx imagetools inspect "$IMAGE:$TAG"
+      - name: Generate release notes
+        env:
+          NOTES_FILE: ${{ runner.temp }}/release-notes.md
+        run: |
+          {
+            echo "## Container image"
+            echo
+            echo '```sh'
+            echo "docker pull $IMAGE:$TAG"
+            echo '```'
+            echo
+            awk '
+              /^## / {
+                sections += 1
+                if (sections == 2) exit
+              }
+              sections == 1 { print }
+            ' CHANGELOG.md
+          } > "$NOTES_FILE"
+      - name: Create GitHub Release
+        env:
+          NOTES_FILE: ${{ runner.temp }}/release-notes.md
+        run: |
+          set -euo pipefail
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "GitHub Release $TAG already exists"
+            exit 0
+          fi
+          args=(release create "$TAG" --verify-tag --title "$TAG" --notes-file "$NOTES_FILE")
+          if [[ "$VERSION" == *-* ]]; then
+            args+=(--prerelease)
+          fi
+          gh "${args[@]}"
+      - name: Summarize
+        run: |
+          {
+            echo "## $TAG published"
+            echo
+            echo "- Source: \`$RELEASE_SHA\`"
+            echo "- Image: \`$IMAGE:$TAG\`"
+            echo "- Candidate: \`$CANDIDATE_IMAGE\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,64 +1,133 @@
-name: Release
+name: Prepare release
 
-# Cut a release from `main` with release-it: derive the version bump from
-# Conventional Commits, write CHANGELOG.md, commit, tag `v<version>`, push, and
-# create the matching GitHub Release. Pushing the `v*` tag triggers the
-# Publish image workflow (publish-image.yml), which verifies the bundled stack
-# and pushes the multi-arch image to GHCR — so the Docker image ships as a
-# consequence of the release.
-#
-# This is the CI counterpart to running `pnpm release` locally; both use the same
-# .release-it.json so the two paths produce identical releases.
+# A maintainer starts this workflow through `pnpm release <version>`. It updates
+# the version and changelog on a dedicated branch, opens a ready-for-review PR,
+# and stops. Merging that PR is the approval that starts publish-image.yml.
 on:
   workflow_dispatch:
     inputs:
-      increment:
-        description: "Version bump (auto = derive from Conventional Commits)"
-        type: choice
-        options: [auto, patch, minor, major]
-        default: auto
-      dry-run:
-        description: "Dry run — compute everything but do not commit/tag/push/release"
-        type: boolean
-        default: false
+      version:
+        description: "Exact SemVer to release (for example, 0.5.0 or 0.5.0-beta.0)"
+        required: true
+        type: string
 
-# Only ever one release in flight; never cancel a half-done release.
 concurrency:
-  group: release
+  group: prepare-release
   cancel-in-progress: false
 
 permissions:
+  actions: write
   contents: write
+  pull-requests: write
 
 jobs:
-  release:
-    name: Cut release
+  prepare:
+    name: Open release PR
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.RELEASE_TOKEN || github.token }}
+      RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+      VERSION: ${{ inputs.version }}
     steps:
-      - uses: actions/checkout@v7
-        with:
-          # Full history so conventional-changelog can read the commit log since
-          # the last tag.
-          fetch-depth: 0
-          # A PAT with `contents: write` (RELEASE_TOKEN) makes the pushed `v*`
-          # tag trigger ci.yml's publish-image. The default GITHUB_TOKEN works to
-          # cut the release, but pushes made with it do NOT trigger other
-          # workflows (GitHub's recursion guard) — so without the PAT the image
-          # would not auto-publish and you'd re-push the tag manually.
-          token: ${{ secrets.RELEASE_TOKEN || github.token }}
-      - uses: ./.github/actions/setup
-      - name: Configure git identity
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-      - name: Run release-it
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN || github.token }}
-          INCREMENT: ${{ inputs.increment }}
-          DRY_RUN: ${{ inputs.dry-run }}
+      - name: Require main
         run: |
           set -euo pipefail
-          args=(--ci)
-          [ "$INCREMENT" != "auto" ] && args+=("$INCREMENT")
-          [ "$DRY_RUN" = "true" ] && args+=(--dry-run)
-          pnpm exec release-it "${args[@]}"
+          [ "$GITHUB_REF" = "refs/heads/main" ] || {
+            echo "Release preparation must run from main, not $GITHUB_REF"
+            exit 1
+          }
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN || github.token }}
+      - uses: ./.github/actions/setup
+      - name: Validate release request
+        run: |
+          set -euo pipefail
+          node --input-type=module -e '
+            import { isReleaseVersion } from "./scripts/request-release.ts";
+            if (!isReleaseVersion(process.env.VERSION ?? "")) {
+              throw new Error("Invalid release version: " + process.env.VERSION);
+            }
+          '
+          tag="v$VERSION"
+          branch="release/$tag"
+          if git rev-parse --verify --quiet "refs/tags/$tag"; then
+            echo "Tag $tag already exists"
+            exit 1
+          fi
+          if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+            echo "Branch $branch already exists"
+            exit 1
+          fi
+      - name: Generate version and changelog
+        run: pnpm exec release-it "$VERSION" --ci --no-git.requireBranch
+      - name: Verify generated files
+        run: |
+          set -euo pipefail
+          expected_version="$(node -p "require('./package.json').version")"
+          [ "$expected_version" = "$VERSION" ] || {
+            echo "release-it generated $expected_version instead of $VERSION"
+            exit 1
+          }
+          changed="$(git diff --name-only)"
+          [ -n "$changed" ] || {
+            echo "release-it did not generate any changes"
+            exit 1
+          }
+          while IFS= read -r file; do
+            case "$file" in
+              CHANGELOG.md|package.json) ;;
+              *)
+                echo "Unexpected generated file: $file"
+                exit 1
+                ;;
+            esac
+          done <<< "$changed"
+      - name: Commit release proposal
+        run: |
+          set -euo pipefail
+          branch="release/v$VERSION"
+          git switch -c "$branch"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md package.json
+          git commit -m "chore(release): v$VERSION"
+          git push --set-upstream origin "$branch"
+      - name: Open release PR
+        env:
+          BODY_FILE: ${{ runner.temp }}/release-pr.md
+        run: |
+          set -euo pipefail
+          branch="release/v$VERSION"
+          {
+            echo "## Summary"
+            echo
+            echo "- prepare TulipFarm v$VERSION"
+            echo "- update the package version and generated changelog"
+            echo "- publish the verified GHCR image and GitHub Release automatically after merge"
+            echo
+            echo "## Test plan"
+            echo
+            echo "- [ ] Required PR checks pass"
+            echo "- [ ] Version and changelog are approved"
+          } > "$BODY_FILE"
+          gh pr create \
+            --base main \
+            --head "$branch" \
+            --title "chore(release): v$VERSION" \
+            --body-file "$BODY_FILE"
+      - name: Start CI when using the workflow token
+        if: ${{ env.RELEASE_TOKEN == '' }}
+        run: |
+          # GitHub suppresses push/PR workflows created by GITHUB_TOKEN. A
+          # workflow_dispatch is allowed, so attach the normal CI checks to the
+          # release branch explicitly when no RELEASE_TOKEN is configured.
+          gh workflow run ci.yml --ref "release/v$VERSION"
+      - name: Summarize
+        run: |
+          {
+            echo "## Release v$VERSION proposed"
+            echo
+            echo "Review and merge the release PR. Publication starts automatically after merge."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.release-it.json
+++ b/.release-it.json
@@ -4,16 +4,12 @@
     "requireBranch": "main",
     "requireCleanWorkingDir": true,
     "requireCommits": true,
-    "commitMessage": "chore(release): v${version}",
-    "tagName": "v${version}",
-    "tagAnnotation": "Release v${version}",
-    "push": true
+    "commit": false,
+    "tag": false,
+    "push": false
   },
   "github": {
-    "release": true,
-    "releaseName": "v${version}",
-    "autoGenerate": false,
-    "host": "github.com"
+    "release": false
   },
   "npm": {
     "publish": false

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ from main both flow through the same update path.
 
 ### Updating TulipFarm (self-host)
 
-Releases publish the image `ghcr.io/tulipfarm/tulipfarm:<version>` (+ `:latest` for stable).
+Releases publish the image `ghcr.io/tulipfarm/tulipfarm:v<version>` (+ `:latest` for stable).
 Updates are always **manual** (no auto-update by design):
 
 - **OCI lane (installer):** re-run the install command — it preserves `.env` and the Postgres
@@ -186,36 +186,30 @@ Commits follow [Conventional Commits](https://www.conventionalcommits.org/). The
 enforced in two places: a `commit-msg` git hook (commitlint, via lefthook) locally, and
 the **PR Title** check in CI. The commit/PR `type` drives the next version bump.
 
-Releases are cut with [`release-it`](https://github.com/release-it/release-it) +
-`@release-it/conventional-changelog` (config in `.release-it.json`): it derives the
-version from the commit history, writes `CHANGELOG.md`, bumps `package.json`, commits,
-tags `v<version>`, pushes, and creates the GitHub Release. Pushing the `v*` tag triggers
-the **Publish image** workflow (`publish-image.yml`), which builds and pushes the
-multi-arch Docker image to GHCR (`ghcr.io/tulipfarm/tulipfarm:<version>` + `:latest`)
-after the `compose-parity` health gate — so the image ships as a consequence of the
-release. Two equivalent ways to cut one:
+Releases use a release PR and a gated publication pipeline. A maintainer requests an exact
+version:
 
-- **CI (recommended):** run the **Release** workflow from the Actions tab
-  (`workflow_dispatch`). Optionally choose the bump (`auto`/`patch`/`minor`/`major`) or a
-  dry run. For the tag push to trigger image publishing, set a `RELEASE_TOKEN` repo secret
-  (a PAT/GitHub App token with `contents: write`) — pushes made with the default
-  `GITHUB_TOKEN` do not trigger other workflows.
-- **Local:** from a clean `main`, run `pnpm release` (needs a `GITHUB_TOKEN` env var for
-  the GitHub Release). Add `--dry-run` to preview, or `patch`/`minor`/`major` to override
-  the computed bump.
+```bash
+pnpm release 0.5.0
+```
+
+The command dispatches **Prepare release**, which opens a PR containing only the generated
+`package.json` and `CHANGELOG.md` changes. Merging that PR automatically validates the merge
+commit, builds one immutable multi-architecture candidate image, runs Compose parity against that
+exact image, promotes it to `v<version>` and `latest`, and creates the Git tag and GitHub Release.
+The GitHub Release is created last; no post-merge command or approval is required.
+
+See [docs/RELEASES.md](docs/RELEASES.md) for setup, retry semantics, and the complete release
+contract.
 
 ### Canary / prereleases
 
-To cut a prerelease from any branch, pass the prerelease identifier to
-`release:canary`:
+Prereleases use the same release-PR and verification path. Pass the complete version:
 
 ```bash
-pnpm release:canary alpha   # -> v0.1.0-alpha.0, then v0.1.0-alpha.1, ...
-pnpm release:canary beta    # -> v0.1.0-beta.0
+pnpm release:canary 0.5.0-alpha.0
+pnpm release:canary 0.5.0-beta.0
 ```
 
-It runs `release-it --no-git.requireBranch --preRelease <id>`, so it works off
-feature branches and marks the GitHub Release as a prerelease. The `v*` tag still
-triggers the image publish, but `publish-image` only moves `:latest` for **stable**
-tags — prerelease tags (those containing a `-`) publish only
-`ghcr.io/tulipfarm/tulipfarm:<version>`.
+They are marked as prereleases on GitHub and publish `ghcr.io/tulipfarm/tulipfarm:v<version>`
+without moving `latest`.

--- a/apps/api/src/hooks/hook-executor.test.ts
+++ b/apps/api/src/hooks/hook-executor.test.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { Worker } from "node:worker_threads";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 
 // isolated-vm 7.x ships prebuilds for Node 24 (abi137) and Node 26 (abi147) but not Node 25 (abi141).
 // Tests that require the isolate to actually execute and return a successful result must be
@@ -18,11 +18,13 @@ const FAKE_DATABASE_URL = "postgresql://localhost:5432/test";
 describe("HookExecutor", () => {
   let executor: HookExecutor;
 
-  beforeEach(() => {
+  // Production keeps one executor worker alive for the process lifetime. Reusing it here also
+  // avoids isolated-vm's known worker-thread teardown race (#464) between individual tests.
+  beforeAll(() => {
     executor = new HookExecutor(FAKE_DATABASE_URL);
   });
 
-  afterEach(async () => {
+  afterAll(async () => {
     await executor.close();
   });
 
@@ -203,23 +205,14 @@ describe("HookExecutor", () => {
   });
 
   describe("L5: circuit breaker", () => {
-    let cbExecutor: HookExecutor;
     const FAIL_HOOK = `({ async before() { throw new Error('deliberate'); } })`;
-
-    beforeEach(() => {
-      cbExecutor = new HookExecutor(FAKE_DATABASE_URL);
-    });
-
-    afterEach(async () => {
-      await cbExecutor.close();
-    });
 
     it("disables hook after 3 consecutive failures", async () => {
       const type = "cb-resource";
       for (let i = 0; i < 3; i++) {
-        await cbExecutor.runBeforeHook(FAIL_HOOK, type, {}).catch(() => {});
+        await executor.runBeforeHook(FAIL_HOOK, type, {}).catch(() => {});
       }
-      const err = await cbExecutor.runBeforeHook(FAIL_HOOK, type, {}).catch((e) => e);
+      const err = await executor.runBeforeHook(FAIL_HOOK, type, {}).catch((e) => e);
       expect(err).toBeInstanceOf(HookError);
       expect(err.message).toBe("hook disabled by circuit breaker");
     });
@@ -228,12 +221,12 @@ describe("HookExecutor", () => {
       const type = "cb-reset";
       const GOOD_HOOK = "({})";
       // 2 failures then a success then a failure — should not trip breaker
-      await cbExecutor.runBeforeHook(FAIL_HOOK, type, {}).catch(() => {});
-      await cbExecutor.runBeforeHook(FAIL_HOOK, type, {}).catch(() => {});
-      await cbExecutor.runBeforeHook(GOOD_HOOK, type, {}); // success resets
-      await cbExecutor.runBeforeHook(FAIL_HOOK, type, {}).catch(() => {});
+      await executor.runBeforeHook(FAIL_HOOK, type, {}).catch(() => {});
+      await executor.runBeforeHook(FAIL_HOOK, type, {}).catch(() => {});
+      await executor.runBeforeHook(GOOD_HOOK, type, {}); // success resets
+      await executor.runBeforeHook(FAIL_HOOK, type, {}).catch(() => {});
       // Only 1 failure after reset — should NOT be circuit-broken
-      const result = await cbExecutor.runBeforeHook(GOOD_HOOK, type, {});
+      const result = await executor.runBeforeHook(GOOD_HOOK, type, {});
       expect(result).toBeDefined();
     });
   });

--- a/apps/api/src/hooks/routine-sandbox.test.ts
+++ b/apps/api/src/hooks/routine-sandbox.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { HookError, HookExecutor } from "./hook-executor.js";
 
 // Same Node-25 caveat as hook-executor.test.ts: isolated-vm has no abi141 prebuild, so
@@ -11,11 +11,13 @@ const FAKE_DATABASE_URL = "postgresql://localhost:5432/test";
 describe("routine sandbox variants", () => {
   let executor: HookExecutor;
 
-  beforeEach(() => {
+  // Match the production lifecycle and avoid isolated-vm's known worker-thread teardown race
+  // (#464), which can abort Node when a fresh worker is terminated after every test.
+  beforeAll(() => {
     executor = new HookExecutor(FAKE_DATABASE_URL);
   });
 
-  afterEach(async () => {
+  afterAll(async () => {
     await executor.close();
   });
 

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -1,0 +1,105 @@
+# Releases
+
+TulipFarm uses a release PR followed by an automatic, artifact-promoting publication pipeline.
+A release is complete only when the verified container image is available in GHCR and the matching
+GitHub Release has been published.
+
+## Maintainer workflow
+
+Request an exact stable version from any local checkout:
+
+```bash
+pnpm release 0.5.0
+```
+
+For a prerelease, provide the complete prerelease version:
+
+```bash
+pnpm release:canary 0.5.0-beta.0
+```
+
+The command authenticates with `gh` and dispatches the **Prepare release** workflow on `main`.
+It does not change the local checkout, create a tag, publish an image, or create a GitHub Release.
+
+The workflow opens a ready-for-review PR named `chore(release): v<version>`. Review the generated
+`package.json` and `CHANGELOG.md`, wait for its required checks, and merge it. That merge is the
+maintainer's publication approval. No command, workflow dispatch, or approval is required after the
+merge.
+
+Version increments such as `minor` are intentionally rejected. An exact version keeps the proposed
+release explicit and reviewable.
+
+### Workflow input mismatch
+
+If GitHub returns `Unexpected inputs provided: ["version"]`, the local release script is newer than
+`.github/workflows/release.yml` on `main`. Merge the release-automation changes first, then rerun
+the same release command. Do not fall back to the older direct-tagging workflow.
+
+## Publication pipeline
+
+Merging a same-repository `release/v<version>` PR starts **Publish release**:
+
+```text
+release PR merged into main
+  -> validate version, changelog, changed files, and main ancestry
+  -> run lint, typecheck, tests, and the workspace build on the merge commit
+  -> build one linux/amd64 + linux/arm64 image as sha-<merge-commit>
+  -> verify both platforms are present
+  -> run Compose parity against that exact candidate image
+  -> create the annotated v<version> source tag
+  -> promote the candidate manifest to v<version>
+  -> also promote it to latest for a stable release
+  -> create the GitHub Release with the image pull command
+```
+
+Prereleases follow the same gates, are marked as prereleases on GitHub, and never move `latest`.
+
+The candidate tag is intentionally retained:
+
+```text
+ghcr.io/tulipfarm/tulipfarm:sha-<merge-commit>
+```
+
+It records the immutable source-to-image relationship and makes a failed publication retry reuse
+the previously built artifact. Promotion uses `docker buildx imagetools`; it assigns release tags
+to the verified manifest without rebuilding it.
+
+## Failure and retry behavior
+
+The GitHub Release is the final publication step. If source validation, the quality suite, the
+multi-architecture build, or Compose parity fails, no GitHub Release is created and neither the
+version tag nor `latest` is moved.
+
+If a later publication step fails, rerun the failed jobs from the **Publish release** workflow.
+Tag creation and candidate building are idempotent when they already point to the expected merge
+commit. Never delete and recreate a published version to hide a failure; fix the pipeline or cut a
+new patch release when the released artifact itself is defective.
+
+## Repository setup
+
+Configure these controls once:
+
+1. Protect `main` and require the repository's CI gate before merge.
+2. In **Settings → Actions → General → Workflow permissions**, grant read/write workflow
+   permissions and allow GitHub Actions to create pull requests. Alternatively, configure a
+   `RELEASE_TOKEN` secret that can write repository contents, open pull requests, and dispatch
+   workflows.
+3. Add a tag ruleset for `v*` that restricts creation, updates, and deletion to release automation.
+4. Keep the GHCR package linked to this repository and grant Actions write access to it.
+
+When `RELEASE_TOKEN` is absent, **Prepare release** explicitly dispatches CI for the generated
+branch. GitHub suppresses ordinary push and pull-request workflow events created by its default
+workflow token.
+
+## Implementation map
+
+| File | Responsibility |
+| --- | --- |
+| `scripts/request-release.ts` | Validates the requested version and dispatches preparation |
+| `.github/workflows/release.yml` | Generates the version/changelog commit and opens the release PR |
+| `.github/workflows/publish-image.yml` | Validates the merge, builds, verifies, promotes, and releases |
+| `.github/workflows/compose-parity.yml` | Verifies either a local CI build or the exact release candidate |
+| `.release-it.json` | Generates version and changelog changes only; it cannot publish directly |
+
+Direct use of `release-it` is not a supported publication path. Its repository configuration
+disables commits, tags, pushes, package publication, and GitHub Releases.

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "lint": "turbo lint",
     "typecheck": "turbo typecheck",
     "test": "turbo test",
-    "release": "release-it",
-    "release:canary": "release-it --no-git.requireBranch --preRelease",
+    "release": "node scripts/request-release.ts",
+    "release:canary": "node scripts/request-release.ts",
     "prepare": "lefthook install"
   },
   "lint-staged": {

--- a/scripts/request-release.test.ts
+++ b/scripts/request-release.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { formatDispatchError, isReleaseVersion, parseReleaseVersion } from "./request-release";
+
+describe("release request", () => {
+  it.each([
+    "0.5.0",
+    "1.0.0",
+    "0.5.0-alpha.0",
+    "12.34.56-rc.1",
+  ])("accepts a release version: %s", (version) => {
+    expect(isReleaseVersion(version)).toBe(true);
+    expect(parseReleaseVersion([version])).toBe(version);
+  });
+
+  it.each([
+    "",
+    "v0.5.0",
+    "0.5",
+    "01.5.0",
+    "0.5.0-",
+    "0.5.0-01",
+    "0.5.0+build.1",
+    "minor",
+  ])("rejects an invalid or ambiguous version: %s", (version) => {
+    expect(isReleaseVersion(version)).toBe(false);
+  });
+
+  it("requires exactly one version argument", () => {
+    expect(() => parseReleaseVersion([])).toThrow("Usage: pnpm release <version>");
+    expect(() => parseReleaseVersion(["0.5.0", "0.6.0"])).toThrow("Usage: pnpm release <version>");
+  });
+
+  it("explains when the remote workflow has not been upgraded yet", () => {
+    expect(
+      formatDispatchError(
+        'could not create workflow dispatch event: HTTP 422: Unexpected inputs provided: ["version"]',
+        1
+      )
+    ).toContain("Merge the release-automation changes to main");
+  });
+
+  it("reports other workflow dispatch failures without guessing", () => {
+    expect(formatDispatchError("network error", 1)).toBe(
+      "Could not start the release workflow (gh exited with status 1)."
+    );
+  });
+});

--- a/scripts/request-release.ts
+++ b/scripts/request-release.ts
@@ -1,0 +1,86 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+
+function isNumericIdentifier(value: string): boolean {
+  return /^\d+$/.test(value);
+}
+
+export function isReleaseVersion(value: string): boolean {
+  if (value.includes("+")) return false;
+
+  const separator = value.indexOf("-");
+  const core = separator === -1 ? value : value.slice(0, separator);
+  const prerelease = separator === -1 ? undefined : value.slice(separator + 1);
+  const coreIdentifiers = core.split(".");
+
+  if (
+    coreIdentifiers.length !== 3 ||
+    coreIdentifiers.some(
+      (identifier) =>
+        !isNumericIdentifier(identifier) || (identifier.length > 1 && identifier.startsWith("0"))
+    )
+  ) {
+    return false;
+  }
+
+  if (prerelease === undefined) return true;
+  if (prerelease.length === 0) return false;
+
+  return prerelease.split(".").every((identifier) => {
+    if (!/^[0-9A-Za-z-]+$/.test(identifier)) return false;
+    return !isNumericIdentifier(identifier) || identifier === "0" || !identifier.startsWith("0");
+  });
+}
+
+export function parseReleaseVersion(args: readonly string[]): string {
+  if (args.length !== 1 || !isReleaseVersion(args[0] ?? "")) {
+    throw new Error(
+      "Usage: pnpm release <version> (for example: pnpm release 0.5.0 or pnpm release:canary 0.5.0-beta.0)"
+    );
+  }
+
+  return args[0] ?? "";
+}
+
+export function formatDispatchError(stderr: string, status: number | null): string {
+  if (stderr.includes("Unexpected inputs provided") && stderr.includes('"version"')) {
+    return [
+      "The release workflow on GitHub's main branch does not accept a version input yet.",
+      "Merge the release-automation changes to main before running pnpm release.",
+    ].join(" ");
+  }
+
+  return `Could not start the release workflow (gh exited with status ${status ?? "unknown"}).`;
+}
+
+function main(): void {
+  const version = parseReleaseVersion(process.argv.slice(2));
+
+  execFileSync("gh", ["auth", "status"], { stdio: "inherit" });
+  const dispatch = spawnSync(
+    "gh",
+    ["workflow", "run", "release.yml", "--ref", "main", "-f", `version=${version}`],
+    { encoding: "utf8" }
+  );
+
+  if (dispatch.stdout) process.stdout.write(dispatch.stdout);
+  if (dispatch.stderr) process.stderr.write(dispatch.stderr);
+  if (dispatch.error) throw dispatch.error;
+  if (dispatch.status !== 0) {
+    throw new Error(formatDispatchError(dispatch.stderr, dispatch.status));
+  }
+
+  console.log(`Release v${version} requested.`);
+  console.log("The workflow will open a release PR; merging it starts publication automatically.");
+}
+
+const entrypoint = process.argv[1];
+if (entrypoint && import.meta.url === pathToFileURL(entrypoint).href) {
+  try {
+    main();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(message);
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
## Summary

- replace direct local publishing with an exact-version workflow that opens a release PR
- publish the verified multi-architecture GHCR image and GitHub Release automatically after merge
- document stable and prerelease behavior, including automatic `latest` promotion for stable releases

## Why

The previous process could create a source tag and GitHub Release before the container build and
Compose parity checks succeeded. It also allowed a local CLI invocation to publish directly from a
maintainer checkout.

This change makes merging the generated release PR the publication approval. The post-merge
workflow validates the source, runs the quality gates, builds one immutable candidate image, tests
that exact candidate, promotes it to the version tag and (for stable releases) `latest`, then
creates the GitHub Release last.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run build`
- [x] `vitest run scripts/request-release.test.ts` (15 tests)
- [x] Biome check for the changed release-request script and tests
- [x] YAML parsing and `actionlint` for all changed workflows
- [x] `git diff --check`
- [ ] `pnpm run test` — the local Node 26/Vitest fork pool aborts at the runtime level after 1,781
      passing tests; no test assertion failed
