### PR TITLE
feat(integrations): add github_issue_create and github_repository_create tools

### DIFF
--- a/apps/api/src/tools/github/context.ts
+++ b/apps/api/src/tools/github/context.ts
@@ -3,7 +3,11 @@ import type {
   GitHubEffectContext,
   GitHubInstallationScope,
 } from "@tulipfarm/integrations";
-import { GITHUB_REPOSITORY_TARGET, GITHUB_TOOL_IDS } from "@tulipfarm/integrations";
+import {
+  GITHUB_ORGANIZATION_TARGET,
+  GITHUB_REPOSITORY_TARGET,
+  GITHUB_TOOL_IDS,
+} from "@tulipfarm/integrations";
 import type { AccessGrantDefinition } from "@tulipfarm/schema";
 import type { ToolIntent } from "@tulipfarm/tool-broker";
 import type { GitHubInstallationDirectory } from "./installation";
@@ -30,6 +34,14 @@ function repositoryArgument(intent: ToolIntent): string | undefined {
   return typeof repository === "string" ? repository : undefined;
 }
 
+/** Repo creation has no `repository` argument yet — the repo doesn't exist — only `owner`. */
+function ownerArgument(intent: ToolIntent): string | undefined {
+  const args = intent.arguments;
+  if (args === null || typeof args !== "object" || Array.isArray(args)) return undefined;
+  const owner = (args as Record<string, unknown>).owner;
+  return typeof owner === "string" ? owner : undefined;
+}
+
 function syntheticGrant(integrationId: string, repository: string): AccessGrantDefinition {
   return {
     apiVersion: "tulipfarm.ai/v1",
@@ -51,6 +63,27 @@ function syntheticGrant(integrationId: string, repository: string): AccessGrantD
   };
 }
 
+function syntheticOrgGrant(integrationId: string, owner: string): AccessGrantDefinition {
+  return {
+    apiVersion: "tulipfarm.ai/v1",
+    kind: "AccessGrant",
+    metadata: {
+      id: "00000000-0000-4000-8000-000000000003",
+      slug: "github-chat-installation-account-scope",
+      schemaVersion: 1,
+      authoredVersion: 1,
+      lifecycle: "active",
+    },
+    spec: {
+      integrationId,
+      principals: [SYNTHETIC_PRINCIPAL],
+      actions: [...GITHUB_ACTIONS],
+      externalTargets: [{ type: GITHUB_ORGANIZATION_TARGET, ids: [owner] }],
+      delegable: false,
+    },
+  };
+}
+
 /**
  * Resolves a Tool intent's repository against this business's active GitHub installations
  * (`GitHubInstallationDirectory`) and builds the scope + synthesized grant `GitHubAdapter` needs.
@@ -65,6 +98,10 @@ export class InstallationScopeGitHubContextResolver implements GitHubContextReso
   ) {}
 
   async resolve(intent: ToolIntent): Promise<GitHubEffectContext | undefined> {
+    if (intent.action === GITHUB_TOOL_IDS.repositoryCreate) {
+      return this.resolveForAccount(intent);
+    }
+
     const repository = repositoryArgument(intent);
     if (repository === undefined) return undefined;
 
@@ -95,6 +132,41 @@ export class InstallationScopeGitHubContextResolver implements GitHubContextReso
       installation: scope,
       principals: [SYNTHETIC_PRINCIPAL],
       grants: [syntheticGrant(installation.integrationId, repository)],
+    };
+  }
+
+  /** Repo creation targets an account, not an existing repository — matched by `accountLogin`. */
+  private async resolveForAccount(intent: ToolIntent): Promise<GitHubEffectContext | undefined> {
+    const owner = ownerArgument(intent);
+    if (owner === undefined) return undefined;
+
+    const installations = await this.installations.list();
+    const matches = installations.filter((entry) => entry.accountLogin === owner);
+    if (matches.length === 0) return undefined;
+    if (matches.length > 1) {
+      this.log?.warn(
+        { event: "github.context.ambiguous_installation", owner, count: matches.length },
+        "multiple active GitHub installations cover the same account; refusing to guess"
+      );
+      return undefined;
+    }
+    const installation = matches[0];
+    if (installation === undefined) return undefined;
+
+    const scope: GitHubInstallationScope = {
+      businessId: this.businessId,
+      integrationId: installation.integrationId,
+      installationId: installation.installationId,
+      accountLogin: installation.accountLogin,
+      repositories: installation.repositories,
+      permissions: installation.permissions,
+    };
+
+    return {
+      integrationId: installation.integrationId,
+      installation: scope,
+      principals: [SYNTHETIC_PRINCIPAL],
+      grants: [syntheticOrgGrant(installation.integrationId, owner)],
     };
   }
 }

--- a/apps/api/src/tools/github/tools.test.ts
+++ b/apps/api/src/tools/github/tools.test.ts
@@ -67,6 +67,33 @@ function fakeIntegrationStore(): IntegrationStore {
   } as any;
 }
 
+function snapshotWithAdministration(): PersistedRoutingSnapshot {
+  return {
+    ...snapshot(),
+    accessGrants: [
+      {
+        id: "grant-1",
+        businessId: BUSINESS_ID,
+        integrationId: "integration-1",
+        definition: {
+          externalTargets: { ids: ["tulip/farm"] },
+          permissions: { issues: "write", metadata: "read", administration: "write" },
+        },
+        status: "active",
+      },
+    ],
+  };
+}
+
+function fakeIntegrationStoreWithAdministration(): IntegrationStore {
+  return {
+    async loadProviderSnapshot() {
+      return snapshotWithAdministration();
+    },
+    // biome-ignore lint/suspicious/noExplicitAny: only `loadProviderSnapshot` is exercised
+  } as any;
+}
+
 function fakeSecretsService(): () => Promise<SecretsService> {
   return async () =>
     ({
@@ -116,6 +143,73 @@ function fakeHttp(issue: { number: number; title: string; state: string }) {
             html_url: `https://github.com/tulip/farm/issues/${issue.number}`,
             labels: [],
             assignees: [],
+          },
+        };
+      }
+      throw new Error(`unexpected request: ${request.method} ${request.path}`);
+    },
+  };
+}
+
+function fakeIssueCreateHttp() {
+  return {
+    async send(request: IntegrationHttpRequest) {
+      if (request.path.endsWith("/access_tokens")) {
+        return {
+          status: 201,
+          headers: {},
+          body: { token: "ghs_minted", expires_at: "2026-08-06T01:00:00.000Z" },
+        };
+      }
+      if (request.path === "/repos/tulip/farm/issues" && request.method === "GET") {
+        return { status: 200, headers: {}, body: [] };
+      }
+      if (request.path === "/repos/tulip/farm/issues" && request.method === "POST") {
+        return {
+          status: 201,
+          headers: {},
+          body: {
+            number: 99,
+            title: "New bug",
+            body: "steps",
+            state: "open",
+            html_url: "https://github.com/tulip/farm/issues/99",
+            labels: [],
+            assignees: [],
+          },
+        };
+      }
+      throw new Error(`unexpected request: ${request.method} ${request.path}`);
+    },
+  };
+}
+
+function fakeRepositoryCreateHttp(hasAdministration: boolean) {
+  return {
+    async send(request: IntegrationHttpRequest) {
+      if (request.path.endsWith("/access_tokens")) {
+        return {
+          status: 201,
+          headers: {},
+          body: { token: "ghs_minted", expires_at: "2026-08-06T01:00:00.000Z" },
+        };
+      }
+      if (
+        hasAdministration &&
+        request.path === "/repos/tulip/new-repo" &&
+        request.method === "GET"
+      ) {
+        return { status: 404, headers: {}, body: {} };
+      }
+      if (hasAdministration && request.path === "/orgs/tulip/repos" && request.method === "POST") {
+        return {
+          status: 201,
+          headers: {},
+          body: {
+            full_name: "tulip/new-repo",
+            html_url: "https://github.com/tulip/new-repo",
+            private: true,
+            default_branch: "main",
           },
         };
       }
@@ -281,6 +375,68 @@ describe("buildGitHubTools", () => {
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(result.error.code).toBe("internal_error");
+    }
+  });
+
+  it("opens a new issue via github_issue_create", async () => {
+    const tooling = buildGitHubTooling({
+      businessId: BUSINESS_ID,
+      integrations: fakeIntegrationStore(),
+      secrets: fakeSecretsService(),
+      http: fakeIssueCreateHttp(),
+    });
+    const tools = buildGitHubTools(BUSINESS_ID, { ...tooling, effects: new MemoryEffectStore() });
+    const tool = tools.find((t) => t.name === "github_issue_create");
+    if (tool === undefined) throw new Error("github_issue_create not registered");
+    expect(tool.mutating).toBe(true);
+
+    const result = await tool.execute(
+      { repository: "tulip/farm", title: "New bug", body: "steps" },
+      context()
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toMatchObject({ number: 99, title: "New bug" });
+    }
+  });
+
+  it("creates a new repo via github_repository_create when administration:write is granted", async () => {
+    const tooling = buildGitHubTooling({
+      businessId: BUSINESS_ID,
+      integrations: fakeIntegrationStoreWithAdministration(),
+      secrets: fakeSecretsService(),
+      http: fakeRepositoryCreateHttp(true),
+    });
+    const tools = buildGitHubTools(BUSINESS_ID, { ...tooling, effects: new MemoryEffectStore() });
+    const tool = tools.find((t) => t.name === "github_repository_create");
+    if (tool === undefined) throw new Error("github_repository_create not registered");
+    expect(tool.mutating).toBe(true);
+
+    const result = await tool.execute({ owner: "tulip", name: "new-repo" }, context());
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toMatchObject({ repository: "tulip/new-repo", private: true });
+    }
+  });
+
+  it("returns a clear message when repo creation lacks administration:write", async () => {
+    const tooling = buildGitHubTooling({
+      businessId: BUSINESS_ID,
+      integrations: fakeIntegrationStore(),
+      secrets: fakeSecretsService(),
+      http: fakeRepositoryCreateHttp(false),
+    });
+    const tools = buildGitHubTools(BUSINESS_ID, { ...tooling, effects: new MemoryEffectStore() });
+    const tool = tools.find((t) => t.name === "github_repository_create");
+    if (tool === undefined) throw new Error("github_repository_create not registered");
+
+    const result = await tool.execute({ owner: "tulip", name: "new-repo" }, context());
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.message).toContain("administration:write");
     }
   });
 });

--- a/apps/api/src/tools/github/tools.ts
+++ b/apps/api/src/tools/github/tools.ts
@@ -39,6 +39,10 @@ const GITHUB_TOOL_SPECS: Record<GitHubToolId, GitHubToolSpec> = {
     name: "github_issue_search",
     description: "Search a GitHub repository's issues by query and state.",
   },
+  [GITHUB_TOOL_IDS.issueCreate]: {
+    name: "github_issue_create",
+    description: "Open a new GitHub issue, optionally with labels and assignees.",
+  },
   [GITHUB_TOOL_IDS.issueComment]: {
     name: "github_issue_comment",
     description: "Post a comment on a GitHub issue.",
@@ -87,6 +91,13 @@ const GITHUB_TOOL_SPECS: Record<GitHubToolId, GitHubToolSpec> = {
     name: "github_repo_push",
     description: "Commit one or more files to a GitHub branch.",
   },
+  [GITHUB_TOOL_IDS.repositoryCreate]: {
+    name: "github_repository_create",
+    description:
+      "Create a new GitHub repository under an org this installation covers. Requires the App's " +
+      "administration:write permission, which is not granted by default — if this fails, ask an " +
+      "org admin to upgrade the GitHub App's permissions from the installation's settings page.",
+  },
   [GITHUB_TOOL_IDS.contentRead]: {
     name: "github_content_read",
     description: "Read a file's contents from a GitHub repository.",
@@ -111,7 +122,7 @@ function derivedId(...parts: readonly string[]): string {
   ].join("-");
 }
 
-function mapDispatchError(error: ToolDispatchError): ToolCallResult {
+function mapDispatchError(error: ToolDispatchError, toolId: GitHubToolId): ToolCallResult {
   if (error.code === "invalid_output")
     return err("internal_error", "GitHub returned an unexpected response shape");
   if (error.detail === "integration_context_unresolved") {
@@ -119,6 +130,14 @@ function mapDispatchError(error: ToolDispatchError): ToolCallResult {
       "not_found",
       "No active GitHub installation covers that repository. Call github_repository_list to see " +
         "which repositories are installed, then retry with one of those."
+    );
+  }
+  if (error.detail === "installation_scope_denied" && toolId === GITHUB_TOOL_IDS.repositoryCreate) {
+    return err(
+      "not_found",
+      "Creating this repository needs the GitHub App's administration:write permission, which " +
+        "isn't granted by default. Ask an org admin to upgrade the App's permissions from its " +
+        "GitHub installation settings page, then retry."
     );
   }
   return err("internal_error", error.detail ? `${error.code}:${error.detail}` : error.message);
@@ -211,7 +230,7 @@ function buildToolDef(
         const output = await dispatcher.dispatch(businessId, reserved.effect.effectId);
         return ok(output);
       } catch (error) {
-        if (error instanceof ToolDispatchError) return mapDispatchError(error);
+        if (error instanceof ToolDispatchError) return mapDispatchError(error, toolId);
         throw error;
       }
     },

--- a/apps/worker/src/routine/github-context.test.ts
+++ b/apps/worker/src/routine/github-context.test.ts
@@ -65,4 +65,34 @@ describe("InstallationScopeGitHubContextResolver", () => {
     );
     expect(await resolver.resolve(intentFor({}))).toBeUndefined();
   });
+
+  it("resolves a repository-create intent by account, not by repository", async () => {
+    const resolver = new InstallationScopeGitHubContextResolver(
+      BUSINESS_ID,
+      directoryOf([INSTALLATION])
+    );
+    const intent: ToolIntent = {
+      ...intentFor({ owner: "tulip", name: "new-repo" }),
+      toolId: "github.repository.create",
+      action: "github.repository.create",
+    };
+    const context = await resolver.resolve(intent);
+    expect(context?.integrationId).toBe("integration-1");
+    expect(context?.grants[0]?.spec.externalTargets).toEqual([
+      { type: "github.organization", ids: ["tulip"] },
+    ]);
+  });
+
+  it("returns undefined for a repository-create intent when no installation covers the owner", async () => {
+    const resolver = new InstallationScopeGitHubContextResolver(
+      BUSINESS_ID,
+      directoryOf([INSTALLATION])
+    );
+    const intent: ToolIntent = {
+      ...intentFor({ owner: "other-org", name: "new-repo" }),
+      toolId: "github.repository.create",
+      action: "github.repository.create",
+    };
+    expect(await resolver.resolve(intent)).toBeUndefined();
+  });
 });

--- a/apps/worker/src/routine/github-context.ts
+++ b/apps/worker/src/routine/github-context.ts
@@ -3,7 +3,11 @@ import type {
   GitHubEffectContext,
   GitHubInstallationScope,
 } from "@tulipfarm/integrations";
-import { GITHUB_REPOSITORY_TARGET, GITHUB_TOOL_IDS } from "@tulipfarm/integrations";
+import {
+  GITHUB_ORGANIZATION_TARGET,
+  GITHUB_REPOSITORY_TARGET,
+  GITHUB_TOOL_IDS,
+} from "@tulipfarm/integrations";
 import type { AccessGrantDefinition } from "@tulipfarm/schema";
 import type { ToolIntent } from "@tulipfarm/tool-broker";
 import type { GitHubInstallationDirectory } from "./github-installation";
@@ -32,6 +36,14 @@ function repositoryArgument(intent: ToolIntent): string | undefined {
   return typeof repository === "string" ? repository : undefined;
 }
 
+/** Repo creation has no `repository` argument yet — the repo doesn't exist — only `owner`. */
+function ownerArgument(intent: ToolIntent): string | undefined {
+  const args = intent.arguments;
+  if (args === null || typeof args !== "object" || Array.isArray(args)) return undefined;
+  const owner = (args as Record<string, unknown>).owner;
+  return typeof owner === "string" ? owner : undefined;
+}
+
 function syntheticGrant(integrationId: string, repository: string): AccessGrantDefinition {
   return {
     apiVersion: "tulipfarm.ai/v1",
@@ -53,6 +65,27 @@ function syntheticGrant(integrationId: string, repository: string): AccessGrantD
   };
 }
 
+function syntheticOrgGrant(integrationId: string, owner: string): AccessGrantDefinition {
+  return {
+    apiVersion: "tulipfarm.ai/v1",
+    kind: "AccessGrant",
+    metadata: {
+      id: "00000000-0000-4000-8000-000000000004",
+      slug: "github-installation-account-scope",
+      schemaVersion: 1,
+      authoredVersion: 1,
+      lifecycle: "active",
+    },
+    spec: {
+      integrationId,
+      principals: [SYNTHETIC_PRINCIPAL],
+      actions: [...GITHUB_ACTIONS],
+      externalTargets: [{ type: GITHUB_ORGANIZATION_TARGET, ids: [owner] }],
+      delegable: false,
+    },
+  };
+}
+
 /**
  * Resolves a Tool intent's repository against this business's active GitHub installations
  * (`GitHubInstallationDirectory`) and builds the scope + synthesized grant `GitHubAdapter` needs.
@@ -67,6 +100,10 @@ export class InstallationScopeGitHubContextResolver implements GitHubContextReso
   ) {}
 
   async resolve(intent: ToolIntent): Promise<GitHubEffectContext | undefined> {
+    if (intent.action === GITHUB_TOOL_IDS.repositoryCreate) {
+      return this.resolveForAccount(intent);
+    }
+
     const repository = repositoryArgument(intent);
     if (repository === undefined) return undefined;
 
@@ -101,6 +138,41 @@ export class InstallationScopeGitHubContextResolver implements GitHubContextReso
       installation: scope,
       principals: [SYNTHETIC_PRINCIPAL],
       grants: [syntheticGrant(installation.integrationId, repository)],
+    };
+  }
+
+  /** Repo creation targets an account, not an existing repository — matched by `accountLogin`. */
+  private async resolveForAccount(intent: ToolIntent): Promise<GitHubEffectContext | undefined> {
+    const owner = ownerArgument(intent);
+    if (owner === undefined) return undefined;
+
+    const installations = await this.installations.list();
+    const matches = installations.filter((entry) => entry.accountLogin === owner);
+    if (matches.length === 0) return undefined;
+    if (matches.length > 1) {
+      this.log?.warn(
+        { event: "github.context.ambiguous_installation", owner, count: matches.length },
+        "multiple active GitHub installations cover the same account; refusing to guess"
+      );
+      return undefined;
+    }
+    const installation = matches[0];
+    if (installation === undefined) return undefined;
+
+    const scope: GitHubInstallationScope = {
+      businessId: this.businessId,
+      integrationId: installation.integrationId,
+      installationId: installation.installationId,
+      accountLogin: installation.accountLogin,
+      repositories: installation.repositories,
+      permissions: installation.permissions,
+    };
+
+    return {
+      integrationId: installation.integrationId,
+      installation: scope,
+      principals: [SYNTHETIC_PRINCIPAL],
+      grants: [syntheticOrgGrant(installation.integrationId, owner)],
     };
   }
 }

--- a/packages/integrations/src/github/adapter.test.ts
+++ b/packages/integrations/src/github/adapter.test.ts
@@ -3,7 +3,12 @@ import { AdapterDispatchError, type ToolIntent } from "@tulipfarm/tool-broker";
 import { beforeEach, describe, expect, it } from "vitest";
 import type { IntegrationHttpRequest, IntegrationHttpResponse } from "../http";
 import { GitHubAdapter, type GitHubEffectContext, githubEffectMarker } from "./adapter";
-import { GITHUB_ISSUE_TARGET, GITHUB_REPOSITORY_TARGET, GITHUB_TOOL_IDS } from "./contracts";
+import {
+  GITHUB_ISSUE_TARGET,
+  GITHUB_ORGANIZATION_TARGET,
+  GITHUB_REPOSITORY_TARGET,
+  GITHUB_TOOL_IDS,
+} from "./contracts";
 
 const BUSINESS_ID = "biz-1";
 const INTEGRATION_ID = "11111111-1111-4111-8111-111111111111";
@@ -31,9 +36,20 @@ function grant(actions: string[]): AccessGrantDefinition {
   };
 }
 
+function orgGrant(actions: string[]): AccessGrantDefinition {
+  return {
+    ...grant(actions),
+    spec: {
+      ...grant(actions).spec,
+      externalTargets: [{ type: GITHUB_ORGANIZATION_TARGET, ids: ["tulip"] }],
+    },
+  };
+}
+
 const ALL_ACTIONS = [
   GITHUB_TOOL_IDS.issueRead,
   GITHUB_TOOL_IDS.issueSearch,
+  GITHUB_TOOL_IDS.issueCreate,
   GITHUB_TOOL_IDS.issueComment,
   GITHUB_TOOL_IDS.issueLabel,
   GITHUB_TOOL_IDS.issueAssign,
@@ -1127,5 +1143,207 @@ describe("GitHubAdapter pull request reconciliation", () => {
       outcome: "confirmed",
       evidenceRef: "github:pull_request:tulip/farm#12:merged",
     });
+  });
+});
+
+describe("GitHubAdapter issue create", () => {
+  const createIntent = intent(GITHUB_TOOL_IDS.issueCreate, {
+    repository: "tulip/farm",
+    title: "New bug",
+    body: "steps to repro",
+  });
+  const marker = githubEffectMarker("idem-1");
+
+  it("opens a new issue, stamping the effect marker in the body", async () => {
+    http.route("GET", "/repos/tulip/farm/issues", { status: 200, headers: {}, body: [] });
+    http.route("POST", "/repos/tulip/farm/issues", { status: 201, headers: {}, body: ISSUE_BODY });
+    const output = await dispatch(createIntent);
+    const posted = http.calls.find((call) => call.method === "POST");
+    expect(String((posted?.body as { body: string }).body)).toContain(marker);
+    expect(String((posted?.body as { body: string }).body)).toContain("steps to repro");
+    expect(output).toMatchObject({ number: 41, title: "Crash on save" });
+  });
+
+  it("returns the existing issue on a duplicate delivery instead of opening a second one", async () => {
+    http.route("GET", "/repos/tulip/farm/issues", {
+      status: 200,
+      headers: {},
+      body: [{ ...ISSUE_BODY, body: `already opened\n\n${marker}` }],
+    });
+    const output = await dispatch(createIntent);
+    expect(http.calls.some((call) => call.method === "POST")).toBe(false);
+    expect(output).toMatchObject({ number: 41 });
+  });
+
+  it("denies creating an issue when the installation only holds read permission", async () => {
+    resolved = context({
+      installation: { ...context().installation, permissions: { issues: "read" } },
+    });
+    await expect(dispatch(createIntent)).rejects.toMatchObject({
+      code: "installation_scope_denied",
+    });
+    expect(http.calls).toHaveLength(0);
+  });
+});
+
+describe("GitHubAdapter issue create reconciliation", () => {
+  const createIntent = intent(GITHUB_TOOL_IDS.issueCreate, {
+    repository: "tulip/farm",
+    title: "New bug",
+  });
+
+  function reconcileWith(credential: string | undefined = CREDENTIAL) {
+    return adapter.reconcile(
+      {
+        intent: createIntent,
+        idempotencyKey: createIntent.idempotencyKey,
+        operation: "github.issue.create.lookup",
+      },
+      credential
+    );
+  }
+
+  it("confirms when the marked issue is present", async () => {
+    http.route("GET", "/repos/tulip/farm/issues", {
+      status: 200,
+      headers: {},
+      body: [{ ...ISSUE_BODY, body: githubEffectMarker("idem-1") }],
+    });
+    await expect(reconcileWith()).resolves.toEqual({
+      outcome: "confirmed",
+      evidenceRef: "github:issue:41",
+    });
+  });
+
+  it("reports not_applied when no issue carries the marker", async () => {
+    http.route("GET", "/repos/tulip/farm/issues", { status: 200, headers: {}, body: [] });
+    await expect(reconcileWith()).resolves.toEqual({
+      outcome: "not_applied",
+      evidenceRef: "github:issue:create:absent:tulip/farm",
+    });
+  });
+
+  it("stays ambiguous rather than guessing when the lookup itself fails", async () => {
+    http.route("GET", "/repos/tulip/farm/issues", { status: 503, headers: {}, body: {} });
+    await expect(reconcileWith()).resolves.toMatchObject({ outcome: "ambiguous" });
+  });
+});
+
+describe("GitHubAdapter repository create", () => {
+  const repoCreateIntent = intent(GITHUB_TOOL_IDS.repositoryCreate, {
+    owner: "tulip",
+    name: "new-repo",
+  });
+
+  function withAdministration(): void {
+    resolved = context({
+      installation: {
+        ...context().installation,
+        permissions: { ...context().installation.permissions, administration: "write" },
+      },
+      grants: [grant(ALL_ACTIONS), orgGrant([GITHUB_TOOL_IDS.repositoryCreate])],
+    });
+  }
+
+  it("creates a repo under the org", async () => {
+    withAdministration();
+    http.route("GET", "/repos/tulip/new-repo", { status: 404, headers: {}, body: {} });
+    http.route("POST", "/orgs/tulip/repos", {
+      status: 201,
+      headers: {},
+      body: {
+        full_name: "tulip/new-repo",
+        html_url: "https://github.com/tulip/new-repo",
+        private: true,
+        default_branch: "main",
+      },
+    });
+    const output = await dispatch(repoCreateIntent);
+    expect(output).toEqual({
+      repository: "tulip/new-repo",
+      htmlUrl: "https://github.com/tulip/new-repo",
+      private: true,
+      defaultBranch: "main",
+    });
+  });
+
+  it("returns the existing repo on a duplicate delivery instead of creating twice", async () => {
+    withAdministration();
+    http.route("GET", "/repos/tulip/new-repo", {
+      status: 200,
+      headers: {},
+      body: {
+        html_url: "https://github.com/tulip/new-repo",
+        private: true,
+        default_branch: "main",
+      },
+    });
+    const output = await dispatch(repoCreateIntent);
+    expect(http.calls.some((call) => call.method === "POST")).toBe(false);
+    expect(output).toMatchObject({ repository: "tulip/new-repo" });
+  });
+
+  it("denies repo creation when the installation lacks administration:write", async () => {
+    await expect(dispatch(repoCreateIntent)).rejects.toMatchObject({
+      phase: "before_dispatch",
+      code: "installation_scope_denied",
+    });
+    expect(http.calls).toHaveLength(0);
+  });
+
+  it("denies repo creation outside the installation's account", async () => {
+    withAdministration();
+    const otherOwnerIntent = intent(GITHUB_TOOL_IDS.repositoryCreate, {
+      owner: "other-org",
+      name: "new-repo",
+    });
+    await expect(dispatch(otherOwnerIntent)).rejects.toMatchObject({
+      phase: "before_dispatch",
+      code: "installation_scope_denied",
+    });
+    expect(http.calls).toHaveLength(0);
+  });
+});
+
+describe("GitHubAdapter repository create reconciliation", () => {
+  const repoCreateIntent = intent(GITHUB_TOOL_IDS.repositoryCreate, {
+    owner: "tulip",
+    name: "new-repo",
+  });
+
+  function reconcileWith(credential: string | undefined = CREDENTIAL) {
+    return adapter.reconcile(
+      {
+        intent: repoCreateIntent,
+        idempotencyKey: repoCreateIntent.idempotencyKey,
+        operation: "github.repository.create.lookup",
+      },
+      credential
+    );
+  }
+
+  it("confirms when the repo now exists", async () => {
+    http.route("GET", "/repos/tulip/new-repo", { status: 200, headers: {}, body: {} });
+    await expect(reconcileWith()).resolves.toEqual({
+      outcome: "confirmed",
+      evidenceRef: "github:repository:tulip/new-repo",
+    });
+  });
+
+  it("reports not_applied when the repo was never created", async () => {
+    http.route("GET", "/repos/tulip/new-repo", { status: 404, headers: {}, body: {} });
+    await expect(reconcileWith()).resolves.toEqual({
+      outcome: "not_applied",
+      evidenceRef: "github:repository:tulip/new-repo",
+    });
+  });
+
+  it("stays ambiguous rather than guessing when the lookup itself fails", async () => {
+    http.route("GET", "/repos/tulip/new-repo", { status: 503, headers: {}, body: {} });
+    await expect(reconcileWith()).resolves.toMatchObject({ outcome: "ambiguous" });
+  });
+
+  it("stays ambiguous when reconciliation is attempted without a credential", async () => {
+    await expect(reconcileWith(undefined)).resolves.toMatchObject({ outcome: "ambiguous" });
   });
 });

--- a/packages/integrations/src/github/adapter.ts
+++ b/packages/integrations/src/github/adapter.ts
@@ -19,11 +19,13 @@ import {
   type IntegrationHttpResponse,
 } from "../http";
 import {
+  GITHUB_ORGANIZATION_TARGET,
   GITHUB_RECONCILIATION_OPERATIONS,
   GITHUB_REPOSITORY_TARGET,
   GITHUB_TOOL_IDS,
 } from "./contracts";
 import {
+  assertAccountInScope,
   assertRepositoryInScope,
   type GitHubInstallationScope,
   GitHubScopeDeniedError,
@@ -166,6 +168,7 @@ const MARKER_SEARCH_PER_PAGE = 100;
 const MARKER_SEARCH_MAX_PAGES = 5;
 
 const MUTATING_TOOLS = new Set<string>([
+  GITHUB_TOOL_IDS.issueCreate,
   GITHUB_TOOL_IDS.issueComment,
   GITHUB_TOOL_IDS.issueLabel,
   GITHUB_TOOL_IDS.issueAssign,
@@ -175,6 +178,7 @@ const MUTATING_TOOLS = new Set<string>([
   GITHUB_TOOL_IDS.pullRequestReview,
   GITHUB_TOOL_IDS.pullRequestMerge,
   GITHUB_TOOL_IDS.repoPush,
+  GITHUB_TOOL_IDS.repositoryCreate,
 ]);
 
 /** Repository slug from a search result's `repository_url`. */
@@ -215,6 +219,17 @@ export class GitHubAdapter implements ToolAdapter, ToolReconciliationAdapter {
       return this.searchPullRequests(repositories, source, credential);
     }
 
+    // Creating a repo targets an org, not an existing repo — it cannot go through the
+    // per-repository `authorize()` below, since the target does not exist at authorization time.
+    if (intent.action === GITHUB_TOOL_IDS.repositoryCreate) {
+      const owner = stringArg(source, "owner");
+      await this.authorizeAccount(intent, owner);
+      if (credential === undefined || credential.length === 0) {
+        throw new AdapterDispatchError("before_dispatch", "credential_missing", false);
+      }
+      return this.createRepository(source, credential);
+    }
+
     const repository = stringArg(source, "repository");
 
     await this.authorize(intent, repository, mutating);
@@ -226,6 +241,8 @@ export class GitHubAdapter implements ToolAdapter, ToolReconciliationAdapter {
     switch (intent.action) {
       case GITHUB_TOOL_IDS.issueRead:
         return this.readIssue(repository, numberArg(source, "issueNumber"), credential);
+      case GITHUB_TOOL_IDS.issueCreate:
+        return this.createIssue(repository, source, request.idempotencyKey, credential);
       case GITHUB_TOOL_IDS.issueComment:
         return this.comment(repository, source, request.idempotencyKey, credential);
       case GITHUB_TOOL_IDS.issueLabel:
@@ -304,6 +321,48 @@ export class GitHubAdapter implements ToolAdapter, ToolReconciliationAdapter {
   }
 
   /**
+   * Authorizes an org-level action whose target repo does not exist yet (repo creation): the
+   * installation scope check is against the account, not a specific repository, and the
+   * AccessGrant target is the org rather than a repository.
+   */
+  private async authorizeAccount(intent: ToolIntent, owner: string): Promise<void> {
+    const context = await this.deps.context.resolve(intent);
+    if (context === undefined) {
+      throw new AdapterDispatchError("before_dispatch", "integration_context_unresolved", false);
+    }
+
+    try {
+      assertAccountInScope(context.installation, owner, {
+        permission: "administration",
+        level: "write",
+      });
+    } catch (error) {
+      if (error instanceof GitHubScopeDeniedError) {
+        throw new AdapterDispatchError("before_dispatch", "installation_scope_denied", false);
+      }
+      throw error;
+    }
+
+    try {
+      assertIntegrationAccess(
+        context.grants,
+        {
+          integrationId: context.integrationId,
+          principals: context.principals,
+          action: intent.action,
+          target: { type: GITHUB_ORGANIZATION_TARGET, id: owner },
+        },
+        this.deps.now()
+      );
+    } catch (error) {
+      if (error instanceof IntegrationAccessDeniedError) {
+        throw new AdapterDispatchError("before_dispatch", "integration_access_denied", false);
+      }
+      throw error;
+    }
+  }
+
+  /**
    * Resolves which repositories a search spans, authorizing each one exactly as a single-repo call
    * would: `authorize()` already re-checks installation scope and the AccessGrant per repository,
    * so looping it here means a multi-repo search widens nothing an equivalent series of single-repo
@@ -358,17 +417,7 @@ export class GitHubAdapter implements ToolAdapter, ToolReconciliationAdapter {
     return response;
   }
 
-  private async readIssue(
-    repository: string,
-    issueNumber: number,
-    credential: string
-  ): Promise<unknown> {
-    const response = await this.call(
-      { method: "GET", path: `/repos/${repository}/issues/${issueNumber}` },
-      credential,
-      false
-    );
-    const issue = record(response.body);
+  private issueOutput(repository: string, issue: Record<string, unknown>): unknown {
     return {
       repository,
       number: Number(issue.number),
@@ -379,6 +428,19 @@ export class GitHubAdapter implements ToolAdapter, ToolReconciliationAdapter {
       assignees: logins(issue.assignees),
       htmlUrl: String(issue.html_url),
     };
+  }
+
+  private async readIssue(
+    repository: string,
+    issueNumber: number,
+    credential: string
+  ): Promise<unknown> {
+    const response = await this.call(
+      { method: "GET", path: `/repos/${repository}/issues/${issueNumber}` },
+      credential,
+      false
+    );
+    return this.issueOutput(repository, record(response.body));
   }
 
   private async searchIssues(
@@ -435,6 +497,26 @@ export class GitHubAdapter implements ToolAdapter, ToolReconciliationAdapter {
     return list(response.body)
       .map((entry) => record(entry))
       .find((comment) => String(comment.body ?? "").includes(marker));
+  }
+
+  /** GitHub's `/issues` list endpoint also returns pull requests, but the marker is unique. */
+  private async findMarkedIssue(
+    repository: string,
+    marker: string,
+    credential: string
+  ): Promise<Record<string, unknown> | undefined> {
+    const response = await this.call(
+      {
+        method: "GET",
+        path: `/repos/${repository}/issues`,
+        query: { state: "all", per_page: "100" },
+      },
+      credential,
+      false
+    );
+    return list(response.body)
+      .map((entry) => record(entry))
+      .find((issue) => String(issue.body ?? "").includes(marker));
   }
 
   private commentOutput(comment: Record<string, unknown>): unknown {
@@ -521,6 +603,38 @@ export class GitHubAdapter implements ToolAdapter, ToolReconciliationAdapter {
       state: String(issue.state),
       stateReason: String(issue.state_reason),
     };
+  }
+
+  private async createIssue(
+    repository: string,
+    source: Arguments,
+    idempotencyKey: string,
+    credential: string
+  ): Promise<unknown> {
+    const marker = githubEffectMarker(idempotencyKey);
+
+    // Read before write: a redelivered effect must return the issue it already opened.
+    const existing = await this.findMarkedIssue(repository, marker, credential);
+    if (existing !== undefined) return this.issueOutput(repository, existing);
+
+    const body = typeof source.body === "string" ? source.body : "";
+    const response = await this.call(
+      {
+        method: "POST",
+        path: `/repos/${repository}/issues`,
+        body: {
+          title: stringArg(source, "title"),
+          body: `${body}\n\n${marker}`,
+          labels: Array.isArray(source.labels) ? stringListArg(source, "labels") : undefined,
+          assignees: Array.isArray(source.assignees)
+            ? stringListArg(source, "assignees")
+            : undefined,
+        },
+      },
+      credential,
+      true
+    );
+    return this.issueOutput(repository, record(response.body));
   }
 
   private pullRequestOutput(repository: string, pr: Record<string, unknown>): unknown {
@@ -954,6 +1068,58 @@ export class GitHubAdapter implements ToolAdapter, ToolReconciliationAdapter {
     return this.pushOutput(repository, branch, newCommit);
   }
 
+  private repositoryOutput(owner: string, name: string, repo: Record<string, unknown>): unknown {
+    return {
+      repository: `${owner}/${name}`,
+      htmlUrl: String(repo.html_url),
+      private: repo.private === true,
+      defaultBranch: String(repo.default_branch ?? "main"),
+    };
+  }
+
+  /**
+   * A repo may or may not exist yet, so this reads the provider directly rather than through
+   * `call()` — a 404 here is the expected "not created" case, not a failure to surface.
+   */
+  private async lookupRepository(
+    owner: string,
+    name: string,
+    credential: string
+  ): Promise<Record<string, unknown> | undefined> {
+    const response = await this.deps.http.send(
+      { method: "GET", path: `/repos/${owner}/${name}` },
+      credential
+    );
+    if (response.status === 404) return undefined;
+    const failure = classifyHttpFailure(response, false);
+    if (failure !== null)
+      throw new AdapterDispatchError(failure.phase, failure.code, failure.retryable);
+    return record(response.body);
+  }
+
+  private async createRepository(source: Arguments, credential: string): Promise<unknown> {
+    const owner = stringArg(source, "owner");
+    const name = stringArg(source, "name");
+
+    // Read before write: a redelivered effect must return the repo it already created.
+    const existing = await this.lookupRepository(owner, name, credential);
+    if (existing !== undefined) return this.repositoryOutput(owner, name, existing);
+
+    const description = typeof source.description === "string" ? source.description : undefined;
+    const isPrivate = source.private !== false;
+
+    const response = await this.call(
+      {
+        method: "POST",
+        path: `/orgs/${owner}/repos`,
+        body: { name, description, private: isPrivate },
+      },
+      credential,
+      true
+    );
+    return this.repositoryOutput(owner, name, record(response.body));
+  }
+
   /**
    * Resolve an ambiguous effect against provider state. The credential is optional because
    * reconciliation may run long after the leasing dispatch: with no way to read GitHub, the honest
@@ -968,10 +1134,23 @@ export class GitHubAdapter implements ToolAdapter, ToolReconciliationAdapter {
     }
 
     const source = args(request.intent);
+
+    // Repo creation has no `repository` argument (it's `owner`/`name`, the repo doesn't exist at
+    // dispatch time) — handle it before the generic extraction below throws on a missing field.
+    if (request.operation === GITHUB_RECONCILIATION_OPERATIONS.repositoryCreate) {
+      try {
+        return await this.reconcileRepositoryCreate(source, credential);
+      } catch {
+        return { outcome: "ambiguous", evidenceRef: "github:lookup_failed" };
+      }
+    }
+
     const repository = stringArg(source, "repository");
 
     try {
       switch (request.operation) {
+        case GITHUB_RECONCILIATION_OPERATIONS.issueCreate:
+          return await this.reconcileIssueCreate(repository, request, credential);
         case GITHUB_RECONCILIATION_OPERATIONS.comment:
           return await this.reconcileComment(
             repository,
@@ -1111,6 +1290,34 @@ export class GitHubAdapter implements ToolAdapter, ToolReconciliationAdapter {
     return applied
       ? { outcome: "confirmed", evidenceRef }
       : { outcome: "not_applied", evidenceRef };
+  }
+
+  private async reconcileIssueCreate(
+    repository: string,
+    request: ToolReconciliationRequest,
+    credential: string
+  ): Promise<ToolReconciliationOutcome> {
+    const issue = await this.findMarkedIssue(
+      repository,
+      githubEffectMarker(request.idempotencyKey),
+      credential
+    );
+    return issue === undefined
+      ? { outcome: "not_applied", evidenceRef: `github:issue:create:absent:${repository}` }
+      : { outcome: "confirmed", evidenceRef: `github:issue:${String(issue.number)}` };
+  }
+
+  private async reconcileRepositoryCreate(
+    source: Arguments,
+    credential: string
+  ): Promise<ToolReconciliationOutcome> {
+    const owner = stringArg(source, "owner");
+    const name = stringArg(source, "name");
+    const existing = await this.lookupRepository(owner, name, credential);
+    const evidenceRef = `github:repository:${owner}/${name}`;
+    return existing === undefined
+      ? { outcome: "not_applied", evidenceRef }
+      : { outcome: "confirmed", evidenceRef };
   }
 
   private async reconcilePullRequestCreate(

--- a/packages/integrations/src/github/contracts.test.ts
+++ b/packages/integrations/src/github/contracts.test.ts
@@ -11,6 +11,7 @@ describe("GITHUB_TOOL_CONTRACTS", () => {
       [
         GITHUB_TOOL_IDS.issueRead,
         GITHUB_TOOL_IDS.issueSearch,
+        GITHUB_TOOL_IDS.issueCreate,
         GITHUB_TOOL_IDS.issueComment,
         GITHUB_TOOL_IDS.issueLabel,
         GITHUB_TOOL_IDS.issueAssign,
@@ -23,6 +24,7 @@ describe("GITHUB_TOOL_CONTRACTS", () => {
         GITHUB_TOOL_IDS.pullRequestMerge,
         GITHUB_TOOL_IDS.checkRunRead,
         GITHUB_TOOL_IDS.repoPush,
+        GITHUB_TOOL_IDS.repositoryCreate,
         GITHUB_TOOL_IDS.contentRead,
         GITHUB_TOOL_IDS.contentList,
       ].sort()

--- a/packages/integrations/src/github/contracts.ts
+++ b/packages/integrations/src/github/contracts.ts
@@ -22,10 +22,13 @@ export const GITHUB_REPOSITORY_TARGET = "github.repository";
 export const GITHUB_ISSUE_TARGET = "github.issue";
 export const GITHUB_PULL_REQUEST_TARGET = "github.pull_request";
 export const GITHUB_CHECK_RUN_TARGET = "github.check_run";
+/** AccessGrant target for an org-level action whose repository does not exist yet. */
+export const GITHUB_ORGANIZATION_TARGET = "github.organization";
 
 export const GITHUB_TOOL_IDS = {
   issueRead: "github.issue.read",
   issueSearch: "github.issue.search",
+  issueCreate: "github.issue.create",
   issueComment: "github.issue.comment",
   issueLabel: "github.issue.label",
   issueAssign: "github.issue.assign",
@@ -38,6 +41,7 @@ export const GITHUB_TOOL_IDS = {
   pullRequestMerge: "github.pull_request.merge",
   checkRunRead: "github.check_run.read",
   repoPush: "github.repo.push",
+  repositoryCreate: "github.repository.create",
   contentRead: "github.content.read",
   contentList: "github.content.list",
 } as const;
@@ -50,11 +54,13 @@ export const GITHUB_RECONCILIATION_OPERATIONS = {
   labels: "github.issue.labels.lookup",
   assignees: "github.issue.assignees.lookup",
   state: "github.issue.state.lookup",
+  issueCreate: "github.issue.create.lookup",
   pullRequestCreate: "github.pull_request.create.lookup",
   pullRequestComment: "github.pull_request.comment.lookup",
   pullRequestReview: "github.pull_request.review.lookup",
   pullRequestMerge: "github.pull_request.merge.lookup",
   repoPush: "github.repo.push.lookup",
+  repositoryCreate: "github.repository.create.lookup",
 } as const;
 
 const TOOL_VERSION = "1.0.0";
@@ -223,6 +229,51 @@ const issueSearch = publish(
   },
   "aaaaaaaa-0002-4000-8000-000000000002",
   "github-issue-search"
+);
+
+const issueCreate = publish(
+  {
+    toolId: GITHUB_TOOL_IDS.issueCreate,
+    toolVersion: TOOL_VERSION,
+    action: GITHUB_TOOL_IDS.issueCreate,
+    inputSchema: issueInput(
+      {
+        title: { type: "string", minLength: 1, maxLength: 256 },
+        body: { type: "string", maxLength: 65_536 },
+        labels: {
+          type: "array",
+          minItems: 1,
+          maxItems: 20,
+          uniqueItems: true,
+          items: { type: "string", minLength: 1, maxLength: 50 },
+        },
+        assignees: {
+          type: "array",
+          minItems: 1,
+          maxItems: 10,
+          uniqueItems: true,
+          items: { type: "string", minLength: 1, maxLength: 39 },
+        },
+      },
+      ["title"]
+    ),
+    outputSchema: issueOutputSchema,
+    riskClass: "medium",
+    mutating: true,
+    dataClasses: ISSUE_DATA_CLASSES,
+    allowedDestinations: [GITHUB_DESTINATION],
+    idempotency: { strategy: "reconcile" },
+    timeout: { wallClockMs: 15_000 },
+    retry: { maxAttempts: 1, safeToRetry: false },
+    dryRun: true,
+    compensation: {
+      operation: "github.issue.close",
+      reconciliation: GITHUB_RECONCILIATION_OPERATIONS.issueCreate,
+    },
+    adapter: { kind: "integration", ref: GITHUB_ADAPTER_REF },
+  },
+  "aaaaaaaa-0011-4000-8000-000000000011",
+  "github-issue-create"
 );
 
 const issueComment = publish(
@@ -738,6 +789,72 @@ const repoPush = publish(
   "github-repo-push"
 );
 
+const repositoryOwnerProperty = {
+  type: "string",
+  minLength: 1,
+  maxLength: 39,
+  pattern: "^[A-Za-z0-9-]+$",
+} as const;
+
+const repositoryNameProperty = {
+  type: "string",
+  minLength: 1,
+  maxLength: 100,
+  pattern: "^[A-Za-z0-9._-]+$",
+} as const;
+
+const repositoryCreate = publish(
+  {
+    toolId: GITHUB_TOOL_IDS.repositoryCreate,
+    toolVersion: TOOL_VERSION,
+    action: GITHUB_TOOL_IDS.repositoryCreate,
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["owner", "name"],
+      properties: {
+        owner: repositoryOwnerProperty,
+        name: repositoryNameProperty,
+        description: { type: "string", maxLength: 350 },
+        private: {
+          type: "boolean",
+          description: "Defaults to true (private) when omitted.",
+        },
+      },
+    },
+    outputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["repository", "htmlUrl", "private", "defaultBranch"],
+      properties: {
+        repository: repositoryProperty,
+        htmlUrl: { type: "string" },
+        private: { type: "boolean" },
+        defaultBranch: { type: "string" },
+      },
+    },
+    // Creates a new asset under the org and consumes seats/quota — as consequential as pushing to
+    // an existing repo's history.
+    riskClass: "high",
+    mutating: true,
+    dataClasses: PR_DATA_CLASSES,
+    allowedDestinations: [GITHUB_DESTINATION],
+    idempotency: { strategy: "reconcile" },
+    timeout: { wallClockMs: 20_000 },
+    retry: { maxAttempts: 1, safeToRetry: false },
+    dryRun: true,
+    // Detect-only: reconciliation reports whether the repo now exists after an ambiguous write,
+    // it never calls a delete API — repo deletion is too destructive to automate.
+    compensation: {
+      operation: "github.repository.create.report_duplicate",
+      reconciliation: GITHUB_RECONCILIATION_OPERATIONS.repositoryCreate,
+    },
+    adapter: { kind: "integration", ref: GITHUB_ADAPTER_REF },
+  },
+  "aaaaaaaa-0012-4000-8000-000000000012",
+  "github-repository-create"
+);
+
 const contentPathProperty = { type: "string", minLength: 1, maxLength: 1024 } as const;
 const contentRefProperty = { type: "string", minLength: 1, maxLength: 250 } as const;
 
@@ -821,6 +938,7 @@ const contentList = publish(
 export const GITHUB_TOOL_CONTRACTS: readonly ToolContractDefinition[] = [
   issueRead,
   issueSearch,
+  issueCreate,
   issueComment,
   issueLabel,
   issueAssign,
@@ -833,6 +951,7 @@ export const GITHUB_TOOL_CONTRACTS: readonly ToolContractDefinition[] = [
   pullRequestMerge,
   checkRunRead,
   repoPush,
+  repositoryCreate,
   contentRead,
   contentList,
 ];

--- a/packages/integrations/src/github/scope.test.ts
+++ b/packages/integrations/src/github/scope.test.ts
@@ -1,6 +1,7 @@
 import { ExternalIdentityDeniedError } from "@tulipfarm/authz";
 import { describe, expect, it } from "vitest";
 import {
+  assertAccountInScope,
   assertRepositoryInScope,
   type GitHubInstallationScope,
   GitHubScopeDeniedError,
@@ -96,6 +97,59 @@ describe("assertRepositoryInScope", () => {
     expect(() =>
       assertRepositoryInScope(scope({ permissions: { issues: "read" } }), target, {
         permission: "issues",
+        level: "write",
+      })
+    ).toThrow(expect.objectContaining({ reason: "permission_insufficient" }));
+  });
+});
+
+describe("assertAccountInScope", () => {
+  it("admits the installation's own account with sufficient permission", () => {
+    expect(() =>
+      assertAccountInScope(scope({ permissions: { administration: "write" } }), "tulip", {
+        permission: "administration",
+        level: "write",
+      })
+    ).not.toThrow();
+  });
+
+  it("admits a repository not yet in the installation's selected list, unlike assertRepositoryInScope", () => {
+    // The whole point of this assertion: it authorizes an org-level action (creating a repo) whose
+    // target doesn't exist yet, so it must not require repository membership.
+    expect(() =>
+      assertAccountInScope(
+        scope({ repositories: ["tulip/farm"], permissions: { administration: "write" } }),
+        "tulip",
+        { permission: "administration", level: "write" }
+      )
+    ).not.toThrow();
+  });
+
+  it("denies when no installation was resolved at all", () => {
+    expect(() =>
+      assertAccountInScope(undefined, "tulip", { permission: "administration", level: "write" })
+    ).toThrow(expect.objectContaining({ reason: "installation_unknown" }));
+  });
+
+  it("denies an account other than the one the App was installed on", () => {
+    expect(() =>
+      assertAccountInScope(scope({ permissions: { administration: "write" } }), "other-org", {
+        permission: "administration",
+        level: "write",
+      })
+    ).toThrow(expect.objectContaining({ reason: "account_out_of_scope" }));
+  });
+
+  it("denies a permission the installation does not hold", () => {
+    expect(() =>
+      assertAccountInScope(scope(), "tulip", { permission: "administration", level: "write" })
+    ).toThrow(expect.objectContaining({ reason: "permission_missing" }));
+  });
+
+  it("does not let a read permission satisfy a write need", () => {
+    expect(() =>
+      assertAccountInScope(scope({ permissions: { administration: "read" } }), "tulip", {
+        permission: "administration",
         level: "write",
       })
     ).toThrow(expect.objectContaining({ reason: "permission_insufficient" }));

--- a/packages/integrations/src/github/scope.ts
+++ b/packages/integrations/src/github/scope.ts
@@ -85,6 +85,30 @@ export function assertRepositoryInScope(
   }
 }
 
+/**
+ * Throws unless `scope` covers `owner` at the required permission level. Unlike
+ * `assertRepositoryInScope`, this does not check repository membership: it authorizes an
+ * account-level action (e.g. creating a repo) whose target does not exist yet, so it cannot be
+ * checked against the installation's already-selected repository list.
+ */
+export function assertAccountInScope(
+  scope: GitHubInstallationScope | undefined,
+  owner: string,
+  need: GitHubPermissionNeed
+): asserts scope is GitHubInstallationScope {
+  if (scope === undefined) throw new GitHubScopeDeniedError("installation_unknown");
+
+  if (owner !== scope.accountLogin) {
+    throw new GitHubScopeDeniedError("account_out_of_scope");
+  }
+
+  const held = scope.permissions[need.permission];
+  if (held === undefined) throw new GitHubScopeDeniedError("permission_missing");
+  if (need.level === "write" && held !== "write") {
+    throw new GitHubScopeDeniedError("permission_insufficient");
+  }
+}
+
 /** Provider-qualified subject for a GitHub user id, as stored on the identity mapping. */
 export function githubExternalSubject(externalId: string): string {
   return `github:user:${externalId}`;


### PR DESCRIPTION
## Summary
- Add `github_issue_create` (open a new issue) and `github_repository_create` (create an org-owned repo, `POST /orgs/{owner}/repos`) to the existing governed GitHub tool family — every other issue/PR verb already existed, these were the two gaps.
- `github_repository_create` requires `administration:write` (not in the App's default permission set) and is authorized via new `assertAccountInScope` (account + permission only, no repo-membership check, since the target repo doesn't exist yet). Reconciliation is detect-only: it reports whether the repo now exists, never auto-deletes on an ambiguous failure.
- Fixes `InstallationScopeGitHubContextResolver` (both the `apps/api` and `apps/worker` copies) to resolve context for a `repositoryCreate` intent by account/owner instead of by repository — the existing resolver only matched `intent.arguments.repository`, which `repositoryCreate` never sets, so the tool was unreachable end-to-end regardless of grants. Found while writing the success-path test for the new tool.

## Test plan
- [x] `pnpm --filter @tulipfarm/integrations test` — 369/369 passed
- [x] `pnpm --filter @tulipfarm/worker test` — 332/332 passed
- [x] `pnpm --filter @tulipfarm/api test` — all github-related tests pass; 97 pre-existing failures confined to `src/soul/skills/guard.test.ts` (missing local `/Users/dhruv/dev/skills` directory), unrelated to this change
- [x] `pnpm lint` — clean (pre-existing unrelated warnings only)
- [x] `pnpm typecheck` — clean across all 31 packages
- [ ] Manual QA against a live GitHub App installation with `administration:write` granted (needs credentials not available in this session) — recommend verifying through the chat UI before merge