### PR TITLE
fix(system): allow runtime version env override over build constant

### DIFF
--- a/apps/api/src/system/version.test.ts
+++ b/apps/api/src/system/version.test.ts
@@ -31,4 +31,11 @@ describe("runningVersion", () => {
     expect(runningVersion()).toBe("dev");
     if (prev !== undefined) process.env.TULIPFARM_VERSION = prev;
   });
+
+  it("handles latest TULIPFARM_VERSION env correctly", () => {
+    const prev = process.env.TULIPFARM_VERSION;
+    process.env.TULIPFARM_VERSION = "latest";
+    expect(runningVersion()).toBe("latest");
+    if (prev !== undefined) process.env.TULIPFARM_VERSION = prev;
+  });
 });

--- a/apps/api/src/system/version.ts
+++ b/apps/api/src/system/version.ts
@@ -6,10 +6,14 @@
 declare const __TULIPFARM_VERSION__: string | undefined;
 
 export function runningVersion(): string {
+  const envVer = process.env.TULIPFARM_VERSION;
+  if (typeof envVer === "string" && envVer.length > 0 && envVer !== "latest") {
+    return envVer;
+  }
   if (typeof __TULIPFARM_VERSION__ === "string" && __TULIPFARM_VERSION__.length > 0) {
     return __TULIPFARM_VERSION__;
   }
-  return process.env.TULIPFARM_VERSION ?? "dev";
+  return envVer ?? "dev";
 }
 
 /**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,7 @@ services:
       WEBHOOK_SIGNING_SECRET: ${WEBHOOK_SIGNING_SECRET:-}
       SOUL_PATH: /opt/tulipfarm/soul
       TF_DATA_DIR: /data
+      TULIPFARM_VERSION: ${TULIPFARM_VERSION:-}
     ports:
       # HOST_BIND=127.0.0.1 keeps the plain-HTTP port off the network behind a proxy.
       - "${HOST_BIND:-0.0.0.0}:${HOST_PORT:-8080}:8080"


### PR DESCRIPTION
## Summary
- Ensure `TULIPFARM_VERSION` environment variable takes precedence when set to a specific release tag, allowing runtime overrides over the compiled `__TULIPFARM_VERSION__` constant.
- Forward `TULIPFARM_VERSION: ${TULIPFARM_VERSION:-}` into the `app` container environment in `docker-compose.yml`.
- Add unit test coverage in `version.test.ts` to verify environment override resolution.

## Test Plan
- `pnpm --filter @tulipfarm/api exec vitest run src/system/version.test.ts`
- `pnpm --filter @tulipfarm/api lint && pnpm --filter @tulipfarm/api typecheck`