### PR TITLE
docs: turn README into a landing page, add contributor docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Something isn't working the way it should
+title: "fix: "
+labels: bug
+---
+
+**What happened?**
+
+**What did you expect to happen?**
+
+**Steps to reproduce**
+
+1.
+2.
+3.
+
+**Install method**
+
+<!-- installer script / Docker Compose / source checkout -->
+
+**TulipFarm version**
+
+<!-- shown on the setup/about page, or `docker inspect --format='{{.Config.Image}}' <container>` -->
+
+**Logs**
+
+<!-- `docker compose logs app`, or terminal output if running from source. Redact secrets. -->
+
+```
+
+```

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/TulipFarm/tulipfarm/security
+    about: Report privately via GitHub Security Advisories — do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: Suggest something TulipFarm should do
+title: "feat: "
+labels: enhancement
+---
+
+**What problem does this solve?**
+
+<!-- What are you trying to do that you can't today? -->
+
+**Proposed solution**
+
+<!-- What would you like to happen? -->
+
+**Alternatives considered**
+
+<!-- Any workarounds you're using now, or other approaches you thought about. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## Summary
+
+<!-- What changed, and why. Link the driving issue if one exists. -->
+
+## Test plan
+
+<!-- Commands you ran, or manual steps / screenshots for UI changes. -->
+
+- [ ] `pnpm lint`
+- [ ] `pnpm typecheck`
+- [ ] `pnpm test` (or the scoped `--filter` you actually ran)
+
+## Checklist
+
+- [ ] PR title follows Conventional Commits (`type(scope): subject`) — CI checks this
+- [ ] Scoped to one logical change
+- [ ] Tests added/updated for the behavior that changed

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,72 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a
+harassment-free experience for everyone, regardless of age, body size, visible or invisible
+disability, ethnicity, sex characteristics, gender identity and expression, level of
+experience, education, socio-economic status, nationality, personal appearance, race,
+religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse,
+inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing for mistakes, and learning from them
+- Focusing on what is best for the community as a whole
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without
+  their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional
+  setting
+
+## Enforcement Responsibilities
+
+Maintainers are responsible for clarifying and enforcing our standards of acceptable
+behavior and will take appropriate and fair corrective action in response to any behavior
+they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces (issues, pull requests,
+discussions) and also applies when an individual is officially representing the community
+in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by
+opening a private [security advisory](https://github.com/TulipFarm/tulipfarm/security) on
+this repository — the same private channel used for security reports — or by contacting a
+maintainer directly through GitHub. All complaints will be reviewed and investigated
+promptly and fairly, and reporter privacy and safety will be respected.
+
+## Enforcement Guidelines
+
+Maintainers will follow these Community Impact Guidelines in determining the consequences
+for any action they deem in violation of this Code of Conduct:
+
+1. **Correction** — A private, written warning, providing clarity around the violation and
+   why it was inappropriate.
+2. **Warning** — A warning with consequences for continued behavior, including no
+   interaction with the people involved for a specified period.
+3. **Temporary Ban** — A temporary ban from any sort of interaction or public communication
+   with the community for a specified period.
+4. **Permanent Ban** — A permanent ban from any sort of public interaction within the
+   community.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,116 @@
+# Contributing to TulipFarm
+
+Thanks for taking the time to contribute. This guide covers everything you need to get a
+local dev environment running, make a change, and open a pull request.
+
+Please also read the [Code of Conduct](CODE_OF_CONDUCT.md). Found a security
+vulnerability? See [SECURITY.md](SECURITY.md) instead of opening a public issue.
+
+> If you only want to **run** TulipFarm, don't clone this repo — use the
+> [one-line installer](https://tulipfarm.site/docs/installation) or
+> [Docker Compose](https://tulipfarm.site/docs/deploy/docker-compose). This guide is for
+> people changing TulipFarm's code.
+
+## Local development setup
+
+**Prerequisites**
+
+| | |
+| --- | --- |
+| **Node.js** | `26.5.0` — pinned in `.node-version`. Use `fnm`, `nvm`, or `mise`. |
+| **pnpm** | `11.5.3`. Never npm or yarn — the lockfile is pnpm's. |
+| **Docker** | Docker Desktop or Docker Engine, with the Compose v2 plugin. |
+
+Postgres always runs as the bundled `pgvector/pgvector:pg17` container — the same image CI
+and production use, so local dev can't drift from the tested path.
+
+```bash
+git clone https://github.com/TulipFarm/tulipfarm.git
+cd tulipfarm
+
+bash scripts/setup-dev.sh   # starts Postgres, inits soul repo, writes .env.local — no prompts
+pnpm install
+pnpm dev                    # api :4010, web :4000, worker :4020, integration-worker :4030
+```
+
+Open `http://localhost:4000` and create an admin account at the `/setup` wizard.
+
+Run a single app with `pnpm dev:api`, `pnpm dev:web`, `pnpm dev:worker`, or
+`pnpm dev:integration-worker`. Start over from a clean slate with `pnpm reset:dev`.
+
+Full walkthrough (soul repo internals, headless admin seeding, marketplace branch testing,
+troubleshooting): **[Local development](https://tulipfarm.site/docs/development)** on the
+docs site.
+
+## Making a change
+
+1. **Read the nearest `AGENTS.md`.** Every app and package has one with local conventions —
+   it's the authoritative guide for that directory. The root [AGENTS.md](AGENTS.md) has the
+   full repo layout and the test-verification tiers (don't run the full `pnpm test` suite
+   for a small change — it's the slowest way to get a signal; see the "Verifying your work"
+   section).
+2. **Match the code style.** [Biome](https://biomejs.dev) is the only linter/formatter —
+   no ESLint, no Prettier. A pre-commit hook auto-fixes staged files, so conforming code
+   makes it a no-op:
+   ```bash
+   pnpm exec biome check --write .
+   ```
+3. **Add tests** for behavior you change or add. Vitest, colocated as `*.test.ts` next to
+   the source. Run just what you touched:
+   ```bash
+   pnpm --filter @tulipfarm/api test apps/api/src/your-file.test.ts
+   ```
+4. **Before opening a PR**, run the full gate once — it's what CI runs, cached and fast on
+   a repeat run:
+   ```bash
+   pnpm lint && pnpm typecheck && pnpm test
+   ```
+
+Complete conventions (migrations, API route schemas, terminology rules, where things live):
+**[Development workflow](https://tulipfarm.site/docs/development/workflow)** on the docs
+site.
+
+## Commit messages
+
+[Conventional Commits](https://www.conventionalcommits.org/), enforced locally by a
+`commit-msg` hook and again by CI on the PR title:
+
+```
+type(scope): subject
+```
+
+`type` is one of `feat`, `fix`, `chore`, `docs`, `refactor`, `perf`, `test`, `build`, `ci`,
+`style`, `revert`. Imperative mood, no trailing period, under ~72 characters. Use the body
+to explain *why*, not *what* — the diff already shows what. One logical change per commit.
+
+## Opening a pull request
+
+1. Branch from `main`.
+2. Keep the PR scoped to one logical change — smaller PRs review faster.
+3. Title the PR the same way as a commit message: `type(scope): subject`. CI rejects titles
+   that don't match.
+4. Fill in the PR template: a short summary of what changed and why, and a test plan
+   listing the commands you actually ran (or manual steps / screenshots for UI changes).
+5. CI runs lint, typecheck, and tests automatically. Fix red checks before requesting
+   review.
+6. A maintainer reviews and merges — releases are cut separately (see
+   [docs/RELEASES.md](docs/RELEASES.md)), so you don't need to bump versions or touch the
+   changelog yourself.
+
+## Reporting bugs and requesting features
+
+Open a [GitHub issue](https://github.com/TulipFarm/tulipfarm/issues/new/choose) using the
+bug report or feature request template. For a bug, include:
+
+- What you expected vs. what happened
+- Steps to reproduce
+- Your install method (installer / Compose / source) and TulipFarm version
+- Relevant logs (`docker compose logs app`, or terminal output for a source checkout)
+
+Not sure if something is a bug? Open an issue anyway with what you're seeing — we'll help
+you sort it out.
+
+## Questions
+
+If something in this guide is wrong or missing, that's a documentation bug — please open an
+issue or a PR fixing it.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,70 @@
   <img src="https://shieldcn.dev/badge/status-research%20preview-orange.svg" alt="Research Preview" />
   <img src="https://shieldcn.dev/github/release/TulipFarm/tulipfarm.svg?label=docker" alt="Docker Version" />
   <a href="https://tulipfarm.site"><img src="https://shieldcn.dev/badge/website-tulipfarm.site-blue.svg" alt="Website" /></a>
+  <a href="LICENSE"><img src="https://shieldcn.dev/badge/license-MIT-lightgrey.svg" alt="License: MIT" /></a>
 </p>
+
+<p align="center">
+  <a href="https://tulipfarm.site/docs">Documentation</a> ·
+  <a href="#install-self-host">Install</a> ·
+  <a href="#features">Features</a> ·
+  <a href="#architecture">Architecture</a> ·
+  <a href="CONTRIBUTING.md">Contributing</a>
+</p>
+
+## What is TulipFarm
+
+TulipFarm is a self-hosted control panel where autonomous agents run your business
+operations. You **describe what you want in chat** — "track our customers", "create a
+support agent", "review this pull request" — and agents build and run it for you. You do
+not configure it by editing files or writing code.
+
+It runs entirely on your own infrastructure, against your own model provider keys. Nothing
+about your business data leaves your instance unless an agent's job is to send it somewhere
+you've authorized.
+
+## Features
+
+Once a model is configured, everything below is created by asking for it in chat:
+
+- **Resource types** — the things your business tracks. Describe one and its tables, forms,
+  and list screens appear.
+- **Agents** — named owners for a job, each with its own instructions, tools, and bounded
+  authority.
+- **Routines** — repeatable operations that run on a schedule, on an event, or on request.
+- **Knowledge** — a wiki your agents read from and cite, with provenance attached to every
+  answer.
+- **Skills** — installable capability packages from a git repository, audited before they
+  run.
+- **Integrations** — reach your agents where work already happens: GitHub, Slack, Telegram,
+  Notion, Confluence, and Google Workspace ship in the box, and any provider can be added as
+  a manifest.
+
+See the [full documentation](https://tulipfarm.site/docs) for a guided tour, or
+[docs/concepts](https://tulipfarm.site/docs/concepts) for how these fit together.
+
+## Architecture
+
+A TulipFarm instance has two halves:
+
+- **The soul** — a git-backed configuration store. Your resource schemas, agents, skills,
+  routines, and integrations live here as files. Agents write to the soul when you ask them
+  to build something; the git history is your audit trail.
+- **The runtime** — the API and workers that load the soul, store your records, index your
+  knowledge, and run agent turns against your configured LLM providers.
+
+The codebase is a TypeScript pnpm/Turborepo monorepo:
+
+| App / package | What it does |
+| --- | --- |
+| `apps/api` | Fastify API server. PostgreSQL (pgvector + pg-boss), migration-on-boot, soul git store. |
+| `apps/web` | Remix + React web UI. |
+| `apps/worker` | Durable Run dispatch, Agent/Tool States, timers, reconciliation. |
+| `apps/integration-worker` | Integration ingress, sync, delivery, retries, reconciliation. |
+| `packages/*` | Domain packages (auth, agent runtime, tool broker, knowledge, memory, soul, and more) — see [AGENTS.md](AGENTS.md) for the full layout. |
+
+Accepted architecture decisions and the boundaries between packages are recorded in
+[`docs/architecture`](docs/architecture/decision-index.md).
 
 ## Install (self-host)
 
@@ -47,188 +110,56 @@ its generated secrets.
 > `TF_BASE_URL=https://raw.githubusercontent.com/TulipFarm/tulipfarm` together with
 > `TF_REF=<tag-or-branch>`. To test a local build, set `TF_LOCAL_SRC=1`.
 
+**Compose by hand** (Portainer, Coolify, Dokploy, Unraid, or a plain `docker compose`) —
+grab `docker-compose.yml` from <https://tulipfarm.site/docker-compose.yml> and run it
+as-is; no `.env` and no key generation are needed. See the header of `docker-compose.yml`
+for every knob (TLS, `POSTGRES_PASSWORD`, `PUBLIC_URL`).
+
+**Updating**: releases publish `ghcr.io/tulipfarm/tulipfarm:v<version>` (+ `:latest` for
+stable). Updates are always **manual** (no auto-update by design) — re-run the install
+command, or `docker compose pull && docker compose up -d`. Database migrations run
+automatically on boot; there are **no down-migrations**, so back up before updating. See
+the [update guide](https://tulipfarm.site/docs/deploy/updating) for the full procedure and
+every deployment target.
+
 **Uninstall permanently** (deletes the database, soul, secrets, backups, volumes, and
 TulipFarm images after a typed confirmation):
 ```bash
 curl -fsSL https://tulipfarm.site/uninstall.sh | bash
 ```
-Docker/Podman itself and externally managed databases are left untouched. See the
-[uninstall guide](https://tulipfarm.site/docs/uninstall) before running it.
+See the [uninstall guide](https://tulipfarm.site/docs/uninstall) before running it.
 
-**Compose by hand** (Portainer, Coolify, Dokploy, Unraid, or a plain `docker compose`) —
-grab `docker-compose.yml` from <https://tulipfarm.site/docker-compose.yml> and run it
-as-is; no `.env` and no key generation are needed.
-The app generates its bootstrap secrets on first boot and persists them to the
-`tulipfarm-data` volume, so **back that volume up** — it holds the key that decrypts every
-secret the instance stores. The bundled database uses the default password `tulipfarm`
-(safe only because port 5432 is never published — don't publish it); set
-`POSTGRES_PASSWORD` to change it. For TLS, put a reverse proxy in front and set
-`PUBLIC_URL` to the external `https://` origin. See the header of `docker-compose.yml` for
-every knob.
+> You never need to clone this repository to run TulipFarm — every path above pulls a
+> published image. The source tree here is for contributors — see
+> [CONTRIBUTING.md](CONTRIBUTING.md).
 
-## Local Development
+## Security & secrets
 
-### Prerequisites
+- The app generates its bootstrap secrets on first boot and persists them to the
+  `tulipfarm-data` volume — **back that volume up**, it holds the key that decrypts every
+  secret the instance stores.
+- The bundled database uses a default password, safe only because port 5432 is never
+  published by default — don't publish it; set `POSTGRES_PASSWORD` to change it.
+- Secrets (integration credentials, API keys) are stored encrypted and only decrypted
+  immediately before an authorized use — see
+  [`packages/secrets`](packages/secrets/AGENTS.md) and the
+  [security docs](https://tulipfarm.site/docs/security).
+- Found a vulnerability? See [SECURITY.md](SECURITY.md) — please don't file a public issue.
 
-- **Node.js** (see `.node-version`)
-- **pnpm** (`npm install -g pnpm`)
-- **Docker** (Docker Desktop or Docker Engine, with the Compose v2 plugin)
+## Contributing
 
-### Quick Start
+Bug reports, feature requests, and PRs are welcome. Start with
+[CONTRIBUTING.md](CONTRIBUTING.md) for local dev setup, how the test/lint gates work, commit
+conventions, and how to open a PR. Please also read the
+[Code of Conduct](CODE_OF_CONDUCT.md).
 
-Postgres always runs as the bundled `pgvector/pgvector:pg17` container — the same image CI
-and production use, so dev cannot drift from the tested path. App processes run on the host
-(`pnpm dev`, hot reload).
+## Releases
 
-1. **Provision Postgres** — run the setup script:
-   ```bash
-   bash scripts/setup-dev.sh
-   ```
-   It starts the container (exposed on `localhost:5432`, password generated into `.env`),
-   wires `DATABASE_URL` into `.env.local`, initializes the soul directory, and generates the
-   rest of `.env.local`. No prompts.
+Releases use a release PR and a gated publication pipeline; a maintainer requests an exact
+version with `pnpm release 0.5.0`. See [docs/RELEASES.md](docs/RELEASES.md) for the
+complete release contract, and [CONTRIBUTING.md](CONTRIBUTING.md#commit-messages) for the
+commit convention that drives it.
 
-2. **Verify the datastore is running:**
-   ```bash
-   pg_isready -h localhost -p 5432 -U tulipfarm
-   ```
+## License
 
-3. **Install dependencies and start development:**
-   ```bash
-   pnpm install
-   pnpm dev
-   ```
-   - API will start on `http://localhost:4010` (default, configurable via `PORT` env var)
-   - Web UI will start on `http://localhost:4000` (default, configurable via `VITE_PORT` env var)
-
-   **Individual app development:**
-   ```bash
-   pnpm dev:api   # Run only the API server
-   pnpm dev:web   # Run only the Web UI
-   ```
-
-4. **Check API health:**
-   ```bash
-   curl http://localhost:4010/health
-   ```
-
-### Environment Setup
-
-The `scripts/setup-dev.sh` script automatically:
-- Starts the bundled PostgreSQL 17 + pgvector container on `localhost:5432`
-- Generates `POSTGRES_PASSWORD` into `.env` and points `DATABASE_URL` at the container
-- Initializes the soul git repository at `~/.tulipfarm/soul` with the required directory structure
-- Generates `.env.local` with random bootstrap env config (`ENCRYPTION_KEY`, `JWT_SECRET`, `WEBHOOK_SIGNING_SECRET`)
-
-**Manual adjustments:** Edit `.env.local` to customize the datastore or add optional variables like `SOUL_GIT_REMOTE_URL` for syncing soul changes to a remote repository.
-
-### Soul Repository
-
-The soul lives at `~/.tulipfarm/soul` — a git repository that stores your system configuration (resources, routines, agents, skills, integrations). By default, it is local-only. To enable remote sync:
-
-1. Create a private GitHub repository for your soul
-2. Add the remote and set `SOUL_GIT_REMOTE_URL` in `.env.local`:
-   ```bash
-   git -C ~/.tulipfarm/soul remote add origin https://github.com/your-org/your-soul.git
-   git -C ~/.tulipfarm/soul push -u origin main
-   ```
-3. Update `.env.local`: `SOUL_GIT_REMOTE_URL=https://github.com/your-org/your-soul.git`
-
-Or configure it from the Settings UI setup wizard, which persists the remote + credential and syncs immediately (no restart needed).
-
-### Testing a marketplace branch (integrations / skills)
-
-The marketplace endpoints clone their source repo per request, so you can point an instance
-at any repo **and branch** without code changes — useful for testing an integrations or
-skills branch before merging it to main:
-
-```bash
-# integrations marketplace (default: tulipfarm/integrations, remote default branch)
-INTEGRATIONS_MARKETPLACE_SOURCE=tulipfarm/integrations#my-feature-branch
-
-# skills marketplace (default: tulipfarm/skills)
-MARKETPLACE_SOURCE=tulipfarm/skills#my-feature-branch
-```
-
-Accepted forms: `owner/repo`, `owner/repo#branch-or-tag`, a full `https://` git URL (also with
-`#ref`), or `file:///abs/path` for a local checkout. Set in `.env.local` for local dev; on a
-hosted instance (e.g. Azure App Service) set the app setting and restart:
-
-```bash
-az webapp config appsettings set -n <app> -g <rg> \
-  --settings INTEGRATIONS_MARKETPLACE_SOURCE=tulipfarm/integrations#my-feature-branch
-```
-
-Installs record provenance (source URL + resolved commit SHA + content hash) in
-`integrations-lock.json` / `skills-lock.json`; the marketplace shows **Update** when the
-locked hash differs from the source's current content — reinstalling from a branch and later
-from main both flow through the same update path.
-
-### Updating TulipFarm (self-host)
-
-Releases publish the image `ghcr.io/tulipfarm/tulipfarm:v<version>` (+ `:latest` for stable).
-Updates are always **manual** (no auto-update by design):
-
-- **OCI lane (installer):** re-run the install command — it preserves `.env` and the Postgres
-  volume, pulls the pinned `TULIPFARM_VERSION` (default `latest`), and restarts.
-- **Compose by hand:** `docker compose pull && docker compose up -d`.
-- **Azure App Service (sitecontainer on `:latest`):** `az webapp restart -n <app> -g <rg>` —
-  the restart pulls the newest image.
-- **Pinned installs:** bump `TULIPFARM_VERSION` in `.env`, then pull + up.
-
-**Database migrations run automatically on boot** — pulling a new image applies pending
-schema migrations before the API starts serving. The corollaries:
-
-- There are **no down-migrations**: rolling back to an older image after a migration ran
-  requires restoring a database backup, not just repointing the image tag.
-- A failed boot migration restart-loops the app — fix forward (patched release) or restore.
-- **Back up before updating**: `pg_dump` the database (or rely on your managed Postgres
-  point-in-time restore) so a bad update is a restore away from recovery.
-
-Installed **integrations and skills** update independently of the app: the marketplace pages
-show an **Update** button when the source repo has newer content (lock-hash comparison).
-Updating a connected integration restarts its MCP server automatically.
-
-### Stopping Services
-
-To stop PostgreSQL (keeps the data volume):
-```bash
-docker compose -f docker-compose.yml -f docker-compose.dev.yml down
-```
-
-To stop the dev servers, press `Ctrl+C` in the terminal running `pnpm dev`.
-
-## Commits & Releases
-
-Commits follow [Conventional Commits](https://www.conventionalcommits.org/). They're
-enforced in two places: a `commit-msg` git hook (commitlint, via lefthook) locally, and
-the **PR Title** check in CI. The commit/PR `type` drives the next version bump.
-
-Releases use a release PR and a gated publication pipeline. A maintainer requests an exact
-version:
-
-```bash
-pnpm release 0.5.0
-```
-
-The command dispatches **Prepare release**, which opens a PR containing only the generated
-`package.json` and `CHANGELOG.md` changes for a frozen `main` snapshot. Merging that PR
-automatically validates and builds the reviewed snapshot, runs Compose parity against that exact
-multi-architecture image, promotes it to `v<version>` and `latest`, and creates the Git tag and
-GitHub Release with the matching changelog section. The GitHub Release is created last; no
-post-merge command or approval is required.
-
-See [docs/RELEASES.md](docs/RELEASES.md) for setup, retry semantics, and the complete release
-contract.
-
-### Canary / prereleases
-
-Prereleases use the same release-PR and verification path. Pass the complete version:
-
-```bash
-pnpm release:canary 0.5.0-alpha.0
-pnpm release:canary 0.5.0-beta.0
-```
-
-They are marked as prereleases on GitHub and publish `ghcr.io/tulipfarm/tulipfarm:v<version>`
-without moving `latest`.
+[MIT](LICENSE)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+## Supported versions
+
+TulipFarm is a research preview, released as a single rolling line — only the latest
+release receives security fixes. There is no long-term-support branch. Always run the
+`latest` tag or the newest tagged version.
+
+## Reporting a vulnerability
+
+**Do not open a public GitHub issue for a security vulnerability.**
+
+Report it privately through GitHub:
+
+1. Go to the [Security tab](https://github.com/TulipFarm/tulipfarm/security) of this
+   repository.
+2. Click **Report a vulnerability**.
+3. Include what you found, the affected version/commit, steps to reproduce, and the
+   potential impact.
+
+This opens a private advisory visible only to you and the maintainers, so we can discuss
+and fix the issue before it's public.
+
+## What to expect
+
+- We'll acknowledge your report and confirm we can reproduce it.
+- We'll work with you on a fix and, where relevant, a disclosure timeline.
+- Once a patched release is out, we'll publish a GitHub Security Advisory crediting you
+  (unless you'd rather stay anonymous).
+
+## Scope
+
+In scope: the TulipFarm application (`apps/*`, `packages/*`), the installer scripts, and
+the published Docker images. Out of scope: third-party services you connect via
+Integrations, and vulnerabilities in dependencies that don't affect TulipFarm's use of
+them (report those upstream instead).


### PR DESCRIPTION
## Summary
- README trimmed to a real landing page: what TulipFarm is, features, architecture, install, security & secrets, license — dev setup moved out.
- New `CONTRIBUTING.md`: local dev setup, code style, commits, PR flow, bug/feature reporting (links to the existing public dev docs instead of duplicating them).
- New `SECURITY.md`, `CODE_OF_CONDUCT.md`, `.github/PULL_REQUEST_TEMPLATE.md`, `.github/ISSUE_TEMPLATE/*` — standard OSS files the repo didn't have.
- Enabled private vulnerability reporting in repo settings so the "Report a vulnerability" button SECURITY.md points to actually works.

## Test plan
- [x] Verified every doc link added resolves to a real page on tulipfarm.site/docs (installation, deploy/docker-compose, deploy/updating, uninstall, security, development, development/workflow)
- [x] Confirmed GitHub Discussions is off and removed references to it
- [x] `pre-commit`/`commit-msg` hooks passed (Biome + commitlint)
- [x] Docs-only change — no lint/typecheck/test run needed per repo convention