### PR TITLE
fix(web): guard secure-context-only browser APIs

### DIFF
--- a/apps/web/app/components/chat/chat-debug-drawer.tsx
+++ b/apps/web/app/components/chat/chat-debug-drawer.tsx
@@ -1,5 +1,6 @@
 import { Bug, Check, Copy, RefreshCw, X } from "lucide-react";
 import { type ReactNode, useCallback, useEffect, useRef, useState } from "react";
+import { copyText } from "~/lib/clipboard";
 import { type DebugContext, getDebugContext } from "~/lib/conversations";
 import { cn } from "~/lib/utils";
 
@@ -123,13 +124,9 @@ function DebugDrawer({ conversationId }: { conversationId?: string }) {
     : "";
 
   async function copy() {
-    try {
-      await navigator.clipboard.writeText(json);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
-    } catch {
-      // clipboard unavailable (non-secure context) — no-op
-    }
+    if (!(await copyText(json))) return;
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
   }
 
   const iconBtn =

--- a/apps/web/app/components/chat/transcript.tsx
+++ b/apps/web/app/components/chat/transcript.tsx
@@ -2,6 +2,7 @@ import { Check, Copy, RotateCcw, ThumbsDown, ThumbsUp } from "lucide-react";
 import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { MarkdownView } from "~/components/markdown-view";
 import type { ChatMessage, ChatStatus, TimelinePart } from "~/lib/chat/types";
+import { copyText } from "~/lib/clipboard";
 import { MessagePartView } from "./parts";
 import type { MentionEntry } from "./use-mention-catalog";
 
@@ -68,13 +69,9 @@ function IconAction({
 function CopyButton({ text }: { text: string }) {
   const [copied, setCopied] = useState(false);
   async function copy() {
-    try {
-      await navigator.clipboard.writeText(text);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
-    } catch {
-      // clipboard unavailable (e.g. a non-secure context) — no-op
-    }
+    if (!(await copyText(text))) return;
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
   }
   return (
     <IconAction label={copied ? "copied" : "copy"} onClick={copy}>

--- a/apps/web/app/components/forms/governed-form.tsx
+++ b/apps/web/app/components/forms/governed-form.tsx
@@ -2,6 +2,7 @@ import type { FormSubmissionResult, GovernedForm } from "@tulipfarm/surface";
 import { useEffect, useRef, useState } from "react";
 import { Button } from "~/components/ui/button";
 import { type FormSubmissionBody, submitGovernedForm } from "~/lib/forms";
+import { randomUUID } from "~/lib/uuid";
 
 interface FieldSchema {
   readonly type?: string;
@@ -63,7 +64,7 @@ export function GovernedFormView({
         schemaRef: form.schemaRef,
         guardrailRevision: form.guardrailRevision,
         data: values,
-        idempotencyKey: crypto.randomUUID(),
+        idempotencyKey: randomUUID(),
         ...(form.mode === "run_wait" ? { runId: form.runId, resumeToken } : {}),
       });
       setResult(submitted);

--- a/apps/web/app/lib/chat/hydrate.ts
+++ b/apps/web/app/lib/chat/hydrate.ts
@@ -1,5 +1,6 @@
 import type { ChatMessage, SourceRef, TimelinePart } from "~/lib/chat/types";
 import type { ConversationMessage, WireMessagePart } from "~/lib/conversations";
+import { randomUUID } from "~/lib/uuid";
 
 /*
  * Rehydrate a restored conversation's persisted messages into the renderable timeline the chat
@@ -10,7 +11,7 @@ import type { ConversationMessage, WireMessagePart } from "~/lib/conversations";
  */
 
 function newId(): string {
-  return crypto.randomUUID();
+  return randomUUID();
 }
 
 // Map a persisted assistant `content` (string or parts) to renderable timeline parts.

--- a/apps/web/app/lib/chat/reducer.ts
+++ b/apps/web/app/lib/chat/reducer.ts
@@ -14,6 +14,7 @@ import type {
   ChatState,
   TimelinePart,
 } from "~/lib/chat/types";
+import { randomUUID } from "~/lib/uuid";
 
 export const initialChatState: ChatState = {
   messages: [],
@@ -22,7 +23,7 @@ export const initialChatState: ChatState = {
 };
 
 function newId(): string {
-  return crypto.randomUUID();
+  return randomUUID();
 }
 
 // Push a user message and mark the turn submitted. Used by the hook before opening the stream.

--- a/apps/web/app/lib/chat/use-chat-stream.ts
+++ b/apps/web/app/lib/chat/use-chat-stream.ts
@@ -32,6 +32,7 @@ import type {
   ModelTier,
 } from "~/lib/chat/types";
 import { clearFeedback, sendFeedback as postFeedback } from "~/lib/feedback";
+import { randomUUID } from "~/lib/uuid";
 
 export type SendOptions = {
   model?: ModelTier;
@@ -179,7 +180,7 @@ export function useChatStream(opts?: UseChatStreamOptions) {
     abortRef.current = controller;
     // Minted once per turn: it is what the server deduplicates a re-sent POST by. A regenerate is a
     // deliberately new turn, so it mints its own key rather than resolving to the previous Run.
-    const idempotencyKey = crypto.randomUUID();
+    const idempotencyKey = randomUUID();
     try {
       await postChat(
         {

--- a/apps/web/app/lib/clipboard.test.ts
+++ b/apps/web/app/lib/clipboard.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { copyText } from "~/lib/clipboard";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("copyText", () => {
+  it("uses the async clipboard API when available", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    await expect(copyText("hello")).resolves.toBe(true);
+    expect(writeText).toHaveBeenCalledWith("hello");
+  });
+
+  // A non-secure context (plain http on a LAN IP) does not expose `navigator.clipboard` at all.
+  it("falls back to execCommand when the clipboard API is missing", async () => {
+    vi.stubGlobal("navigator", {});
+    const exec = vi.fn().mockReturnValue(true);
+    // biome-ignore lint/suspicious/noExplicitAny: execCommand is deprecated and untyped in lib.dom
+    (document as any).execCommand = exec;
+
+    await expect(copyText("hello")).resolves.toBe(true);
+    expect(exec).toHaveBeenCalledWith("copy");
+    expect(document.querySelector("textarea")).toBeNull(); // temp node cleaned up
+  });
+
+  it("reports failure when both paths fail", async () => {
+    vi.stubGlobal("navigator", {
+      clipboard: { writeText: vi.fn().mockRejectedValue(new Error()) },
+    });
+    // biome-ignore lint/suspicious/noExplicitAny: execCommand is deprecated and untyped in lib.dom
+    (document as any).execCommand = vi.fn().mockReturnValue(false);
+    await expect(copyText("hello")).resolves.toBe(false);
+  });
+});

--- a/apps/web/app/lib/clipboard.ts
+++ b/apps/web/app/lib/clipboard.ts
@@ -1,0 +1,33 @@
+/*
+ * `navigator.clipboard` is a secure-context-only API — it is undefined when the app is served over
+ * plain http from a LAN IP, so reading `.writeText` off it throws. Fall back to the legacy
+ * `document.execCommand("copy")` path, which still works on insecure origins.
+ *
+ * Returns whether the text made it to the clipboard so callers can skip their "copied" state.
+ */
+
+export async function copyText(text: string): Promise<boolean> {
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Permission denied or a transient failure — fall through to the legacy path.
+    }
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.opacity = "0";
+  document.body.appendChild(textarea);
+  try {
+    textarea.select();
+    return document.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    textarea.remove();
+  }
+}

--- a/apps/web/app/lib/routines/authoring.ts
+++ b/apps/web/app/lib/routines/authoring.ts
@@ -1,5 +1,6 @@
 import type { routine as routineSchema } from "@tulipfarm/schema";
 import { apiCommand, apiGet, apiWrite } from "../api";
+import { randomUUID } from "../uuid";
 
 export interface RoutineAuthoringBase {
   readonly definition: routineSchema.RoutineDefinition;
@@ -45,9 +46,5 @@ export async function proposeRoutineChangeset(
   slug: string,
   body: RoutineAuthoringBody
 ): Promise<{ readonly changesetId: string; readonly status: string }> {
-  return apiCommand(
-    `/api/v1/routines/${encodeURIComponent(slug)}/changesets`,
-    body,
-    crypto.randomUUID()
-  );
+  return apiCommand(`/api/v1/routines/${encodeURIComponent(slug)}/changesets`, body, randomUUID());
 }

--- a/apps/web/app/lib/uuid.test.ts
+++ b/apps/web/app/lib/uuid.test.ts
@@ -1,0 +1,21 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { randomUUID } from "~/lib/uuid";
+
+const V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("randomUUID", () => {
+  it("uses the native implementation when available", () => {
+    expect(randomUUID()).toMatch(V4);
+  });
+
+  // A non-secure context (plain http on a LAN IP) does not expose `crypto.randomUUID`.
+  it("falls back to getRandomValues when randomUUID is missing", () => {
+    vi.stubGlobal("crypto", { getRandomValues: crypto.getRandomValues.bind(crypto) });
+    expect(randomUUID()).toMatch(V4);
+    expect(randomUUID()).not.toBe(randomUUID());
+  });
+});

--- a/apps/web/app/lib/uuid.ts
+++ b/apps/web/app/lib/uuid.ts
@@ -1,0 +1,15 @@
+/*
+ * `crypto.randomUUID` is a secure-context-only API — it is undefined when the app is served over
+ * plain http from a LAN IP (a common prod/self-host setup). `crypto.getRandomValues` has no such
+ * restriction, so fall back to building a v4 UUID from it.
+ */
+
+export function randomUUID(): string {
+  if (typeof crypto.randomUUID === "function") return crypto.randomUUID();
+
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  bytes[6] = (bytes[6] & 0x0f) | 0x40; // version 4
+  bytes[8] = (bytes[8] & 0x3f) | 0x80; // variant 10xx
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}

--- a/apps/web/app/routes/_app.integrations.$name.tsx
+++ b/apps/web/app/routes/_app.integrations.$name.tsx
@@ -13,6 +13,7 @@ import { ErrorState, NotFoundState } from "~/components/states";
 import { Button } from "~/components/ui/button";
 import { Modal } from "~/components/ui/modal";
 import { ApiError } from "~/lib/api";
+import { copyText } from "~/lib/clipboard";
 import {
   connectIntegration,
   deleteIntegration,
@@ -299,7 +300,7 @@ export default function IntegrationDetailPage() {
                 variant="outline"
                 size="sm"
                 onClick={() => {
-                  void navigator.clipboard.writeText(integration.ingress?.webhookUrl ?? "");
+                  void copyText(integration.ingress?.webhookUrl ?? "");
                 }}
               >
                 Copy


### PR DESCRIPTION
## Summary

- The prod SPA is served over plain http from a LAN IP (e.g. `http://192.168.68.110:8085`), which browsers treat as a **non-secure context**. Secure-context-only APIs are `undefined` there, so `crypto.randomUUID()` threw `TypeError: crypto.randomUUID is not a function` on the first chat send and took the whole app down with "Application Error". `localhost` is a secure context by spec carve-out, which is why dev never reproduced it.
- Routed both affected APIs through guarded helpers: `~/lib/uuid` (`randomUUID`) falls back to `crypto.getRandomValues`, which carries no secure-context restriction; `~/lib/clipboard` (`copyText`) falls back to `document.execCommand("copy")`.
- The webhook-URL copy button in `_app.integrations.$name.tsx` was unguarded and would have thrown the identical `TypeError`; the two chat copy buttons swallowed the throw but silently did nothing. Both now actually copy over http.

Swept the rest of the client (`apps/web`, `apps/docs`, `packages/{surface,surface-web,ui,utils}`) for the same class of bug — `crypto.subtle`, service workers, `caches`, `navigator.credentials`/`storage`/`locks`/`mediaDevices`/`share`/`geolocation`, `Notification`, `SharedArrayBuffer` — and found no other usages. Cookie `Secure` was already handled by `useSecureCookies()` in `apps/api/src/auth/cookie-security.ts`.

## Test plan

- [x] New `app/lib/uuid.test.ts` and `app/lib/clipboard.test.ts` stub the global to simulate a non-secure context and assert the fallbacks produce a valid v4 UUID / reach `execCommand`
- [x] `pnpm --filter @tulipfarm/web test` — 398 passed (72 files)
- [x] `pnpm --filter @tulipfarm/web typecheck` — clean
- [x] `pnpm exec biome check apps/web/app` — clean
- [x] Rebuilt the prod bundle and grepped `build/client/assets`: `randomUUID` appears only in `uuid-*.js` and `navigator.clipboard` only in `clipboard-*.js` (our guarded helpers), zero `crypto.subtle` — no dependency reintroduces a raw call
- [ ] Reinstall on a LAN-IP host over plain http, send a chat message, confirm no `TypeError` and that the copy buttons work

## Note

Neither this bug nor the CSP `unsafe-eval` loop in #283 was reachable by the current test suite: `apps/web` is tested with Vitest + jsdom only, and jsdom is always a secure context and never enforces CSP. The closest prod-like CI job (`scripts/test/installer-smoke.sh`) only curls `/health` and never loads the bundle in a browser. A follow-up adding a headless-browser smoke check against the installed image — pointed at a LAN IP, **not** localhost — would cover both classes. Out of scope here.