### PR TITLE
refactor(worker): load exact Routine definitions

### DIFF
--- a/apps/worker/AGENTS.md
+++ b/apps/worker/AGENTS.md
@@ -134,7 +134,11 @@ a Run a killed worker abandoned. Run with `--maxWorkers=1`.
 ## Imports
 
 May import: `schema`, `authz`, `audit`, `secrets`, `run-kernel`, `tool-broker`, `agent-runtime`,
-`knowledge`, `memory`, `surface`, `integrations`, `sandbox`, `storage`, `observability`,
+`knowledge`, `memory`, `surface`, `integrations`, `sandbox`, `soul`, `storage`, `observability`,
 `constants` (all under `@tulipfarm/*`). See
 [`docs/architecture/dependency-rules.md`](../../docs/architecture/dependency-rules.md). This app
 never imports another application (`apps/api`, `apps/integration-worker`, `apps/web`).
+
+The `soul` edge is narrow: execution may read a Run's exact immutable bundle through
+`PgBundleStore` and verify its signature. The Worker must never load the live Soul checkout,
+resolve an active alias, publish a changeset, or run Git sync.

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -12,6 +12,7 @@
     "@tulipfarm/sandbox": "workspace:*",
     "@tulipfarm/schema": "workspace:*",
     "@tulipfarm/secrets": "workspace:*",
+    "@tulipfarm/soul": "workspace:*",
     "@tulipfarm/storage": "workspace:*",
     "ai": "^7.0.2",
     "dotenv": "^17.4.2",

--- a/apps/worker/src/routine/definition-loader.test.ts
+++ b/apps/worker/src/routine/definition-loader.test.ts
@@ -1,0 +1,138 @@
+import {
+  compileExecutionBundle,
+  createHmacBundleSigner,
+  InMemoryBundleStore,
+  PinnedDefinitionLoader,
+  signExecutionBundle,
+} from "@tulipfarm/soul";
+import type { PersistedRun } from "@tulipfarm/storage";
+import { describe, expect, it } from "vitest";
+import { RoutineDefinitionLoadError, WorkerRoutineDefinitionLoader } from "./definition-loader";
+
+const signer = createHmacBundleSigner("bundle-key", "test-secret");
+
+function routine(lifecycle = "published") {
+  return {
+    apiVersion: "tulipfarm.ai/v1",
+    kind: "Routine",
+    metadata: {
+      id: "00000000-0000-4000-8000-000000000101",
+      slug: "daily-digest",
+      schemaVersion: 1,
+      authoredVersion: 3,
+      lifecycle,
+    },
+    spec: {
+      owner: "agent:assistant",
+      start: "Finish",
+      states: [{ type: "branch", name: "Finish", conditions: [{ condition: "true", end: true }] }],
+    },
+  };
+}
+
+function run(override: Partial<PersistedRun> = {}): PersistedRun {
+  return {
+    id: "00000000-0000-4000-8000-000000000001",
+    businessId: "business-1",
+    source: "routine",
+    bundle: {
+      digest: "bundle-digest",
+      routineId: "00000000-0000-4000-8000-000000000101",
+      routineVersion: "3",
+    },
+    identity: {
+      initiator: { kind: "agent", id: "assistant" },
+      effectiveSubject: { kind: "agent", id: "assistant" },
+      guardrailContextRef: "guardrail:default",
+    },
+    bounds: {
+      wallTimeMs: 60_000,
+      activeTimeMs: 30_000,
+      attempts: 3,
+      sideEffects: 0,
+    },
+    status: "claimed",
+    version: 1,
+    createdAt: "2026-08-02T00:00:00.000Z",
+    startedAt: null,
+    finishedAt: null,
+    resultArtifactId: null,
+    errorEvidenceRef: null,
+    leaseOwner: "worker-1",
+    leaseExpiresAt: "2026-08-02T00:01:00.000Z",
+    ...override,
+  };
+}
+
+async function loader(document = routine()) {
+  const bundles = new InMemoryBundleStore();
+  const record = signExecutionBundle(
+    compileExecutionBundle({
+      businessId: "business-1",
+      changesetId: "changeset-1",
+      commitSha: "commit-1",
+      documents: [document],
+    }),
+    signer
+  );
+  await bundles.put(record);
+  return {
+    record,
+    loader: new WorkerRoutineDefinitionLoader(new PinnedDefinitionLoader(bundles, signer)),
+  };
+}
+
+describe("WorkerRoutineDefinitionLoader", () => {
+  it("loads the immutable Routine named by the Run rather than an active alias", async () => {
+    const { loader: definitions, record } = await loader();
+
+    const loaded = await definitions.load(
+      run({
+        bundle: {
+          digest: record.digest,
+          routineId: "00000000-0000-4000-8000-000000000101",
+          routineVersion: "3",
+        },
+      })
+    );
+
+    expect(loaded.bundle.digest).toBe(record.digest);
+    expect(loaded.document.metadata.slug).toBe("daily-digest");
+    expect(loaded.document.spec.start).toBe("Finish");
+  });
+
+  it("fails closed when the Run's exact bundle pin cannot be found", async () => {
+    const { loader: definitions } = await loader();
+
+    await expect(definitions.load(run())).rejects.toEqual(
+      new RoutineDefinitionLoadError(
+        "pinned_routine_unavailable",
+        "00000000-0000-4000-8000-000000000001"
+      )
+    );
+  });
+
+  it("refuses a non-Routine Run", async () => {
+    const { loader: definitions } = await loader();
+
+    await expect(definitions.load(run({ source: "chat" }))).rejects.toMatchObject({
+      code: "non_routine_run",
+    });
+  });
+
+  it("refuses a non-published Routine even when its bundle is signed", async () => {
+    const { loader: definitions, record } = await loader(routine("draft"));
+
+    await expect(
+      definitions.load(
+        run({
+          bundle: {
+            digest: record.digest,
+            routineId: "00000000-0000-4000-8000-000000000101",
+            routineVersion: "3",
+          },
+        })
+      )
+    ).rejects.toMatchObject({ code: "unpublished_routine" });
+  });
+});

--- a/apps/worker/src/routine/definition-loader.test.ts
+++ b/apps/worker/src/routine/definition-loader.test.ts
@@ -99,7 +99,7 @@ describe("WorkerRoutineDefinitionLoader", () => {
     expect(loaded.bundle.digest).toBe(record.digest);
     expect(loaded.document.metadata.slug).toBe("daily-digest");
     expect(loaded.document.spec.start).toBe("Finish");
-  });
+  }, 30_000);
 
   it("fails closed when the Run's exact bundle pin cannot be found", async () => {
     const { loader: definitions } = await loader();

--- a/apps/worker/src/routine/definition-loader.ts
+++ b/apps/worker/src/routine/definition-loader.ts
@@ -1,0 +1,70 @@
+import { routine } from "@tulipfarm/schema";
+import type { PinnedDefinition, PinnedDefinitionLoader } from "@tulipfarm/soul";
+import type { PersistedRun } from "@tulipfarm/storage";
+
+export type RoutineDefinitionLoadErrorCode =
+  | "invalid_routine_definition"
+  | "non_routine_run"
+  | "pinned_routine_unavailable"
+  | "unpublished_routine";
+
+/** Payload-safe refusal to execute a Run whose exact Routine cannot be proved. */
+export class RoutineDefinitionLoadError extends Error {
+  readonly name = "RoutineDefinitionLoadError";
+
+  constructor(
+    readonly code: RoutineDefinitionLoadErrorCode,
+    readonly runId: string
+  ) {
+    super(`${code}:${runId}`);
+  }
+}
+
+type ExactDefinitionReader = Pick<PinnedDefinitionLoader, "load">;
+
+export interface LoadedRoutineDefinition extends PinnedDefinition {
+  readonly document: Readonly<routine.RoutineDefinition>;
+}
+
+/**
+ * Maps a claimed Routine Run onto its exact signed Soul definition.
+ *
+ * This adapter deliberately has no active-publication or Git port. A Run that waited through a
+ * newer publication resumes against the same digest, id, and authored version it started with.
+ */
+export class WorkerRoutineDefinitionLoader {
+  constructor(private readonly definitions: ExactDefinitionReader) {}
+
+  async load(run: PersistedRun): Promise<LoadedRoutineDefinition> {
+    if (run.source !== "routine") {
+      throw new RoutineDefinitionLoadError("non_routine_run", run.id);
+    }
+
+    const authoredVersion = Number(run.bundle.routineVersion);
+    if (!Number.isSafeInteger(authoredVersion)) {
+      throw new RoutineDefinitionLoadError("pinned_routine_unavailable", run.id);
+    }
+    const pinned = await this.definitions.load({
+      businessId: run.businessId,
+      bundleDigest: run.bundle.digest,
+      kind: "Routine",
+      definitionId: run.bundle.routineId,
+      authoredVersion,
+    });
+    if (pinned === undefined) {
+      throw new RoutineDefinitionLoadError("pinned_routine_unavailable", run.id);
+    }
+
+    let document: Readonly<routine.RoutineDefinition>;
+    try {
+      document = routine.validateRoutineDefinition(pinned.definition.document).document;
+    } catch {
+      throw new RoutineDefinitionLoadError("invalid_routine_definition", run.id);
+    }
+    if (document.metadata.lifecycle !== "published") {
+      throw new RoutineDefinitionLoadError("unpublished_routine", run.id);
+    }
+
+    return { ...pinned, document };
+  }
+}

--- a/docs/architecture/dependency-rules.md
+++ b/docs/architecture/dependency-rules.md
@@ -59,13 +59,19 @@ the Agent runtime. Applications register implementations during composition.
 | Consumer | May import from |
 | --- | --- |
 | `apps/api` | `schema`, `soul`, `constants`, `authz`, `audit`, `secrets`, `run-kernel`, `tool-broker`, `agent-runtime`, `knowledge`, `memory`, `surface`, `surface-web`, `surface-slack`, `surface-telegram`, `surface-github`, `sandbox`, `integrations`, `storage`, `observability` |
-| `apps/worker` | `schema`, `constants`, `authz`, `audit`, `secrets`, `run-kernel`, `tool-broker`, `agent-runtime`, `knowledge`, `memory`, `surface`, `integrations`, `sandbox`, `storage`, `observability` |
+| `apps/worker` | `schema`, `constants`, `authz`, `audit`, `secrets`, `soul`, `run-kernel`, `tool-broker`, `agent-runtime`, `knowledge`, `memory`, `surface`, `integrations`, `sandbox`, `storage`, `observability` |
 | `apps/integration-worker` | `schema`, `authz`, `audit`, `run-kernel`, `tool-broker`, `integrations`, `storage`, `observability` |
 | `apps/web` | `schema`, `surface`, `surface-web`, and presentation-only packages such as `ui`/`editor` |
 
 `packages/constants` is a dependency-free leaf holding non-sensitive deployment defaults. The API
 and the worker must resolve the same business scope or the worker claims nothing, and an app may
 not import another app, so both read it from there. Secrets never belong in it.
+
+The Worker may import `packages/soul` only for the Git-free execution-bundle read path. A durable
+Run is pinned to an immutable bundle digest and exact definition identity; `PgBundleStore`,
+`PinnedDefinitionLoader`, and signature verification are the single authority for opening that
+definition. This edge does not license `SoulLoader`, Git sync, changeset writes, publication, or
+active-alias resolution in the Worker.
 
 `apps/api` may import `sandbox` and `agent-runtime` for one reason only: those packages own the
 single implementation of something both applications need, and the alternative is a second copy.

--- a/packages/soul/AGENTS.md
+++ b/packages/soul/AGENTS.md
@@ -18,6 +18,9 @@ git remote. Implements `specs/SOUL.md`. See root `AGENTS.md` for commands/lint.
   immutable execution bundles: exact-version resolution, canonical digest, signature, and the
   Git-free `RuntimeBundle` workers execute against. `InMemoryBundleStore` implements the
   content-addressed `BundleStore` port.
+- **`PinnedDefinitionLoader`** — opens the exact bundle digest and definition identity a durable
+  Run recorded. It never consults Git or the active publication alias, so a waiting Run cannot
+  change behavior when a newer bundle becomes active.
 - **`SoulPublicationCoordinator`** — projects a signed bundle through the outbox and activates one
   digest only after every stage (`committed → projected → stored → active`) committed. `publish()`
   records + enqueues, `drain()` is the durable job (resumes at the recorded stage after a crash),

--- a/packages/soul/src/bundle-store.pg.test.ts
+++ b/packages/soul/src/bundle-store.pg.test.ts
@@ -34,7 +34,7 @@ describe("PgBundleStore", () => {
     database = new PGlite();
     for (const statement of SOUL_BUNDLE_STORAGE_STATEMENTS) await database.query(statement);
     store = new PgBundleStore(transactions(database));
-  }, 30_000);
+  }, 120_000);
 
   afterAll(async () => {
     await database.close();

--- a/packages/soul/src/index.ts
+++ b/packages/soul/src/index.ts
@@ -75,6 +75,8 @@ export type {
 export { SoulGitStore, SoulGitStoreError } from "./git-store";
 export { GitSyncService } from "./git-sync";
 export type { SoulMigration } from "./migrations/index";
+export type { PinnedDefinition, PinnedDefinitionRef } from "./pinned-definition";
+export { PinnedDefinitionLoader } from "./pinned-definition";
 export type {
   SoulPublicationErrorCode,
   SoulPublicationOutcome,

--- a/packages/soul/src/pinned-definition.test.ts
+++ b/packages/soul/src/pinned-definition.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { InMemoryBundleStore } from "./bundle";
+import { compileExecutionBundle } from "./compiler";
+import { PinnedDefinitionLoader } from "./pinned-definition";
+import { createHmacBundleSigner, signExecutionBundle } from "./signatures";
+
+const signer = createHmacBundleSigner("bundle-key", "test-secret");
+
+function routine() {
+  return {
+    apiVersion: "tulipfarm.ai/v1",
+    kind: "Routine",
+    metadata: {
+      id: "00000000-0000-4000-8000-000000000101",
+      slug: "daily-digest",
+      schemaVersion: 1,
+      authoredVersion: 3,
+      lifecycle: "published",
+    },
+    spec: {
+      owner: "agent:assistant",
+      start: "Finish",
+      states: [{ type: "branch", name: "Finish", conditions: [{ condition: "true", end: true }] }],
+    },
+  };
+}
+
+async function fixture() {
+  const bundles = new InMemoryBundleStore();
+  const record = signExecutionBundle(
+    compileExecutionBundle({
+      businessId: "business-1",
+      changesetId: "changeset-1",
+      commitSha: "commit-1",
+      documents: [routine()],
+    }),
+    signer
+  );
+  await bundles.put(record);
+  return { loader: new PinnedDefinitionLoader(bundles, signer), record };
+}
+
+describe("PinnedDefinitionLoader", () => {
+  it("opens the exact signed definition pinned by a Run", async () => {
+    const { loader, record } = await fixture();
+
+    const loaded = await loader.load({
+      businessId: "business-1",
+      bundleDigest: record.digest,
+      kind: "Routine",
+      definitionId: "00000000-0000-4000-8000-000000000101",
+      authoredVersion: 3,
+    });
+
+    expect(loaded?.bundle.digest).toBe(record.digest);
+    expect(loaded?.definition.document).toEqual(routine());
+  });
+
+  it.each([
+    ["another business", { businessId: "business-2" }],
+    ["another definition", { definitionId: "routine-2" }],
+    ["another kind", { kind: "Agent" }],
+    ["another version", { authoredVersion: 4 }],
+  ])("refuses %s rather than widening an exact pin", async (_name, override) => {
+    const { loader, record } = await fixture();
+
+    await expect(
+      loader.load({
+        businessId: "business-1",
+        bundleDigest: record.digest,
+        kind: "Routine",
+        definitionId: "00000000-0000-4000-8000-000000000101",
+        authoredVersion: 3,
+        ...override,
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it("refuses an unknown digest", async () => {
+    const { loader } = await fixture();
+
+    await expect(
+      loader.load({
+        businessId: "business-1",
+        bundleDigest: "missing",
+        kind: "Routine",
+        definitionId: "00000000-0000-4000-8000-000000000101",
+        authoredVersion: 3,
+      })
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/soul/src/pinned-definition.ts
+++ b/packages/soul/src/pinned-definition.ts
@@ -1,0 +1,52 @@
+import type { BundleDefinition, BundleStore, RuntimeBundle } from "./bundle";
+import type { BundleSigner } from "./signatures";
+import { verifyExecutionBundle } from "./signatures";
+
+/** Exact authored identity a durable Run recorded when it was minted. */
+export interface PinnedDefinitionRef {
+  readonly businessId: string;
+  readonly bundleDigest: string;
+  readonly kind: string;
+  readonly definitionId: string;
+  readonly authoredVersion: number;
+}
+
+/** A definition opened only after its immutable bundle and signature were verified. */
+export interface PinnedDefinition {
+  readonly bundle: RuntimeBundle;
+  readonly definition: BundleDefinition;
+}
+
+/**
+ * Git-free exact-definition reader for durable execution.
+ *
+ * A Run pins all five identity fields above. This loader accepts only a stored bundle whose
+ * signature is valid and whose definition matches every pin; it never consults the active alias,
+ * so publishing a newer bundle cannot change a Run that is already queued or waiting.
+ */
+export class PinnedDefinitionLoader {
+  constructor(
+    private readonly bundles: Pick<BundleStore, "get">,
+    private readonly signer: BundleSigner
+  ) {}
+
+  async load(ref: PinnedDefinitionRef): Promise<PinnedDefinition | undefined> {
+    const record = await this.bundles.get(ref.bundleDigest);
+    if (record === undefined) return undefined;
+
+    const bundle = verifyExecutionBundle(record, this.signer);
+    if (bundle.digest !== ref.bundleDigest || bundle.businessId !== ref.businessId)
+      return undefined;
+
+    const definition = bundle.getById(ref.definitionId);
+    if (
+      definition === undefined ||
+      definition.kind !== ref.kind ||
+      definition.authoredVersion !== ref.authoredVersion
+    ) {
+      return undefined;
+    }
+
+    return { bundle, definition };
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -465,6 +465,9 @@ importers:
       '@tulipfarm/secrets':
         specifier: workspace:*
         version: link:../../packages/secrets
+      '@tulipfarm/soul':
+        specifier: workspace:*
+        version: link:../../packages/soul
       '@tulipfarm/storage':
         specifier: workspace:*
         version: link:../../packages/storage

--- a/scripts/lib/architecture-rules.ts
+++ b/scripts/lib/architecture-rules.ts
@@ -186,6 +186,7 @@ export const ARCHITECTURE_CONFIG: ArchitectureConfig = {
       "authz",
       "audit",
       "secrets",
+      "soul",
       "run-kernel",
       "tool-broker",
       "agent-runtime",


### PR DESCRIPTION
## Summary

- add a package-owned `PinnedDefinitionLoader` that opens only the signed bundle digest and exact definition identity recorded by a durable Run
- add the Worker adapter that validates the pinned document with the canonical Routine schema and refuses missing, mismatched, malformed, draft, or non-Routine inputs
- document and enforce the narrow Worker to Soul dependency: immutable PostgreSQL bundle reads and signature verification only, with no Git, publication, or active-alias access
- harden the Soul PGlite suite and the first canonical validator test against repository-wide fan-out saturation

## Discovery correction

The production Routine submission path already goes through `DurableInvocationGateway`: it commits the request Artifact, canonical `runs` row, exact bundle pin, and initial `run_states` row together. The old API `routine_runs` engine is not composed in production and uses the retired CNCF-style Routine schema, while the canonical run-kernel currently provides pure graph/state processors rather than a live orchestrator. Step 4 is therefore a rewrite onto canonical Run/State persistence, not a direct move of the legacy engine.

This PR supplies the next bounded prerequisite in that rewrite: a Worker can now resolve a claimed Run to its immutable canonical Routine without consulting live Git or whichever bundle is active later.

## Dependency decisions

- exact bundle and definition lookup: promote to `@tulipfarm/soul` as `PinnedDefinitionLoader`; this reuses the single `BundleStore` and signature-verification authority
- Worker Routine mapping and canonical validation: thin Worker-local adapter over the package reader and `@tulipfarm/schema`; no duplicated bundle logic
- internal HTTP call: none; exact Routine execution must survive API downtime and must not re-resolve an active alias
- pg-boss consumers: none move in this prerequisite slice; the Routine cron/run/wake/sweep and knowledge consumer decisions remain for the subsequent cutover slices

## Handoff deviation

The handoff framed step 4 as moving an existing Routine executor. Discovery found no compatible live executor to move: the uncomposed API implementation and `packages/routine-engine` operate on a different model. This additional prerequisite avoids introducing a compatibility path or second authority.

This PR does not claim the final zero-`boss.work` acceptance. Production matches remain in the legacy Routine source files and the two knowledge consumers; State scheduling/execution, consumer deletion, and final composition assertions remain in the following PR4 slices.

## Test plan

- [x] `pnpm exec biome check apps packages` — 1,465 files checked; exit 0 (one pre-existing informational `noUselessConstructor` diagnostic)
- [x] `pnpm typecheck` — 32/32 Turbo tasks plus e2e TypeScript passed
- [x] `pnpm architecture:test` — 9 files, 62 tests passed
- [x] `pnpm --filter @tulipfarm/api exec vitest run --maxWorkers=1` — 186 files passed; 1,734 passed, 1 skipped
- [x] `pnpm --filter @tulipfarm/worker exec vitest run` — 32 files, 203 tests passed
- [x] `turbo test --filter='!@tulipfarm/api' --force` — 30/30 tasks passed, 0 cached
- [x] focused Soul bundle/definition tests — 2 files, 9 tests passed
- [x] focused Worker definition-loader tests — 1 file, 4 tests passed
- [x] isolated merged-main Web setup test after a saturated fan-out retry — 1 file, 3 tests passed
