### PR TITLE
refactor(runs): separate source from routine identity

### DIFF
--- a/apps/api/AGENTS.md
+++ b/apps/api/AGENTS.md
@@ -140,6 +140,11 @@ Artifact in one transaction. The gateway and PostgreSQL adapter are owned by
 pass a `payloadRef` that names nothing — the Artifact is what makes a Run reconstructable after a
 crash.
 
+The invocation source (`manual`, `schedule`, `integration`, and so on) records what accepted the
+request. The Run source (`chat`, `integration`, `routine`) selects the Worker executor and is stored
+separately from the pinned bundle's canonical Routine id. Do not route work through
+`bundle.routineId`.
+
 A chat turn is persisted by exactly one `ChatTurnSubmitter` (declared and implemented in
 `chat/turn-submit.ts`): no turn machinery in this app writes a user Message, so a new entrypoint
 must submit through this port rather than writing its own. `durableTurnSubmitter` writes the Turn,

--- a/apps/api/src/approvals/routes.test.ts
+++ b/apps/api/src/approvals/routes.test.ts
@@ -251,6 +251,7 @@ describe("approval routes — durable tool_call kind", () => {
     await runs.start({
       id: runId,
       businessId: DEPLOYMENT_BUSINESS_ID,
+      source: "chat",
       createdAt: new Date().toISOString(),
       bundle: { digest: "bundle-digest", routineId: "chat", routineVersion: "1" },
       identity: {

--- a/apps/api/src/approvals/tool-approvals.pg.test.ts
+++ b/apps/api/src/approvals/tool-approvals.pg.test.ts
@@ -69,6 +69,7 @@ describe("tool approvals as durable waits", () => {
   async function startRunningRun(idempotencyKey = "key-1"): Promise<string> {
     const started = await invocations.start({
       source: "chat",
+      runSource: "chat",
       businessId: DEPLOYMENT_BUSINESS_ID,
       initiator: SUBJECT,
       effectiveSubject: SUBJECT,

--- a/apps/api/src/conversations/chat-turns.ts
+++ b/apps/api/src/conversations/chat-turns.ts
@@ -47,6 +47,7 @@ function chatRunLauncher(
     start: async ({ businessId, turnId, attempt }) => {
       const result = await invocations.start({
         source: "chat",
+        runSource: "chat",
         businessId,
         initiator: principal,
         effectiveSubject: principal,

--- a/apps/api/src/internal/delivery-host.ts
+++ b/apps/api/src/internal/delivery-host.ts
@@ -430,7 +430,7 @@ export class IngressDeliveryHost {
     const run = await this.options.runs.find(businessId, runId);
     if (run === null) throw new DeliveryDeniedError("run_not_found");
     if (run.status !== "running") throw new DeliveryDeniedError("run_not_running");
-    if (run.bundle.routineId !== DELIVERY_SOURCE) {
+    if (run.source !== DELIVERY_SOURCE) {
       throw new DeliveryDeniedError("not_a_delivery");
     }
 

--- a/apps/api/src/internal/turn-host.ts
+++ b/apps/api/src/internal/turn-host.ts
@@ -29,6 +29,7 @@ export interface HostedRunReader {
     runId: string
   ): Promise<{
     readonly status: string;
+    readonly source: string;
     readonly bundle: { readonly digest: string; readonly routineId: string };
     readonly identity: { readonly effectiveSubject: InvocationPrincipal };
   } | null>;
@@ -52,12 +53,13 @@ export interface TurnAuthority {
   /** Whom the turn acts as, as recorded when the Run was minted. */
   readonly subject: InvocationPrincipal;
   /**
-   * What minted the Run — `chat`, `integration`, and the rest of `INVOCATION_SOURCES`.
+   * Which Worker executor owns the Run — `chat`, `integration`, `routine`, and so on.
    *
    * It decides which Artifact holds the turn's parameters: a Chat Run's request *is* the Chat
    * request, while an Integration Run's request is a provider envelope that a classifier turned
    * into one. Taking it from the Run rather than from a caller-supplied hint is what keeps a
-   * delivery from claiming to be an interactive turn.
+   * delivery from claiming to be an interactive turn. The invocation source (for example,
+   * `manual` or `schedule`) remains separate audit/idempotency metadata.
    */
   readonly source: string;
   /** The Run's bundle digest, recorded on the Context manifest as what produced this Context. */
@@ -195,7 +197,7 @@ export class InternalTurnHost {
       runId,
       turn,
       subject: run.identity.effectiveSubject,
-      source: run.bundle.routineId,
+      source: run.source,
       bundleDigest: run.bundle.digest,
     };
   }

--- a/apps/api/src/pg-migrate.test.ts
+++ b/apps/api/src/pg-migrate.test.ts
@@ -20,6 +20,7 @@ describe("runPgMigrations", () => {
     await db.query("CREATE TABLE conversations (id uuid PRIMARY KEY)");
     await db.query("CREATE TABLE messages (id uuid PRIMARY KEY)");
     await db.query("CREATE TABLE users (id uuid PRIMARY KEY)");
+    await db.query("CREATE TABLE runs (id uuid PRIMARY KEY, bundle jsonb NOT NULL)");
     await db.query("CREATE TABLE run_events (run_id uuid NOT NULL, sequence bigint NOT NULL)");
     await db.query(`CREATE TABLE api_clients (
       id            uuid PRIMARY KEY,
@@ -146,6 +147,34 @@ describe("runPgMigrations", () => {
         "soul_publication_outbox",
         "soul_publications",
       ]);
+    });
+  });
+
+  describe("migration 21", () => {
+    it("backfills the Run source from the formerly overloaded Routine id", async () => {
+      await db.query(`CREATE TABLE runs (
+        id uuid PRIMARY KEY,
+        bundle jsonb NOT NULL
+      )`);
+      await db.query(`INSERT INTO runs (id, bundle)
+        VALUES ('00000000-0000-4000-8000-000000000001', '{"routineId":"chat"}'::jsonb)`);
+      await db.query(`CREATE TABLE schema_version (
+        id boolean PRIMARY KEY DEFAULT true,
+        version integer NOT NULL,
+        CONSTRAINT schema_version_single_row CHECK (id)
+      )`);
+      await db.query("INSERT INTO schema_version (id, version) VALUES (true, 20)");
+
+      await runPgMigrations(db, undefined, () => {});
+
+      const source = await db.query<{ source: string }>("SELECT source FROM runs");
+      expect(source.rows[0]?.source).toBe("chat");
+      await expect(
+        db.query(
+          `INSERT INTO runs (id, source, bundle)
+           VALUES ('00000000-0000-4000-8000-000000000002', '', '{"routineId":"ignored"}'::jsonb)`
+        )
+      ).rejects.toThrow();
     });
   });
 });

--- a/apps/api/src/pg-migrations/index.ts
+++ b/apps/api/src/pg-migrations/index.ts
@@ -718,4 +718,19 @@ export const PG_MIGRATIONS: PgMigration[] = [
       }
     },
   },
+  {
+    version: 21,
+    description: "separate Run source from pinned Routine identity",
+    up: async (q) => {
+      await q.query("ALTER TABLE runs ADD COLUMN IF NOT EXISTS source text");
+      // Before this migration the dispatcher overloaded `bundle.routineId` as the Run source. Copy
+      // it once so queued and in-flight Runs keep the same executor after every reader cuts over to
+      // the dedicated column; new writers must supply the source explicitly.
+      await q.query("UPDATE runs SET source = bundle->>'routineId' WHERE source IS NULL");
+      await q.query("ALTER TABLE runs ALTER COLUMN source SET NOT NULL");
+      await q.query(
+        "ALTER TABLE runs ADD CONSTRAINT runs_source_nonempty CHECK (length(source) > 0)"
+      );
+    },
+  },
 ];

--- a/apps/api/src/runtime/invocation-callers.pg.test.ts
+++ b/apps/api/src/runtime/invocation-callers.pg.test.ts
@@ -115,13 +115,18 @@ describe("non-chat invocation callers", () => {
   it("stores a Routine trigger's inputs as its request Artifact", async () => {
     const { runId } = await manualRoutineTrigger(invocations)("daily-digest", { limit: 5 });
 
-    const runs = await db.query<{ source: string; identity: { initiator: { id: string } } }>(
-      `SELECT runs.identity, invocation.source
+    const runs = await db.query<{
+      source: string;
+      run_source: string;
+      identity: { initiator: { id: string } };
+    }>(
+      `SELECT runs.identity, runs.source AS run_source, invocation.source
          FROM runs
          JOIN durable_invocations invocation
            ON invocation.business_id = runs.business_id AND invocation.run_id = runs.id`
     );
     expect(runs.rows[0]?.source).toBe("manual");
+    expect(runs.rows[0]?.run_source).toBe("routine");
     expect(runs.rows[0]?.identity.initiator.id).toBe("assistant");
     await expect(
       reader().read({

--- a/apps/api/src/runtime/invocation-callers.ts
+++ b/apps/api/src/runtime/invocation-callers.ts
@@ -24,6 +24,7 @@ export function manualRoutineTrigger(invocations: DurableInvocationGateway) {
     const payload = { slug, inputs: inputs ?? {} };
     const result = await invocations.start({
       source: "manual",
+      runSource: "routine",
       businessId: DEPLOYMENT_BUSINESS_ID,
       initiator: { kind: "agent", id: "assistant" },
       effectiveSubject: { kind: "agent", id: "assistant" },
@@ -57,6 +58,7 @@ export function integrationInvoker(invocations: DurableInvocationGateway) {
       job.headers === undefined ? { slug: job.slug, body: job.body } : job;
     await invocations.start({
       source: "integration",
+      runSource: "integration",
       businessId: DEPLOYMENT_BUSINESS_ID,
       initiator: { kind: "integration", id: job.slug },
       effectiveSubject: { kind: "integration", id: job.slug },

--- a/apps/api/src/runtime/invocation-composition.pg.test.ts
+++ b/apps/api/src/runtime/invocation-composition.pg.test.ts
@@ -23,6 +23,7 @@ const CHAT_REQUEST = { message: { role: "user", content: "hello" } };
 
 const START_INPUT = {
   source: "chat" as const,
+  runSource: "chat" as const,
   businessId: "business-1",
   initiator: { kind: "user", id: "user-1" },
   effectiveSubject: { kind: "user", id: "user-1" },
@@ -87,6 +88,9 @@ describe("PgDurableInvocationStore", () => {
     // A replay must not publish a second Artifact: `artifacts` is append-only, so a second write
     // under the same id with a different `producer.runId` could never be corrected.
     expect(await countRows(database, "artifacts")).toBe(1);
+
+    const runs = await database.query<{ source: string }>("SELECT source FROM runs");
+    expect(runs.rows[0]?.source).toBe("chat");
 
     const states = await database.query<{ resolved_input: { payloadRef: string } }>(
       "SELECT resolved_input FROM run_states"

--- a/apps/api/src/test/turn-host-fixtures.ts
+++ b/apps/api/src/test/turn-host-fixtures.ts
@@ -85,7 +85,7 @@ export function fakeRuns(
   run: {
     status?: string;
     digest?: string;
-    /** What minted the Run — the `bundle.routineId` a host reads its source from. */
+    /** What minted the Run, persisted independently from its pinned Routine identity. */
     source?: string;
     subject?: { kind: string; id: string };
   } | null = {}
@@ -95,7 +95,8 @@ export function fakeRuns(
       if (run === null) return null;
       return {
         status: run.status ?? "running",
-        bundle: { digest: run.digest ?? "bundle-digest", routineId: run.source ?? "chat" },
+        source: run.source ?? "chat",
+        bundle: { digest: run.digest ?? "bundle-digest", routineId: "routine-id" },
         identity: { effectiveSubject: run.subject ?? { kind: "user", id: "user-1" } },
       };
     },

--- a/apps/worker/AGENTS.md
+++ b/apps/worker/AGENTS.md
@@ -33,8 +33,10 @@ a deliberate local copy, since an app may not import another app), `preflight.ts
 `loop.ts` (abortable, backing-off loop), `executors.ts` / `delivery.ts` (registries),
 `probe-server.ts` (`/livez`, `/readyz`), `shutdown.ts` (drain).
 
-Two Run sources are registered, keyed by `RunExecutorRegistry.sourceOf` (`bundle.routineId`):
-`chat` (`turn/chat-executor.ts`) and `integration` (`turn/integration-executor.ts`). The
+Two Run sources are registered, keyed by the Run's dedicated `source` column through
+`RunExecutorRegistry.sourceOf`: `chat` (`turn/chat-executor.ts`) and `integration`
+(`turn/integration-executor.ts`). Source is independent of the Routine id in the pinned bundle, so
+a published Routine can carry its canonical identity without changing which executor owns it. The
 Integration executor classifies its delivery and then hands the Run to **the same** chat executor
 instance, so a Slack turn and a web turn are answered by one code path.
 

--- a/apps/worker/src/config.ts
+++ b/apps/worker/src/config.ts
@@ -7,7 +7,7 @@ import { DEPLOYMENT_BUSINESS_ID } from "@tulipfarm/constants";
  * not exist or may not have the columns it writes, so it refuses to start rather than corrupt.
  * Raise it whenever a migration lands that the worker's queries depend on.
  */
-export const REQUIRED_SCHEMA_VERSION = 17;
+export const REQUIRED_SCHEMA_VERSION = 21;
 
 export interface WorkerConfig {
   readonly databaseUrl: string;

--- a/apps/worker/src/executors.test.ts
+++ b/apps/worker/src/executors.test.ts
@@ -10,7 +10,8 @@ function persistedRun(overrides: Partial<PersistedRun> = {}): PersistedRun {
   return {
     id: "00000000-0000-4000-8000-000000000001",
     businessId: BUSINESS_ID,
-    bundle: { digest: "sha256:bundle-1", routineId: "chat", routineVersion: "1" },
+    source: "chat",
+    bundle: { digest: "sha256:bundle-1", routineId: "routine-1", routineVersion: "1" },
     identity: {
       initiator: { kind: "user", id: "user-1" },
       effectiveSubject: { kind: "agent", id: "agent-1" },

--- a/apps/worker/src/executors.ts
+++ b/apps/worker/src/executors.ts
@@ -37,9 +37,9 @@ export class RunExecutorRegistry {
     return this.executors.size;
   }
 
-  /** The Run's source, as `DurableInvocationGateway` records it on the bundle. */
+  /** The Run's persisted source, independent of its pinned Routine identity. */
   static sourceOf(run: PersistedRun): string {
-    return run.bundle.routineId;
+    return run.source;
   }
 
   async execute(run: PersistedRun): Promise<RunOutcome> {

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -1,5 +1,10 @@
 import { randomUUID } from "node:crypto";
-import { RunLeaseManager, RunResumeGateway, WaitTimerSweeper } from "@tulipfarm/run-kernel";
+import {
+  RunLeaseManager,
+  RunResumeGateway,
+  type RunSource,
+  WaitTimerSweeper,
+} from "@tulipfarm/run-kernel";
 import {
   loadActiveDek,
   loadEncryptionKeys,
@@ -35,11 +40,11 @@ import { RunStoreStateTransitions } from "./turn/kernel-ports";
 const OUTBOX_CONSUMER = "worker.run-dispatch";
 
 /**
- * The Run source the Chat executor owns, as `DurableInvocationGateway` records it on the bundle.
+ * The Run source the Chat executor owns, persisted independently from its pinned Routine identity.
  * Slack and Telegram requests reach the same executor because the ingress path derives a chat
  * request from the envelope — the executor never learns which channel asked.
  */
-const CHAT_RUN_SOURCE = "chat";
+const CHAT_RUN_SOURCE: RunSource = "chat";
 
 /**
  * The Run source an Integration delivery is minted under.
@@ -48,7 +53,7 @@ const CHAT_RUN_SOURCE = "chat";
  * executor, so a Slack message and a web message are answered by one code path — the difference
  * between them ends at the classifier.
  */
-const INTEGRATION_RUN_SOURCE = "integration";
+const INTEGRATION_RUN_SOURCE: RunSource = "integration";
 
 const logger = {
   info: (message: string) => console.log(message),

--- a/apps/worker/src/recovery/run-dispatch.test.ts
+++ b/apps/worker/src/recovery/run-dispatch.test.ts
@@ -14,6 +14,7 @@ function run(overrides: Partial<PersistedRun> = {}): PersistedRun {
   return {
     id: RUN_ID,
     businessId: BUSINESS_ID,
+    source: "routine",
     bundle: { digest: "sha256:bundle-1", routineId: "routine-1", routineVersion: "1" },
     identity: {
       initiator: { kind: "user", id: "user-1" },

--- a/apps/worker/src/run-dispatcher.test.ts
+++ b/apps/worker/src/run-dispatcher.test.ts
@@ -9,6 +9,7 @@ function persistedRun(overrides: Partial<PersistedRun> = {}): PersistedRun {
   return {
     id: "00000000-0000-4000-8000-000000000001",
     businessId: BUSINESS_ID,
+    source: "routine",
     bundle: { digest: "sha256:bundle-1", routineId: "routine-1", routineVersion: "1" },
     identity: {
       initiator: { kind: "user", id: "user-1" },

--- a/apps/worker/src/turn/chat-executor.test.ts
+++ b/apps/worker/src/turn/chat-executor.test.ts
@@ -17,6 +17,7 @@ import type { RunEventAppendPort } from "./run-events";
 const RUN: PersistedRun = {
   id: "run-1",
   businessId: "business-1",
+  source: "chat",
   bundle: { digest: "sha256:bundle", routineId: "chat", routineVersion: "1" },
   identity: {
     initiator: { kind: "user", id: "user-1" },

--- a/apps/worker/src/turn/integration-executor.test.ts
+++ b/apps/worker/src/turn/integration-executor.test.ts
@@ -12,6 +12,7 @@ import type { RunEventAppendPort } from "./run-events";
 const RUN: PersistedRun = {
   id: "run-1",
   businessId: "business-1",
+  source: "integration",
   bundle: { digest: "sha256:bundle", routineId: "integration", routineVersion: "1" },
   identity: {
     initiator: { kind: "integration", id: "chatapp" },

--- a/apps/worker/test/process/scratch-database.ts
+++ b/apps/worker/test/process/scratch-database.ts
@@ -106,9 +106,10 @@ export async function insertQueuedRun(
   return scratch.runs.start({
     id: options.runId,
     businessId: options.businessId,
+    source: options.source ?? "chat",
     bundle: {
       digest: "published:agent:assistant",
-      routineId: options.source ?? "chat",
+      routineId: "routine-id",
       routineVersion: "1",
     },
     identity: {

--- a/packages/run-kernel/src/invocation/gateway.test.ts
+++ b/packages/run-kernel/src/invocation/gateway.test.ts
@@ -27,6 +27,14 @@ class FakeStore implements DurableInvocationStore {
 }
 
 const SOURCES = ["chat", "manual", "webhook", "schedule", "channel", "integration"] as const;
+const RUN_SOURCE = {
+  chat: "chat",
+  manual: "routine",
+  webhook: "routine",
+  schedule: "routine",
+  channel: "integration",
+  integration: "integration",
+} as const;
 
 const validator = new TypedOutputValidator(INVOCATION_REQUEST_SCHEMAS);
 
@@ -43,6 +51,7 @@ describe("DurableInvocationGateway", () => {
     await expect(
       gateway.start({
         source,
+        runSource: RUN_SOURCE[source],
         businessId: "business-1",
         initiator: { kind: "user", id: "user-1" },
         effectiveSubject: { kind: "user", id: "user-1" },
@@ -57,6 +66,7 @@ describe("DurableInvocationGateway", () => {
       expect.objectContaining({
         runId: `run-${source}`,
         source,
+        runSource: RUN_SOURCE[source],
         state: {
           key: "invoke",
           definitionRef: `published:${source}:v1`,
@@ -64,6 +74,34 @@ describe("DurableInvocationGateway", () => {
         },
       }),
     ]);
+  });
+
+  it("keeps the invocation source separate from the Worker executor source", async () => {
+    const store = new FakeStore();
+    const gateway = new DurableInvocationGateway({
+      store,
+      validator,
+      nextId: () => "run-1",
+      now: () => "2026-07-26T00:00:00.000Z",
+    });
+
+    await gateway.start({
+      source: "manual",
+      runSource: "routine",
+      businessId: "business-1",
+      initiator: { kind: "user", id: "user-1" },
+      effectiveSubject: { kind: "user", id: "user-1" },
+      definitionRef: "published:routine:daily",
+      payload: { slug: "daily", inputs: {} },
+      payloadSchemaRef: MANUAL_REQUEST_SCHEMA_REF,
+      idempotencyKey: "delivery-1",
+    });
+
+    expect(store.records[0]).toMatchObject({
+      source: "manual",
+      runSource: "routine",
+      bundle: { routineId: "routine" },
+    });
   });
 
   it("hands the store a request Artifact the Run executor can read", async () => {
@@ -78,6 +116,7 @@ describe("DurableInvocationGateway", () => {
 
     await gateway.start({
       source: "chat",
+      runSource: "chat",
       businessId: "business-1",
       initiator: { kind: "user", id: "user-1" },
       effectiveSubject: { kind: "user", id: "user-1" },
@@ -114,6 +153,7 @@ describe("DurableInvocationGateway", () => {
 
     await gateway.start({
       source: "channel",
+      runSource: "integration",
       businessId: "business-1",
       initiator: { kind: "integration", id: "slack" },
       effectiveSubject: { kind: "user", id: "owner-1" },
@@ -142,6 +182,7 @@ describe("DurableInvocationGateway", () => {
     });
     const input = {
       source: "webhook" as const,
+      runSource: "routine" as const,
       businessId: "business-1",
       initiator: { kind: "service", id: "github" },
       effectiveSubject: { kind: "service", id: "github" },
@@ -163,6 +204,7 @@ describe("DurableInvocationGateway", () => {
     await expect(
       gateway.start({
         source: "channel",
+        runSource: "integration",
         businessId: "business-1",
         initiator: { kind: "external", id: "sender-1" },
         effectiveSubject: { kind: "user", id: "owner-1" },
@@ -186,6 +228,7 @@ describe("DurableInvocationGateway", () => {
     await expect(
       gateway.start({
         source: "manual",
+        runSource: "routine",
         businessId: "business-1",
         initiator: { kind: "user", id: "user-1" },
         effectiveSubject: { kind: "user", id: "user-1" },

--- a/packages/run-kernel/src/invocation/gateway.ts
+++ b/packages/run-kernel/src/invocation/gateway.ts
@@ -13,6 +13,10 @@ export const INVOCATION_SOURCES = [
 
 export type InvocationSource = (typeof INVOCATION_SOURCES)[number];
 
+/** Closed Worker executor selectors. Invocation sources map onto one of these explicitly. */
+export const RUN_SOURCES = ["chat", "integration", "routine"] as const;
+export type RunSource = (typeof RUN_SOURCES)[number];
+
 export interface InvocationPrincipal {
   readonly kind: string;
   readonly id: string;
@@ -49,7 +53,10 @@ export function chatRequestArtifactId(runId: string): string {
 
 export interface DurableInvocationRecord {
   readonly runId: string;
+  /** What accepted the invocation: manual, schedule, Integration delivery, and so on. */
   readonly source: InvocationSource;
+  /** Selects the Worker executor without overloading the pinned Routine identity. */
+  readonly runSource: RunSource;
   readonly businessId: string;
   readonly initiator: InvocationPrincipal;
   readonly effectiveSubject: InvocationPrincipal;
@@ -81,7 +88,10 @@ export interface DurableInvocationStore {
 }
 
 export interface StartInvocationInput {
+  /** What accepted the invocation: manual, schedule, Integration delivery, and so on. */
   readonly source: InvocationSource;
+  /** Selects the Worker executor without overloading the pinned Routine identity. */
+  readonly runSource: RunSource;
   readonly businessId: string;
   readonly initiator: InvocationPrincipal;
   readonly effectiveSubject: InvocationPrincipal;
@@ -142,6 +152,7 @@ export class DurableInvocationGateway {
     if (
       input.businessId.length === 0 ||
       input.idempotencyKey.length === 0 ||
+      !RUN_SOURCES.includes(input.runSource) ||
       input.initiator.id.length === 0 ||
       input.effectiveSubject.id.length === 0
     ) {
@@ -170,6 +181,7 @@ export class DurableInvocationGateway {
     return this.options.store.persist({
       runId,
       source: input.source,
+      runSource: input.runSource,
       businessId: input.businessId,
       initiator: input.initiator,
       effectiveSubject: input.effectiveSubject,
@@ -180,7 +192,7 @@ export class DurableInvocationGateway {
       createdAt,
       bundle: {
         digest: input.definitionRef,
-        routineId: input.source,
+        routineId: input.runSource,
         routineVersion: input.definitionRef,
       },
       state: {

--- a/packages/run-kernel/src/invocation/store.pg.ts
+++ b/packages/run-kernel/src/invocation/store.pg.ts
@@ -65,11 +65,12 @@ export class PgDurableInvocationStore implements DurableInvocationStore {
       await this.artifacts(transaction).publish(record.requestArtifact);
 
       await transaction.query(
-        `INSERT INTO runs (id, business_id, bundle, identity, bounds, created_at)
-         VALUES ($1, $2, $3::jsonb, $4::jsonb, $5::jsonb, $6::timestamptz)`,
+        `INSERT INTO runs (id, business_id, source, bundle, identity, bounds, created_at)
+         VALUES ($1, $2, $3, $4::jsonb, $5::jsonb, $6::jsonb, $7::timestamptz)`,
         [
           record.runId,
           record.businessId,
+          record.runSource,
           JSON.stringify(record.bundle),
           JSON.stringify({
             initiator: record.initiator,

--- a/packages/run-kernel/src/lease.test.ts
+++ b/packages/run-kernel/src/lease.test.ts
@@ -10,6 +10,7 @@ function persistedRun(overrides: Partial<PersistedRun> = {}): PersistedRun {
   return {
     id: RUN_ID,
     businessId: BUSINESS_ID,
+    source: "routine",
     bundle: { digest: "sha256:bundle-1", routineId: "routine-1", routineVersion: "1" },
     identity: {
       initiator: { kind: "user", id: "user-1" },

--- a/packages/run-kernel/src/resilience/simulator.ts
+++ b/packages/run-kernel/src/resilience/simulator.ts
@@ -29,6 +29,7 @@ function baseRun(overrides: Partial<PersistedRun>): PersistedRun {
   return {
     id: RUN_ID,
     businessId: BUSINESS_ID,
+    source: "routine",
     bundle: { digest: "sha256:bundle-1", routineId: "routine-1", routineVersion: "1" },
     identity: {
       initiator: { kind: "user", id: "user-1" },

--- a/packages/storage/AGENTS.md
+++ b/packages/storage/AGENTS.md
@@ -10,8 +10,9 @@ append-only `artifacts`, `state_output_bindings`, and `artifact_lineage` tables 
 plus `MemoryArtifactStore`) that `@tulipfarm/run-kernel` drives. `src/runs/` owns the `runs`,
 `run_states`, `run_attempts`, `run_lineage`, `run_waits`, and `run_wait_signals` tables
 (`RunStore`, `WaitStore`, plus `MemoryWaitStore`), including resume-token digests and
-lock-guarded wait resolution, plus the write-once `run_budgets` ledger (`BudgetStore`) and the
-lock-guarded `run_concurrency_keys`/`run_concurrency_slots` tables (`ConcurrencyStore`), plus the
+lock-guarded wait resolution. A Run's `source` selects its Worker executor independently from the
+canonical Routine identity pinned in `bundle`. The write-once `run_budgets` ledger (`BudgetStore`)
+and lock-guarded `run_concurrency_keys`/`run_concurrency_slots` tables (`ConcurrencyStore`), plus the
 authority-immutable, detach-final `run_child_links` table (`ChildLinkStore`), plus the append-only,
 audience-scoped `run_events` stream with a gapless per-Run sequence (`RunEventStore`). tsconfig extends
 `@tulipfarm/tsconfig/base.json`. See root `AGENTS.md` for commands/lint.

--- a/packages/storage/src/runs/budget-store.pg.test.ts
+++ b/packages/storage/src/runs/budget-store.pg.test.ts
@@ -19,6 +19,7 @@ function run(): StartRunInput {
   return {
     id: RUN_ID,
     businessId: BUSINESS,
+    source: "routine",
     bundle: { digest: "sha256:bundle-1", routineId: "routine-1", routineVersion: "1" },
     identity: {
       initiator: { kind: "user", id: "user-1" },

--- a/packages/storage/src/runs/child-store.pg.test.ts
+++ b/packages/storage/src/runs/child-store.pg.test.ts
@@ -28,6 +28,7 @@ function run(id: string): StartRunInput {
   return {
     id,
     businessId: BUSINESS,
+    source: "routine",
     bundle: { digest: "sha256:bundle-1", routineId: "routine-1", routineVersion: "1" },
     identity: {
       initiator: { kind: "user", id: "user-1" },

--- a/packages/storage/src/runs/concurrency-store.pg.test.ts
+++ b/packages/storage/src/runs/concurrency-store.pg.test.ts
@@ -26,6 +26,7 @@ function run(id: string): StartRunInput {
   return {
     id,
     businessId: BUSINESS,
+    source: "routine",
     bundle: { digest: "sha256:bundle-1", routineId: "routine-1", routineVersion: "1" },
     identity: {
       initiator: { kind: "user", id: "user-1" },

--- a/packages/storage/src/runs/events.pg.test.ts
+++ b/packages/storage/src/runs/events.pg.test.ts
@@ -20,6 +20,7 @@ function run(id: string): StartRunInput {
   return {
     id,
     businessId: BUSINESS,
+    source: "routine",
     bundle: { digest: "sha256:bundle-1", routineId: "routine-1", routineVersion: "1" },
     identity: {
       initiator: { kind: "user", id: "user-1" },

--- a/packages/storage/src/runs/run-store.pg.test.ts
+++ b/packages/storage/src/runs/run-store.pg.test.ts
@@ -22,6 +22,7 @@ function run(overrides: Partial<StartRunInput> = {}): StartRunInput {
   return {
     id: "00000000-0000-4000-8000-000000000001",
     businessId: "business-1",
+    source: "routine",
     bundle: {
       digest: "sha256:bundle-1",
       routineId: "routine-1",
@@ -80,6 +81,7 @@ describe("RunStore (PostgreSQL)", () => {
 
     expect(persisted).toMatchObject({
       businessId: "business-1",
+      source: "routine",
       status: "queued",
       version: 0,
       bundle: run().bundle,

--- a/packages/storage/src/runs/run-store.ts
+++ b/packages/storage/src/runs/run-store.ts
@@ -60,6 +60,8 @@ export type RunLineageRelation = "child" | "replay";
 export interface StartRunInput {
   readonly id: string;
   readonly businessId: string;
+  /** Selects the Worker executor; independent of the Routine identity pinned in `bundle`. */
+  readonly source: string;
   readonly bundle: RunBundle;
   readonly identity: RunIdentity;
   readonly bounds: RunBounds;
@@ -72,6 +74,8 @@ export interface StartRunInput {
 export interface PersistedRun {
   readonly id: string;
   readonly businessId: string;
+  /** Selects the Worker executor; independent of the Routine identity pinned in `bundle`. */
+  readonly source: string;
   readonly bundle: RunBundle;
   readonly identity: RunIdentity;
   readonly bounds: RunBounds;
@@ -228,6 +232,7 @@ export const RUN_STORAGE_STATEMENTS: readonly string[] = [
   `CREATE TABLE IF NOT EXISTS runs (
     id                    uuid PRIMARY KEY,
     business_id           text NOT NULL,
+    source                text NOT NULL CHECK (length(source) > 0),
     bundle                jsonb NOT NULL CHECK (jsonb_typeof(bundle) = 'object'),
     identity              jsonb NOT NULL CHECK (jsonb_typeof(identity) = 'object'),
     bounds                jsonb NOT NULL CHECK (
@@ -374,6 +379,7 @@ export const RUN_STORAGE_STATEMENTS: readonly string[] = [
 interface RunRow {
   id: string;
   business_id: string;
+  source: string;
   bundle: RunBundle;
   identity: RunIdentity;
   bounds: RunBounds;
@@ -427,6 +433,7 @@ function persistedRun(row: RunRow): PersistedRun {
   return {
     id: row.id,
     businessId: row.business_id,
+    source: row.source,
     bundle: row.bundle,
     identity: row.identity,
     bounds: row.bounds,
@@ -484,7 +491,7 @@ function decodeRunCursor(decoded: string | undefined): RunCursor | null {
   return { createdAt, id };
 }
 
-const RUN_COLUMNS = `id, business_id, bundle, identity, bounds, status, version, created_at,
+const RUN_COLUMNS = `id, business_id, source, bundle, identity, bounds, status, version, created_at,
   started_at, finished_at, result_artifact_id, error_evidence_ref, lease_owner, lease_expires_at`;
 const STATE_COLUMNS = `business_id, run_id, state_key, definition_ref, resolved_input, status,
   version, created_at, started_at, finished_at, result_artifact_id, error_evidence_ref`;
@@ -496,12 +503,13 @@ export class RunStore {
   async start(input: StartRunInput): Promise<PersistedRun> {
     return this.transactions.withTransaction(async (transaction) => {
       const inserted = await transaction.query<RunRow>(
-        `INSERT INTO runs (id, business_id, bundle, identity, bounds, created_at)
-         VALUES ($1, $2, $3::jsonb, $4::jsonb, $5::jsonb, $6::timestamptz)
+        `INSERT INTO runs (id, business_id, source, bundle, identity, bounds, created_at)
+         VALUES ($1, $2, $3, $4::jsonb, $5::jsonb, $6::jsonb, $7::timestamptz)
          RETURNING ${RUN_COLUMNS}`,
         [
           input.id,
           input.businessId,
+          input.source,
           JSON.stringify(input.bundle),
           JSON.stringify(input.identity),
           JSON.stringify(input.bounds),
@@ -696,7 +704,7 @@ export class RunStore {
                 lease_expires_at = NULL
            FROM candidates
           WHERE runs.id = candidates.id
-         RETURNING runs.id, runs.business_id, runs.bundle, runs.identity, runs.bounds,
+         RETURNING runs.id, runs.business_id, runs.source, runs.bundle, runs.identity, runs.bounds,
                    runs.status, runs.version, runs.created_at, runs.started_at, runs.finished_at,
                    runs.result_artifact_id, runs.error_evidence_ref, runs.lease_owner,
                    runs.lease_expires_at`,
@@ -733,7 +741,7 @@ export class RunStore {
                 lease_expires_at = $3::timestamptz
            FROM candidates
           WHERE runs.id = candidates.id
-         RETURNING runs.id, runs.business_id, runs.bundle, runs.identity, runs.bounds,
+         RETURNING runs.id, runs.business_id, runs.source, runs.bundle, runs.identity, runs.bounds,
                    runs.status, runs.version, runs.created_at, runs.started_at, runs.finished_at,
                    runs.result_artifact_id, runs.error_evidence_ref, runs.lease_owner,
                    runs.lease_expires_at`,

--- a/packages/storage/src/runs/wait-store.pg.test.ts
+++ b/packages/storage/src/runs/wait-store.pg.test.ts
@@ -27,6 +27,7 @@ function run(): StartRunInput {
   return {
     id: RUN_ID,
     businessId: BUSINESS,
+    source: "routine",
     bundle: { digest: "sha256:bundle-1", routineId: "routine-1", routineVersion: "1" },
     identity: {
       initiator: { kind: "user", id: "user-1" },


### PR DESCRIPTION
## Summary

- Persist a dedicated Run `source` so Worker dispatch and API host authority no longer overload the pinned Routine identity in `bundle.routineId`.
- Backfill existing Runs once in PostgreSQL migration 21, require every new Run writer to provide a non-empty source, and raise the Worker schema floor to 21.
- Cut chat, integration, and Routine invocation callers, Worker executors, and internal delivery/turn hosts over to the explicit source with regression coverage proving source and Routine identity can differ.

This is the prerequisite discovered while tracing exact active-bundle pinning after #293: a canonical Routine must own `bundle.routineId`, while dispatch needs a separate stable selector.

## Dependency decisions

- **Promote to package:** the closed `RunSource` contract lives in `@tulipfarm/run-kernel`, at the durable invocation boundary.
- **Promote to package:** persisted `source` lives in the shared Run model and PostgreSQL repository in `@tulipfarm/storage`.
- **Thin local copy:** none.
- **Internal HTTP call:** none; API and Worker consume the shared contracts directly.

## Deviations / follow-up

- Exact active-bundle composition and canonical start-State pinning are intentionally not included here. Discovery showed that doing them first would make the canonical Routine id replace the value still used for dispatch. The next PR can now pin the exact Routine bundle without creating a second execution authority or compatibility path.
- Migration 21 performs the only legacy read of `bundle.routineId`, as a one-time backfill. New writers require `source`, and runtime readers never fall back to the bundle.
- The final PR4 `boss.work(` API acceptance criterion is not claimed by this prerequisite; the remaining Routine and knowledge consumers are unchanged here.

## Test plan

- [x] `pnpm exec biome check apps packages` — 1,443 files checked; no errors (one pre-existing informational diagnostic).
- [x] `pnpm typecheck` — 32/32 tasks passed.
- [x] `pnpm architecture:test` — 9 files, 62 tests passed.
- [x] `pnpm --filter @tulipfarm/api exec vitest run --maxWorkers=1` — 184 files passed; 1,725 passed, 1 skipped.
- [x] `pnpm --filter @tulipfarm/worker exec vitest run` — 31 files, 197 tests passed.
- [x] `turbo test --filter='!@tulipfarm/api' --force` — 30/30 tasks passed.
