### PR TITLE
chore(release): v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [0.4.2](https://github.com/TulipFarm/tulipfarm/compare/v0.4.1...v0.4.2) (2026-07-29)
+
 ## [0.4.1](https://github.com/TulipFarm/tulipfarm/compare/v0.4.0...v0.4.1) (2026-07-29)
 
 ## [0.4.0](https://github.com/TulipFarm/tulipfarm/compare/v0.3.0-integrations.1...v0.4.0) (2026-07-29)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tulipfarm",
   "private": true,
-  "version": "0.4.1",
+  "version": "0.4.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/TulipFarm/tulipfarm.git"


### PR DESCRIPTION
## Summary

- prepare TulipFarm v0.4.2
- update the package version and generated changelog
- publish the verified GHCR image and GitHub Release automatically after merge

## Test plan

- [ ] Required PR checks pass
- [ ] Version and changelog are approved
