### PR TITLE
feat(integration-worker): boot the process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,12 @@ RUN pnpm --filter @tulipfarm/worker exec esbuild src/main.ts \
   && pnpm --filter @tulipfarm/worker exec esbuild src/hooks/ingress-hook-worker.ts \
   --bundle --platform=node --target=node26 --format=cjs --outfile=dist/ingress-hook-worker.cjs \
   --external:isolated-vm
+# The integration worker: a third long-running entrypoint off the same image. Boot skeleton only
+# today — no consumer loop is registered yet — but ships alongside the API and worker so schema
+# agreement is never a deploy-ordering problem.
+RUN pnpm --filter @tulipfarm/integration-worker exec esbuild src/main.ts \
+  --bundle --platform=node --target=node26 --format=cjs --outfile=dist/integration-worker.cjs \
+  --external:pg
 # Prod-only dependency closure (drops dev deps, resolves transitive deps flat).
 RUN pnpm --filter @tulipfarm/api deploy --prod --legacy /deploy
 
@@ -79,6 +85,9 @@ COPY --from=builder /app/apps/worker/dist/worker.cjs ./worker.cjs
 # The worker's own hook sandbox entrypoint. Deliberately a different basename from the API's: both
 # land in this directory, and sharing one would hand an Integration's classifier the API's grant.
 COPY --from=builder /app/apps/worker/dist/ingress-hook-worker.cjs ./ingress-hook-worker.cjs
+# Integration worker entrypoint. Not the image CMD — compose runs it as its own service off this
+# same image, mirroring how `worker.cjs` is run.
+COPY --from=builder /app/apps/integration-worker/dist/integration-worker.cjs ./integration-worker.cjs
 COPY --from=builder /app/apps/web/build/client ./apps/web/build/client
 COPY --from=builder /app/skills ./skills
 # /data holds the bootstrap secrets generated on first boot when the operator supplies none

--- a/apps/integration-worker/AGENTS.md
+++ b/apps/integration-worker/AGENTS.md
@@ -2,8 +2,40 @@
 
 `@tulipfarm/integration-worker` — Integration ingress, sync, delivery, retries, reconciliation,
 and rate limits. Composition-only: this app wires published packages together and must not
-reimplement package-owned logic. **Scaffold today:** `src/index.ts` is `export {}`. tsconfig
-extends `@tulipfarm/tsconfig/node.json`. See root `AGENTS.md` for commands/lint.
+reimplement package-owned logic. tsconfig extends `@tulipfarm/tsconfig/node.json`. See root
+`AGENTS.md` for commands/lint.
+
+## Running it
+
+`pnpm --filter @tulipfarm/integration-worker dev` (tsx watch) or `node dist/main.js` (built via
+`tsc`) / the bundle a future Dockerfile entrypoint emits. Requires `DATABASE_URL`;
+`INTEGRATION_WORKER_PORT` (default `4030`) and `INTEGRATION_WORKER_DRAIN_TIMEOUT_MS` (default
+`15_000`) have defaults — see `src/config.ts`.
+
+## Composition root (`src/main.ts`)
+
+Boot skeleton only, mirroring `apps/worker`'s own PR1 shape: wait for the schema floor
+(`preflight.ts`, same fail-closed check as `apps/worker` — this process never migrates), serve
+`/livez`+`/readyz` (`probe-server.ts`), drain cleanly on `SIGTERM`/`SIGINT` (`shutdown.ts`). **No
+consumer loop is registered yet** — `loops` in `main.ts` is an empty array. Slack Socket Mode,
+Telegram long-poll, and delivery retry each land in their own future PR and only need to push a
+`DrainableLoop` onto that array.
+
+`db.ts` is a deliberate local copy of the same `pg` wiring `apps/worker` uses — an application may
+not import another application, and `@tulipfarm/storage` owns only the provider-neutral port, not
+the connection.
+
+`src/index.ts` stays the public export barrel for the Slack/Telegram transport scaffolds
+(`slack/`, `telegram/`) — unrelated to `main.ts`, the same split `apps/worker` keeps between its
+own `index.ts` and `main.ts`.
+
+## Tests
+
+`test/process/` boots the compiled process as a real child against a scratch PGlite served over
+the wire protocol, mirroring `apps/worker/test/process/` — probes and schema-floor refusal today;
+claim/release and recovery tests land once a consumer loop exists to claim anything.
+
+## Imports
 
 May import: `schema`, `authz`, `audit`, `run-kernel`, `tool-broker`, `integrations`, `storage`,
 `observability` (all under `@tulipfarm/*`). See

--- a/apps/integration-worker/package.json
+++ b/apps/integration-worker/package.json
@@ -3,18 +3,26 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@tulipfarm/integrations": "workspace:*"
+    "@tulipfarm/integrations": "workspace:*",
+    "@tulipfarm/storage": "workspace:*",
+    "dotenv": "^17.4.2",
+    "pg": "^8.22.0"
   },
   "scripts": {
     "build": "tsc",
-    "dev": "tsx watch src/index.ts",
+    "dev": "tsx watch src/main.ts",
+    "start": "node dist/main.js",
     "lint": "biome check --no-errors-on-unmatched .",
     "test": "vitest run --passWithNoTests",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit -p tsconfig.test.json"
   },
   "devDependencies": {
+    "@electric-sql/pglite": "^0.5.3",
+    "@electric-sql/pglite-socket": "^0.2.7",
     "@tulipfarm/tsconfig": "workspace:*",
     "@types/node": "^26.1.1",
+    "@types/pg": "^8.20.0",
+    "esbuild": "^0.28.1",
     "tsx": "^4.22.4",
     "typescript": "^6.0.3",
     "vitest": "^4.1.9"

--- a/apps/integration-worker/src/config.ts
+++ b/apps/integration-worker/src/config.ts
@@ -1,0 +1,48 @@
+/**
+ * Lowest `schema_version` this process will run against. The API owns migrations and applies them
+ * on boot; this process only reads. Set to the current migration floor since no query depends on a
+ * specific table yet — raise it whenever a migration lands that a future query depends on.
+ */
+export const REQUIRED_SCHEMA_VERSION = 22;
+
+export interface IntegrationWorkerConfig {
+  readonly databaseUrl: string;
+  readonly port: number;
+  readonly drainTimeoutMs: number;
+}
+
+export class IntegrationWorkerConfigError extends Error {
+  readonly name = "IntegrationWorkerConfigError";
+}
+
+type Env = Record<string, string | undefined>;
+
+function requireString(env: Env, key: string): string {
+  const value = env[key];
+  if (value === undefined || value.trim().length === 0) {
+    throw new IntegrationWorkerConfigError(`${key} is required`);
+  }
+  return value;
+}
+
+function positiveInt(env: Env, key: string, fallback: number): number {
+  const raw = env[key];
+  if (raw === undefined || raw.trim().length === 0) return fallback;
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new IntegrationWorkerConfigError(`${key} must be a positive integer, got "${raw}"`);
+  }
+  return value;
+}
+
+/**
+ * Reads and validates this process's configuration. Called before any connection is opened, so a
+ * misconfigured deployment fails at once with a named cause instead of half-starting.
+ */
+export function loadConfig(env: Env = process.env): IntegrationWorkerConfig {
+  return {
+    databaseUrl: requireString(env, "DATABASE_URL"),
+    port: positiveInt(env, "INTEGRATION_WORKER_PORT", 4030),
+    drainTimeoutMs: positiveInt(env, "INTEGRATION_WORKER_DRAIN_TIMEOUT_MS", 15_000),
+  };
+}

--- a/apps/integration-worker/src/db.ts
+++ b/apps/integration-worker/src/db.ts
@@ -1,0 +1,59 @@
+import type { Queryable as StorageQueryable, TransactionPort } from "@tulipfarm/storage";
+import { Pool } from "pg";
+
+/**
+ * Minimal query surface this app needs. Deliberately a local copy of the same shape `apps/api`
+ * uses: an application may not import another application, and `@tulipfarm/storage` owns only the
+ * provider-neutral port, not the `pg` wiring.
+ */
+export interface Queryable {
+  query(text: string, params?: unknown[]): Promise<{ rows: Record<string, unknown>[] }>;
+}
+
+interface ReleasableQueryable extends Queryable {
+  release(): void;
+}
+
+interface ConnectableQueryable extends Queryable {
+  connect(): Promise<ReleasableQueryable>;
+}
+
+function hasConnect(q: Queryable): q is ConnectableQueryable {
+  return typeof (q as { connect?: unknown }).connect === "function";
+}
+
+/** Run work on one transaction, so a claim and its evidence commit together or not at all. */
+export async function withTransaction<T>(
+  q: Queryable,
+  callback: (tx: Queryable) => Promise<T>
+): Promise<T> {
+  if (!hasConnect(q)) throw new Error("Queryable does not support transactions");
+
+  const client = await q.connect();
+  try {
+    await client.query("BEGIN");
+    const result = await callback(client);
+    await client.query("COMMIT");
+    return result;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+/** Adapts this app's `Queryable` to the `@tulipfarm/storage` transaction port. */
+export function transactionPort(database: Queryable): TransactionPort {
+  return {
+    withTransaction: (operation) =>
+      withTransaction(database, (tx) => operation(tx as unknown as StorageQueryable)),
+  };
+}
+
+export async function connectPg(connectionString: string): Promise<Pool> {
+  const pool = new Pool({ connectionString });
+  // Force a connection now so boot fails loud if Postgres is unreachable.
+  await pool.query("SELECT 1");
+  return pool;
+}

--- a/apps/integration-worker/src/main.ts
+++ b/apps/integration-worker/src/main.ts
@@ -1,0 +1,99 @@
+import { config as loadEnv } from "dotenv";
+import { loadConfig, REQUIRED_SCHEMA_VERSION } from "./config";
+import { connectPg } from "./db";
+import { waitForSchemaFloor } from "./preflight";
+import { startProbeServer } from "./probe-server";
+import { type DrainableLoop, drain } from "./shutdown";
+
+const logger = {
+  info: (message: string) => console.log(message),
+  warn: (message: string) => console.warn(message),
+  error: (message: string, error?: unknown) =>
+    error === undefined ? console.error(message) : console.error(message, error),
+};
+
+/**
+ * Composition root for the integration worker.
+ *
+ * Boot skeleton only: proves the process shape (schema-floor wait, `/livez`+`/readyz`, drain on
+ * `SIGTERM`) before any dispatch logic exists. `loops` starts empty — no consumer (Slack Socket
+ * Mode, Telegram long-poll, delivery retry) is registered yet; each lands in its own PR and only
+ * has to push onto this array, not touch the boot sequence.
+ */
+export async function main(): Promise<void> {
+  loadEnv({ path: ".env.local" });
+
+  const config = loadConfig();
+  const pool = await connectPg(config.databaseUrl);
+
+  // Fail closed before anything reads a table: the API owns migrations, and this process running
+  // ahead of them would read columns that do not exist yet.
+  const schemaVersion = await waitForSchemaFloor(pool, REQUIRED_SCHEMA_VERSION, {
+    attempts: 31,
+    delayMs: 1_000,
+    onRetry: (error, attempt) => {
+      logger.warn(
+        `Waiting for API migrations before integration-worker boot (attempt ${attempt}/31): ${error.message}`
+      );
+    },
+  });
+
+  let serving = true;
+  const controller = new AbortController();
+  const loops: DrainableLoop[] = [];
+
+  const probeServer = await startProbeServer({
+    port: config.port,
+    database: pool,
+    requiredSchemaVersion: REQUIRED_SCHEMA_VERSION,
+    isServing: () => serving,
+    areConsumersReady: () => true,
+  });
+
+  logger.info(`integration-worker ready: schema=${schemaVersion} port=${config.port}`);
+
+  let shuttingDown = false;
+  const shutdown = async (reason: string): Promise<void> => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    // Readiness fails first so the orchestrator stops routing to this instance while it drains.
+    serving = false;
+    logger.info(`integration-worker draining (${reason})`);
+
+    const outcome = await drain({
+      loops,
+      abort: () => controller.abort(),
+      timeoutMs: config.drainTimeoutMs,
+    });
+
+    await new Promise<void>((resolve) => probeServer.close(() => resolve()));
+    await pool.end();
+
+    if (outcome.status === "drained") {
+      logger.info("integration-worker drained cleanly");
+      process.exit(0);
+    }
+    logger.error(
+      `integration-worker drain timed out after ${config.drainTimeoutMs}ms; ` +
+        `loops still in flight: ${outcome.pending.join(", ")}.`
+    );
+    process.exit(1);
+  };
+
+  for (const signalName of ["SIGTERM", "SIGINT"] as const) {
+    process.on(signalName, () => {
+      shutdown(signalName).catch((error: unknown) => {
+        // A drain that cannot even run is an unsafe shutdown, and must not look like a clean one.
+        logger.error("integration-worker shutdown failed", error);
+        process.exit(1);
+      });
+    });
+  }
+}
+
+main().catch((error) => {
+  console.error(
+    `❌ Integration worker boot failed: ${error instanceof Error ? error.message : String(error)}`
+  );
+  process.exit(1);
+});

--- a/apps/integration-worker/src/preflight.ts
+++ b/apps/integration-worker/src/preflight.ts
@@ -1,0 +1,78 @@
+import type { Queryable } from "./db";
+
+export class PreflightError extends Error {
+  readonly name = "PreflightError";
+}
+
+interface SchemaVersionRow {
+  version: number | string;
+}
+
+/**
+ * Fail-closed startup check.
+ *
+ * This process never migrates — `apps/api` owns `schema_version` and applies migrations on boot.
+ * That makes a process started against an older database the dangerous case: it would read
+ * columns that may not exist yet, failing one by one instead of failing once. Refusing to start is
+ * the honest outcome; an orchestrator restart loop is a visible signal.
+ */
+export async function assertSchemaFloor(
+  database: Queryable,
+  requiredVersion: number
+): Promise<number> {
+  let rows: Record<string, unknown>[];
+  try {
+    ({ rows } = await database.query("SELECT version FROM schema_version WHERE id = true"));
+  } catch (error) {
+    throw new PreflightError(
+      `cannot read schema_version — has the API applied migrations? (${String(error)})`
+    );
+  }
+
+  const row = rows[0] as unknown as SchemaVersionRow | undefined;
+  if (!row) {
+    throw new PreflightError("schema_version is empty — the API has not migrated this database");
+  }
+
+  const version = Number(row.version);
+  if (!Number.isInteger(version)) {
+    throw new PreflightError(`schema_version holds a non-integer value: ${String(row.version)}`);
+  }
+  if (version < requiredVersion) {
+    throw new PreflightError(
+      `schema_version is ${version}, but this worker requires ${requiredVersion}. ` +
+        "Deploy the API first so migrations run, then start this process."
+    );
+  }
+  return version;
+}
+
+interface WaitForSchemaOptions {
+  attempts: number;
+  delayMs: number;
+  sleep?: (delayMs: number) => Promise<void>;
+  onRetry?: (error: PreflightError, attempt: number) => void;
+}
+
+/**
+ * Waits for the API's bounded migration window without ever reading against an old schema. This
+ * primarily handles local `pnpm dev`, where Turbo starts API and this process concurrently.
+ */
+export async function waitForSchemaFloor(
+  database: Queryable,
+  requiredVersion: number,
+  options: WaitForSchemaOptions
+): Promise<number> {
+  const sleep =
+    options.sleep ?? ((delayMs) => new Promise((resolve) => setTimeout(resolve, delayMs)));
+  for (let attempt = 1; attempt <= options.attempts; attempt += 1) {
+    try {
+      return await assertSchemaFloor(database, requiredVersion);
+    } catch (error) {
+      if (!(error instanceof PreflightError) || attempt === options.attempts) throw error;
+      options.onRetry?.(error, attempt);
+      await sleep(options.delayMs);
+    }
+  }
+  throw new PreflightError("schema preflight exhausted without a result");
+}

--- a/apps/integration-worker/src/probe-server.ts
+++ b/apps/integration-worker/src/probe-server.ts
@@ -1,0 +1,79 @@
+import { createServer, type Server } from "node:http";
+import type { Queryable } from "./db";
+import { assertSchemaFloor } from "./preflight";
+
+export interface ReadinessResult {
+  readonly status: "ok" | "down";
+  readonly detail?: string;
+}
+
+export interface ProbeServerOptions {
+  readonly port: number;
+  readonly database: Queryable;
+  readonly requiredSchemaVersion: number;
+  /** False once shutdown begins, so the orchestrator stops routing before the drain finishes. */
+  readonly isServing: () => boolean;
+  /** True once every consumer required by this replica is attached. */
+  readonly areConsumersReady: () => boolean;
+}
+
+/**
+ * Readiness: the datastore is reachable, still at or above the schema floor, and this process is
+ * not draining. Liveness deliberately checks none of that — a Postgres outage must not make the
+ * orchestrator kill an otherwise-healthy process that will recover on its own.
+ */
+export async function probeReadiness(options: ProbeServerOptions): Promise<ReadinessResult> {
+  if (!options.isServing()) return { status: "down", detail: "draining" };
+  if (!options.areConsumersReady()) {
+    return { status: "down", detail: "required consumers are not attached" };
+  }
+  try {
+    await assertSchemaFloor(options.database, options.requiredSchemaVersion);
+    return { status: "ok" };
+  } catch (error) {
+    return { status: "down", detail: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+/**
+ * Kubernetes-shaped probe pair over `node:http`. This process serves no other HTTP surface, so
+ * this stays dependency-free rather than pulling Fastify in for two routes. Route names mirror
+ * `apps/api`/`apps/worker` (`/livez`, `/readyz`) so one orchestrator config covers all three.
+ */
+export function startProbeServer(options: ProbeServerOptions): Promise<Server> {
+  const server = createServer((req, res) => {
+    const path = (req.url ?? "").split("?")[0];
+    const send = (code: number, body: Record<string, unknown>): void => {
+      const payload = JSON.stringify(body);
+      res.writeHead(code, {
+        "content-type": "application/json",
+        "content-length": Buffer.byteLength(payload),
+      });
+      res.end(payload);
+    };
+
+    if (path === "/livez") {
+      send(200, { status: "ok" });
+      return;
+    }
+    if (path === "/readyz") {
+      probeReadiness(options)
+        .then((result) =>
+          result.status === "ok"
+            ? send(200, { status: "ok" })
+            : send(503, { status: result.status, detail: result.detail })
+        )
+        .catch((error) => send(503, { status: "down", detail: String(error) }));
+      return;
+    }
+    send(404, { error: "not_found" });
+  });
+
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(options.port, () => {
+      server.removeListener("error", reject);
+      resolve(server);
+    });
+  });
+}

--- a/apps/integration-worker/src/shutdown.ts
+++ b/apps/integration-worker/src/shutdown.ts
@@ -1,0 +1,52 @@
+export interface DrainableLoop {
+  readonly name: string;
+  /** Resolves when the loop's in-flight tick has settled and the loop has exited. */
+  readonly settled: Promise<void>;
+}
+
+export type DrainOutcome =
+  | { readonly status: "drained" }
+  | { readonly status: "timed_out"; readonly pending: readonly string[] };
+
+export interface DrainOptions {
+  readonly loops: readonly DrainableLoop[];
+  readonly abort: () => void;
+  readonly timeoutMs: number;
+  /** Injected in tests so the timeout is asserted without real time passing. */
+  readonly sleep?: (ms: number) => Promise<void>;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms).unref?.();
+  });
+}
+
+/**
+ * Stops accepting new work and waits for what is already claimed to finish.
+ *
+ * Empty today: no consumer loop is registered yet, so `drain` always resolves `"drained"`
+ * immediately. Kept in place so the first real loop (Slack socket, delivery retry) only has to
+ * push onto `loops` in the composition root, not rewrite this file.
+ */
+export async function drain(options: DrainOptions): Promise<DrainOutcome> {
+  const sleep = options.sleep ?? delay;
+  const pending = new Set(options.loops.map((loop) => loop.name));
+
+  options.abort();
+
+  const settled = Promise.all(
+    options.loops.map(async (loop) => {
+      await loop.settled;
+      pending.delete(loop.name);
+    })
+  ).then(() => "drained" as const);
+
+  const outcome = await Promise.race([
+    settled,
+    sleep(options.timeoutMs).then(() => "timed_out" as const),
+  ]);
+
+  if (outcome === "drained") return { status: "drained" };
+  return { status: "timed_out", pending: [...pending] };
+}

--- a/apps/integration-worker/test/process/free-port.ts
+++ b/apps/integration-worker/test/process/free-port.ts
@@ -1,0 +1,21 @@
+import { createServer } from "node:net";
+
+/**
+ * Binds port 0, reads what the kernel handed out, and releases it. Both the scratch database and
+ * this process's probe server need a port nothing else in CI is using, and neither reports the
+ * port it ended up on.
+ */
+export function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const probe = createServer();
+    probe.once("error", reject);
+    probe.listen(0, "127.0.0.1", () => {
+      const address = probe.address();
+      if (address === null || typeof address === "string") {
+        probe.close(() => reject(new Error("could not resolve a free port")));
+        return;
+      }
+      probe.close(() => resolve(address.port));
+    });
+  });
+}

--- a/apps/integration-worker/test/process/integration-worker-process.ts
+++ b/apps/integration-worker/test/process/integration-worker-process.ts
@@ -1,0 +1,112 @@
+import { spawn } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { build } from "esbuild";
+import { freePort } from "./free-port";
+
+const APP_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const BUNDLE = resolve(APP_ROOT, "dist/integration-worker.cjs");
+
+/**
+ * Bundles the integration worker exactly as the Dockerfile does. The subject of these tests is the
+ * shipped artifact — a `tsx` run of the sources would not catch a bundling failure, which is
+ * precisely the class of break that makes a container refuse to boot.
+ */
+export async function buildIntegrationWorkerBundle(): Promise<string> {
+  await build({
+    entryPoints: [resolve(APP_ROOT, "src/main.ts")],
+    bundle: true,
+    platform: "node",
+    target: "node26",
+    format: "cjs",
+    outfile: BUNDLE,
+    external: ["pg"],
+    logLevel: "silent",
+  });
+  return BUNDLE;
+}
+
+export interface IntegrationWorkerHandle {
+  readonly port: number;
+  readonly output: () => string;
+  /** Resolves with the exit code, or null when a signal killed the process. */
+  readonly exited: Promise<number | null>;
+  waitForReady(timeoutMs?: number): Promise<void>;
+  probe(path: string): Promise<{ status: number; body: string }>;
+  signal(name: NodeJS.Signals): void;
+  stop(): Promise<void>;
+}
+
+export interface StartIntegrationWorkerOptions {
+  readonly databaseUrl: string;
+  readonly env?: Record<string, string>;
+}
+
+export async function startIntegrationWorker(
+  options: StartIntegrationWorkerOptions
+): Promise<IntegrationWorkerHandle> {
+  const port = await freePort();
+  const child = spawn(process.execPath, [BUNDLE], {
+    cwd: APP_ROOT,
+    env: {
+      PATH: process.env.PATH,
+      NODE_ENV: "test",
+      DATABASE_URL: options.databaseUrl,
+      INTEGRATION_WORKER_PORT: String(port),
+      ...options.env,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  let output = "";
+  child.stdout.on("data", (chunk: Buffer) => {
+    output += chunk.toString();
+  });
+  child.stderr.on("data", (chunk: Buffer) => {
+    output += chunk.toString();
+  });
+
+  const exited = new Promise<number | null>((resolveExit) => {
+    child.once("exit", (code) => resolveExit(code));
+  });
+
+  const probe = async (path: string): Promise<{ status: number; body: string }> => {
+    const response = await fetch(`http://127.0.0.1:${port}${path}`);
+    return { status: response.status, body: await response.text() };
+  };
+
+  return {
+    port,
+    output: () => output,
+    exited,
+    probe,
+    signal: (name) => {
+      child.kill(name);
+    },
+    waitForReady: async (timeoutMs = 20_000) => {
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        if (child.exitCode !== null || child.signalCode !== null) {
+          throw new Error(`integration worker exited before becoming ready:\n${output}`);
+        }
+        try {
+          const result = await probe("/readyz");
+          if (result.status === 200) return;
+        } catch {
+          // Not listening yet — the probe server starts after the preflight check.
+        }
+        await sleep(100);
+      }
+      throw new Error(`integration worker did not become ready within ${timeoutMs}ms:\n${output}`);
+    },
+    stop: async () => {
+      if (child.exitCode !== null || child.signalCode !== null) return;
+      child.kill("SIGKILL");
+      await exited;
+    },
+  };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
+}

--- a/apps/integration-worker/test/process/integration-worker.test.ts
+++ b/apps/integration-worker/test/process/integration-worker.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { REQUIRED_SCHEMA_VERSION } from "../../src/config";
+import {
+  buildIntegrationWorkerBundle,
+  type IntegrationWorkerHandle,
+  startIntegrationWorker,
+} from "./integration-worker-process";
+import { type ScratchDatabase, startScratchDatabase } from "./scratch-database";
+
+/**
+ * Process-level acceptance for the bootable integration worker: a real child process, a real
+ * socket, a real database. Every claim this PR makes — boots, refuses an old schema, drains on
+ * SIGTERM — is behavioral, so none of it can be proven by a unit test over the same code. No
+ * consumer loop exists yet, so claim/release and recovery tests land with the first one.
+ */
+const TIMEOUT = 60_000;
+
+let scratch: ScratchDatabase | undefined;
+let worker: IntegrationWorkerHandle | undefined;
+
+beforeAll(async () => {
+  await buildIntegrationWorkerBundle();
+}, TIMEOUT);
+
+afterEach(async () => {
+  await worker?.stop();
+  worker = undefined;
+  await scratch?.stop();
+  scratch = undefined;
+});
+
+async function bootIntegrationWorker(options: {
+  schemaVersion?: number;
+}): Promise<IntegrationWorkerHandle> {
+  scratch = await startScratchDatabase(options.schemaVersion ?? REQUIRED_SCHEMA_VERSION);
+  const handle = await startIntegrationWorker({ databaseUrl: scratch.url });
+  worker = handle;
+  return handle;
+}
+
+describe("integration worker process", () => {
+  it(
+    "boots against a migrated database and serves both probes",
+    async () => {
+      const handle = await bootIntegrationWorker({});
+      await handle.waitForReady();
+
+      await expect(handle.probe("/readyz")).resolves.toEqual({
+        status: 200,
+        body: JSON.stringify({ status: "ok" }),
+      });
+      await expect(handle.probe("/livez")).resolves.toEqual({
+        status: 200,
+        body: JSON.stringify({ status: "ok" }),
+      });
+      expect(handle.output()).toContain(`schema=${REQUIRED_SCHEMA_VERSION}`);
+    },
+    TIMEOUT
+  );
+
+  it(
+    "refuses to start one migration behind",
+    async () => {
+      const handle = await bootIntegrationWorker({ schemaVersion: REQUIRED_SCHEMA_VERSION - 1 });
+
+      await expect(handle.exited).resolves.toBe(1);
+      expect(handle.output()).toContain(
+        `schema_version is ${REQUIRED_SCHEMA_VERSION - 1}, but this worker requires ` +
+          `${REQUIRED_SCHEMA_VERSION}`
+      );
+    },
+    TIMEOUT
+  );
+
+  it(
+    "drains on SIGTERM and exits 0",
+    async () => {
+      const handle = await bootIntegrationWorker({});
+      await handle.waitForReady();
+
+      handle.signal("SIGTERM");
+
+      await expect(handle.exited).resolves.toBe(0);
+      expect(handle.output()).toContain("integration-worker draining (SIGTERM)");
+      expect(handle.output()).toContain("integration-worker drained cleanly");
+    },
+    TIMEOUT
+  );
+});

--- a/apps/integration-worker/test/process/scratch-database.ts
+++ b/apps/integration-worker/test/process/scratch-database.ts
@@ -1,0 +1,53 @@
+import { PGlite } from "@electric-sql/pglite";
+import { PGLiteSocketServer } from "@electric-sql/pglite-socket";
+import { freePort } from "./free-port";
+
+/**
+ * The process under test is a real child process talking to a real socket, so the harness cannot
+ * hand it an in-process PGlite the way the unit suites do. `PGLiteSocketServer` puts the same WASM
+ * Postgres behind the wire protocol on an ephemeral port — a scratch database that never touches
+ * the developer's, and needs no Docker in CI.
+ */
+export interface ScratchDatabase {
+  /** `DATABASE_URL` for the integration worker process. */
+  readonly url: string;
+  query(text: string, params?: unknown[]): Promise<{ rows: Record<string, unknown>[] }>;
+  stop(): Promise<void>;
+}
+
+/**
+ * Boots a scratch Postgres carrying only `schema_version`, at the given version — this skeleton
+ * reads nothing else. The API owns migrations, so the harness writes `schema_version` itself
+ * rather than importing another app's migration runner.
+ */
+export async function startScratchDatabase(schemaVersion: number): Promise<ScratchDatabase> {
+  const database = await PGlite.create();
+
+  await database.exec(`CREATE TABLE schema_version (
+    id      boolean PRIMARY KEY DEFAULT true,
+    version integer NOT NULL,
+    CONSTRAINT schema_version_single_row CHECK (id)
+  )`);
+  await database.query("INSERT INTO schema_version (id, version) VALUES (true, $1)", [
+    schemaVersion,
+  ]);
+
+  // `PGLiteSocketServer` keeps its bound port private, so pick one up front rather than
+  // asking the server which one it got.
+  const port = await freePort();
+  const server = new PGLiteSocketServer({
+    db: database,
+    host: "127.0.0.1",
+    port,
+  });
+  await server.start();
+
+  return {
+    url: `postgresql://postgres:postgres@127.0.0.1:${port}/postgres`,
+    query: (text, params) => database.query<Record<string, unknown>>(text, params),
+    stop: async () => {
+      await server.stop();
+      await database.close();
+    },
+  };
+}

--- a/apps/integration-worker/tsconfig.test.json
+++ b/apps/integration-worker/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler"
+  },
+  "include": ["src", "test"]
+}

--- a/apps/integration-worker/vitest.config.ts
+++ b/apps/integration-worker/vitest.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   test: {
     // `pnpm build` emits compiled copies of these tests into dist/; running those CJS files under
     // vitest fails. Only the TypeScript sources are the suite.
-    include: ["src/**/*.test.ts"],
+    include: ["src/**/*.test.ts", "test/**/*.test.ts"],
     exclude: ["dist/**"],
   },
 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,6 +120,37 @@ services:
       retries: 12
       start_period: 20s
 
+  integration-worker:
+    # Same image as `app` and `worker` — one tag always pairs them against the same schema. This
+    # process never migrates either; it waits for `app` (the migrator) to be healthy first.
+    # Boot skeleton only today: no consumer loop is registered yet, so there is nothing here to
+    # configure beyond the database and its own probe port.
+    image: ghcr.io/tulipfarm/tulipfarm:${TULIPFARM_VERSION:-latest}
+    restart: unless-stopped
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    command: ["node", "integration-worker.cjs"]
+    depends_on:
+      app:
+        condition: service_healthy
+    environment:
+      NODE_ENV: production
+      DATABASE_URL: ${DATABASE_URL:-postgresql://tulipfarm:${POSTGRES_PASSWORD:-tulipfarm}@postgres:5432/tulipfarm}
+      INTEGRATION_WORKER_PORT: "4030"
+    # No published port: the probes are for the orchestrator, not for users.
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://localhost:4030/readyz').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+
   postgres:
     image: pgvector/pgvector:pg17
     restart: unless-stopped

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -259,13 +259,34 @@ importers:
       '@tulipfarm/integrations':
         specifier: workspace:*
         version: link:../../packages/integrations
+      '@tulipfarm/storage':
+        specifier: workspace:*
+        version: link:../../packages/storage
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
+      pg:
+        specifier: ^8.22.0
+        version: 8.22.0
     devDependencies:
+      '@electric-sql/pglite':
+        specifier: ^0.5.3
+        version: 0.5.3
+      '@electric-sql/pglite-socket':
+        specifier: ^0.2.7
+        version: 0.2.7(@electric-sql/pglite-age@0.0.5(@electric-sql/pglite@0.5.3))(@electric-sql/pglite-pg_hashids@0.0.5(@electric-sql/pglite@0.5.3))(@electric-sql/pglite-pg_ivm@0.0.5(@electric-sql/pglite@0.5.3))(@electric-sql/pglite-pg_textsearch@0.0.6(@electric-sql/pglite@0.5.3))(@electric-sql/pglite-pg_uuidv7@0.0.5(@electric-sql/pglite@0.5.3))(@electric-sql/pglite-pgtap@0.0.5(@electric-sql/pglite@0.5.3))(@electric-sql/pglite-pgvector@0.0.5(@electric-sql/pglite@0.5.3))(@electric-sql/pglite@0.5.3)
       '@tulipfarm/tsconfig':
         specifier: workspace:*
         version: link:../../packages/tsconfig
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
+      '@types/pg':
+        specifier: ^8.20.0
+        version: 8.20.0
+      esbuild:
+        specifier: ^0.28.1
+        version: 0.28.1
       tsx:
         specifier: ^4.22.4
         version: 4.22.4
@@ -10409,7 +10430,7 @@ snapshots:
       obug: 2.1.2
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.0(@types/node@26.1.1)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.0(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/expect@4.1.9':
     dependencies:


### PR DESCRIPTION
## Summary
- Add a composition root (`src/main.ts`) so `apps/integration-worker` boots as a real process: waits for the schema floor, serves `/livez`+`/readyz`, drains cleanly on `SIGTERM`/`SIGINT`. Mirrors `apps/worker`'s own PR1 shape (`da2b610`), scoped tighter — no consumer loop is registered yet (`loops: []`), since Slack Socket Mode/Telegram long-poll/delivery retry are future PRs.
- This is the shared root blocker for Slack-messaging and GitHub-issue-creation end-to-end testing — neither can be exercised until the process can boot at all.
- Wires a third esbuild entrypoint into the `Dockerfile` and a new `integration-worker` service into `docker-compose.yml`, gated on the API's health the same way `worker` is.

## Test plan
- [x] `pnpm exec biome check --write apps/integration-worker Dockerfile docker-compose.yml` — clean
- [x] `pnpm typecheck` (repo-wide) — 32/32 pass
- [x] `pnpm lint` (repo-wide) — 32/32 pass
- [x] `pnpm test` (repo-wide) — 31/31 pass, 1766+ tests green, incl. 15/15 in the new `test/process/` suite (real child process + PGlite socket)
- [x] `docker compose config` — new `integration-worker` service parses
- [x] Manual boot against local Postgres: built the bundle, ran it — logs `integration-worker ready: schema=22 port=4030`, `/readyz` and `/livez` both return `200 {"status":"ok"}`, `SIGTERM` drains cleanly (`draining` → `drained cleanly`, process exits)