### PR TITLE
feat(soul): persist execution bundles

### DIFF
--- a/apps/api/src/pg-migrate.test.ts
+++ b/apps/api/src/pg-migrate.test.ts
@@ -123,4 +123,29 @@ describe("runPgMigrations", () => {
       expect(column.rows[0]?.is_nullable).toBe("YES");
     });
   });
+
+  describe("migration 20", () => {
+    it("installs durable Soul publication and immutable bundle storage", async () => {
+      await runPgMigrations(db, undefined, () => {});
+
+      const tables = await db.query<{ table_name: string }>(`SELECT table_name
+        FROM information_schema.tables
+        WHERE table_schema = 'public'
+          AND table_name IN (
+            'soul_publications',
+            'soul_publication_outbox',
+            'soul_definition_projections',
+            'soul_active_bundles',
+            'soul_execution_bundles'
+          )
+        ORDER BY table_name`);
+      expect(tables.rows.map((row) => row.table_name)).toEqual([
+        "soul_active_bundles",
+        "soul_definition_projections",
+        "soul_execution_bundles",
+        "soul_publication_outbox",
+        "soul_publications",
+      ]);
+    });
+  });
 });

--- a/apps/api/src/pg-migrations/index.ts
+++ b/apps/api/src/pg-migrations/index.ts
@@ -1,3 +1,4 @@
+import { SOUL_BUNDLE_STORAGE_STATEMENTS } from "@tulipfarm/soul";
 import {
   ARTIFACT_STORAGE_STATEMENTS,
   BUDGET_STORAGE_STATEMENTS,
@@ -10,6 +11,7 @@ import {
   RUN_EVENT_NOTIFY_STATEMENTS,
   RUN_EVENT_STORAGE_STATEMENTS,
   RUN_STORAGE_STATEMENTS,
+  SOUL_PUBLICATION_STORAGE_STATEMENTS,
   WAIT_STORAGE_STATEMENTS,
 } from "@tulipfarm/storage";
 import { EFFECT_STORAGE_STATEMENTS } from "@tulipfarm/tool-broker";
@@ -702,6 +704,18 @@ export const PG_MIGRATIONS: PgMigration[] = [
       // list can show an owner nobody can page — which is the truth about a process, and better
       // than attributing it to whichever human happened to run setup first.
       await q.query("ALTER TABLE api_clients ALTER COLUMN owner_user_id DROP NOT NULL");
+    },
+  },
+  {
+    version: 20,
+    description: "durable Soul publication and immutable execution bundles",
+    up: async (q) => {
+      for (const sql of [
+        ...SOUL_PUBLICATION_STORAGE_STATEMENTS,
+        ...SOUL_BUNDLE_STORAGE_STATEMENTS,
+      ]) {
+        await q.query(sql);
+      }
     },
   },
 ];

--- a/packages/soul/package.json
+++ b/packages/soul/package.json
@@ -17,6 +17,7 @@
     "yaml": "^2.9.0"
   },
   "devDependencies": {
+    "@electric-sql/pglite": "^0.5.3",
     "@tulipfarm/tsconfig": "workspace:*",
     "@types/node": "^26.1.1",
     "typescript": "^6.0.3",

--- a/packages/soul/src/bundle-store.pg.test.ts
+++ b/packages/soul/src/bundle-store.pg.test.ts
@@ -1,0 +1,61 @@
+import { PGlite } from "@electric-sql/pglite";
+import type { Queryable, TransactionPort } from "@tulipfarm/storage";
+import { beforeEach, describe, expect, it } from "vitest";
+import { computeBundleDigest, type ExecutionBundle, type SignedExecutionBundle } from "./bundle";
+import { PgBundleStore, SOUL_BUNDLE_STORAGE_STATEMENTS } from "./bundle-store.pg";
+
+function transactions(database: PGlite): TransactionPort {
+  return {
+    withTransaction: (operation) =>
+      database.transaction((transaction) => operation(transaction as Queryable)),
+  };
+}
+
+function signed(signature = "signature-1"): SignedExecutionBundle {
+  const bundle: ExecutionBundle = {
+    bundleVersion: 1,
+    businessId: "business-1",
+    changesetId: "changeset-1",
+    commitSha: "commit-1",
+    definitions: [],
+  };
+  return {
+    bundle,
+    digest: computeBundleDigest(bundle),
+    signature: { keyId: "key-1", value: signature },
+  };
+}
+
+describe("PgBundleStore", () => {
+  let database: PGlite;
+  let store: PgBundleStore;
+
+  beforeEach(async () => {
+    database = new PGlite();
+    for (const statement of SOUL_BUNDLE_STORAGE_STATEMENTS) await database.query(statement);
+    store = new PgBundleStore(transactions(database));
+  });
+
+  it("round-trips one immutable signed bundle", async () => {
+    const record = signed();
+
+    await store.put(record);
+    await store.put(record);
+
+    expect(await store.get(record.digest)).toEqual(record);
+  });
+
+  it("rejects a conflicting signature for an existing digest", async () => {
+    await store.put(signed());
+
+    await expect(store.put(signed("different"))).rejects.toMatchObject({
+      code: "DIGEST_CONFLICT",
+    });
+  });
+
+  it("rejects a record whose digest does not cover its bundle", async () => {
+    await expect(store.put({ ...signed(), digest: "tampered" })).rejects.toMatchObject({
+      code: "DIGEST_MISMATCH",
+    });
+  });
+});

--- a/packages/soul/src/bundle-store.pg.test.ts
+++ b/packages/soul/src/bundle-store.pg.test.ts
@@ -1,6 +1,6 @@
 import { PGlite } from "@electric-sql/pglite";
 import type { Queryable, TransactionPort } from "@tulipfarm/storage";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { computeBundleDigest, type ExecutionBundle, type SignedExecutionBundle } from "./bundle";
 import { PgBundleStore, SOUL_BUNDLE_STORAGE_STATEMENTS } from "./bundle-store.pg";
 
@@ -30,10 +30,18 @@ describe("PgBundleStore", () => {
   let database: PGlite;
   let store: PgBundleStore;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     database = new PGlite();
     for (const statement of SOUL_BUNDLE_STORAGE_STATEMENTS) await database.query(statement);
     store = new PgBundleStore(transactions(database));
+  }, 30_000);
+
+  afterAll(async () => {
+    await database.close();
+  }, 30_000);
+
+  beforeEach(async () => {
+    await database.query("TRUNCATE TABLE soul_execution_bundles");
   });
 
   it("round-trips one immutable signed bundle", async () => {

--- a/packages/soul/src/bundle-store.pg.ts
+++ b/packages/soul/src/bundle-store.pg.ts
@@ -1,0 +1,99 @@
+import type { TransactionPort } from "@tulipfarm/storage";
+import {
+  BundleError,
+  type BundleStore,
+  computeBundleDigest,
+  type SignedExecutionBundle,
+} from "./bundle";
+
+export const SOUL_BUNDLE_STORAGE_STATEMENTS: readonly string[] = [
+  `CREATE TABLE IF NOT EXISTS soul_execution_bundles (
+    digest       text PRIMARY KEY CHECK (length(digest) > 0),
+    business_id  text NOT NULL CHECK (length(business_id) > 0),
+    changeset_id text NOT NULL CHECK (length(changeset_id) > 0),
+    commit_sha   text NOT NULL CHECK (length(commit_sha) > 0),
+    bundle       jsonb NOT NULL CHECK (jsonb_typeof(bundle) = 'object'),
+    signature    jsonb NOT NULL CHECK (
+      jsonb_typeof(signature) = 'object'
+      AND signature ?& ARRAY['keyId', 'value']
+    ),
+    created_at   timestamptz NOT NULL DEFAULT now()
+  )`,
+  `CREATE INDEX IF NOT EXISTS soul_execution_bundles_business_idx
+    ON soul_execution_bundles (business_id, created_at DESC)`,
+];
+
+interface BundleRow {
+  readonly digest: string;
+  readonly bundle: SignedExecutionBundle["bundle"];
+  readonly signature: SignedExecutionBundle["signature"];
+}
+
+function recordOf(row: BundleRow): SignedExecutionBundle {
+  return { digest: row.digest, bundle: row.bundle, signature: row.signature };
+}
+
+function assertSameSignature(stored: SignedExecutionBundle, incoming: SignedExecutionBundle): void {
+  if (
+    stored.signature.keyId !== incoming.signature.keyId ||
+    stored.signature.value !== incoming.signature.value
+  ) {
+    throw new BundleError(
+      "DIGEST_CONFLICT",
+      `Bundle store: digest ${incoming.digest} is already stored with a different signature`
+    );
+  }
+}
+
+/** Durable, append-only PostgreSQL storage for signed execution bundles. */
+export class PgBundleStore implements BundleStore {
+  constructor(private readonly transactions: TransactionPort) {}
+
+  async put(record: SignedExecutionBundle): Promise<void> {
+    const digest = computeBundleDigest(record.bundle);
+    if (digest !== record.digest) {
+      throw new BundleError(
+        "DIGEST_MISMATCH",
+        "Bundle store: record digest does not cover its bundle"
+      );
+    }
+
+    await this.transactions.withTransaction(async (transaction) => {
+      const inserted = await transaction.query<{ digest: string }>(
+        `INSERT INTO soul_execution_bundles (
+           digest, business_id, changeset_id, commit_sha, bundle, signature
+         ) VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb)
+         ON CONFLICT (digest) DO NOTHING
+         RETURNING digest`,
+        [
+          record.digest,
+          record.bundle.businessId,
+          record.bundle.changesetId,
+          record.bundle.commitSha,
+          JSON.stringify(record.bundle),
+          JSON.stringify(record.signature),
+        ]
+      );
+      if (inserted.rows.length === 1) return;
+
+      const existing = await transaction.query<BundleRow>(
+        "SELECT digest, bundle, signature FROM soul_execution_bundles WHERE digest = $1",
+        [record.digest]
+      );
+      const row = existing.rows[0];
+      if (!row) throw new Error("bundle_conflict_without_row");
+      assertSameSignature(recordOf(row), record);
+    });
+  }
+
+  async get(digest: string): Promise<SignedExecutionBundle | undefined> {
+    return this.transactions.withTransaction(async (transaction) => {
+      const result = await transaction.query<BundleRow>(
+        "SELECT digest, bundle, signature FROM soul_execution_bundles WHERE digest = $1",
+        [digest]
+      );
+      const row = result.rows[0];
+      return row ? recordOf(row) : undefined;
+    });
+  }
+}

--- a/packages/soul/src/index.ts
+++ b/packages/soul/src/index.ts
@@ -23,6 +23,7 @@ export {
   EXECUTION_BUNDLE_VERSION,
   InMemoryBundleStore,
 } from "./bundle";
+export { PgBundleStore, SOUL_BUNDLE_STORAGE_STATEMENTS } from "./bundle-store.pg";
 export type {
   SoulChangeset,
   SoulChangesetErrorCode,

--- a/packages/storage/src/soul/index.ts
+++ b/packages/storage/src/soul/index.ts
@@ -6,4 +6,9 @@ export type {
   SoulPublicationStore,
   SoulPublicationTx,
 } from "./publication-store";
-export { InMemorySoulPublicationStore, SOUL_PUBLICATION_STAGES } from "./publication-store";
+export {
+  InMemorySoulPublicationStore,
+  PgSoulPublicationStore,
+  SOUL_PUBLICATION_STAGES,
+  SOUL_PUBLICATION_STORAGE_STATEMENTS,
+} from "./publication-store";

--- a/packages/storage/src/soul/publication-store.pg.test.ts
+++ b/packages/storage/src/soul/publication-store.pg.test.ts
@@ -1,0 +1,125 @@
+import { PGlite } from "@electric-sql/pglite";
+import { beforeEach, describe, expect, it } from "vitest";
+import type { Queryable, TransactionPort } from "../ports";
+import {
+  PgSoulPublicationStore,
+  SOUL_PUBLICATION_STORAGE_STATEMENTS,
+  type SoulPublicationRecord,
+} from "./publication-store";
+
+const BUSINESS = "business-1";
+
+function transactions(database: PGlite): TransactionPort {
+  return {
+    withTransaction: (operation) =>
+      database.transaction((transaction) => operation(transaction as Queryable)),
+  };
+}
+
+function record(overrides: Partial<SoulPublicationRecord> = {}): SoulPublicationRecord {
+  return {
+    changesetId: "changeset-1",
+    businessId: BUSINESS,
+    commitSha: "commit-1",
+    digest: "digest-1",
+    stage: "committed",
+    attempts: 0,
+    ...overrides,
+  };
+}
+
+describe("PgSoulPublicationStore", () => {
+  let database: PGlite;
+  let store: PgSoulPublicationStore;
+
+  beforeEach(async () => {
+    database = new PGlite();
+    for (const statement of SOUL_PUBLICATION_STORAGE_STATEMENTS) {
+      await database.query(statement);
+    }
+    store = new PgSoulPublicationStore(transactions(database));
+  });
+
+  it("commits a publication, projection, activation, and outbox acknowledgement", async () => {
+    await store.withTransaction(async (transaction) => {
+      await transaction.putPublication(record());
+      await transaction.replaceProjection(BUSINESS, [
+        {
+          businessId: BUSINESS,
+          digest: "digest-1",
+          kind: "Routine",
+          id: "routine-1",
+          slug: "daily",
+          authoredVersion: 1,
+          hash: "hash-1",
+        },
+      ]);
+      await transaction.enqueue({
+        id: "changeset-1:publish",
+        businessId: BUSINESS,
+        changesetId: "changeset-1",
+        topic: "soul.publication.requested",
+      });
+      await transaction.setActiveDigest(BUSINESS, "digest-1");
+    });
+
+    await store.withTransaction(async (transaction) => {
+      expect(await transaction.getPublication("changeset-1")).toEqual(record());
+      expect(await transaction.findPublicationByDigest(BUSINESS, "digest-1")).toEqual(record());
+      expect(await transaction.listProjection(BUSINESS)).toEqual([
+        expect.objectContaining({ kind: "Routine", slug: "daily" }),
+      ]);
+      expect(await transaction.getActiveDigest(BUSINESS)).toBe("digest-1");
+      expect(await transaction.pendingOutbox(10)).toHaveLength(1);
+      await transaction.markConsumed("changeset-1:publish", "worker-1");
+      await transaction.markConsumed("changeset-1:publish", "worker-2");
+      expect(await transaction.pendingOutbox(10)).toEqual([]);
+    });
+
+    const consumed = await database.query<{ consumed_by: string }>(
+      "SELECT consumed_by FROM soul_publication_outbox WHERE id = 'changeset-1:publish'"
+    );
+    expect(consumed.rows[0]?.consumed_by).toBe("worker-1");
+  });
+
+  it("rolls back the entire publication transaction on failure", async () => {
+    await expect(
+      store.withTransaction(async (transaction) => {
+        await transaction.putPublication(record());
+        await transaction.setActiveDigest(BUSINESS, "digest-1");
+        throw new Error("stop");
+      })
+    ).rejects.toThrow("stop");
+
+    await store.withTransaction(async (transaction) => {
+      expect(await transaction.getPublication("changeset-1")).toBeUndefined();
+      expect(await transaction.getActiveDigest(BUSINESS)).toBeUndefined();
+    });
+  });
+
+  it("atomically replaces one business projection", async () => {
+    const definition = {
+      businessId: BUSINESS,
+      digest: "digest-1",
+      kind: "Routine",
+      id: "routine-1",
+      slug: "daily",
+      authoredVersion: 1,
+      hash: "hash-1",
+    };
+    await store.withTransaction((transaction) =>
+      transaction.replaceProjection(BUSINESS, [definition])
+    );
+    await store.withTransaction((transaction) =>
+      transaction.replaceProjection(BUSINESS, [
+        { ...definition, digest: "digest-2", authoredVersion: 2, hash: "hash-2" },
+      ])
+    );
+
+    await store.withTransaction(async (transaction) => {
+      expect(await transaction.listProjection(BUSINESS)).toEqual([
+        { ...definition, digest: "digest-2", authoredVersion: 2, hash: "hash-2" },
+      ]);
+    });
+  });
+});

--- a/packages/storage/src/soul/publication-store.ts
+++ b/packages/storage/src/soul/publication-store.ts
@@ -1,3 +1,5 @@
+import type { Queryable, TransactionPort } from "../ports";
+
 /**
  * Soul publication persistence (SPEC §8.2 steps 13–15).
  *
@@ -18,6 +20,46 @@
  * resumes at the recorded stage and the previously active digest is never disturbed.
  */
 export const SOUL_PUBLICATION_STAGES = ["committed", "projected", "stored", "active"] as const;
+
+const SOUL_PUBLICATION_STAGE_SQL = SOUL_PUBLICATION_STAGES.map((stage) => `'${stage}'`).join(", ");
+
+export const SOUL_PUBLICATION_STORAGE_STATEMENTS: readonly string[] = [
+  `CREATE TABLE IF NOT EXISTS soul_publications (
+    changeset_id text PRIMARY KEY CHECK (length(changeset_id) > 0),
+    business_id  text NOT NULL CHECK (length(business_id) > 0),
+    commit_sha   text NOT NULL CHECK (length(commit_sha) > 0),
+    digest       text NOT NULL CHECK (length(digest) > 0),
+    stage        text NOT NULL CHECK (stage IN (${SOUL_PUBLICATION_STAGE_SQL})),
+    attempts     integer NOT NULL DEFAULT 0 CHECK (attempts >= 0),
+    failure_code text,
+    UNIQUE (business_id, digest)
+  )`,
+  `CREATE TABLE IF NOT EXISTS soul_publication_outbox (
+    id           text PRIMARY KEY CHECK (length(id) > 0),
+    business_id  text NOT NULL CHECK (length(business_id) > 0),
+    changeset_id text NOT NULL REFERENCES soul_publications(changeset_id),
+    topic        text NOT NULL CHECK (length(topic) > 0),
+    consumed_by  text,
+    created_at   timestamptz NOT NULL DEFAULT now()
+  )`,
+  `CREATE INDEX IF NOT EXISTS soul_publication_outbox_pending_idx
+    ON soul_publication_outbox (created_at, id) WHERE consumed_by IS NULL`,
+  `CREATE TABLE IF NOT EXISTS soul_definition_projections (
+    business_id     text NOT NULL CHECK (length(business_id) > 0),
+    digest          text NOT NULL CHECK (length(digest) > 0),
+    kind            text NOT NULL CHECK (length(kind) > 0),
+    definition_id   text NOT NULL CHECK (length(definition_id) > 0),
+    slug            text NOT NULL CHECK (length(slug) > 0),
+    authored_version integer NOT NULL CHECK (authored_version > 0),
+    hash            text NOT NULL CHECK (length(hash) > 0),
+    PRIMARY KEY (business_id, kind, definition_id),
+    UNIQUE (business_id, kind, slug)
+  )`,
+  `CREATE TABLE IF NOT EXISTS soul_active_bundles (
+    business_id text PRIMARY KEY CHECK (length(business_id) > 0),
+    digest      text NOT NULL CHECK (length(digest) > 0)
+  )`,
+];
 
 export type SoulPublicationStage = (typeof SOUL_PUBLICATION_STAGES)[number];
 
@@ -171,5 +213,188 @@ export class InMemorySoulPublicationStore implements SoulPublicationStore {
         return state.active.get(businessId);
       },
     };
+  }
+}
+
+interface PublicationRow {
+  readonly changeset_id: string;
+  readonly business_id: string;
+  readonly commit_sha: string;
+  readonly digest: string;
+  readonly stage: SoulPublicationStage;
+  readonly attempts: number;
+  readonly failure_code: string | null;
+}
+
+interface ProjectionRow {
+  readonly business_id: string;
+  readonly digest: string;
+  readonly kind: string;
+  readonly definition_id: string;
+  readonly slug: string;
+  readonly authored_version: number;
+  readonly hash: string;
+}
+
+function publication(row: PublicationRow): SoulPublicationRecord {
+  return {
+    changesetId: row.changeset_id,
+    businessId: row.business_id,
+    commitSha: row.commit_sha,
+    digest: row.digest,
+    stage: row.stage,
+    attempts: Number(row.attempts),
+    ...(row.failure_code === null ? {} : { failureCode: row.failure_code }),
+  };
+}
+
+function projection(row: ProjectionRow): SoulDefinitionProjection {
+  return {
+    businessId: row.business_id,
+    digest: row.digest,
+    kind: row.kind,
+    id: row.definition_id,
+    slug: row.slug,
+    authoredVersion: Number(row.authored_version),
+    hash: row.hash,
+  };
+}
+
+function pgTransaction(transaction: Queryable): SoulPublicationTx {
+  return {
+    async putPublication(record) {
+      await transaction.query(
+        `INSERT INTO soul_publications (
+           changeset_id, business_id, commit_sha, digest, stage, attempts, failure_code
+         ) VALUES ($1, $2, $3, $4, $5, $6, $7)
+         ON CONFLICT (changeset_id) DO UPDATE SET
+           business_id = EXCLUDED.business_id,
+           commit_sha = EXCLUDED.commit_sha,
+           digest = EXCLUDED.digest,
+           stage = EXCLUDED.stage,
+           attempts = EXCLUDED.attempts,
+           failure_code = EXCLUDED.failure_code`,
+        [
+          record.changesetId,
+          record.businessId,
+          record.commitSha,
+          record.digest,
+          record.stage,
+          record.attempts,
+          record.failureCode ?? null,
+        ]
+      );
+    },
+    async getPublication(changesetId) {
+      const result = await transaction.query<PublicationRow>(
+        `SELECT changeset_id, business_id, commit_sha, digest, stage, attempts, failure_code
+           FROM soul_publications WHERE changeset_id = $1`,
+        [changesetId]
+      );
+      const row = result.rows[0];
+      return row ? publication(row) : undefined;
+    },
+    async findPublicationByDigest(businessId, digest) {
+      const result = await transaction.query<PublicationRow>(
+        `SELECT changeset_id, business_id, commit_sha, digest, stage, attempts, failure_code
+           FROM soul_publications WHERE business_id = $1 AND digest = $2`,
+        [businessId, digest]
+      );
+      const row = result.rows[0];
+      return row ? publication(row) : undefined;
+    },
+    async enqueue(message) {
+      await transaction.query(
+        `INSERT INTO soul_publication_outbox (id, business_id, changeset_id, topic)
+         VALUES ($1, $2, $3, $4)
+         ON CONFLICT (id) DO NOTHING`,
+        [message.id, message.businessId, message.changesetId, message.topic]
+      );
+    },
+    async pendingOutbox(max) {
+      const result = await transaction.query<{
+        id: string;
+        business_id: string;
+        changeset_id: string;
+        topic: string;
+        consumed_by: string | null;
+      }>(
+        `SELECT id, business_id, changeset_id, topic, consumed_by
+           FROM soul_publication_outbox
+          WHERE consumed_by IS NULL
+          ORDER BY created_at, id
+          LIMIT $1`,
+        [Math.max(0, Math.trunc(max))]
+      );
+      return result.rows.map((row) => ({
+        id: row.id,
+        businessId: row.business_id,
+        changesetId: row.changeset_id,
+        topic: row.topic,
+      }));
+    },
+    async markConsumed(id, consumer) {
+      await transaction.query(
+        `UPDATE soul_publication_outbox
+            SET consumed_by = $2
+          WHERE id = $1 AND consumed_by IS NULL`,
+        [id, consumer]
+      );
+    },
+    async replaceProjection(businessId, definitions) {
+      await transaction.query("DELETE FROM soul_definition_projections WHERE business_id = $1", [
+        businessId,
+      ]);
+      for (const definition of definitions) {
+        await transaction.query(
+          `INSERT INTO soul_definition_projections (
+             business_id, digest, kind, definition_id, slug, authored_version, hash
+           ) VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+          [
+            definition.businessId,
+            definition.digest,
+            definition.kind,
+            definition.id,
+            definition.slug,
+            definition.authoredVersion,
+            definition.hash,
+          ]
+        );
+      }
+    },
+    async listProjection(businessId) {
+      const result = await transaction.query<ProjectionRow>(
+        `SELECT business_id, digest, kind, definition_id, slug, authored_version, hash
+           FROM soul_definition_projections
+          WHERE business_id = $1
+          ORDER BY kind, slug`,
+        [businessId]
+      );
+      return result.rows.map(projection);
+    },
+    async setActiveDigest(businessId, digest) {
+      await transaction.query(
+        `INSERT INTO soul_active_bundles (business_id, digest)
+         VALUES ($1, $2)
+         ON CONFLICT (business_id) DO UPDATE SET digest = EXCLUDED.digest`,
+        [businessId, digest]
+      );
+    },
+    async getActiveDigest(businessId) {
+      const result = await transaction.query<{ digest: string }>(
+        "SELECT digest FROM soul_active_bundles WHERE business_id = $1",
+        [businessId]
+      );
+      return result.rows[0]?.digest;
+    },
+  };
+}
+
+/** PostgreSQL publication adapter with real transactional stage transitions and outbox writes. */
+export class PgSoulPublicationStore implements SoulPublicationStore {
+  constructor(private readonly transactions: TransactionPort) {}
+
+  withTransaction<T>(fn: (tx: SoulPublicationTx) => Promise<T>): Promise<T> {
+    return this.transactions.withTransaction((transaction) => fn(pgTransaction(transaction)));
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -899,6 +899,9 @@ importers:
         specifier: ^2.9.0
         version: 2.9.0
     devDependencies:
+      '@electric-sql/pglite':
+        specifier: ^0.5.3
+        version: 0.5.3
       '@tulipfarm/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig


### PR DESCRIPTION
## Summary

- add an append-only PostgreSQL `BundleStore` for signed, content-addressed execution bundles
- add a transactional PostgreSQL `SoulPublicationStore` for publication stages, outbox delivery,
  authored projections, and the active bundle digest
- install the five durable Soul tables in API migration 20 and cover the adapters with PGlite

## Routine discovery and deviation from the handoff

The discovery step found that Routine execution is a rewrite, not the move described by the
handoff:

- the reachable manual Routine trigger does use `DurableInvocationGateway`, but it records a
  nominal definition reference and only one `invoke` State
- the only implementation that actually advances Routine work uses the separate legacy
  `routine_runs` / `routine_run_events` model and `@tulipfarm/routine-engine`
- the canonical Routine schema and `@tulipfarm/run-kernel` planners are not composed into a
  production executor
- signed `ExecutionBundle` compilation/publication existed only behind in-memory stores, so a
  Worker could not load a pinned, verified, Git-free `RuntimeBundle`

Because the handoff explicitly says to stop rather than silently expand a materially larger step,
this PR lands the durable publication prerequisite as the next reviewable slice after #290. It does
not add a second Routine authority or a compatibility executor; the Worker executor and legacy
engine removal remain subsequent work.

## Dependency decisions

- **Promote to package:** durable signed-bundle storage lives in `@tulipfarm/soul`, which owns the
  bundle contract and digest/signature invariants.
- **Promote to package:** publication, outbox, projection, and active-digest persistence lives in
  `@tulipfarm/storage`, which owns PostgreSQL transaction mechanics.
- **Thin local copy:** none.
- **Internal HTTP call:** none.
- **Worker → Soul:** deferred until the Worker consumes verified RuntimeBundles; this PR makes no
  Worker allowlist change.

## Test plan

- [x] `pnpm exec biome check apps packages` — 1,442 files checked, no errors (one pre-existing
  informational `noUselessConstructor` diagnostic)
- [x] `pnpm typecheck` — 32/32 tasks successful
- [x] `pnpm architecture:test` — 9 files, 62 tests passed
- [x] `pnpm --filter @tulipfarm/api exec vitest run --maxWorkers=1` — passed (exit 0)
- [x] `pnpm --filter @tulipfarm/worker exec vitest run` — 31 files, 197 tests passed
- [x] `turbo test --filter='!@tulipfarm/api' --force` — passed (exit 0), including Soul 189/189
  and Storage 149/149

