### PR TITLE
fix(release): exclude non-conventional commits from changelog instead of blocking

### DIFF
--- a/scripts/release-changelog.test.ts
+++ b/scripts/release-changelog.test.ts
@@ -101,13 +101,22 @@ describe("release changelog generation", () => {
     );
   });
 
-  it("rejects commits that would otherwise disappear silently", async () => {
+  it("excludes non-Conventional Commit subjects instead of blocking the release", async () => {
+    const cwd = createRepository();
+    commitChange(cwd, 'Revert "feat(web): redesign chat UI (#320)" (#324)');
+    commitChange(cwd, "fix(api): repair a regression");
+
+    const generated = await generateReleaseFiles("1.0.1", cwd);
+
+    expect(generated.section).toContain("repair a regression");
+    expect(generated.section).not.toContain("Revert");
+  });
+
+  it("fails the release when no commits are Conventional Commits", async () => {
     const cwd = createRepository();
     commitChange(cwd, "unknown: omit me");
 
-    await expect(generateReleaseFiles("1.0.1", cwd)).rejects.toThrow(
-      "is not an allowed Conventional Commit"
-    );
+    await expect(generateReleaseFiles("1.0.1", cwd)).rejects.toThrow("No releasable commits exist");
   });
 
   it("rejects an empty release section", () => {

--- a/scripts/release-changelog.ts
+++ b/scripts/release-changelog.ts
@@ -136,9 +136,10 @@ export function collectReleaseCommits(sourceSha: string, cwd = process.cwd()): R
       const match = CONVENTIONAL_SUBJECT.exec(subject);
       const type = match?.[1];
       if (!sha || !type || !ALLOWED_COMMIT_TYPES.has(type)) {
-        throw new Error(
-          `Commit ${sha || "(unknown)"} is not an allowed Conventional Commit: ${subject}`
+        console.warn(
+          `Excluding commit ${sha || "(unknown)"} from changelog — not an allowed Conventional Commit: ${subject}`
         );
+        return undefined;
       }
 
       return { sha, subject, type };


### PR DESCRIPTION
## Summary
- `release-changelog.ts generate` hard-threw on any commit subject that didn't parse as a Conventional Commit, blocking the entire release pipeline — this is what broke the 0.6.0 release on commit `1d796ce` (a squash-merged GitHub auto-revert: `Revert "feat(web): ... (#320)" (#324)`), which never carries a `type:` prefix.
- Non-conforming commits are now excluded from the changelog (with a stderr warning) instead of raising. Release generation still fails if *zero* commits qualify.

## Test plan
- [x] `pnpm exec vitest run scripts/release-changelog.test.ts` — updated test replaces the old "rejects" case with one asserting exclusion + release success, plus a new case confirming an all-non-conventional history still fails release generation
- [x] `pnpm exec biome check --write scripts/release-changelog.ts scripts/release-changelog.test.ts`