### PR TITLE
fix(api): reply into the Slack thread after a Surface interaction resolves

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -637,6 +637,9 @@ export async function buildApp(opts: AppOptions = {}) {
           {
             identity: channelDeps.identity,
             actions: channelDeps.surfaceActionStore,
+            store: channelDeps.store,
+            invocations: channelDeps.invocations,
+            runDeliveries: channelDeps.runDeliveries,
             ...(opts.guardrailsService ? { guardrails: opts.guardrailsService } : {}),
           },
           requireAuth

--- a/apps/api/src/internal/surfaces-routes.test.ts
+++ b/apps/api/src/internal/surfaces-routes.test.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type { PGlite } from "@electric-sql/pglite";
 import { Type } from "@sinclair/typebox";
+import { DEPLOYMENT_BUSINESS_ID } from "@tulipfarm/constants";
 import {
   DurableInvocationGateway,
   DurableWaitManager,
@@ -75,6 +76,8 @@ describe("POST /api/v1/internal/surfaces/interactions", () => {
   let mappings: MemoryExternalIdentityRepo;
   let surfaceActionStore: MemorySurfaceActionStore;
   let surfaceArtifactStore: MemorySurfaceArtifactStore;
+  let conversationStore: FakeConversationStore;
+  let runDeliveries: ChannelRunDeliveryStore;
 
   beforeEach(async () => {
     db = await makePglite();
@@ -111,6 +114,8 @@ describe("POST /api/v1/internal/surfaces/interactions", () => {
     });
     surfaceActionStore = new MemorySurfaceActionStore();
     surfaceArtifactStore = new MemorySurfaceArtifactStore();
+    conversationStore = new FakeConversationStore();
+    runDeliveries = new ChannelRunDeliveryStore(transactions, () => new Date().toISOString());
 
     app = await buildApp({
       sessionStore: sessions,
@@ -119,7 +124,7 @@ describe("POST /api/v1/internal/surfaces/interactions", () => {
       identity: { apiClientRepo },
       toolApprovals,
       channels: () => ({
-        store: new FakeConversationStore(),
+        store: conversationStore,
         invocations: new DurableInvocationGateway({
           store: {
             persist: async (record) => ({ outcome: "started", runId: record.runId }),
@@ -134,7 +139,7 @@ describe("POST /api/v1/internal/surfaces/interactions", () => {
           log: { warn: () => {}, error: () => {}, info: () => {}, debug: () => {} } as never,
           mappings,
         }),
-        runDeliveries: new ChannelRunDeliveryStore(transactions, () => new Date().toISOString()),
+        runDeliveries,
         toolApprovals,
         surfaceStore: surfaceArtifactStore,
         surfaceActionStore,
@@ -204,6 +209,70 @@ describe("POST /api/v1/internal/surfaces/interactions", () => {
     const body = res.json();
     expect(body.artifactId).toBe("artifact-1");
     expect(body.principal).toBe(slackUser._id);
+  });
+
+  it("submits a follow-up turn and a new channel delivery so the reply reaches Slack", async () => {
+    const artifact = createSurfaceArtifact({
+      id: "artifact-2",
+      component: { name: "Actions", version: "1.0" },
+      props: { actions: [{ label: "Create it", action: { event: "resource.create" } }] },
+      target: { channel: "slack", surface: "message" },
+      audience: [slackUser._id],
+      classification: "internal",
+    });
+    await surfaceArtifactStore.create(artifact, { runId: "run-1" });
+    const handle = await surfaceActionStore.create({
+      artifactId: artifact.id,
+      revision: artifact.revision,
+      inputSchema: Type.Object({}),
+      audience: [slackUser._id],
+      target: artifact.target,
+      destination: "C-OPS",
+      conversationId: "conv-1",
+      runId: "run-1",
+      waitId: null,
+      guardrailRevision: "none",
+      expiresAt: new Date(Date.now() + 60_000),
+      action: { event: "resource.create" },
+    });
+
+    await runDeliveries.create({
+      businessId: DEPLOYMENT_BUSINESS_ID,
+      runId: "run-1",
+      integrationId: "integration-1",
+      routeId: "route-1",
+      provider: "slack",
+      destination: "C-OPS",
+      threadId: "T-1",
+      agentId: "agent-1",
+      principalId: slackUser._id,
+      idempotencyKey: "orig-event",
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/internal/surfaces/interactions",
+      headers: asWorker(),
+      payload: {
+        handle: handle.handle,
+        provider: "slack",
+        externalSubject: "U-LINKED",
+        input: {},
+      },
+    });
+    expect(res.statusCode).toBe(200);
+
+    expect(conversationStore.turns).toHaveLength(1);
+    expect(conversationStore.turns[0]?.conversationId).toBe("conv-1");
+    expect(conversationStore.messages[0]?.content).toBe("Submitted");
+
+    const pending = await runDeliveries.listPending(DEPLOYMENT_BUSINESS_ID);
+    expect(pending).toHaveLength(2);
+    const followUp = pending.find((row) => row.runId !== "run-1");
+    expect(followUp?.destination).toBe("C-OPS");
+    expect(followUp?.threadId).toBe("T-1");
+    expect(followUp?.provider).toBe("slack");
+    expect(followUp?.agentId).toBe("agent-1");
   });
 
   it("proxies the store's denial code for an unmapped sender", async () => {

--- a/apps/api/src/internal/surfaces-routes.ts
+++ b/apps/api/src/internal/surfaces-routes.ts
@@ -1,7 +1,13 @@
 import type { GuardrailsService } from "@tulipfarm/agent-runtime";
+import { DEPLOYMENT_BUSINESS_ID } from "@tulipfarm/constants";
+import type { DurableInvocationGateway } from "@tulipfarm/run-kernel";
+import type { ChannelRunDeliveryStore } from "@tulipfarm/storage";
 import { SurfaceInteractionSchema } from "@tulipfarm/surface";
-import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import type { FastifyBaseLogger, FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { ErrorSchema } from "../auth/schemas";
+import { durableTurnSubmitter } from "../chat/turn-submit";
+import type { ChatTurnPrincipal } from "../conversations/chat-turns";
+import type { ConversationStore } from "../conversations/service";
 import type { IngressIdentityResolver } from "../ingress/identity";
 import type { SurfaceActionStore } from "../surfaces/action-store";
 
@@ -12,12 +18,32 @@ type PreHandler = (req: FastifyRequest, reply: FastifyReply) => Promise<void>;
  * click (a Slack button/select). Resolves the clicking sender to its own Tulip principal in this
  * process, then delegates straight to `SurfaceActionStore.resolve()` — the same resolution
  * `/api/v1/surfaces/interactions` (web) already performs. No new resolution logic here.
+ *
+ * Unlike the web route, nothing here streams a reply back to the caller — a Slack click gets no
+ * open connection to answer on. So after a successful resolution, this route itself submits a
+ * follow-up chat turn (the web client does this client-side via `send(surfaceInteractionAnswer(...))`
+ * after `postSurfaceInteraction` resolves) and re-registers a Channel run delivery so the
+ * integration-worker's delivery poll loop picks up the agent's reply and posts it back into the same
+ * Slack channel/thread the Artifact was presented in.
  */
 export interface SurfaceInternalRouteDeps {
   readonly identity: IngressIdentityResolver;
   readonly actions: SurfaceActionStore;
   /** Same revision the handle was minted against (`present`/`request_input`'s `ctx.guardrailRevision`). */
   readonly guardrails?: GuardrailsService;
+  readonly store: ConversationStore;
+  readonly invocations: DurableInvocationGateway;
+  readonly runDeliveries: ChannelRunDeliveryStore;
+}
+
+/** Mirrors the web client's `surfaceInteractionAnswer` (`use-chat-stream.ts`) for the channel path. */
+function surfaceInteractionAnswer(input: Readonly<Record<string, unknown>>): string {
+  if (typeof input.value === "string" && input.value.trim().length > 0) return input.value;
+  const entries = Object.entries(input);
+  if (entries.length === 0) return "Submitted";
+  return entries
+    .map(([key, value]) => `${key}: ${typeof value === "string" ? value : JSON.stringify(value)}`)
+    .join("\n");
 }
 
 export function registerSurfaceInternalRoutes(
@@ -101,6 +127,53 @@ export function registerSurfaceInternalRoutes(
           code: result.code,
         });
       }
+
+      const { conversationId, runId } = result.handle;
+      if (conversationId !== null && runId !== null) {
+        try {
+          const delivery = await deps.runDeliveries.find(DEPLOYMENT_BUSINESS_ID, runId);
+          if (delivery !== null) {
+            const principal: ChatTurnPrincipal = {
+              kind: "user",
+              id: resolution.user._id,
+              businessId: DEPLOYMENT_BUSINESS_ID,
+            };
+            const content = surfaceInteractionAnswer(result.interaction.input);
+            const idempotencyKey = `sf:${result.interaction.id}`;
+            const submitter = durableTurnSubmitter({
+              store: deps.store,
+              invocations: deps.invocations,
+              principal,
+              payload: {
+                conversationId,
+                agentId: delivery.agentId,
+                message: { role: "user" as const, content },
+              },
+              agentId: delivery.agentId,
+              idempotencyKey,
+              log: req.log as FastifyBaseLogger,
+            });
+            const submission = await submitter.submit({ conversationId, content });
+            if (submission.outcome === "submitted" && submission.run) {
+              await deps.runDeliveries.create({
+                businessId: DEPLOYMENT_BUSINESS_ID,
+                runId: submission.run.runId,
+                integrationId: delivery.integrationId,
+                routeId: delivery.routeId,
+                provider: delivery.provider,
+                destination: delivery.destination,
+                ...(delivery.threadId === undefined ? {} : { threadId: delivery.threadId }),
+                agentId: delivery.agentId,
+                principalId: resolution.user._id,
+                idempotencyKey,
+              });
+            }
+          }
+        } catch (error) {
+          req.log.warn({ error }, "surface interaction follow-up turn failed");
+        }
+      }
+
       return reply.send(result.interaction);
     }
   );


### PR DESCRIPTION
## Summary
- A Slack button/select click on a Surface Artifact (e.g. "Create it") executed the underlying action but never sent any reply back into the Slack thread, even on success — `handleSlackInteractive`'s `sf_` branch resolved the interaction via `/api/v1/internal/surfaces/interactions` and returned, with no follow-up turn or Channel delivery ever submitted.
- `apps/api/src/internal/surfaces-routes.ts` now recovers the original Run's Channel delivery (provider/destination/threadId/agentId) via `runDeliveries.find(businessId, handle.runId)`, submits a follow-up chat turn on the same conversation (mirroring the web client's client-side `send(surfaceInteractionAnswer(...))` after `postSurfaceInteraction`), and registers a new delivery row for the resulting Run so the integration-worker's poll loop posts the reply into the same Slack channel/thread.
- Wired the extra deps (`store`, `invocations`, `runDeliveries`) through in `apps/api/src/app.ts`, reusing what's already built for `registerChannelInternalRoutes`.

## Test plan
- [x] `pnpm --filter @tulipfarm/api exec vitest run src/internal/surfaces-routes.test.ts` — 6/6 passing, including a new test asserting a follow-up turn and a second `channel_run_deliveries` row (same destination/thread/provider/agent) are created after a Surface interaction resolves.
- [x] `pnpm exec turbo lint` — clean (pre-existing warnings in unrelated files only).
- [x] `pnpm exec turbo typecheck` — clean, 32/32 packages.
- [x] `pnpm exec turbo test --concurrency=1` — full repo suite, 31/31 packages passing (api: 192 files / 1828 tests passed, 1 skipped).