### PR TITLE
fix(docker): ship bundled integrations directory into runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,6 +90,7 @@ COPY --from=builder /app/apps/worker/dist/ingress-hook-worker.cjs ./ingress-hook
 COPY --from=builder /app/apps/integration-worker/dist/integration-worker.cjs ./integration-worker.cjs
 COPY --from=builder /app/apps/web/build/client ./apps/web/build/client
 COPY --from=builder /app/skills ./skills
+COPY --from=builder /app/integrations ./integrations
 # /data holds the bootstrap secrets generated on first boot when the operator supplies none
 # (and, later, backups) — it must be a mounted volume or those keys die with the container.
 RUN mkdir -p /opt/tulipfarm/soul /data


### PR DESCRIPTION
## Summary
- The runtime Docker image copied `skills/` into the container but had no matching `COPY` for `integrations/`, so built-in integrations (e.g. Slack) never reached deployed containers.
- `bundledIntegrationsDir()` (`apps/api/src/soul/integrations/bundled.ts`) checks `/app/integrations` first, then falls back to a dev-tree-relative path that only resolves correctly when running from source — not from the bundled `server.cjs` at `/app`. With neither path present in prod, it silently returned zero integrations, so "Installed" showed 0 even though `integrations/slack/manifest.yml` is present and valid in the repo.
- Fix: add `COPY --from=builder /app/integrations ./integrations` to the Dockerfile, mirroring the existing `skills` line. No app code change needed — `bundledIntegrationsDir()`'s existing `existsSync(IMAGE_INTEGRATIONS_DIR)` check now finds the directory in prod exactly as it already does for skills.

## Test plan
- [ ] Rebuild the image and confirm `/app/integrations/slack` exists in the container
- [ ] Deploy and confirm Slack appears under Integrations > Installed with zero manual setup