### PR TITLE
refactor(api): compose triggerInvoke Trigger consumption

### DIFF
--- a/apps/api/src/app.composition.test.ts
+++ b/apps/api/src/app.composition.test.ts
@@ -19,12 +19,10 @@ const indexSource = readFileSync(join(__dirname, "index.ts"), "utf8");
  * decision with an owner, never a silent omission.
  */
 const DEFERRED_OPTIONS: Readonly<Record<string, string>> = {
-  // PR 4: PR 3 gave the worker executors for `chat` and `integration`, so Chat and every channel
-  // execute — but all three of these options resolve *Triggers* and *Routines*, whose Run sources
-  // still have no executor. Composing them would mint Runs the worker can only park for
-  // reconciliation, which is the same reason they were deferred before, now naming the PR that
-  // actually lands the consumers.
-  triggerInvoke: "PR 4 — Routine/Trigger consumers on the worker",
+  // PR 4: PR 3 gave the worker executors for `chat` and `integration`, and the Routine executor
+  // landed across PR 4's own worker slices — `triggerInvoke` is now composed. `hookIngress` still
+  // resolves *webhook* Triggers, which need signature-verification/secret plumbing that does not
+  // exist yet.
   hookIngress: "PR 4 — Routine/Trigger consumers on the worker",
   // Replay recompiles the recorded Routine and re-executes it; the run-event stream it reads is
   // only half of what it needs.

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,5 +1,7 @@
+import { randomUUID } from "node:crypto";
 import { EventEmitter } from "node:events";
 import { GuardrailsService } from "@tulipfarm/agent-runtime";
+import { DEPLOYMENT_BUSINESS_ID } from "@tulipfarm/constants";
 import { EmbeddingService, LlmService } from "@tulipfarm/llm";
 import {
   ArtifactService,
@@ -28,6 +30,7 @@ import {
 import {
   ArtifactStore,
   ChildLinkStore,
+  EventStore,
   PgSoulPublicationStore,
   RunEventStore,
   RunStore,
@@ -101,8 +104,15 @@ import { PgRateLimiter } from "./rate-limit";
 import { reconcileResourceTables, registerResourceReconcile } from "./resources/reconcile";
 import { PgCounterStore, PgResourceRepoFactory } from "./resources/repo";
 import { runCanceller } from "./runs/cancel";
-import { integrationInvoker, manualRoutineTrigger } from "./runtime/invocation-callers";
-import { ActiveRoutineInvocationResolver } from "./runtime/invocation-definitions";
+import {
+  integrationInvoker,
+  manualRoutineTrigger,
+  triggerRunStarter,
+} from "./runtime/invocation-callers";
+import {
+  ActiveRoutineInvocationResolver,
+  ActiveTriggerInvocationResolver,
+} from "./runtime/invocation-definitions";
 import { resolveSoulBundleSigner } from "./runtime/soul-bundle-signer";
 import { bootstrapFromEnv } from "./setup/bootstrap";
 import {
@@ -222,6 +232,14 @@ async function boot() {
       validator: invocationValidator,
       routineDefinitions: new ActiveRoutineInvocationResolver(soulPublications, soulBundleSigner),
     });
+    // Canonical event intake/outbox for Trigger invocation, shared in shape (not process) with the
+    // Worker's own `EventStore` — this is the first API-side instantiation of it.
+    const events = new EventStore(runTransactions, randomUUID);
+    const triggerDefinitions = new ActiveTriggerInvocationResolver(
+      soulPublications,
+      soulBundleSigner,
+      DEPLOYMENT_BUSINESS_ID
+    );
     // Read side of the same canonical `runs` / `run_states` tables the gateway writes.
     const runStore = new RunStore(runTransactions);
     const runEventStore = new RunEventStore(runTransactions);
@@ -500,6 +518,12 @@ async function boot() {
         deliveries: ingressDeliveries,
         invoke: integrationInvoker(invocations),
         resolveSecret: (value) => resolveSecretRef(value, secretsService),
+      },
+      triggerInvoke: {
+        resolveTrigger: (slug) => triggerDefinitions.resolveTrigger(slug),
+        sink: events,
+        startRun: triggerRunStarter(invocations),
+        nextEventId: randomUUID,
       },
     });
 

--- a/apps/api/src/runtime/invocation-callers.pg.test.ts
+++ b/apps/api/src/runtime/invocation-callers.pg.test.ts
@@ -5,9 +5,14 @@ import {
   DurableInvocationGateway,
   InvocationDeniedError,
   PgDurableInvocationStore,
+  type RunInvocation,
   TypedOutputValidator,
 } from "@tulipfarm/run-kernel";
-import { INTEGRATION_REQUEST_SCHEMA_REF, INVOCATION_REQUEST_SCHEMAS } from "@tulipfarm/schema";
+import {
+  INTEGRATION_REQUEST_SCHEMA_REF,
+  INVOCATION_REQUEST_SCHEMAS,
+  MANUAL_REQUEST_SCHEMA_REF,
+} from "@tulipfarm/schema";
 import {
   compileExecutionBundle,
   createHmacBundleSigner,
@@ -20,7 +25,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ambientTransactionPort, type Queryable, transactionPort } from "../db";
 import { runPgMigrations } from "../pg-migrate";
 import { makePglite } from "../test/pglite";
-import { integrationInvoker, manualRoutineTrigger } from "./invocation-callers";
+import { integrationInvoker, manualRoutineTrigger, triggerRunStarter } from "./invocation-callers";
 import { ActiveRoutineInvocationResolver } from "./invocation-definitions";
 
 /** A verified Slack delivery as the ingress route hands it over, after signature + accept checks. */
@@ -33,6 +38,24 @@ const SLACK_JOB = {
   },
   headers: { "x-slack-request-timestamp": "1785400000" },
 };
+
+/** A bound Trigger invocation as `buildInvocation` would produce it. */
+function runInvocation(overrides: Partial<RunInvocation> = {}): RunInvocation {
+  return {
+    businessId: DEPLOYMENT_BUSINESS_ID,
+    routineRef: { name: "daily-digest", version: "7" },
+    triggerSlug: "start-digest",
+    triggerVersion: 3,
+    eventId: "event-1",
+    idempotencyKey: "start-digest:3:start-digest:event-1",
+    backgroundIdentity: { principalKind: "system", principalId: "trigger-runner" },
+    mode: "routine",
+    input: { limit: 5 },
+    classification: [],
+    causationId: "event-1",
+    ...overrides,
+  };
+}
 
 /**
  * The non-chat entrypoints over real SQL. A channel delivery and a Routine trigger get the same
@@ -199,6 +222,58 @@ describe("non-chat invocation callers", () => {
         now: new Date(),
       })
     ).resolves.toMatchObject({ content: { slug: "daily-digest", inputs: { limit: 5 } } });
+  });
+
+  it("starts a Routine from a bound Trigger invocation, under the Trigger's background identity", async () => {
+    const { runId, outcome } = await triggerRunStarter(invocations)(runInvocation());
+    expect(outcome).toBe("started");
+
+    const runs = await db.query<{
+      source: string;
+      run_source: string;
+      identity: { initiator: { kind: string; id: string } };
+    }>(
+      `SELECT runs.source AS run_source, runs.identity, invocation.source
+         FROM runs
+         JOIN durable_invocations invocation
+           ON invocation.business_id = runs.business_id AND invocation.run_id = runs.id
+        WHERE runs.id = $1`,
+      [runId]
+    );
+    expect(runs.rows[0]?.run_source).toBe("routine");
+    expect(runs.rows[0]?.source).toBe("manual");
+    expect(runs.rows[0]?.identity.initiator).toEqual({
+      kind: "system",
+      id: "trigger-runner",
+    });
+
+    // Reused as-is: the Worker's Routine executor only reconstructs a manual request shape from
+    // the request Artifact, regardless of what minted the Run.
+    await expect(
+      reader().read({
+        businessId: DEPLOYMENT_BUSINESS_ID,
+        artifactId: `${runId}:request`,
+        reader: "service:run-executor",
+        allowedClassifications: [],
+        now: new Date(),
+      })
+    ).resolves.toMatchObject({
+      schemaRef: MANUAL_REQUEST_SCHEMA_REF,
+      content: { slug: "daily-digest", inputs: { limit: 5 } },
+    });
+  });
+
+  it("resolves a redelivered Trigger invocation to the Run its first delivery minted", async () => {
+    const start = triggerRunStarter(invocations);
+    const first = await start(runInvocation());
+    const second = await start(runInvocation());
+
+    expect(first.outcome).toBe("started");
+    expect(second.outcome).toBe("duplicate");
+    expect(second.runId).toBe(first.runId);
+
+    const counts = await db.query<{ runs: number }>("SELECT count(*)::int AS runs FROM runs");
+    expect(counts.rows[0]?.runs).toBe(1);
   });
 
   it("mints no Run when a Routine has no active publication", async () => {

--- a/apps/api/src/runtime/invocation-callers.ts
+++ b/apps/api/src/runtime/invocation-callers.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { DEPLOYMENT_BUSINESS_ID } from "@tulipfarm/constants";
-import type { DurableInvocationGateway } from "@tulipfarm/run-kernel";
+import type { DurableInvocationGateway, RunInvocation } from "@tulipfarm/run-kernel";
 import { INTEGRATION_REQUEST_SCHEMA_REF, MANUAL_REQUEST_SCHEMA_REF } from "@tulipfarm/schema";
 import type { IngressJobPayload } from "../ingress/routes";
 
@@ -67,5 +67,38 @@ export function integrationInvoker(invocations: DurableInvocationGateway) {
       payloadSchemaRef: INTEGRATION_REQUEST_SCHEMA_REF,
       idempotencyKey: digest(payload),
     });
+  };
+}
+
+/**
+ * Starts a Routine from a bound Trigger invocation. Reuses `MANUAL_REQUEST_SCHEMA_REF` rather than
+ * a Trigger-specific schema: the Worker's Routine executor only reconstructs a manual request
+ * (`{slug, inputs}`) from the request Artifact, so a Trigger-invoked Run must publish the same shape
+ * or the Worker parks it for reconciliation instead of executing it.
+ *
+ * `initiator` and `effectiveSubject` are both the Trigger's authored background identity — never the
+ * event's principal, so a caller cannot borrow authority beyond what the Trigger declared.
+ */
+export function triggerRunStarter(invocations: DurableInvocationGateway) {
+  return async (
+    invocation: RunInvocation
+  ): Promise<{ runId: string; outcome: "started" | "duplicate" }> => {
+    const identity = {
+      kind: invocation.backgroundIdentity.principalKind,
+      id: invocation.backgroundIdentity.principalId,
+    };
+    const payload = { slug: invocation.routineRef.name, inputs: invocation.input };
+    const result = await invocations.start({
+      source: "manual",
+      runSource: "routine",
+      businessId: invocation.businessId,
+      initiator: identity,
+      effectiveSubject: identity,
+      definitionRef: `published:routine:${invocation.routineRef.name}`,
+      payload,
+      payloadSchemaRef: MANUAL_REQUEST_SCHEMA_REF,
+      idempotencyKey: invocation.idempotencyKey,
+    });
+    return { runId: result.runId, outcome: result.outcome };
   };
 }

--- a/apps/api/src/runtime/invocation-definitions.test.ts
+++ b/apps/api/src/runtime/invocation-definitions.test.ts
@@ -8,7 +8,10 @@ import {
 } from "@tulipfarm/soul";
 import { InMemorySoulPublicationStore } from "@tulipfarm/storage";
 import { describe, expect, it, vi } from "vitest";
-import { ActiveRoutineInvocationResolver } from "./invocation-definitions";
+import {
+  ActiveRoutineInvocationResolver,
+  ActiveTriggerInvocationResolver,
+} from "./invocation-definitions";
 
 const BUSINESS_ID = "business-1";
 const signer = createHmacBundleSigner("bundle-key-1", "secret");
@@ -50,6 +53,48 @@ async function activeResolver(document: VersionedSchemaDocument) {
   await publications.publish({ bundle: signExecutionBundle(bundle, signer) });
   await publications.drain("test");
   return new ActiveRoutineInvocationResolver(publications, signer);
+}
+
+function trigger(
+  overrides: { lifecycle?: "draft" | "published"; type?: unknown; inputMapping?: unknown } = {}
+): VersionedSchemaDocument {
+  return {
+    apiVersion: "tulipfarm.ai/v1",
+    kind: "Trigger",
+    metadata: {
+      id: "22222222-2222-4222-8222-222222222222",
+      slug: "start-digest",
+      schemaVersion: 1,
+      authoredVersion: 3,
+      lifecycle: overrides.lifecycle ?? "published",
+    },
+    spec: {
+      type: overrides.type ?? "manual",
+      routineRef: { name: "daily-digest", version: "7" },
+      eventType: "digest.requested",
+      eventVersion: 1,
+      backgroundIdentity: { principalKind: "system", principalId: "trigger-runner" },
+      deduplication: { key: "digest" },
+      ...(overrides.inputMapping === undefined ? {} : { inputMapping: overrides.inputMapping }),
+    },
+  } as VersionedSchemaDocument;
+}
+
+async function activeTriggerResolver(document: VersionedSchemaDocument) {
+  const publications = new SoulPublicationCoordinator(
+    new InMemorySoulPublicationStore(),
+    new InMemoryBundleStore(),
+    { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+  );
+  const bundle = compileExecutionBundle({
+    businessId: BUSINESS_ID,
+    changesetId: "changeset-1",
+    commitSha: "c0ffee",
+    documents: [document, routine()],
+  });
+  await publications.publish({ bundle: signExecutionBundle(bundle, signer) });
+  await publications.drain("test");
+  return new ActiveTriggerInvocationResolver(publications, signer, BUSINESS_ID);
 }
 
 describe("ActiveRoutineInvocationResolver", () => {
@@ -113,5 +158,63 @@ describe("ActiveRoutineInvocationResolver", () => {
         definitionRef: "published:agent:daily-digest",
       })
     ).resolves.toBeUndefined();
+  });
+});
+
+describe("ActiveTriggerInvocationResolver", () => {
+  it("maps the verified active Trigger to a RegisteredTrigger", async () => {
+    const resolver = await activeTriggerResolver(trigger());
+
+    await expect(resolver.resolveTrigger("start-digest")).resolves.toEqual({
+      triggerSlug: "start-digest",
+      authoredVersion: 3,
+      lifecycle: "published",
+      type: "manual",
+      eventType: "digest.requested",
+      eventVersion: 1,
+      routineRef: { name: "daily-digest", version: "7" },
+      backgroundIdentity: { principalKind: "system", principalId: "trigger-runner" },
+    });
+  });
+
+  it("maps an authored inputMapping to string-keyed inputMappings", async () => {
+    const resolver = await activeTriggerResolver(
+      trigger({ inputMapping: { subject: "record.id" } })
+    );
+
+    await expect(resolver.resolveTrigger("start-digest")).resolves.toMatchObject({
+      inputMappings: { subject: "record.id" },
+    });
+  });
+
+  it("does not consult another source when no bundle is active", async () => {
+    const publications = new SoulPublicationCoordinator(
+      new InMemorySoulPublicationStore(),
+      new InMemoryBundleStore(),
+      { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    );
+    const resolver = new ActiveTriggerInvocationResolver(publications, signer, BUSINESS_ID);
+
+    await expect(resolver.resolveTrigger("start-digest")).resolves.toBeNull();
+  });
+
+  it("refuses a draft Trigger even when its bundle was activated", async () => {
+    const resolver = await activeTriggerResolver(trigger({ lifecycle: "draft" }));
+    await expect(resolver.resolveTrigger("start-digest")).resolves.toBeNull();
+  });
+
+  it("refuses an unknown Trigger type", async () => {
+    const resolver = await activeTriggerResolver(trigger({ type: "unsupported" }));
+    await expect(resolver.resolveTrigger("start-digest")).resolves.toBeNull();
+  });
+
+  it("refuses a malformed inputMapping value", async () => {
+    const resolver = await activeTriggerResolver(trigger({ inputMapping: { subject: 42 } }));
+    await expect(resolver.resolveTrigger("start-digest")).resolves.toBeNull();
+  });
+
+  it("refuses an unknown slug", async () => {
+    const resolver = await activeTriggerResolver(trigger());
+    await expect(resolver.resolveTrigger("missing")).resolves.toBeNull();
   });
 });

--- a/apps/api/src/runtime/invocation-definitions.ts
+++ b/apps/api/src/runtime/invocation-definitions.ts
@@ -1,16 +1,35 @@
 import {
+  type RegisteredTrigger,
   type ResolvedRoutineInvocation,
   type RoutineInvocationResolver,
   routineStateDefinitionRef,
+  type TriggerKind,
 } from "@tulipfarm/run-kernel";
+import { definitions } from "@tulipfarm/schema";
 import type { BundleSigner, SoulPublicationCoordinator } from "@tulipfarm/soul";
 
 const ROUTINE_DEFINITION_PREFIX = "published:routine:";
+
+// Widened so `.includes` accepts a raw `string` read off an authored document rather than only a
+// value already known to be a `TriggerType`.
+const TRIGGER_TYPES: readonly string[] = definitions.trigger.TRIGGER_TYPES;
 
 type ActiveBundleReader = Pick<SoulPublicationCoordinator, "activeBundle">;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** `undefined`: no mapping authored. `null`: authored but malformed — the caller must fail closed. */
+function mapInputMappings(raw: unknown): Record<string, string> | undefined | null {
+  if (raw === undefined) return undefined;
+  if (!isRecord(raw)) return null;
+  const mapped: Record<string, string> = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (typeof value !== "string") return null;
+    mapped[key] = value;
+  }
+  return mapped;
 }
 
 /**
@@ -65,6 +84,87 @@ export class ActiveRoutineInvocationResolver implements RoutineInvocationResolve
           start
         ),
       },
+    };
+  }
+}
+
+/**
+ * Resolves a Trigger only from the verified active Soul bundle, for the same reason as
+ * {@link ActiveRoutineInvocationResolver}: a missing, draft, or malformed active definition denies
+ * the invocation before it can mint a Run. `semanticIntakeAgent` is never set — no authored Trigger
+ * can declare it today — and `requireVerified` is never set, since the manual/internal_api envelopes
+ * this resolver serves are always constructed `unverified` by the invoking route.
+ */
+export class ActiveTriggerInvocationResolver {
+  constructor(
+    private readonly publications: ActiveBundleReader,
+    private readonly signer: BundleSigner,
+    private readonly businessId: string
+  ) {}
+
+  async resolveTrigger(slug: string): Promise<RegisteredTrigger | null> {
+    if (slug.length === 0) return null;
+
+    const bundle = await this.publications.activeBundle(this.businessId, this.signer);
+    const definition = bundle?.get("Trigger", slug);
+    if (!bundle || !definition) return null;
+
+    const document = definition.document;
+    const metadata = isRecord(document.metadata) ? document.metadata : undefined;
+    const spec = isRecord(document.spec) ? document.spec : undefined;
+    if (metadata?.lifecycle !== "published" || spec === undefined) return null;
+
+    const type = spec.type;
+    if (typeof type !== "string" || !TRIGGER_TYPES.includes(type)) return null;
+
+    const routineRef = spec.routineRef;
+    if (
+      !isRecord(routineRef) ||
+      typeof routineRef.name !== "string" ||
+      routineRef.name.length === 0 ||
+      typeof routineRef.version !== "string" ||
+      routineRef.version.length === 0
+    ) {
+      return null;
+    }
+
+    const eventType = spec.eventType;
+    const eventVersion = spec.eventVersion;
+    if (
+      typeof eventType !== "string" ||
+      eventType.length === 0 ||
+      typeof eventVersion !== "number"
+    ) {
+      return null;
+    }
+
+    const backgroundIdentity = spec.backgroundIdentity;
+    if (
+      !isRecord(backgroundIdentity) ||
+      typeof backgroundIdentity.principalKind !== "string" ||
+      backgroundIdentity.principalKind.length === 0 ||
+      typeof backgroundIdentity.principalId !== "string" ||
+      backgroundIdentity.principalId.length === 0
+    ) {
+      return null;
+    }
+
+    const inputMappings = mapInputMappings(spec.inputMapping);
+    if (inputMappings === null) return null;
+
+    return {
+      triggerSlug: slug,
+      authoredVersion: definition.authoredVersion,
+      lifecycle: "published",
+      type: type as TriggerKind,
+      eventType,
+      eventVersion,
+      routineRef: { name: routineRef.name, version: routineRef.version },
+      backgroundIdentity: {
+        principalKind: backgroundIdentity.principalKind,
+        principalId: backgroundIdentity.principalId,
+      },
+      ...(inputMappings === undefined ? {} : { inputMappings }),
     };
   }
 }

--- a/docs/architecture/aw-program-status.md
+++ b/docs/architecture/aw-program-status.md
@@ -51,7 +51,7 @@ and fails unless a missing option is listed in `DEFERRED_OPTIONS` with the PR th
 | `operationalApi` | yes | `/api/v1/runs`, `/admin/operations`, `/inbox`, `/roles`, `/guardrails` |
 | `runEvents` | yes | `/api/v1/runs/:id/events`, and the same reader behind `POST /api/v1/chat` — the worker writes the events as of PR 3 |
 | `internalTurns` | yes | `/api/v1/internal/*` — Context, Tool dispatch, delivery classification, and Turn completion for the Worker (service principals only) |
-| `triggerInvoke` | no | Chat and Integration have executors as of PR 3, but Trigger/Routine Run sources do not, so a trigger would only mint Runs to be parked — PR 4 |
+| `triggerInvoke` | yes | `POST /api/v1/triggers/:slug/invoke` — resolves `manual`/`internal_api` Triggers from the active signed Soul bundle, persists the canonical event through `EventStore`, and starts the bound Routine through the same `DurableInvocationGateway` Chat and Integration use; the Worker's Routine executor (PR 4) runs it rather than parking it |
 | `hookIngress` | no | same: signed webhook ingress is inert until its Run source has an executor — PR 4 |
 | `runReplay` | no | replay recompiles the recorded Routine; the run-event stream it reads is only half of what it needs — PR 4 |
 | `routines` / `routineAuthoring` | no | `@tulipfarm/routine-engine` is being retired, not revived — PR 4 |


### PR DESCRIPTION
## Summary
- Wires `ActiveTriggerInvocationResolver` (resolves published Triggers from the active signed Soul bundle) and `triggerRunStarter` (mints a Routine Run via `DurableInvocationGateway`) into `apps/api/src/index.ts`'s `buildApp` call, alongside a new `EventStore` instantiation for the trigger-invoke sink.
- The Worker's Routine executor is already composed (PRs #297-#304), so a Trigger-minted Run now actually executes instead of being parked as `needs_reconciliation`.
- Removes `triggerInvoke` from `app.composition.test.ts`'s `DEFERRED_OPTIONS` and flips its row in `docs/architecture/aw-program-status.md` to composed.

No new schema, migration, or persistence class — `apps/api/src/triggers/routes.ts`, `run-kernel`'s `buildInvocation`, and `EventStore` were already built and tested; this PR only composes them.

## Test plan
- [x] `pnpm exec biome check --write` on touched files
- [x] `pnpm --filter @tulipfarm/api exec tsc --noEmit`
- [x] Scoped vitest: `invocation-definitions.test.ts`, `invocation-callers.pg.test.ts`, `app.composition.test.ts`, `triggers/routes.test.ts` — 31/31 pass
- [x] Full gate: `pnpm lint && pnpm typecheck && pnpm test` — all green (1757/1758 tests pass across 31 packages, 1 pre-existing skip)