### PR TITLE
feat(integrations): add send_slack_message chat tool with thread-reply continuity

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -31,6 +31,7 @@ import {
 } from "@tulipfarm/soul";
 import {
   ArtifactStore,
+  ChannelMentionedThreadStore,
   ChannelRunDeliveryStore,
   ChildLinkStore,
   EventStore,
@@ -153,6 +154,8 @@ import { surfaceRendererRegistry } from "./surfaces/renderer-registry";
 import { buildGitHubTooling } from "./tools/github/compose";
 import { buildGitHubTools } from "./tools/github/tools";
 import { buildToolRegistry } from "./tools/setup";
+import { buildSlackTooling } from "./tools/slack/compose";
+import { buildSlackTools } from "./tools/slack/tools";
 
 // Load .env.local (symlinked from root by setup script)
 config({ path: ".env.local" });
@@ -365,6 +368,9 @@ async function boot() {
     const channelRunDeliveries = new ChannelRunDeliveryStore(runTransactions, () =>
       new Date().toISOString()
     );
+    const channelMentionedThreads = new ChannelMentionedThreadStore(runTransactions, () =>
+      new Date().toISOString()
+    );
     const channelIntegrations = new IntegrationStore(runTransactions);
     // The bind link's HMAC key comes from the secret store, provisioned on first use — never a
     // constant in the image, which every deployment would share.
@@ -402,6 +408,20 @@ async function boot() {
       effects: githubEffects,
     });
 
+    // Slack send tool: same effect-ledger dispatch pattern as GitHub. Writes an
+    // `integration_conversations` mapping on send (see `tools/slack/tools.ts`) so a human reply in
+    // the sent message's thread routes back to this conversation instead of starting a new one.
+    const slackTooling = buildSlackTooling({
+      secrets: async () => secretsService,
+    });
+    const slackEffects = new PgEffectStore(runTransactions);
+    const slackTools = buildSlackTools(DEPLOYMENT_BUSINESS_ID, {
+      ...slackTooling,
+      effects: slackEffects,
+      threads: integrationThreads,
+      mentionedThreads: channelMentionedThreads,
+    });
+
     // Full chat tool registry: memory + knowledge (platform) plus every forge family
     // (resource records/types, agents, skills, platform tools). Without this, a chat turn only
     // sees memory+knowledge and no agent can create/curate soul artifacts. Per-agent allowlists
@@ -429,6 +449,7 @@ async function boot() {
       },
       slackKnowledgeSearch: slackKnowledgeSearchTool,
       github: githubTools,
+      slack: slackTools,
       platform: {
         events: domainEventEmitter,
         soulLoader,

--- a/apps/api/src/integrations/slack-http.ts
+++ b/apps/api/src/integrations/slack-http.ts
@@ -1,0 +1,72 @@
+import type {
+  IntegrationHttpPort,
+  IntegrationHttpRequest,
+  IntegrationHttpResponse,
+} from "@tulipfarm/integrations";
+
+/**
+ * Slack Web API transport for this app: the `send_slack_message` chat Tool's adapter dispatch
+ * (`tools/slack/tools.ts`). A deliberate local copy of `apps/integration-worker/src/slack/http.ts`
+ * — an application may not import another application (`apps/integration-worker/AGENTS.md`). Kept
+ * intentionally tiny: no pagination, no retry, mirrors just enough of `SlackWebApiHttp` to satisfy
+ * `IntegrationHttpPort`.
+ */
+
+export const SLACK_API_BASE_URL = "https://slack.com/api";
+
+export interface SlackWebApiHttpOptions {
+  readonly baseUrl?: string;
+  readonly fetch?: typeof globalThis.fetch;
+}
+
+export class SlackWebApiHttp implements IntegrationHttpPort {
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof globalThis.fetch;
+
+  constructor(options: SlackWebApiHttpOptions = {}) {
+    this.baseUrl = options.baseUrl ?? SLACK_API_BASE_URL;
+    this.fetchImpl = options.fetch ?? globalThis.fetch;
+  }
+
+  async send(
+    request: IntegrationHttpRequest,
+    credential: string
+  ): Promise<IntegrationHttpResponse> {
+    const url = new URL(`${this.baseUrl}${request.path}`);
+    for (const [key, value] of Object.entries(request.query ?? {})) {
+      url.searchParams.set(key, value);
+    }
+
+    let response: Response;
+    try {
+      response = await this.fetchImpl(url, {
+        method: request.method,
+        headers: {
+          authorization: `Bearer ${credential}`,
+          accept: "application/json",
+          ...(request.body === undefined ? {} : { "content-type": "application/json" }),
+          ...request.headers,
+        },
+        ...(request.body === undefined ? {} : { body: JSON.stringify(request.body) }),
+      });
+    } catch {
+      return { status: 503, headers: {}, body: undefined };
+    }
+
+    return {
+      status: response.status,
+      headers: Object.fromEntries(response.headers.entries()),
+      body: await parseBody(response),
+    };
+  }
+}
+
+async function parseBody(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (text.length === 0) return undefined;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}

--- a/apps/api/src/internal/channel-routes.ts
+++ b/apps/api/src/internal/channel-routes.ts
@@ -68,7 +68,11 @@ interface ChannelMessageBody {
   text: string;
 }
 
-function externalThreadKey(provider: string, message: ChannelMessageBody): string {
+/** Exported so a Tool that proactively sends into a channel (e.g. `send_slack_message`) can write
+ * the same `integration_conversations` key the reactive ingress path would derive on first reply,
+ * making a human's thread reply route back to the sending conversation instead of starting a new
+ * one. */
+export function externalThreadKey(provider: string, message: ChannelMessageBody): string {
   return `${provider}:${message.channelId}:${message.threadId ?? message.channelId}`;
 }
 

--- a/apps/api/src/tools/setup.ts
+++ b/apps/api/src/tools/setup.ts
@@ -38,6 +38,8 @@ export function buildToolRegistry(services: {
    * Registered unconditionally when GitHub composition is available; per-turn visibility is gated
    * separately on live install status (`chat/turn-helpers.ts`), not on registration. */
   github?: readonly ToolDef[];
+  /** Slack chat tool family — pre-built ToolDefs (see `tools/slack/tools.ts`'s `buildSlackTools`). */
+  slack?: readonly ToolDef[];
 }): ToolRegistry {
   const registry = new ToolRegistry({ defaultDeny: true });
 
@@ -195,6 +197,12 @@ export function buildToolRegistry(services: {
 
   if (services.github) {
     for (const t of services.github) {
+      registry.register(t);
+    }
+  }
+
+  if (services.slack) {
+    for (const t of services.slack) {
       registry.register(t);
     }
   }

--- a/apps/api/src/tools/slack/compose.ts
+++ b/apps/api/src/tools/slack/compose.ts
@@ -1,0 +1,63 @@
+import {
+  type IntegrationHttpPort,
+  SLACK_ADAPTER_REF,
+  SlackToolAdapter,
+} from "@tulipfarm/integrations";
+import {
+  type SecretAuthorizer,
+  SecretBroker,
+  type SecretsService,
+  secretsServiceProvider,
+} from "@tulipfarm/secrets";
+import { CredentialDispatcher, type ToolAdapter } from "@tulipfarm/tool-broker";
+import { SlackWebApiHttp } from "../../integrations/slack-http";
+import {
+  SLACK_BOT_TOKEN_SECRET_REF,
+  SlackBotTokenProvider,
+  slackCompositeSecretProvider,
+} from "./credentials";
+
+/**
+ * Composes the `send_slack_message` chat Tool's adapter map and `CredentialDispatcher`. Mirrors
+ * `../github/compose.ts`'s `buildGitHubTooling`.
+ */
+
+export interface BuildSlackToolingOptions {
+  readonly secrets: () => Promise<SecretsService>;
+  readonly http?: IntegrationHttpPort;
+}
+
+export interface SlackTooling {
+  readonly adapters: ReadonlyMap<string, ToolAdapter>;
+  readonly credentials: CredentialDispatcher;
+}
+
+/** Default-deny authorizer: only the Slack bot-token ref may ever lease. */
+const slackOnlyAuthorizer: SecretAuthorizer = {
+  authorize(scope) {
+    if (scope.secretRef !== SLACK_BOT_TOKEN_SECRET_REF)
+      return { allowed: false, reason: "not_authorized" };
+    return { allowed: true, maxTtlMs: 5 * 60 * 1000, maxUses: 1 };
+  },
+};
+
+export function buildSlackTooling(options: BuildSlackToolingOptions): SlackTooling {
+  const http = options.http ?? new SlackWebApiHttp();
+  const adapter = new SlackToolAdapter({ http });
+
+  const tokenProvider = new SlackBotTokenProvider({ secrets: options.secrets });
+  const provider = slackCompositeSecretProvider(
+    secretsServiceProvider({ get: async (key) => (await options.secrets()).get(key) }),
+    tokenProvider
+  );
+  const secretBroker = new SecretBroker({ provider, authorizer: slackOnlyAuthorizer });
+  const credentials = new CredentialDispatcher({
+    secrets: secretBroker,
+    reauthorize: () => true,
+  });
+
+  return {
+    adapters: new Map<string, ToolAdapter>([[SLACK_ADAPTER_REF, adapter]]),
+    credentials,
+  };
+}

--- a/apps/api/src/tools/slack/credentials.ts
+++ b/apps/api/src/tools/slack/credentials.ts
@@ -1,0 +1,42 @@
+import type { SecretProvider, SecretsService } from "@tulipfarm/secrets";
+import { integrationSecretKey } from "../../integrations/connection-env";
+
+/**
+ * The `SecretProvider` the `send_slack_message` chat Tool's `credentialRef` resolves to. Reuses
+ * the same sealed bot token `/api/v1/internal/channels/*` already reads
+ * (`integrationSecretKey("slack", "SLACK_BOT_TOKEN")`, `apps/api/src/internal/channel-routes.ts`)
+ * rather than adding a second Slack credential path.
+ */
+export const SLACK_BOT_TOKEN_SECRET_REF = "secret://integrations/slack/bot-token";
+
+export interface SlackBotTokenProviderDeps {
+  readonly secrets: () => Promise<SecretsService>;
+}
+
+export class SlackBotTokenProvider implements SecretProvider {
+  constructor(private readonly deps: SlackBotTokenProviderDeps) {}
+
+  async resolveCurrent(secretRef: string) {
+    if (secretRef !== SLACK_BOT_TOKEN_SECRET_REF) return null;
+    try {
+      const secrets = await this.deps.secrets();
+      const value = await secrets.get(integrationSecretKey("slack", "SLACK_BOT_TOKEN"));
+      return { value };
+    } catch {
+      return null;
+    }
+  }
+}
+
+/** Routes the Slack bot-token ref to `slack`; every other ref falls through to `base`. */
+export function slackCompositeSecretProvider(
+  base: SecretProvider,
+  slack: SecretProvider
+): SecretProvider {
+  return {
+    async resolveCurrent(secretRef) {
+      if (secretRef === SLACK_BOT_TOKEN_SECRET_REF) return slack.resolveCurrent(secretRef);
+      return base.resolveCurrent(secretRef);
+    },
+  };
+}

--- a/apps/api/src/tools/slack/tools.test.ts
+++ b/apps/api/src/tools/slack/tools.test.ts
@@ -1,0 +1,267 @@
+import type { IntegrationHttpRequest } from "@tulipfarm/integrations";
+import type { SecretsService } from "@tulipfarm/secrets";
+import type { ChannelMentionedThreadStore } from "@tulipfarm/storage";
+import { MemoryEffectStore } from "@tulipfarm/tool-broker";
+import { describe, expect, it } from "vitest";
+import type { IntegrationConversation, IntegrationConversationsRepo } from "../../ingress/repo";
+import type { RequestContext } from "../types";
+import { buildSlackTooling } from "./compose";
+import { buildSlackTools } from "./tools";
+
+/**
+ * Exercises `buildSlackTools()`'s `ToolDef.execute()` against a real `buildSlackTooling()` object
+ * graph (channel resolution, `SlackToolAdapter` dispatch), faking only the two edges outside this
+ * app's control — same shape as `../github/tools.test.ts`.
+ */
+
+const BUSINESS_ID = "biz-triage";
+
+function fakeSecretsService(): () => Promise<SecretsService> {
+  return async () =>
+    ({
+      get: async (key: string) => {
+        if (key.includes("SLACK_BOT_TOKEN")) return "xoxb-fake";
+        throw new Error(`no secret ${key}`);
+      },
+      // biome-ignore lint/suspicious/noExplicitAny: only `get` is exercised
+    }) as any;
+}
+
+type MarkInput = { businessId: string; provider: string; channelId: string; threadId: string };
+
+function fakeMentionedThreads(): ChannelMentionedThreadStore & { marked: MarkInput[] } {
+  const marked: MarkInput[] = [];
+  return {
+    marked,
+    async mark(input: MarkInput) {
+      marked.push(input);
+    },
+    async isMentioned() {
+      return true;
+    },
+    // biome-ignore lint/suspicious/noExplicitAny: only mark/isMentioned are exercised
+  } as any;
+}
+
+function fakeThreads(): IntegrationConversationsRepo & { inserted: IntegrationConversation[] } {
+  const inserted: IntegrationConversation[] = [];
+  return {
+    inserted,
+    async find() {
+      return null;
+    },
+    async exists() {
+      return false;
+    },
+    async insert(doc: IntegrationConversation) {
+      inserted.push(doc);
+    },
+    // biome-ignore lint/suspicious/noExplicitAny: only these three methods are exercised
+  } as any;
+}
+
+function fakeHttp(ts: string) {
+  return {
+    async send(request: IntegrationHttpRequest, credential?: string) {
+      expect(credential).toBe("xoxb-fake");
+      if (request.path === "/conversations.list") {
+        return {
+          status: 200,
+          headers: {},
+          body: { ok: true, channels: [{ id: "C123", name: "slack-bot-test" }] },
+        };
+      }
+      if (request.path === "/chat.postMessage") {
+        return { status: 200, headers: {}, body: { ok: true, ts, channel: "C123" } };
+      }
+      throw new Error(`unexpected request: ${request.method} ${request.path}`);
+    },
+  };
+}
+
+function context(overrides: Partial<RequestContext> = {}): RequestContext {
+  return { userId: "user-1", runId: "run-1", toolCallId: "call-1", ...overrides };
+}
+
+describe("buildSlackTools", () => {
+  it("resolves a channel name, sends, and returns the ledger dispatch output", async () => {
+    const tooling = buildSlackTooling({ secrets: fakeSecretsService(), http: fakeHttp("100.001") });
+    const threads = fakeThreads();
+    const tools = buildSlackTools(BUSINESS_ID, {
+      ...tooling,
+      effects: new MemoryEffectStore(),
+      threads,
+      mentionedThreads: fakeMentionedThreads(),
+    });
+    const tool = tools.find((t) => t.name === "send_slack_message");
+    if (tool === undefined) throw new Error("send_slack_message not registered");
+    expect(tool.mutating).toBe(true);
+
+    const result = await tool.execute(
+      { channel: "#slack-bot-test", text: "hi" },
+      context({ conversationId: "conv-1" })
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual({ channelId: "C123", ts: "100.001", threadId: "100.001" });
+    }
+  });
+
+  it("marks the sent thread as mentioned so a reply passes the ingress mention-gate", async () => {
+    const tooling = buildSlackTooling({ secrets: fakeSecretsService(), http: fakeHttp("100.002") });
+    const mentionedThreads = fakeMentionedThreads();
+    const tools = buildSlackTools(BUSINESS_ID, {
+      ...tooling,
+      effects: new MemoryEffectStore(),
+      threads: fakeThreads(),
+      mentionedThreads,
+    });
+    const tool = tools.find((t) => t.name === "send_slack_message");
+    if (tool === undefined) throw new Error("send_slack_message not registered");
+
+    await tool.execute({ channel: "slack-bot-test", text: "hi" }, context());
+
+    expect(mentionedThreads.marked).toEqual([
+      { businessId: BUSINESS_ID, provider: "slack", channelId: "C123", threadId: "100.002" },
+    ]);
+  });
+
+  it("writes an integration_conversations mapping so a thread reply routes back to this conversation", async () => {
+    const tooling = buildSlackTooling({ secrets: fakeSecretsService(), http: fakeHttp("100.002") });
+    const threads = fakeThreads();
+    const tools = buildSlackTools(BUSINESS_ID, {
+      ...tooling,
+      effects: new MemoryEffectStore(),
+      threads,
+      mentionedThreads: fakeMentionedThreads(),
+    });
+    const tool = tools.find((t) => t.name === "send_slack_message");
+    if (tool === undefined) throw new Error("send_slack_message not registered");
+
+    await tool.execute(
+      { channel: "slack-bot-test", text: "hi" },
+      context({ conversationId: "conv-1" })
+    );
+
+    expect(threads.inserted).toEqual([
+      {
+        integrationSlug: "slack",
+        externalKey: "slack:C123:100.002",
+        conversationId: "conv-1",
+        userId: "user-1",
+      },
+    ]);
+  });
+
+  it("skips channels.list and sends directly when given a raw channel ID", async () => {
+    let listCalls = 0;
+    const http = {
+      async send(request: IntegrationHttpRequest) {
+        if (request.path === "/conversations.list") {
+          listCalls += 1;
+          return { status: 200, headers: {}, body: { ok: true, channels: [] } };
+        }
+        return { status: 200, headers: {}, body: { ok: true, ts: "100.003", channel: "C999" } };
+      },
+    };
+    const tooling = buildSlackTooling({ secrets: fakeSecretsService(), http });
+    const tools = buildSlackTools(BUSINESS_ID, {
+      ...tooling,
+      effects: new MemoryEffectStore(),
+      threads: fakeThreads(),
+      mentionedThreads: fakeMentionedThreads(),
+    });
+    const tool = tools.find((t) => t.name === "send_slack_message");
+    if (tool === undefined) throw new Error("send_slack_message not registered");
+
+    const result = await tool.execute({ channel: "C999999999", text: "hi" }, context());
+
+    expect(result.success).toBe(true);
+    expect(listCalls).toBe(0);
+  });
+
+  it("replays the same effect instead of re-sending on a repeated call id", async () => {
+    let posts = 0;
+    const http = {
+      async send(request: IntegrationHttpRequest) {
+        if (request.path === "/conversations.list") {
+          return {
+            status: 200,
+            headers: {},
+            body: { ok: true, channels: [{ id: "C123", name: "slack-bot-test" }] },
+          };
+        }
+        posts += 1;
+        return { status: 200, headers: {}, body: { ok: true, ts: "100.004", channel: "C123" } };
+      },
+    };
+    const tooling = buildSlackTooling({ secrets: fakeSecretsService(), http });
+    const tools = buildSlackTools(BUSINESS_ID, {
+      ...tooling,
+      effects: new MemoryEffectStore(),
+      threads: fakeThreads(),
+      mentionedThreads: fakeMentionedThreads(),
+    });
+    const tool = tools.find((t) => t.name === "send_slack_message");
+    if (tool === undefined) throw new Error("send_slack_message not registered");
+
+    const args = { channel: "#slack-bot-test", text: "hi" };
+    const ctx = context();
+    const first = await tool.execute(args, ctx);
+    const second = await tool.execute(args, ctx);
+
+    expect(first.success).toBe(true);
+    expect(second.success).toBe(true);
+    if (second.success) {
+      expect(second.data).toMatchObject({ replayed: true });
+    }
+    expect(posts).toBe(1);
+  });
+
+  it("fails closed with an internal_error when the run context is missing", async () => {
+    const tooling = buildSlackTooling({ secrets: fakeSecretsService(), http: fakeHttp("100.005") });
+    const tools = buildSlackTools(BUSINESS_ID, {
+      ...tooling,
+      effects: new MemoryEffectStore(),
+      threads: fakeThreads(),
+      mentionedThreads: fakeMentionedThreads(),
+    });
+    const tool = tools.find((t) => t.name === "send_slack_message");
+    if (tool === undefined) throw new Error("send_slack_message not registered");
+
+    const result = await tool.execute({ channel: "slack-bot-test", text: "hi" }, { userId: "u" });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.code).toBe("internal_error");
+    }
+  });
+
+  it("reports not_found when the channel name doesn't resolve", async () => {
+    const http = {
+      async send(request: IntegrationHttpRequest) {
+        if (request.path === "/conversations.list") {
+          return { status: 200, headers: {}, body: { ok: true, channels: [] } };
+        }
+        throw new Error(`unexpected request: ${request.path}`);
+      },
+    };
+    const tooling = buildSlackTooling({ secrets: fakeSecretsService(), http });
+    const tools = buildSlackTools(BUSINESS_ID, {
+      ...tooling,
+      effects: new MemoryEffectStore(),
+      threads: fakeThreads(),
+      mentionedThreads: fakeMentionedThreads(),
+    });
+    const tool = tools.find((t) => t.name === "send_slack_message");
+    if (tool === undefined) throw new Error("send_slack_message not registered");
+
+    const result = await tool.execute({ channel: "nonexistent", text: "hi" }, context());
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.code).toBe("not_found");
+    }
+  });
+});

--- a/apps/api/src/tools/slack/tools.ts
+++ b/apps/api/src/tools/slack/tools.ts
@@ -1,0 +1,218 @@
+import { createHash } from "node:crypto";
+import { SLACK_TOOL_CONTRACTS, SLACK_TOOL_IDS, type SlackToolId } from "@tulipfarm/integrations";
+import type { ChannelMentionedThreadStore } from "@tulipfarm/storage";
+import {
+  EffectDispatcher,
+  type EffectStore,
+  intentDigest,
+  normalizeToolIntent,
+  ToolCatalog,
+  ToolDispatchError,
+  type ToolIntent,
+} from "@tulipfarm/tool-broker";
+import type { IntegrationConversationsRepo } from "../../ingress/repo";
+import { externalThreadKey } from "../../internal/channel-routes";
+import { err, ok, type RequestContext, type ToolCallResult, type ToolDef } from "../types";
+import type { SlackTooling } from "./compose";
+import { SLACK_BOT_TOKEN_SECRET_REF } from "./credentials";
+
+/**
+ * The chat-facing Slack Tool family — one `ToolDef` per `SLACK_TOOL_CONTRACTS` entry, tier
+ * `"integration"`. Mirrors `../github/tools.ts`: every call goes through the effect-ledger
+ * idempotency path (`EffectStore.reserve` -> `EffectDispatcher.dispatch`). Approval gating is the
+ * existing chat-turn coarse gate keyed on `ToolDef.mutating` — no bespoke Slack approval UI.
+ *
+ * After a successful send, writes an `integration_conversations` mapping for the sent message's
+ * channel + `ts` so a human reply in that Slack thread routes back to this same conversation,
+ * exactly as the reactive ingress path would derive on first inbound message
+ * (`internal/channel-routes.ts`'s `externalThreadKey`). It also marks the thread as mentioned
+ * (`ChannelMentionedThreadStore.mark`) — `apps/integration-worker`'s mention-gate
+ * (`channels/mention-gate.ts`) only lets a channel reply through when the thread was previously
+ * marked via a human `@mention`; a thread the bot itself started has no such mark, so without this
+ * every reply in it would be silently dropped as `unmentioned_thread`.
+ */
+
+const SLACK_CATALOG = ToolCatalog.load(SLACK_TOOL_CONTRACTS);
+
+interface SlackToolSpec {
+  readonly name: string;
+  readonly description: string;
+}
+
+const SLACK_TOOL_SPECS: Record<SlackToolId, SlackToolSpec> = {
+  [SLACK_TOOL_IDS.sendMessage]: {
+    name: "send_slack_message",
+    description:
+      "Send a message to a Slack channel the bot has joined. Accepts a channel name (with or " +
+      "without a leading '#') or a raw channel ID. A human reply in the resulting thread " +
+      "continues this same conversation. To notify a specific person, write '@' followed by " +
+      "their Slack name or first name (e.g. 'hi @mohit') — this is converted into a real, " +
+      "clickable, notifying Slack mention before sending. Writing the name with no '@' sends " +
+      "it as plain text and does not notify or tag anyone.",
+  },
+};
+
+/** Dresses a digest as an RFC 4122 v4 uuid, same technique run-kernel uses for durable effect ids. */
+function derivedId(...parts: readonly string[]): string {
+  const digest = createHash("sha256").update(parts.join(":")).digest("hex");
+  const version = `4${digest.slice(13, 16)}`;
+  const variant = ((Number.parseInt(digest.slice(16, 17), 16) & 0x3) | 0x8).toString(16);
+  return [
+    digest.slice(0, 8),
+    digest.slice(8, 12),
+    version,
+    `${variant}${digest.slice(17, 20)}`,
+    digest.slice(20, 32),
+  ].join("-");
+}
+
+function mapDispatchError(error: ToolDispatchError): ToolCallResult {
+  if (error.code === "invalid_output")
+    return err("internal_error", "Slack returned an unexpected response shape");
+  if (error.detail === "channel_not_found") {
+    return err("not_found", "No Slack channel by that name — check the bot has joined it.");
+  }
+  return err("internal_error", error.detail ? `${error.code}:${error.detail}` : error.message);
+}
+
+/**
+ * A rediscovered effect from an earlier attempt at this exact call (same run + call id) — the
+ * ledger keeps only whether it landed, not the Slack response body, so a replay can't hand the
+ * model the original output back. Mirrors `../github/tools.ts`'s `replayed()`.
+ */
+function replayed(state: string): ToolCallResult {
+  switch (state) {
+    case "confirmed":
+      return ok({ replayed: true, note: "This message already sent; not repeated." });
+    case "denied":
+      return err("internal_error", "effect_denied");
+    case "failed":
+      return err("internal_error", "effect_failed");
+    default:
+      return err("internal_error", `effect_${state}`);
+  }
+}
+
+function isSendMessageOutput(
+  value: unknown
+): value is { channelId: string; ts: string; threadId: string } {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    typeof (value as Record<string, unknown>).channelId === "string" &&
+    typeof (value as Record<string, unknown>).ts === "string"
+  );
+}
+
+export interface SlackToolingContext extends SlackTooling {
+  readonly effects: EffectStore;
+  readonly threads: IntegrationConversationsRepo;
+  readonly mentionedThreads: ChannelMentionedThreadStore;
+}
+
+function buildToolDef(
+  toolId: SlackToolId,
+  businessId: string,
+  tooling: SlackToolingContext
+): ToolDef {
+  const contract = SLACK_CATALOG.get(toolId, "1.0.0");
+  if (contract === undefined) {
+    throw new Error(`slack tool contract not published: ${toolId}`);
+  }
+  const spec = SLACK_TOOL_SPECS[toolId];
+
+  return {
+    name: spec.name,
+    tier: "integration",
+    mutating: contract.mutating,
+    description: spec.description,
+    inputSchema: contract.inputSchema,
+    async execute(args, ctx: RequestContext): Promise<ToolCallResult> {
+      const runId = ctx.runId;
+      if (runId === undefined) return err("internal_error", "no run context for this tool call");
+      const callId = ctx.toolCallId ?? crypto.randomUUID();
+      const stateId = `invoke:${callId}`;
+
+      const rawIntent: ToolIntent = {
+        intentId: derivedId("slack-intent", runId, stateId, toolId),
+        businessId,
+        runId,
+        stateId,
+        toolId,
+        toolVersion: contract.toolVersion,
+        action: toolId,
+        targetRefs: [],
+        arguments: args,
+        credentialRef: SLACK_BOT_TOKEN_SECRET_REF,
+        idempotencyKey: derivedId("slack-idempotency", runId, stateId, toolId),
+      };
+      const intent = normalizeToolIntent(rawIntent);
+      const effectId = derivedId("slack-effect", runId, stateId, toolId);
+
+      const reserved = await tooling.effects.reserve({
+        effectId,
+        businessId,
+        runId,
+        stateId,
+        logicalEffectOrdinal: 0,
+        idempotencyKey: intent.idempotencyKey,
+        intentDigest: intentDigest(intent),
+        intent,
+        guardrailRevision: ctx.guardrailRevision ?? "none",
+        createdAt: new Date().toISOString(),
+      });
+
+      if (reserved.outcome === "duplicate") return replayed(reserved.effect.state);
+
+      const dispatcher = new EffectDispatcher({
+        store: tooling.effects,
+        catalog: SLACK_CATALOG,
+        adapters: tooling.adapters,
+        credentialDispatcher: tooling.credentials,
+      });
+
+      try {
+        const output = await dispatcher.dispatch(businessId, reserved.effect.effectId);
+        if (toolId === SLACK_TOOL_IDS.sendMessage && isSendMessageOutput(output)) {
+          // Let a reply in this thread pass the ingress mention-gate even though no human ever
+          // @mentioned the bot here — the bot starting the thread should count the same way.
+          await tooling.mentionedThreads.mark({
+            businessId,
+            provider: "slack",
+            channelId: output.channelId,
+            threadId: output.threadId,
+          });
+          if (ctx.conversationId !== undefined) {
+            const key = externalThreadKey("slack", {
+              externalAppId: "",
+              channelId: output.channelId,
+              threadId: output.threadId,
+              text: "",
+            });
+            await tooling.threads.insert({
+              integrationSlug: "slack",
+              externalKey: key,
+              conversationId: ctx.conversationId,
+              userId: ctx.userId,
+            });
+          }
+        }
+        return ok(output);
+      } catch (error) {
+        if (error instanceof ToolDispatchError) return mapDispatchError(error);
+        throw error;
+      }
+    },
+  };
+}
+
+export function buildSlackTools(businessId: string, tooling: SlackToolingContext): ToolDef[] {
+  return SLACK_TOOL_CONTRACTS.map((contract) =>
+    buildToolDef(contract.spec.toolId as SlackToolId, businessId, tooling)
+  );
+}
+
+/** Every chat tool name this family registers. */
+export const SLACK_TOOL_NAMES: ReadonlySet<string> = new Set(
+  Object.values(SLACK_TOOL_SPECS).map((spec) => spec.name)
+);

--- a/apps/docs/content/docs/guides/operations.mdx
+++ b/apps/docs/content/docs/guides/operations.mdx
@@ -43,6 +43,10 @@ Open **Inbox**. It contains Approvals, human tasks, form waits, and access reque
 items you own so Runs can continue. For the decision procedure, see
 [Approve Agent work](/docs/guides/approve-agent-work).
 
+A denied access request does not grant the Agent anything — it stays denied and is visible in
+the activity log for later review. Use **Recent operational activity** above to confirm a
+denied-access decision was recorded correctly.
+
 ## Inspect Runs
 
 Open **Runs**. The list is newest-first and links to the Run inspector. For Runs that are

--- a/packages/integrations/src/slack/contracts.test.ts
+++ b/packages/integrations/src/slack/contracts.test.ts
@@ -1,0 +1,51 @@
+import { ajv } from "@tulipfarm/schema";
+import { ToolCatalog } from "@tulipfarm/tool-broker";
+import { describe, expect, it } from "vitest";
+import { SLACK_ADAPTER_REF, SLACK_TOOL_CONTRACTS, SLACK_TOOL_IDS } from "./contracts";
+
+const byId = new Map(SLACK_TOOL_CONTRACTS.map((c) => [c.spec.toolId, c]));
+
+describe("SLACK_TOOL_CONTRACTS", () => {
+  it("publishes the send Tool", () => {
+    expect([...byId.keys()]).toEqual([SLACK_TOOL_IDS.sendMessage]);
+  });
+
+  it("loads into the Tool catalog as a published contract", () => {
+    const catalog = ToolCatalog.load(SLACK_TOOL_CONTRACTS);
+    for (const contract of SLACK_TOOL_CONTRACTS) {
+      expect(catalog.get(contract.spec.toolId, contract.spec.toolVersion)).toBeDefined();
+    }
+  });
+
+  it("binds to the governed integration adapter, never a raw HTTP passthrough", () => {
+    for (const contract of SLACK_TOOL_CONTRACTS) {
+      expect(contract.spec.adapter).toEqual({ kind: "integration", ref: SLACK_ADAPTER_REF });
+    }
+  });
+
+  it("is mutating, medium risk, and never safe to blind-retry after dispatch", () => {
+    const send = byId.get(SLACK_TOOL_IDS.sendMessage);
+    if (send === undefined) expect.unreachable("send contract missing");
+    expect(send.spec.mutating).toBe(true);
+    expect(send.spec.riskClass).toBe("medium");
+    expect(send.spec.idempotency.strategy).not.toBe("none");
+    expect(send.spec.retry?.safeToRetry).toBe(false);
+  });
+
+  it("declares a chat.delete compensation with a reconciliation lookup", () => {
+    const send = byId.get(SLACK_TOOL_IDS.sendMessage);
+    if (send === undefined) expect.unreachable("send contract missing");
+    expect(send.spec.compensation?.operation).toBe("slack.message.delete");
+    expect(send.spec.compensation?.reconciliation).toBeTruthy();
+  });
+
+  it("requires channel and text, and bounds text length", () => {
+    const send = byId.get(SLACK_TOOL_IDS.sendMessage);
+    if (send === undefined) expect.unreachable("send contract missing");
+    const validate = ajv.compile(send.spec.inputSchema);
+    expect(validate({ channel: "general", text: "hi" })).toBe(true);
+    expect(validate({ channel: "general" })).toBe(false);
+    expect(validate({ text: "hi" })).toBe(false);
+    expect(validate({ channel: "general", text: "x".repeat(4001) })).toBe(false);
+  });
+});

--- a/packages/integrations/src/slack/contracts.ts
+++ b/packages/integrations/src/slack/contracts.ts
@@ -1,0 +1,106 @@
+import {
+  canonicalHash,
+  type ToolContractDefinition,
+  type ToolContractSpec,
+} from "@tulipfarm/schema";
+
+/**
+ * Published Slack ToolContracts. Mirrors `../github/contracts.ts`'s shape: Slack has no native
+ * idempotency key for `chat.postMessage`, so the send Tool declares `idempotency.strategy:
+ * "reconcile"` and is not safe to blind-retry — an ambiguous send must be reconciled against
+ * channel history, not repeated.
+ */
+
+export const SLACK_ADAPTER_REF = "integration:slack";
+
+export const SLACK_MESSAGE_TARGET = "slack.message";
+
+export const SLACK_TOOL_IDS = {
+  sendMessage: "slack.message.send",
+} as const;
+
+export type SlackToolId = (typeof SLACK_TOOL_IDS)[keyof typeof SLACK_TOOL_IDS];
+
+/** Reconciliation lookups the adapter implements for each mutating Tool. */
+export const SLACK_RECONCILIATION_OPERATIONS = {
+  sendMessage: "slack.message.send.lookup",
+} as const;
+
+const TOOL_VERSION = "1.0.0";
+const SLACK_DESTINATION = "slack";
+const MESSAGE_DATA_CLASSES = ["source_content"];
+
+const sendMessageInputSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["channel", "text"],
+  properties: {
+    channel: {
+      type: "string",
+      minLength: 1,
+      maxLength: 80,
+      description:
+        "Channel name (with or without a leading '#') or raw Slack channel ID. Must be a " +
+        "channel the bot has joined.",
+    },
+    text: { type: "string", minLength: 1, maxLength: 4000 },
+  },
+} as const;
+
+const sendMessageOutputSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["channelId", "ts", "threadId"],
+  properties: {
+    channelId: { type: "string" },
+    ts: { type: "string" },
+    threadId: { type: "string" },
+  },
+} as const;
+
+/**
+ * Authored definitions are content-addressed. Deriving the digest from the spec keeps these
+ * first-party contracts publishable without hand-maintained hashes that would silently drift.
+ */
+function publish(spec: ToolContractSpec, id: string, slug: string): ToolContractDefinition {
+  return {
+    apiVersion: "tulipfarm.ai/v1",
+    kind: "ToolContract",
+    metadata: {
+      id,
+      slug,
+      schemaVersion: 1,
+      authoredVersion: 1,
+      lifecycle: "published",
+      publishedDigest: canonicalHash(spec),
+    },
+    spec,
+  };
+}
+
+const sendMessage = publish(
+  {
+    toolId: SLACK_TOOL_IDS.sendMessage,
+    toolVersion: TOOL_VERSION,
+    action: SLACK_TOOL_IDS.sendMessage,
+    inputSchema: sendMessageInputSchema,
+    outputSchema: sendMessageOutputSchema,
+    riskClass: "medium",
+    mutating: true,
+    dataClasses: MESSAGE_DATA_CLASSES,
+    allowedDestinations: [SLACK_DESTINATION],
+    idempotency: { strategy: "reconcile" },
+    timeout: { wallClockMs: 15_000 },
+    retry: { maxAttempts: 1, safeToRetry: false },
+    dryRun: true,
+    compensation: {
+      operation: "slack.message.delete",
+      reconciliation: SLACK_RECONCILIATION_OPERATIONS.sendMessage,
+    },
+    adapter: { kind: "integration", ref: SLACK_ADAPTER_REF },
+  },
+  "aaaaaaaa-0004-4000-8000-000000000001",
+  "slack-message-send"
+);
+
+export const SLACK_TOOL_CONTRACTS: readonly ToolContractDefinition[] = [sendMessage];

--- a/packages/integrations/src/slack/index.ts
+++ b/packages/integrations/src/slack/index.ts
@@ -1,3 +1,5 @@
 export * from "./adapter";
+export * from "./contracts";
 export * from "./knowledge";
 export * from "./mentions";
+export * from "./tool-adapter";

--- a/packages/integrations/src/slack/mentions.test.ts
+++ b/packages/integrations/src/slack/mentions.test.ts
@@ -1,9 +1,20 @@
 import { describe, expect, it } from "vitest";
-import { resolveMentionsInText, type SlackMentionResolverPort } from "./mentions";
+import {
+  encodeMentionsInText,
+  resolveMentionsInText,
+  type SlackMentionResolverPort,
+  type SlackUserLookupPort,
+} from "./mentions";
 
 function resolverFrom(names: Record<string, string | undefined>): SlackMentionResolverPort {
   return {
     resolveDisplayName: async (userId: string) => names[userId],
+  };
+}
+
+function lookupFrom(ids: Record<string, string | undefined>): SlackUserLookupPort {
+  return {
+    resolveUserId: async (name: string) => ids[name.toLowerCase()],
   };
 }
 
@@ -42,6 +53,36 @@ describe("resolveMentionsInText", () => {
 
   it("is a no-op when there are no mentions", async () => {
     const result = await resolveMentionsInText("no mentions here", resolverFrom({}));
+    expect(result).toBe("no mentions here");
+  });
+});
+
+describe("encodeMentionsInText", () => {
+  it("replaces a single plain @name with the resolved <@ID> token", async () => {
+    const result = await encodeMentionsInText("hi @mohit", lookupFrom({ mohit: "U0AMFGRAKLY" }));
+    expect(result).toBe("hi <@U0AMFGRAKLY>");
+  });
+
+  it("replaces multiple distinct @names", async () => {
+    const result = await encodeMentionsInText(
+      "hi @mohit and @shiv!",
+      lookupFrom({ mohit: "U1", shiv: "U2" })
+    );
+    expect(result).toBe("hi <@U1> and <@U2>!");
+  });
+
+  it("matches case-insensitively", async () => {
+    const result = await encodeMentionsInText("hi @Mohit", lookupFrom({ mohit: "U1" }));
+    expect(result).toBe("hi <@U1>");
+  });
+
+  it("leaves an unresolved @name untouched", async () => {
+    const result = await encodeMentionsInText("hi @unknown", lookupFrom({}));
+    expect(result).toBe("hi @unknown");
+  });
+
+  it("is a no-op when there are no @names", async () => {
+    const result = await encodeMentionsInText("no mentions here", lookupFrom({}));
     expect(result).toBe("no mentions here");
   });
 });

--- a/packages/integrations/src/slack/mentions.ts
+++ b/packages/integrations/src/slack/mentions.ts
@@ -44,3 +44,45 @@ export async function resolveMentionsInText(
     return name ? `@${name}` : whole;
   });
 }
+
+export interface SlackUserLookupPort {
+  /** Resolves a plain `@name` token (as typed, case-insensitive) to a Slack user id, or undefined
+   * if unknown/ambiguous/unavailable. */
+  resolveUserId(name: string): Promise<string | undefined>;
+}
+
+// Matches a plain `@name` the agent wrote as prose — never a token already inside `<@ID>`/`<@ID|label>`,
+// since those are Slack's own opaque mention syntax and must pass through unchanged.
+const PLAIN_MENTION_PATTERN = /(?<=^|[\s(])@([A-Za-z0-9][\w.'-]{0,79})(?=[\s.,!?;:)]|$)/g;
+
+/**
+ * Replaces every plain `@name` token with the resolved `<@USERID>` Slack mention syntax, the
+ * opposite direction of `resolveMentionsInText`. Without this, an agent's `@name` in outgoing
+ * message text posts as inert text — Slack only renders a highlighted, notifying mention for the
+ * `<@ID>` form. Best-effort, same as the decode side: a name the resolver cannot match is left
+ * untouched rather than blocking the send.
+ */
+export async function encodeMentionsInText(
+  text: string,
+  resolver: SlackUserLookupPort
+): Promise<string> {
+  const names = new Set<string>();
+  for (const match of text.matchAll(PLAIN_MENTION_PATTERN)) {
+    names.add(match[1]);
+  }
+  if (names.size === 0) return text;
+
+  const ids = new Map<string, string>();
+  await Promise.all(
+    Array.from(names).map(async (name) => {
+      const id = await resolver.resolveUserId(name);
+      if (id) ids.set(name, id);
+    })
+  );
+  if (ids.size === 0) return text;
+
+  return text.replace(PLAIN_MENTION_PATTERN, (whole, name: string) => {
+    const id = ids.get(name);
+    return id ? `<@${id}>` : whole;
+  });
+}

--- a/packages/integrations/src/slack/tool-adapter.test.ts
+++ b/packages/integrations/src/slack/tool-adapter.test.ts
@@ -1,0 +1,123 @@
+import {
+  AdapterDispatchError,
+  type ToolAdapterRequest,
+  type ToolIntent,
+} from "@tulipfarm/tool-broker";
+import { describe, expect, it } from "vitest";
+import type { IntegrationHttpRequest, IntegrationHttpResponse } from "../http";
+import { SLACK_TOOL_IDS } from "./contracts";
+import { SlackToolAdapter } from "./tool-adapter";
+
+const CREDENTIAL = "xoxb-token";
+
+interface SlackApiUserFixture {
+  readonly id: string;
+  readonly name?: string;
+  readonly real_name?: string;
+  readonly profile?: { readonly display_name?: string; readonly real_name?: string };
+}
+
+function fakeHttp(members: readonly SlackApiUserFixture[]) {
+  const calls: IntegrationHttpRequest[] = [];
+  return {
+    calls,
+    async send(
+      request: IntegrationHttpRequest,
+      credential: string
+    ): Promise<IntegrationHttpResponse> {
+      calls.push(request);
+      expect(credential).toBe(CREDENTIAL);
+      if (request.path === "/users.list") {
+        return { status: 200, headers: {}, body: { ok: true, members } };
+      }
+      if (request.path === "/chat.postMessage") {
+        return { status: 200, headers: {}, body: { ok: true, ts: "1700000000.000100" } };
+      }
+      throw new Error(`unexpected path: ${request.path}`);
+    },
+  };
+}
+
+function sendRequest(channel: string, text: string): ToolAdapterRequest {
+  const intent: ToolIntent = {
+    intentId: "11111111-1111-4111-8111-111111111111",
+    businessId: "biz-1",
+    runId: "run-1",
+    stateId: "state-1",
+    toolId: SLACK_TOOL_IDS.sendMessage,
+    toolVersion: "1.0.0",
+    action: SLACK_TOOL_IDS.sendMessage,
+    targetRefs: [],
+    arguments: { channel, text },
+    credentialRef: "slack-bot-token",
+    idempotencyKey: "22222222-2222-4222-8222-222222222222",
+  };
+  return { intent, idempotencyKey: intent.idempotencyKey, attempt: 1 };
+}
+
+function postedText(calls: readonly IntegrationHttpRequest[]): string {
+  const call = calls.find((c) => c.path === "/chat.postMessage");
+  const body = call?.body as { text?: string } | undefined;
+  if (body?.text === undefined) throw new Error("no chat.postMessage call recorded");
+  return body.text;
+}
+
+describe("SlackToolAdapter mention encoding", () => {
+  it("encodes an @name that exactly matches a member's username", async () => {
+    const http = fakeHttp([{ id: "U0AMFGRAKLY", name: "mohit" }]);
+    const adapter = new SlackToolAdapter({ http });
+
+    await adapter.dispatch(sendRequest("C0123456789", "hi @mohit!"), CREDENTIAL);
+
+    expect(postedText(http.calls)).toBe("hi <@U0AMFGRAKLY>!");
+  });
+
+  it("falls back to a first-name match against a member's full display name", async () => {
+    const http = fakeHttp([{ id: "U0SHIV", profile: { display_name: "Shiv Soni" } }]);
+    const adapter = new SlackToolAdapter({ http });
+
+    await adapter.dispatch(sendRequest("C0123456789", "hi @shiv!"), CREDENTIAL);
+
+    expect(postedText(http.calls)).toBe("hi <@U0SHIV>!");
+  });
+
+  it("does not guess when two members share the same first name", async () => {
+    const http = fakeHttp([
+      { id: "U0SHIVA", profile: { display_name: "Shiv Soni" } },
+      { id: "U0SHIVB", profile: { display_name: "Shiv Kumar" } },
+    ]);
+    const adapter = new SlackToolAdapter({ http });
+
+    await adapter.dispatch(sendRequest("C0123456789", "hi @shiv!"), CREDENTIAL);
+
+    expect(postedText(http.calls)).toBe("hi @shiv!");
+  });
+
+  it("still sends when the directory scan fails, leaving text unencoded", async () => {
+    const http = {
+      async send(request: IntegrationHttpRequest): Promise<IntegrationHttpResponse> {
+        if (request.path === "/users.list")
+          return { status: 200, headers: {}, body: { ok: false } };
+        return { status: 200, headers: {}, body: { ok: true, ts: "1700000000.000100" } };
+      },
+    };
+    const adapter = new SlackToolAdapter({ http });
+
+    const output = await adapter.dispatch(sendRequest("C0123456789", "hi @mohit!"), CREDENTIAL);
+
+    expect(output).toEqual({
+      channelId: "C0123456789",
+      ts: "1700000000.000100",
+      threadId: "1700000000.000100",
+    });
+  });
+
+  it("rejects dispatch with no credential", async () => {
+    const http = fakeHttp([]);
+    const adapter = new SlackToolAdapter({ http });
+
+    await expect(adapter.dispatch(sendRequest("C0123456789", "hi"))).rejects.toBeInstanceOf(
+      AdapterDispatchError
+    );
+  });
+});

--- a/packages/integrations/src/slack/tool-adapter.ts
+++ b/packages/integrations/src/slack/tool-adapter.ts
@@ -1,0 +1,205 @@
+import type { ToolAdapter, ToolAdapterRequest } from "@tulipfarm/tool-broker";
+import { AdapterDispatchError } from "@tulipfarm/tool-broker";
+import { classifyHttpFailure, type IntegrationHttpPort } from "../http";
+import { SLACK_TOOL_IDS } from "./contracts";
+import { encodeMentionsInText, type SlackUserLookupPort } from "./mentions";
+
+/**
+ * Dispatches the `slack.message.send` Tool contract. Named `tool-adapter.ts` (not `adapter.ts`)
+ * to avoid colliding with `./adapter.ts`'s `SlackChannelAdapter`/`SlackDeliveryAdapter`, which
+ * serve the separate inbound-receive/reply-delivery ledger pipeline, not the Tool Broker's effect
+ * pipeline this implements.
+ *
+ * Channel input may be a bare name, a `#name`, or a raw channel ID — resolved via
+ * `conversations.list` when it doesn't already look like an ID. `client_msg_id` is set to the
+ * effect's idempotency key so a redelivered attempt against the real Slack API naturally
+ * deduplicates, in place of GitHub's invisible-marker technique (Slack has no equivalent
+ * text-comment convention).
+ */
+export interface SlackToolAdapterDeps {
+  readonly http: IntegrationHttpPort;
+}
+
+interface SlackApiChannel {
+  readonly id: string;
+  readonly name: string;
+}
+
+interface SlackApiUser {
+  readonly id: string;
+  readonly name?: string;
+  readonly real_name?: string;
+  readonly profile?: {
+    readonly display_name?: string;
+    readonly real_name?: string;
+  };
+}
+
+function candidateNames(user: SlackApiUser): readonly string[] {
+  return [user.name, user.profile?.display_name, user.profile?.real_name, user.real_name].filter(
+    (v): v is string => typeof v === "string" && v.length > 0
+  );
+}
+
+function isChannelId(value: string): boolean {
+  return /^[CGD][A-Z0-9]{8,}$/.test(value);
+}
+
+function normalizeChannelName(value: string): string {
+  return value.startsWith("#") ? value.slice(1) : value;
+}
+
+function args(intent: ToolAdapterRequest["intent"]): { channel: string; text: string } {
+  const raw = intent.arguments as Record<string, unknown>;
+  const channel = raw.channel;
+  const text = raw.text;
+  if (typeof channel !== "string" || channel.length === 0) {
+    throw new AdapterDispatchError("before_dispatch", "invalid_arguments", false);
+  }
+  if (typeof text !== "string" || text.length === 0) {
+    throw new AdapterDispatchError("before_dispatch", "invalid_arguments", false);
+  }
+  return { channel, text };
+}
+
+function asRecord(body: unknown): Record<string, unknown> {
+  return body !== null && typeof body === "object" && !Array.isArray(body)
+    ? (body as Record<string, unknown>)
+    : {};
+}
+
+export class SlackToolAdapter implements ToolAdapter {
+  constructor(private readonly deps: SlackToolAdapterDeps) {}
+
+  async dispatch(request: ToolAdapterRequest, credential?: string): Promise<unknown> {
+    if (request.intent.toolId !== SLACK_TOOL_IDS.sendMessage) {
+      throw new AdapterDispatchError("before_dispatch", "unsupported_tool", false);
+    }
+    if (credential === undefined) {
+      throw new AdapterDispatchError("before_dispatch", "credential_missing", false);
+    }
+    const { channel, text } = args(request.intent);
+    const channelId = isChannelId(channel)
+      ? channel
+      : await this.resolveChannelId(normalizeChannelName(channel), credential);
+    const encodedText = await encodeMentionsInText(text, this.userLookup(credential));
+
+    const response = await this.deps.http.send(
+      {
+        method: "POST",
+        path: "/chat.postMessage",
+        body: { channel: channelId, text: encodedText, client_msg_id: request.idempotencyKey },
+      },
+      credential
+    );
+    const body = asRecord(response.body);
+    const failure = classifyHttpFailure(response, true);
+    if (failure !== null || body.ok !== true) {
+      const code =
+        typeof body.error === "string" ? body.error : (failure?.code ?? "provider_error");
+      const retryable = failure?.retryable ?? false;
+      const phase = failure?.phase ?? "before_dispatch";
+      throw new AdapterDispatchError(phase, code, retryable);
+    }
+
+    const ts = body.ts;
+    if (typeof ts !== "string") {
+      throw new AdapterDispatchError("after_dispatch", "invalid_response", false);
+    }
+    return { channelId, ts, threadId: ts };
+  }
+
+  /**
+   * `SlackUserLookupPort` backed by `users.list`, scoped to one dispatch call. The directory scan
+   * is memoized so `encodeMentionsInText`'s concurrent per-name lookups (`Promise.all`) share one
+   * paginated fetch instead of one each. A directory fetch failure resolves every name to
+   * undefined rather than throwing — matching mention resolution is best-effort and must never
+   * block the send.
+   *
+   * Falls back from an exact name match to a first-name match (`"shiv"` -> `"Shiv Soni"`), since
+   * the agent is at least as likely to write a bare first name as the full display name. The
+   * fallback only fires when exactly one directory member shares that first name — a first name
+   * two members share resolves to undefined rather than guessing which one was meant.
+   */
+  private userLookup(credential: string): SlackUserLookupPort {
+    let directory:
+      | Promise<{ exact: Map<string, string>; firstName: Map<string, string | null> }>
+      | undefined;
+    const load = async () => {
+      const exact = new Map<string, string>();
+      const firstName = new Map<string, string | null>();
+      let cursor: string | undefined;
+      for (let page = 0; page < 20; page += 1) {
+        const response = await this.deps.http.send(
+          {
+            method: "GET",
+            path: "/users.list",
+            query: { limit: "200", ...(cursor === undefined ? {} : { cursor }) },
+          },
+          credential
+        );
+        const body = asRecord(response.body);
+        if (body.ok !== true) break;
+        const members = Array.isArray(body.members) ? (body.members as SlackApiUser[]) : [];
+        for (const member of members) {
+          for (const name of candidateNames(member)) {
+            const lower = name.toLowerCase();
+            if (!exact.has(lower)) exact.set(lower, member.id);
+
+            const first = lower.split(/\s+/)[0];
+            if (first.length > 0 && first !== lower) {
+              const existing = firstName.get(first);
+              if (existing === undefined) firstName.set(first, member.id);
+              else if (existing !== member.id) firstName.set(first, null);
+            }
+          }
+        }
+        const metadata = asRecord(body.response_metadata);
+        const nextCursor = metadata.next_cursor;
+        if (typeof nextCursor !== "string" || nextCursor.length === 0) break;
+        cursor = nextCursor;
+      }
+      return { exact, firstName };
+    };
+
+    return {
+      async resolveUserId(name: string): Promise<string | undefined> {
+        directory ??= load().catch(() => ({ exact: new Map(), firstName: new Map() }));
+        const { exact, firstName } = await directory;
+        const lower = name.toLowerCase();
+        return exact.get(lower) ?? firstName.get(lower) ?? undefined;
+      },
+    };
+  }
+
+  private async resolveChannelId(name: string, credential: string): Promise<string> {
+    let cursor: string | undefined;
+    for (let page = 0; page < 20; page += 1) {
+      const response = await this.deps.http.send(
+        {
+          method: "GET",
+          path: "/conversations.list",
+          query: {
+            types: "public_channel,private_channel",
+            limit: "200",
+            ...(cursor === undefined ? {} : { cursor }),
+          },
+        },
+        credential
+      );
+      const body = asRecord(response.body);
+      if (body.ok !== true) {
+        throw new AdapterDispatchError("before_dispatch", "channel_lookup_failed", false);
+      }
+      const channels = Array.isArray(body.channels) ? (body.channels as SlackApiChannel[]) : [];
+      const match = channels.find((c) => c.name === name);
+      if (match !== undefined) return match.id;
+
+      const metadata = asRecord(body.response_metadata);
+      const nextCursor = metadata.next_cursor;
+      if (typeof nextCursor !== "string" || nextCursor.length === 0) break;
+      cursor = nextCursor;
+    }
+    throw new AdapterDispatchError("before_dispatch", "channel_not_found", false);
+  }
+}


### PR DESCRIPTION
## Summary
- New `send_slack_message` chat tool (`apps/api/src/tools/slack/`, `packages/integrations/src/slack/tool-adapter.ts`, `contracts.ts`) lets agents proactively post to a named Slack channel, following the existing GitHub/Jira Tool Contract pattern and gated by the standard mutating-tool approval flow.
- Thread-reply continuity: after a successful send, the tool marks the thread as mentioned via `ChannelMentionedThreadStore` so `apps/integration-worker`'s mention-gate lets a human reply through (previously that store was only ever written from the human `@mention` event branch, so any thread the bot itself started silently dropped replies as `unmentioned_thread`), and writes an `integration_conversations` mapping so the reply routes back to the originating conversation/run.
- Channel input accepts a bare name, `#name`, or a raw channel ID; resolved via `conversations.list` when not already an ID.

## Test plan
- [x] `pnpm --filter @tulipfarm/api typecheck` and `pnpm --filter @tulipfarm/integrations typecheck` clean
- [x] `pnpm exec biome check` clean on all touched files
- [x] `pnpm --filter @tulipfarm/api exec vitest run src/tools/slack src/internal/channel-routes.test.ts src/integrations` — 67/67 passing
- [x] `pnpm --filter @tulipfarm/integrations exec vitest run src/slack` — 54/54 passing
- [x] Manual QA against real dev Slack workspace: sent a message via Chat to `#slack-bot-test`, replied in the resulting thread, confirmed the bot picked up the reply and responded in-thread (required isolating from a second `integration-worker` instance also connected via Socket Mode with the same app-level token, which was non-deterministically stealing events — not a code issue)