### PR TITLE
fix(web): allow unsafe-eval in prod CSP for Ajv schema compilation

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -244,7 +244,8 @@ export async function buildApp(opts: AppOptions = {}) {
       reply.header(
         "content-security-policy",
         spaCspHeader ??
-          "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; " +
+          "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; " +
+            "style-src 'self' 'unsafe-inline'; " +
             "img-src 'self' data:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'"
       );
     }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -36,7 +36,9 @@ function cspHashPlugin(): Plugin {
         }
       }
 
-      const scriptSrc = ["'self'", ...hashes].join(" ");
+      // 'unsafe-eval' is required because Ajv (schema validation, @tulipfarm/surface) compiles
+      // validators via `new Function(...)` at runtime in the browser.
+      const scriptSrc = ["'self'", "'unsafe-eval'", ...hashes].join(" ");
       const cspHeader =
         `default-src 'self'; script-src ${scriptSrc}; style-src 'self' 'unsafe-inline'; ` +
         "img-src 'self' data:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'";


### PR DESCRIPTION
## Summary
- Prod SPA CSP's `script-src` had no `'unsafe-eval'`, but Ajv (`@tulipfarm/schema`, `@tulipfarm/surface`) compiles JSON Schema validators via `new Function(...)` in the browser at Surface Artifact render time.
- Result: `EvalError` on that compile call → lazy route module fails to load → app's reload-on-failure handler loops → infinite loading spinner in production (Docker install), plus rate-limit 429s from the reload spam hitting `/api/v1/setup/status`.
- Added `'unsafe-eval'` to `script-src` in both places the SPA CSP header is built: `apps/web/vite.config.ts` (build-time hash plugin) and the `apps/api/src/app.ts` fallback string.

## Test plan
- [x] `pnpm exec biome check apps/api/src/app.ts apps/web/vite.config.ts` — clean
- [ ] Rebuild + push the `ghcr.io/tulipfarm/tulipfarm` image, reinstall on a fresh host, confirm the artifact-rendering page loads without the CSP EvalError / reload loop