### PR TITLE
fix(knowledge): stop Slack history sync wedging on large channels, fix tool routing

### DIFF
--- a/apps/api/src/knowledge-sources/slack-http.test.ts
+++ b/apps/api/src/knowledge-sources/slack-http.test.ts
@@ -119,6 +119,24 @@ describe("SlackHttpKnowledgeApi", () => {
     expect(messages.map((m) => m.ts)).toEqual(["1.0", "2.0"]);
   });
 
+  it("stops gracefully after the page bound instead of throwing, so the caller can checkpoint and resume", async () => {
+    const page = (ts: string, hasMore: boolean, nextCursor?: string) =>
+      jsonResponse({
+        ok: true,
+        has_more: hasMore,
+        ...(nextCursor ? { response_metadata: { next_cursor: nextCursor } } : {}),
+        messages: [{ ts, user: "U1", text: `msg-${ts}` }],
+      });
+    const fetchImpl = vi.fn().mockImplementation(() => page("1.0", true, "next"));
+    const api = new SlackHttpKnowledgeApi({ token: "xoxb-test", teamId: "T1", fetch: fetchImpl });
+
+    const { messages } = await api.listMessages({ channelId: "C1", pageLimit: 200 });
+
+    // Bounded at 25 pages; never throws, always resolves with whatever it collected.
+    expect(fetchImpl).toHaveBeenCalledTimes(25);
+    expect(messages.length).toBeGreaterThan(0);
+  });
+
   it("sends the bot token as a bearer header", async () => {
     const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ ok: true, channels: [] }));
     const api = new SlackHttpKnowledgeApi({ token: "xoxb-secret", teamId: "T1", fetch: fetchImpl });

--- a/apps/api/src/knowledge-sources/slack-http.ts
+++ b/apps/api/src/knowledge-sources/slack-http.ts
@@ -132,26 +132,33 @@ export class SlackHttpKnowledgeApi implements SlackKnowledgeApiPort {
     readonly messages: readonly SlackKnowledgeMessage[];
     readonly nextCursor?: string;
   }> {
-    const raw = await collectPages<SlackHistoryMessage>(
-      async (cursor) => {
-        const page = await this.call<{
-          messages: SlackHistoryMessage[];
-          has_more?: boolean;
-          response_metadata?: { next_cursor?: string };
-        }>("conversations.history", {
-          channel: input.channelId,
-          limit: "200",
-          ...(input.cursor === undefined ? {} : { oldest: input.cursor }),
-          ...(cursor === undefined ? {} : { cursor }),
-        });
-        const nextCursor = page.has_more ? page.response_metadata?.next_cursor : undefined;
-        return {
-          items: page.messages,
-          ...(nextCursor ? { nextCursor } : {}),
-        };
-      },
-      { maxPages: 25, maxItems: 5000 }
-    );
+    // Bounded batch, not an all-or-nothing read: unlike listChannels/listMembers (where an
+    // incomplete answer would be actively wrong), history is consumed through a durable
+    // per-channel checkpoint (`syncChannel` in sync.ts). Stopping early after `maxPages`/
+    // `maxItems` and returning what was gathered lets that checkpoint advance so the next sync
+    // run resumes from where this one stopped, rather than the whole channel wedging forever on
+    // `PaginationBoundError` for having more backlog than one run can fetch (a channel with a
+    // large history would otherwise re-request the same unbounded range and fail every 15
+    // minutes indefinitely).
+    const bounds = { maxPages: 25, maxItems: 5000 };
+    const raw: SlackHistoryMessage[] = [];
+    let pageCursor: string | undefined;
+    for (let page = 0; page < bounds.maxPages && raw.length < bounds.maxItems; page += 1) {
+      const body = await this.call<{
+        messages: SlackHistoryMessage[];
+        has_more?: boolean;
+        response_metadata?: { next_cursor?: string };
+      }>("conversations.history", {
+        channel: input.channelId,
+        limit: "200",
+        ...(input.cursor === undefined ? {} : { oldest: input.cursor }),
+        ...(pageCursor === undefined ? {} : { cursor: pageCursor }),
+      });
+      raw.push(...body.messages);
+      const nextSlackCursor = body.has_more ? body.response_metadata?.next_cursor : undefined;
+      if (nextSlackCursor === undefined) break;
+      pageCursor = nextSlackCursor;
+    }
 
     const messages = raw
       .filter((message): message is SlackHistoryMessage & { user: string; text: string } =>

--- a/apps/api/src/knowledge/tools.ts
+++ b/apps/api/src/knowledge/tools.ts
@@ -96,7 +96,7 @@ const validateCreatePage = ajv.compile(CREATE_PAGE_SCHEMA);
 const queryKnowledge: KnowledgeTool = {
   name: "query_knowledge",
   description:
-    "Search the shared knowledge base by meaning (vector) with a lexical fallback. Returns ranked OKF wiki pages and authorized indexed source snippets, each labelled with its origin. Read OKF pages with `get_page` before answering; source snippets are already the retrievable excerpt. Pass `spaceId` to scope the search to a single space (wiki only).",
+    "Search the shared knowledge base by meaning (vector) with a lexical fallback. Returns ranked OKF wiki pages and authorized indexed source snippets from every connected source — including synced Slack channel history, Confluence pages, and other connectors — each labelled with its origin. Use this (not a messaging tool) to answer questions about what was said in a Slack channel or any other connected source. Read OKF pages with `get_page` before answering; source snippets are already the retrievable excerpt. Pass `spaceId` to scope the search to a single space (wiki only).",
   mutating: false,
   inputSchema: QUERY_SCHEMA,
   handler: async (args, ctx) => {


### PR DESCRIPTION
## Summary
- `SlackHttpKnowledgeApi.listMessages` used the shared bounded `collectPages` helper, which throws `PaginationBoundError` once a channel's backlog exceeds 25 pages / 5000 items. Message history is consumed through a durable per-channel checkpoint, so a bounded partial read should let the next sync run resume — not fail the whole channel every 15 minutes forever. Replaced with a manual bounded loop that stops gracefully and returns whatever it collected.
- `query_knowledge`'s tool description never mentioned Slack, so weaker models routed "what did X say in Slack" questions to `send_slack_message` instead of searching indexed history. Updated the description to name Slack/Confluence/connector sources explicitly and to steer the model toward searching rather than messaging.

## Test plan
- [x] `rtk proxy pnpm lint` (repo-wide) — clean, no new findings
- [x] `rtk proxy pnpm typecheck` (repo-wide) — clean
- [x] `rtk proxy pnpm --filter @tulipfarm/api exec vitest run` — 229 files / 2279 tests passed, including a new regression test asserting `listMessages` stops after the page bound instead of throwing
- [x] Live QA against the running dev server via Claude in Chrome: asked the real chat UI "What did dhruv say in the tech Slack channel about gemma?" — model now correctly calls `query_knowledge` (not `send_slack_message`) and returns an accurate, grounded answer matching the real Slack message content