### PR TITLE
feat(installer): add production uninstaller

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -30,7 +30,11 @@ jobs:
           docker buildx build --check .
           docker compose config --quiet
           docker compose -f docker-compose.yml -f docker-compose.dev.yml config --quiet
-          bash -n scripts/install.sh scripts/test/compose-parity.sh scripts/test/installer-smoke.sh
+          bash -n \
+            scripts/install.sh \
+            scripts/uninstall.sh \
+            scripts/test/compose-parity.sh \
+            scripts/test/installer-smoke.sh
 
   build:
     name: Build image (${{ matrix.platform }})

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Verifies WSL2 + a distro, then runs the Linux installer inside WSL.
 
 Overrides (env vars): `TF_VERSION` (image tag, default `latest`), `TF_PORT` (default
 `8080`), `TF_INSTALL_DIR` (default `/opt/tulipfarm`), `TF_RUNTIME` (`docker`|`podman`),
-`TF_BASE_URL`/`TF_REF`. Full guide: see `apps/docs/content/docs/installation.mdx`.
+`TF_BASE_URL`/`TF_REF`. See the
+[installation guide](https://tulipfarm.site/docs/installation) for every option.
 An explicit `TF_PORT` also moves an existing install to that host port without rotating
 its generated secrets.
 
@@ -39,6 +40,14 @@ its generated secrets.
 > `main`; to install an exact ref instead, set
 > `TF_BASE_URL=https://raw.githubusercontent.com/TulipFarm/tulipfarm` together with
 > `TF_REF=<tag-or-branch>`. To test a local build, set `TF_LOCAL_SRC=1`.
+
+**Uninstall permanently** (deletes the database, soul, secrets, backups, volumes, and
+TulipFarm images after a typed confirmation):
+```bash
+curl -fsSL https://tulipfarm.site/uninstall.sh | bash
+```
+Docker/Podman itself and externally managed databases are left untouched. See the
+[uninstall guide](https://tulipfarm.site/docs/uninstall) before running it.
 
 **Compose by hand** (Portainer, Coolify, Dokploy, Unraid, or a plain `docker compose`) —
 grab `docker-compose.yml` from <https://tulipfarm.site/docker-compose.yml> and run it

--- a/apps/docs/.gitignore
+++ b/apps/docs/.gitignore
@@ -6,6 +6,7 @@
 
 # install assets copied from the repo root by scripts/sync-public-assets.mjs
 /public/install.sh
+/public/uninstall.sh
 /public/install.ps1
 /public/docker-compose.yml
 /public/env.example

--- a/apps/docs/AGENTS.md
+++ b/apps/docs/AGENTS.md
@@ -54,8 +54,8 @@ How it works — do not route prompts through the syntax highlighter:
 ## Never write the site domain — use `{{SITE_URL}}`
 
 Install commands point at the docs site itself (`https://tulipfarm.site/install.sh`), which
-also serves `docker-compose.yml`, `install.ps1`, and `env.example`. The domain lives in
-exactly one place: `SITE_URL` in `lib/shared.ts`.
+also serves `uninstall.sh`, `docker-compose.yml`, `install.ps1`, and `env.example`. The
+domain lives in exactly one place: `SITE_URL` in `lib/shared.ts`.
 
 In MDX, write the token — `lib/remark-site-url.ts` substitutes it at the mdast stage, so
 fences stay real ` ```bash ` blocks with highlighting and a copy button:

--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -27,18 +27,20 @@ pnpm --filter @tulipfarm/docs typecheck  # fumadocs-mdx + next typegen + tsc
 | `app/docs` | Documentation layout and pages |
 | `app/api/search` | Search index, statically generated (Orama) |
 | `source.config.ts` | Fumadocs MDX config (frontmatter schema etc.) |
-| `scripts/sync-public-assets.mjs` | Copies the install assets into `public/` before build/dev |
+| `scripts/sync-public-assets.mjs` | Copies the install and uninstall assets into `public/` before build/dev |
 
 ## Published install assets
 
 The site is the distribution point for the installer and the Compose file, so
-`https://tulipfarm.site/install.sh` works. `scripts/sync-public-assets.mjs` runs ahead of
-`next build` and `next dev` (chained in `package.json` — **not** a `prebuild` hook, which
-pnpm does not run by default) and copies these byte-identical from the repo root:
+`https://tulipfarm.site/install.sh` and `https://tulipfarm.site/uninstall.sh` work.
+`scripts/sync-public-assets.mjs` runs ahead of `next build` and `next dev` (chained in
+`package.json` — **not** a `prebuild` hook, which pnpm does not run by default) and copies
+these byte-identical from the repo root:
 
 | Served at | Source |
 | --- | --- |
 | `/install.sh` | `scripts/install.sh` |
+| `/uninstall.sh` | `scripts/uninstall.sh` |
 | `/install.ps1` | `scripts/install.ps1` |
 | `/docker-compose.yml` | `docker-compose.yml` |
 | `/env.example` | `.env.example` |

--- a/apps/docs/content/docs/installation.mdx
+++ b/apps/docs/content/docs/installation.mdx
@@ -38,6 +38,9 @@ pulls the pinned version, and restarts. An explicit `TF_PORT` changes the saved 
 and its installer-generated local URLs. See
 [Updating and rollback](/docs/deploy/updating).
 
+To permanently remove the stack and all local data, use the
+[production uninstaller](/docs/uninstall).
+
 ## Windows
 
 From PowerShell:

--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -3,6 +3,7 @@
     "index",
     "---Self-host---",
     "installation",
+    "uninstall",
     "deploy",
     "---Use TulipFarm---",
     "getting-started",

--- a/apps/docs/content/docs/uninstall.mdx
+++ b/apps/docs/content/docs/uninstall.mdx
@@ -1,0 +1,93 @@
+---
+title: Uninstall
+description: Permanently remove a TulipFarm self-hosted installation, including its database, soul, secrets, backups, and container images.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+The production uninstaller removes an installation created by the
+[one-line installer](/docs/installation), including all local data. It is intentionally
+interactive and refuses to proceed until you type the complete confirmation phrase.
+
+<Callout type="error">
+  **This cannot be undone.** Export or copy anything you need before continuing. The
+  uninstaller permanently deletes the bundled PostgreSQL database, the soul repository,
+  generated encryption keys, locally stored backups, and every locally cached TulipFarm
+  application image.
+</Callout>
+
+## Run the uninstaller
+
+```bash
+curl -fsSL {{SITE_URL}}/uninstall.sh | bash
+```
+
+The script prints the exact Compose project and install directory it will remove. Type
+`uninstall tulipfarm` at the prompt to continue. Any other response stops without changing
+the installation.
+
+The script requests `sudo` only when the container runtime or install directory requires
+it. You can inspect the exact script before running it:
+
+```bash
+curl -fsSLO {{SITE_URL}}/uninstall.sh
+less uninstall.sh
+bash uninstall.sh
+```
+
+## What it removes
+
+| Artifact | Result |
+| --- | --- |
+| App, worker, and PostgreSQL containers | Force-stopped and removed |
+| Compose networks | Removed |
+| `tulipfarm-postgres` volume | Removed with the complete bundled database |
+| `tulipfarm-soul` volume | Removed with the complete soul repository |
+| `tulipfarm-data` volume | Removed with generated secrets and local backups |
+| TulipFarm application images | Every local `ghcr.io/tulipfarm/tulipfarm` tag is removed |
+| Bundled PostgreSQL image | Removed when another container or tag does not share it |
+| `/opt/tulipfarm` | Removed with `docker-compose.yml`, `.env`, `.env.example`, and the installer marker |
+
+After cleanup, the script checks again for TulipFarm containers, volumes, networks, images,
+and installer files. It exits with an error and names anything it could not remove.
+
+<Callout type="info">
+  Docker or Podman itself is not removed because other applications may use it. An external
+  or managed PostgreSQL database is also never modified; delete that database through its
+  provider only when you are certain it is dedicated to TulipFarm.
+</Callout>
+
+## Custom installations
+
+Use the same values that were supplied during installation:
+
+```bash
+TF_INSTALL_DIR=/srv/tulipfarm TF_RUNTIME=podman \
+  bash -c "curl -fsSL {{SITE_URL}}/uninstall.sh | bash"
+```
+
+`TF_RUNTIME` can be `docker` or `podman`. Without it, the script checks both available
+runtimes. For a non-default Compose project, also set `TF_PROJECT_NAME`.
+
+The script validates the install directory using the marker written by the installer or a
+TulipFarm Compose file. It refuses to recursively remove an unrecognized directory, a
+symlink, or a broad system path.
+
+## Non-interactive automation
+
+Interactive confirmation is the default. For controlled automation, pass `--yes`
+explicitly:
+
+```bash
+curl -fsSL {{SITE_URL}}/uninstall.sh | bash -s -- --yes
+```
+
+Do not place this form in general-purpose cleanup jobs: it permanently erases the instance
+without waiting for a person.
+
+## Deployments managed by another platform
+
+The script targets shell-based Docker or Podman deployments. For Portainer, Coolify,
+Dokploy, Kubernetes, or another orchestrator, remove the workload and its persistent
+volumes through that platform. Then remove any TulipFarm image tags from the platform's
+registry or node cache.

--- a/apps/docs/public/_headers
+++ b/apps/docs/public/_headers
@@ -5,6 +5,9 @@
 /install.sh
   Content-Type: text/plain; charset=utf-8
 
+/uninstall.sh
+  Content-Type: text/plain; charset=utf-8
+
 /install.ps1
   Content-Type: text/plain; charset=utf-8
 

--- a/apps/docs/scripts/sync-public-assets.mjs
+++ b/apps/docs/scripts/sync-public-assets.mjs
@@ -1,7 +1,7 @@
 /**
  * Copies the install assets from the repo root into `public/`, so the static export serves
- * them at the domain root — `{SITE_URL}/install.sh`, `{SITE_URL}/docker-compose.yml`, and
- * so on. Runs before `next build` and `next dev` (see package.json); the copies are
+ * them at the domain root — `{SITE_URL}/install.sh`, `{SITE_URL}/uninstall.sh`,
+ * `{SITE_URL}/docker-compose.yml`, and so on. Runs before `next build` and `next dev`; the copies are
  * gitignored, and `scripts/site-url.test.ts` asserts every source below still exists.
  *
  * Copies are byte-identical on purpose: the file a user curls is the same artifact CI
@@ -22,6 +22,7 @@ const PUBLIC_DIR = join(DOCS_ROOT, "public");
 /** Served path (relative to the domain root) → source path (relative to the repo root). */
 export const PUBLIC_ASSETS = {
   "install.sh": "scripts/install.sh",
+  "uninstall.sh": "scripts/uninstall.sh",
   "install.ps1": "scripts/install.ps1",
   "docker-compose.yml": "docker-compose.yml",
   "env.example": ".env.example",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -335,6 +335,18 @@ update_runtime_port() {
 # shellcheck disable=SC2086  # $SUDO may be empty and $ENGINE is a bare word — both must split
 compose() { ( cd "$INSTALL_DIR" && $SUDO $ENGINE compose "$@" ); }
 
+write_install_marker() {
+  local project_name="${COMPOSE_PROJECT_NAME:-tulipfarm}" tmp
+  tmp="$($SUDO mktemp "${INSTALL_DIR}/.tulipfarm-install.tmp.XXXXXX")"
+  $SUDO tee "$tmp" >/dev/null <<EOF
+managed-by=tulipfarm-installer
+compose-project=${project_name}
+runtime=${ENGINE}
+EOF
+  $SUDO chmod 644 "$tmp"
+  $SUDO mv "$tmp" "${INSTALL_DIR}/.tulipfarm-install"
+}
+
 stack_app_owns_port() {
   local container mapping mappings
   container="$(compose ps -q app 2>/dev/null || true)"
@@ -419,6 +431,7 @@ main() {
   fetch_file docker-compose.yml "${INSTALL_DIR}/docker-compose.yml"
   fetch_file .env.example "${INSTALL_DIR}/.env.example" || true
   configure_runtime_port
+  write_install_marker
   bring_up
   wait_health
 }

--- a/scripts/site-url.test.ts
+++ b/scripts/site-url.test.ts
@@ -43,6 +43,7 @@ describe("site URL stays in one place", () => {
       "apps/docs/README.md",
       "apps/docs/AGENTS.md",
       "scripts/install.sh",
+      "scripts/uninstall.sh",
       "scripts/install.ps1",
     ];
     for (const file of files) {

--- a/scripts/test/installer-smoke.sh
+++ b/scripts/test/installer-smoke.sh
@@ -58,6 +58,10 @@ TF_INSTALL_DIR="$INSTALL_DIR" \
 TF_PORT="$PORT" \
   bash "${REPO_ROOT}/scripts/install.sh" \
   || fail "installer exited non-zero"
+grep -qx "managed-by=tulipfarm-installer" "${INSTALL_DIR}/.tulipfarm-install" \
+  || fail "installer ownership marker was not written"
+grep -qx "compose-project=${COMPOSE_PROJECT_NAME}" "${INSTALL_DIR}/.tulipfarm-install" \
+  || fail "installer marker did not record the Compose project"
 
 # 3. Re-assert /health on the host port (the installer already gates on this).
 log "asserting /health on :${PORT}…"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,395 @@
+#!/usr/bin/env bash
+# TulipFarm production uninstaller for one-line and Compose installations.
+#
+#   curl -fsSL https://tulipfarm.site/uninstall.sh | bash
+#
+# Permanently removes the TulipFarm Compose project, its named volumes (Postgres,
+# Soul, generated secrets, and backups), locally cached TulipFarm application
+# images, and the installer-managed directory. Docker/Podman itself and external
+# datastores are never removed.
+#
+# Overrides:
+#   TF_INSTALL_DIR   installer directory (default: /opt/tulipfarm)
+#   TF_RUNTIME       restrict cleanup to docker or podman (default: inspect both)
+#   TF_PROJECT_NAME  Compose project name (default: marker value, then tulipfarm)
+#
+# Non-interactive use:
+#   curl -fsSL https://tulipfarm.site/uninstall.sh | bash -s -- --yes
+set -uo pipefail
+
+INSTALL_DIR="${TF_INSTALL_DIR:-/opt/tulipfarm}"
+RUNTIME_OVERRIDE="${TF_RUNTIME:-}"
+PROJECT_OVERRIDE="${TF_PROJECT_NAME:-${COMPOSE_PROJECT_NAME:-}}"
+PROJECT_NAME=""
+ASSUME_YES=false
+TTY_INPUT="${TF_TTY_INPUT:-/dev/tty}"
+TTY_OUTPUT="${TF_TTY_OUTPUT:-/dev/tty}"
+FS_SUDO=""
+ERRORS=0
+RUNTIMES_CLEANED=0
+PROJECT_IMAGE_IDS=()
+
+log() { printf '\033[0;32m▸\033[0m %s\n' "$*"; }
+warn() { printf '\033[0;33m⚠\033[0m  %s\n' "$*" >&2; }
+fail() {
+  printf '\033[0;31m✗\033[0m %s\n' "$*" >&2
+  ERRORS=$((ERRORS + 1))
+}
+die() {
+  printf '\033[0;31m✗\033[0m %s\n' "$*" >&2
+  exit 1
+}
+
+usage() {
+  printf '%s\n' \
+    "TulipFarm production uninstaller" \
+    "" \
+    "Usage:" \
+    "  uninstall.sh [--yes]" \
+    "" \
+    "Options:" \
+    "  -y, --yes   skip the typed confirmation (destructive)" \
+    "  -h, --help  show this help"
+}
+
+parse_args() {
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      -y | --yes) ASSUME_YES=true ;;
+      -h | --help)
+        usage
+        exit 0
+        ;;
+      *) die "unknown option: $1 (use --help for usage)" ;;
+    esac
+    shift
+  done
+}
+
+ensure_privilege_helper() {
+  if [ "$(id -u)" -eq 0 ]; then
+    FS_SUDO=""
+    return
+  fi
+  if [ -e "$INSTALL_DIR" ] && [ -w "$INSTALL_DIR" ]; then
+    FS_SUDO=""
+    return
+  fi
+  if [ ! -e "$INSTALL_DIR" ] && [ -w "$(dirname "$INSTALL_DIR")" ]; then
+    FS_SUDO=""
+    return
+  fi
+  command -v sudo >/dev/null 2>&1 \
+    || die "need root or sudo to remove ${INSTALL_DIR}"
+  FS_SUDO="sudo"
+}
+
+fs() {
+  if [ -n "$FS_SUDO" ]; then
+    "$FS_SUDO" "$@"
+  else
+    "$@"
+  fi
+}
+
+read_marker_value() {
+  local key="$1" marker="${INSTALL_DIR}/.tulipfarm-install"
+  [ -f "$marker" ] || return 0
+  fs grep -E "^${key}=" "$marker" 2>/dev/null | head -1 | cut -d= -f2- || true
+}
+
+resolve_project_name() {
+  local marked
+  marked="$(read_marker_value compose-project)"
+  PROJECT_NAME="${PROJECT_OVERRIDE:-${marked:-tulipfarm}}"
+  [[ "$PROJECT_NAME" =~ ^[a-zA-Z0-9][a-zA-Z0-9_.-]*$ ]] \
+    || die "unsafe Compose project name: ${PROJECT_NAME}"
+}
+
+validate_install_dir() {
+  local original="$INSTALL_DIR"
+  [ -n "$INSTALL_DIR" ] || die "refusing an empty TF_INSTALL_DIR"
+  case "$INSTALL_DIR" in
+    /*) ;;
+    *) INSTALL_DIR="${PWD}/${INSTALL_DIR}" ;;
+  esac
+
+  [ ! -L "$INSTALL_DIR" ] \
+    || die "refusing to recursively remove symlinked install directory: ${original}"
+
+  if [ -d "$INSTALL_DIR" ]; then
+    INSTALL_DIR="$(cd "$INSTALL_DIR" && pwd -P)" \
+      || die "cannot resolve install directory: ${original}"
+  fi
+
+  case "$INSTALL_DIR" in
+    / | /bin | /etc | /home | /opt | /root | /sbin | /tmp | /usr | /var | "$HOME")
+      die "refusing unsafe install directory: ${INSTALL_DIR}"
+      ;;
+  esac
+}
+
+is_managed_install_dir() {
+  local marker="${INSTALL_DIR}/.tulipfarm-install"
+  local compose_file="${INSTALL_DIR}/docker-compose.yml"
+  if [ -f "$marker" ] \
+    && fs grep -qx "managed-by=tulipfarm-installer" "$marker" 2>/dev/null; then
+    return 0
+  fi
+  [ -f "$compose_file" ] \
+    && fs grep -q "ghcr.io/tulipfarm/tulipfarm:" "$compose_file" 2>/dev/null
+}
+
+validate_managed_install_dir() {
+  [ ! -e "$INSTALL_DIR" ] || is_managed_install_dir \
+    || die "refusing unrecognized install directory: ${INSTALL_DIR}"
+}
+
+validate_runtime_override() {
+  case "$RUNTIME_OVERRIDE" in
+    "" | docker | podman) ;;
+    *) die "TF_RUNTIME must be docker or podman, got: ${RUNTIME_OVERRIDE}" ;;
+  esac
+}
+
+confirm_uninstall() {
+  local reply
+  $ASSUME_YES && return 0
+
+  printf '\n'
+  warn "This permanently deletes the TulipFarm instance and cannot be undone."
+  printf 'The purge includes:\n'
+  printf '  • Compose project: %s (containers and networks)\n' "$PROJECT_NAME"
+  printf '  • Named volumes: PostgreSQL, Soul, generated secrets, and local backups\n'
+  printf '  • TulipFarm application images and unshared images used by this project\n'
+  printf '  • Install directory: %s (including .env files)\n' "$INSTALL_DIR"
+  printf '\nDocker/Podman itself and externally managed databases are not removed.\n\n'
+
+  if ! { exec 8<"$TTY_INPUT"; } 2>/dev/null \
+    || ! { exec 9>"$TTY_OUTPUT"; } 2>/dev/null; then
+    die "no interactive terminal available; inspect the script, then re-run with --yes"
+  fi
+  printf "Type 'uninstall tulipfarm' to continue: " >&9
+  IFS= read -r reply <&8 || die "could not read confirmation"
+  exec 8<&-
+  exec 9>&-
+  [ "$reply" = "uninstall tulipfarm" ] || die "confirmation did not match; nothing was removed"
+}
+
+runtime() {
+  local engine="$1"
+  shift
+  if "$engine" info >/dev/null 2>&1; then
+    "$engine" "$@"
+    return
+  fi
+  if [ -n "$FS_SUDO" ] && "$FS_SUDO" "$engine" info >/dev/null 2>&1; then
+    "$FS_SUDO" "$engine" "$@"
+    return
+  fi
+  return 127
+}
+
+runtime_is_available() {
+  local engine="$1"
+  command -v "$engine" >/dev/null 2>&1 || return 1
+  runtime "$engine" info >/dev/null 2>&1
+}
+
+remember_image_id() {
+  local candidate="$1" existing
+  [ -n "$candidate" ] || return 0
+  for existing in "${PROJECT_IMAGE_IDS[@]:-}"; do
+    [ "$existing" = "$candidate" ] && return 0
+  done
+  PROJECT_IMAGE_IDS+=("$candidate")
+}
+
+collect_project_image_ids() {
+  local engine="$1" container image_id
+  while IFS= read -r container; do
+    [ -n "$container" ] || continue
+    image_id="$(runtime "$engine" inspect --format '{{.Image}}' "$container" 2>/dev/null || true)"
+    remember_image_id "$image_id"
+  done < <(
+    runtime "$engine" ps -aq \
+      --filter "label=com.docker.compose.project=${PROJECT_NAME}" 2>/dev/null || true
+  )
+}
+
+remove_project_containers() {
+  local engine="$1" id
+  while IFS= read -r id; do
+    [ -n "$id" ] || continue
+    runtime "$engine" rm -f "$id" >/dev/null 2>&1 \
+      || fail "${engine}: could not remove project container ${id}"
+  done < <(
+    runtime "$engine" ps -aq \
+      --filter "label=com.docker.compose.project=${PROJECT_NAME}" 2>/dev/null || true
+  )
+}
+
+remove_project_volumes() {
+  local engine="$1" id suffix
+  while IFS= read -r id; do
+    [ -n "$id" ] || continue
+    runtime "$engine" volume rm "$id" >/dev/null 2>&1 \
+      || fail "${engine}: could not remove project volume ${id}"
+  done < <(
+    runtime "$engine" volume ls -q \
+      --filter "label=com.docker.compose.project=${PROJECT_NAME}" 2>/dev/null || true
+  )
+
+  # Some Podman Compose releases do not preserve Docker's project labels. These
+  # exact fallback names are the only volumes declared by TulipFarm's Compose file.
+  for suffix in tulipfarm-postgres tulipfarm-soul tulipfarm-data; do
+    id="${PROJECT_NAME}_${suffix}"
+    if runtime "$engine" volume inspect "$id" >/dev/null 2>&1; then
+      runtime "$engine" volume rm "$id" >/dev/null 2>&1 \
+        || fail "${engine}: could not remove project volume ${id}"
+    fi
+  done
+}
+
+remove_project_networks() {
+  local engine="$1" id fallback="${PROJECT_NAME}_default"
+  while IFS= read -r id; do
+    [ -n "$id" ] || continue
+    runtime "$engine" network rm "$id" >/dev/null 2>&1 \
+      || fail "${engine}: could not remove project network ${id}"
+  done < <(
+    runtime "$engine" network ls -q \
+      --filter "label=com.docker.compose.project=${PROJECT_NAME}" 2>/dev/null || true
+  )
+  if runtime "$engine" network inspect "$fallback" >/dev/null 2>&1; then
+    runtime "$engine" network rm "$fallback" >/dev/null 2>&1 \
+      || fail "${engine}: could not remove project network ${fallback}"
+  fi
+}
+
+remove_tulipfarm_images() {
+  local engine="$1" reference image_id
+  while IFS= read -r reference; do
+    case "$reference" in
+      ghcr.io/tulipfarm/tulipfarm:*)
+        runtime "$engine" image rm "$reference" >/dev/null 2>&1 \
+          || fail "${engine}: could not remove TulipFarm image ${reference}"
+        ;;
+    esac
+  done < <(runtime "$engine" image ls --format '{{.Repository}}:{{.Tag}}' 2>/dev/null || true)
+
+  # Remove the bundled PostgreSQL image too when no other container uses it. A
+  # shared third-party image is left intact rather than disrupting another stack.
+  for image_id in "${PROJECT_IMAGE_IDS[@]:-}"; do
+    [ -n "$image_id" ] || continue
+    if runtime "$engine" image inspect "$image_id" >/dev/null 2>&1; then
+      runtime "$engine" image rm "$image_id" >/dev/null 2>&1 \
+        || warn "${engine}: kept shared image ${image_id} because another reference uses it"
+    fi
+  done
+}
+
+verify_runtime_clean() {
+  local engine="$1" remaining reference suffix
+  remaining="$(
+    runtime "$engine" ps -aq \
+      --filter "label=com.docker.compose.project=${PROJECT_NAME}" 2>/dev/null || true
+  )"
+  [ -z "$remaining" ] || fail "${engine}: TulipFarm project containers remain"
+
+  remaining="$(
+    runtime "$engine" volume ls -q \
+      --filter "label=com.docker.compose.project=${PROJECT_NAME}" 2>/dev/null || true
+  )"
+  [ -z "$remaining" ] || fail "${engine}: TulipFarm project volumes remain"
+
+  remaining="$(
+    runtime "$engine" network ls -q \
+      --filter "label=com.docker.compose.project=${PROJECT_NAME}" 2>/dev/null || true
+  )"
+  [ -z "$remaining" ] || fail "${engine}: TulipFarm project networks remain"
+
+  for suffix in tulipfarm-postgres tulipfarm-soul tulipfarm-data; do
+    runtime "$engine" volume inspect "${PROJECT_NAME}_${suffix}" >/dev/null 2>&1 \
+      && fail "${engine}: TulipFarm volume ${PROJECT_NAME}_${suffix} remains"
+  done
+
+  while IFS= read -r reference; do
+    case "$reference" in
+      ghcr.io/tulipfarm/tulipfarm:*)
+        fail "${engine}: TulipFarm image ${reference} remains"
+        ;;
+    esac
+  done < <(runtime "$engine" image ls --format '{{.Repository}}:{{.Tag}}' 2>/dev/null || true)
+}
+
+clean_runtime() {
+  local engine="$1"
+  log "Removing TulipFarm artifacts from ${engine}…"
+  PROJECT_IMAGE_IDS=()
+  collect_project_image_ids "$engine"
+  remove_project_containers "$engine"
+  remove_project_volumes "$engine"
+  remove_project_networks "$engine"
+  remove_tulipfarm_images "$engine"
+  verify_runtime_clean "$engine"
+  RUNTIMES_CLEANED=$((RUNTIMES_CLEANED + 1))
+}
+
+clean_runtimes() {
+  local engine candidates
+  candidates="${RUNTIME_OVERRIDE:-docker podman}"
+
+  for engine in $candidates; do
+    if command -v "$engine" >/dev/null 2>&1; then
+      if runtime_is_available "$engine"; then
+        clean_runtime "$engine"
+      else
+        fail "${engine} is installed but its engine is not accessible"
+      fi
+    fi
+  done
+  [ "$RUNTIMES_CLEANED" -gt 0 ] \
+    || fail "no accessible Docker or Podman engine; container artifacts could not be verified"
+}
+
+remove_install_dir() {
+  [ -e "$INSTALL_DIR" ] || return 0
+  if ! is_managed_install_dir; then
+    fail "refusing to remove unrecognized directory ${INSTALL_DIR}"
+    return
+  fi
+  log "Removing installer files and environment from ${INSTALL_DIR}…"
+  fs rm -rf -- "$INSTALL_DIR" || fail "could not remove ${INSTALL_DIR}"
+}
+
+verify_install_dir_clean() {
+  [ ! -e "$INSTALL_DIR" ] || fail "install directory remains: ${INSTALL_DIR}"
+}
+
+main() {
+  parse_args "$@"
+  validate_install_dir
+  ensure_privilege_helper
+  resolve_project_name
+  validate_runtime_override
+  validate_managed_install_dir
+  confirm_uninstall
+  clean_runtimes
+  if [ "$ERRORS" -eq 0 ]; then
+    remove_install_dir
+    verify_install_dir_clean
+  else
+    warn "Retaining ${INSTALL_DIR} so the uninstall can be retried safely."
+  fi
+
+  printf '\n'
+  if [ "$ERRORS" -gt 0 ]; then
+    die "uninstall incomplete (${ERRORS} cleanup error(s)); review the messages above"
+  fi
+  log "TulipFarm was completely removed from this host."
+}
+
+if [[ -z "${BASH_SOURCE[0]:-}" || "${BASH_SOURCE[0]}" = "$0" ]]; then
+  main "$@"
+fi

--- a/scripts/uninstall.test.ts
+++ b/scripts/uninstall.test.ts
@@ -1,0 +1,205 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const ROOT = resolve(import.meta.dirname, "..");
+const UNINSTALLER = join(ROOT, "scripts/uninstall.sh");
+const temporaryDirectories: string[] = [];
+
+function temporaryDirectory(): string {
+  const directory = mkdtempSync(join(tmpdir(), "tulipfarm-uninstaller-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function writeHarness(script: string): string {
+  const path = join(temporaryDirectory(), "harness.sh");
+  writeFileSync(path, `source "$1"\n${script}`);
+  return path;
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+describe("production uninstaller", () => {
+  it("requires the complete typed confirmation phrase", () => {
+    const terminalDirectory = temporaryDirectory();
+    const inputPath = join(terminalDirectory, "input");
+    const outputPath = join(terminalDirectory, "output");
+    writeFileSync(inputPath, "uninstall\n");
+    writeFileSync(outputPath, "");
+    const harness = writeHarness(`
+      ASSUME_YES=false
+      PROJECT_NAME=tulipfarm
+      INSTALL_DIR=/opt/tulipfarm
+      TTY_INPUT="$2"
+      TTY_OUTPUT="$3"
+      confirm_uninstall
+    `);
+
+    const result = spawnSync("bash", [harness, UNINSTALLER, inputPath, outputPath], {
+      cwd: ROOT,
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("nothing was removed");
+    expect(readFileSync(outputPath, "utf8")).toContain("uninstall tulipfarm");
+  });
+
+  it("accepts the exact typed confirmation phrase", () => {
+    const terminalDirectory = temporaryDirectory();
+    const inputPath = join(terminalDirectory, "input");
+    const outputPath = join(terminalDirectory, "output");
+    writeFileSync(inputPath, "uninstall tulipfarm\n");
+    writeFileSync(outputPath, "");
+    const harness = writeHarness(`
+      ASSUME_YES=false
+      PROJECT_NAME=tulipfarm
+      INSTALL_DIR=/opt/tulipfarm
+      TTY_INPUT="$2"
+      TTY_OUTPUT="$3"
+      confirm_uninstall
+    `);
+
+    const result = spawnSync("bash", [harness, UNINSTALLER, inputPath, outputPath], {
+      cwd: ROOT,
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(0);
+  });
+
+  it("refuses broad and symlinked install directories", () => {
+    const target = temporaryDirectory();
+    const link = join(temporaryDirectory(), "linked-install");
+    execFileSync("ln", ["-s", target, link]);
+    const harness = writeHarness(`
+      INSTALL_DIR="$2"
+      validate_install_dir
+    `);
+
+    const rootResult = spawnSync("bash", [harness, UNINSTALLER, "/"], {
+      cwd: ROOT,
+      encoding: "utf8",
+    });
+    const linkResult = spawnSync("bash", [harness, UNINSTALLER, link], {
+      cwd: ROOT,
+      encoding: "utf8",
+    });
+
+    expect(rootResult.status).toBe(1);
+    expect(rootResult.stderr).toContain("unsafe install directory");
+    expect(linkResult.status).toBe(1);
+    expect(linkResult.stderr).toContain("symlinked install directory");
+  });
+
+  it("purges project resources and verifies the managed directory is gone", () => {
+    const state = temporaryDirectory();
+    const installDirectory = temporaryDirectory();
+    const commandLog = join(state, "commands");
+    const containers = join(state, "containers");
+    const volumes = join(state, "volumes");
+    const networks = join(state, "networks");
+    const images = join(state, "images");
+    const imageIds = join(state, "image-ids");
+    writeFileSync(
+      join(installDirectory, ".tulipfarm-install"),
+      "managed-by=tulipfarm-installer\ncompose-project=tf-test\nruntime=docker\n"
+    );
+    writeFileSync(join(installDirectory, ".env"), "JWT_SECRET=secret\n");
+    writeFileSync(containers, "app-container\npostgres-container\n");
+    writeFileSync(
+      volumes,
+      ["tf-test_tulipfarm-postgres", "tf-test_tulipfarm-soul", "tf-test_tulipfarm-data", ""].join(
+        "\n"
+      )
+    );
+    writeFileSync(networks, "tf-test_default\n");
+    writeFileSync(images, "ghcr.io/tulipfarm/tulipfarm:latest\n");
+    writeFileSync(imageIds, "sha-app\nsha-postgres\n");
+    writeFileSync(commandLog, "");
+
+    const harness = writeHarness(`
+      STATE="$2"
+      INSTALL_DIR="$3"
+      RUNTIME_OVERRIDE=docker
+      docker() { :; }
+      runtime_is_available() { [ "$1" = docker ]; }
+      remove_state_line() {
+        grep -vxF "$2" "$1" > "$1.tmp" || true
+        mv "$1.tmp" "$1"
+      }
+      runtime() {
+        local engine="$1"
+        shift
+        printf "%s\\n" "$*" >> "$STATE/commands"
+        case "$1" in
+          ps)
+            [ -s "$STATE/containers" ] && cat "$STATE/containers"
+            ;;
+          inspect)
+            case "\${*: -1}" in
+              app-container) printf "sha-app\\n" ;;
+              postgres-container) printf "sha-postgres\\n" ;;
+              *) return 1 ;;
+            esac
+            ;;
+          rm)
+            remove_state_line "$STATE/containers" "$3"
+            ;;
+          volume)
+            case "$2" in
+              ls) [ -s "$STATE/volumes" ] && cat "$STATE/volumes" ;;
+              rm) remove_state_line "$STATE/volumes" "$3" ;;
+              inspect) grep -qxF "$3" "$STATE/volumes" ;;
+            esac
+            ;;
+          network)
+            case "$2" in
+              ls) [ -s "$STATE/networks" ] && cat "$STATE/networks" ;;
+              rm) remove_state_line "$STATE/networks" "$3" ;;
+              inspect) grep -qxF "$3" "$STATE/networks" ;;
+            esac
+            ;;
+          image)
+            case "$2" in
+              ls) [ -s "$STATE/images" ] && cat "$STATE/images" ;;
+              inspect) grep -qxF "$3" "$STATE/image-ids" ;;
+              rm)
+                case "$3" in
+                  ghcr.io/tulipfarm/tulipfarm:*)
+                    : > "$STATE/images"
+                    remove_state_line "$STATE/image-ids" sha-app
+                    ;;
+                  *) remove_state_line "$STATE/image-ids" "$3" ;;
+                esac
+                ;;
+            esac
+            ;;
+          *) return 1 ;;
+        esac
+      }
+      main --yes
+    `);
+
+    const output = execFileSync("bash", [harness, UNINSTALLER, state, installDirectory], {
+      cwd: ROOT,
+      encoding: "utf8",
+    });
+
+    expect(output).toContain("completely removed");
+    expect(readFileSync(containers, "utf8")).toBe("");
+    expect(readFileSync(volumes, "utf8")).toBe("");
+    expect(readFileSync(networks, "utf8")).toBe("");
+    expect(readFileSync(images, "utf8")).toBe("");
+    expect(readFileSync(imageIds, "utf8")).toBe("");
+    expect(() => readFileSync(installDirectory)).toThrow();
+    expect(readFileSync(commandLog, "utf8")).toContain("label=com.docker.compose.project=tf-test");
+  });
+});

--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,8 @@
     "docker-compose.yml",
     ".env.example",
     "scripts/install.sh",
-    "scripts/install.ps1"
+    "scripts/install.ps1",
+    "scripts/uninstall.sh"
   ],
   "tasks": {
     "build": {


### PR DESCRIPTION
## Summary

- add a confirmation-gated production uninstaller that purges TulipFarm containers, networks, named volumes, soul, generated secrets, local backups, installer files, and application images
- add installer ownership metadata, unsafe-path guards, retry-safe partial-failure handling, post-uninstall verification, and hermetic cleanup tests
- publish `/uninstall.sh` through the docs site and add installation/uninstallation documentation with public website links

## Test plan

- [x] `bash -n scripts/install.sh scripts/uninstall.sh scripts/test/installer-smoke.sh`
- [x] `pnpm exec vitest run scripts/uninstall.test.ts scripts/installer-port.test.ts scripts/site-url.test.ts`
- [x] `pnpm --filter @tulipfarm/docs lint`
- [x] `pnpm --filter @tulipfarm/docs typecheck`
- [x] `pnpm --filter @tulipfarm/docs build`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
