### PR TITLE
fix(chat): budget the turn routes per caller

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -499,6 +499,7 @@ export async function buildApp(opts: AppOptions = {}) {
             conversationStore: opts.conversationStore,
             invocations: opts.invocations,
             stream: opts.runEvents,
+            ...(opts.rateLimiter ? { rateLimiter: opts.rateLimiter } : {}),
             ...(opts.runCancel ? { cancel: opts.runCancel } : {}),
             ...(opts.soulLoader ? { soulLoader: opts.soulLoader } : {}),
             ...(opts.domainEventEmitter ? { events: opts.domainEventEmitter } : {}),

--- a/apps/api/src/chat/durable-submission.pg.test.ts
+++ b/apps/api/src/chat/durable-submission.pg.test.ts
@@ -118,8 +118,11 @@ describe("durable chat submission over HTTP", () => {
   let sid: string;
   let otherSid: string;
   let validator: TypedOutputValidator;
+  /** Flipped by the budget test; every other test runs with the budget open. */
+  let withinBudget: boolean;
 
   beforeEach(async () => {
+    withinBudget = true;
     db = await makePglite();
     await runPgMigrations(db as unknown as Queryable);
 
@@ -175,6 +178,14 @@ describe("durable chat submission over HTTP", () => {
       runCancel: runCanceller(
         new RunCancellationManager(runStore, new ChildLinkStore(runTransactions))
       ),
+      rateLimiter: {
+        check: async (_key, limit) => ({
+          allowed: withinBudget,
+          limit,
+          remaining: withinBudget ? limit - 1 : 0,
+          resetAt: Date.now() + 60_000,
+        }),
+      },
     });
   });
 
@@ -246,6 +257,19 @@ describe("durable chat submission over HTTP", () => {
     );
     return result.rows[0]?.count ?? 0;
   }
+
+  it("refuses a turn over budget before it mints anything", async () => {
+    withinBudget = false;
+
+    const response = await postChat();
+
+    expect(response.statusCode).toBe(429);
+    // The budget is worth having only if it is spent before the Run is: a refusal that still
+    // committed a Run would cap nothing a Worker or a model actually does.
+    expect(await count("runs")).toBe(0);
+    expect(await count("conversation_turns")).toBe(0);
+    expect(await count("messages")).toBe(0);
+  });
 
   it("commits a Turn, a Run, and the request Artifact before it streams", async () => {
     const response = await chat();

--- a/apps/api/src/chat/routes.ts
+++ b/apps/api/src/chat/routes.ts
@@ -4,6 +4,7 @@ import type { SoulLoader } from "@tulipfarm/soul";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { ErrorSchema } from "../auth/schemas";
 import type { ConversationStore } from "../conversations/service";
+import { MemoryRateLimiter, makeRateLimitHook, type RateLimiter } from "../rate-limit";
 import {
   type RunEventStreamDeps,
   type RunStreamGrant,
@@ -48,7 +49,18 @@ export interface ChatRoutesOptions {
   readonly cancel?: ChatRunCanceller;
   readonly soulLoader?: SoulLoader;
   readonly events?: EventEmitter;
+  /** Shared limiter; absent falls back to an in-process one, so a turn is never unbudgeted. */
+  readonly rateLimiter?: RateLimiter;
 }
+
+/**
+ * Per-caller budget on submitting a turn. A turn is the most expensive thing this API accepts —
+ * it mints a Run, spends model tokens, and occupies a Worker — so it is capped by principal
+ * rather than by IP: behind a proxy every caller shares one address, and a budget keyed on that
+ * would let one participant exhaust everyone's.
+ */
+const CHAT_LIMIT = 60;
+const CHAT_WINDOW_MS = 60_000;
 
 /**
  * The Chat turn over HTTP: submit durably, then read back the Run's own event stream.
@@ -65,11 +77,19 @@ export function registerChatRoutes(
   requireAuth: PreHandler
 ): void {
   const { stream } = options;
+  // Authenticated, so the key is the principal — `req.ip` only stands in before `requireAuth` has
+  // resolved one, which is a request that is refused anyway.
+  const rateLimitHook = makeRateLimitHook(
+    options.rateLimiter ?? new MemoryRateLimiter(),
+    (req) => `rl:chat:${req.principal?.id ?? req.ip}`,
+    CHAT_LIMIT,
+    CHAT_WINDOW_MS
+  );
 
   app.post(
     "/api/v1/chat",
     {
-      preHandler: requireAuth,
+      preHandler: [requireAuth, rateLimitHook],
       schema: {
         description:
           "Submit one chat turn and stream the Run that answers it (SSE, Run event vocabulary — " +
@@ -91,6 +111,7 @@ export function registerChatRoutes(
           403: ErrorSchema,
           404: ErrorSchema,
           409: DuplicateInvocationSchema,
+          429: ErrorSchema,
           503: ErrorSchema,
         },
       },
@@ -191,7 +212,7 @@ export function registerChatRoutes(
   app.post(
     "/api/v1/chat/runs/:runId/stop",
     {
-      preHandler: requireAuth,
+      preHandler: [requireAuth, rateLimitHook],
       schema: {
         description:
           "Stop the Run answering a chat turn. Cancellation is requested of the Run itself, so it " +
@@ -209,6 +230,7 @@ export function registerChatRoutes(
           401: ErrorSchema,
           403: ErrorSchema,
           404: ErrorSchema,
+          429: ErrorSchema,
           503: ErrorSchema,
         },
       },


### PR DESCRIPTION
## Summary

- CodeQL flagged both chat routes on #286 (`js/missing-rate-limiting`, 2 high) as authenticated database work with no rate limit. The fix landed a commit too late for that PR's merge, so it comes over on its own.
- `POST /api/v1/chat` and `POST /api/v1/chat/runs/:runId/stop` now spend a per-caller budget (60/min) through the existing `makeRateLimitHook`, wired the same way `runs/events.ts` is: a shared limiter is injected from `app.ts` in production, and without one an in-process `MemoryRateLimiter` still applies — no turn is ever unbudgeted.
- The key is the principal, not the IP. Behind a proxy every caller shares one address, and a budget keyed on that would let one participant exhaust everyone's.
- The budget is spent in `preHandler`, before the Run, Turn, and Message are committed — so a refusal caps what a Worker and a model actually do, not just what the response body says.

Both routes declare `429: ErrorSchema`, so the limit is visible in the generated OpenAPI spec.

## Test plan

- `pnpm exec biome check apps packages` — clean.
- `pnpm typecheck` — 32/32.
- `rtk proxy pnpm --filter @tulipfarm/api exec vitest run --maxWorkers=1 src/chat` — 11 files, 97 pass.
- New test in `chat/durable-submission.pg.test.ts`: a turn refused over budget returns 429 and leaves zero rows in `runs`, `conversation_turns`, and `messages` — proving the refusal happens before anything is minted.
- Expect the two open `js/missing-rate-limiting` alerts on `apps/api/src/chat/routes.ts` to close on this PR's CodeQL analysis.
