### PR TITLE
refactor(run-kernel): schedule durable Routine States

### DIFF
--- a/apps/api/src/runtime/invocation-definitions.ts
+++ b/apps/api/src/runtime/invocation-definitions.ts
@@ -1,4 +1,8 @@
-import type { ResolvedRoutineInvocation, RoutineInvocationResolver } from "@tulipfarm/run-kernel";
+import {
+  type ResolvedRoutineInvocation,
+  type RoutineInvocationResolver,
+  routineStateDefinitionRef,
+} from "@tulipfarm/run-kernel";
 import type { BundleSigner, SoulPublicationCoordinator } from "@tulipfarm/soul";
 
 const ROUTINE_DEFINITION_PREFIX = "published:routine:";
@@ -7,19 +11,6 @@ type ActiveBundleReader = Pick<SoulPublicationCoordinator, "activeBundle">;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function bundledStateRef(
-  digest: string,
-  routineId: string,
-  routineVersion: string,
-  stateKey: string
-): string {
-  return [
-    `bundle:${encodeURIComponent(digest)}`,
-    `routines/${encodeURIComponent(routineId)}@${encodeURIComponent(routineVersion)}`,
-    `states/${encodeURIComponent(stateKey)}`,
-  ].join("/");
 }
 
 /**
@@ -69,7 +60,10 @@ export class ActiveRoutineInvocationResolver implements RoutineInvocationResolve
       },
       startState: {
         key: start,
-        definitionRef: bundledStateRef(bundle.digest, definition.id, routineVersion, start),
+        definitionRef: routineStateDefinitionRef(
+          { digest: bundle.digest, routineId: definition.id, routineVersion },
+          start
+        ),
       },
     };
   }

--- a/packages/run-kernel/src/routine/index.ts
+++ b/packages/run-kernel/src/routine/index.ts
@@ -1,4 +1,5 @@
 export * from "./compiler";
 export * from "./expressions";
 export * from "./plan";
+export * from "./scheduling";
 export * from "./states";

--- a/packages/run-kernel/src/routine/scheduling.test.ts
+++ b/packages/run-kernel/src/routine/scheduling.test.ts
@@ -1,0 +1,132 @@
+import type {
+  EnsureStateInput,
+  EnsureStateResult,
+  PersistedRun,
+  PersistedState,
+} from "@tulipfarm/storage";
+import { describe, expect, it } from "vitest";
+import {
+  RoutineStateScheduleError,
+  RoutineStateScheduler,
+  type RoutineStateScheduleStore,
+} from "./scheduling";
+
+const RUN: PersistedRun = {
+  id: "00000000-0000-4000-8000-000000000001",
+  businessId: "business-1",
+  source: "routine",
+  bundle: {
+    digest: "digest/one",
+    routineId: "routine one",
+    routineVersion: "7/beta",
+  },
+  identity: {
+    initiator: { kind: "user", id: "user-1" },
+    effectiveSubject: { kind: "agent", id: "agent-1" },
+    guardrailContextRef: "guardrail-context-1",
+  },
+  bounds: { wallTimeMs: 60_000, activeTimeMs: 30_000, attempts: 3, sideEffects: 2 },
+  status: "running",
+  version: 2,
+  createdAt: "2026-08-02T10:00:00.000Z",
+  startedAt: "2026-08-02T10:00:01.000Z",
+  finishedAt: null,
+  resultArtifactId: null,
+  errorEvidenceRef: null,
+  leaseOwner: "worker-1",
+  leaseExpiresAt: "2026-08-02T10:01:01.000Z",
+};
+
+function state(input: EnsureStateInput): PersistedState {
+  return {
+    businessId: input.businessId,
+    runId: input.runId,
+    key: input.key,
+    definitionRef: input.definitionRef,
+    resolvedInput: input.resolvedInput,
+    status: "pending",
+    version: 0,
+    createdAt: input.createdAt,
+    startedAt: null,
+    finishedAt: null,
+    resultArtifactId: null,
+    errorEvidenceRef: null,
+  };
+}
+
+class RecordingScheduleStore implements RoutineStateScheduleStore {
+  readonly inputs: EnsureStateInput[] = [];
+
+  async ensureState(input: EnsureStateInput): Promise<EnsureStateResult> {
+    this.inputs.push(input);
+    return { outcome: "inserted", state: state(input) };
+  }
+}
+
+describe("RoutineStateScheduler", () => {
+  it("pins an authored State to the Run bundle under a distinct durable occurrence key", async () => {
+    const store = new RecordingScheduleStore();
+    const scheduler = new RoutineStateScheduler(store);
+
+    await expect(
+      scheduler.schedule({
+        run: RUN,
+        stateKey: "Notify:item:0",
+        definitionStateKey: "Notify owner",
+        resolvedInput: { artifactId: "artifact-output-1" },
+        createdAt: "2026-08-02T10:00:02.000Z",
+      })
+    ).resolves.toMatchObject({ outcome: "inserted", state: { key: "Notify:item:0" } });
+    expect(store.inputs).toEqual([
+      {
+        businessId: "business-1",
+        runId: RUN.id,
+        key: "Notify:item:0",
+        definitionRef: "bundle:digest%2Fone/routines/routine%20one@7%2Fbeta/states/Notify%20owner",
+        resolvedInput: { artifactId: "artifact-output-1" },
+        createdAt: "2026-08-02T10:00:02.000Z",
+      },
+    ]);
+  });
+
+  it("rejects non-Routine Runs before persistence", async () => {
+    const store = new RecordingScheduleStore();
+    const scheduler = new RoutineStateScheduler(store);
+
+    await expect(
+      scheduler.schedule({
+        run: { ...RUN, source: "chat" },
+        stateKey: "Notify",
+        definitionStateKey: "Notify",
+        resolvedInput: {},
+        createdAt: "2026-08-02T10:00:02.000Z",
+      })
+    ).rejects.toEqual(new RoutineStateScheduleError("non_routine_run", RUN.id));
+    expect(store.inputs).toEqual([]);
+  });
+
+  it("rejects incomplete State or bundle identity before persistence", async () => {
+    const store = new RecordingScheduleStore();
+    const scheduler = new RoutineStateScheduler(store);
+
+    await expect(
+      scheduler.schedule({
+        run: RUN,
+        stateKey: "",
+        definitionStateKey: "Notify",
+        resolvedInput: {},
+        createdAt: "2026-08-02T10:00:02.000Z",
+      })
+    ).rejects.toEqual(new RoutineStateScheduleError("invalid_state_identity", RUN.id));
+    await expect(
+      scheduler.schedule({
+        run: { ...RUN, bundle: { ...RUN.bundle, digest: "" } },
+        stateKey: "Notify",
+        definitionStateKey: "Notify",
+        resolvedInput: {},
+        createdAt: "2026-08-02T10:00:02.000Z",
+      })
+    ).rejects.toEqual(new RoutineStateScheduleError("invalid_state_identity", RUN.id));
+    expect(store.inputs).toEqual([]);
+  });
+});

--- a/packages/run-kernel/src/routine/scheduling.ts
+++ b/packages/run-kernel/src/routine/scheduling.ts
@@ -1,0 +1,74 @@
+import type {
+  EnsureStateInput,
+  EnsureStateResult,
+  PersistedRun,
+  RunBundle,
+} from "@tulipfarm/storage";
+
+export type RoutineStateScheduleErrorCode = "invalid_state_identity" | "non_routine_run";
+
+/** Payload-safe refusal to schedule a State outside its Run's exact Routine identity. */
+export class RoutineStateScheduleError extends Error {
+  readonly name = "RoutineStateScheduleError";
+
+  constructor(
+    readonly code: RoutineStateScheduleErrorCode,
+    readonly runId: string
+  ) {
+    super(`${code}:${runId}`);
+  }
+}
+
+/** Stable reference to one authored State inside an immutable Routine bundle. */
+export function routineStateDefinitionRef(bundle: RunBundle, stateKey: string): string {
+  return [
+    `bundle:${encodeURIComponent(bundle.digest)}`,
+    `routines/${encodeURIComponent(bundle.routineId)}@${encodeURIComponent(bundle.routineVersion)}`,
+    `states/${encodeURIComponent(stateKey)}`,
+  ].join("/");
+}
+
+/** Narrow surface the scheduler needs; `@tulipfarm/storage`'s `RunStore` satisfies it. */
+export interface RoutineStateScheduleStore {
+  ensureState(input: EnsureStateInput): Promise<EnsureStateResult>;
+}
+
+export interface ScheduleRoutineStateInput {
+  readonly run: PersistedRun;
+  /** Durable State occurrence key. It may differ from the authored key for bounded fan-out. */
+  readonly stateKey: string;
+  /** State name in the pinned Routine definition. */
+  readonly definitionStateKey: string;
+  readonly resolvedInput: Record<string, unknown>;
+  readonly createdAt: string;
+}
+
+/** Persist-first, replay-safe scheduling for later States in a Routine Run. */
+export class RoutineStateScheduler {
+  constructor(private readonly store: RoutineStateScheduleStore) {}
+
+  async schedule(input: ScheduleRoutineStateInput): Promise<EnsureStateResult> {
+    if (input.run.source !== "routine") {
+      throw new RoutineStateScheduleError("non_routine_run", input.run.id);
+    }
+    const { bundle } = input.run;
+    if (
+      input.stateKey.length === 0 ||
+      input.definitionStateKey.length === 0 ||
+      bundle.digest.length === 0 ||
+      bundle.routineId.length === 0 ||
+      bundle.routineVersion.length === 0
+    ) {
+      throw new RoutineStateScheduleError("invalid_state_identity", input.run.id);
+    }
+
+    return this.store.ensureState({
+      businessId: input.run.businessId,
+      runId: input.run.id,
+      key: input.stateKey,
+      definitionRef: routineStateDefinitionRef(bundle, input.definitionStateKey),
+      resolvedInput: input.resolvedInput,
+      createdAt: input.createdAt,
+    });
+  }
+}

--- a/packages/storage/src/runs/index.ts
+++ b/packages/storage/src/runs/index.ts
@@ -43,6 +43,8 @@ export type {
   AttemptEvent,
   AttemptEvidence,
   ClaimNextQueuedInput,
+  EnsureStateInput,
+  EnsureStateResult,
   HeartbeatInput,
   ListRunsInput,
   PersistedRun,

--- a/packages/storage/src/runs/run-store.pg.test.ts
+++ b/packages/storage/src/runs/run-store.pg.test.ts
@@ -120,6 +120,76 @@ describe("RunStore (PostgreSQL)", () => {
     expect(await store.findState("business-1", run().id, "ghost")).toBeNull();
   });
 
+  it("inserts a later State once and returns the original State on replay", async () => {
+    await store.start(run());
+    const scheduled = {
+      businessId: "business-1",
+      runId: run().id,
+      key: "notify:0",
+      definitionRef: "sha256:bundle-1#/states/notify",
+      resolvedInput: { recipient: "operator", artifactId: "artifact-output-1" },
+      createdAt: CREATED_AT,
+    };
+
+    const first = await store.ensureState(scheduled);
+    const replay = await store.ensureState({
+      ...scheduled,
+      resolvedInput: { artifactId: "artifact-output-1", recipient: "operator" },
+      createdAt: "2026-07-24T10:01:00.000Z",
+    });
+
+    expect(first).toMatchObject({
+      outcome: "inserted",
+      state: {
+        key: "notify:0",
+        definitionRef: "sha256:bundle-1#/states/notify",
+        status: "pending",
+        version: 0,
+        createdAt: CREATED_AT,
+      },
+    });
+    expect(replay).toEqual({ outcome: "existing", state: first.state });
+    expect(
+      (await store.listStates("business-1", run().id)).filter((state) => state.key === "notify:0")
+    ).toHaveLength(1);
+  });
+
+  it("rejects a later State replay that changes immutable execution identity", async () => {
+    await store.start(run());
+    const scheduled = {
+      businessId: "business-1",
+      runId: run().id,
+      key: "notify:0",
+      definitionRef: "sha256:bundle-1#/states/notify",
+      resolvedInput: { artifactId: "artifact-output-1" },
+      createdAt: CREATED_AT,
+    };
+    await store.ensureState(scheduled);
+
+    await expect(
+      store.ensureState({ ...scheduled, definitionRef: "sha256:bundle-2#/states/notify" })
+    ).rejects.toEqual(new RunPersistenceError("state_conflict"));
+    await expect(
+      store.ensureState({ ...scheduled, resolvedInput: { artifactId: "artifact-output-2" } })
+    ).rejects.toEqual(new RunPersistenceError("state_conflict"));
+  });
+
+  it("keeps later State scheduling scoped to an existing business Run", async () => {
+    await store.start(run());
+
+    await expect(
+      store.ensureState({
+        businessId: "business-2",
+        runId: run().id,
+        key: "notify:0",
+        definitionRef: "sha256:bundle-1#/states/notify",
+        resolvedInput: {},
+        createdAt: CREATED_AT,
+      })
+    ).rejects.toThrow();
+    expect(await store.findState("business-1", run().id, "notify:0")).toBeNull();
+  });
+
   it("rolls back the Run when a State violates a database constraint", async () => {
     await expect(
       store.start(

--- a/packages/storage/src/runs/run-store.ts
+++ b/packages/storage/src/runs/run-store.ts
@@ -55,6 +55,17 @@ export interface StartStateInput {
   readonly resolvedInput: Record<string, unknown>;
 }
 
+export interface EnsureStateInput extends StartStateInput {
+  readonly businessId: string;
+  readonly runId: string;
+  readonly createdAt: string;
+}
+
+export interface EnsureStateResult {
+  readonly outcome: "inserted" | "existing";
+  readonly state: PersistedState;
+}
+
 export type RunLineageRelation = "child" | "replay";
 
 export interface StartRunInput {
@@ -198,7 +209,7 @@ export interface RunPage {
 
 export const MAX_RUN_PAGE_SIZE = 100;
 
-export type RunPersistenceErrorCode = "attempt_conflict" | "invalid_cursor";
+export type RunPersistenceErrorCode = "attempt_conflict" | "invalid_cursor" | "state_conflict";
 
 export class RunPersistenceError extends Error {
   readonly name = "RunPersistenceError";
@@ -556,6 +567,53 @@ export class RunStore {
       );
       const row = result.rows[0];
       return row ? persistedRun(row) : null;
+    });
+  }
+
+  /**
+   * Inserts one later State, or returns the identical State a previous attempt already inserted.
+   * The first scheduling timestamp wins; a retry may use a later clock value but cannot change the
+   * State definition or its resolved input under the same durable key.
+   */
+  async ensureState(input: EnsureStateInput): Promise<EnsureStateResult> {
+    return this.transactions.withTransaction(async (transaction) => {
+      const inserted = await transaction.query<StateRow>(
+        `INSERT INTO run_states (
+           business_id, run_id, state_key, definition_ref, resolved_input, created_at
+         ) VALUES ($1, $2, $3, $4, $5::jsonb, $6::timestamptz)
+         ON CONFLICT (business_id, run_id, state_key) DO NOTHING
+         RETURNING ${STATE_COLUMNS}`,
+        [
+          input.businessId,
+          input.runId,
+          input.key,
+          input.definitionRef,
+          JSON.stringify(input.resolvedInput),
+          input.createdAt,
+        ]
+      );
+      const created = inserted.rows[0];
+      if (created) return { outcome: "inserted", state: persistedState(created) };
+
+      const existing = await transaction.query<StateRow>(
+        `SELECT ${STATE_COLUMNS}
+           FROM run_states
+          WHERE business_id = $1
+            AND run_id = $2
+            AND state_key = $3
+            AND definition_ref = $4
+            AND resolved_input = $5::jsonb`,
+        [
+          input.businessId,
+          input.runId,
+          input.key,
+          input.definitionRef,
+          JSON.stringify(input.resolvedInput),
+        ]
+      );
+      const state = existing.rows[0];
+      if (!state) throw new RunPersistenceError("state_conflict");
+      return { outcome: "existing", state: persistedState(state) };
     });
   }
 


### PR DESCRIPTION
## Summary

- Add an insert-once RunStore boundary for later States, returning an identical existing State on replay and rejecting changed definition or resolved input under the same durable key.
- Add RoutineStateScheduler in the Run Kernel so every later Routine State is pinned to the Run exact immutable bundle, while keeping its durable occurrence key separate from its authored State name for bounded fan-out and loops.
- Reuse the package-owned Routine State reference builder at the API invocation boundary, removing the API-local copy.

This is the next bounded prerequisite in the PR 4 stack. It gives the Worker a crash-safe way to persist a continuation before dispatching it; it does not add a second executor or compatibility path.

## Dependency decisions

- Promote to package: State insertion mechanics live in @tulipfarm/storage; exact Routine scheduling and reference construction live in @tulipfarm/run-kernel.
- Thin local copy: none.
- Internal HTTP call: none.
- Per-consumer decisions: no pg-boss consumer moves in this prerequisite slice, so there is no consumer-specific collaborator decision yet.

## Discovery and deviations

- Discovery confirmed production Routine invocation already uses DurableInvocationGateway with an immutable request Artifact, exact bundle pin, and initial canonical State. The old API Routine engine is not production-composed, so the eventual executor move is a rewrite onto runs and run_states rather than a relocation of routine_runs.
- Deviation from the handoff execution unit: PR 4 is landing as a sequence of independently green prerequisite PRs. This slice intentionally does not yet satisfy the final zero boss.work registrations acceptance criterion; consumer removal remains in the following slices.

## Test plan

- [x] pnpm exec biome check apps packages — 1,467 files checked; one pre-existing informational lint, zero errors
- [x] pnpm typecheck — 32/32 workspace tasks plus e2e TypeScript passed
- [x] pnpm architecture:test — 9 files, 62 tests passed
- [x] pnpm --filter @tulipfarm/api exec vitest run --maxWorkers=1 — 186 files, 1,734 passed, 1 skipped
- [x] pnpm --filter @tulipfarm/worker exec vitest run — 32 files, 203 passed
- [x] turbo test --filter=!@tulipfarm/api --force — 30/30 tasks passed; storage 152 tests and Run Kernel 382 tests passed
- [x] Targeted PostgreSQL storage suite — 22 passed
- [x] Targeted Routine State scheduler suite — 3 passed
- [x] Targeted API invocation definition suite — 5 passed