### PR TITLE
refactor(worker): execute Routine waits and bounded fan-out

### DIFF
--- a/apps/worker/AGENTS.md
+++ b/apps/worker/AGENTS.md
@@ -42,12 +42,28 @@ hands the Run to **the same** chat executor instance, so a Slack turn and a web 
 one code path.
 
 The Routine executor opens only the Run's exact signed bundle and reconstructs manual input from
-its immutable request Artifact. Its first bounded capability is deterministic `branch` State
-execution: each successor is persisted before its predecessor succeeds, making a crash between the
-two writes replay through `ensureState` without duplicate work. State types with effects and
-Context roots the request Artifact cannot reconstruct are claimed and parked as
-`needs_reconciliation`; they are never interpreted as successful or dispatched through a second
-authority.
+its immutable request Artifact. It owns the deterministic capabilities: `branch` graphs, durable
+`wait` timers, and the bounded fan-out and loop constructs (`parallel`, `foreach`, `repeat_until`).
+Two rules make it replay-safe. Each successor is persisted before its predecessor succeeds, so a
+crash between the two writes replays through `ensureState` without duplicate work. And a fan-out
+unit is addressed by a durable occurrence key (`routineOccurrenceKey` — `${parent}#${unit}/${state}`)
+derived from the pinned collection, never from a counter this process holds, so progress is
+*replayed* off the durable State rows rather than tracked in memory: there is no second progress
+ledger to fall out of step with them.
+
+A `wait` opens its timer through `DurableWaitManager` in this process — the wait id is derived from
+`(runId, occurrence key)`, so a worker that died between creating the wait and parking the State
+finds its own wait instead of opening a second one — and returns `waiting`, which parks the Run
+holding no lease. The `wait-sweep` loop above resolves the deadline and requeues the Run; the
+executor then replays the chain from the top against the durable rows. An expired timer takes the
+State's authored `onError` path for `wait_timed_out`, or parks. An `event` wait is refused
+(`unsupported_wait`): nothing in this process delivers that signal, and opening it would strand the
+Run.
+
+State types with effects and Context roots the request Artifact cannot reconstruct are claimed and
+parked as `needs_reconciliation`; they are never interpreted as successful or dispatched through a
+second authority. A satisfied `any`/`quorum` join that still names units to cancel is refused for
+the same reason — this executor can settle a unit but cannot cancel one parked on a live timer.
 
 ## Executing a turn (`src/turn/`)
 

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import {
   ArtifactService,
+  DurableWaitManager,
   RoutineStateScheduler,
   RunLeaseManager,
   RunResumeGateway,
@@ -137,6 +138,9 @@ export async function main(): Promise<void> {
   const leases = new RunLeaseManager(runStore);
   const resume = new RunResumeGateway(runStore);
   const sweeper = new WaitTimerSweeper(waitStore, resume);
+  // Routine `wait` States open their timers here rather than over the internal API: nothing on the
+  // far side decides a timer, and the same sweeper above is what resolves it.
+  const waits = new DurableWaitManager(waitStore, resume);
 
   // The turn host answers every question a turn has that this process cannot answer itself: which
   // Turn a Run answers, the assembled Context, Tool dispatch, and the durable completion.
@@ -198,6 +202,7 @@ export async function main(): Promise<void> {
       runs: runStore,
       scheduler: new RoutineStateScheduler(runStore),
       transitions: new RunStoreStateTransitions(runStore),
+      waits,
     })
   );
 

--- a/apps/worker/src/routine/executor.test.ts
+++ b/apps/worker/src/routine/executor.test.ts
@@ -1,6 +1,11 @@
-import { type ArtifactContent, RoutineStateScheduler } from "@tulipfarm/run-kernel";
+import {
+  type ArtifactContent,
+  type RegisterWaitInput,
+  RoutineStateScheduler,
+  routineWaitId,
+} from "@tulipfarm/run-kernel";
 import { MANUAL_REQUEST_SCHEMA_REF, type routine } from "@tulipfarm/schema";
-import type { PersistedRun, PersistedState } from "@tulipfarm/storage";
+import type { PersistedRun, PersistedState, PersistedWait } from "@tulipfarm/storage";
 import { describe, expect, it } from "vitest";
 import type { StateTransitionPort } from "../agent-state";
 import type { LoadedRoutineDefinition } from "./definition-loader";
@@ -76,7 +81,7 @@ function state(key: string, status: PersistedState["status"] = "pending"): Persi
 
 const requestArtifact: ArtifactContent = {
   schemaRef: MANUAL_REQUEST_SCHEMA_REF,
-  content: { slug: "daily-digest", inputs: { score: 7, region: "west" } },
+  content: { slug: "daily-digest", inputs: { score: 7, region: "west", tags: ["a", "b"] } },
   contentHash: "request-hash",
 };
 
@@ -107,6 +112,31 @@ class StateHarness implements StateTransitionPort {
       return { outcome: "inserted", state: inserted };
     },
   });
+
+  readonly waits = new Map<string, PersistedWait>();
+
+  readonly waitPort = {
+    register: async (input: RegisterWaitInput) => {
+      this.events.push(`${input.stateKey}:wait-opened`);
+      const wait = {
+        ...input,
+        status: "pending" as const,
+        resolvedAt: null,
+        version: 0,
+      } satisfies PersistedWait;
+      this.waits.set(input.id, wait);
+      return { wait };
+    },
+    find: async (_businessId: string, waitId: string) => this.waits.get(waitId) ?? null,
+  };
+
+  /** Stands in for the deadline sweep: resolves a registered timer the way `resolveDueWait` does. */
+  resolveWait(stateKey: string, status: "satisfied" | "timed_out"): void {
+    const id = routineWaitId(run().id, stateKey);
+    const wait = this.waits.get(id);
+    if (wait === undefined) throw new Error(`no wait for ${stateKey}`);
+    this.waits.set(id, { ...wait, status, resolvedAt: STARTED_AT });
+  }
 
   async transition(input: Parameters<StateTransitionPort["transition"]>[0]): Promise<void> {
     const persisted = this.states.get(input.stateKey);
@@ -142,6 +172,7 @@ function executor(document: routine.RoutineDefinition, harness: StateHarness) {
     runs: { listStates: async () => [...harness.states.values()] },
     scheduler: harness.scheduler,
     transitions: harness,
+    waits: harness.waitPort,
     now: () => new Date(STARTED_AT),
   });
 }
@@ -265,5 +296,247 @@ describe("createRoutineExecutor", () => {
 
     await expect(execute(run())).resolves.toBe("needs_reconciliation");
     expect(harness.states.get("Start")?.errorEvidenceRef).toBe("routine:unsupported_context");
+  });
+});
+
+describe("createRoutineExecutor — durable waits", () => {
+  function waitDefinition(overrides: Record<string, unknown> = {}): routine.RoutineDefinition {
+    return definition([
+      {
+        type: "wait",
+        name: "Start",
+        waitFor: { kind: "timer", durationMs: 60_000 },
+        end: true,
+        ...overrides,
+      },
+    ]);
+  }
+
+  it("opens a timer and parks the Run on it", async () => {
+    const harness = new StateHarness([state("Start")]);
+
+    await expect(executor(waitDefinition(), harness)(run())).resolves.toBe("waiting");
+    expect(harness.transitions).toEqual([
+      "Start:pending->ready",
+      "Start:ready->claimed",
+      "Start:claimed->running",
+      "Start:running->waiting",
+    ]);
+    const wait = harness.waits.get(routineWaitId(run().id, "Start"));
+    expect(wait).toMatchObject({ kind: "timer", stateKey: "Start", status: "pending" });
+    expect(wait?.deadlineAt).toBe("2026-08-02T00:01:00.000Z");
+  });
+
+  it("re-parks a replay whose timer has not resolved without opening a second wait", async () => {
+    const harness = new StateHarness([state("Start")]);
+    const execute = executor(waitDefinition(), harness);
+
+    await expect(execute(run())).resolves.toBe("waiting");
+    await expect(execute(run())).resolves.toBe("waiting");
+    expect(harness.waits.size).toBe(1);
+    expect(harness.events.filter((event) => event === "Start:wait-opened")).toHaveLength(1);
+  });
+
+  it("resumes the chain once the deadline sweep satisfies the timer", async () => {
+    const harness = new StateHarness([state("Start")]);
+    const withSuccessor = executor(
+      definition([
+        {
+          type: "wait",
+          name: "Start",
+          waitFor: { kind: "timer", durationMs: 60_000 },
+          transition: "Finish",
+        },
+        {
+          type: "branch",
+          name: "Finish",
+          conditions: [{ condition: "true", end: true }],
+          default: { end: true },
+        },
+      ]),
+      harness
+    );
+
+    await expect(withSuccessor(run())).resolves.toBe("waiting");
+    harness.resolveWait("Start", "satisfied");
+    await expect(withSuccessor(run())).resolves.toBe("succeeded");
+    expect(harness.transitions.slice(4)).toEqual([
+      "Start:waiting->ready",
+      "Start:ready->claimed",
+      "Start:claimed->running",
+      "Start:running->succeeded",
+      "Finish:pending->ready",
+      "Finish:ready->claimed",
+      "Finish:claimed->running",
+      "Finish:running->succeeded",
+    ]);
+  });
+
+  it("takes the authored error path when the timer expires unsatisfied", async () => {
+    const harness = new StateHarness([state("Start")]);
+    const execute = executor(
+      waitDefinition({ end: undefined, onError: [{ errorRef: "wait_timed_out", end: true }] }),
+      harness
+    );
+
+    await expect(execute(run())).resolves.toBe("waiting");
+    harness.resolveWait("Start", "timed_out");
+    await expect(execute(run())).resolves.toBe("succeeded");
+  });
+
+  it("parks an expired timer the Routine declared no handler for", async () => {
+    const harness = new StateHarness([state("Start")]);
+    const execute = executor(waitDefinition(), harness);
+
+    await expect(execute(run())).resolves.toBe("waiting");
+    harness.resolveWait("Start", "timed_out");
+    await expect(execute(run())).resolves.toBe("needs_reconciliation");
+    expect(harness.states.get("Start")?.errorEvidenceRef).toBe("routine:wait_timed_out");
+  });
+
+  it("parks an event wait nothing in this process can signal", async () => {
+    const harness = new StateHarness([state("Start")]);
+    const execute = executor(
+      waitDefinition({ waitFor: { kind: "event", eventType: "invoice.paid" } }),
+      harness
+    );
+
+    await expect(execute(run())).resolves.toBe("needs_reconciliation");
+    expect(harness.states.get("Start")?.errorEvidenceRef).toBe("routine:unsupported_wait");
+    expect(harness.waits.size).toBe(0);
+  });
+});
+
+describe("createRoutineExecutor — bounded fan-out", () => {
+  function leaf(name: string): routine.RoutineState {
+    return {
+      type: "branch",
+      name,
+      conditions: [{ condition: "true", end: true }],
+      default: { end: true },
+    };
+  }
+
+  function parallelDefinition(overrides: Record<string, unknown> = {}) {
+    return definition([
+      {
+        type: "parallel",
+        name: "Start",
+        branches: ["Left", "Right"],
+        maxConcurrency: 2,
+        join: "all",
+        end: true,
+        ...overrides,
+      },
+      leaf("Left"),
+      leaf("Right"),
+    ]);
+  }
+
+  it("executes every branch under its own occurrence key", async () => {
+    const harness = new StateHarness([state("Start")]);
+
+    await expect(executor(parallelDefinition(), harness)(run())).resolves.toBe("succeeded");
+    expect(harness.states.get("Start#Left/Left")?.status).toBe("succeeded");
+    expect(harness.states.get("Start#Right/Right")?.status).toBe("succeeded");
+    expect(harness.inserted).toBe(2);
+    expect(harness.events.indexOf("Start#Right/Right:running->succeeded")).toBeLessThan(
+      harness.events.indexOf("Start:running->succeeded")
+    );
+  });
+
+  it("dispatches in batches no larger than the authored concurrency bound", async () => {
+    const harness = new StateHarness([state("Start")]);
+    const execute = executor(parallelDefinition({ maxConcurrency: 1 }), harness);
+
+    await expect(execute(run())).resolves.toBe("succeeded");
+    expect(harness.events.indexOf("Start#Left/Left:running->succeeded")).toBeLessThan(
+      harness.events.indexOf("Start#Right/Right:scheduled")
+    );
+  });
+
+  it("replays a crashed fan-out against its durable rows without repeating settled work", async () => {
+    const harness = new StateHarness([state("Start")]);
+    const execute = executor(parallelDefinition(), harness);
+    harness.failAfterSchedule = true;
+
+    await expect(execute(run())).rejects.toThrow("injected crash");
+    expect(harness.states.get("Start#Left/Left")?.status).toBe("succeeded");
+    await expect(execute(run())).resolves.toBe("succeeded");
+    expect(harness.inserted).toBe(2);
+  });
+
+  it("fans a foreach out over the pinned collection with per-item Context", async () => {
+    const harness = new StateHarness([state("Start")]);
+    const execute = executor(
+      definition([
+        {
+          type: "foreach",
+          name: "Start",
+          items: "input.tags",
+          body: "Body",
+          maxItems: 10,
+          maxConcurrency: 2,
+          end: true,
+        },
+        {
+          type: "branch",
+          name: "Body",
+          input: { tag: "${ item }" },
+          conditions: [{ condition: "true", end: true }],
+          default: { end: true },
+        },
+      ]),
+      harness
+    );
+
+    await expect(execute(run())).resolves.toBe("succeeded");
+    expect(harness.states.get("Start#0/Body")?.resolvedInput).toEqual({ tag: "a" });
+    expect(harness.states.get("Start#1/Body")?.resolvedInput).toEqual({ tag: "b" });
+    expect(harness.inserted).toBe(2);
+  });
+
+  it("repeats a bounded loop until its authored condition holds", async () => {
+    const harness = new StateHarness([state("Start")]);
+    const execute = executor(
+      definition([
+        {
+          type: "repeat_until",
+          name: "Start",
+          condition: "loop.iteration >= 2",
+          body: "Body",
+          maxIterations: 5,
+          maxDurationMs: 60_000,
+          end: true,
+        },
+        leaf("Body"),
+      ]),
+      harness
+    );
+
+    await expect(execute(run())).resolves.toBe("succeeded");
+    expect([...harness.states.keys()]).toEqual(["Start", "Start#0/Body", "Start#1/Body"]);
+  });
+
+  it("parks a loop that exhausts its iteration bound rather than exiting silently", async () => {
+    const harness = new StateHarness([state("Start")]);
+    const execute = executor(
+      definition([
+        {
+          type: "repeat_until",
+          name: "Start",
+          condition: "loop.iteration >= 5",
+          body: "Body",
+          maxIterations: 1,
+          maxDurationMs: 60_000,
+          end: true,
+        },
+        leaf("Body"),
+      ]),
+      harness
+    );
+
+    await expect(execute(run())).resolves.toBe("needs_reconciliation");
+    expect(harness.states.get("Start")?.errorEvidenceRef).toBe("routine:iteration_cap_exceeded");
   });
 });

--- a/apps/worker/src/routine/executor.ts
+++ b/apps/worker/src/routine/executor.ts
@@ -5,13 +5,34 @@ import {
   type CompiledState,
   compileRoutine,
   decideBranch,
+  type ForeachProgress,
   type IdentityCeiling,
+  initForeachProgress,
+  initParallelProgress,
+  isTimerWait,
+  joinForeach,
+  joinParallel,
+  type ParallelProgress,
+  type PersistedWait,
+  planForeach,
+  planParallel,
+  planTimerWait,
+  type RegisterWaitInput,
   RoutineInputResolutionError,
   type RoutineStateScheduler,
   RoutineStepError,
   RUN_EXECUTOR_PRINCIPAL_REF,
+  resolveErrorPath,
+  resolveForeachItems,
   resolveRoutineStateInput,
+  routineOccurrenceKey,
+  routineWaitId,
   type StateStatus,
+  type StepOutcome,
+  settleForeachItem,
+  settleParallelBranch,
+  stateOutcome,
+  stepRepeat,
 } from "@tulipfarm/run-kernel";
 import { MANUAL_REQUEST_SCHEMA_REF } from "@tulipfarm/schema";
 import type { PersistedRun, PersistedState, RunStore } from "@tulipfarm/storage";
@@ -23,7 +44,9 @@ export type RoutineExecutionRefusalCode =
   | "invalid_request_artifact"
   | "missing_state"
   | "unsupported_context"
-  | "unsupported_state";
+  | "unsupported_join"
+  | "unsupported_state"
+  | "unsupported_wait";
 
 /** Payload-safe refusal for a Routine capability this executor does not yet own. */
 export class RoutineExecutionRefusal extends Error {
@@ -45,12 +68,23 @@ interface RoutineRunStateReader {
   listStates: Pick<RunStore, "listStates">["listStates"];
 }
 
+/**
+ * Durable-wait surface the executor needs; `@tulipfarm/run-kernel`'s `DurableWaitManager`
+ * satisfies it. The executor never redeems a wait — the deadline sweep does — so no resume token
+ * is read here.
+ */
+export interface RoutineWaitPort {
+  register(input: RegisterWaitInput): Promise<{ readonly wait: PersistedWait }>;
+  find(businessId: string, waitId: string): Promise<PersistedWait | null>;
+}
+
 interface RoutineExecutorOptions {
   readonly definitions: Pick<WorkerRoutineDefinitionLoader, "load">;
   readonly artifacts: RoutineArtifactReader;
   readonly runs: RoutineRunStateReader;
   readonly scheduler: Pick<RoutineStateScheduler, "schedule">;
   readonly transitions: StateTransitionPort;
+  readonly waits: RoutineWaitPort;
   readonly now?: () => Date;
   readonly identityCeiling?: (run: PersistedRun) => IdentityCeiling;
 }
@@ -60,8 +94,27 @@ interface ManualRoutineRequest {
   readonly inputs: Record<string, unknown>;
 }
 
+/** How one chain of States — a Run's main line, a fan-out unit, or a loop body — ended. */
+type ChainOutcome = "succeeded" | "failed" | "waiting" | "needs_reconciliation" | "cancelled";
+
+type StateOutputs = Record<string, { readonly output: unknown }>;
+
 const CLAIM_PATH: readonly StateStatus[] = ["ready", "claimed", "running"];
-const SUPPORTED_ROOTS: ReadonlySet<string> = new Set(["input", "states"]);
+
+/** Expression roots this executor can reconstruct from the Run's immutable request Artifact. */
+const SUPPORTED_ROOTS: ReadonlySet<string> = new Set(["input", "states", "item", "loop"]);
+
+/** Deterministic State types with no external effect and no Context this executor cannot build. */
+const SUPPORTED_TYPES: ReadonlySet<string> = new Set([
+  "branch",
+  "wait",
+  "parallel",
+  "foreach",
+  "repeat_until",
+]);
+
+/** Error reference an expired `wait` raises, so an authored `onError` handler can claim it. */
+const WAIT_TIMED_OUT = "wait_timed_out";
 
 function defaultIdentityCeiling(run: PersistedRun): IdentityCeiling {
   return {
@@ -104,11 +157,17 @@ function assertSupportedExpression(expression: CompiledExpression, state: string
 }
 
 function assertSupportedState(state: CompiledState): void {
-  if (state.type !== "branch") {
+  if (!SUPPORTED_TYPES.has(state.type)) {
     throw new RoutineExecutionRefusal("unsupported_state", state.name);
   }
   for (const condition of state.conditions) {
     assertSupportedExpression(condition.condition, state.name);
+  }
+  if (state.iterator !== null) assertSupportedExpression(state.iterator, state.name);
+  // An `event` wait is resolved by a signal nothing in this process delivers; parking it is the
+  // only honest answer, because opening it would strand the Run on a wait with no signaller.
+  if (state.type === "wait" && !isTimerWait(state)) {
+    throw new RoutineExecutionRefusal("unsupported_wait", state.name);
   }
 }
 
@@ -118,42 +177,36 @@ function assertSupportedInput(state: CompiledState): void {
   }
 }
 
-function scopeFor(
-  input: Record<string, unknown>,
-  outputs: Readonly<Record<string, { readonly output: unknown }>>
-): Readonly<Record<string, unknown>> {
-  return { input, states: outputs };
-}
-
-function nextState(
-  routine: CompiledRoutine,
-  current: CompiledState,
-  target: string
-): CompiledState {
-  const next = routine.states.get(target);
-  if (next === undefined) throw new RoutineExecutionRefusal("missing_state", current.name);
-  return next;
-}
-
 function progressionFrom(status: PersistedState["status"]): readonly StateStatus[] | null {
+  // `waiting` re-enters the same claim path: `waiting → ready → claimed → running`.
+  if (status === "pending" || status === "waiting") return CLAIM_PATH;
   const index = CLAIM_PATH.indexOf(status as StateStatus);
-  if (status === "pending") return CLAIM_PATH;
-  if (index >= 0) return CLAIM_PATH.slice(index + 1);
-  return null;
+  return index >= 0 ? CLAIM_PATH.slice(index + 1) : null;
+}
+
+function isRefusal(error: unknown): error is RoutineExecutionRefusal | RoutineStepError {
+  return error instanceof RoutineExecutionRefusal || error instanceof RoutineStepError;
 }
 
 /**
- * Worker-owned executor for the first deterministic Routine capability: pure `branch` graphs.
+ * Worker-owned executor for the deterministic Routine capabilities: `branch` graphs, durable
+ * `wait` timers, and the bounded fan-out and loop constructs (`parallel`, `foreach`,
+ * `repeat_until`).
  *
- * Successors are persisted before their predecessor succeeds. A crash in between therefore
- * replays the same branch decision into `ensureState`, which returns the one existing State rather
- * than duplicating work. Every other State type is parked without dispatching an effect.
+ * Two rules make it replay-safe. Every successor is persisted **before** its predecessor succeeds,
+ * so a crash between the two writes replays the same decision into `ensureState` and finds the row
+ * it already made. And a fan-out unit is addressed by a durable occurrence key derived from the
+ * pinned collection — never from a counter this process holds — so re-executing an attempt walks
+ * the same rows instead of scheduling a second copy of settled work.
+ *
+ * Every other State type is claimed and parked as `needs_reconciliation`: an effect this executor
+ * cannot dispatch is never interpreted as a success, and never routed through a second authority.
  */
 export function createRoutineExecutor(options: RoutineExecutorOptions): RunExecutor {
   const now = options.now ?? (() => new Date());
   const ceiling = options.identityCeiling ?? defaultIdentityCeiling;
 
-  return async (run): Promise<"succeeded" | "failed" | "needs_reconciliation" | "cancelled"> => {
+  return async (run) => {
     const loaded = await options.definitions.load(run);
     const routine = compileRoutine(loaded.document, { identityCeiling: ceiling(run) });
     const persisted = new Map(
@@ -175,101 +228,432 @@ export function createRoutineExecutor(options: RoutineExecutorOptions): RunExecu
     const request = manualRequest(requestArtifact.content, start.key);
     if (request.slug !== routine.slug) return "needs_reconciliation";
 
-    const outputs: Record<string, { readonly output: unknown }> = {};
-    let currentName = routine.start;
+    const execution = new RoutineExecution({
+      run,
+      routine,
+      request,
+      persisted,
+      options,
+      now,
+    });
+    // `waiting` parks the Run holding no lease; the deadline sweep requeues it when its timer
+    // fires, and this executor replays the chain from the top against the durable rows.
+    return execution.runChain(routine.start, "", {}, {}, 0);
+  };
+}
 
-    for (let step = 0; step <= routine.order.length; step += 1) {
-      const state = routine.states.get(currentName);
-      const row = persisted.get(currentName);
+interface ExecutionContext {
+  readonly run: PersistedRun;
+  readonly routine: CompiledRoutine;
+  readonly request: ManualRoutineRequest;
+  readonly persisted: Map<string, PersistedState>;
+  readonly options: RoutineExecutorOptions;
+  readonly now: () => Date;
+}
+
+/** One attempt at one Routine Run. Holds no state a replay could not rebuild from the database. */
+class RoutineExecution {
+  constructor(private readonly ctx: ExecutionContext) {}
+
+  /**
+   * Walk one chain of States to its end.
+   *
+   * `prefix` addresses the chain's durable rows: empty for the Run's main line, and the fan-out
+   * occurrence prefix inside a unit. `extras` carries the roots only a unit has — `item` for a
+   * `foreach` body, `loop` for a `repeat_until` body.
+   */
+  async runChain(
+    startName: string,
+    prefix: string,
+    extras: Readonly<Record<string, unknown>>,
+    outputs: StateOutputs,
+    depth: number
+  ): Promise<ChainOutcome> {
+    if (depth > this.ctx.routine.order.length) return "needs_reconciliation";
+    let currentName = startName;
+
+    for (let step = 0; step <= this.ctx.routine.order.length; step += 1) {
+      const state = this.ctx.routine.states.get(currentName);
+      const key = `${prefix}${currentName}`;
+      const row = this.ctx.persisted.get(key);
       if (state === undefined || row === undefined) return "needs_reconciliation";
 
       if (row.status === "failed") return "failed";
       if (row.status === "cancelled" || row.status === "cancelling") return "cancelled";
-      if (row.status === "needs_reconciliation") return "needs_reconciliation";
-      if (row.status === "waiting" || row.status === "skipped") return "needs_reconciliation";
-
-      const scope = scopeFor(request.inputs, outputs);
-      if (row.status === "succeeded") {
-        outputs[state.name] = { output: null };
-        try {
-          assertSupportedState(state);
-          const { outcome } = decideBranch(state, scope);
-          if (outcome.kind === "end") return "succeeded";
-          if (!persisted.has(outcome.target)) return "needs_reconciliation";
-          currentName = outcome.target;
-          continue;
-        } catch (error) {
-          if (error instanceof RoutineExecutionRefusal || error instanceof RoutineStepError) {
-            return "needs_reconciliation";
-          }
-          throw error;
-        }
-      }
-
-      const progression = progressionFrom(row.status);
-      if (progression === null) return "needs_reconciliation";
-      let from: StateStatus = row.status;
-      for (const to of progression) {
-        await options.transitions.transition({
-          businessId: run.businessId,
-          runId: run.id,
-          stateKey: state.name,
-          from,
-          to,
-        });
-        from = to;
-      }
-
-      try {
-        assertSupportedState(state);
-        const { outcome } = decideBranch(state, scope);
-        if (outcome.kind === "transition") {
-          const target = nextState(routine, state, outcome.target);
-          assertSupportedInput(target);
-          const targetScope = scopeFor(request.inputs, {
-            ...outputs,
-            [state.name]: { output: null },
-          });
-          const scheduled = await options.scheduler.schedule({
-            run,
-            stateKey: target.name,
-            definitionStateKey: target.name,
-            resolvedInput: resolveRoutineStateInput(target, targetScope),
-            createdAt: now().toISOString(),
-          });
-          persisted.set(target.name, scheduled.state);
-        }
-
-        await options.transitions.transition({
-          businessId: run.businessId,
-          runId: run.id,
-          stateKey: state.name,
-          from: "running",
-          to: "succeeded",
-        });
-        outputs[state.name] = { output: null };
-        if (outcome.kind === "end") return "succeeded";
-        currentName = outcome.target;
-      } catch (error) {
-        if (
-          !(error instanceof RoutineExecutionRefusal) &&
-          !(error instanceof RoutineInputResolutionError) &&
-          !(error instanceof RoutineStepError)
-        ) {
-          throw error;
-        }
-        await options.transitions.transition({
-          businessId: run.businessId,
-          runId: run.id,
-          stateKey: state.name,
-          from: "running",
-          to: "needs_reconciliation",
-          reason: `routine:${error.code}`,
-        });
+      if (row.status === "needs_reconciliation" || row.status === "skipped") {
         return "needs_reconciliation";
       }
+
+      const scope = { input: this.ctx.request.inputs, states: outputs, ...extras };
+      let outcome: StepOutcome;
+
+      try {
+        if (row.status === "succeeded") {
+          assertSupportedState(state);
+          outcome = this.replayOutcome(state, scope);
+        } else {
+          const settled = await this.executeState(state, key, row, scope, outputs, depth);
+          if (settled.kind !== "outcome") return settled.kind;
+          outcome = settled.outcome;
+        }
+      } catch (error) {
+        if (!isRefusal(error) && !(error instanceof RoutineInputResolutionError)) throw error;
+        // A settled State cannot be parked; every other path claimed the State before it could
+        // refuse, so the reason is recorded on the State an operator will be looking at.
+        if (row.status === "succeeded") return "needs_reconciliation";
+        await this.park(key, `routine:${error.code}`);
+        return "needs_reconciliation";
+      }
+
+      outputs[state.name] = { output: null };
+      if (outcome.kind === "end") return "succeeded";
+      currentName = outcome.target;
     }
 
     return "needs_reconciliation";
-  };
+  }
+
+  /**
+   * Recompute a settled State's successor. The decision is a pure function of the Context, so a
+   * replay of an already-succeeded State can only reach the successor its first execution chose.
+   */
+  private replayOutcome(
+    state: CompiledState,
+    scope: Readonly<Record<string, unknown>>
+  ): StepOutcome {
+    const outcome =
+      state.type === "branch" ? decideBranch(state, scope).outcome : stateOutcome(state);
+    if (outcome.kind === "transition" && !this.ctx.routine.states.has(outcome.target)) {
+      throw new RoutineExecutionRefusal("missing_state", state.name);
+    }
+    return outcome;
+  }
+
+  /** Claim an unsettled State and run it to its own conclusion. */
+  private async executeState(
+    state: CompiledState,
+    key: string,
+    row: PersistedState,
+    scope: Readonly<Record<string, unknown>>,
+    outputs: StateOutputs,
+    depth: number
+  ): Promise<{ kind: "outcome"; outcome: StepOutcome } | { kind: ChainOutcome }> {
+    let outcome: StepOutcome | ChainOutcome | null;
+
+    // A `waiting` State is resolved by its wait, not by re-running it.
+    if (row.status === "waiting") {
+      const resumed = await this.resumeWait(state, key, row);
+      if (resumed.kind !== "outcome") return { kind: resumed.kind };
+      outcome = resumed.outcome;
+    } else {
+      const progression = progressionFrom(row.status);
+      if (progression === null) return { kind: "needs_reconciliation" };
+      await this.claim(key, row.status as StateStatus, progression);
+      assertSupportedState(state);
+
+      if (state.type === "wait") return this.openWait(state, key);
+
+      outcome =
+        state.type === "branch"
+          ? decideBranch(state, scope).outcome
+          : await this.runComposite(state, key, scope, outputs, depth);
+    }
+    if (outcome === null) return { kind: "waiting" };
+    if (outcome === "failed") {
+      await this.transition(key, "running", "failed", `routine:${state.name}`);
+      return { kind: "failed" };
+    }
+    if (typeof outcome !== "object") return { kind: outcome };
+
+    if (outcome.kind === "transition") {
+      await this.scheduleSuccessor(
+        state,
+        outcome.target,
+        prefixOf(key, state.name),
+        scope,
+        outputs
+      );
+    }
+    await this.transition(key, "running", "succeeded");
+    return { kind: "outcome", outcome };
+  }
+
+  /**
+   * Fan-out and loop States. Units execute in the authored order, in batches no larger than the
+   * authored concurrency bound, and each unit is replayed rather than tracked in memory — the
+   * durable rows under its occurrence key are the only record of what has settled.
+   */
+  private async runComposite(
+    state: CompiledState,
+    key: string,
+    scope: Readonly<Record<string, unknown>>,
+    outputs: StateOutputs,
+    depth: number
+  ): Promise<StepOutcome | ChainOutcome | null> {
+    if (state.type === "parallel") return this.runParallel(state, key, outputs, depth);
+    if (state.type === "foreach") return this.runForeach(state, key, scope, outputs, depth);
+    if (state.type === "repeat_until") return this.runRepeat(state, key, scope, outputs, depth);
+    throw new RoutineExecutionRefusal("unsupported_state", state.name);
+  }
+
+  private async runParallel(
+    state: CompiledState,
+    key: string,
+    outputs: StateOutputs,
+    depth: number
+  ): Promise<StepOutcome | ChainOutcome | null> {
+    let progress: ParallelProgress = initParallelProgress(state);
+
+    for (;;) {
+      const plan = planParallel(state, progress);
+      if (plan.dispatch.length === 0) break;
+      for (const branch of plan.dispatch) {
+        const settled = await this.runUnit(branch, key, branch, {}, outputs, depth);
+        if (settled === "cancelled" || settled === "needs_reconciliation") return settled;
+        progress = settleParallelBranch(progress, branch, unitStatus(settled));
+      }
+    }
+
+    return this.join(joinParallel(state, progress), state);
+  }
+
+  private async runForeach(
+    state: CompiledState,
+    key: string,
+    scope: Readonly<Record<string, unknown>>,
+    outputs: StateOutputs,
+    depth: number
+  ): Promise<StepOutcome | ChainOutcome | null> {
+    if (state.body === null) throw new RoutineStepError("missing_body", state.name);
+    const items = resolveForeachItems(state, scope);
+    let progress: ForeachProgress = initForeachProgress(state, items);
+
+    for (;;) {
+      const plan = planForeach(state, progress);
+      if (plan.dispatch.length === 0) break;
+      for (const index of plan.dispatch) {
+        const settled = await this.runUnit(
+          state.body,
+          key,
+          String(index),
+          { item: items[index] },
+          outputs,
+          depth
+        );
+        if (settled === "cancelled" || settled === "needs_reconciliation") return settled;
+        progress = settleForeachItem(state, progress, index, unitStatus(settled));
+      }
+    }
+
+    return this.join(joinForeach(state, progress), state);
+  }
+
+  /**
+   * A bounded loop. The iteration count is recovered by replaying the durable bodies rather than
+   * held in memory, and the elapsed-duration bound is measured from the State's own `startedAt`,
+   * so a worker that died mid-loop resumes against the same bounds the first attempt was under.
+   */
+  private async runRepeat(
+    state: CompiledState,
+    key: string,
+    scope: Readonly<Record<string, unknown>>,
+    outputs: StateOutputs,
+    depth: number
+  ): Promise<StepOutcome | ChainOutcome | null> {
+    const row = this.ctx.persisted.get(key);
+    const startedAtMs = Date.parse(row?.startedAt ?? this.ctx.now().toISOString());
+    let iterations = 0;
+
+    for (;;) {
+      const loopScope = { ...scope, loop: { iteration: iterations } };
+      const decision = stepRepeat(
+        state,
+        { iterations, startedAtMs },
+        loopScope,
+        this.ctx.now().getTime()
+      );
+      if (decision.kind === "exit") return decision.outcome;
+
+      const settled = await this.runUnit(
+        decision.target,
+        key,
+        String(decision.iteration),
+        { loop: { iteration: decision.iteration } },
+        outputs,
+        depth
+      );
+      if (settled === "succeeded") {
+        iterations += 1;
+        continue;
+      }
+      return settled === "waiting" ? null : settled;
+    }
+  }
+
+  /** Schedule a unit's first State under its occurrence key, then walk that unit's chain. */
+  private async runUnit(
+    bodyName: string,
+    parentKey: string,
+    unit: string,
+    extras: Readonly<Record<string, unknown>>,
+    outputs: StateOutputs,
+    depth: number
+  ): Promise<ChainOutcome> {
+    const body = this.ctx.routine.states.get(bodyName);
+    if (body === undefined) throw new RoutineExecutionRefusal("missing_state", bodyName);
+    const prefix = routineOccurrenceKey(parentKey, unit, "");
+    const unitScope = { input: this.ctx.request.inputs, states: { ...outputs }, ...extras };
+
+    assertSupportedInput(body);
+    const scheduled = await this.ctx.options.scheduler.schedule({
+      run: this.ctx.run,
+      stateKey: `${prefix}${body.name}`,
+      definitionStateKey: body.name,
+      resolvedInput: resolveRoutineStateInput(body, unitScope),
+      createdAt: this.ctx.now().toISOString(),
+    });
+    this.ctx.persisted.set(`${prefix}${body.name}`, scheduled.state);
+
+    return this.runChain(bodyName, prefix, extras, { ...outputs }, depth + 1);
+  }
+
+  /**
+   * Resolve a settled fan-out.
+   *
+   * A satisfied join that still names units to cancel is refused: this executor can settle a unit
+   * but cannot cancel one that is parked on a live timer, and proceeding past it would leave a
+   * wait whose resume has nowhere to go.
+   */
+  private join(
+    decision: ReturnType<typeof joinParallel>,
+    state: CompiledState
+  ): StepOutcome | ChainOutcome | null {
+    if (decision.kind === "pending") return null;
+    if (decision.kind === "failed") return "failed";
+    if (decision.cancel.length > 0) {
+      throw new RoutineExecutionRefusal("unsupported_join", state.name);
+    }
+    return decision.outcome;
+  }
+
+  /** Open a durable timer and park the State on it. */
+  private async openWait(
+    state: CompiledState,
+    key: string
+  ): Promise<{ kind: "outcome"; outcome: StepOutcome } | { kind: ChainOutcome }> {
+    const waitId = routineWaitId(this.ctx.run.id, key);
+    // A worker that died between creating the wait and parking the State finds its own wait here.
+    const existing = await this.ctx.options.waits.find(this.ctx.run.businessId, waitId);
+    if (existing === null) {
+      await this.ctx.options.waits.register(
+        planTimerWait(state, {
+          businessId: this.ctx.run.businessId,
+          runId: this.ctx.run.id,
+          waitId,
+          stateKey: key,
+          now: this.ctx.now().toISOString(),
+        })
+      );
+    }
+    await this.transition(key, "running", "waiting");
+    return { kind: "waiting" };
+  }
+
+  /**
+   * Continue a State whose timer has resolved; a timer that expired takes its authored path.
+   *
+   * A resolved State is left `running` and its continuation handed back, so the caller settles it
+   * on the one path that persists the successor first — a resumed wait is scheduled exactly like
+   * any other State's successor.
+   */
+  private async resumeWait(
+    state: CompiledState,
+    key: string,
+    row: PersistedState
+  ): Promise<{ kind: "outcome"; outcome: StepOutcome } | { kind: ChainOutcome }> {
+    const wait = await this.ctx.options.waits.find(
+      this.ctx.run.businessId,
+      routineWaitId(this.ctx.run.id, key)
+    );
+    if (wait === null) return { kind: "needs_reconciliation" };
+    if (wait.status === "pending") return { kind: "waiting" };
+
+    await this.claim(key, row.status as StateStatus, CLAIM_PATH);
+    if (wait.status === "satisfied") return { kind: "outcome", outcome: stateOutcome(state) };
+
+    const decision = resolveErrorPath(state, WAIT_TIMED_OUT, "attention");
+    if (decision.kind === "handled") return { kind: "outcome", outcome: decision.outcome };
+    if (decision.kind === "failed") {
+      await this.transition(key, "running", "failed", `routine:${WAIT_TIMED_OUT}`);
+      return { kind: "failed" };
+    }
+    await this.park(key, `routine:${WAIT_TIMED_OUT}`);
+    return { kind: "needs_reconciliation" };
+  }
+
+  /** Persist the successor before its predecessor succeeds. */
+  private async scheduleSuccessor(
+    state: CompiledState,
+    target: string,
+    prefix: string,
+    scope: Readonly<Record<string, unknown>>,
+    outputs: StateOutputs
+  ): Promise<void> {
+    const next = this.ctx.routine.states.get(target);
+    if (next === undefined) throw new RoutineExecutionRefusal("missing_state", state.name);
+    assertSupportedInput(next);
+    const targetScope = { ...scope, states: { ...outputs, [state.name]: { output: null } } };
+    const scheduled = await this.ctx.options.scheduler.schedule({
+      run: this.ctx.run,
+      stateKey: `${prefix}${next.name}`,
+      definitionStateKey: next.name,
+      resolvedInput: resolveRoutineStateInput(next, targetScope),
+      createdAt: this.ctx.now().toISOString(),
+    });
+    this.ctx.persisted.set(`${prefix}${next.name}`, scheduled.state);
+  }
+
+  private async claim(
+    key: string,
+    from: StateStatus,
+    progression: readonly StateStatus[]
+  ): Promise<void> {
+    let current = from;
+    for (const to of progression) {
+      await this.transition(key, current, to);
+      current = to;
+    }
+  }
+
+  private async park(key: string, reason: string): Promise<void> {
+    await this.transition(key, "running", "needs_reconciliation", reason);
+  }
+
+  private async transition(
+    key: string,
+    from: StateStatus,
+    to: StateStatus,
+    reason?: string
+  ): Promise<void> {
+    await this.ctx.options.transitions.transition({
+      businessId: this.ctx.run.businessId,
+      runId: this.ctx.run.id,
+      stateKey: key,
+      from,
+      to,
+      ...(reason === undefined ? {} : { reason }),
+    });
+  }
+}
+
+/** The chain prefix a State's own successors are addressed under. */
+function prefixOf(key: string, stateName: string): string {
+  return key.slice(0, key.length - stateName.length);
+}
+
+/** A unit parked on a wait is still running, not settled — its join stays pending. */
+function unitStatus(outcome: ChainOutcome): "succeeded" | "failed" | "running" {
+  if (outcome === "succeeded") return "succeeded";
+  if (outcome === "failed") return "failed";
+  return "running";
 }

--- a/packages/run-kernel/src/routine/scheduling.test.ts
+++ b/packages/run-kernel/src/routine/scheduling.test.ts
@@ -9,6 +9,8 @@ import {
   RoutineStateScheduleError,
   RoutineStateScheduler,
   type RoutineStateScheduleStore,
+  routineOccurrenceKey,
+  routineWaitId,
 } from "./scheduling";
 
 const RUN: PersistedRun = {
@@ -128,5 +130,31 @@ describe("RoutineStateScheduler", () => {
       })
     ).rejects.toEqual(new RoutineStateScheduleError("invalid_state_identity", RUN.id));
     expect(store.inputs).toEqual([]);
+  });
+});
+
+describe("routineOccurrenceKey", () => {
+  it("addresses one occurrence of an authored State inside a fan-out", () => {
+    expect(routineOccurrenceKey("Fan", "0", "Notify")).toBe("Fan#0/Notify");
+  });
+
+  it("nests, so a fan-out inside a fan-out keeps distinct rows", () => {
+    const outer = routineOccurrenceKey("Fan", "0", "Inner");
+    expect(routineOccurrenceKey(outer, "1", "Notify")).toBe("Fan#0/Inner#1/Notify");
+  });
+});
+
+describe("routineWaitId", () => {
+  it("derives a stable uuid, so a replay finds the wait it already opened", () => {
+    const first = routineWaitId(RUN.id, "Fan#0/Notify");
+    expect(first).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+    expect(routineWaitId(RUN.id, "Fan#0/Notify")).toBe(first);
+  });
+
+  it("separates occurrences and Runs", () => {
+    expect(routineWaitId(RUN.id, "Fan#0/Notify")).not.toBe(routineWaitId(RUN.id, "Fan#1/Notify"));
+    expect(routineWaitId(RUN.id, "Notify")).not.toBe(
+      routineWaitId("00000000-0000-4000-8000-000000000002", "Notify")
+    );
   });
 });

--- a/packages/run-kernel/src/routine/scheduling.ts
+++ b/packages/run-kernel/src/routine/scheduling.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type {
   EnsureStateInput,
   EnsureStateResult,
@@ -26,6 +27,39 @@ export function routineStateDefinitionRef(bundle: RunBundle, stateKey: string): 
     `routines/${encodeURIComponent(bundle.routineId)}@${encodeURIComponent(bundle.routineVersion)}`,
     `states/${encodeURIComponent(stateKey)}`,
   ].join("/");
+}
+
+/**
+ * Durable key for one occurrence of an authored State inside a bounded fan-out or loop.
+ *
+ * A `foreach` item, a `parallel` branch, and a `repeat_until` iteration each execute the same
+ * authored States more than once, so the authored name cannot be the durable key. The unit label
+ * is part of the key and derived from the pinned collection or the authored branch list, never
+ * from a counter this process holds: replaying the same fan-out therefore addresses the same rows
+ * instead of scheduling a second copy of work already done.
+ */
+export function routineOccurrenceKey(parentKey: string, unit: string, stateKey: string): string {
+  return `${parentKey}#${unit}/${stateKey}`;
+}
+
+/**
+ * Deterministic wait id for one State occurrence. `run_waits.id` is a primary key, so deriving it
+ * from the Run and the occurrence key is what makes registering a wait replay-safe: a worker that
+ * died between creating the wait and parking the State finds the wait it already created rather
+ * than opening a second timer against the same State.
+ */
+export function routineWaitId(runId: string, stateKey: string): string {
+  const digest = createHash("sha256").update(`routine-wait:${runId}:${stateKey}`).digest("hex");
+  // RFC 4122 version 4 / variant 10 bits, so the value is a legal uuid for the `uuid` column.
+  const version = `4${digest.slice(13, 16)}`;
+  const variant = ((Number.parseInt(digest.slice(16, 17), 16) & 0x3) | 0x8).toString(16);
+  return [
+    digest.slice(0, 8),
+    digest.slice(8, 12),
+    version,
+    `${variant}${digest.slice(17, 20)}`,
+    digest.slice(20, 32),
+  ].join("-");
 }
 
 /** Narrow surface the scheduler needs; `@tulipfarm/storage`'s `RunStore` satisfies it. */

--- a/packages/run-kernel/src/routine/states/index.ts
+++ b/packages/run-kernel/src/routine/states/index.ts
@@ -8,4 +8,5 @@ export * from "./human";
 export * from "./parallel";
 export * from "./repeat";
 export * from "./step";
+export * from "./wait";
 export * from "./wait-plan";

--- a/packages/run-kernel/src/routine/states/step.ts
+++ b/packages/run-kernel/src/routine/states/step.ts
@@ -34,7 +34,8 @@ export type RoutineStepErrorCode =
   | "missing_iterator"
   | "state_cannot_progress"
   | "unknown_branch"
-  | "unknown_item";
+  | "unknown_item"
+  | "wait_kind_not_supported";
 
 export class RoutineStepError extends Error {
   constructor(

--- a/packages/run-kernel/src/routine/states/wait.test.ts
+++ b/packages/run-kernel/src/routine/states/wait.test.ts
@@ -1,0 +1,64 @@
+import type { routine as routineSchema } from "@tulipfarm/schema";
+import { describe, expect, it } from "vitest";
+import { RoutineStepError } from "./step";
+import { compileWithTargets } from "./test-support";
+import { isTimerWait, planTimerWait } from "./wait";
+
+const ctx = {
+  businessId: "biz",
+  runId: "run-1",
+  waitId: "wait-1",
+  stateKey: "Settle#0/Pause",
+  now: "2026-07-25T10:00:00.000Z",
+};
+
+function wait(waitFor: Record<string, unknown>) {
+  const state: routineSchema.RoutineState = {
+    type: "wait",
+    name: "Pause",
+    waitFor,
+    transition: "Done",
+  };
+  return compileWithTargets(state);
+}
+
+describe("isTimerWait", () => {
+  it("recognises a clock wait and rejects an event wait", () => {
+    expect(isTimerWait(wait({ kind: "timer", durationMs: 1_000 }))).toBe(true);
+    expect(isTimerWait(wait({ kind: "event", eventType: "invoice.paid" }))).toBe(false);
+  });
+});
+
+describe("planTimerWait", () => {
+  it("opens a bounded timer under the durable occurrence key", () => {
+    expect(planTimerWait(wait({ kind: "timer", durationMs: 3_600_000 }), ctx)).toEqual({
+      id: "wait-1",
+      businessId: "biz",
+      runId: "run-1",
+      stateKey: "Settle#0/Pause",
+      kind: "timer",
+      aggregation: "first",
+      schemaRef: "wait:timer:Pause",
+      allowedPrincipals: [],
+      expectedSignals: 1,
+      quorum: null,
+      deadlineAt: "2026-07-25T11:00:00.000Z",
+      createdAt: ctx.now,
+    });
+  });
+
+  it("refuses a timer with no positive duration", () => {
+    expect(() => planTimerWait(wait({ kind: "timer" }), ctx)).toThrow(
+      new RoutineStepError("deadline_not_bounded", "Pause")
+    );
+    expect(() => planTimerWait(wait({ kind: "timer", durationMs: 0 }), ctx)).toThrow(
+      new RoutineStepError("deadline_not_bounded", "Pause")
+    );
+  });
+
+  it("refuses a wait no clock can resolve", () => {
+    expect(() => planTimerWait(wait({ kind: "event", eventType: "invoice.paid" }), ctx)).toThrow(
+      new RoutineStepError("wait_kind_not_supported", "Pause")
+    );
+  });
+});

--- a/packages/run-kernel/src/routine/states/wait.ts
+++ b/packages/run-kernel/src/routine/states/wait.ts
@@ -1,0 +1,63 @@
+import type { RegisterWaitInput } from "../../waits";
+import type { CompiledState } from "../compiler";
+import { RoutineStepError } from "./step";
+import { waitSchemaRef } from "./wait-plan";
+
+/**
+ * The `wait` State (SPEC §9.2). Unlike the States in `wait-plan.ts`, nobody signals a timer: it is
+ * resolved by the deadline sweep alone, which is why it is the one wait kind that names no
+ * principals. An authored `wait` with no bounded duration is a denial — a Run parked on an
+ * unbounded timer is a Run nothing will ever resume.
+ */
+
+export interface TimerWaitContext {
+  readonly businessId: string;
+  readonly runId: string;
+  readonly waitId: string;
+  /** Durable State occurrence key; it may differ from the authored name inside a fan-out. */
+  readonly stateKey: string;
+  /** ISO-8601 instant the wait is opened at. */
+  readonly now: string;
+}
+
+function durationMsOf(state: CompiledState): number {
+  const waitFor = state.definition.waitFor;
+  if (typeof waitFor !== "object" || waitFor === null) {
+    throw new RoutineStepError("deadline_not_bounded", state.name);
+  }
+  const value = (waitFor as Record<string, unknown>).durationMs;
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    throw new RoutineStepError("deadline_not_bounded", state.name);
+  }
+  return value;
+}
+
+/** True when the authored State waits on the clock rather than on an external event. */
+export function isTimerWait(state: CompiledState): boolean {
+  const waitFor = state.definition.waitFor;
+  if (typeof waitFor !== "object" || waitFor === null) return false;
+  return (waitFor as Record<string, unknown>).kind === "timer";
+}
+
+/**
+ * Plan a durable timer. Nothing here performs I/O: the caller registers the wait and only then
+ * parks the State, so a crash in between replays to the same plan under the same wait id.
+ */
+export function planTimerWait(state: CompiledState, ctx: TimerWaitContext): RegisterWaitInput {
+  if (!isTimerWait(state)) throw new RoutineStepError("wait_kind_not_supported", state.name);
+  const durationMs = durationMsOf(state);
+  return {
+    id: ctx.waitId,
+    businessId: ctx.businessId,
+    runId: ctx.runId,
+    stateKey: ctx.stateKey,
+    kind: "timer",
+    aggregation: "first",
+    schemaRef: waitSchemaRef(state, "timer"),
+    allowedPrincipals: [],
+    expectedSignals: 1,
+    quorum: null,
+    deadlineAt: new Date(Date.parse(ctx.now) + durationMs).toISOString(),
+    createdAt: ctx.now,
+  };
+}


### PR DESCRIPTION
## Summary

- The worker's Routine executor now serves `wait`, `parallel`, `foreach`, and `repeat_until` States alongside `branch`, so a published Routine that pauses on a timer or fans out over a collection runs to completion instead of parking as `needs_reconciliation`. No new effects and no Tool Broker dependency — every construct here is deterministic.
- Fan-out progress is replayed from the durable per-occurrence State rows (`${parent}#${unit}/${state}`) rather than held in memory, and wait ids are derived from `(runId, occurrence key)`, so a worker that dies mid-dispatch resumes without duplicating units or opening a second timer. Timers open through the existing `DurableWaitManager` and resolve on the existing `wait-sweep` loop.
- Fixed while testing: a resumed wait settled itself without ever persisting its successor, so a `wait` with a transition succeeded with nowhere to go and the next poll found no row. The resume path and the normal path now converge on the single settlement tail that schedules the successor first.

Completes plan task 055 in `docs/architecture/aw-program-status.md` — long waits and fan-out now resume after a worker restart. `event` waits and satisfied joins that still name units to cancel are explicitly refused: this process delivers no such signal and cannot cancel a unit parked on a live timer.

## Test plan

- [x] `pnpm lint` — 32/32 workspaces
- [x] `pnpm typecheck` — 32/32 workspaces
- [x] `pnpm test` — all workspaces green (run-kernel 41 files, worker 34 files / 222 tests, api 186 files / 1735 tests, web 78 files, storage 24, tool-broker 8, testkit 9)
- [x] New coverage: `packages/run-kernel/src/routine/states/wait.test.ts` (timer-wait planner, 5 tests), `scheduling.test.ts` (occurrence keys + deterministic wait ids, 4 tests), `apps/worker/src/routine/executor.test.ts` (durable waits + bounded fan-out, 12 new tests — including crash-replay keeping fan-out at 2 inserted rows and `repeat_until` producing exactly the expected occurrence sequence)
- [ ] Note: `packages/tool-broker` `src/effects/store.test.ts` intermittently hits `Error: Hook timed out in 30000ms.` in its PGlite `beforeEach` under full-suite parallel load. Pre-existing, unrelated to this diff — passes 8/8 files, 37/37 tests when run in isolation.