### PR TITLE
feat(worker): dispatch Routine Tool States through the broker

### DIFF
--- a/apps/worker/AGENTS.md
+++ b/apps/worker/AGENTS.md
@@ -60,9 +60,25 @@ State's authored `onError` path for `wait_timed_out`, or parks. An `event` wait 
 (`unsupported_wait`): nothing in this process delivers that signal, and opening it would strand the
 Run.
 
-State types with effects and Context roots the request Artifact cannot reconstruct are claimed and
-parked as `needs_reconciliation`; they are never interpreted as successful or dispatched through a
-second authority. A satisfied `any`/`quorum` join that still names units to cancel is refused for
+A `tool` State is planned in the run-kernel (`planToolDispatch` — arguments, idempotency key, and
+effect id all derived from the Run and the durable occurrence key) and then decided by
+`routine/tool-port.ts`, this app's only Tool authority for Routines. Everything that decides the
+call is read from the Run's own pinned bundle: the ToolContract it names, and the Guardrails
+compiled into engine rules by `compileGuardrailPolicy`. The bundle digest is recorded as the
+effect's `guardrailRevision`, so the evidence names the exact policy the Run is bound to. Order is
+fail-closed: authorize, then reserve in the effect ledger, then dispatch — a denial never reaches
+an adapter, and a replayed Run finds its own reserved effect instead of writing a second one. A
+confirmed effect succeeds; a definitive refusal takes the State's authored `onError` path for
+`tool_<reason>` and fails the Run when no handler claims it; everything else parks. **Two pieces
+are absent in production and both park rather than improvise:** no source supplies the Run's
+`authorityLayers` (so the broker denies), and the adapter map is empty until installed-Integration
+context has an owner in this process (so an authorized dispatch parks on `adapter_not_found`).
+Routine Approvals are not composed either — an intent policy sends to a human parks with
+`routine:approval_required`.
+
+Other State types with effects and Context roots the request Artifact cannot reconstruct are
+claimed and parked as `needs_reconciliation`; they are never interpreted as successful or
+dispatched through a second authority. A satisfied `any`/`quorum` join that still names units to cancel is refused for
 the same reason — this executor can settle a unit but cannot cancel one parked on a live timer.
 
 ## Executing a turn (`src/turn/`)
@@ -141,7 +157,9 @@ Broker's reconciliation story, not a second ledger here.
   expectedStatus)`; a worker that dies without releasing is recovered by `reclaimExpired`, not by
   anyone forcing a status.
 - `RunExecutorRegistry` holds `chat`, `integration`, and `routine`; `DeliveryTargetRegistry` is empty
-  (delivery targets land in PR 6).
+  (delivery targets land in PR 6), and the Routine Tool port's adapter map is empty for the same
+  reason — never register an adapter here that reaches a provider by a route other than an
+  installed Integration.
 
 `TurnContextPort`, `TurnCompletionStore`, and the delivery host are all backed over HTTP by the
 API's `/api/v1/internal/*` routes (`internal/turn-host.ts`, `internal/delivery-host.ts`). The

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -26,6 +26,7 @@ import {
   RunStore,
   WaitStore,
 } from "@tulipfarm/storage";
+import { PgEffectStore } from "@tulipfarm/tool-broker";
 import { config as loadEnv } from "dotenv";
 import { loadConfig, REQUIRED_SCHEMA_VERSION, type WorkerConfig } from "./config";
 import { loadDataDirEnv } from "./data-dir";
@@ -46,6 +47,7 @@ import { startProbeServer } from "./probe-server";
 import { WorkerRoutineDefinitionLoader } from "./routine/definition-loader";
 import { createRoutineExecutor } from "./routine/executor";
 import { WorkerPinnedDefinitionReader } from "./routine/pinned-definitions";
+import { BrokerRoutineToolPort } from "./routine/tool-port";
 import { RunDispatcher } from "./run-dispatcher";
 import { type DrainableLoop, drain } from "./shutdown";
 import { createChatExecutor } from "./turn/chat-executor";
@@ -203,6 +205,15 @@ export async function main(): Promise<void> {
       scheduler: new RoutineStateScheduler(runStore),
       transitions: new RunStoreStateTransitions(runStore),
       waits,
+      // Every Tool a Routine dispatches goes through the Broker: it authorizes against the Run's
+      // own pinned Guardrails, reserves the effect in the ledger, and only then calls an adapter.
+      // The adapter map is empty until installed-Integration context has an owner in this process,
+      // so an authorized dispatch parks for reconciliation instead of reaching a provider by some
+      // other route — there is no second path to an external effect here.
+      tools: new BrokerRoutineToolPort({
+        effects: new PgEffectStore(transactions),
+        adapters: new Map(),
+      }),
     })
   );
 

--- a/apps/worker/src/routine/executor.test.ts
+++ b/apps/worker/src/routine/executor.test.ts
@@ -2,6 +2,7 @@ import {
   type ArtifactContent,
   type RegisterWaitInput,
   RoutineStateScheduler,
+  routineEffectId,
   routineWaitId,
 } from "@tulipfarm/run-kernel";
 import { MANUAL_REQUEST_SCHEMA_REF, type routine } from "@tulipfarm/schema";
@@ -10,6 +11,7 @@ import { describe, expect, it } from "vitest";
 import type { StateTransitionPort } from "../agent-state";
 import type { LoadedRoutineDefinition } from "./definition-loader";
 import { createRoutineExecutor } from "./executor";
+import type { RoutineToolOutcome, RoutineToolRequest } from "./tool-port";
 
 const STARTED_AT = "2026-08-02T00:00:00.000Z";
 const INPUT_REGION_EXPRESSION = `\${ input.region }`;
@@ -538,5 +540,139 @@ describe("createRoutineExecutor — bounded fan-out", () => {
 
     await expect(execute(run())).resolves.toBe("needs_reconciliation");
     expect(harness.states.get("Start")?.errorEvidenceRef).toBe("routine:iteration_cap_exceeded");
+  });
+});
+
+describe("createRoutineExecutor — tool States", () => {
+  const bundle = { digest: "bundle-digest" } as unknown as LoadedRoutineDefinition["bundle"];
+
+  function toolExecutor(
+    document: routine.RoutineDefinition,
+    harness: StateHarness,
+    outcome: RoutineToolOutcome,
+    calls: RoutineToolRequest[] = []
+  ) {
+    return createRoutineExecutor({
+      definitions: {
+        load: async () => ({ document, bundle }) as LoadedRoutineDefinition,
+      },
+      artifacts: { read: async () => requestArtifact },
+      runs: { listStates: async () => [...harness.states.values()] },
+      scheduler: harness.scheduler,
+      transitions: harness,
+      waits: harness.waitPort,
+      tools: {
+        execute: async (request) => {
+          calls.push(request);
+          return outcome;
+        },
+      },
+      authority: () => [{ name: "routine", grants: [] }],
+      now: () => new Date(STARTED_AT),
+    });
+  }
+
+  const commentState: routine.RoutineState = {
+    type: "tool",
+    name: "Start",
+    toolRef: { name: "github.issue.comment", version: "1.0.0" },
+    action: "issue.comment",
+    destination: "github",
+    input: { body: INPUT_REGION_EXPRESSION },
+    end: true,
+  } as routine.RoutineState;
+
+  it("dispatches a Tool State through the broker port and settles it", async () => {
+    const harness = new StateHarness([state("Start")]);
+    const calls: RoutineToolRequest[] = [];
+    const execute = toolExecutor(definition([commentState]), harness, { kind: "succeeded" }, calls);
+
+    await expect(execute(run())).resolves.toBe("succeeded");
+    expect(harness.transitions).toEqual([
+      "Start:pending->ready",
+      "Start:ready->claimed",
+      "Start:claimed->running",
+      "Start:running->succeeded",
+    ]);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.plan.arguments).toEqual({ body: "west" });
+    expect(calls[0]?.plan.effectId).toBe(routineEffectId(run().id, "Start"));
+    expect(calls[0]?.authorityLayers).toEqual([{ name: "routine", grants: [] }]);
+  });
+
+  it("parks a Tool State when no Tool authority is composed", async () => {
+    const harness = new StateHarness([state("Start")]);
+    const execute = createRoutineExecutor({
+      definitions: {
+        load: async () =>
+          ({ document: definition([commentState]), bundle }) as LoadedRoutineDefinition,
+      },
+      artifacts: { read: async () => requestArtifact },
+      runs: { listStates: async () => [...harness.states.values()] },
+      scheduler: harness.scheduler,
+      transitions: harness,
+      waits: harness.waitPort,
+      now: () => new Date(STARTED_AT),
+    });
+
+    await expect(execute(run())).resolves.toBe("needs_reconciliation");
+    expect(harness.states.get("Start")?.errorEvidenceRef).toBe("routine:unsupported_state");
+  });
+
+  it("parks an intent awaiting a human rather than dispatching or failing it", async () => {
+    const harness = new StateHarness([state("Start")]);
+    const execute = toolExecutor(definition([commentState]), harness, {
+      kind: "awaiting_approval",
+      reason: "approval_required",
+    });
+
+    await expect(execute(run())).resolves.toBe("needs_reconciliation");
+    expect(harness.states.get("Start")?.errorEvidenceRef).toBe("routine:approval_required");
+  });
+
+  it("parks an effect only reconciliation can resolve, naming what stopped it", async () => {
+    const harness = new StateHarness([state("Start")]);
+    const execute = toolExecutor(definition([commentState]), harness, {
+      kind: "unavailable",
+      reason: "effect_ambiguous",
+    });
+
+    await expect(execute(run())).resolves.toBe("needs_reconciliation");
+    expect(harness.states.get("Start")?.errorEvidenceRef).toBe("routine:effect_ambiguous");
+  });
+
+  it("lets an authored handler claim a denied dispatch", async () => {
+    const harness = new StateHarness([state("Start")]);
+    const execute = toolExecutor(
+      definition([
+        {
+          ...commentState,
+          end: undefined,
+          onError: [{ errorRef: "tool_guardrail_denied", transition: "Fallback" }],
+        } as routine.RoutineState,
+        {
+          type: "branch",
+          name: "Fallback",
+          conditions: [{ condition: "input.score > 0", end: true }],
+          default: { end: true },
+        },
+      ]),
+      harness,
+      { kind: "failed", reason: "guardrail_denied" }
+    );
+
+    await expect(execute(run())).resolves.toBe("succeeded");
+    expect(harness.events).toContain("Fallback:scheduled");
+  });
+
+  it("fails a Tool State whose refusal no handler claims", async () => {
+    const harness = new StateHarness([state("Start")]);
+    const execute = toolExecutor(definition([commentState]), harness, {
+      kind: "failed",
+      reason: "dispatch_failed",
+    });
+
+    await expect(execute(run())).resolves.toBe("failed");
+    expect(harness.transitions).toContain("Start:running->failed");
   });
 });

--- a/apps/worker/src/routine/executor.ts
+++ b/apps/worker/src/routine/executor.ts
@@ -1,3 +1,4 @@
+import type { AuthorityLayer } from "@tulipfarm/authz";
 import {
   type ArtifactService,
   type CompiledExpression,
@@ -17,6 +18,7 @@ import {
   planForeach,
   planParallel,
   planTimerWait,
+  planToolDispatch,
   type RegisterWaitInput,
   RoutineInputResolutionError,
   type RoutineStateScheduler,
@@ -35,10 +37,12 @@ import {
   stepRepeat,
 } from "@tulipfarm/run-kernel";
 import { MANUAL_REQUEST_SCHEMA_REF } from "@tulipfarm/schema";
+import type { RuntimeBundle } from "@tulipfarm/soul";
 import type { PersistedRun, PersistedState, RunStore } from "@tulipfarm/storage";
 import type { StateTransitionPort } from "../agent-state";
 import type { RunExecutor } from "../executors";
 import type { WorkerRoutineDefinitionLoader } from "./definition-loader";
+import type { RoutineToolPort } from "./tool-port";
 
 export type RoutineExecutionRefusalCode =
   | "invalid_request_artifact"
@@ -85,6 +89,16 @@ interface RoutineExecutorOptions {
   readonly scheduler: Pick<RoutineStateScheduler, "schedule">;
   readonly transitions: StateTransitionPort;
   readonly waits: RoutineWaitPort;
+  /**
+   * Tool authority for `tool` States. Absent, a Tool State is parked rather than dispatched: this
+   * executor holds no second path to an external effect.
+   */
+  readonly tools?: RoutineToolPort;
+  /**
+   * The authority a Routine Run acts under. Fail-closed by default — with no layers the Tool
+   * Broker denies every intent — because nothing in this process may mint authority of its own.
+   */
+  readonly authority?: (run: PersistedRun, state: CompiledState) => readonly AuthorityLayer[];
   readonly now?: () => Date;
   readonly identityCeiling?: (run: PersistedRun) => IdentityCeiling;
 }
@@ -107,6 +121,7 @@ const SUPPORTED_ROOTS: ReadonlySet<string> = new Set(["input", "states", "item",
 /** Deterministic State types with no external effect and no Context this executor cannot build. */
 const SUPPORTED_TYPES: ReadonlySet<string> = new Set([
   "branch",
+  "tool",
   "wait",
   "parallel",
   "foreach",
@@ -115,6 +130,9 @@ const SUPPORTED_TYPES: ReadonlySet<string> = new Set([
 
 /** Error reference an expired `wait` raises, so an authored `onError` handler can claim it. */
 const WAIT_TIMED_OUT = "wait_timed_out";
+
+/** Prefix an authored `onError` handler claims a refused or failed Tool dispatch by. */
+const TOOL_ERROR_PREFIX = "tool_";
 
 function defaultIdentityCeiling(run: PersistedRun): IdentityCeiling {
   return {
@@ -231,6 +249,7 @@ export function createRoutineExecutor(options: RoutineExecutorOptions): RunExecu
     const execution = new RoutineExecution({
       run,
       routine,
+      bundle: loaded.bundle,
       request,
       persisted,
       options,
@@ -245,6 +264,8 @@ export function createRoutineExecutor(options: RoutineExecutorOptions): RunExecu
 interface ExecutionContext {
   readonly run: PersistedRun;
   readonly routine: CompiledRoutine;
+  /** The Run's exact pinned bundle — the only source of Tool contracts and Guardrail policy. */
+  readonly bundle: RuntimeBundle;
   readonly request: ManualRoutineRequest;
   readonly persisted: Map<string, PersistedState>;
   readonly options: RoutineExecutorOptions;
@@ -356,7 +377,9 @@ class RoutineExecution {
       outcome =
         state.type === "branch"
           ? decideBranch(state, scope).outcome
-          : await this.runComposite(state, key, scope, outputs, depth);
+          : state.type === "tool"
+            ? await this.runTool(state, key, scope)
+            : await this.runComposite(state, key, scope, outputs, depth);
     }
     if (outcome === null) return { kind: "waiting" };
     if (outcome === "failed") {
@@ -376,6 +399,49 @@ class RoutineExecution {
     }
     await this.transition(key, "running", "succeeded");
     return { kind: "outcome", outcome };
+  }
+
+  /**
+   * One `tool` State: planned here, decided and dispatched by the Tool Broker.
+   *
+   * A confirmed effect succeeds. A definitive refusal — denied by policy, or failed at the
+   * provider — takes the State's authored `onError` path so an author can handle a denial the way
+   * they handle any other failure, and fails the Run when no handler claims it. Everything else
+   * parks: an intent awaiting a human has no Approval to wait on in this process yet, and an
+   * ambiguous or undispatchable effect is a question only reconciliation may answer.
+   */
+  private async runTool(
+    state: CompiledState,
+    key: string,
+    scope: Readonly<Record<string, unknown>>
+  ): Promise<StepOutcome | ChainOutcome | null> {
+    const port = this.ctx.options.tools;
+    if (port === undefined) throw new RoutineExecutionRefusal("unsupported_state", state.name);
+
+    const result = await port.execute({
+      businessId: this.ctx.run.businessId,
+      runId: this.ctx.run.id,
+      stateKey: key,
+      plan: planToolDispatch(state, scope, {
+        businessId: this.ctx.run.businessId,
+        runId: this.ctx.run.id,
+        stateKey: key,
+      }),
+      bundle: this.ctx.bundle,
+      authorityLayers: this.ctx.options.authority?.(this.ctx.run, state) ?? [],
+    });
+
+    if (result.kind === "succeeded") return stateOutcome(state);
+    if (result.kind !== "failed") {
+      await this.park(key, `routine:${result.reason}`);
+      return "needs_reconciliation";
+    }
+
+    const decision = resolveErrorPath(state, `${TOOL_ERROR_PREFIX}${result.reason}`, "failed");
+    if (decision.kind === "handled") return decision.outcome;
+    if (decision.kind === "failed") return "failed";
+    await this.park(key, `routine:${TOOL_ERROR_PREFIX}${result.reason}`);
+    return "needs_reconciliation";
   }
 
   /**

--- a/apps/worker/src/routine/tool-port.test.ts
+++ b/apps/worker/src/routine/tool-port.test.ts
@@ -1,0 +1,281 @@
+import type { AuthorityLayer } from "@tulipfarm/authz";
+import type { ToolDispatchPlan } from "@tulipfarm/run-kernel";
+import type { GuardrailDefinition, ToolContractDefinition } from "@tulipfarm/schema";
+import type { BundleDefinition, RuntimeBundle } from "@tulipfarm/soul";
+import {
+  AdapterDispatchError,
+  MemoryEffectStore,
+  type ToolAdapter,
+  type ToolAdapterRequest,
+} from "@tulipfarm/tool-broker";
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+import { BrokerRoutineToolPort, type RoutineToolRequest } from "./tool-port";
+
+const BUSINESS_ID = "biz-1";
+const RUN_ID = "11111111-1111-4111-8111-111111111111";
+const STATE_KEY = "CommentIssue";
+
+const PLAN: ToolDispatchPlan = {
+  toolRef: { name: "github.issue.comment", version: "1.0.0" },
+  action: "issue.comment",
+  destination: "github",
+  arguments: { body: "hello" },
+  idempotencyKey: `routine:${RUN_ID}:${STATE_KEY}`,
+  effectId: "22222222-2222-4222-8222-222222222222",
+  logicalEffectOrdinal: 3,
+};
+
+/** The Routine's authority: it may act on the Tools it declares, and nothing here widens that. */
+const AUTHORITY: readonly AuthorityLayer[] = [
+  { name: "routine", grants: [{ action: "*", resourceType: "*", effect: "allow" }] },
+];
+
+function contract(overrides: Partial<ToolContractDefinition["spec"]> = {}): ToolContractDefinition {
+  return {
+    apiVersion: "tulipfarm.ai/v1",
+    kind: "ToolContract",
+    metadata: {
+      id: "01J0000000000000000000TOOL",
+      slug: "github-issue-comment",
+      schemaVersion: 1,
+      authoredVersion: 1,
+      lifecycle: "published",
+      publishedDigest: "a".repeat(64),
+    },
+    spec: {
+      toolId: "github.issue.comment",
+      toolVersion: "1.0.0",
+      action: "issue.comment",
+      inputSchema: { type: "object", properties: { body: { type: "string" } } },
+      outputSchema: { type: "object", properties: { commentId: { type: "number" } } },
+      riskClass: "medium",
+      mutating: true,
+      dataClasses: ["source-content"],
+      allowedDestinations: ["github"],
+      idempotency: { strategy: "provider_key" },
+      dryRun: false,
+      adapter: { kind: "integration", ref: "github" },
+      ...overrides,
+    },
+  } as ToolContractDefinition;
+}
+
+function guardrail(rules: unknown[]): GuardrailDefinition {
+  return {
+    apiVersion: "tulipfarm.ai/v1",
+    kind: "Guardrail",
+    metadata: {
+      id: "01J0000000000000000000GUAR",
+      slug: "triage",
+      schemaVersion: 1,
+      authoredVersion: 1,
+      lifecycle: "published",
+    },
+    spec: { defaultDecision: "deny", rules },
+  } as GuardrailDefinition;
+}
+
+const ALLOW_COMMENT = {
+  id: "allow-comment",
+  type: "allow",
+  actions: ["issue.comment"],
+  dataClasses: ["source-content"],
+  destinations: ["github"],
+};
+
+function bundle(documents: readonly { kind: string; document: unknown }[]): RuntimeBundle {
+  const definitions = documents.map((entry, index) => ({
+    kind: entry.kind,
+    id: `def-${index}`,
+    slug: `def-${index}`,
+    authoredVersion: 1,
+    hash: "b".repeat(64),
+    document: entry.document,
+    references: [],
+  })) as unknown as readonly BundleDefinition[];
+
+  return {
+    digest: "c".repeat(64),
+    businessId: BUSINESS_ID,
+    changesetId: "changeset-1",
+    commitSha: "d".repeat(40),
+    definitions,
+    get: (kind, slug) => definitions.find((d) => d.kind === kind && d.slug === slug),
+    getById: (id) => definitions.find((d) => d.id === id),
+  };
+}
+
+function request(overrides: Partial<RoutineToolRequest> = {}): RoutineToolRequest {
+  return {
+    businessId: BUSINESS_ID,
+    runId: RUN_ID,
+    stateKey: STATE_KEY,
+    plan: PLAN,
+    bundle: bundle([
+      { kind: "ToolContract", document: contract() },
+      { kind: "Guardrail", document: guardrail([ALLOW_COMMENT]) },
+    ]),
+    authorityLayers: AUTHORITY,
+    ...overrides,
+  };
+}
+
+let effects: MemoryEffectStore;
+let dispatch: Mock<ToolAdapter["dispatch"]>;
+let adapters: Map<string, ToolAdapter>;
+
+beforeEach(() => {
+  effects = new MemoryEffectStore();
+  dispatch = vi.fn<ToolAdapter["dispatch"]>(async (_request: ToolAdapterRequest) => ({
+    commentId: 12,
+  }));
+  adapters = new Map<string, ToolAdapter>([["github", { dispatch }]]);
+});
+
+function port(): BrokerRoutineToolPort {
+  return new BrokerRoutineToolPort({ effects, adapters });
+}
+
+describe("BrokerRoutineToolPort", () => {
+  it("authorizes against the Run's pinned policy, reserves the effect, then dispatches", async () => {
+    expect(await port().execute(request())).toEqual({ kind: "succeeded" });
+
+    const effect = await effects.get(BUSINESS_ID, PLAN.effectId);
+    expect(effect?.state).toBe("confirmed");
+    expect(effect?.runId).toBe(RUN_ID);
+    expect(effect?.stateId).toBe(STATE_KEY);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("records the pinned bundle digest as the guardrail revision the effect was decided under", async () => {
+    const input = request();
+    await port().execute(input);
+
+    const effect = await effects.get(BUSINESS_ID, PLAN.effectId);
+    expect(effect?.guardrailRevision).toBe(input.bundle.digest);
+  });
+
+  it("never reaches an adapter when policy denies the intent", async () => {
+    const denied = request({
+      bundle: bundle([
+        { kind: "ToolContract", document: contract() },
+        { kind: "Guardrail", document: guardrail([{ ...ALLOW_COMMENT, type: "deny" }]) },
+      ]),
+    });
+
+    expect(await port().execute(denied)).toEqual({ kind: "failed", reason: "guardrail_denied" });
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(await effects.get(BUSINESS_ID, PLAN.effectId)).toBeUndefined();
+  });
+
+  it("denies when the Run carries no authority, rather than reading absence as permission", async () => {
+    expect(await port().execute(request({ authorityLayers: [] }))).toEqual({
+      kind: "failed",
+      reason: "authorization_denied",
+    });
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("parks an intent policy sends to a human, because no Approval is composed here yet", async () => {
+    const gated = request({
+      bundle: bundle([
+        { kind: "ToolContract", document: contract() },
+        {
+          kind: "Guardrail",
+          document: guardrail([
+            ALLOW_COMMENT,
+            {
+              id: "approve-comment",
+              type: "approval",
+              actions: ["issue.comment"],
+              category: "highRiskAction",
+              minimumApprovers: 1,
+              separationOfDuties: false,
+            },
+          ]),
+        },
+      ]),
+    });
+
+    expect(await port().execute(gated)).toEqual({
+      kind: "awaiting_approval",
+      reason: "approval_required",
+    });
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("replays a confirmed effect instead of dispatching it a second time", async () => {
+    const subject = port();
+    await subject.execute(request());
+
+    expect(await subject.execute(request())).toEqual({ kind: "succeeded" });
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("parks an ambiguous effect, which only reconciliation may resolve", async () => {
+    dispatch.mockRejectedValue(
+      new AdapterDispatchError("after_dispatch", "provider_timeout", false)
+    );
+
+    expect(await port().execute(request())).toEqual({
+      kind: "unavailable",
+      reason: "effect_ambiguous",
+    });
+    expect((await effects.get(BUSINESS_ID, PLAN.effectId))?.state).toBe("ambiguous");
+  });
+
+  it("parks when no adapter is registered for the contract's provider", async () => {
+    adapters = new Map();
+
+    expect(await port().execute(request())).toEqual({
+      kind: "unavailable",
+      reason: "adapter_not_found",
+    });
+  });
+
+  it("parks when the pinned bundle names no contract for the Tool the State references", async () => {
+    const missing = request({
+      bundle: bundle([{ kind: "Guardrail", document: guardrail([ALLOW_COMMENT]) }]),
+    });
+
+    expect(await port().execute(missing)).toEqual({
+      kind: "failed",
+      reason: "unknown_contract",
+    });
+  });
+
+  it("parks a Guardrail this deployment cannot express exactly, rather than dropping the rule", async () => {
+    const unsupported = request({
+      bundle: bundle([
+        { kind: "ToolContract", document: contract() },
+        {
+          kind: "Guardrail",
+          document: guardrail([{ ...ALLOW_COMMENT, constraints: { maxBytes: 1024 } }]),
+        },
+      ]),
+    });
+
+    expect(await port().execute(unsupported)).toEqual({
+      kind: "unavailable",
+      reason: "guardrail_unsupported_constraint",
+    });
+  });
+
+  it("refuses a destination the contract does not allow", async () => {
+    const elsewhere = request({ plan: { ...PLAN, destination: "slack" } });
+
+    expect(await port().execute(elsewhere)).toEqual({
+      kind: "failed",
+      reason: "destination_denied",
+    });
+  });
+
+  it("refuses arguments the contract's input schema rejects", async () => {
+    const malformed = request({ plan: { ...PLAN, arguments: { body: 12 } } });
+
+    expect(await port().execute(malformed)).toEqual({
+      kind: "failed",
+      reason: "invalid_arguments",
+    });
+  });
+});

--- a/apps/worker/src/routine/tool-port.ts
+++ b/apps/worker/src/routine/tool-port.ts
@@ -1,0 +1,212 @@
+import {
+  type AuthorityLayer,
+  compileGuardrailPolicy,
+  type GuardrailPolicy,
+  GuardrailPolicyError,
+} from "@tulipfarm/authz";
+import type { ToolDispatchPlan } from "@tulipfarm/run-kernel";
+import type { GuardrailDefinition, ToolContractDefinition } from "@tulipfarm/schema";
+import type { RuntimeBundle } from "@tulipfarm/soul";
+import {
+  type CredentialDispatcher,
+  EffectDispatcher,
+  type EffectStore,
+  type ToolAdapter,
+  ToolBroker,
+  ToolCatalog,
+  ToolCatalogError,
+  ToolDispatchError,
+  type ToolIntent,
+} from "@tulipfarm/tool-broker";
+
+/**
+ * The Worker's Tool authority for Routine Runs.
+ *
+ * Everything a Tool State needs is read from the Run's own pinned, signature-verified bundle: the
+ * ToolContract it names, and the Guardrails that decide it. That is what makes the evidence exact
+ * — the policy that authorized a dispatch and the contract that shaped it are the ones this Run is
+ * bound to, not whatever the live Soul says now — and it is why the bundle digest is the
+ * `guardrailRevision` recorded against the effect.
+ *
+ * Order is load-bearing and fail-closed at every step: authorize, then reserve, then dispatch. A
+ * denial never reaches an adapter; a dispatch never happens without a durable reservation carrying
+ * the intent digest and the guardrail revision, so a replayed Run finds the effect it already made
+ * instead of writing a second one. Nothing here interprets a missing piece as permission: no
+ * authority layers, an uncompilable policy, or an unregistered adapter all stop the State.
+ */
+
+export type RoutineToolOutcome =
+  /** Dispatched and confirmed, or recognized as an effect this Run already confirmed. */
+  | { readonly kind: "succeeded" }
+  /** A definitive negative the authored `onError` path may claim, named by its reason code. */
+  | { readonly kind: "failed"; readonly reason: string }
+  /** Policy requires a human. Routine Approvals are not composed yet, so the Run parks. */
+  | { readonly kind: "awaiting_approval"; readonly reason: string }
+  /** Nothing decided the call. The State parks for reconciliation rather than guessing. */
+  | { readonly kind: "unavailable"; readonly reason: string };
+
+export interface RoutineToolRequest {
+  readonly businessId: string;
+  readonly runId: string;
+  /** Durable State occurrence key; the ledger's `state_id`. */
+  readonly stateKey: string;
+  readonly plan: ToolDispatchPlan;
+  /** The Run's exact pinned bundle — the only source of contracts and policy. */
+  readonly bundle: RuntimeBundle;
+  readonly authorityLayers: readonly AuthorityLayer[];
+}
+
+export interface RoutineToolPort {
+  execute(request: RoutineToolRequest): Promise<RoutineToolOutcome>;
+}
+
+export interface BrokerRoutineToolPortOptions {
+  readonly effects: EffectStore;
+  /** Keyed by `ToolContract.adapter.ref`, exactly as `EffectDispatcher` resolves them. */
+  readonly adapters: ReadonlyMap<string, ToolAdapter>;
+  readonly credentials?: CredentialDispatcher;
+  readonly now?: () => Date;
+}
+
+function definitionsOf<T>(bundle: RuntimeBundle, kind: string): T[] {
+  return bundle.definitions
+    .filter((definition) => definition.kind === kind)
+    .map((definition) => definition.document as unknown as T);
+}
+
+function intentOf(request: RoutineToolRequest): ToolIntent {
+  const { plan } = request;
+  return {
+    // Derived from the Run and the State occurrence, so a replay proposes the same intent.
+    intentId: plan.effectId,
+    businessId: request.businessId,
+    runId: request.runId,
+    stateId: request.stateKey,
+    toolId: plan.toolRef.name,
+    toolVersion: plan.toolRef.version,
+    action: plan.action,
+    targetRefs: [],
+    arguments: plan.arguments,
+    ...(plan.destination === undefined ? {} : { destination: plan.destination }),
+    ...(plan.credentialRef === undefined ? {} : { credentialRef: plan.credentialRef }),
+    idempotencyKey: plan.idempotencyKey,
+  };
+}
+
+/**
+ * A Tool State whose effect is already durable. `confirmed` is the work this attempt was about to
+ * do, so the State succeeds without repeating it; `ambiguous` is the one answer no executor may
+ * resolve on its own — reconciliation reads the provider, this process does not guess.
+ */
+function replayed(state: string): RoutineToolOutcome {
+  switch (state) {
+    case "confirmed":
+      return { kind: "succeeded" };
+    case "denied":
+      return { kind: "failed", reason: "effect_denied" };
+    case "failed":
+      return { kind: "failed", reason: "effect_failed" };
+    default:
+      return { kind: "unavailable", reason: `effect_${state}` };
+  }
+}
+
+export class BrokerRoutineToolPort implements RoutineToolPort {
+  private readonly now: () => Date;
+  /** Per-bundle, because a bundle is immutable: compiling it twice can only produce the same. */
+  private readonly policies = new Map<string, GuardrailPolicy>();
+  private readonly catalogs = new Map<string, ToolCatalog>();
+
+  constructor(private readonly options: BrokerRoutineToolPortOptions) {
+    this.now = options.now ?? (() => new Date());
+  }
+
+  async execute(request: RoutineToolRequest): Promise<RoutineToolOutcome> {
+    let policy: GuardrailPolicy;
+    let catalog: ToolCatalog;
+    try {
+      policy = this.policyFor(request.bundle);
+      catalog = this.catalogFor(request.bundle);
+    } catch (error) {
+      // An authored rule this deployment cannot express exactly, or a contract the bundle did not
+      // publish. Either way the policy that would decide this call is not the authored one.
+      if (error instanceof GuardrailPolicyError) {
+        return { kind: "unavailable", reason: `guardrail_${error.code}` };
+      }
+      if (error instanceof ToolCatalogError) {
+        return { kind: "unavailable", reason: error.code };
+      }
+      throw error;
+    }
+
+    const intent = intentOf(request);
+    const outcome = new ToolBroker(catalog).authorize(intent, {
+      authorityLayers: request.authorityLayers,
+      guardrailRules: policy.rules,
+      dlpRules: policy.dlpRules,
+      // The bundle digest is the revision: it names every Guardrail this Run is bound to, and
+      // nothing else can change under a Run that is already pinned to it.
+      guardrailRevision: request.bundle.digest,
+      taint: "untrusted",
+      autonomy: "execute_policy_authorized",
+      now: this.now(),
+    });
+    if (outcome.outcome === "denied") return { kind: "failed", reason: outcome.reason };
+    if (outcome.outcome === "awaiting_approval") {
+      return { kind: "awaiting_approval", reason: "approval_required" };
+    }
+
+    const reserved = await this.options.effects.reserve({
+      effectId: request.plan.effectId,
+      businessId: request.businessId,
+      runId: request.runId,
+      stateId: request.stateKey,
+      logicalEffectOrdinal: request.plan.logicalEffectOrdinal,
+      idempotencyKey: request.plan.idempotencyKey,
+      intentDigest: outcome.intentDigest,
+      intent,
+      guardrailRevision: request.bundle.digest,
+      createdAt: this.now().toISOString(),
+    });
+    if (reserved.outcome === "duplicate") return replayed(reserved.effect.state);
+
+    const dispatcher = new EffectDispatcher({
+      store: this.options.effects,
+      catalog,
+      adapters: this.options.adapters,
+      ...(this.options.credentials === undefined
+        ? {}
+        : { credentialDispatcher: this.options.credentials }),
+      now: () => this.now().toISOString(),
+    });
+    try {
+      await dispatcher.dispatch(request.businessId, request.plan.effectId);
+      return { kind: "succeeded" };
+    } catch (error) {
+      if (!(error instanceof ToolDispatchError)) throw error;
+      // `ambiguous` means the provider may or may not have applied the write. Only reconciliation
+      // can answer that, so the State parks rather than retrying or failing over it.
+      const effect = await this.options.effects.get(request.businessId, request.plan.effectId);
+      if (effect?.state === "ambiguous") return { kind: "unavailable", reason: "effect_ambiguous" };
+      return error.code === "adapter_not_found"
+        ? { kind: "unavailable", reason: error.code }
+        : { kind: "failed", reason: error.code };
+    }
+  }
+
+  private policyFor(bundle: RuntimeBundle): GuardrailPolicy {
+    const cached = this.policies.get(bundle.digest);
+    if (cached !== undefined) return cached;
+    const policy = compileGuardrailPolicy(definitionsOf<GuardrailDefinition>(bundle, "Guardrail"));
+    this.policies.set(bundle.digest, policy);
+    return policy;
+  }
+
+  private catalogFor(bundle: RuntimeBundle): ToolCatalog {
+    const cached = this.catalogs.get(bundle.digest);
+    if (cached !== undefined) return cached;
+    const catalog = ToolCatalog.load(definitionsOf<ToolContractDefinition>(bundle, "ToolContract"));
+    this.catalogs.set(bundle.digest, catalog);
+    return catalog;
+  }
+}

--- a/docs/architecture/aw-program-status.md
+++ b/docs/architecture/aw-program-status.md
@@ -67,9 +67,9 @@ and fails unless a missing option is listed in `DEFERRED_OPTIONS` with the PR th
 | `agent-runtime` | 15 | composed — the turn engine the Worker executes: context assembly, the bounded loop, and all three guardrail stages (PR 3) |
 | `surface` | 11 | composed — Artifacts are created by the `surface_*` Tools the Worker dispatches through the internal host |
 | `sandbox` | 11 | composed — one isolated-vm implementation, used by the API's resource hooks and by the Worker's Integration classifier (PR 3) |
-| `authz` | 5 | partly composed — principal/identity types plus the deployment role catalog (`apps/api/src/identity/roles.ts`); the policy engine (`decideEffectivePermission`, `evaluateGuardrail`, `checkDlpBoundary`) still has no production caller |
+| `authz` | 6 | partly composed — principal/identity types plus the deployment role catalog (`apps/api/src/identity/roles.ts`); the policy engine (`decideEffectivePermission`, `evaluateGuardrail`, `checkDlpBoundary`) now decides Routine Tool intents through `compileGuardrailPolicy` over the Run's pinned Guardrails, but no production caller supplies authority layers yet, so it denies fail-closed |
 | `integrations` | 5 | partly composed — the Worker's Integration executor runs the manifest classifier and reply binding (PR 3); the four `apps/integration-worker` importers still never start (D2) |
-| `tool-broker` | 1 | not composed — SQL DDL constant only. The Worker's `ToolDispatchPort` is served over HTTP by `/api/v1/internal/tools`, so PR 3's dispatch path does **not** go through the broker as planned; PR 4 owns that move |
+| `tool-broker` | 2 | partly composed — Routine `tool` States authorize, reserve, and dispatch through the broker in the Worker (`apps/worker/src/routine/tool-port.ts`, PR 4), but with an empty adapter map and no Routine authority source, so an authorized dispatch parks instead of reaching a provider. Chat turns still dispatch over HTTP through `/api/v1/internal/tools` |
 | `routine-engine` | 2 | orphan subtree, scheduled for retirement |
 | `validation`, `testkit`, `audit`, `observability`, `knowledge`, `memory` | 0 | not composed |
 

--- a/packages/authz/src/guardrails/policy.test.ts
+++ b/packages/authz/src/guardrails/policy.test.ts
@@ -1,0 +1,220 @@
+import type { GuardrailDefinition } from "@tulipfarm/schema";
+import { describe, expect, it } from "vitest";
+import { checkDlpBoundary } from "./dlp";
+import { evaluateGuardrail } from "./engine";
+import { compileGuardrailPolicy, GuardrailPolicyError } from "./policy";
+
+type AuthoredRule = GuardrailDefinition["spec"]["rules"][number];
+
+function guardrail(...rules: AuthoredRule[]): GuardrailDefinition {
+  return {
+    apiVersion: "tulipfarm.ai/v1",
+    kind: "Guardrail",
+    metadata: {
+      id: "01J0000000000000000000GUAR",
+      slug: "triage",
+      schemaVersion: 1,
+      authoredVersion: 1,
+      lifecycle: "published",
+    },
+    spec: { defaultDecision: "deny", rules },
+  } as GuardrailDefinition;
+}
+
+const allowComment: AuthoredRule = {
+  id: "allow-comment",
+  type: "allow",
+  actions: ["issue.comment"],
+  dataClasses: ["source-content"],
+  destinations: ["github"],
+} as AuthoredRule;
+
+describe("compileGuardrailPolicy", () => {
+  it("compiles a scoped allow into a rule that permits exactly what it names", () => {
+    const { rules } = compileGuardrailPolicy([guardrail(allowComment)]);
+
+    expect(
+      evaluateGuardrail(rules, {
+        action: "issue.comment",
+        resourceType: "github.issue",
+        dataClass: "source-content",
+        destination: "github",
+      })
+    ).toEqual({ effect: "allow", reason: "allowed", ruleId: "allow-comment" });
+  });
+
+  it("does not let a scoped allow decide a Context that omits the scoped dimension", () => {
+    const { rules } = compileGuardrailPolicy([guardrail(allowComment)]);
+
+    expect(
+      evaluateGuardrail(rules, { action: "issue.comment", resourceType: "github.issue" })
+    ).toEqual({ effect: "deny", reason: "no_matching_rule" });
+  });
+
+  it("expands every authored dimension, so each combination is its own rule", () => {
+    const { rules } = compileGuardrailPolicy([
+      guardrail({
+        id: "allow-two",
+        type: "allow",
+        actions: ["issue.comment", "issue.label"],
+        destinations: ["github", "jira"],
+        scope: { resource: { types: ["github.issue"] } },
+      } as AuthoredRule),
+    ]);
+
+    expect(rules).toHaveLength(4);
+    expect(rules.every((rule) => rule.resourceType === "github.issue")).toBe(true);
+  });
+
+  it("turns an authored allow's data classes into the DLP permits they describe", () => {
+    const { dlpRules } = compileGuardrailPolicy([guardrail(allowComment)]);
+
+    expect(
+      checkDlpBoundary(dlpRules, { dataClasses: ["source-content"], destination: "github" })
+    ).toEqual({ effect: "allow", reason: "allowed" });
+    expect(
+      checkDlpBoundary(dlpRules, { dataClasses: ["source-content"], destination: "slack" })
+    ).toMatchObject({ effect: "deny", reason: "destination_not_allowed" });
+  });
+
+  it("keeps an explicit deny winning over an allow for the same action", () => {
+    const { rules } = compileGuardrailPolicy([
+      guardrail(allowComment, {
+        id: "deny-comment",
+        type: "deny",
+        actions: ["issue.comment"],
+      } as AuthoredRule),
+    ]);
+
+    expect(
+      evaluateGuardrail(rules, {
+        action: "issue.comment",
+        resourceType: "github.issue",
+        dataClass: "source-content",
+        destination: "github",
+      })
+    ).toEqual({ effect: "deny", reason: "explicit_deny", ruleId: "deny-comment" });
+  });
+
+  it("compiles an approval rule into the stricter require_approval effect", () => {
+    const { rules } = compileGuardrailPolicy([
+      guardrail(allowComment, {
+        id: "approve-comment",
+        type: "approval",
+        actions: ["issue.comment"],
+        category: "highRiskAction",
+        minimumApprovers: 1,
+        separationOfDuties: false,
+      } as AuthoredRule),
+    ]);
+
+    expect(
+      evaluateGuardrail(rules, {
+        action: "issue.comment",
+        resourceType: "github.issue",
+        dataClass: "source-content",
+        destination: "github",
+      })
+    ).toMatchObject({ effect: "require_approval", ruleId: "approve-comment" });
+  });
+
+  it("compiles a blocking DLP rule into a deny on the classes it detects", () => {
+    const { rules } = compileGuardrailPolicy([
+      guardrail(allowComment, {
+        id: "block-pii",
+        type: "dlp",
+        detectors: [{ type: "dataClass", values: ["pii"] }],
+        action: "block",
+      } as AuthoredRule),
+    ]);
+
+    expect(
+      evaluateGuardrail(rules, {
+        action: "issue.comment",
+        resourceType: "github.issue",
+        dataClass: "pii",
+      })
+    ).toEqual({ effect: "deny", reason: "explicit_deny", ruleId: "block-pii" });
+  });
+
+  it("leaves a secret detector to the DLP boundary's own default", () => {
+    const { rules, dlpRules } = compileGuardrailPolicy([
+      guardrail({
+        id: "block-secrets",
+        type: "dlp",
+        detectors: [{ type: "secret" }],
+        action: "block",
+      } as AuthoredRule),
+    ]);
+
+    expect(rules).toHaveLength(0);
+    expect(
+      checkDlpBoundary(dlpRules, { dataClasses: ["source-content"], secretDetected: true })
+    ).toEqual({ effect: "deny", reason: "secret_detected" });
+  });
+
+  it.each([
+    [
+      "a condition it cannot evaluate",
+      { scope: { conditions: [{ attribute: "issue.state", operator: "equals", value: "open" }] } },
+      "unsupported_condition",
+    ],
+    [
+      "an expiry it cannot check",
+      { scope: { expiresAt: "2026-01-01T00:00:00Z" } },
+      "unsupported_expiry",
+    ],
+    [
+      "a constraint enforced elsewhere",
+      { constraints: { maxBytes: 1024 } },
+      "unsupported_constraint",
+    ],
+  ])("refuses an allow carrying %s", (_case, extra, code) => {
+    expect(() =>
+      compileGuardrailPolicy([guardrail({ ...allowComment, ...extra } as AuthoredRule)])
+    ).toThrow(new GuardrailPolicyError(code as never, "allow-comment"));
+  });
+
+  it("refuses a redacting DLP rule rather than compiling it into a decision", () => {
+    expect(() =>
+      compileGuardrailPolicy([
+        guardrail({
+          id: "redact-pii",
+          type: "dlp",
+          detectors: [{ type: "dataClass", values: ["pii"] }],
+          action: "redact",
+        } as AuthoredRule),
+      ])
+    ).toThrow(new GuardrailPolicyError("unsupported_dlp_action", "redact-pii"));
+  });
+
+  it("carries an authored record ceiling onto the allow that declares it", () => {
+    const { rules } = compileGuardrailPolicy([
+      guardrail({ ...allowComment, constraints: { maxRecords: 2 } } as AuthoredRule),
+    ]);
+    const context = {
+      action: "issue.comment",
+      resourceType: "github.issue",
+      dataClass: "source-content",
+      destination: "github",
+    };
+
+    expect(evaluateGuardrail(rules, { ...context, recordCount: 2 })).toMatchObject({
+      effect: "allow",
+    });
+    expect(evaluateGuardrail(rules, { ...context, recordCount: 3 })).toMatchObject({
+      effect: "deny",
+      reason: "volume_exceeded",
+    });
+  });
+
+  it("compiles nothing from no definitions, which the engine reads as a denial", () => {
+    const { rules, dlpRules } = compileGuardrailPolicy([]);
+
+    expect(dlpRules).toHaveLength(0);
+    expect(evaluateGuardrail(rules, { action: "issue.comment", resourceType: "*" })).toEqual({
+      effect: "deny",
+      reason: "no_matching_rule",
+    });
+  });
+});

--- a/packages/authz/src/guardrails/policy.ts
+++ b/packages/authz/src/guardrails/policy.ts
@@ -1,0 +1,219 @@
+/**
+ * Compiles authored `Guardrail` definitions into the rules this package's engine decides with
+ * (SPEC §12, §13). The engine is a permit list — with no fully matching allow the answer is a
+ * denial — so compilation may only ever *narrow*: an authored rule this compiler cannot express
+ * exactly is refused with its id rather than dropped, because a dropped `deny` silently widens
+ * the policy and a dropped ceiling silently removes one.
+ *
+ * What each authored rule becomes:
+ *
+ * - A scoped `allow` / `deny` becomes one `GuardrailRule` per authored combination of action,
+ *   Resource type, Record id, data class, destination, and audience. The expansion is what keeps
+ *   selector semantics identical to `AccessGrant` matching: a rule scoped to a dimension never
+ *   matches a Context that omits it.
+ * - A scoped `allow` that names data classes *also* becomes a DLP permit for those classes, since
+ *   the destinations and audiences it lists are exactly the crossings the author permitted.
+ * - An `approval` rule becomes a `require_approval` rule. Its approver count and separation of
+ *   duties are the Approval gate's concern, not the engine's; leaving them out here is safe
+ *   because `require_approval` is already stricter than the allow it replaces.
+ * - A `dlp` rule with `action: block` becomes a `deny` — on its data classes, or on its protected
+ *   fields. A `secret` detector needs no rule: `checkDlpBoundary` denies a flagged crossing before
+ *   any rule is consulted. `action: requireApproval` becomes `require_approval` the same way.
+ *
+ * Refused outright: `scope.conditions` and `scope.expiresAt` (the engine evaluates neither
+ * attributes nor time), every constraint but `maxRecords` (bytes, cost, time windows, network, and
+ * execution environments are enforced where the work runs, not where it is decided), and
+ * `action: redact` (the engine decides, it does not transform).
+ */
+
+import type { GuardrailDefinition } from "@tulipfarm/schema";
+import type { GuardrailEffect } from "./decision";
+import type { DlpRule } from "./dlp";
+import type { GuardrailRule } from "./engine";
+
+export type GuardrailPolicyRefusalCode =
+  | "unsupported_condition"
+  | "unsupported_constraint"
+  | "unsupported_dlp_action"
+  | "unsupported_expiry";
+
+/** Payload-safe refusal naming the authored rule that could not be compiled exactly. */
+export class GuardrailPolicyError extends Error {
+  readonly name = "GuardrailPolicyError";
+
+  constructor(
+    readonly code: GuardrailPolicyRefusalCode,
+    readonly ruleId: string
+  ) {
+    super(`${code}:${ruleId}`);
+  }
+}
+
+export interface GuardrailPolicy {
+  readonly rules: readonly GuardrailRule[];
+  readonly dlpRules: readonly DlpRule[];
+}
+
+type AuthoredRule = GuardrailDefinition["spec"]["rules"][number];
+type ScopedAuthoredRule = Extract<AuthoredRule, { type: "allow" | "deny" }>;
+type AuthoredScope = NonNullable<AuthoredRule["scope"]>;
+type AuthoredConstraints = NonNullable<AuthoredRule["constraints"]>;
+
+/** `undefined` for "unscoped", so an expansion over it yields exactly one unscoped rule. */
+function dimension(values: readonly string[] | undefined): readonly (string | undefined)[] {
+  return values === undefined || values.length === 0 ? [undefined] : values;
+}
+
+function assertScopeSupported(rule: AuthoredRule): void {
+  const scope: AuthoredScope | undefined = rule.scope;
+  if (scope === undefined) return;
+  if (scope.conditions !== undefined) {
+    throw new GuardrailPolicyError("unsupported_condition", rule.id);
+  }
+  if (scope.expiresAt !== undefined) throw new GuardrailPolicyError("unsupported_expiry", rule.id);
+}
+
+/**
+ * The record ceiling this rule carries, if any. Every other constraint is refused: a ceiling the
+ * engine cannot check is a ceiling nothing checks.
+ */
+function recordCeiling(rule: AuthoredRule): number | undefined {
+  const constraints: AuthoredConstraints | undefined = rule.constraints;
+  if (constraints === undefined) return undefined;
+  const { maxRecords, ...rest } = constraints;
+  for (const value of Object.values(rest)) {
+    if (value !== undefined) throw new GuardrailPolicyError("unsupported_constraint", rule.id);
+  }
+  return maxRecords;
+}
+
+interface ExpansionScope {
+  /** Actions the rule covers; a `dlp` rule names none, so it covers every action. */
+  readonly actions?: readonly string[];
+  readonly dataClasses?: readonly string[];
+  readonly destinations?: readonly string[];
+  readonly audiences?: readonly string[];
+  readonly fieldSelector?: readonly string[];
+}
+
+/** One `GuardrailRule` per authored combination; ids stay the authored id, never a payload. */
+function expand(
+  rule: AuthoredRule,
+  effect: GuardrailEffect,
+  scope: ExpansionScope
+): GuardrailRule[] {
+  assertScopeSupported(rule);
+  // Read on every path so an unsupported constraint is refused even where the engine would
+  // ignore the ceiling it carries.
+  const ceiling = recordCeiling(rule);
+  const maxRecordCount = effect === "allow" ? ceiling : undefined;
+
+  const resource = rule.scope?.resource;
+  const fieldSelector = scope.fieldSelector ?? resource?.fields;
+  const rules: GuardrailRule[] = [];
+
+  for (const action of scope.actions ?? ["*"]) {
+    for (const resourceType of dimension(resource?.types)) {
+      for (const recordSelector of dimension(resource?.recordIds)) {
+        for (const dataClass of dimension(scope.dataClasses)) {
+          for (const destination of dimension(scope.destinations)) {
+            for (const audience of dimension(scope.audiences)) {
+              rules.push({
+                id: rule.id,
+                effect,
+                action,
+                resourceType: resourceType ?? "*",
+                ...(recordSelector === undefined ? {} : { recordSelector }),
+                ...(fieldSelector === undefined ? {} : { fieldSelector }),
+                ...(dataClass === undefined ? {} : { dataClass }),
+                ...(destination === undefined ? {} : { destination }),
+                ...(audience === undefined ? {} : { audience }),
+                ...(maxRecordCount === undefined ? {} : { maxRecordCount }),
+              });
+            }
+          }
+        }
+      }
+    }
+  }
+  return rules;
+}
+
+/** DLP permits an authored `allow` grants: one per data class it names. */
+function permits(rule: ScopedAuthoredRule): DlpRule[] {
+  return (rule.dataClasses ?? []).map((dataClass) => ({
+    dataClass,
+    ...(rule.destinations === undefined ? {} : { allowedDestinations: rule.destinations }),
+    ...(rule.audiences === undefined ? {} : { allowedAudiences: rule.audiences }),
+  }));
+}
+
+function compileDlp(rule: Extract<AuthoredRule, { type: "dlp" }>): GuardrailRule[] {
+  if (rule.action === "redact") {
+    throw new GuardrailPolicyError("unsupported_dlp_action", rule.id);
+  }
+  const effect: GuardrailEffect = rule.action === "block" ? "deny" : "require_approval";
+  const rules: GuardrailRule[] = [];
+
+  for (const detector of rule.detectors) {
+    // A flagged secret is denied by `checkDlpBoundary` before any rule is read, so a `secret`
+    // detector needs nothing here — and expressing it as a rule would weaken that default.
+    if (detector.type === "secret") continue;
+    const scope: ExpansionScope = {
+      destinations: rule.destinations,
+      audiences: rule.audiences,
+      ...(detector.type === "dataClass"
+        ? { dataClasses: detector.values }
+        : { fieldSelector: detector.values }),
+    };
+    rules.push(...expand(rule, effect, scope));
+  }
+  return rules;
+}
+
+/**
+ * Compiles every authored Guardrail into one policy. Rule order is the authored order across
+ * definitions in the order given, which the engine's precedence (explicit deny first) makes
+ * order-independent for the decision itself.
+ */
+export function compileGuardrailPolicy(
+  definitions: readonly GuardrailDefinition[]
+): GuardrailPolicy {
+  const rules: GuardrailRule[] = [];
+  const dlpRules: DlpRule[] = [];
+
+  for (const definition of definitions) {
+    for (const rule of definition.spec.rules) {
+      switch (rule.type) {
+        case "allow":
+          rules.push(
+            ...expand(rule, "allow", {
+              actions: rule.actions,
+              dataClasses: rule.dataClasses,
+              destinations: rule.destinations,
+              audiences: rule.audiences,
+            })
+          );
+          dlpRules.push(...permits(rule));
+          break;
+        case "deny":
+          rules.push(
+            ...expand(rule, "deny", {
+              actions: rule.actions,
+              dataClasses: rule.dataClasses,
+              destinations: rule.destinations,
+              audiences: rule.audiences,
+            })
+          );
+          break;
+        case "approval":
+          rules.push(...expand(rule, "require_approval", { actions: rule.actions }));
+          break;
+        default:
+          rules.push(...compileDlp(rule));
+      }
+    }
+  }
+
+  return { rules, dlpRules };
+}

--- a/packages/authz/src/index.ts
+++ b/packages/authz/src/index.ts
@@ -45,6 +45,8 @@ export type { DlpCrossing, DlpRule } from "./guardrails/dlp";
 export { checkDlpBoundary } from "./guardrails/dlp";
 export type { GuardrailContext, GuardrailRule } from "./guardrails/engine";
 export { evaluateGuardrail } from "./guardrails/engine";
+export type { GuardrailPolicy, GuardrailPolicyRefusalCode } from "./guardrails/policy";
+export { compileGuardrailPolicy, GuardrailPolicyError } from "./guardrails/policy";
 export type { AutonomyLevel, TaintLevel } from "./guardrails/risk";
 export { autonomyWithin, taintWithin } from "./guardrails/risk";
 export type { Guest, GuestDenialReason, GuestStatus } from "./guests";

--- a/packages/run-kernel/src/routine/scheduling.ts
+++ b/packages/run-kernel/src/routine/scheduling.ts
@@ -49,8 +49,22 @@ export function routineOccurrenceKey(parentKey: string, unit: string, stateKey: 
  * than opening a second timer against the same State.
  */
 export function routineWaitId(runId: string, stateKey: string): string {
-  const digest = createHash("sha256").update(`routine-wait:${runId}:${stateKey}`).digest("hex");
-  // RFC 4122 version 4 / variant 10 bits, so the value is a legal uuid for the `uuid` column.
+  return derivedId("routine-wait", runId, stateKey);
+}
+
+/**
+ * Deterministic effect id for one Tool State occurrence. `effect_records.effect_id` is a primary
+ * key, so deriving it the same way makes reserving an effect replay-safe: a worker that died
+ * between reserving and recording the reservation finds its own row instead of writing a second
+ * one against the same State.
+ */
+export function routineEffectId(runId: string, stateKey: string): string {
+  return derivedId("routine-effect", runId, stateKey);
+}
+
+/** A `uuid` column needs a legal uuid, so the digest is dressed as an RFC 4122 version 4 value. */
+function derivedId(purpose: string, runId: string, stateKey: string): string {
+  const digest = createHash("sha256").update(`${purpose}:${runId}:${stateKey}`).digest("hex");
   const version = `4${digest.slice(13, 16)}`;
   const variant = ((Number.parseInt(digest.slice(16, 17), 16) & 0x3) | 0x8).toString(16);
   return [

--- a/packages/run-kernel/src/routine/states/index.ts
+++ b/packages/run-kernel/src/routine/states/index.ts
@@ -8,5 +8,6 @@ export * from "./human";
 export * from "./parallel";
 export * from "./repeat";
 export * from "./step";
+export * from "./tool";
 export * from "./wait";
 export * from "./wait-plan";

--- a/packages/run-kernel/src/routine/states/step.ts
+++ b/packages/run-kernel/src/routine/states/step.ts
@@ -29,6 +29,7 @@ export type RoutineStepErrorCode =
   | "missing_body"
   | "missing_routine_ref"
   | "missing_target_ref"
+  | "missing_tool_ref"
   | "output_schema_not_declared"
   | "principals_not_declared"
   | "missing_iterator"

--- a/packages/run-kernel/src/routine/states/tool.test.ts
+++ b/packages/run-kernel/src/routine/states/tool.test.ts
@@ -1,0 +1,96 @@
+import type { routine as routineSchema } from "@tulipfarm/schema";
+import { describe, expect, it } from "vitest";
+import { routineEffectId } from "../scheduling";
+import { RoutineStepError } from "./step";
+import { compileWithTargets } from "./test-support";
+import { planToolDispatch, routineIdempotencyKey } from "./tool";
+
+const CTX = {
+  businessId: "biz-1",
+  runId: "11111111-1111-4111-8111-111111111111",
+  stateKey: "CommentIssue",
+};
+
+function toolState(overrides: Record<string, unknown> = {}): routineSchema.RoutineState {
+  return {
+    type: "tool",
+    name: "CommentIssue",
+    toolRef: { name: "github.issue.comment", version: "1.0.0" },
+    action: "issue.comment",
+    destination: "github",
+    credentialRef: "secret://integrations/github/triage",
+    input: { issueNumber: "${input.issueNumber}", body: "hello" },
+    end: true,
+    ...overrides,
+  } as routineSchema.RoutineState;
+}
+
+describe("planToolDispatch", () => {
+  it("plans the authored dispatch with its arguments resolved from the Context", () => {
+    const plan = planToolDispatch(
+      compileWithTargets(toolState()),
+      { input: { issueNumber: 7 } },
+      CTX
+    );
+
+    expect(plan.toolRef).toEqual({ name: "github.issue.comment", version: "1.0.0" });
+    expect(plan.action).toBe("issue.comment");
+    expect(plan.destination).toBe("github");
+    expect(plan.credentialRef).toBe("secret://integrations/github/triage");
+    expect(plan.arguments).toEqual({ issueNumber: 7, body: "hello" });
+  });
+
+  it("derives the idempotency key and effect id from the Run and the State occurrence", () => {
+    const plan = planToolDispatch(
+      compileWithTargets(toolState()),
+      { input: { issueNumber: 7 } },
+      CTX
+    );
+
+    expect(plan.idempotencyKey).toBe(routineIdempotencyKey(CTX.runId, CTX.stateKey));
+    expect(plan.effectId).toBe(routineEffectId(CTX.runId, CTX.stateKey));
+  });
+
+  it("replays to the same identities and arguments, so a retry converges on one effect", () => {
+    const state = compileWithTargets(toolState());
+    const first = planToolDispatch(state, { input: { issueNumber: 7 } }, CTX);
+    const second = planToolDispatch(state, { input: { issueNumber: 7 } }, CTX);
+
+    expect(second).toEqual(first);
+  });
+
+  it("addresses a fan-out occurrence separately from the authored State", () => {
+    const state = compileWithTargets(toolState());
+    const unit = planToolDispatch(
+      state,
+      { input: { issueNumber: 7 } },
+      {
+        ...CTX,
+        stateKey: "Fanout#item-2/CommentIssue",
+      }
+    );
+
+    expect(unit.effectId).not.toBe(routineEffectId(CTX.runId, CTX.stateKey));
+    expect(unit.idempotencyKey).toContain("Fanout#item-2/CommentIssue");
+  });
+
+  it("refuses a State whose authored Tool reference is unusable", () => {
+    const state = compileWithTargets(toolState());
+    const withoutRef = { ...state, definition: { ...state.definition, toolRef: undefined } };
+
+    expect(() => planToolDispatch(withoutRef, {}, CTX)).toThrow(
+      new RoutineStepError("missing_tool_ref", "CommentIssue")
+    );
+  });
+
+  it("refuses to plan a State that is not a Tool State", () => {
+    const agent = compileWithTargets({
+      type: "agent",
+      name: "Classify",
+      agentRef: { name: "triage", version: "1.0.0" },
+      end: true,
+    } as routineSchema.RoutineState);
+
+    expect(() => planToolDispatch(agent, {}, CTX)).toThrow(RoutineStepError);
+  });
+});

--- a/packages/run-kernel/src/routine/states/tool.ts
+++ b/packages/run-kernel/src/routine/states/tool.ts
@@ -1,0 +1,103 @@
+import type { CompiledState } from "../compiler";
+import { resolveRoutineStateInput } from "../input";
+import { routineEffectId } from "../scheduling";
+import { RoutineStepError } from "./step";
+
+/**
+ * Planning for a `tool` State. This decides *what* would be dispatched and never dispatches it:
+ * the Tool Broker owns authorization, the effect ledger owns the reservation, and an adapter owns
+ * the call. Keeping the plan here — rather than in whichever process happens to hold a broker —
+ * is what lets a replay reach byte-identical arguments, the same idempotency key, and the same
+ * effect id as the attempt it is replaying.
+ *
+ * The two derived identities carry the replay guarantee:
+ *
+ * - `idempotencyKey` is derived from the Run and the durable State occurrence, so a retried
+ *   attempt, a resumed Run, and a re-executed fan-out unit all converge on the effect already
+ *   reserved instead of writing a second one.
+ * - `effectId` is derived from the same pair, so a worker that died between reserving an effect
+ *   and recording that it did finds its own reservation rather than opening another.
+ */
+
+export interface ToolStateRef {
+  readonly name: string;
+  readonly version: string;
+  readonly id?: string;
+}
+
+export interface ToolDispatchContext {
+  readonly businessId: string;
+  readonly runId: string;
+  /** Durable State occurrence key — the authored name outside a fan-out, the occurrence inside. */
+  readonly stateKey: string;
+}
+
+export interface ToolDispatchPlan {
+  readonly toolRef: ToolStateRef;
+  readonly action: string;
+  readonly destination?: string;
+  readonly credentialRef?: string;
+  readonly arguments: Record<string, unknown>;
+  readonly idempotencyKey: string;
+  readonly effectId: string;
+  /** Position of the effect within its Run, so the ledger can reject a second one for the State. */
+  readonly logicalEffectOrdinal: number;
+}
+
+function authored(state: CompiledState): Record<string, unknown> {
+  return state.definition as unknown as Record<string, unknown>;
+}
+
+/**
+ * The authored Tool reference and action. Both are required by the Routine schema; reading them
+ * defensively means a State that reached here without them is refused by name rather than
+ * dispatched against a reference this code invented.
+ */
+function toolRefOf(state: CompiledState): { ref: ToolStateRef; action: string } {
+  const value = authored(state).toolRef;
+  const action = authored(state).action;
+  if (typeof value !== "object" || value === null || typeof action !== "string") {
+    throw new RoutineStepError("missing_tool_ref", state.name);
+  }
+  const { name, version, id } = value as Record<string, unknown>;
+  if (typeof name !== "string" || typeof version !== "string") {
+    throw new RoutineStepError("missing_tool_ref", state.name);
+  }
+  return {
+    ref: { name, version, ...(typeof id === "string" ? { id } : {}) },
+    action,
+  };
+}
+
+function optionalString(state: CompiledState, key: string): string | undefined {
+  const value = authored(state)[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+/** Deterministic idempotency key for one Tool State occurrence in one Run. */
+export function routineIdempotencyKey(runId: string, stateKey: string): string {
+  return `routine:${runId}:${stateKey}`;
+}
+
+/** Plan the dispatch a `tool` State describes, with its arguments resolved from the Context. */
+export function planToolDispatch(
+  state: CompiledState,
+  scope: Readonly<Record<string, unknown>>,
+  ctx: ToolDispatchContext
+): ToolDispatchPlan {
+  if (state.type !== "tool") throw new RoutineStepError("state_cannot_progress", state.name);
+  const { ref, action } = toolRefOf(state);
+  const destination = optionalString(state, "destination");
+  const credentialRef = optionalString(state, "credentialRef");
+
+  return {
+    toolRef: ref,
+    action,
+    ...(destination === undefined ? {} : { destination }),
+    ...(credentialRef === undefined ? {} : { credentialRef }),
+    arguments: resolveRoutineStateInput(state, scope),
+    idempotencyKey: routineIdempotencyKey(ctx.runId, ctx.stateKey),
+    effectId: routineEffectId(ctx.runId, ctx.stateKey),
+    logicalEffectOrdinal: state.index,
+  };
+}


### PR DESCRIPTION
## Summary

- Routine `tool` States now execute through `@tulipfarm/tool-broker` in the Worker instead of parking as unsupported. `planToolDispatch` (run-kernel) resolves the arguments from the Context and derives the idempotency key and effect id from the Run plus the durable occurrence key; `BrokerRoutineToolPort` (`apps/worker/src/routine/tool-port.ts`) authorizes the intent, reserves the effect in the ledger, and only then dispatches — so a denial never reaches an adapter and a replayed Run finds its own effect rather than writing a second one.
- New `compileGuardrailPolicy` (`@tulipfarm/authz`) is the first compiler from authored `Guardrail` definitions to engine rules. It reads only the Run's pinned bundle, and refuses any authored rule it cannot express exactly (conditions, expiry, non-`maxRecords` constraints, `redact`) rather than dropping it — a dropped deny silently widens a policy. The bundle digest is recorded as the effect's `guardrailRevision`.
- A confirmed effect succeeds; a definitive refusal takes the State's authored `onError` path for `tool_<reason>` and fails the Run when no handler claims it; an approval-required intent, an ambiguous effect, and a missing adapter all park with a named reason.

## Known gaps (both park, neither improvises)

- **No Routine authority source exists yet.** `authorityLayers` are injected and default to `[]`, so the broker denies fail-closed. Routine Approvals land in the following slice.
- **The production adapter map is empty**, because installed-Integration context has no owner in this process yet (PR 6). An authorized dispatch therefore parks on `adapter_not_found` rather than reaching a provider by some other route. Tool State outputs also remain `{ output: null }`, so an authored `${states.X.output.y}` still parks.

Net effect in production today: a Tool State parks with a *different, more honest* refusal, and the full authorize → reserve → dispatch path is proven by tests.

## Test plan

- `pnpm lint` — clean
- `pnpm typecheck` — clean
- `pnpm test` — 31/31 workspaces pass
- New suites: `packages/authz/src/guardrails/policy.test.ts` (14), `packages/run-kernel/src/routine/states/tool.test.ts` (6), `apps/worker/src/routine/tool-port.test.ts` (12 — authorize/reserve/dispatch order, deny never reaching an adapter, empty authority denying, approval parking, confirmed-effect replay without a second dispatch, ambiguous and missing-adapter parking, destination and argument refusals), plus 6 executor-level `tool` State cases in `apps/worker/src/routine/executor.test.ts`