### PR TITLE
fix(integrations): resolve Slack mention tokens before agent turn

### DIFF
--- a/apps/integration-worker/src/channels/index.ts
+++ b/apps/integration-worker/src/channels/index.ts
@@ -13,6 +13,7 @@ import { InternalApiClient } from "../internal/client";
 import type { DrainableLoop } from "../shutdown";
 import { dispatchSlackEnvelope } from "../slack/dispatch";
 import { SlackWebApiHttp } from "../slack/http";
+import { slackUserDirectoryMentionResolver } from "../slack/mention-resolver";
 import { SlackSocketTransport } from "../slack/socket-transport";
 import { SlackSocketWorker } from "../slack/worker";
 import { channelDeliveryAuthorization } from "./delivery-authorization";
@@ -98,7 +99,15 @@ export async function createSlackChannelLoops(
     assistantStatus: { http, credential: botToken, log: deps.log },
   });
 
-  const channelAdapter = new SlackChannelAdapter({ inbound, identities, routing, runs, now });
+  const mentions = slackUserDirectoryMentionResolver(http, botToken, deps.log);
+  const channelAdapter = new SlackChannelAdapter({
+    inbound,
+    identities,
+    routing,
+    runs,
+    now,
+    mentions,
+  });
   const deliveryAdapter = new SlackDeliveryAdapter({
     ledger: channelDeliveryLedger(deliveryStore),
     authorization: channelDeliveryAuthorization(new IntegrationStore(transactions)),

--- a/apps/integration-worker/src/slack/mention-resolver.test.ts
+++ b/apps/integration-worker/src/slack/mention-resolver.test.ts
@@ -1,0 +1,72 @@
+import type { IntegrationHttpPort, IntegrationHttpResponse } from "@tulipfarm/integrations";
+import { describe, expect, it, vi } from "vitest";
+import { slackUserDirectoryMentionResolver } from "./mention-resolver";
+
+function fakeHttp(send: (path: string) => Promise<IntegrationHttpResponse>): IntegrationHttpPort {
+  return { send: async (request) => send(request.path) };
+}
+
+const log = { warn: vi.fn() };
+
+describe("slackUserDirectoryMentionResolver", () => {
+  it("resolves display_name from the profile", async () => {
+    const http = fakeHttp(async () => ({
+      status: 200,
+      headers: {},
+      body: { ok: true, user: { name: "mohit", profile: { display_name: "Mohit" } } },
+    }));
+    const resolver = slackUserDirectoryMentionResolver(http, "xoxb-token", log);
+
+    expect(await resolver.resolveDisplayName("U0AMFGRAKLY")).toBe("Mohit");
+  });
+
+  it("falls back through profile.real_name, user.real_name, then user.name", async () => {
+    const http = fakeHttp(async () => ({
+      status: 200,
+      headers: {},
+      body: { ok: true, user: { name: "mohit", real_name: "Mohit R", profile: {} } },
+    }));
+    const resolver = slackUserDirectoryMentionResolver(http, "xoxb-token", log);
+
+    expect(await resolver.resolveDisplayName("U1")).toBe("Mohit R");
+  });
+
+  it("resolves undefined on a non-2xx response", async () => {
+    const http = fakeHttp(async () => ({ status: 401, headers: {}, body: { ok: false } }));
+    const resolver = slackUserDirectoryMentionResolver(http, "xoxb-token", log);
+
+    expect(await resolver.resolveDisplayName("U1")).toBeUndefined();
+  });
+
+  it("resolves undefined on a malformed body", async () => {
+    const http = fakeHttp(async () => ({ status: 200, headers: {}, body: { ok: false } }));
+    const resolver = slackUserDirectoryMentionResolver(http, "xoxb-token", log);
+
+    expect(await resolver.resolveDisplayName("U1")).toBeUndefined();
+  });
+
+  it("resolves undefined instead of throwing when the transport throws", async () => {
+    const http: IntegrationHttpPort = {
+      send: async () => {
+        throw new Error("network down");
+      },
+    };
+    const resolver = slackUserDirectoryMentionResolver(http, "xoxb-token", log);
+
+    await expect(resolver.resolveDisplayName("U1")).resolves.toBeUndefined();
+  });
+
+  it("caches a resolution and does not call send twice for the same id", async () => {
+    const send = vi.fn(async () => ({
+      status: 200,
+      headers: {},
+      body: { ok: true, user: { name: "mohit", profile: { display_name: "Mohit" } } },
+    }));
+    const resolver = slackUserDirectoryMentionResolver({ send }, "xoxb-token", log);
+
+    await resolver.resolveDisplayName("U0AMFGRAKLY");
+    await resolver.resolveDisplayName("U0AMFGRAKLY");
+
+    expect(send).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/integration-worker/src/slack/mention-resolver.ts
+++ b/apps/integration-worker/src/slack/mention-resolver.ts
@@ -1,0 +1,62 @@
+import {
+  classifyHttpFailure,
+  type IntegrationHttpPort,
+  type SlackMentionResolverPort,
+} from "@tulipfarm/integrations";
+
+interface SlackUsersInfoResponse {
+  ok?: boolean;
+  user?: {
+    name?: string;
+    real_name?: string;
+    profile?: {
+      display_name?: string;
+      real_name?: string;
+    };
+  };
+}
+
+function displayNameFrom(body: SlackUsersInfoResponse): string | undefined {
+  const user = body.user;
+  if (!body.ok || !user) return undefined;
+  return user.profile?.display_name || user.profile?.real_name || user.real_name || user.name;
+}
+
+/**
+ * `SlackMentionResolverPort` backed by `users.info`, reusing the same `IntegrationHttpPort` +
+ * bot token already leased for delivery. Best-effort: any failure resolves to `undefined` rather
+ * than throwing, so a Slack API hiccup never blocks message ingestion. Cached per-instance
+ * (one instance per business boot) since the same person is commonly mentioned repeatedly.
+ */
+export function slackUserDirectoryMentionResolver(
+  http: IntegrationHttpPort,
+  credential: string,
+  log: { warn: (message: string, error?: unknown) => void }
+): SlackMentionResolverPort {
+  const cache = new Map<string, string | undefined>();
+
+  return {
+    async resolveDisplayName(userId: string): Promise<string | undefined> {
+      if (cache.has(userId)) return cache.get(userId);
+
+      let name: string | undefined;
+      try {
+        const response = await http.send(
+          { method: "GET", path: "/users.info", query: { user: userId } },
+          credential
+        );
+        const failure = classifyHttpFailure(response, false);
+        if (failure) {
+          log.warn(`slack users.info failed for ${userId}: ${failure.code}`);
+        } else {
+          name = displayNameFrom(response.body as SlackUsersInfoResponse);
+        }
+      } catch (err) {
+        log.warn(`slack users.info threw for ${userId}`, err);
+      }
+
+      cache.set(userId, name);
+      return name;
+    },
+  };
+}

--- a/packages/integrations/src/slack/adapter.test.ts
+++ b/packages/integrations/src/slack/adapter.test.ts
@@ -228,6 +228,60 @@ describe("SlackChannelAdapter", () => {
     expect(start).not.toHaveBeenCalled();
   });
 
+  it("resolves mention tokens in the text handed to the Run, not in the persisted event", async () => {
+    let persisted: ChannelInboundEvent | undefined;
+    const start = vi.fn(async () => ({ runId: "run-1", outcome: "started" as const }));
+    const mentionEvent = event();
+    if (mentionEvent.event === undefined) throw new Error("test setup: event missing");
+    mentionEvent.event.text = "create a task for <@U0AMFGRAKLY>";
+    const adapter = new SlackChannelAdapter({
+      inbound: {
+        accept: async (input) => {
+          persisted = input;
+          return { outcome: "accepted" };
+        },
+      },
+      identities: {
+        resolve: async () => ({ kind: "user", id: PRINCIPAL_ID }),
+      },
+      routing: { load: async () => routing() },
+      runs: { start },
+      now: () => "2026-07-26T10:00:00.000Z",
+      mentions: {
+        resolveDisplayName: async (userId: string) =>
+          userId === "U0AMFGRAKLY" ? "Mohit" : undefined,
+      },
+    });
+
+    await adapter.receive(BUSINESS_ID, mentionEvent, async () => undefined);
+
+    expect(persisted?.data.text).toBe("create a task for <@U0AMFGRAKLY>");
+    expect(start).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.objectContaining({ text: "create a task for @Mohit" }),
+      })
+    );
+  });
+
+  it("passes text through unchanged when no mentions resolver is configured", async () => {
+    const start = vi.fn(async () => ({ runId: "run-1", outcome: "started" as const }));
+    const adapter = new SlackChannelAdapter({
+      inbound: { accept: async () => ({ outcome: "accepted" }) },
+      identities: {
+        resolve: async () => ({ kind: "user", id: PRINCIPAL_ID }),
+      },
+      routing: { load: async () => routing() },
+      runs: { start },
+      now: () => "2026-07-26T10:00:00.000Z",
+    });
+
+    await adapter.receive(BUSINESS_ID, event(), async () => undefined);
+
+    expect(start).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.objectContaining({ text: "status?" }) })
+    );
+  });
+
   it("reloads routing for every event so an Integration revocation applies immediately", async () => {
     let calls = 0;
     const start = vi.fn(async () => ({ runId: "run-1", outcome: "started" as const }));

--- a/packages/integrations/src/slack/adapter.ts
+++ b/packages/integrations/src/slack/adapter.ts
@@ -13,6 +13,7 @@ import type {
 import { classifyHttpFailure, type IntegrationHttpPort } from "../http";
 import { ChannelRouteDeniedError, resolveChannelRoute } from "../model";
 import { toSlackMrkdwn } from "./markdown";
+import { resolveMentionsInText, type SlackMentionResolverPort } from "./mentions";
 
 export interface SlackFile {
   id?: unknown;
@@ -54,6 +55,11 @@ export interface SlackChannelAdapterDeps {
   routing: ChannelRoutingSource;
   runs: ChannelRunStarter;
   now: () => string;
+  /**
+   * Resolves `<@USERID>` mention tokens to display names before the agent sees the message text.
+   * Undefined skips resolution — the raw token passes through, matching prior behavior.
+   */
+  mentions?: SlackMentionResolverPort;
 }
 
 function requiredString(value: unknown): string {
@@ -181,6 +187,12 @@ export class SlackChannelAdapter {
         action: "channels.message.receive",
         targetType: "slack.channel",
       });
+      const resolvedText = this.deps.mentions
+        ? await resolveMentionsInText(inbound.data.text, this.deps.mentions).catch(
+            () => inbound.data.text
+          )
+        : inbound.data.text;
+
       const run = await this.deps.runs.start({
         businessId,
         eventId: inbound.eventId,
@@ -188,7 +200,7 @@ export class SlackChannelAdapter {
         routeId: route.routeId,
         agentId: route.agentId,
         principal,
-        message: inbound.data,
+        message: { ...inbound.data, text: resolvedText },
       });
       return { outcome: run.outcome, runId: run.runId };
     } catch (error) {

--- a/packages/integrations/src/slack/index.ts
+++ b/packages/integrations/src/slack/index.ts
@@ -1,2 +1,3 @@
 export * from "./adapter";
 export * from "./knowledge";
+export * from "./mentions";

--- a/packages/integrations/src/slack/mentions.test.ts
+++ b/packages/integrations/src/slack/mentions.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { resolveMentionsInText, type SlackMentionResolverPort } from "./mentions";
+
+function resolverFrom(names: Record<string, string | undefined>): SlackMentionResolverPort {
+  return {
+    resolveDisplayName: async (userId: string) => names[userId],
+  };
+}
+
+describe("resolveMentionsInText", () => {
+  it("replaces a single mention with the resolved display name", async () => {
+    const result = await resolveMentionsInText(
+      "create a task for <@U0AMFGRAKLY>",
+      resolverFrom({ U0AMFGRAKLY: "Mohit" })
+    );
+    expect(result).toBe("create a task for @Mohit");
+  });
+
+  it("replaces multiple distinct mentions", async () => {
+    const result = await resolveMentionsInText(
+      "assign to <@U1> and cc <@U2>",
+      resolverFrom({ U1: "Alice", U2: "Bob" })
+    );
+    expect(result).toBe("assign to @Alice and cc @Bob");
+  });
+
+  it("leaves an unresolved mention untouched", async () => {
+    const result = await resolveMentionsInText(
+      "task for <@U-UNKNOWN>",
+      resolverFrom({ "U-UNKNOWN": undefined })
+    );
+    expect(result).toBe("task for <@U-UNKNOWN>");
+  });
+
+  it("handles the display-hint mention form <@ID|label>", async () => {
+    const result = await resolveMentionsInText(
+      "task for <@U0AMFGRAKLY|mohit>",
+      resolverFrom({ U0AMFGRAKLY: "Mohit" })
+    );
+    expect(result).toBe("task for @Mohit");
+  });
+
+  it("is a no-op when there are no mentions", async () => {
+    const result = await resolveMentionsInText("no mentions here", resolverFrom({}));
+    expect(result).toBe("no mentions here");
+  });
+});

--- a/packages/integrations/src/slack/mentions.ts
+++ b/packages/integrations/src/slack/mentions.ts
@@ -11,7 +11,10 @@ export interface SlackMentionResolverPort {
   resolveDisplayName(userId: string): Promise<string | undefined>;
 }
 
-const MENTION_PATTERN = /<@([A-Z0-9]+)(?:\|[^>]*)?>/g;
+// The `|label` suffix is bounded (Slack ids/labels are short) so a long run of unterminated
+// `<@ID|` tokens in untrusted message text can't make this scan quadratic (CodeQL: polynomial
+// regex on uncontrolled input).
+const MENTION_PATTERN = /<@([A-Z0-9]+)(?:\|[^>]{0,80})?>/g;
 
 /**
  * Replaces every `<@USERID>` token with `@DisplayName`. A token whose id the resolver cannot

--- a/packages/integrations/src/slack/mentions.ts
+++ b/packages/integrations/src/slack/mentions.ts
@@ -1,0 +1,43 @@
+/**
+ * Slack renders an `@mention` in outgoing message text as an opaque `<@USERID>` token. Nothing
+ * downstream (the LLM agent, resource records, other channel replies) can turn that back into a
+ * name, so an unresolved mention becomes a raw Slack id wherever the agent copies it — e.g. into a
+ * record's `assignee` field. Resolving mentions here, before the agent ever sees the text, means
+ * the fix applies uniformly to every field or record type an agent might write the name into.
+ */
+
+export interface SlackMentionResolverPort {
+  /** Resolves a Slack user id to a display name, or undefined if unknown/unavailable. */
+  resolveDisplayName(userId: string): Promise<string | undefined>;
+}
+
+const MENTION_PATTERN = /<@([A-Z0-9]+)(?:\|[^>]*)?>/g;
+
+/**
+ * Replaces every `<@USERID>` token with `@DisplayName`. A token whose id the resolver cannot
+ * resolve is left untouched — best-effort, never blocks the message on a Slack API hiccup.
+ */
+export async function resolveMentionsInText(
+  text: string,
+  resolver: SlackMentionResolverPort
+): Promise<string> {
+  const ids = new Set<string>();
+  for (const match of text.matchAll(MENTION_PATTERN)) {
+    ids.add(match[1]);
+  }
+  if (ids.size === 0) return text;
+
+  const names = new Map<string, string>();
+  await Promise.all(
+    Array.from(ids).map(async (id) => {
+      const name = await resolver.resolveDisplayName(id);
+      if (name) names.set(id, name);
+    })
+  );
+  if (names.size === 0) return text;
+
+  return text.replace(MENTION_PATTERN, (whole, id: string) => {
+    const name = names.get(id);
+    return name ? `@${name}` : whole;
+  });
+}


### PR DESCRIPTION
## Summary
- Slack sends `@mentions` as opaque `<@USERID>` tokens; nothing resolved them back to a name, so the agent copied the raw Slack id verbatim into record fields (e.g. a task's `assignee`) — surfacing as `U0AMFGRAKLY` in both the web UI and Slack replies, and unmatchable by name search.
- Resolves mentions via `users.info` at the Slack ingress choke point (`SlackChannelAdapter.receive`, `packages/integrations/src/slack/adapter.ts`), before the text reaches the agent. The durably persisted inbound event keeps the raw text (audit trail unchanged); only the copy handed to the Run is resolved.
- Best-effort: any Slack API failure/unknown user falls back to the raw token rather than blocking ingestion. New `SlackMentionResolverPort` implemented in `apps/integration-worker/src/slack/mention-resolver.ts`, wired via the existing `SlackWebApiHttp` + bot token in `channels/index.ts`. No changes needed to the web or Slack renderers — they already render whatever string is stored.

## Test plan
- [x] `pnpm --filter @tulipfarm/integrations test` — 220 passed, including new `mentions.test.ts` and two new `adapter.test.ts` cases (mention resolved into the Run text but not the persisted event; passthrough unchanged when no resolver configured)
- [x] `pnpm --filter @tulipfarm/integration-worker test` — 93 passed, including new `mention-resolver.test.ts` (happy path, field-precedence fallback, non-2xx, malformed body, thrown transport error, cache hit)
- [x] `pnpm exec biome check` and `tsc --noEmit` clean on both touched packages
- [ ] Manual QA in a connected Slack workspace: DM the bot "create a task for @Mohit" (real mention autocomplete), confirm the task's assignee shows "Mohit" in the web UI and in the bot's "show all tasks" reply, and "show tasks for Mohit" finds it