### PR TITLE
refactor(routines): pin Runs to active Soul bundles

### DIFF
--- a/apps/api/AGENTS.md
+++ b/apps/api/AGENTS.md
@@ -145,6 +145,13 @@ request. The Run source (`chat`, `integration`, `routine`) selects the Worker ex
 separately from the pinned bundle's canonical Routine id. Do not route work through
 `bundle.routineId`.
 
+Routine invocations resolve only through `runtime/invocation-definitions.ts`: it verifies the
+business's active signed Soul bundle, selects the published canonical Routine, and pins the exact
+bundle digest, stable Routine id/version, and authored start State before the Run is created. Never
+fall back to the live Soul checkout or the legacy Routine registry. Missing or invalid active
+publication means no Run. The HMAC verification material is the durable auto-generated Secret
+`soul-bundle.signing-key`, resolved during API boot.
+
 A chat turn is persisted by exactly one `ChatTurnSubmitter` (declared and implemented in
 `chat/turn-submit.ts`): no turn machinery in this app writes a user Message, so a new entrypoint
 must submit through this port rather than writing its own. `durableTurnSubmitter` writes the Turn,

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -18,10 +18,17 @@ import {
   PgSecretRepo,
   SecretsService,
 } from "@tulipfarm/secrets";
-import { GitSyncService, runSoulMigrations, SoulLoader } from "@tulipfarm/soul";
+import {
+  GitSyncService,
+  PgBundleStore,
+  runSoulMigrations,
+  SoulLoader,
+  SoulPublicationCoordinator,
+} from "@tulipfarm/soul";
 import {
   ArtifactStore,
   ChildLinkStore,
+  PgSoulPublicationStore,
   RunEventStore,
   RunStore,
   WaitStore,
@@ -93,6 +100,8 @@ import { reconcileResourceTables, registerResourceReconcile } from "./resources/
 import { PgCounterStore, PgResourceRepoFactory } from "./resources/repo";
 import { runCanceller } from "./runs/cancel";
 import { integrationInvoker, manualRoutineTrigger } from "./runtime/invocation-callers";
+import { ActiveRoutineInvocationResolver } from "./runtime/invocation-definitions";
+import { resolveSoulBundleSigner } from "./runtime/soul-bundle-signer";
 import { bootstrapFromEnv } from "./setup/bootstrap";
 import {
   assertNoOrphanedDeks,
@@ -193,6 +202,12 @@ async function boot() {
     // before minting a Run, and the same instance re-validates on publish and on every later read.
     const invocationValidator = new TypedOutputValidator(INVOCATION_REQUEST_SCHEMAS);
     const runTransactions = transactionPort(pool);
+    const soulBundleSigner = await resolveSoulBundleSigner(secretsService);
+    const soulPublications = new SoulPublicationCoordinator(
+      new PgSoulPublicationStore(runTransactions),
+      new PgBundleStore(runTransactions),
+      console
+    );
     const invocations = new DurableInvocationGateway({
       store: new PgDurableInvocationStore(
         runTransactions,
@@ -203,6 +218,7 @@ async function boot() {
           )
       ),
       validator: invocationValidator,
+      routineDefinitions: new ActiveRoutineInvocationResolver(soulPublications, soulBundleSigner),
     });
     // Read side of the same canonical `runs` / `run_states` tables the gateway writes.
     const runStore = new RunStore(runTransactions);

--- a/apps/api/src/runtime/invocation-callers.pg.test.ts
+++ b/apps/api/src/runtime/invocation-callers.pg.test.ts
@@ -8,12 +8,20 @@ import {
   TypedOutputValidator,
 } from "@tulipfarm/run-kernel";
 import { INTEGRATION_REQUEST_SCHEMA_REF, INVOCATION_REQUEST_SCHEMAS } from "@tulipfarm/schema";
-import { ArtifactStore } from "@tulipfarm/storage";
+import {
+  compileExecutionBundle,
+  createHmacBundleSigner,
+  PgBundleStore,
+  SoulPublicationCoordinator,
+  signExecutionBundle,
+} from "@tulipfarm/soul";
+import { ArtifactStore, PgSoulPublicationStore } from "@tulipfarm/storage";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ambientTransactionPort, type Queryable, transactionPort } from "../db";
 import { runPgMigrations } from "../pg-migrate";
 import { makePglite } from "../test/pglite";
 import { integrationInvoker, manualRoutineTrigger } from "./invocation-callers";
+import { ActiveRoutineInvocationResolver } from "./invocation-definitions";
 
 /** A verified Slack delivery as the ingress route hands it over, after signature + accept checks. */
 const SLACK_JOB = {
@@ -40,13 +48,52 @@ describe("non-chat invocation callers", () => {
     db = await makePglite();
     await runPgMigrations(db as unknown as Queryable);
     validator = new TypedOutputValidator(INVOCATION_REQUEST_SCHEMAS);
+    const transactions = transactionPort(db as unknown as Queryable);
+    const signer = createHmacBundleSigner("bundle-key-1", "secret");
+    const publications = new SoulPublicationCoordinator(
+      new PgSoulPublicationStore(transactions),
+      new PgBundleStore(transactions),
+      console
+    );
+    const bundle = compileExecutionBundle({
+      businessId: DEPLOYMENT_BUSINESS_ID,
+      changesetId: "changeset-routine-1",
+      commitSha: "c0ffee",
+      documents: [
+        {
+          apiVersion: "tulipfarm.ai/v1",
+          kind: "Routine",
+          metadata: {
+            id: "11111111-1111-4111-8111-111111111111",
+            slug: "daily-digest",
+            schemaVersion: 1,
+            authoredVersion: 7,
+            lifecycle: "published",
+          },
+          spec: {
+            owner: "platform",
+            start: "Collect",
+            states: [
+              {
+                type: "wait",
+                name: "Collect",
+                waitFor: { kind: "timer", durationMs: 1 },
+              },
+            ],
+          },
+        },
+      ],
+    });
+    await publications.publish({ bundle: signExecutionBundle(bundle, signer) });
+    await publications.drain("test");
     invocations = new DurableInvocationGateway({
       store: new PgDurableInvocationStore(
-        transactionPort(db as unknown as Queryable),
+        transactions,
         (transaction) =>
           new ArtifactService(new ArtifactStore(ambientTransactionPort(transaction)), validator)
       ),
       validator,
+      routineDefinitions: new ActiveRoutineInvocationResolver(publications, signer),
     });
   });
 
@@ -118,16 +165,31 @@ describe("non-chat invocation callers", () => {
     const runs = await db.query<{
       source: string;
       run_source: string;
+      bundle: { digest: string; routineId: string; routineVersion: string };
       identity: { initiator: { id: string } };
+      state_key: string;
+      definition_ref: string;
     }>(
-      `SELECT runs.identity, runs.source AS run_source, invocation.source
+      `SELECT runs.identity, runs.source AS run_source, runs.bundle, invocation.source,
+              state.state_key, state.definition_ref
          FROM runs
          JOIN durable_invocations invocation
-           ON invocation.business_id = runs.business_id AND invocation.run_id = runs.id`
+           ON invocation.business_id = runs.business_id AND invocation.run_id = runs.id
+         JOIN run_states state
+           ON state.business_id = runs.business_id AND state.run_id = runs.id`
     );
     expect(runs.rows[0]?.source).toBe("manual");
     expect(runs.rows[0]?.run_source).toBe("routine");
     expect(runs.rows[0]?.identity.initiator.id).toBe("assistant");
+    expect(runs.rows[0]?.bundle).toEqual({
+      digest: expect.stringMatching(/^[0-9a-f]{64}$/),
+      routineId: "11111111-1111-4111-8111-111111111111",
+      routineVersion: "7",
+    });
+    expect(runs.rows[0]?.state_key).toBe("Collect");
+    expect(runs.rows[0]?.definition_ref).toMatch(
+      /^bundle:[0-9a-f]{64}\/routines\/11111111-1111-4111-8111-111111111111@7\/states\/Collect$/
+    );
     await expect(
       reader().read({
         businessId: DEPLOYMENT_BUSINESS_ID,
@@ -137,6 +199,19 @@ describe("non-chat invocation callers", () => {
         now: new Date(),
       })
     ).resolves.toMatchObject({ content: { slug: "daily-digest", inputs: { limit: 5 } } });
+  });
+
+  it("mints no Run when a Routine has no active publication", async () => {
+    await db.query("DELETE FROM soul_active_bundles");
+
+    await expect(manualRoutineTrigger(invocations)("daily-digest", { limit: 5 })).rejects.toEqual(
+      expect.objectContaining({ code: "unpublished_definition" })
+    );
+
+    const counts = await db.query<{ runs: number; artifacts: number }>(
+      "SELECT (SELECT count(*) FROM runs)::int AS runs, (SELECT count(*) FROM artifacts)::int AS artifacts"
+    );
+    expect(counts.rows[0]).toEqual({ runs: 0, artifacts: 0 });
   });
 
   it("stores a delivery from an Integration that declares no context headers", async () => {

--- a/apps/api/src/runtime/invocation-definitions.test.ts
+++ b/apps/api/src/runtime/invocation-definitions.test.ts
@@ -1,0 +1,117 @@
+import type { VersionedSchemaDocument } from "@tulipfarm/schema";
+import {
+  compileExecutionBundle,
+  createHmacBundleSigner,
+  InMemoryBundleStore,
+  SoulPublicationCoordinator,
+  signExecutionBundle,
+} from "@tulipfarm/soul";
+import { InMemorySoulPublicationStore } from "@tulipfarm/storage";
+import { describe, expect, it, vi } from "vitest";
+import { ActiveRoutineInvocationResolver } from "./invocation-definitions";
+
+const BUSINESS_ID = "business-1";
+const signer = createHmacBundleSigner("bundle-key-1", "secret");
+
+function routine(
+  lifecycle: "draft" | "published" = "published",
+  start = "Collect"
+): VersionedSchemaDocument {
+  return {
+    apiVersion: "tulipfarm.ai/v1",
+    kind: "Routine",
+    metadata: {
+      id: "11111111-1111-4111-8111-111111111111",
+      slug: "daily-digest",
+      schemaVersion: 1,
+      authoredVersion: 7,
+      lifecycle,
+    },
+    spec: {
+      owner: "platform",
+      start,
+      states: [{ type: "wait", name: "Collect", waitFor: { kind: "timer", durationMs: 1 } }],
+    },
+  } as VersionedSchemaDocument;
+}
+
+async function activeResolver(document: VersionedSchemaDocument) {
+  const publications = new SoulPublicationCoordinator(
+    new InMemorySoulPublicationStore(),
+    new InMemoryBundleStore(),
+    { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+  );
+  const bundle = compileExecutionBundle({
+    businessId: BUSINESS_ID,
+    changesetId: "changeset-1",
+    commitSha: "c0ffee",
+    documents: [document],
+  });
+  await publications.publish({ bundle: signExecutionBundle(bundle, signer) });
+  await publications.drain("test");
+  return new ActiveRoutineInvocationResolver(publications, signer);
+}
+
+describe("ActiveRoutineInvocationResolver", () => {
+  it("pins the verified active digest, stable Routine identity, version, and start State", async () => {
+    const resolver = await activeResolver(routine());
+
+    await expect(
+      resolver.resolve({
+        businessId: BUSINESS_ID,
+        definitionRef: "published:routine:daily-digest",
+      })
+    ).resolves.toEqual({
+      bundle: {
+        digest: expect.stringMatching(/^[0-9a-f]{64}$/),
+        routineId: "11111111-1111-4111-8111-111111111111",
+        routineVersion: "7",
+      },
+      startState: {
+        key: "Collect",
+        definitionRef: expect.stringMatching(
+          /^bundle:[0-9a-f]{64}\/routines\/11111111-1111-4111-8111-111111111111@7\/states\/Collect$/
+        ),
+      },
+    });
+  });
+
+  it("does not consult another source when no bundle is active", async () => {
+    const publications = new SoulPublicationCoordinator(
+      new InMemorySoulPublicationStore(),
+      new InMemoryBundleStore(),
+      { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    );
+    const resolver = new ActiveRoutineInvocationResolver(publications, signer);
+
+    await expect(
+      resolver.resolve({
+        businessId: BUSINESS_ID,
+        definitionRef: "published:routine:daily-digest",
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it.each([
+    ["a draft Routine", routine("draft")],
+    ["an unknown start State", routine("published", "Missing")],
+  ])("refuses %s even when its bundle was activated", async (_label, document) => {
+    const resolver = await activeResolver(document);
+    await expect(
+      resolver.resolve({
+        businessId: BUSINESS_ID,
+        definitionRef: "published:routine:daily-digest",
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it("refuses a non-Routine definition reference", async () => {
+    const resolver = await activeResolver(routine());
+    await expect(
+      resolver.resolve({
+        businessId: BUSINESS_ID,
+        definitionRef: "published:agent:daily-digest",
+      })
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/api/src/runtime/invocation-definitions.ts
+++ b/apps/api/src/runtime/invocation-definitions.ts
@@ -1,0 +1,76 @@
+import type { ResolvedRoutineInvocation, RoutineInvocationResolver } from "@tulipfarm/run-kernel";
+import type { BundleSigner, SoulPublicationCoordinator } from "@tulipfarm/soul";
+
+const ROUTINE_DEFINITION_PREFIX = "published:routine:";
+
+type ActiveBundleReader = Pick<SoulPublicationCoordinator, "activeBundle">;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function bundledStateRef(
+  digest: string,
+  routineId: string,
+  routineVersion: string,
+  stateKey: string
+): string {
+  return [
+    `bundle:${encodeURIComponent(digest)}`,
+    `routines/${encodeURIComponent(routineId)}@${encodeURIComponent(routineVersion)}`,
+    `states/${encodeURIComponent(stateKey)}`,
+  ].join("/");
+}
+
+/**
+ * Resolves a Routine only from the verified active Soul bundle. The live Git checkout and the
+ * legacy Routine registry are deliberately not consulted: a missing, draft, or malformed active
+ * definition denies the invocation before it can mint a Run.
+ */
+export class ActiveRoutineInvocationResolver implements RoutineInvocationResolver {
+  constructor(
+    private readonly publications: ActiveBundleReader,
+    private readonly signer: BundleSigner
+  ) {}
+
+  async resolve(input: {
+    readonly businessId: string;
+    readonly definitionRef: string;
+  }): Promise<ResolvedRoutineInvocation | undefined> {
+    if (!input.definitionRef.startsWith(ROUTINE_DEFINITION_PREFIX)) return undefined;
+    const slug = input.definitionRef.slice(ROUTINE_DEFINITION_PREFIX.length);
+    if (slug.length === 0) return undefined;
+
+    const bundle = await this.publications.activeBundle(input.businessId, this.signer);
+    const definition = bundle?.get("Routine", slug);
+    if (!bundle || !definition) return undefined;
+
+    const document = definition.document;
+    const metadata = isRecord(document.metadata) ? document.metadata : undefined;
+    const spec = isRecord(document.spec) ? document.spec : undefined;
+    const start = spec?.start;
+    const states = spec?.states;
+    if (
+      metadata?.lifecycle !== "published" ||
+      typeof start !== "string" ||
+      start.length === 0 ||
+      !Array.isArray(states) ||
+      !states.some((state) => isRecord(state) && state.name === start)
+    ) {
+      return undefined;
+    }
+
+    const routineVersion = String(definition.authoredVersion);
+    return {
+      bundle: {
+        digest: bundle.digest,
+        routineId: definition.id,
+        routineVersion,
+      },
+      startState: {
+        key: start,
+        definitionRef: bundledStateRef(bundle.digest, definition.id, routineVersion, start),
+      },
+    };
+  }
+}

--- a/apps/api/src/runtime/soul-bundle-signer.test.ts
+++ b/apps/api/src/runtime/soul-bundle-signer.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  resolveSoulBundleSigner,
+  SOUL_BUNDLE_SIGNING_KEY,
+  SOUL_BUNDLE_SIGNING_KEY_ID,
+  type SoulBundleSigningKeyStore,
+} from "./soul-bundle-signer";
+
+class MemorySigningKeys implements SoulBundleSigningKeyStore {
+  readonly values = new Map<string, string>();
+  readonly set = vi.fn(async (key: string, value: string, _type: "auto-generated") => {
+    this.values.set(key, value);
+  });
+
+  async list() {
+    return [...this.values.keys()].map((key) => ({ key }));
+  }
+
+  async get(key: string) {
+    const value = this.values.get(key);
+    if (value === undefined) throw new Error("missing key");
+    return value;
+  }
+}
+
+describe("resolveSoulBundleSigner", () => {
+  it("provisions one durable key and returns a stable signer", async () => {
+    const keys = new MemorySigningKeys();
+    const first = await resolveSoulBundleSigner(keys);
+    const second = await resolveSoulBundleSigner(keys);
+
+    expect(first.keyId).toBe(SOUL_BUNDLE_SIGNING_KEY_ID);
+    expect(first.sign("payload")).toBe(second.sign("payload"));
+    expect(keys.set).toHaveBeenCalledTimes(1);
+    expect(keys.values.get(SOUL_BUNDLE_SIGNING_KEY)).toMatch(/^[A-Za-z0-9+/]+={0,2}$/);
+  });
+
+  it("uses existing material without replacing it", async () => {
+    const keys = new MemorySigningKeys();
+    keys.values.set(SOUL_BUNDLE_SIGNING_KEY, "existing-secret");
+
+    const signer = await resolveSoulBundleSigner(keys);
+
+    expect(keys.set).not.toHaveBeenCalled();
+    expect(signer.sign("payload")).toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/apps/api/src/runtime/soul-bundle-signer.ts
+++ b/apps/api/src/runtime/soul-bundle-signer.ts
@@ -1,0 +1,35 @@
+import { randomBytes } from "node:crypto";
+import { type BundleSigner, createHmacBundleSigner } from "@tulipfarm/soul";
+
+/** Encrypted Secret holding the HMAC material shared by bundle publication and verification. */
+export const SOUL_BUNDLE_SIGNING_KEY = "soul-bundle.signing-key";
+
+/** Stable public key identity recorded beside every signed execution bundle. */
+export const SOUL_BUNDLE_SIGNING_KEY_ID = "soul-bundle-v1";
+
+export interface SoulBundleSigningKeyStore {
+  list(): Promise<readonly { readonly key: string }[]>;
+  get(key: string): Promise<string>;
+  set(key: string, plaintext: string, type: "auto-generated"): Promise<void>;
+}
+
+/**
+ * Resolve one durable signing key, provisioning it on first boot. The value is re-read after the
+ * write so the signer always uses the encrypted material that actually persisted.
+ */
+export async function resolveSoulBundleSigner(
+  secrets: SoulBundleSigningKeyStore
+): Promise<BundleSigner> {
+  const known = await secrets.list();
+  if (!known.some((secret) => secret.key === SOUL_BUNDLE_SIGNING_KEY)) {
+    await secrets.set(
+      SOUL_BUNDLE_SIGNING_KEY,
+      randomBytes(32).toString("base64"),
+      "auto-generated"
+    );
+  }
+  return createHmacBundleSigner(
+    SOUL_BUNDLE_SIGNING_KEY_ID,
+    await secrets.get(SOUL_BUNDLE_SIGNING_KEY)
+  );
+}

--- a/packages/run-kernel/AGENTS.md
+++ b/packages/run-kernel/AGENTS.md
@@ -28,3 +28,6 @@ public port, not the reverse).
 `ArtifactService` inside the transaction that creates the Run, and PR 3's worker reads it back as
 `service:run-executor`. Artifact rows are append-only (a trigger rejects UPDATE/DELETE), so an ACL
 or classification must be correct on the first write — there is no correcting write.
+Routine Runs additionally require the package-neutral `RoutineInvocationResolver` port. The API
+implements it against the verified active Soul publication; the gateway fails closed when exact
+bundle identity and the canonical start State cannot be resolved, before allocating a Run id.

--- a/packages/run-kernel/src/invocation/gateway.test.ts
+++ b/packages/run-kernel/src/invocation/gateway.test.ts
@@ -10,6 +10,7 @@ import {
   DurableInvocationGateway,
   type DurableInvocationRecord,
   type DurableInvocationStore,
+  type RoutineInvocationResolver,
 } from "./gateway";
 
 class FakeStore implements DurableInvocationStore {
@@ -37,6 +38,18 @@ const RUN_SOURCE = {
 } as const;
 
 const validator = new TypedOutputValidator(INVOCATION_REQUEST_SCHEMAS);
+const routineDefinitions: RoutineInvocationResolver = {
+  async resolve({ definitionRef }) {
+    return {
+      bundle: {
+        digest: "active-bundle-digest",
+        routineId: "routine-id",
+        routineVersion: "7",
+      },
+      startState: { key: "invoke", definitionRef },
+    };
+  },
+};
 
 describe("DurableInvocationGateway", () => {
   it.each(SOURCES)("creates the same persist-first Run/State shape for %s", async (source) => {
@@ -44,6 +57,7 @@ describe("DurableInvocationGateway", () => {
     const gateway = new DurableInvocationGateway({
       store,
       validator,
+      routineDefinitions,
       nextId: () => `run-${source}`,
       now: () => "2026-07-26T00:00:00.000Z",
     });
@@ -81,6 +95,7 @@ describe("DurableInvocationGateway", () => {
     const gateway = new DurableInvocationGateway({
       store,
       validator,
+      routineDefinitions,
       nextId: () => "run-1",
       now: () => "2026-07-26T00:00:00.000Z",
     });
@@ -100,7 +115,11 @@ describe("DurableInvocationGateway", () => {
     expect(store.records[0]).toMatchObject({
       source: "manual",
       runSource: "routine",
-      bundle: { routineId: "routine" },
+      bundle: {
+        digest: "active-bundle-digest",
+        routineId: "routine-id",
+        routineVersion: "7",
+      },
     });
   });
 
@@ -109,6 +128,7 @@ describe("DurableInvocationGateway", () => {
     const gateway = new DurableInvocationGateway({
       store,
       validator,
+      routineDefinitions,
       nextId: () => "run-1",
       now: () => "2026-07-26T00:00:00.000Z",
     });
@@ -177,6 +197,7 @@ describe("DurableInvocationGateway", () => {
     const gateway = new DurableInvocationGateway({
       store,
       validator,
+      routineDefinitions,
       nextId: () => `run-${++id}`,
       now: () => "2026-07-26T00:00:00.000Z",
     });
@@ -195,6 +216,61 @@ describe("DurableInvocationGateway", () => {
     await expect(gateway.start(input)).resolves.toEqual({ outcome: "started", runId: "run-1" });
     await expect(gateway.start(input)).resolves.toEqual({ outcome: "duplicate", runId: "run-1" });
     expect(store.records).toHaveLength(1);
+  });
+
+  it("persists the resolved canonical start State and records it as the Artifact producer", async () => {
+    const store = new FakeStore();
+    const gateway = new DurableInvocationGateway({
+      store,
+      validator,
+      routineDefinitions: {
+        async resolve() {
+          return {
+            bundle: { digest: "digest-1", routineId: "routine-1", routineVersion: "3" },
+            startState: { key: "Collect", definitionRef: "bundle:digest-1/state:Collect" },
+          };
+        },
+      },
+      nextId: () => "run-1",
+    });
+
+    await gateway.start({
+      source: "manual",
+      runSource: "routine",
+      businessId: "business-1",
+      initiator: { kind: "user", id: "user-1" },
+      effectiveSubject: { kind: "user", id: "user-1" },
+      definitionRef: "published:routine:daily",
+      payload: { slug: "daily", inputs: {} },
+      payloadSchemaRef: MANUAL_REQUEST_SCHEMA_REF,
+      idempotencyKey: "delivery-1",
+    });
+
+    expect(store.records[0]).toMatchObject({
+      bundle: { digest: "digest-1", routineId: "routine-1", routineVersion: "3" },
+      state: { key: "Collect", definitionRef: "bundle:digest-1/state:Collect" },
+      requestArtifact: { producer: { runId: "run-1", stateKey: "Collect", attempt: 0 } },
+    });
+  });
+
+  it("denies a Routine invocation when no active definition resolves", async () => {
+    const store = new FakeStore();
+    const gateway = new DurableInvocationGateway({ store, validator });
+
+    await expect(
+      gateway.start({
+        source: "manual",
+        runSource: "routine",
+        businessId: "business-1",
+        initiator: { kind: "user", id: "user-1" },
+        effectiveSubject: { kind: "user", id: "user-1" },
+        definitionRef: "published:routine:missing",
+        payload: { slug: "missing", inputs: {} },
+        payloadSchemaRef: MANUAL_REQUEST_SCHEMA_REF,
+        idempotencyKey: "delivery-1",
+      })
+    ).rejects.toMatchObject({ code: "unpublished_definition" });
+    expect(store.records).toHaveLength(0);
   });
 
   it("denies identity substitution before persistence", async () => {

--- a/packages/run-kernel/src/invocation/gateway.ts
+++ b/packages/run-kernel/src/invocation/gateway.ts
@@ -22,7 +22,7 @@ export interface InvocationPrincipal {
   readonly id: string;
 }
 
-/** The single State every invocation starts on, and the Artifact producer it is recorded under. */
+/** Default first State for non-Routine invocations and its request Artifact producer. */
 export const INVOKE_STATE_KEY = "invoke";
 
 /** Principal the Run executor reads request Artifacts as; every request ACL must include it. */
@@ -69,7 +69,7 @@ export interface DurableInvocationRecord {
     readonly routineVersion: string;
   };
   readonly state: {
-    readonly key: typeof INVOKE_STATE_KEY;
+    readonly key: string;
     readonly definitionRef: string;
     readonly resolvedInput: { readonly payloadRef: string };
   };
@@ -85,6 +85,31 @@ export interface DurableInvocationStore {
   persist(
     record: DurableInvocationRecord
   ): Promise<{ readonly outcome: "started" | "duplicate"; readonly runId: string }>;
+}
+
+/** Exact active Routine identity and start State resolved before a Routine Run is minted. */
+export interface ResolvedRoutineInvocation {
+  readonly bundle: {
+    readonly digest: string;
+    readonly routineId: string;
+    readonly routineVersion: string;
+  };
+  readonly startState: {
+    readonly key: string;
+    readonly definitionRef: string;
+  };
+}
+
+/**
+ * Package-neutral port to the active Soul publication authority. `@tulipfarm/run-kernel` owns the
+ * invocation boundary but cannot import `@tulipfarm/soul`; the composing app supplies the verified
+ * active Routine resolution.
+ */
+export interface RoutineInvocationResolver {
+  resolve(input: {
+    readonly businessId: string;
+    readonly definitionRef: string;
+  }): Promise<ResolvedRoutineInvocation | undefined>;
 }
 
 export interface StartInvocationInput {
@@ -122,6 +147,8 @@ export interface DurableInvocationGatewayOptions {
   readonly store: DurableInvocationStore;
   /** Compiled over `INVOCATION_REQUEST_SCHEMAS`; the gateway accepts no unregistered schema. */
   readonly validator: TypedOutputValidator;
+  /** Required for Routine Runs. Its absence denies rather than manufacturing a nominal pin. */
+  readonly routineDefinitions?: RoutineInvocationResolver;
   readonly nextId?: () => string;
   readonly now?: () => string;
 }
@@ -176,6 +203,36 @@ export class DurableInvocationGateway {
       throw error;
     }
 
+    const routineDefinition =
+      input.runSource === "routine"
+        ? await this.options.routineDefinitions?.resolve({
+            businessId: input.businessId,
+            definitionRef: input.definitionRef,
+          })
+        : undefined;
+    if (input.runSource === "routine" && routineDefinition === undefined) {
+      throw new InvocationDeniedError("unpublished_definition");
+    }
+
+    const bundle = routineDefinition?.bundle ?? {
+      digest: input.definitionRef,
+      routineId: input.runSource,
+      routineVersion: input.definitionRef,
+    };
+    const initialState = routineDefinition?.startState ?? {
+      key: INVOKE_STATE_KEY,
+      definitionRef: input.definitionRef,
+    };
+    if (
+      bundle.digest.length === 0 ||
+      bundle.routineId.length === 0 ||
+      bundle.routineVersion.length === 0 ||
+      initialState.key.length === 0 ||
+      initialState.definitionRef.length === 0
+    ) {
+      throw new InvocationDeniedError("invalid_invocation");
+    }
+
     const runId = this.nextId();
     const createdAt = this.now();
     return this.options.store.persist({
@@ -190,14 +247,10 @@ export class DurableInvocationGateway {
         : { identityMappingEvidenceRef: input.identityMappingEvidenceRef }),
       idempotencyKey: input.idempotencyKey,
       createdAt,
-      bundle: {
-        digest: input.definitionRef,
-        routineId: input.runSource,
-        routineVersion: input.definitionRef,
-      },
+      bundle,
       state: {
-        key: INVOKE_STATE_KEY,
-        definitionRef: input.definitionRef,
+        key: initialState.key,
+        definitionRef: initialState.definitionRef,
         resolvedInput: { payloadRef: requestPayloadRef(runId) },
       },
       requestArtifact: {
@@ -222,7 +275,7 @@ export class DurableInvocationGateway {
         },
         retention: { policy: "standard", expiresAt: null },
         redaction: { redactedPaths: [] },
-        producer: { runId, stateKey: INVOKE_STATE_KEY, attempt: 0 },
+        producer: { runId, stateKey: initialState.key, attempt: 0 },
         createdAt,
       },
     });

--- a/packages/soul/AGENTS.md
+++ b/packages/soul/AGENTS.md
@@ -23,6 +23,8 @@ git remote. Implements `specs/SOUL.md`. See root `AGENTS.md` for commands/lint.
   records + enqueues, `drain()` is the durable job (resumes at the recorded stage after a crash),
   `activeDigest()`/`activeBundle()` are the runtime read side, `rebuildProjection()` recompiles the
   authored projection from Git. Persistence is `@tulipfarm/storage`'s `SoulPublicationStore`.
+  `apps/api` composes the verified `activeBundle()` read side for Routine invocation; it does not
+  consult live Git when pinning a Run.
 - **`runSoulMigrations()`** + type `SoulMigration`.
 - Types: `SoulAgent`, `SoulSkill`, `SoulResource`, `SoulRoutine`, `SoulIntegration`.
 


### PR DESCRIPTION
## Summary\n\n- require Routine submissions to resolve an exact active Soul bundle before a Run is minted\n- persist the verified digest, stable Routine id and authored version, canonical start State, and matching request Artifact producer\n- provision the bundle HMAC key as an encrypted auto-generated Secret and fail closed when no valid active publication exists\n\n## Dependency decisions\n\n- Routine definition resolution: package-neutral port in @tulipfarm/run-kernel, implemented as a thin API-local adapter over @tulipfarm/soul activeBundle; no cross-app import and no internal HTTP call\n- publication persistence: reuse the promoted PgSoulPublicationStore and PgBundleStore package implementations\n- signing material: thin API-local boot composition over @tulipfarm/secrets; no duplicate storage path\n- pg-boss consumers: none move in this prerequisite slice, so the per-consumer decisions from the handoff are unchanged\n\n## Handoff deviation\n\nDiscovery found no production writer for Soul changesets or active bundles, and the legacy SoulLoader Routine shape is not the canonical ExecutionBundle document shape. This slice therefore composes only the verified active read authority needed by Worker execution. It does not invent a compatibility path or read live Git: without an active canonical publication, a Routine submission creates no Run.\n\nThis is an additional prerequisite in the iterative PR4 stack. It does not claim the final zero-boss.work acceptance yet; the remaining API source implementations are the Routine and knowledge consumers scheduled for the subsequent moves.\n\n## Test plan\n\n- [x] pnpm exec biome check apps packages — 1450 files checked, exit 0 (one pre-existing informational noUselessConstructor diagnostic)\n- [x] pnpm typecheck — 32 Turbo tasks passed plus scripts/test TypeScript\n- [x] pnpm architecture:test — 9 files, 62 tests passed\n- [x] pnpm --filter @tulipfarm/api exec vitest run --maxWorkers=1 — 186 files passed; 1734 passed, 1 skipped\n- [x] pnpm --filter @tulipfarm/worker exec vitest run — 31 files, 197 tests passed\n- [x] turbo test --filter=!@tulipfarm/api --force — 30 tasks passed, 0 cached\n- [x] focused run-kernel and API resolver/PostgreSQL tests — 29 tests passed