### PR TITLE
fix(installer): handle occupied host ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@
 
 One line stands up the full stack (the `app` image + bundled PostgreSQL 17 + pgvector)
 with Docker or Podman, generates all secrets, and prints the setup-wizard URL — zero
-config questions. Re-running is the upgrade path (preserves `.env` + data).
+config questions unless the host port is occupied, in which case it suggests a free port
+and asks you to confirm it. Re-running is the upgrade path (preserves secrets + data).
 
 **Linux / macOS:**
 ```bash
@@ -31,6 +32,8 @@ Verifies WSL2 + a distro, then runs the Linux installer inside WSL.
 Overrides (env vars): `TF_VERSION` (image tag, default `latest`), `TF_PORT` (default
 `8080`), `TF_INSTALL_DIR` (default `/opt/tulipfarm`), `TF_RUNTIME` (`docker`|`podman`),
 `TF_BASE_URL`/`TF_REF`. Full guide: see `apps/docs/content/docs/installation.mdx`.
+An explicit `TF_PORT` also moves an existing install to that host port without rotating
+its generated secrets.
 
 > `TF_VERSION=<tag>` pins the app image. The site serves the compose file from the tip of
 > `main`; to install an exact ref instead, set

--- a/apps/docs/content/docs/installation.mdx
+++ b/apps/docs/content/docs/installation.mdx
@@ -7,7 +7,10 @@ import { Callout } from "fumadocs-ui/components/callout";
 
 The one-line installer stands up the full TulipFarm stack (the `app` image + a bundled
 PostgreSQL 17 + pgvector) with Docker or Podman, generates all secrets for you, and
-prints the setup-wizard URL. It asks **zero configuration questions**.
+prints the setup-wizard URL. It normally asks **zero configuration questions**.
+
+If the selected host port is already in use, the installer asks for another port in the
+terminal and suggests the next available one. Press Enter to accept the suggestion.
 
 <Callout type="info">
   There is nothing to clone, build, or compile. The installer pulls a published container
@@ -30,8 +33,9 @@ brings the stack up, polls `/health`, and prints the URL to open.
   On macOS with no container runtime, install Docker Desktop or Podman first.
 </Callout>
 
-Re-running the installer is the upgrade path: it preserves your `.env` (never regenerating
-secrets) and your database, pulls the pinned version, and restarts. See
+Re-running the installer is the upgrade path: it preserves your secrets and database,
+pulls the pinned version, and restarts. An explicit `TF_PORT` changes the saved host port
+and its installer-generated local URLs. See
 [Updating and rollback](/docs/deploy/updating).
 
 ## Windows
@@ -100,7 +104,7 @@ All optional, set as environment variables before running:
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `TF_VERSION` | `latest` | App image tag to run (`ghcr.io/tulipfarm/tulipfarm:<tag>`). |
-| `TF_PORT` | `8080` | Host port to publish. |
+| `TF_PORT` | `8080` | Host port to publish; also changes it on an existing install. |
 | `TF_INSTALL_DIR` | `/opt/tulipfarm` | Install directory. |
 | `TF_RUNTIME` | auto | Force `docker` or `podman`. |
 | `TF_BASE_URL` / `TF_REF` | `{{SITE_URL}}` / empty | Where compose + `.env.example` are fetched from. |
@@ -111,6 +115,10 @@ Example — pin a version on a custom port:
 TF_VERSION=v0.1.0 TF_PORT=9000 \
   bash -c "curl -fsSL {{SITE_URL}}/install.sh | sudo -E bash"
 ```
+
+When no port override is supplied and the saved port belongs to another process, the
+installer prompts for a replacement. In a non-interactive environment, set `TF_PORT`
+before running instead.
 
 ### Installing an exact ref
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,8 +5,9 @@
 #   curl -fsSL https://tulipfarm.site/install.sh | sudo bash
 #
 # Detects/installs a container engine, fetches docker-compose.yml + .env.example,
-# generates bootstrap secrets (zero questions), brings the 3-service stack up, polls
-# /health, and prints the setup-wizard URL. Re-running = update (preserves .env, PGDATA).
+# generates bootstrap secrets, resolves host-port conflicts interactively, brings the
+# 3-service stack up, polls /health, and prints the setup-wizard URL. Re-running = update
+# (preserves secrets and PGDATA).
 #
 # Files are fetched from https://tulipfarm.site, which serves a flat layout built from the
 # tip of main. TF_VERSION still pins the app image, but the compose file is always latest.
@@ -31,15 +32,87 @@ TF_BASE_URL="${TF_BASE_URL:-https://tulipfarm.site}"
 TF_REF="${TF_REF:-}"
 TF_VERSION="${TF_VERSION:-latest}"
 INSTALL_DIR="${TF_INSTALL_DIR:-/opt/tulipfarm}"
-PORT="${TF_PORT:-${HOST_PORT:-8080}}"
+PORT_OVERRIDE="${TF_PORT:-${HOST_PORT:-}}"
+PORT="${PORT_OVERRIDE:-8080}"
 TF_RUNTIME="${TF_RUNTIME:-}"
 TF_LOCAL_SRC="${TF_LOCAL_SRC:-}"
+TTY_INPUT="/dev/tty"
+TTY_OUTPUT="/dev/tty"
 
 # ---- logging -----------------------------------------------------------------
 log()  { printf '\033[0;32m▸\033[0m %s\n' "$*"; }
 warn() { printf '\033[0;33m⚠\033[0m  %s\n' "$*"; }
 die()  { printf '\033[0;31m✗\033[0m %s\n' "$*" >&2; exit 1; }
 need() { command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"; }
+
+# ---- host port ---------------------------------------------------------------
+normalize_port() {
+  local value="$1"
+  [[ "$value" =~ ^[0-9]{1,5}$ ]] || return 1
+  value=$((10#$value))
+  [ "$value" -ge 1 ] && [ "$value" -le 65535 ] || return 1
+  printf '%s' "$value"
+}
+
+port_is_in_use() {
+  local port="$1"
+  if command -v ss >/dev/null 2>&1; then
+    [ -n "$(ss -H -ltn "sport = :${port}" 2>/dev/null)" ]
+    return
+  fi
+  if command -v lsof >/dev/null 2>&1; then
+    lsof -nP -iTCP:"${port}" -sTCP:LISTEN >/dev/null 2>&1
+    return
+  fi
+  ( exec 3<>"/dev/tcp/127.0.0.1/${port}" ) >/dev/null 2>&1
+}
+
+next_available_port() {
+  local candidate attempts=0
+  candidate=$((PORT + 1))
+  [ "$candidate" -le 65535 ] || candidate=1024
+  while [ "$attempts" -lt 1000 ]; do
+    if ! port_is_in_use "$candidate"; then
+      printf '%s' "$candidate"
+      return 0
+    fi
+    candidate=$((candidate + 1))
+    [ "$candidate" -le 65535 ] || candidate=1024
+    attempts=$((attempts + 1))
+  done
+  return 1
+}
+
+prompt_for_available_port() {
+  local answer normalized suggested
+  if ! exec 8<"$TTY_INPUT" 2>/dev/null || ! exec 9>"$TTY_OUTPUT" 2>/dev/null; then
+    die "host port ${PORT} is already in use — re-run with TF_PORT=<free-port>"
+  fi
+
+  warn "Host port ${PORT} is already in use."
+  while true; do
+    suggested="$(next_available_port)" \
+      || die "could not find a free host port — re-run with TF_PORT=<free-port>"
+    printf 'Choose another host port [%s]: ' "$suggested" >&9
+    IFS= read -r answer <&8 \
+      || die "could not read a host port — re-run with TF_PORT=<free-port>"
+    answer="${answer:-$suggested}"
+    if ! normalized="$(normalize_port "$answer")"; then
+      printf 'Port must be a number from 1 to 65535.\n' >&9
+      continue
+    fi
+    if port_is_in_use "$normalized"; then
+      printf 'Host port %s is also in use.\n' "$normalized" >&9
+      PORT="$normalized"
+      continue
+    fi
+    exec 8<&-
+    exec 9>&-
+    PORT="$normalized"
+    log "Using host port ${PORT}."
+    return
+  done
+}
 
 # ---- privilege ---------------------------------------------------------------
 SUDO=""
@@ -195,9 +268,120 @@ load_runtime_info() {
   [ -n "$u" ] && PUBLIC_URL="$u"
 }
 
+read_env_value() {
+  local key="$1"
+  $SUDO grep -E "^${key}=" "${INSTALL_DIR}/.env" 2>/dev/null \
+    | head -1 | cut -d= -f2- || true
+}
+
+update_runtime_port() {
+  local old_port="$1" old_public old_cors new_public new_cors tmp
+  old_public="$(read_env_value PUBLIC_URL)"
+  old_cors="$(read_env_value CORS_ORIGIN)"
+  new_public="$old_public"
+  new_cors="$old_cors"
+
+  # Keep custom reverse-proxy origins intact. Only adjust the direct HTTP origin that
+  # the installer generated, where the old host port is visibly part of the URL.
+  if [[ "$old_public" =~ ^http://[^/]+:${old_port}$ ]]; then
+    new_public="${old_public%:*}:${PORT}"
+    [ -n "$old_cors" ] && [ "$old_cors" != "$old_public" ] \
+      || new_cors="$new_public"
+  elif [ -z "$old_public" ]; then
+    detect_public_url
+    new_public="$PUBLIC_URL"
+    [ -n "$old_cors" ] || new_cors="$new_public"
+  fi
+
+  tmp="$($SUDO mktemp "${INSTALL_DIR}/.env.tmp.XXXXXX")"
+  $SUDO awk \
+    -v host_port="$PORT" \
+    -v public_url="$new_public" \
+    -v cors_origin="$new_cors" '
+      BEGIN {
+        saw_host_port = 0
+        saw_public_url = 0
+        saw_cors_origin = 0
+      }
+      /^HOST_PORT=/ {
+        print "HOST_PORT=" host_port
+        saw_host_port = 1
+        next
+      }
+      /^PUBLIC_URL=/ {
+        print "PUBLIC_URL=" public_url
+        saw_public_url = 1
+        next
+      }
+      /^CORS_ORIGIN=/ {
+        print "CORS_ORIGIN=" cors_origin
+        saw_cors_origin = 1
+        next
+      }
+      { print }
+      END {
+        if (!saw_host_port) print "HOST_PORT=" host_port
+        if (!saw_public_url) print "PUBLIC_URL=" public_url
+        if (!saw_cors_origin) print "CORS_ORIGIN=" cors_origin
+      }
+    ' "${INSTALL_DIR}/.env" | $SUDO tee "$tmp" >/dev/null
+  $SUDO chmod 600 "$tmp"
+  $SUDO mv "$tmp" "${INSTALL_DIR}/.env"
+  PUBLIC_URL="$new_public"
+  log "Updated the existing install to host port ${PORT}."
+}
+
 # ---- compose -----------------------------------------------------------------
 # shellcheck disable=SC2086  # $SUDO may be empty and $ENGINE is a bare word — both must split
 compose() { ( cd "$INSTALL_DIR" && $SUDO $ENGINE compose "$@" ); }
+
+stack_app_owns_port() {
+  local container mapping mappings
+  container="$(compose ps -q app 2>/dev/null || true)"
+  [ -n "$container" ] || return 1
+  mappings="$(compose port app 8080 2>/dev/null || true)"
+  while IFS= read -r mapping; do
+    [ "${mapping##*:}" = "$PORT" ] && return 0
+  done <<<"$mappings"
+  return 1
+}
+
+ensure_port_available() {
+  local allow_running_stack="${1:-0}" normalized
+  normalized="$(normalize_port "$PORT")" \
+    || die "invalid host port '${PORT}' — expected a number from 1 to 65535"
+  PORT="$normalized"
+  port_is_in_use "$PORT" || return 0
+  if [ "$allow_running_stack" = "1" ] && stack_app_owns_port; then
+    return
+  fi
+  prompt_for_available_port
+}
+
+configure_runtime_port() {
+  local saved_port
+  if $SUDO test -f "${INSTALL_DIR}/.env"; then
+    write_env
+    load_runtime_info
+    saved_port="$PORT"
+    if [ -n "$PORT_OVERRIDE" ]; then
+      PORT="$PORT_OVERRIDE"
+    fi
+    if [ "$PORT" = "$saved_port" ]; then
+      ensure_port_available 1
+    else
+      ensure_port_available 0
+    fi
+    if [ "$PORT" != "$saved_port" ]; then
+      update_runtime_port "$saved_port"
+    fi
+    return
+  fi
+
+  ensure_port_available 0
+  write_env
+  load_runtime_info
+}
 
 bring_up() {
   log "Pulling images and starting the stack…"
@@ -234,10 +418,11 @@ main() {
   $SUDO mkdir -p "$INSTALL_DIR"
   fetch_file docker-compose.yml "${INSTALL_DIR}/docker-compose.yml"
   fetch_file .env.example "${INSTALL_DIR}/.env.example" || true
-  write_env
-  load_runtime_info
+  configure_runtime_port
   bring_up
   wait_health
 }
 
-main "$@"
+if [[ -z "${BASH_SOURCE[0]:-}" || "${BASH_SOURCE[0]}" = "$0" ]]; then
+  main "$@"
+fi

--- a/scripts/installer-port.test.ts
+++ b/scripts/installer-port.test.ts
@@ -14,6 +14,15 @@ function temporaryDirectory(): string {
   return directory;
 }
 
+function simulatedTerminal(): { inputPath: string; outputPath: string } {
+  const directory = temporaryDirectory();
+  const inputPath = join(directory, "input");
+  const outputPath = join(directory, "output");
+  writeFileSync(inputPath, "\n");
+  writeFileSync(outputPath, "");
+  return { inputPath, outputPath };
+}
+
 function runInstallerFunctions(script: string, args: string[] = [], input = ""): string {
   return execFileSync("bash", ["-c", `source "$1"\n${script}`, "bash", INSTALLER, ...args], {
     cwd: ROOT,
@@ -30,18 +39,18 @@ afterEach(() => {
 
 describe("installer host-port handling", () => {
   it("prompts on the terminal and accepts the suggested free port", () => {
+    const terminal = simulatedTerminal();
     const output = runInstallerFunctions(
       `
         PORT=8080
-        TTY_INPUT=/dev/stdin
-        TTY_OUTPUT=/dev/stdout
+        TTY_INPUT="$2"
+        TTY_OUTPUT="$3"
         port_is_in_use() { [ "$1" = 8080 ]; }
         stack_app_owns_port() { return 1; }
         ensure_port_available 0
         printf "%s" "$PORT"
       `,
-      [],
-      "\n"
+      [terminal.inputPath, terminal.outputPath]
     );
 
     expect(output).toContain("Using host port 8081.");
@@ -62,6 +71,7 @@ describe("installer host-port handling", () => {
 
   it("repairs a failed first install whose saved port was claimed", () => {
     const installDirectory = temporaryDirectory();
+    const terminal = simulatedTerminal();
     const envPath = join(installDirectory, ".env");
     writeFileSync(
       envPath,
@@ -80,14 +90,13 @@ describe("installer host-port handling", () => {
         SUDO=""
         PORT_OVERRIDE=""
         PORT=8080
-        TTY_INPUT=/dev/stdin
-        TTY_OUTPUT=/dev/stdout
+        TTY_INPUT="$3"
+        TTY_OUTPUT="$4"
         port_is_in_use() { [ "$1" = 8080 ]; }
         stack_app_owns_port() { return 1; }
         configure_runtime_port
       `,
-      [installDirectory],
-      "\n"
+      [installDirectory, terminal.inputPath, terminal.outputPath]
     );
 
     expect(readFileSync(envPath, "utf8")).toContain("HOST_PORT=8081\n");

--- a/scripts/installer-port.test.ts
+++ b/scripts/installer-port.test.ts
@@ -23,11 +23,12 @@ function simulatedTerminal(): { inputPath: string; outputPath: string } {
   return { inputPath, outputPath };
 }
 
-function runInstallerFunctions(script: string, args: string[] = [], input = ""): string {
-  return execFileSync("bash", ["-c", `source "$1"\n${script}`, "bash", INSTALLER, ...args], {
+function runInstallerFunctions(script: string, args: string[] = []): string {
+  const harnessPath = join(temporaryDirectory(), "harness.sh");
+  writeFileSync(harnessPath, `source "$1"\n${script}`);
+  return execFileSync("bash", [harnessPath, INSTALLER, ...args], {
     cwd: ROOT,
     encoding: "utf8",
-    input,
   });
 }
 

--- a/scripts/installer-port.test.ts
+++ b/scripts/installer-port.test.ts
@@ -1,0 +1,168 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const ROOT = resolve(import.meta.dirname, "..");
+const INSTALLER = join(ROOT, "scripts/install.sh");
+const temporaryDirectories: string[] = [];
+
+function temporaryDirectory(): string {
+  const directory = mkdtempSync(join(tmpdir(), "tulipfarm-installer-port-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function runInstallerFunctions(script: string, args: string[] = [], input = ""): string {
+  return execFileSync("bash", ["-c", `source "$1"\n${script}`, "bash", INSTALLER, ...args], {
+    cwd: ROOT,
+    encoding: "utf8",
+    input,
+  });
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+describe("installer host-port handling", () => {
+  it("prompts on the terminal and accepts the suggested free port", () => {
+    const output = runInstallerFunctions(
+      `
+        PORT=8080
+        TTY_INPUT=/dev/stdin
+        TTY_OUTPUT=/dev/stdout
+        port_is_in_use() { [ "$1" = 8080 ]; }
+        stack_app_owns_port() { return 1; }
+        ensure_port_available 0
+        printf "%s" "$PORT"
+      `,
+      [],
+      "\n"
+    );
+
+    expect(output).toContain("Using host port 8081.");
+    expect(output.endsWith("8081")).toBe(true);
+  });
+
+  it("does not treat the running TulipFarm app as a conflicting process", () => {
+    const output = runInstallerFunctions(`
+      PORT=8080
+      port_is_in_use() { return 0; }
+      stack_app_owns_port() { return 0; }
+      ensure_port_available 1
+      printf "%s" "$PORT"
+    `);
+
+    expect(output).toBe("8080");
+  });
+
+  it("repairs a failed first install whose saved port was claimed", () => {
+    const installDirectory = temporaryDirectory();
+    const envPath = join(installDirectory, ".env");
+    writeFileSync(
+      envPath,
+      [
+        "PUBLIC_URL=http://192.168.68.110:8080",
+        "CORS_ORIGIN=http://192.168.68.110:8080",
+        "HOST_PORT=8080",
+        "JWT_SECRET=keep-me",
+        "",
+      ].join("\n")
+    );
+
+    runInstallerFunctions(
+      `
+        INSTALL_DIR="$2"
+        SUDO=""
+        PORT_OVERRIDE=""
+        PORT=8080
+        TTY_INPUT=/dev/stdin
+        TTY_OUTPUT=/dev/stdout
+        port_is_in_use() { [ "$1" = 8080 ]; }
+        stack_app_owns_port() { return 1; }
+        configure_runtime_port
+      `,
+      [installDirectory],
+      "\n"
+    );
+
+    expect(readFileSync(envPath, "utf8")).toContain("HOST_PORT=8081\n");
+    expect(readFileSync(envPath, "utf8")).toContain("JWT_SECRET=keep-me\n");
+  });
+
+  it("honors a new TF_PORT on an existing install and preserves secrets", () => {
+    const installDirectory = temporaryDirectory();
+    const envPath = join(installDirectory, ".env");
+    writeFileSync(
+      envPath,
+      [
+        "PUBLIC_URL=http://192.168.68.110:8080",
+        "CORS_ORIGIN=http://192.168.68.110:8080",
+        "HOST_PORT=8080",
+        "JWT_SECRET=keep-me",
+        "",
+      ].join("\n")
+    );
+
+    runInstallerFunctions(
+      `
+        INSTALL_DIR="$2"
+        SUDO=""
+        PORT_OVERRIDE=9000
+        PORT=9000
+        port_is_in_use() { return 1; }
+        configure_runtime_port
+      `,
+      [installDirectory]
+    );
+
+    expect(readFileSync(envPath, "utf8")).toBe(
+      [
+        "PUBLIC_URL=http://192.168.68.110:9000",
+        "CORS_ORIGIN=http://192.168.68.110:9000",
+        "HOST_PORT=9000",
+        "JWT_SECRET=keep-me",
+        "",
+      ].join("\n")
+    );
+  });
+
+  it("does not rewrite custom reverse-proxy origins when the host port changes", () => {
+    const installDirectory = temporaryDirectory();
+    const envPath = join(installDirectory, ".env");
+    writeFileSync(
+      envPath,
+      [
+        "PUBLIC_URL=https://tulipfarm.example.com",
+        "CORS_ORIGIN=https://app.example.com",
+        "HOST_PORT=8080",
+        "JWT_SECRET=keep-me",
+        "",
+      ].join("\n")
+    );
+
+    runInstallerFunctions(
+      `
+        INSTALL_DIR="$2"
+        SUDO=""
+        PORT=9000
+        update_runtime_port 8080
+      `,
+      [installDirectory]
+    );
+
+    expect(readFileSync(envPath, "utf8")).toBe(
+      [
+        "PUBLIC_URL=https://tulipfarm.example.com",
+        "CORS_ORIGIN=https://app.example.com",
+        "HOST_PORT=9000",
+        "JWT_SECRET=keep-me",
+        "",
+      ].join("\n")
+    );
+  });
+});

--- a/scripts/test/installer-smoke.sh
+++ b/scripts/test/installer-smoke.sh
@@ -67,6 +67,8 @@ curl -fsS --retry 5 --retry-connrefused --retry-delay 2 \
 
 # 4. Assert idempotency: a second run preserves the generated .env (update mode).
 env_before="$(sha256sum "${INSTALL_DIR}/.env" | awk '{print $1}')"
+secrets_before="$(grep -E '^(POSTGRES_PASSWORD|ENCRYPTION_KEY|JWT_SECRET|WEBHOOK_SIGNING_SECRET)=' \
+  "${INSTALL_DIR}/.env")"
 log "re-running installer (idempotency check)…"
 TF_LOCAL_SRC="$REPO_ROOT" TF_VERSION="ci" TF_RUNTIME="docker" \
 TF_INSTALL_DIR="$INSTALL_DIR" TF_PORT="$PORT" \
@@ -75,4 +77,21 @@ TF_INSTALL_DIR="$INSTALL_DIR" TF_PORT="$PORT" \
 env_after="$(sha256sum "${INSTALL_DIR}/.env" | awk '{print $1}')"
 [ "$env_before" = "$env_after" ] || fail "re-run mutated .env (secrets not preserved)"
 
-log "PASS — stack healthy and re-run preserved secrets"
+# 5. A deliberate port override updates runtime settings without rotating secrets.
+UPDATED_PORT=$((PORT + 1))
+log "moving existing install to port ${UPDATED_PORT}…"
+TF_LOCAL_SRC="$REPO_ROOT" TF_VERSION="ci" TF_RUNTIME="docker" \
+TF_INSTALL_DIR="$INSTALL_DIR" TF_PORT="$UPDATED_PORT" \
+  bash "${REPO_ROOT}/scripts/install.sh" >/dev/null 2>&1 \
+  || fail "installer port override exited non-zero"
+grep -qx "HOST_PORT=${UPDATED_PORT}" "${INSTALL_DIR}/.env" \
+  || fail "port override did not update HOST_PORT"
+[ "$secrets_before" = \
+  "$(grep -E '^(POSTGRES_PASSWORD|ENCRYPTION_KEY|JWT_SECRET|WEBHOOK_SIGNING_SECRET)=' \
+    "${INSTALL_DIR}/.env")" ] \
+  || fail "port override changed generated secrets"
+curl -fsS --retry 5 --retry-connrefused --retry-delay 2 \
+  "http://localhost:${UPDATED_PORT}/health" >/dev/null \
+  || fail "/health did not move to :${UPDATED_PORT}"
+
+log "PASS — stack healthy, re-runs preserved secrets, and the host port changed cleanly"


### PR DESCRIPTION
## Summary

- detect occupied host ports before Compose starts and prompt interactive curl installs to use the next available port
- honor an explicit `TF_PORT` during updates and failed-install recovery while preserving generated secrets and custom reverse-proxy origins
- add installer regression tests, port-migration smoke coverage, and deployment documentation

## Root cause

The installer wrote `.env` before Compose startup, then treated every retry as update mode and preserved its saved `HOST_PORT`. After a bind failure on port 8080, setting `TF_PORT` on the retry was therefore silently ignored.

## Test plan

- [x] `bash -n scripts/install.sh scripts/test/installer-smoke.sh`
- [x] `pnpm exec vitest run scripts/installer-port.test.ts`
- [x] `pnpm architecture:test`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm --filter @tulipfarm/docs build`
- [x] `bash scripts/test/installer-smoke.sh`