### PR TITLE
refactor(api): compose hookIngress signed webhook Trigger consumption

### DIFF
--- a/apps/api/src/app.composition.test.ts
+++ b/apps/api/src/app.composition.test.ts
@@ -19,11 +19,6 @@ const indexSource = readFileSync(join(__dirname, "index.ts"), "utf8");
  * decision with an owner, never a silent omission.
  */
 const DEFERRED_OPTIONS: Readonly<Record<string, string>> = {
-  // PR 4: PR 3 gave the worker executors for `chat` and `integration`, and the Routine executor
-  // landed across PR 4's own worker slices — `triggerInvoke` is now composed. `hookIngress` still
-  // resolves *webhook* Triggers, which need signature-verification/secret plumbing that does not
-  // exist yet.
-  hookIngress: "PR 4 — Routine/Trigger consumers on the worker",
   // Replay recompiles the recorded Routine and re-executes it; the run-event stream it reads is
   // only half of what it needs.
   runReplay: "PR 4 — Routine/Trigger consumers on the worker",

--- a/apps/api/src/hooks/raw-payload-vault.pg.test.ts
+++ b/apps/api/src/hooks/raw-payload-vault.pg.test.ts
@@ -1,0 +1,85 @@
+import { randomBytes } from "node:crypto";
+import type { PGlite } from "@electric-sql/pglite";
+import { decryptSecret, type SecretEnvelope } from "@tulipfarm/secrets";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Queryable } from "../db";
+import { runPgMigrations } from "../pg-migrate";
+import { makePglite } from "../test/pglite";
+import { PgRawPayloadVault } from "./raw-payload-vault";
+
+describe("PgRawPayloadVault", () => {
+  let db: PGlite;
+  let dekKey: Buffer;
+  let vault: PgRawPayloadVault;
+
+  beforeEach(async () => {
+    db = await makePglite();
+    await runPgMigrations(db as unknown as Queryable);
+    dekKey = randomBytes(32);
+    vault = new PgRawPayloadVault(db as unknown as Queryable, dekKey);
+  });
+
+  afterEach(async () => {
+    await db.close();
+  });
+
+  it("stores the raw delivery bytes encrypted, round-tripping through decryptSecret", async () => {
+    const rawBody = Buffer.from(JSON.stringify({ event: "push", ref: "refs/heads/main" }));
+
+    const { artifactId } = await vault.store({
+      businessId: "business-1",
+      provider: "github",
+      triggerSlug: "github-push",
+      rawBody,
+      receivedAt: "2026-08-03T00:00:00.000Z",
+    });
+
+    const rows = await db.query<{
+      business_id: string;
+      provider: string;
+      trigger_slug: string;
+      encrypted_body: string;
+      iv: string;
+      auth_tag: string;
+      received_at: string;
+    }>("SELECT * FROM webhook_raw_payloads WHERE id = $1", [artifactId]);
+
+    expect(rows.rows).toHaveLength(1);
+    const row = rows.rows[0];
+    expect(row?.business_id).toBe("business-1");
+    expect(row?.provider).toBe("github");
+    expect(row?.trigger_slug).toBe("github-push");
+
+    const envelope: SecretEnvelope = {
+      encryptedValue: row?.encrypted_body ?? "",
+      iv: row?.iv ?? "",
+      authTag: row?.auth_tag ?? "",
+    };
+    const decrypted = decryptSecret(envelope, { current: dekKey });
+    expect(Buffer.from(decrypted, "base64")).toEqual(rawBody);
+  });
+
+  it("stores distinct rows for redelivered payloads", async () => {
+    const rawBody = Buffer.from("payload");
+    const first = await vault.store({
+      businessId: "business-1",
+      provider: "github",
+      triggerSlug: "github-push",
+      rawBody,
+      receivedAt: "2026-08-03T00:00:00.000Z",
+    });
+    const second = await vault.store({
+      businessId: "business-1",
+      provider: "github",
+      triggerSlug: "github-push",
+      rawBody,
+      receivedAt: "2026-08-03T00:00:01.000Z",
+    });
+
+    expect(first.artifactId).not.toBe(second.artifactId);
+    const rows = await db.query<{ count: string }>(
+      "SELECT count(*)::int AS count FROM webhook_raw_payloads"
+    );
+    expect(rows.rows[0]?.count).toBe(2);
+  });
+});

--- a/apps/api/src/hooks/raw-payload-vault.ts
+++ b/apps/api/src/hooks/raw-payload-vault.ts
@@ -1,0 +1,46 @@
+import { randomUUID } from "node:crypto";
+import type { RawPayloadVault } from "@tulipfarm/run-kernel";
+import { encryptSecret } from "@tulipfarm/secrets";
+import type { Queryable } from "../db";
+
+/**
+ * Encrypted store for raw webhook delivery bytes, ahead of any Run — `ArtifactService` requires a
+ * `{runId, stateKey, attempt}` producer, which does not exist yet at ingestion time. Encrypted
+ * under the same DEK `SecretsService` uses for stored secrets, so no new key material is
+ * provisioned. Only `store` is implemented: nothing reads this table back yet.
+ */
+export class PgRawPayloadVault implements RawPayloadVault {
+  constructor(
+    private readonly db: Queryable,
+    private readonly dekKey: Buffer
+  ) {}
+
+  async store(input: {
+    businessId: string;
+    provider: string;
+    triggerSlug: string;
+    rawBody: Buffer;
+    receivedAt: string;
+  }): Promise<{ artifactId: string }> {
+    const id = randomUUID();
+    const envelope = encryptSecret(input.rawBody.toString("base64"), this.dekKey);
+
+    await this.db.query(
+      `INSERT INTO webhook_raw_payloads
+         (id, business_id, provider, trigger_slug, encrypted_body, iv, auth_tag, received_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+      [
+        id,
+        input.businessId,
+        input.provider,
+        input.triggerSlug,
+        envelope.encryptedValue,
+        envelope.iv,
+        envelope.authTag,
+        input.receivedAt,
+      ]
+    );
+
+    return { artifactId: id };
+  }
+}

--- a/apps/api/src/hooks/secret-port.ts
+++ b/apps/api/src/hooks/secret-port.ts
@@ -1,0 +1,20 @@
+import type { WebhookSecretPort } from "@tulipfarm/run-kernel";
+import type { ConnectionSecretStore } from "../integrations/connection-env";
+import { resolveSecretRef } from "../integrations/connection-env";
+
+/**
+ * Bridges `resolveSecretRef`'s `string | undefined` contract (missing secret passes through as
+ * `undefined`, for connection.yaml's plaintext fallback) to `WebhookSecretPort`'s throwing
+ * contract — `ingestWebhook` denies the delivery as `secret_unavailable` on a rejected resolve.
+ */
+export function webhookSecretPort(secrets: ConnectionSecretStore): WebhookSecretPort {
+  return {
+    async resolve(secretRef: string): Promise<string> {
+      const value = await resolveSecretRef(secretRef, secrets);
+      if (value === undefined) {
+        throw new Error(`secret not available: ${secretRef}`);
+      }
+      return value;
+    },
+  };
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -61,6 +61,8 @@ import { logEnvironmentStatus, validateEnvironment } from "./env";
 import { FeedbackRepo } from "./feedback/repo";
 import { registerGuardrailsReload } from "./guardrails/reload";
 import { createHookExecutor } from "./hooks/executor";
+import { PgRawPayloadVault } from "./hooks/raw-payload-vault";
+import { webhookSecretPort } from "./hooks/secret-port";
 import { PgApiClientRepo } from "./identity/api-clients";
 import { channelBindKeyResolver } from "./identity/channel-link";
 import { PgExternalIdentityRepo } from "./identity/external-links";
@@ -112,6 +114,7 @@ import {
 import {
   ActiveRoutineInvocationResolver,
   ActiveTriggerInvocationResolver,
+  ActiveWebhookTriggerResolver,
 } from "./runtime/invocation-definitions";
 import { resolveSoulBundleSigner } from "./runtime/soul-bundle-signer";
 import { bootstrapFromEnv } from "./setup/bootstrap";
@@ -240,6 +243,13 @@ async function boot() {
       soulBundleSigner,
       DEPLOYMENT_BUSINESS_ID
     );
+    const webhookTriggerDefinitions = new ActiveWebhookTriggerResolver(
+      soulPublications,
+      soulBundleSigner,
+      DEPLOYMENT_BUSINESS_ID
+    );
+    // Same DEK `SecretsService` encrypts stored secrets with — no separate key material.
+    const webhookRawPayloadVault = new PgRawPayloadVault(pool, activeDek.key);
     // Read side of the same canonical `runs` / `run_states` tables the gateway writes.
     const runStore = new RunStore(runTransactions);
     const runEventStore = new RunEventStore(runTransactions);
@@ -524,6 +534,16 @@ async function boot() {
         sink: events,
         startRun: triggerRunStarter(invocations),
         nextEventId: randomUUID,
+      },
+      hookIngress: {
+        resolveTrigger: (provider, trigger) =>
+          webhookTriggerDefinitions.resolveTrigger(provider, trigger),
+        ingress: {
+          secrets: webhookSecretPort(secretsService),
+          vault: webhookRawPayloadVault,
+          sink: events,
+          nextEventId: randomUUID,
+        },
       },
     });
 

--- a/apps/api/src/pg-migrations/index.ts
+++ b/apps/api/src/pg-migrations/index.ts
@@ -424,6 +424,25 @@ const IDENTITY_STATEMENTS: string[] = [
   )`,
 ];
 
+/**
+ * Raw webhook delivery bytes, stored encrypted before the canonical event is derived. This
+ * predates any Run — `ArtifactService` requires a `{runId, stateKey, attempt}` producer, which
+ * does not exist yet at ingestion time — so it is its own table rather than an Artifact.
+ */
+const WEBHOOK_VAULT_STATEMENTS: string[] = [
+  `CREATE TABLE IF NOT EXISTS webhook_raw_payloads (
+    id             uuid PRIMARY KEY,
+    business_id    text NOT NULL,
+    provider       text NOT NULL,
+    trigger_slug   text NOT NULL,
+    encrypted_body text NOT NULL,
+    iv             text NOT NULL,
+    auth_tag       text NOT NULL,
+    received_at    timestamptz NOT NULL
+  )`,
+  "CREATE INDEX IF NOT EXISTS webhook_raw_payloads_business_idx ON webhook_raw_payloads (business_id)",
+];
+
 async function ensureSurfaceStorage(q: Queryable): Promise<void> {
   await q.query(`CREATE TABLE IF NOT EXISTS surface_actions (
     handle              text PRIMARY KEY,
@@ -731,6 +750,15 @@ export const PG_MIGRATIONS: PgMigration[] = [
       await q.query(
         "ALTER TABLE runs ADD CONSTRAINT runs_source_nonempty CHECK (length(source) > 0)"
       );
+    },
+  },
+  {
+    version: 22,
+    description: "encrypted raw webhook payload vault",
+    up: async (q) => {
+      for (const sql of WEBHOOK_VAULT_STATEMENTS) {
+        await q.query(sql);
+      }
     },
   },
 ];

--- a/apps/api/src/runtime/invocation-definitions.test.ts
+++ b/apps/api/src/runtime/invocation-definitions.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   ActiveRoutineInvocationResolver,
   ActiveTriggerInvocationResolver,
+  ActiveWebhookTriggerResolver,
 } from "./invocation-definitions";
 
 const BUSINESS_ID = "business-1";
@@ -95,6 +96,58 @@ async function activeTriggerResolver(document: VersionedSchemaDocument) {
   await publications.publish({ bundle: signExecutionBundle(bundle, signer) });
   await publications.drain("test");
   return new ActiveTriggerInvocationResolver(publications, signer, BUSINESS_ID);
+}
+
+function webhookTrigger(
+  overrides: {
+    lifecycle?: "draft" | "published";
+    type?: unknown;
+    provider?: unknown;
+    verification?: unknown;
+  } = {}
+): VersionedSchemaDocument {
+  return {
+    apiVersion: "tulipfarm.ai/v1",
+    kind: "Trigger",
+    metadata: {
+      id: "33333333-3333-4333-8333-333333333333",
+      slug: "github-push",
+      schemaVersion: 1,
+      authoredVersion: 2,
+      lifecycle: overrides.lifecycle ?? "published",
+    },
+    spec: {
+      type: overrides.type ?? "webhook",
+      routineRef: { name: "daily-digest", version: "7" },
+      eventType: "github.push",
+      eventVersion: 1,
+      backgroundIdentity: { principalKind: "system", principalId: "trigger-runner" },
+      deduplication: { key: "github-push" },
+      provider: overrides.provider ?? "github",
+      verification: overrides.verification ?? {
+        method: "hmac_sha256",
+        secretRef: "webhook.github.secret",
+        signatureHeader: "x-hub-signature-256",
+      },
+    },
+  } as VersionedSchemaDocument;
+}
+
+async function activeWebhookTriggerResolver(document: VersionedSchemaDocument) {
+  const publications = new SoulPublicationCoordinator(
+    new InMemorySoulPublicationStore(),
+    new InMemoryBundleStore(),
+    { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+  );
+  const bundle = compileExecutionBundle({
+    businessId: BUSINESS_ID,
+    changesetId: "changeset-1",
+    commitSha: "c0ffee",
+    documents: [document, routine()],
+  });
+  await publications.publish({ bundle: signExecutionBundle(bundle, signer) });
+  await publications.drain("test");
+  return new ActiveWebhookTriggerResolver(publications, signer, BUSINESS_ID);
 }
 
 describe("ActiveRoutineInvocationResolver", () => {
@@ -216,5 +269,81 @@ describe("ActiveTriggerInvocationResolver", () => {
   it("refuses an unknown slug", async () => {
     const resolver = await activeTriggerResolver(trigger());
     await expect(resolver.resolveTrigger("missing")).resolves.toBeNull();
+  });
+});
+
+describe("ActiveWebhookTriggerResolver", () => {
+  it("maps the verified active webhook Trigger to a WebhookTrigger", async () => {
+    const resolver = await activeWebhookTriggerResolver(webhookTrigger());
+
+    await expect(resolver.resolveTrigger("github", "github-push")).resolves.toEqual({
+      triggerSlug: "github-push",
+      businessId: BUSINESS_ID,
+      provider: "github",
+      eventType: "github.push",
+      eventVersion: 1,
+      verification: {
+        method: "hmac_sha256",
+        secretRef: "webhook.github.secret",
+        signatureHeader: "x-hub-signature-256",
+      },
+      backgroundIdentity: { principalKind: "system", principalId: "trigger-runner" },
+    });
+  });
+
+  it("maps optional verification fields when authored", async () => {
+    const resolver = await activeWebhookTriggerResolver(
+      webhookTrigger({
+        verification: {
+          method: "hmac_sha256",
+          secretRef: "webhook.github.secret",
+          signatureHeader: "x-hub-signature-256",
+          signingTemplate: "{timestamp}.{body}",
+          signatureFormat: "sha256={signature}",
+          timestampHeader: "x-hub-timestamp",
+          toleranceMs: 300_000,
+        },
+      })
+    );
+
+    await expect(resolver.resolveTrigger("github", "github-push")).resolves.toMatchObject({
+      verification: {
+        signingTemplate: "{timestamp}.{body}",
+        signatureFormat: "sha256={signature}",
+        timestampHeader: "x-hub-timestamp",
+        toleranceMs: 300_000,
+      },
+    });
+  });
+
+  it("does not consult another source when no bundle is active", async () => {
+    const publications = new SoulPublicationCoordinator(
+      new InMemorySoulPublicationStore(),
+      new InMemoryBundleStore(),
+      { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    );
+    const resolver = new ActiveWebhookTriggerResolver(publications, signer, BUSINESS_ID);
+
+    await expect(resolver.resolveTrigger("github", "github-push")).resolves.toBeNull();
+  });
+
+  it("refuses a draft webhook Trigger even when its bundle was activated", async () => {
+    const resolver = await activeWebhookTriggerResolver(webhookTrigger({ lifecycle: "draft" }));
+    await expect(resolver.resolveTrigger("github", "github-push")).resolves.toBeNull();
+  });
+
+  it("refuses a mismatched provider", async () => {
+    const resolver = await activeWebhookTriggerResolver(webhookTrigger({ provider: "github" }));
+    await expect(resolver.resolveTrigger("stripe", "github-push")).resolves.toBeNull();
+  });
+
+  it("refuses a non-webhook Trigger type", async () => {
+    const resolver = await activeWebhookTriggerResolver(trigger());
+    await expect(resolver.resolveTrigger("github", "start-digest")).resolves.toBeNull();
+  });
+
+  it("refuses an unknown slug", async () => {
+    const resolver = await activeWebhookTriggerResolver(webhookTrigger());
+    await expect(resolver.resolveTrigger("github", "missing")).resolves.toBeNull();
   });
 });

--- a/apps/api/src/runtime/invocation-definitions.ts
+++ b/apps/api/src/runtime/invocation-definitions.ts
@@ -4,6 +4,8 @@ import {
   type RoutineInvocationResolver,
   routineStateDefinitionRef,
   type TriggerKind,
+  type WebhookTrigger,
+  type WebhookVerificationMethod,
 } from "@tulipfarm/run-kernel";
 import { definitions } from "@tulipfarm/schema";
 import type { BundleSigner, SoulPublicationCoordinator } from "@tulipfarm/soul";
@@ -13,6 +15,8 @@ const ROUTINE_DEFINITION_PREFIX = "published:routine:";
 // Widened so `.includes` accepts a raw `string` read off an authored document rather than only a
 // value already known to be a `TriggerType`.
 const TRIGGER_TYPES: readonly string[] = definitions.trigger.TRIGGER_TYPES;
+const WEBHOOK_VERIFICATION_METHODS: readonly string[] =
+  definitions.trigger.WEBHOOK_VERIFICATION_METHODS;
 
 type ActiveBundleReader = Pick<SoulPublicationCoordinator, "activeBundle">;
 
@@ -165,6 +169,96 @@ export class ActiveTriggerInvocationResolver {
         principalId: backgroundIdentity.principalId,
       },
       ...(inputMappings === undefined ? {} : { inputMappings }),
+    };
+  }
+}
+
+/**
+ * Resolves a webhook Trigger only from the verified active Soul bundle, for the same reason as
+ * {@link ActiveTriggerInvocationResolver}. Never populates `filter`: the authored `filter` is a
+ * plain dot-path string, structurally incompatible with `WebhookTrigger`'s `{path, equals}` shape.
+ */
+export class ActiveWebhookTriggerResolver {
+  constructor(
+    private readonly publications: ActiveBundleReader,
+    private readonly signer: BundleSigner,
+    private readonly businessId: string
+  ) {}
+
+  async resolveTrigger(provider: string, triggerSlug: string): Promise<WebhookTrigger | null> {
+    if (provider.length === 0 || triggerSlug.length === 0) return null;
+
+    const bundle = await this.publications.activeBundle(this.businessId, this.signer);
+    const definition = bundle?.get("Trigger", triggerSlug);
+    if (!bundle || !definition) return null;
+
+    const document = definition.document;
+    const metadata = isRecord(document.metadata) ? document.metadata : undefined;
+    const spec = isRecord(document.spec) ? document.spec : undefined;
+    if (metadata?.lifecycle !== "published" || spec?.type !== "webhook") return null;
+
+    if (spec.provider !== provider) return null;
+
+    const eventType = spec.eventType;
+    const eventVersion = spec.eventVersion;
+    if (
+      typeof eventType !== "string" ||
+      eventType.length === 0 ||
+      typeof eventVersion !== "number"
+    ) {
+      return null;
+    }
+
+    const verification = spec.verification;
+    if (
+      !isRecord(verification) ||
+      typeof verification.method !== "string" ||
+      !WEBHOOK_VERIFICATION_METHODS.includes(verification.method) ||
+      typeof verification.secretRef !== "string" ||
+      verification.secretRef.length === 0 ||
+      typeof verification.signatureHeader !== "string" ||
+      verification.signatureHeader.length === 0
+    ) {
+      return null;
+    }
+    const optionalStringField = (value: unknown): string | undefined =>
+      typeof value === "string" && value.length > 0 ? value : undefined;
+    const signingTemplate = optionalStringField(verification.signingTemplate);
+    const signatureFormat = optionalStringField(verification.signatureFormat);
+    const timestampHeader = optionalStringField(verification.timestampHeader);
+    const toleranceMs =
+      typeof verification.toleranceMs === "number" ? verification.toleranceMs : undefined;
+
+    const backgroundIdentity = spec.backgroundIdentity;
+    if (
+      !isRecord(backgroundIdentity) ||
+      typeof backgroundIdentity.principalKind !== "string" ||
+      backgroundIdentity.principalKind.length === 0 ||
+      typeof backgroundIdentity.principalId !== "string" ||
+      backgroundIdentity.principalId.length === 0
+    ) {
+      return null;
+    }
+
+    return {
+      triggerSlug,
+      businessId: this.businessId,
+      provider,
+      eventType,
+      eventVersion,
+      verification: {
+        method: verification.method as WebhookVerificationMethod,
+        secretRef: verification.secretRef,
+        signatureHeader: verification.signatureHeader,
+        ...(signingTemplate === undefined ? {} : { signingTemplate }),
+        ...(signatureFormat === undefined ? {} : { signatureFormat }),
+        ...(timestampHeader === undefined ? {} : { timestampHeader }),
+        ...(toleranceMs === undefined ? {} : { toleranceMs }),
+      },
+      backgroundIdentity: {
+        principalKind: backgroundIdentity.principalKind,
+        principalId: backgroundIdentity.principalId,
+      },
     };
   }
 }

--- a/docs/architecture/aw-program-status.md
+++ b/docs/architecture/aw-program-status.md
@@ -52,7 +52,7 @@ and fails unless a missing option is listed in `DEFERRED_OPTIONS` with the PR th
 | `runEvents` | yes | `/api/v1/runs/:id/events`, and the same reader behind `POST /api/v1/chat` — the worker writes the events as of PR 3 |
 | `internalTurns` | yes | `/api/v1/internal/*` — Context, Tool dispatch, delivery classification, and Turn completion for the Worker (service principals only) |
 | `triggerInvoke` | yes | `POST /api/v1/triggers/:slug/invoke` — resolves `manual`/`internal_api` Triggers from the active signed Soul bundle, persists the canonical event through `EventStore`, and starts the bound Routine through the same `DurableInvocationGateway` Chat and Integration use; the Worker's Routine executor (PR 4) runs it rather than parking it |
-| `hookIngress` | no | same: signed webhook ingress is inert until its Run source has an executor — PR 4 |
+| `hookIngress` | yes | `POST /api/v1/hooks/:provider/:trigger` — resolves published `webhook` Triggers from the active signed Soul bundle by `(provider, slug)`, verifies the delivery signature and stores the raw bytes encrypted (`webhook_raw_payloads`, ahead of any Run), then persists the canonical event through the same `EventStore` `triggerInvoke` uses |
 | `runReplay` | no | replay recompiles the recorded Routine; the run-event stream it reads is only half of what it needs — PR 4 |
 | `routines` / `routineAuthoring` | no | `@tulipfarm/routine-engine` is being retired, not revived — PR 4 |
 | `forms` | no | no form storage; `GovernedFormView` is rendered by no route — PR 6 |
@@ -214,9 +214,9 @@ data is withheld. They fill in when PR 1/3/4 land their writers.
   is served over HTTP by `/api/v1/internal/tools`, which runs the API's existing `ToolRegistry`.
   The port is the contract, so PR 4 can swap the implementation, but the broker's approval and
   reconciliation logic is still uncomposed today.
-- **`triggerInvoke`, `hookIngress`, and `runReplay` are still deferred.** Chat and Integration have
-  executors; Trigger/Routine Runs do not, so composing those opts would mint Runs nothing executes.
-  They move with the Routine work in PR 4.
+- **`runReplay` is still deferred.** Chat and Integration have executors; Trigger/Routine Runs do
+  not, so composing that opt would mint Runs nothing executes. It moves with the Routine work in
+  PR 4. `triggerInvoke` and `hookIngress` are composed (PR #305 and this PR).
 - **NOTIFY is installed but nothing listens.** Migration `17` creates the `run_events` trigger;
   the API has no `LISTEN` connection yet, so streams still wake on the 500ms poll. This was always
   a latency hint, never correctness — the reader re-reads by cursor regardless.

--- a/packages/schema/src/definitions/trigger.test.ts
+++ b/packages/schema/src/definitions/trigger.test.ts
@@ -46,7 +46,12 @@ describe("Trigger schema", () => {
 
   it("accepts a webhook trigger only when signature verification is declared", () => {
     const ok = base("webhook", {
-      verification: { method: "hmac_sha256", secretRef: "webhook.github.secret" },
+      provider: "github",
+      verification: {
+        method: "hmac_sha256",
+        secretRef: "webhook.github.secret",
+        signatureHeader: "x-hub-signature-256",
+      },
     });
     expect(() => validateTriggerDefinition(ok)).not.toThrow();
   });

--- a/packages/schema/src/definitions/trigger.ts
+++ b/packages/schema/src/definitions/trigger.ts
@@ -168,17 +168,23 @@ const specVariants = [
   variant(
     "webhook",
     {
+      provider: nonEmptyString,
       verification: {
         type: "object",
         additionalProperties: false,
-        required: ["method", "secretRef"],
+        required: ["method", "secretRef", "signatureHeader"],
         properties: {
           method: { type: "string", enum: [...WEBHOOK_VERIFICATION_METHODS] },
           secretRef: nonEmptyString,
+          signatureHeader: nonEmptyString,
+          signingTemplate: nonEmptyString,
+          signatureFormat: nonEmptyString,
+          timestampHeader: nonEmptyString,
+          toleranceMs: positiveInteger,
         },
       },
     },
-    ["verification"]
+    ["provider", "verification"]
   ),
   variant(
     "integration_event",


### PR DESCRIPTION
## Summary
- Signed webhook Triggers now resolve from the active signed Soul bundle (`ActiveWebhookTriggerResolver`), verify the delivery signature, and vault the raw bytes encrypted (`PgRawPayloadVault`, migration v22, `webhook_raw_payloads`) ahead of any Run — same pattern as `triggerInvoke` (#305).
- Webhook Trigger schema now requires `provider` and a full `verification` object (`method`, `secretRef`, `signatureHeader`, plus optional `signingTemplate`/`signatureFormat`/`timestampHeader`/`toleranceMs`) so an authored Trigger can actually be dispatched by provider and verified.
- New `webhookSecretPort` adapts `ConnectionSecretStore` to the `WebhookSecretPort` contract `ingestWebhook` expects.
- Wired `hookIngress` into `buildApp` from `index.ts`; removed the `hookIngress` entry from `app.composition.test.ts`'s `DEFERRED_OPTIONS` guard.
- Updated `docs/architecture/aw-program-status.md`: `hookIngress` row flipped to composed, "Deviations from the PR 3 plan" no longer lists `triggerInvoke`/`hookIngress` as deferred (only `runReplay` remains).

## Test plan
- [x] `pnpm lint` — clean (pre-existing warnings elsewhere untouched)
- [x] `pnpm typecheck` — 32/32 packages pass
- [x] `pnpm test` — 188 files / 1766 tests pass, 1 pre-existing skip
- [x] Scoped: `invocation-definitions.test.ts`, `raw-payload-vault.pg.test.ts` (PGlite), `hooks/routes.test.ts`, `app.composition.test.ts` — 30/30 pass