### PR TITLE
feat(security): fix high and medium severity findings from security audit

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -278,11 +278,21 @@ export async function buildApp(opts: AppOptions = {}) {
   await app.register(cookie);
 
   // Relax CSP for the Scalar UI page so it can load its scripts and styles.
+  // Scoped to known CDN origins — never wildcard — so an XSS in Scalar cannot
+  // load arbitrary external scripts (SEC-AUDIT H-1).
   app.addHook("onSend", async (req, reply) => {
     if (req.url.startsWith("/docs")) {
       reply.header(
         "content-security-policy",
-        "default-src * 'unsafe-inline' 'unsafe-eval' data: blob:"
+        [
+          "default-src 'self'",
+          "script-src 'self' https://cdn.jsdelivr.net 'unsafe-inline'",
+          "style-src 'self' https://cdn.jsdelivr.net 'unsafe-inline'",
+          "img-src 'self' data: https://cdn.jsdelivr.net",
+          "font-src 'self' data: https://cdn.jsdelivr.net",
+          "connect-src 'self'",
+          "frame-ancestors 'none'",
+        ].join("; ")
       );
     } else if (serveSpa && !isAppApiPath(req.url)) {
       // helmet's API-grade `default-src 'none'` would render the SPA blank. Relax CSP

--- a/apps/api/src/auth/passwords.test.ts
+++ b/apps/api/src/auth/passwords.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { hashPassword, verifyPassword } from "./passwords";
+import {
+  hashPassword,
+  MAX_PASSWORD_LENGTH,
+  MIN_PASSWORD_LENGTH,
+  validatePassword,
+  verifyPassword,
+} from "./passwords";
 
 describe("passwords", () => {
   it("hashes to an argon2id string distinct from the plaintext", async () => {
@@ -20,5 +26,31 @@ describe("passwords", () => {
 
   it("returns false for a malformed hash instead of throwing", async () => {
     expect(await verifyPassword("not-a-hash", "anything")).toBe(false);
+  });
+});
+
+describe("validatePassword", () => {
+  it("accepts a password meeting min length", () => {
+    expect(validatePassword("a".repeat(MIN_PASSWORD_LENGTH))).toBeNull();
+  });
+
+  it("accepts a password at max length", () => {
+    expect(validatePassword("a".repeat(MAX_PASSWORD_LENGTH))).toBeNull();
+  });
+
+  it("rejects a password shorter than min length", () => {
+    const err = validatePassword("short");
+    expect(err).not.toBeNull();
+    expect(err?.message).toMatch(/at least/);
+  });
+
+  it("rejects a password longer than max length", () => {
+    const err = validatePassword("a".repeat(MAX_PASSWORD_LENGTH + 1));
+    expect(err).not.toBeNull();
+    expect(err?.message).toMatch(/at most/);
+  });
+
+  it("rejects an empty password", () => {
+    expect(validatePassword("")).not.toBeNull();
   });
 });

--- a/apps/api/src/auth/passwords.ts
+++ b/apps/api/src/auth/passwords.ts
@@ -3,6 +3,34 @@ import { hash, verify } from "@node-rs/argon2";
 // Argon2id is the @node-rs/argon2 default algorithm. Hash output is self-describing
 // (encoded params), so verify needs only the stored hash + candidate password.
 
+export const MIN_PASSWORD_LENGTH = 8;
+/**
+ * Cap input length before feeding it to Argon2. A multi-megabyte password is
+ * cryptographically pointless (entropy saturates well below 128 chars) and
+ * would let a single request tie up a CPU core for seconds (SEC-AUDIT M-4).
+ */
+export const MAX_PASSWORD_LENGTH = 128;
+
+export interface PasswordValidationError {
+  message: string;
+}
+
+/**
+ * Validate a candidate password against the policy:
+ *   - length between {@link MIN_PASSWORD_LENGTH} and {@link MAX_PASSWORD_LENGTH}
+ *
+ * Returns `null` on success or a `PasswordValidationError` on failure.
+ */
+export function validatePassword(password: string): PasswordValidationError | null {
+  if (password.length < MIN_PASSWORD_LENGTH) {
+    return { message: `password must be at least ${MIN_PASSWORD_LENGTH} characters` };
+  }
+  if (password.length > MAX_PASSWORD_LENGTH) {
+    return { message: `password must be at most ${MAX_PASSWORD_LENGTH} characters` };
+  }
+  return null;
+}
+
 export function hashPassword(password: string): Promise<string> {
   return hash(password);
 }

--- a/apps/api/src/auth/routes/session.ts
+++ b/apps/api/src/auth/routes/session.ts
@@ -2,7 +2,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { sessionCookieOptions } from "../cookie-security";
 import { CSRF_COOKIE, setCsrfCookie } from "../csrf";
 import { SESSION_COOKIE } from "../middleware";
-import { hashPassword, verifyPassword } from "../passwords";
+import { hashPassword, MAX_PASSWORD_LENGTH, verifyPassword } from "../passwords";
 import { ErrorSchema, PublicUserSchema } from "../schemas";
 import { DEFAULT_SESSION_TTL_SECONDS, rotateSession, type SessionStore } from "../session-store";
 import { toPublicUser, type UserRepo } from "../users";
@@ -44,7 +44,7 @@ export function registerSessionRoutes(
           required: ["email", "password"],
           properties: {
             email: { type: "string", format: "email" },
-            password: { type: "string" },
+            password: { type: "string", maxLength: MAX_PASSWORD_LENGTH },
           },
         },
         response: {

--- a/apps/api/src/setup/routes.ts
+++ b/apps/api/src/setup/routes.ts
@@ -7,6 +7,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { sessionCookieOptions } from "../auth/cookie-security";
 import { setCsrfCookie } from "../auth/csrf";
 import { SESSION_COOKIE } from "../auth/middleware";
+import { MAX_PASSWORD_LENGTH, MIN_PASSWORD_LENGTH, validatePassword } from "../auth/passwords";
 import { ErrorSchema, PublicUserSchema } from "../auth/schemas";
 import { DEFAULT_SESSION_TTL_SECONDS, type SessionStore } from "../auth/session-store";
 import { AdminAlreadyExistsError, createUser, toPublicUser, type UserRepo } from "../auth/users";
@@ -150,7 +151,11 @@ export function registerSetupRoutes(app: FastifyInstance, deps: SetupDeps): void
           required: ["email", "password"],
           properties: {
             email: { type: "string", format: "email" },
-            password: { type: "string", minLength: 8 },
+            password: {
+              type: "string",
+              minLength: MIN_PASSWORD_LENGTH,
+              maxLength: MAX_PASSWORD_LENGTH,
+            },
           },
         },
         response: {
@@ -164,10 +169,12 @@ export function registerSetupRoutes(app: FastifyInstance, deps: SetupDeps): void
       const body = (req.body ?? {}) as { email?: unknown; password?: unknown };
       const email = typeof body.email === "string" ? body.email : "";
       const password = typeof body.password === "string" ? body.password : "";
-      if (!email || password.length < 8) {
-        return reply
-          .code(400)
-          .send({ error: "email and a password of at least 8 characters are required" });
+      if (!email) {
+        return reply.code(400).send({ error: "email is required" });
+      }
+      const pwErr = validatePassword(password);
+      if (pwErr) {
+        return reply.code(400).send({ error: pwErr.message });
       }
       // requireSetupOpen's count() check is a fast-path only — it cannot prevent two
       // concurrent requests both observing zero users. The database's single-admin

--- a/apps/web/app/routes/login.tsx
+++ b/apps/web/app/routes/login.tsx
@@ -26,7 +26,9 @@ export default function Login() {
     try {
       await login(email.trim(), password);
       const to = params.get("redirectTo") ?? "/";
-      navigate(to.startsWith("/") ? to : "/", { replace: true });
+      // Block protocol-relative (//evil.com) and backslash-relative (/\evil.com) open redirects.
+      const safe = to.startsWith("/") && !to.startsWith("//") && !to.startsWith("/\\");
+      navigate(safe ? to : "/", { replace: true });
     } catch (err) {
       setError(
         err instanceof ApiError ? err.message : "could not reach the API — is it running on :4010?"

--- a/packages/agent-runtime/src/guardrails/index.ts
+++ b/packages/agent-runtime/src/guardrails/index.ts
@@ -3,6 +3,6 @@ export { makeContentFilterGuard } from "./guards/content-filter";
 export { makePromptInjectionGuard } from "./guards/prompt-injection";
 export type { ToolCallInput } from "./guards/tool-blocklist";
 export { makeToolBlocklistGuard } from "./guards/tool-blocklist";
-export type { Guard, GuardContext, StageResult, Verdict } from "./pipeline";
+export type { FailMode, Guard, GuardContext, StageResult, Verdict } from "./pipeline";
 export { GUARD_TIMEOUT_MS, runStage } from "./pipeline";
 export { GuardrailsService } from "./service";

--- a/packages/agent-runtime/src/guardrails/pipeline.test.ts
+++ b/packages/agent-runtime/src/guardrails/pipeline.test.ts
@@ -110,4 +110,47 @@ describe("runStage", () => {
     expect(result).toEqual({ blocked: false, value: "x" });
     expect(log.warn).toHaveBeenCalledTimes(1);
   });
+
+  it("blocks when a failMode:'closed' guard times out", async () => {
+    vi.useFakeTimers();
+    const log = makeLog();
+    const hang: Guard<string> = {
+      name: "critical",
+      failMode: "closed",
+      run: () => new Promise<Verdict<string>>(() => undefined),
+    };
+    const promise = runStage<string>([hang, passGuard("after")], "x", ctx, log);
+    await vi.advanceTimersByTimeAsync(GUARD_TIMEOUT_MS);
+    const result = await promise;
+    expect(result).toEqual({ blocked: true, guard: "critical", reason: "guard_timeout" });
+    expect(log.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks when a failMode:'closed' guard throws", async () => {
+    const log = makeLog();
+    const boom: Guard<string> = {
+      name: "critical",
+      failMode: "closed",
+      run: () => {
+        throw new Error("kaboom");
+      },
+    };
+    const result = await runStage<string>([boom, passGuard("after")], "x", ctx, log);
+    expect(result).toEqual({ blocked: true, guard: "critical", reason: "guard_error" });
+    expect(log.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips a guard with failMode:'open' on timeout (default behavior)", async () => {
+    vi.useFakeTimers();
+    const log = makeLog();
+    const hang: Guard<string> = {
+      name: "lenient",
+      failMode: "open",
+      run: () => new Promise<Verdict<string>>(() => undefined),
+    };
+    const promise = runStage<string>([hang, passGuard("after")], "x", ctx, log);
+    await vi.advanceTimersByTimeAsync(GUARD_TIMEOUT_MS);
+    const result = await promise;
+    expect(result).toEqual({ blocked: false, value: "x" });
+  });
 });

--- a/packages/agent-runtime/src/guardrails/pipeline.ts
+++ b/packages/agent-runtime/src/guardrails/pipeline.ts
@@ -12,8 +12,19 @@ export interface GuardContext {
   autonomy?: string;
 }
 
+export type FailMode = "open" | "closed";
+
 export interface Guard<T> {
   name: string;
+  /**
+   * How the pipeline treats a timeout or thrown error from this guard.
+   *
+   * - `"open"` (default): skip the guard (treat as `pass`) — availability wins.
+   * - `"closed"`: treat the failure as a `block` — safety wins. Use for
+   *   critical guards (prompt injection, PII filters) where a missed check
+   *   is worse than a stalled turn.
+   */
+  failMode?: FailMode;
   run(input: T, ctx: GuardContext): Promise<Verdict<T>> | Verdict<T>;
 }
 
@@ -53,6 +64,11 @@ export async function runStage<T>(
     try {
       verdict = await Promise.race([Promise.resolve(g.run(value, ctx)), timeout]);
     } catch (err) {
+      if (g.failMode === "closed") {
+        log.warn({ guard: g.name, err }, "guardrail guard errored — blocking (failMode: closed)");
+        clearTimeout(timer);
+        return { blocked: true, guard: g.name, reason: "guard_error" };
+      }
       log.warn({ guard: g.name, err }, "guardrail guard skipped");
       continue;
     } finally {
@@ -60,6 +76,13 @@ export async function runStage<T>(
     }
 
     if (verdict === TIMEOUT) {
+      if (g.failMode === "closed") {
+        log.warn(
+          { guard: g.name, timeoutMs: GUARD_TIMEOUT_MS },
+          "guardrail guard timed out — blocking (failMode: closed)"
+        );
+        return { blocked: true, guard: g.name, reason: "guard_timeout" };
+      }
       log.warn({ guard: g.name, timeoutMs: GUARD_TIMEOUT_MS }, "guardrail guard skipped");
       continue;
     }


### PR DESCRIPTION
Addresses the high and medium severity vulnerabilities found during the security audit.

- **H-1**: Restricts the overly permissive `/docs` CSP to Scalar CDN domains.
- **M-1**: Fixes the open redirect vulnerability in the login `redirectTo` parameter by blocking protocol-relative URLs.
- **M-2**: Makes the guardrail fail-mode configurable per-guard, allowing critical safety checks to fail-closed on timeout or error.
- **M-4**: Enforces a strict minimum (8) and maximum (128) password length to prevent Argon2 DoS attacks and weak passwords.

All tests and typechecks have passed successfully.