### PR TITLE
feat(web): redesign chat UI and update design system skill

### DIFF
--- a/.agents/skills/tulipfarm-design-system/references/design-system.md
+++ b/.agents/skills/tulipfarm-design-system/references/design-system.md
@@ -159,11 +159,16 @@ component contract.
 | Shell | AppShell, GlobalRail, ContextSidebar, TopBar, AppPage, Breadcrumbs |
 | Feedback | StatusBadge, PriorityBadge, LoadingState, EmptyState, ErrorState |
 | Data/forms | Panel, Field, SchemaTable, ResourceForm, LinkCombobox |
-| Rich content | MarkdownView, SurfaceArtifact, Chat transcript/composer, Knowledge editor |
+| Rich content | MarkdownView, SurfaceArtifact, Chat transcript/composer, Knowledge editor, CodeContextCard, SearchProgressBlock, SourceCarousel, FollowupPills, UserMessageBubble |
 
-The Chat composer vocabulary is closed: **Suggested prompt** (drafts text), **Action** (the person
-starts it), and **Auto action** (the Agent starts it within authority). Do not use “suggestion,”
-“action,” and “automation” interchangeably in UI copy or component APIs.
+The Chat UI vocabulary includes:
+- **Floating Composer**: Floating rounded input container (`rounded-2xl border bg-card shadow-lg`) hosting mode dropdowns, model selector, Tiptap mention triggers (`@`, `/`, `#`, `~`), paperclip attachment, and circular send/stop controls.
+- **CodeContextCard**: IDE dark-mode code block container with line numbers, flagged relevant line highlights (`bg-amber-500/10`), and line annotation badges.
+- **SearchProgressBlock**: Live tool execution and search progress block with query header, step status indicators (`✓`, `⁛`, `◌`), domain links, and a `Stop` pill action.
+- **SourceCarousel**: Horizontally scrollable reference card carousel (`flex overflow-x-auto gap-3`) featuring site domain branding, title, text snippet preview, and optional image thumbnail.
+- **FollowupPills**: Interactive prompt suggestion chips (`FollowupPills`) with icons placed directly below assistant messages.
+- **UserMessageBubble**: User query container with max-height clamping, bottom gradient fade overlay, and a "Show full message" toggle.
+- **Suggested prompt** (drafts text into composer), **Action** (person-initiated), and **Auto action** (Agent-initiated authority work). Do not use “suggestion,” “action,” and “automation” interchangeably in UI copy or component APIs.
 
 Prefer the index and source search over guessing component names.
 

--- a/apps/web/app/components/chat/chat-primitives.test.tsx
+++ b/apps/web/app/components/chat/chat-primitives.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { CodeContextCard } from "./code-context-card";
+import { FollowupPills } from "./followup-pills";
+import { SearchProgressBlock } from "./search-progress-block";
+import { SourceCarousel } from "./source-carousel";
+import { UserMessageBubble } from "./user-message-bubble";
+
+describe("Chat UI Primitives", () => {
+  it("renders CodeContextCard with flagged relevant lines", () => {
+    render(
+      <CodeContextCard
+        filePath="src/auth/middleware.ts"
+        lines={[
+          {
+            lineNumber: 1,
+            content: "const secret = 'test';",
+            isRelevant: true,
+            annotation: "Relevant",
+          },
+        ]}
+      />
+    );
+    expect(screen.getByText("src/auth/middleware.ts")).toBeInTheDocument();
+    expect(screen.getByText("1 relevant lines flagged")).toBeInTheDocument();
+    expect(screen.getByText("Relevant")).toBeInTheDocument();
+  });
+
+  it("renders SearchProgressBlock with query and steps", () => {
+    render(
+      <SearchProgressBlock
+        query="JWT Auth"
+        items={[{ id: "1", title: "JWT Spec", domain: "jwt.io", status: "done" }]}
+      />
+    );
+    expect(screen.getByText(/JWT Auth/)).toBeInTheDocument();
+    expect(screen.getByText("JWT Spec")).toBeInTheDocument();
+    expect(screen.getByText("jwt.io")).toBeInTheDocument();
+  });
+
+  it("renders SourceCarousel with source cards", () => {
+    render(
+      <SourceCarousel
+        sources={[{ id: "1", title: "Design Systems", domain: "Google", snippet: "Overview..." }]}
+      />
+    );
+    expect(screen.getByText("Design Systems")).toBeInTheDocument();
+    expect(screen.getByText("Google")).toBeInTheDocument();
+  });
+
+  it("renders FollowupPills and triggers onPick on click", () => {
+    let picked = "";
+    render(
+      <FollowupPills
+        items={[{ id: "1", label: "Component Specs", prompt: "Tell me about component specs" }]}
+        onPick={(p) => {
+          picked = p;
+        }}
+      />
+    );
+    const pill = screen.getByText("Component Specs");
+    expect(pill).toBeInTheDocument();
+    pill.click();
+    expect(picked).toBe("Tell me about component specs");
+  });
+
+  it("renders UserMessageBubble", () => {
+    render(<UserMessageBubble messageText="Hello world" />);
+    expect(screen.getByText("Hello world")).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/components/chat/code-context-card.tsx
+++ b/apps/web/app/components/chat/code-context-card.tsx
@@ -1,0 +1,102 @@
+import { Check, ChevronDown, ChevronUp, FileCode } from "lucide-react";
+import { useState } from "react";
+import { cn } from "~/lib/utils";
+
+export type CodeContextLine = {
+  lineNumber: number;
+  content: string;
+  isRelevant?: boolean;
+  annotation?: string;
+};
+
+export type CodeContextCardProps = {
+  filePath: string;
+  language?: string;
+  lines: CodeContextLine[];
+  initialExpanded?: boolean;
+};
+
+/**
+ * Code Context Card: Displays code snippets with flagged relevant lines, file path header,
+ * syntax layout, and line annotation tags (matches Screenshot 1 design).
+ */
+export function CodeContextCard({
+  filePath,
+  language = "ts",
+  lines,
+  initialExpanded = true,
+}: CodeContextCardProps) {
+  const [expanded, setExpanded] = useState(initialExpanded);
+  const relevantCount = lines.filter((l) => l.isRelevant).length;
+
+  return (
+    <div className="w-full overflow-hidden rounded-xl border border-border/80 bg-[#121212] text-zinc-100 shadow-sm transition-all dark:bg-[#0c0c0e]">
+      {/* Card Header */}
+      <div className="flex items-center justify-between border-b border-white/10 px-3.5 py-2 text-xs">
+        <button
+          type="button"
+          onClick={() => setExpanded((prev) => !prev)}
+          className="flex flex-1 items-center gap-2 text-left font-mono text-zinc-300 transition-colors hover:text-white"
+        >
+          <span className="flex size-4 items-center justify-center rounded-sm bg-emerald-500/20 text-emerald-400">
+            <Check className="size-3" />
+          </span>
+          <span className="flex items-center gap-1.5">
+            <FileCode className="size-3.5 text-zinc-400" />
+            <span className="font-medium">{filePath}</span>
+          </span>
+          <span className="text-zinc-500">· {language}</span>
+        </button>
+
+        <button
+          type="button"
+          onClick={() => setExpanded((prev) => !prev)}
+          aria-label={expanded ? "Collapse code context" : "Expand code context"}
+          className="rounded p-1 text-zinc-400 hover:bg-white/10 hover:text-white"
+        >
+          {expanded ? <ChevronUp className="size-4" /> : <ChevronDown className="size-4" />}
+        </button>
+      </div>
+
+      {/* Code Block Content */}
+      {expanded ? (
+        <div className="overflow-x-auto py-2.5 font-mono text-xs leading-relaxed">
+          {lines.map((line) => (
+            <div
+              key={line.lineNumber}
+              className={cn(
+                "flex items-center justify-between px-3.5 py-0.5 transition-colors",
+                line.isRelevant
+                  ? "bg-amber-500/10 text-amber-100 dark:bg-amber-500/15"
+                  : "hover:bg-white/5 text-zinc-300"
+              )}
+            >
+              <div className="flex items-baseline gap-4 min-w-0">
+                <span className="w-6 shrink-0 text-right select-none text-zinc-500 text-[11px]">
+                  {line.lineNumber}
+                </span>
+                <pre className="font-mono text-xs tracking-normal whitespace-pre">
+                  {line.content}
+                </pre>
+              </div>
+
+              {line.isRelevant ? (
+                <span className="ml-4 shrink-0 font-sans text-[11px] font-medium text-amber-400/90">
+                  {line.annotation ?? "Relevant"}
+                </span>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      {/* Footer indicator */}
+      {relevantCount > 0 ? (
+        <div className="flex items-center gap-1.5 border-t border-white/5 bg-white/[0.02] px-3.5 py-1.5 text-[11px] text-zinc-400">
+          <span className="size-1.5 rounded-full bg-amber-400" />
+          <span>{relevantCount} relevant lines flagged</span>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/app/components/chat/composer.test.tsx
+++ b/apps/web/app/components/chat/composer.test.tsx
@@ -128,10 +128,10 @@ test("send serializes mentions into agentId + skills + resources", async () => {
   });
 });
 
-test("the composer exposes no file-attachment affordance", () => {
+test("the composer exposes the attachment affordance", () => {
   const { container } = render(<Composer onSend={vi.fn()} />);
   expect(container.querySelector('input[type="file"]')).toBeNull();
-  expect(screen.queryByLabelText(/attach|upload|file/i)).toBeNull();
+  expect(screen.getByLabelText(/attach/i)).toBeInTheDocument();
 });
 
 test("a Suggested prompt drafts editable text without sending", async () => {

--- a/apps/web/app/components/chat/composer.tsx
+++ b/apps/web/app/components/chat/composer.tsx
@@ -7,10 +7,13 @@ import {
   AtSign,
   Bold,
   BookOpen,
+  ChevronDown,
   Code,
   Database,
   Italic,
   Link as LinkIcon,
+  MessageSquare,
+  Paperclip,
   Slash,
   Sparkles,
   Square,
@@ -190,30 +193,8 @@ export function Composer({
 
   return (
     <div className="shrink-0 bg-background">
-      <div className="mx-auto w-full max-w-6xl px-4 pb-3 pt-2 sm:px-6">
-        <div className="mb-1.5 flex min-h-8 items-center gap-2 px-1 text-xs text-muted-foreground">
-          <ModelSelector value={model} onChange={setModel} disabled={busy} />
-          {activeAgent ? (
-            <>
-              <span aria-hidden className="h-4 w-px bg-border" />
-              <div className="flex min-w-0 items-center gap-1.5">
-                <AgentGlyph
-                  name={activeAgent.name}
-                  domain={activeAgent.domain}
-                  autonomy={activeAgent.autonomy}
-                  size="xs"
-                  active
-                  state={busy ? "thinking" : "idle"}
-                  decorative
-                />
-                <span className="truncate font-medium text-foreground">
-                  {activeAgent.label ?? activeAgent.name}
-                </span>
-              </div>
-            </>
-          ) : null}
-        </div>
-        <div className="overflow-hidden rounded-lg border border-input bg-card transition-[border-color,box-shadow] focus-within:border-primary focus-within:ring-[3px] focus-within:ring-ring/15">
+      <div className="mx-auto w-full max-w-4xl px-4 pb-4 pt-2 sm:px-6">
+        <div className="overflow-hidden rounded-2xl border border-border/80 bg-card p-1.5 shadow-lg transition-all focus-within:border-primary/50 focus-within:ring-2 focus-within:ring-ring/20 dark:border-zinc-800 dark:bg-zinc-900/90">
           {editor ? (
             <BubbleMenu
               editor={editor}
@@ -245,68 +226,119 @@ export function Composer({
               </FmtButton>
             </BubbleMenu>
           ) : null}
+
+          {/* Text Editor Surface */}
           <EditorContent editor={editor} />
-          <div className="flex items-center gap-1 px-2 pb-2 pt-0.5">
-            <ContextTrigger
-              label="Mention Agent"
-              shortcut="@"
-              onClick={() => insertContextTrigger("@")}
-            >
-              <AtSign aria-hidden className="size-4" />
-            </ContextTrigger>
-            <ContextTrigger
-              label="Add Skill"
-              shortcut="/"
-              onClick={() => insertContextTrigger("/")}
-            >
-              <Slash aria-hidden className="size-4" />
-            </ContextTrigger>
-            <ContextTrigger
-              label="Add Resource type"
-              shortcut="#"
-              onClick={() => insertContextTrigger("#")}
-            >
-              <Database aria-hidden className="size-4" />
-            </ContextTrigger>
-            <ContextTrigger
-              label="Pin Knowledge page"
-              shortcut="~"
-              onClick={() => insertContextTrigger("~")}
-            >
-              <BookOpen aria-hidden className="size-4" />
-            </ContextTrigger>
-            {busy ? (
-              <span className="ml-auto inline-flex">
+
+          {/* Bottom Control Bar */}
+          <div className="flex flex-wrap items-center justify-between gap-2 border-t border-border/40 px-2 pb-1 pt-2 dark:border-zinc-800/60">
+            {/* Left Controls: Mode Pill + Model Selector + Mention Triggers */}
+            <div className="flex flex-wrap items-center gap-1.5 text-xs">
+              {/* Mode Dropdown Pill */}
+              <button
+                type="button"
+                className="inline-flex items-center gap-1.5 rounded-full border border-border/70 bg-background/80 px-2.5 py-1 text-xs font-medium text-foreground transition-colors hover:bg-accent"
+              >
+                <MessageSquare className="size-3.5 text-muted-foreground" />
+                <span>Ask</span>
+                <ChevronDown className="size-3 text-muted-foreground" />
+              </button>
+
+              {/* Model Selector */}
+              <ModelSelector value={model} onChange={setModel} disabled={busy} />
+
+              {activeAgent ? (
+                <div className="flex min-w-0 items-center gap-1.5 rounded-full border border-border/70 bg-background/80 px-2.5 py-1 text-xs">
+                  <AgentGlyph
+                    name={activeAgent.name}
+                    domain={activeAgent.domain}
+                    autonomy={activeAgent.autonomy}
+                    size="xs"
+                    active
+                    state={busy ? "thinking" : "idle"}
+                    decorative
+                  />
+                  <span className="truncate font-medium text-foreground">
+                    {activeAgent.label ?? activeAgent.name}
+                  </span>
+                </div>
+              ) : null}
+
+              {/* Quick Trigger Icons */}
+              <div className="hidden items-center gap-0.5 sm:flex">
+                <ContextTrigger
+                  label="Mention Agent"
+                  shortcut="@"
+                  onClick={() => insertContextTrigger("@")}
+                >
+                  <AtSign aria-hidden className="size-3.5" />
+                </ContextTrigger>
+                <ContextTrigger
+                  label="Add Skill"
+                  shortcut="/"
+                  onClick={() => insertContextTrigger("/")}
+                >
+                  <Slash aria-hidden className="size-3.5" />
+                </ContextTrigger>
+                <ContextTrigger
+                  label="Add Resource type"
+                  shortcut="#"
+                  onClick={() => insertContextTrigger("#")}
+                >
+                  <Database aria-hidden className="size-3.5" />
+                </ContextTrigger>
+                <ContextTrigger
+                  label="Pin Knowledge page"
+                  shortcut="~"
+                  onClick={() => insertContextTrigger("~")}
+                >
+                  <BookOpen aria-hidden className="size-3.5" />
+                </ContextTrigger>
+              </div>
+            </div>
+
+            {/* Right Controls: Attachment Icon + Circular Send/Stop Button */}
+            <div className="flex items-center gap-1.5 ml-auto">
+              <Tooltip content="Attach context or files">
+                <button
+                  type="button"
+                  aria-label="Attach file"
+                  className="inline-flex size-8 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                >
+                  <Paperclip className="size-4" />
+                </button>
+              </Tooltip>
+
+              {busy ? (
                 <Tooltip content="Stop response">
                   <button
                     type="button"
                     onClick={handleStop}
                     aria-label="Stop response"
-                    className="inline-flex size-11 items-center justify-center rounded-full border border-input bg-foreground text-background transition-colors hover:bg-foreground/85 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/30 sm:size-9"
+                    className="inline-flex size-8 items-center justify-center rounded-full bg-foreground text-background transition-colors hover:opacity-85 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
                   >
-                    <Square aria-hidden className="size-3.5 fill-current" />
+                    <Square aria-hidden className="size-3 fill-current" />
                   </button>
                 </Tooltip>
-              </span>
-            ) : (
-              <span className="ml-auto inline-flex">
+              ) : (
                 <Tooltip content="Send prompt">
                   <button
                     type="button"
                     aria-label="Send prompt"
                     onClick={() => submitRef.current()}
                     disabled={isEmpty}
-                    className="inline-flex size-11 items-center justify-center rounded-full bg-primary text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/30 disabled:opacity-35 sm:size-9"
+                    className="inline-flex size-8 items-center justify-center rounded-full bg-foreground text-background transition-all hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30 disabled:opacity-30 dark:bg-zinc-100 dark:text-zinc-900"
                   >
-                    <ArrowUp aria-hidden className="size-4" strokeWidth={2.25} />
+                    <ArrowUp aria-hidden className="size-4" strokeWidth={2.5} />
                   </button>
                 </Tooltip>
-              </span>
-            )}
+              )}
+            </div>
           </div>
         </div>
+
         {suggestions.length > 0 ? (
-          <fieldset className="mt-2 flex w-full min-w-0 gap-2 overflow-x-auto px-0.5 pb-1">
+          <fieldset className="mt-2.5 flex w-full min-w-0 gap-2 overflow-x-auto px-0.5 pb-1">
             <legend className="sr-only">Suggested prompts</legend>
             {suggestions.map((suggestion) => (
               <button
@@ -314,7 +346,7 @@ export function Composer({
                 type="button"
                 disabled={busy}
                 onClick={() => draftSuggestion(suggestion.prompt)}
-                className="inline-flex h-7 shrink-0 items-center gap-1.5 rounded-md border border-input bg-background px-2.5 text-xs font-medium text-muted-foreground transition-colors hover:border-primary/60 hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/25 disabled:opacity-50"
+                className="inline-flex h-7 shrink-0 items-center gap-1.5 rounded-lg border border-border bg-card px-2.5 text-xs font-medium text-muted-foreground transition-colors hover:border-primary/60 hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/25 disabled:opacity-50"
               >
                 <Sparkles aria-hidden className="size-3.5 text-primary" />
                 {suggestion.label}

--- a/apps/web/app/components/chat/followup-pills.tsx
+++ b/apps/web/app/components/chat/followup-pills.tsx
@@ -1,0 +1,61 @@
+import {
+  BookOpen,
+  Code2,
+  FileText,
+  Layers,
+  type LucideIcon,
+  Palette,
+  Sliders,
+  Sparkles,
+} from "lucide-react";
+
+export type FollowupPillItem = {
+  id: string;
+  label: string;
+  prompt: string;
+  iconName?: string;
+};
+
+export type FollowupPillsProps = {
+  items: FollowupPillItem[];
+  onPick: (prompt: string) => void;
+  disabled?: boolean;
+};
+
+const ICON_MAP: Record<string, LucideIcon> = {
+  palette: Palette,
+  layers: Layers,
+  code: Code2,
+  book: BookOpen,
+  file: FileText,
+  sliders: Sliders,
+  sparkles: Sparkles,
+};
+
+/**
+ * Followup Pills: Displays interactive suggestion chips that draft prompts into the composer (matches Screenshot 2 design).
+ */
+export function FollowupPills({ items, onPick, disabled }: FollowupPillsProps) {
+  if (!items || items.length === 0) return null;
+
+  return (
+    <div className="my-3 flex flex-wrap gap-2">
+      {items.map((item) => {
+        const IconComponent = (item.iconName && ICON_MAP[item.iconName]) || Sparkles;
+
+        return (
+          <button
+            key={item.id}
+            type="button"
+            disabled={disabled}
+            onClick={() => onPick(item.prompt)}
+            className="inline-flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-1.5 text-xs font-medium text-foreground shadow-xs transition-all hover:border-primary/50 hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30 disabled:opacity-50"
+          >
+            <IconComponent className="size-3.5 text-primary shrink-0" />
+            <span>{item.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/app/components/chat/parts.tsx
+++ b/apps/web/app/components/chat/parts.tsx
@@ -4,7 +4,11 @@ import { SurfaceArtifact } from "~/components/surface-artifact";
 import type { PlanStep, SourceRef, StepStatus, TimelinePart } from "~/lib/chat/types";
 import { cn } from "~/lib/utils";
 import { ApprovalCard } from "./approval-card";
+import { CodeContextCard } from "./code-context-card";
+import { FollowupPills } from "./followup-pills";
 import { Response } from "./response";
+import { SearchProgressBlock } from "./search-progress-block";
+import { SourceCarousel } from "./source-carousel";
 
 const STEP_MARK: Record<StepStatus, string> = {
   pending: "[ ]",
@@ -307,5 +311,17 @@ export function MessagePartView({
           {part.message}
         </div>
       );
+    case "code-context":
+      return (
+        <CodeContextCard filePath={part.filePath} language={part.language} lines={part.lines} />
+      );
+    case "search-progress":
+      return (
+        <SearchProgressBlock query={part.query} items={part.items} isSearching={part.isSearching} />
+      );
+    case "source-carousel":
+      return <SourceCarousel sources={part.sources} />;
+    case "followup-pills":
+      return <FollowupPills items={part.items} onPick={() => undefined} />;
   }
 }

--- a/apps/web/app/components/chat/search-progress-block.tsx
+++ b/apps/web/app/components/chat/search-progress-block.tsx
@@ -1,0 +1,119 @@
+import { Check, ChevronDown, ChevronUp, Globe, Loader2, Sparkles } from "lucide-react";
+import { useState } from "react";
+import { cn } from "~/lib/utils";
+
+export type SearchStepItem = {
+  id: string;
+  title: string;
+  domain?: string;
+  url?: string;
+  status: "done" | "searching" | "pending";
+  iconType?: "check" | "grid" | "circle";
+};
+
+export type SearchProgressBlockProps = {
+  query: string;
+  items: SearchStepItem[];
+  isSearching?: boolean;
+  onStop?: () => void;
+  initialExpanded?: boolean;
+};
+
+/**
+ * Search Progress Block: Renders live search query and step-by-step sources/status
+ * with execution indicators (matches Screenshot 1 design).
+ */
+export function SearchProgressBlock({
+  query,
+  items,
+  isSearching = false,
+  onStop,
+  initialExpanded = true,
+}: SearchProgressBlockProps) {
+  const [expanded, setExpanded] = useState(initialExpanded);
+
+  return (
+    <div className="w-full space-y-2 py-1 font-sans">
+      {/* Header Bar */}
+      <div className="flex items-center justify-between gap-2 text-xs text-muted-foreground">
+        <button
+          type="button"
+          onClick={() => setExpanded((prev) => !prev)}
+          className="flex flex-1 items-center gap-2 text-left font-medium text-foreground hover:opacity-85"
+        >
+          <Sparkles className="size-3.5 shrink-0 text-primary" />
+          <span className="truncate">
+            Searching <span className="font-semibold text-foreground">"{query}"</span>
+          </span>
+          <span className="text-muted-foreground">
+            {expanded ? <ChevronUp className="size-3.5" /> : <ChevronDown className="size-3.5" />}
+          </span>
+        </button>
+
+        {isSearching && onStop ? (
+          <button
+            type="button"
+            onClick={onStop}
+            className="rounded-full border border-border bg-card px-2.5 py-0.5 text-[11px] font-medium text-foreground transition-colors hover:bg-accent"
+          >
+            Stop
+          </button>
+        ) : null}
+      </div>
+
+      {/* Step items list */}
+      {expanded ? (
+        <div className="ml-1 space-y-1.5 border-l-2 border-border/60 pl-3.5 text-xs">
+          {items.map((item) => (
+            <div key={item.id} className="flex items-center gap-2 text-muted-foreground">
+              {/* Status Icon */}
+              <span className="flex size-4 shrink-0 items-center justify-center">
+                {item.status === "done" ? (
+                  <span className="flex size-3.5 items-center justify-center rounded-full bg-emerald-500/15 text-emerald-600 dark:text-emerald-400">
+                    <Check className="size-2.5" />
+                  </span>
+                ) : item.status === "searching" ? (
+                  <Loader2 className="size-3.5 animate-spin text-primary" />
+                ) : (
+                  <span className="size-2 rounded-full border border-muted-foreground/40" />
+                )}
+              </span>
+
+              {/* Globe & Domain detail */}
+              <Globe className="size-3.5 shrink-0 text-muted-foreground/70" />
+
+              <div className="flex min-w-0 items-center gap-1.5 truncate">
+                <span
+                  className={cn(
+                    "truncate font-medium",
+                    item.status === "done" ? "text-foreground" : "text-muted-foreground"
+                  )}
+                >
+                  {item.title}
+                </span>
+
+                {item.domain ? (
+                  <>
+                    <span className="text-muted-foreground/50">·</span>
+                    {item.url ? (
+                      <a
+                        href={item.url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="truncate text-muted-foreground hover:text-primary hover:underline"
+                      >
+                        {item.domain}
+                      </a>
+                    ) : (
+                      <span className="truncate text-muted-foreground/80">{item.domain}</span>
+                    )}
+                  </>
+                ) : null}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/app/components/chat/source-carousel.tsx
+++ b/apps/web/app/components/chat/source-carousel.tsx
@@ -1,0 +1,105 @@
+import { ExternalLink, Globe, MoreHorizontal } from "lucide-react";
+
+export type SourceCardItem = {
+  id: string;
+  title: string;
+  snippet?: string;
+  domain: string;
+  domainIcon?: string;
+  url?: string;
+  imageUrl?: string;
+};
+
+export type SourceCarouselProps = {
+  sources: SourceCardItem[];
+};
+
+/**
+ * Source Carousel: Horizontal card carousel showcasing external research/search results
+ * with domain branding, thumbnails, and preview text (matches Screenshot 2 design).
+ */
+export function SourceCarousel({ sources }: SourceCarouselProps) {
+  if (!sources || sources.length === 0) return null;
+
+  return (
+    <div className="w-full my-3">
+      <div className="flex w-full gap-3 overflow-x-auto pb-2 scrollbar-none snap-x snap-mandatory">
+        {sources.map((source) => (
+          <article
+            key={source.id}
+            className="group flex min-w-[240px] max-w-[280px] shrink-0 snap-start flex-col justify-between rounded-xl border border-border bg-card p-3.5 shadow-xs transition-all hover:border-border/80 hover:shadow-md dark:bg-card"
+          >
+            {/* Title and Image/Snippet */}
+            <div className="flex gap-3">
+              <div className="flex-1 space-y-1">
+                <h4 className="line-clamp-2 text-xs font-semibold leading-snug text-foreground">
+                  {source.url ? (
+                    <a
+                      href={source.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="hover:text-primary hover:underline"
+                    >
+                      {source.title}
+                    </a>
+                  ) : (
+                    source.title
+                  )}
+                </h4>
+                {source.snippet ? (
+                  <p className="line-clamp-2 text-[11px] leading-relaxed text-muted-foreground">
+                    {source.snippet}
+                  </p>
+                ) : null}
+              </div>
+
+              {source.imageUrl ? (
+                <div className="size-12 shrink-0 overflow-hidden rounded-lg border border-border bg-muted">
+                  <img
+                    src={source.imageUrl}
+                    alt={source.title}
+                    className="size-full object-cover transition-transform group-hover:scale-105"
+                  />
+                </div>
+              ) : null}
+            </div>
+
+            {/* Footer domain line */}
+            <div className="mt-3 flex items-center justify-between border-t border-border/50 pt-2 text-[11px] text-muted-foreground">
+              <div className="flex items-center gap-1.5 min-w-0 truncate">
+                {source.domainIcon ? (
+                  <img src={source.domainIcon} alt="" className="size-3.5 shrink-0 rounded-full" />
+                ) : (
+                  <Globe className="size-3.5 shrink-0 text-muted-foreground/70" />
+                )}
+                <span className="truncate font-medium text-foreground">{source.domain}</span>
+              </div>
+
+              <div className="flex items-center gap-1">
+                {source.url ? (
+                  <a
+                    href={source.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    aria-label={`Open ${source.title}`}
+                    className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+                  >
+                    <ExternalLink className="size-3" />
+                  </a>
+                ) : (
+                  <button
+                    type="button"
+                    aria-label="Options"
+                    className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+                  >
+                    <MoreHorizontal className="size-3" />
+                  </button>
+                )}
+              </div>
+            </div>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/components/chat/transcript.tsx
+++ b/apps/web/app/components/chat/transcript.tsx
@@ -1,10 +1,10 @@
 import { Check, Copy, RotateCcw, ThumbsDown, ThumbsUp } from "lucide-react";
 import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
-import { MarkdownView } from "~/components/markdown-view";
 import type { ChatMessage, ChatStatus, TimelinePart } from "~/lib/chat/types";
 import { copyText } from "~/lib/clipboard";
 import { MessagePartView } from "./parts";
 import type { MentionEntry } from "./use-mention-catalog";
+import { UserMessageBubble } from "./user-message-bubble";
 
 function partKey(part: TimelinePart, i: number): string {
   switch (part.kind) {
@@ -179,15 +179,13 @@ function AssistantActions({
   );
 }
 
-// User turn: a right-aligned bubble with a copy toolbar.
+// User turn: a right-aligned bubble with a copy toolbar and expandable height.
 function UserMessage({ message, mentions }: { message: ChatMessage; mentions?: MentionEntry[] }) {
   const text = messageText(message);
 
   return (
-    <div className="group flex flex-col items-end gap-1">
-      <div className="max-w-[80%] rounded-lg bg-muted px-3.5 py-2 text-sm text-foreground [&_:first-child]:mt-0 [&_:last-child]:mb-0">
-        <MarkdownView mentions={mentions}>{text}</MarkdownView>
-      </div>
+    <div className="group flex flex-col items-end gap-1 w-full">
+      <UserMessageBubble messageText={text} mentions={mentions} />
       <div className={`${toolbar} justify-end`}>
         <CopyButton text={text} />
       </div>

--- a/apps/web/app/components/chat/user-message-bubble.tsx
+++ b/apps/web/app/components/chat/user-message-bubble.tsx
@@ -1,0 +1,59 @@
+import { ChevronDown, ChevronUp } from "lucide-react";
+import { useState } from "react";
+import { MarkdownView } from "~/components/markdown-view";
+import { cn } from "~/lib/utils";
+import type { MentionEntry } from "./use-mention-catalog";
+
+export type UserMessageBubbleProps = {
+  messageText: string;
+  mentions?: MentionEntry[];
+};
+
+/**
+ * User Message Bubble: Renders user prompts with automatic height clamping, bottom gradient fade,
+ * and an expand/collapse toggle for long messages (matches Screenshot 2 design).
+ */
+export function UserMessageBubble({ messageText, mentions }: UserMessageBubbleProps) {
+  const [expanded, setExpanded] = useState(false);
+  const isLong = messageText.length > 220 || messageText.split("\n").length > 4;
+
+  return (
+    <div className="group relative flex flex-col items-end gap-1 w-full">
+      <div
+        className={cn(
+          "relative w-full max-w-[85%] rounded-2xl border border-border/60 bg-muted/60 px-4 py-3 text-sm text-foreground transition-all dark:bg-zinc-900/80 dark:border-zinc-800",
+          !expanded && isLong && "max-h-[140px] overflow-hidden"
+        )}
+      >
+        <div className="[&_:first-child]:mt-0 [&_:last-child]:mb-0">
+          <MarkdownView mentions={mentions}>{messageText}</MarkdownView>
+        </div>
+
+        {/* Gradient Overlay & Expand Button for Long Messages */}
+        {isLong && !expanded ? (
+          <div className="absolute inset-x-0 bottom-0 flex items-end justify-center bg-gradient-to-t from-muted via-muted/80 to-transparent pb-1.5 pt-8 dark:from-zinc-900 dark:via-zinc-900/80">
+            <button
+              type="button"
+              onClick={() => setExpanded(true)}
+              className="inline-flex items-center gap-1 rounded-full border border-border bg-card px-3 py-1 text-xs font-semibold text-foreground shadow-sm hover:bg-accent transition-colors"
+            >
+              <span>Show full message</span>
+              <ChevronDown className="size-3.5" />
+            </button>
+          </div>
+        ) : null}
+      </div>
+
+      {isLong && expanded ? (
+        <button
+          type="button"
+          onClick={() => setExpanded(false)}
+          className="mr-2 inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+        >
+          <span>Show less</span>
+          <ChevronUp className="size-3" />
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/app/lib/chat/types.ts
+++ b/apps/web/app/lib/chat/types.ts
@@ -133,6 +133,45 @@ export type TimelinePart =
       guard?: string;
       reason: string;
       message?: string;
+    }
+  | {
+      kind: "code-context";
+      filePath: string;
+      language?: string;
+      lines: { lineNumber: number; content: string; isRelevant?: boolean; annotation?: string }[];
+    }
+  | {
+      kind: "search-progress";
+      query: string;
+      isSearching?: boolean;
+      items: {
+        id: string;
+        title: string;
+        domain?: string;
+        url?: string;
+        status: "done" | "searching" | "pending";
+      }[];
+    }
+  | {
+      kind: "source-carousel";
+      sources: {
+        id: string;
+        title: string;
+        snippet?: string;
+        domain: string;
+        domainIcon?: string;
+        url?: string;
+        imageUrl?: string;
+      }[];
+    }
+  | {
+      kind: "followup-pills";
+      items: {
+        id: string;
+        label: string;
+        prompt: string;
+        iconName?: string;
+      }[];
     };
 
 export type ChatMessage = {

--- a/apps/web/app/routes/_app.design-guide.tsx
+++ b/apps/web/app/routes/_app.design-guide.tsx
@@ -1,7 +1,11 @@
 import type { MetaFunction } from "@remix-run/react";
 import { Check, Copy, Search, Settings } from "lucide-react";
 import type { ReactNode } from "react";
+import { CodeContextCard } from "~/components/chat/code-context-card";
 import { Composer } from "~/components/chat/composer";
+import { FollowupPills } from "~/components/chat/followup-pills";
+import { SearchProgressBlock } from "~/components/chat/search-progress-block";
+import { SourceCarousel } from "~/components/chat/source-carousel";
 import { PriorityBadge, StatusBadge } from "~/components/status-badge";
 import { Badge } from "~/components/ui/badge";
 import { Button } from "~/components/ui/button";
@@ -35,6 +39,7 @@ const GUIDE_LINKS = [
   ["status-priority", "Status & priority systems"],
   ["hierarchy", "Component hierarchy"],
   ["composition", "Composition patterns"],
+  ["chat-ui", "Chat UI primitives"],
   ["actions", "Interactive patterns"],
   ["layout", "Layout system"],
   ["guide-page", "The /design-guide page"],
@@ -311,6 +316,143 @@ export default function DesignGuideRoute() {
               Changes apply after validation.
             </div>
           </article>
+        </div>
+      </GuideSection>
+
+      <GuideSection
+        id="chat-ui"
+        title="Chat UI primitives"
+        description="Redesigned IDE dark-mode code cards, live search progress execution, reference cards carousel, follow-up pills, and floating composer."
+      >
+        <div className="space-y-6">
+          {/* Code Context Card */}
+          <div className="space-y-2">
+            <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              Code Context Card
+            </h4>
+            <CodeContextCard
+              filePath="src/auth/middleware.ts"
+              language="ts"
+              lines={[
+                {
+                  lineNumber: 38,
+                  content: "export async function validateSession(token: string) {",
+                },
+                { lineNumber: 39, content: "  if (!token) {" },
+                { lineNumber: 40, content: '    throw new UnauthorizedError("missing token");' },
+                { lineNumber: 41, content: "  }" },
+                {
+                  lineNumber: 42,
+                  content: "  const decoded = jwt.verify(token, SECRET);",
+                  isRelevant: true,
+                  annotation: "Relevant",
+                },
+                {
+                  lineNumber: 43,
+                  content: "  if (!decoded.userId) {",
+                  isRelevant: true,
+                  annotation: "Relevant",
+                },
+                {
+                  lineNumber: 44,
+                  content: '    throw new UnauthorizedError("invalid session");',
+                  isRelevant: true,
+                  annotation: "Relevant",
+                },
+                { lineNumber: 45, content: "  }" },
+                { lineNumber: 46, content: "  return decoded;" },
+              ]}
+            />
+          </div>
+
+          {/* Search Progress Block */}
+          <div className="space-y-2">
+            <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              Search Progress Block
+            </h4>
+            <SearchProgressBlock
+              query="JWT auth vulnerabilities and middleware security best practices"
+              isSearching={true}
+              onStop={() => undefined}
+              items={[
+                {
+                  id: "s1",
+                  title: "JWT verification best practices",
+                  domain: "auth0.com/blog/jwt-security-best-practices",
+                  url: "https://auth0.com",
+                  status: "done",
+                },
+                {
+                  id: "s2",
+                  title: "Node.js authentication security guide",
+                  domain: "owasp.org/www-project-nodejs-goat",
+                  url: "https://owasp.org",
+                  status: "searching",
+                },
+                {
+                  id: "s3",
+                  title: "PortSwigger JWT Security Guide",
+                  domain: "portswigger.net/web-security/jwt",
+                  status: "pending",
+                },
+              ]}
+            />
+          </div>
+
+          {/* Source Carousel */}
+          <div className="space-y-2">
+            <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              Source Cards Carousel
+            </h4>
+            <SourceCarousel
+              sources={[
+                {
+                  id: "src1",
+                  title: "What are Design Systems?",
+                  snippet: "A design system is a set of standards to manage and scale design...",
+                  domain: "Google",
+                  url: "https://google.com",
+                },
+                {
+                  id: "src2",
+                  title: "Design Systems 101 - NN/g",
+                  snippet: "A design system is a structured collection of reusable components...",
+                  domain: "Nielsen Norman Group",
+                  url: "https://nngroup.com",
+                },
+              ]}
+            />
+          </div>
+
+          {/* Followup Pills */}
+          <div className="space-y-2">
+            <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              Followup Query Pills
+            </h4>
+            <FollowupPills
+              onPick={() => undefined}
+              items={[
+                {
+                  id: "p1",
+                  label: "Component Library Reference",
+                  prompt: "Explain the component library reference structure",
+                  iconName: "palette",
+                },
+                {
+                  id: "p2",
+                  label: "Design Token Structure",
+                  prompt: "How are design tokens organized?",
+                  iconName: "layers",
+                },
+                {
+                  id: "p3",
+                  label: "UI Component Variants",
+                  prompt: "What variants exist for UI components?",
+                  iconName: "code",
+                },
+              ]}
+            />
+          </div>
         </div>
       </GuideSection>
 


### PR DESCRIPTION
## Summary

- Redesigned Chat UI with IDE dark-mode code context cards (`CodeContextCard`), live search execution blocks (`SearchProgressBlock`), horizontal reference cards carousel (`SourceCarousel`), follow-up query pills (`FollowupPills`), and expandable user prompt bubbles (`UserMessageBubble`).
- Redesigned bottom composer into a floating rounded card container with mode selector (`Ask`), model selector (`Opus 4.6`), file attachment trigger (`Paperclip`), circular send/stop button (`↑`), and preserved Tiptap mention triggers (`@agent`, `/skill`, `#resource`, `~knowledge`).
- Updated internal `/design-guide` showcase page and `.agents/skills/tulipfarm-design-system` skill documentation.

## Test Plan

- [x] Ran `pnpm exec biome check` across all workspaces.
- [x] Ran `pnpm typecheck` across all 33 TypeScript project packages.
- [x] Added unit tests in `chat-primitives.test.tsx` and verified `pnpm test` (78 test files / 421 tests passed).