### PR TITLE
fix(ci): tolerate release cache export failures

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -149,7 +149,7 @@ jobs:
           provenance: mode=max
           sbom: true
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=max,ignore-error=true
       - name: Verify candidate platforms
         env:
           CANDIDATE_IMAGE: ${{ needs.metadata.outputs.candidate }}


### PR DESCRIPTION
## Summary

- keep release image builds successful when the optional GitHub Actions cache export runs out of capacity
- preserve image push, platform verification, and publishing as required release gates

## Test plan

- [x] `git diff --check`
- [x] parse `.github/workflows/publish-image.yml` as YAML
- [x] run `actionlint` against `.github/workflows/publish-image.yml`