### PR TITLE
feat(onboarding): replace step-wizard setup with growing tulip + Companion quests

### DIFF
--- a/.agents/skills/tulipfarm-design-system/references/design-system.md
+++ b/.agents/skills/tulipfarm-design-system/references/design-system.md
@@ -203,6 +203,11 @@ safer. Keep domain fetching and mutations out of primitives.
   "Step n of m" plus a progress bar. Mark progress with `aria-current="step"` and an icon, not tone
   alone. An optional step says so on the step, on its fields, and in a skip action beside the
   primary one.
+  - **First-run onboarding is the deliberate exception.** Pre-login account creation
+    (`/setup`) intentionally hides step count and rail — perceived length is the thing being
+    optimized, not flow legibility for a returning operator. It still marks progress for
+    assistive tech via a visually-hidden `role="status"` announcement, just not a visible
+    number.
 - **Master/detail:** context panel owns selection; main surface owns detail and browser history.
 - **Chat:** transcript owns scrolling; composer remains visible without covering the last message.
 - **Chat composer:** show Effort and active Agent as quiet context above the prompt; keep context
@@ -243,7 +248,9 @@ safer. Keep domain fetching and mutations out of primitives.
 - **Chat step timeline:** use a vertical rail to connect ordered execution steps. The rail reports
   real execution state, not decoration. While a Tool call is running, `.run-rail-active` may show an
   indeterminate sweep; under `prefers-reduced-motion: reduce`, it collapses to a static tinted rail.
-  Motion in this system is permitted only when it reports real state.
+  Motion in this system is permitted only when it reports real state. The onboarding tulip's growth
+  (`TulipGrowth`, `/setup`) passes this same test — each stage is answered-input count, not
+  ornament — so treat it as precedent, not an exception, when judging future progress motion.
 - **Chat inspect pane:** separate Tool Input from Tool Output with explicit labels, independent
   borders, and JSON/code coloring from `code-*` tokens. Preserve order, whitespace where it matters,
   redaction markers, empty states, error states, and long-value wrapping without horizontal page

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -673,6 +673,9 @@ export async function buildApp(opts: AppOptions = {}) {
           hasAnyKnowledgePage: knowledgeService
             ? () => knowledgeService.hasAnyKnowledgePage()
             : undefined,
+          gitSync: opts.gitSync,
+          soulWriter: opts.soulWriter,
+          auditService: opts.auditService,
         });
         if (opts.llmService) {
           registerSkillRoutes(

--- a/apps/api/src/auth/users/index.ts
+++ b/apps/api/src/auth/users/index.ts
@@ -208,6 +208,7 @@ export async function createUser(
   role: Role,
   options: {
     readonly setupBootstrap?: boolean;
+    readonly name?: string;
     readonly insert?: (user: UserDoc) => Promise<void>;
   } = {}
 ): Promise<UserDoc> {
@@ -215,7 +216,7 @@ export async function createUser(
     _id: randomUUID(),
     email: normalizeEmail(email),
     passwordHash: await hashPassword(password),
-    name: null,
+    name: options.name ?? null,
     role,
     status: "active",
     createdAt: new Date(),

--- a/apps/api/src/identity/roles.ts
+++ b/apps/api/src/identity/roles.ts
@@ -50,6 +50,11 @@ export const ADMIN_ONLY_SURFACES: readonly {
   { type: "knowledge_source", actions: ["*"], enforcedIn: "knowledge/routes.ts" },
   { type: "kv_system", actions: ["*"], enforcedIn: "kv/routes.ts" },
   { type: "setup", actions: ["*"], enforcedIn: "setup/routes.ts" },
+  {
+    type: "onboarding",
+    actions: ["onboarding.quest.answer"],
+    enforcedIn: "onboarding/routes.ts",
+  },
   { type: "operations", actions: ["*"], enforcedIn: "admin/runtime.ts; index.ts" },
   /** Arming the effect-plane emergency stop halts other people's work, so it is never self-service. */
   {

--- a/apps/api/src/memory/lifecycle-service.ts
+++ b/apps/api/src/memory/lifecycle-service.ts
@@ -8,7 +8,12 @@ import type {
   MemoryTelemetryPort,
   RememberResult,
 } from "@tulipfarm/memory";
-import { eraseMemory, forgetMemory, rememberProceduralCorrection } from "@tulipfarm/memory";
+import {
+  eraseMemory,
+  forgetMemory,
+  rememberMemory,
+  rememberProceduralCorrection,
+} from "@tulipfarm/memory";
 import type { Queryable } from "../db";
 import { PgMemoryAssertionStore } from "./assertion-store";
 import type { MemoryEmbedder } from "./embedder";
@@ -18,6 +23,19 @@ export const USER_MEMORY_LIFECYCLE_SETTINGS: MemorySettingsView = {
   scopes: ["user_private"],
   inferredDurableMemory: { enabled: false },
 };
+
+/** Onboarding quest answers land as `user_private` or `business` facts, both human-stated. */
+export const ONBOARDING_MEMORY_LIFECYCLE_SETTINGS: MemorySettingsView = {
+  scopes: ["user_private", "business"],
+  inferredDurableMemory: { enabled: false },
+};
+
+export interface FactInput {
+  readonly authorPrincipalId: string;
+  readonly target: { readonly scope: "business" } | { readonly scope: "user_private" };
+  readonly subject: string;
+  readonly statement: string;
+}
 
 export interface ProceduralCorrectionInput {
   readonly userId: string;
@@ -42,15 +60,44 @@ export class MemoryLifecycleService {
     this.pending = new PgPendingMemoryStore(q);
   }
 
-  private deps(): MemoryDeps {
+  private deps(settings: MemorySettingsView = USER_MEMORY_LIFECYCLE_SETTINGS): MemoryDeps {
     return {
       store: this.store,
       pending: this.pending,
-      settings: USER_MEMORY_LIFECYCLE_SETTINGS,
+      settings,
       ...(this.telemetry === undefined ? {} : { telemetry: this.telemetry }),
       now: this.now,
       newId: () => randomUUID(),
     };
+  }
+
+  /** Records a human-stated fact — an onboarding quest answer, not an LLM inference. */
+  rememberFact(input: FactInput): Promise<RememberResult> {
+    return rememberMemory(
+      this.deps(ONBOARDING_MEMORY_LIFECYCLE_SETTINGS),
+      {
+        target: {
+          scope: input.target.scope,
+          businessId: DEPLOYMENT_BUSINESS_ID,
+          ...(input.target.scope === "user_private"
+            ? { subjectPrincipalId: input.authorPrincipalId }
+            : {}),
+        },
+        subject: input.subject,
+        statement: input.statement,
+        confidence: 1,
+        importance: 0.6,
+        memoryType: "fact",
+        trustTier: "user_stated",
+        provenance: {
+          origin: "explicit",
+          authorPrincipalId: input.authorPrincipalId,
+          evidence: [],
+        },
+        entities: [],
+      },
+      { businessId: DEPLOYMENT_BUSINESS_ID, principalId: input.authorPrincipalId }
+    );
   }
 
   rememberCorrection(input: ProceduralCorrectionInput): Promise<RememberResult> {

--- a/apps/api/src/onboarding/personalize.ts
+++ b/apps/api/src/onboarding/personalize.ts
@@ -129,6 +129,102 @@ export async function generatePersonalized(
   return object;
 }
 
+/* Tier 3 profile-gap quests: the same business context, one more question — what would help us
+   round out the business or user profile that a starter-chip suggestion would not ask. Cached
+   under its own key so a personalization failure here never invalidates `suggestions`. */
+
+const PROFILE_GAP_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["gaps"],
+  properties: { gaps: { type: "array", items: ITEM_SCHEMA } },
+} as const;
+
+const PROFILE_GAP_SYSTEM_PROMPT = [
+  "You are TulipFarm's onboarding guide. Given a business and what it has already built, propose",
+  "2-4 profile questions worth asking now: gaps in the BUSINESS profile (employee count,",
+  "industry, website, operating hours) or gaps in what we know about THIS USER (preferred",
+  "language, timezone, role). Never re-ask for the business name or description — both are",
+  "already known.",
+  "",
+  "For every item: `id` short kebab-case slug, `label` short chip text (question style), and",
+  '`prompt` the chat message that starts the conversation for it (e.g. "What are your typical',
+  'operating hours?").',
+  "",
+  "Return raw JSON only. Do not wrap the response in Markdown or a code fence.",
+].join("\n");
+
+const validateProfileGaps = ajv.compile(PROFILE_GAP_SCHEMA);
+
+/** Deterministic fallback when there is no provider key yet or the LLM call fails. */
+export const STATIC_PROFILE_GAPS: Suggestion[] = [
+  {
+    id: "employee-count",
+    label: "How many people work here?",
+    prompt: "Help me record how many employees the business has.",
+  },
+  {
+    id: "preferred-language",
+    label: "What language should I use with you?",
+    prompt: "Help me set my preferred language.",
+  },
+];
+
+export async function generateProfileGaps(
+  model: LlmModel,
+  ctx: { businessName?: string; businessDescription: string; state: SoulState }
+): Promise<Suggestion[]> {
+  const { object } = await generateObject({
+    model,
+    schema: jsonSchema<{ gaps: Suggestion[] }>(PROFILE_GAP_SCHEMA),
+    experimental_repairText: repairFencedJson,
+    system: PROFILE_GAP_SYSTEM_PROMPT,
+    prompt: [
+      `Business name: ${ctx.businessName ?? "(unnamed)"}`,
+      `Business description: ${ctx.businessDescription}`,
+      "",
+      "Already in the soul:",
+      `- resource types: ${ctx.state.resources.join(", ") || "(none)"}`,
+      `- agents: ${ctx.state.agents.join(", ") || "(none)"}`,
+      `- skills: ${ctx.state.skills.join(", ") || "(none)"}`,
+    ].join("\n"),
+  });
+  if (!validateProfileGaps(object)) {
+    throw new Error(
+      `Onboarding profile-gap generation produced invalid output: ${ajv.errorsText(validateProfileGaps.errors)}`
+    );
+  }
+  return object.gaps;
+}
+
+/** Returns tier-3 profile-gap quests, or the static fallback when personalization is unavailable. */
+export async function getProfileGaps(
+  soul: PersonalizeSoulSlice,
+  deps: PersonalizeDeps
+): Promise<Suggestion[]> {
+  const businessDescription = stringField(soul.manifest, "businessDescription");
+  const { llmService, kvService, logger } = deps;
+  if (!businessDescription || !llmService || !kvService) return STATIC_PROFILE_GAPS;
+
+  const state = readSoulState(soul);
+  const key = `profile-gaps:${buildStateKey(businessDescription, state).slice("suggestions:".length)}`;
+  const cached = await kvService.get("system", undefined, KV_NAMESPACE, key);
+  if (cached) return cached.value as Suggestion[];
+
+  try {
+    const gaps = await generateProfileGaps(llmService.effortModel("fast"), {
+      businessName: stringField(soul.manifest, "businessName"),
+      businessDescription,
+      state,
+    });
+    await kvService.set("system", undefined, KV_NAMESPACE, key, gaps);
+    return gaps;
+  } catch (err) {
+    logger?.error({ err }, "onboarding profile-gap generation failed; using static fallback");
+    return STATIC_PROFILE_GAPS;
+  }
+}
+
 function stringField(manifest: Record<string, unknown> | null, key: string): string | undefined {
   const v = manifest?.[key];
   return typeof v === "string" && v.length > 0 ? v : undefined;

--- a/apps/api/src/onboarding/quests.ts
+++ b/apps/api/src/onboarding/quests.ts
@@ -1,0 +1,110 @@
+import type { SoulLoader } from "@tulipfarm/soul";
+import { buildSteps, deriveSignals } from "./checklist";
+import type { Suggestion } from "./suggestions";
+
+/* Quest tiers: 1 = hardcoded gate (no LLM), 2 = deterministic checklist, 3 = AI profile gaps.
+   Tier 2 and 3 stay locked until Tier 1 is fully answered. Tier 1 is only the provider key and
+   the business name — the business description is asked right after the gate opens but does not
+   block it, since nothing downstream strictly needs it to function (personalize.ts falls back to
+   static suggestions when it is still empty). */
+
+export type QuestAction =
+  | { kind: "form"; field: "name" | "description" }
+  | { kind: "link"; href: string }
+  | { kind: "chat"; prompt: string };
+
+export interface Quest {
+  id: string;
+  tier: 1 | 2 | 3;
+  label: string;
+  hint?: string;
+  action: QuestAction;
+}
+
+export type SoulSlice = Pick<SoulLoader, "resources" | "skills" | "agents" | "integrations">;
+
+export interface BuildQuestsInput {
+  soul: SoulSlice;
+  hasKnowledge: boolean;
+  hasProviderKey: boolean;
+  businessName?: string;
+  businessDescription?: string;
+  /** Tier 3 items, LLM-personalized when available; empty when there is nothing to unlock yet. */
+  profileGaps?: Suggestion[];
+  /** Quest ids the current user already dismissed — filtered out before returning. */
+  dismissed: ReadonlySet<string>;
+}
+
+export const TIER1_PROVIDER_KEY = "provider-key";
+export const TIER1_BUSINESS_NAME = "business-name";
+export const TIER1_BUSINESS_DESCRIPTION = "business-description";
+
+function tier1Quests(input: BuildQuestsInput): Quest[] {
+  const quests: Quest[] = [];
+  if (!input.hasProviderKey) {
+    quests.push({
+      id: TIER1_PROVIDER_KEY,
+      tier: 1,
+      label: "Plant your model key",
+      hint: "Agents need one provider connected before they can do anything.",
+      action: { kind: "link", href: "/settings/secrets" },
+    });
+  }
+  if (!input.businessName) {
+    quests.push({
+      id: TIER1_BUSINESS_NAME,
+      tier: 1,
+      label: "What's your business called?",
+      action: { kind: "form", field: "name" },
+    });
+  }
+  return quests;
+}
+
+/* Not gating — asked right after Tier 1 opens, but skippable/dismissable like any other quest. */
+function businessDescriptionQuest(businessDescription?: string): Quest[] {
+  if (businessDescription) return [];
+  return [
+    {
+      id: TIER1_BUSINESS_DESCRIPTION,
+      tier: 2,
+      label: "What does your business do?",
+      hint: "Two or three sentences is plenty — every Agent reads this.",
+      action: { kind: "form", field: "description" },
+    },
+  ];
+}
+
+function tier2Quests(soul: SoulSlice, hasKnowledge: boolean, businessName?: string): Quest[] {
+  const signals = deriveSignals(soul, hasKnowledge, businessName);
+  return buildSteps(signals)
+    .filter((s): s is typeof s & { status: "todo"; prompt: string } => s.status === "todo")
+    .map((s) => ({
+      id: `checklist-${s.id}`,
+      tier: 2 as const,
+      label: s.label,
+      action: { kind: "chat" as const, prompt: s.prompt },
+    }));
+}
+
+function tier3Quests(profileGaps: Suggestion[]): Quest[] {
+  return profileGaps.map((g) => ({
+    id: `profile-${g.id}`,
+    tier: 3 as const,
+    label: g.label,
+    action: { kind: "chat" as const, prompt: g.prompt },
+  }));
+}
+
+export function buildQuests(input: BuildQuestsInput): Quest[] {
+  const tier1 = tier1Quests(input);
+  const gateOpen = tier1.length === 0;
+  const all = gateOpen
+    ? [
+        ...businessDescriptionQuest(input.businessDescription),
+        ...tier2Quests(input.soul, input.hasKnowledge, input.businessName),
+        ...tier3Quests(input.profileGaps ?? []),
+      ]
+    : tier1;
+  return all.filter((q) => !input.dismissed.has(q.id));
+}

--- a/apps/api/src/onboarding/routes.ts
+++ b/apps/api/src/onboarding/routes.ts
@@ -1,19 +1,51 @@
+import { DEPLOYMENT_BUSINESS_ID } from "@tulipfarm/constants";
 import type { LlmService } from "@tulipfarm/llm";
-import type { SoulLoader } from "@tulipfarm/soul";
+import type { GitSyncService, SoulLoader, SoulWriter } from "@tulipfarm/soul";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import type { AuditService } from "../audit/service";
+import { makeSoulAuditWriter } from "../audit/soul-write";
 import { ErrorSchema } from "../auth/schemas";
 import type { UserDoc } from "../auth/users";
 import type { KvService } from "../kv/service";
+import { mergeSoulConfig } from "../setup/soul-config";
+import { commitActorFromRequest } from "../soul/commit-actor";
+import { isSoulWriteError, soulWriteHttpError } from "../soul/write-errors";
 import { buildChecklist } from "./checklist";
-import { getPersonalizedOrRefresh } from "./personalize";
+import { getPersonalizedOrRefresh, getProfileGaps } from "./personalize";
+import { buildQuests, type Quest, TIER1_BUSINESS_DESCRIPTION, TIER1_BUSINESS_NAME } from "./quests";
 import { deriveSuggestions } from "./suggestions";
 
-/* ONB-V1 read-only routes; checklist dismissal lives in user KV `onboarding/checklist`. */
+/* ONB-V1 read-only routes; checklist dismissal lives in user KV `onboarding/checklist`.
+   ONB-V2 adds the quest ladder (tier 1 gate / tier 2 checklist / tier 3 AI profile gaps),
+   dismissal in user KV `onboarding/quests-dismissed`, and a tier-1-only answer sink that
+   reuses the `PUT /api/v1/business` soul-write pattern directly. */
 
 type PreHandler = (req: FastifyRequest, reply: FastifyReply) => Promise<void>;
 
 const KV_NAMESPACE = "onboarding";
 const KV_KEY = "checklist";
+const QUESTS_DISMISSED_KEY = "quests-dismissed";
+
+const QuestSchema = {
+  type: "object",
+  required: ["id", "tier", "label", "action"],
+  properties: {
+    id: { type: "string" },
+    tier: { type: "number", enum: [1, 2, 3] },
+    label: { type: "string" },
+    hint: { type: "string" },
+    action: {
+      type: "object",
+      required: ["kind"],
+      properties: {
+        kind: { type: "string", enum: ["form", "link", "chat"] },
+        field: { type: "string", enum: ["name", "description"] },
+        href: { type: "string" },
+        prompt: { type: "string" },
+      },
+    },
+  },
+} as const;
 
 interface OnboardingDeps {
   /** Cheap "any active knowledge page?" check for the knowledge step (absent → treated as none). */
@@ -22,6 +54,12 @@ interface OnboardingDeps {
   kvService?: KvService;
   /** Powers LLM personalization; absent → static catalog/rules fallback. */
   llmService?: LlmService;
+  /** Soul git sync, to re-emit `soul.synced` after the tier-1 answer sink writes. */
+  gitSync?: GitSyncService;
+  /** Soul write gateway (ADR-007) — the only door for the tier-1 answer sink's soul.yaml patch. */
+  soulWriter?: SoulWriter;
+  /** Optional audit trail for the tier-1 direct soul write. */
+  auditService?: AuditService;
 }
 
 export function registerOnboardingRoutes(
@@ -144,6 +182,196 @@ export function registerOnboardingRoutes(
         steps,
         recommendations: personalized?.recommendations ?? recommendations,
       };
+    }
+  );
+
+  const questsGitSync = deps.gitSync;
+  const questsSoulWriter = deps.soulWriter;
+  const auditWrite = makeSoulAuditWriter(deps.auditService);
+
+  app.get(
+    "/api/v1/onboarding/quests",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description:
+          "The Companion's quest ladder: tier 1 gate (provider key, business name/description), " +
+          "tier 2 checklist, and tier 3 AI-generated profile gaps once tier 1 is answered.",
+        tags: ["onboarding"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        response: {
+          200: {
+            type: "object",
+            required: ["quests"],
+            properties: { quests: { type: "array", items: QuestSchema } },
+          },
+          401: ErrorSchema,
+        },
+      },
+    },
+    async (req): Promise<{ quests: Quest[] }> => {
+      const ownerId = (req.user as UserDoc)._id;
+      const dismissedEntry = await kvService.get(
+        "user",
+        ownerId,
+        KV_NAMESPACE,
+        QUESTS_DISMISSED_KEY
+      );
+      const dismissedList = Array.isArray(dismissedEntry?.value)
+        ? (dismissedEntry.value as unknown[]).filter((v): v is string => typeof v === "string")
+        : [];
+
+      const businessName =
+        typeof soulLoader.manifest?.businessName === "string" &&
+        soulLoader.manifest.businessName.length > 0
+          ? soulLoader.manifest.businessName
+          : undefined;
+      const businessDescription =
+        typeof soulLoader.manifest?.businessDescription === "string" &&
+        soulLoader.manifest.businessDescription.length > 0
+          ? soulLoader.manifest.businessDescription
+          : undefined;
+      const hasProviderKey = deps.llmService?.isConfigured() ?? false;
+      const hasKnowledge = (await deps.hasAnyKnowledgePage?.()) ?? false;
+
+      const gateOpen = hasProviderKey && businessName !== undefined;
+      const profileGaps = gateOpen
+        ? await getProfileGaps(soulLoader, {
+            llmService: deps.llmService,
+            kvService,
+            logger: req.log,
+          })
+        : [];
+
+      const quests = buildQuests({
+        soul: soulLoader,
+        hasKnowledge,
+        hasProviderKey,
+        businessName,
+        businessDescription,
+        profileGaps,
+        dismissed: new Set(dismissedList),
+      });
+      return { quests };
+    }
+  );
+
+  app.post(
+    "/api/v1/onboarding/quests/:id/answer",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description:
+          "Answers a tier-1 quest inline (business name or description; admin only). Writes " +
+          "soul.yaml the same way `PUT /api/v1/business` does and re-emits soul.synced. Tier 2/3 " +
+          "quests are answered through chat instead, not this route.",
+        tags: ["onboarding"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        params: {
+          type: "object",
+          required: ["id"],
+          properties: { id: { type: "string" } },
+        },
+        body: {
+          type: "object",
+          required: ["value"],
+          additionalProperties: false,
+          properties: { value: { type: "string", minLength: 1, maxLength: 2000 } },
+        },
+        response: {
+          200: {
+            type: "object",
+            required: ["id", "answered"],
+            properties: { id: { type: "string" }, answered: { type: "boolean" } },
+          },
+          400: ErrorSchema,
+          401: ErrorSchema,
+          403: ErrorSchema,
+          404: ErrorSchema,
+          409: ErrorSchema,
+          422: ErrorSchema,
+          500: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      if (req.user?.role !== "admin") {
+        return reply.code(403).send({ error: "forbidden" });
+      }
+      if (!questsGitSync || !questsSoulWriter) {
+        return reply.code(400).send({ error: "soul git sync unavailable" });
+      }
+      const { id } = req.params as { id: string };
+      const { value } = req.body as { value: string };
+      const trimmed = value.trim();
+      if (!trimmed) return reply.code(400).send({ error: "value is required" });
+      if (id !== TIER1_BUSINESS_NAME && id !== TIER1_BUSINESS_DESCRIPTION) {
+        return reply.code(400).send({ error: `quest ${id} is not answerable via this route` });
+      }
+      if (id === TIER1_BUSINESS_NAME && trimmed.length > 200) {
+        return reply.code(400).send({ error: "value must be 200 characters or fewer" });
+      }
+
+      const next = mergeSoulConfig(
+        questsSoulWriter.read("Settings"),
+        id === TIER1_BUSINESS_NAME ? { businessName: trimmed } : { businessDescription: trimmed }
+      );
+      try {
+        await questsSoulWriter.apply({
+          subject: "chore: update business profile",
+          source: "api",
+          actor: commitActorFromRequest(req),
+          businessId: DEPLOYMENT_BUSINESS_ID,
+          changes: [{ op: "put", target: { kind: "Settings" }, content: next }],
+        });
+      } catch (e) {
+        if (isSoulWriteError(e)) {
+          const m = soulWriteHttpError(e);
+          return reply.code(m.status).send(m.body);
+        }
+        throw e;
+      }
+      questsGitSync.emit("soul.synced");
+      await auditWrite(req, "soul-config.update", "soul:business-profile", { quest: id });
+
+      return reply.send({ id, answered: true });
+    }
+  );
+
+  app.post(
+    "/api/v1/onboarding/quests/:id/dismiss",
+    {
+      preHandler: requireAuth,
+      schema: {
+        description:
+          "Dismisses a single quest for the current user. Dismissal is per-user, not global.",
+        tags: ["onboarding"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        params: {
+          type: "object",
+          required: ["id"],
+          properties: { id: { type: "string" } },
+        },
+        response: {
+          200: {
+            type: "object",
+            required: ["id", "dismissed"],
+            properties: { id: { type: "string" }, dismissed: { type: "boolean" } },
+          },
+          401: ErrorSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const ownerId = (req.user as UserDoc)._id;
+      const { id } = req.params as { id: string };
+      const entry = await kvService.get("user", ownerId, KV_NAMESPACE, QUESTS_DISMISSED_KEY);
+      const existing = Array.isArray(entry?.value)
+        ? (entry.value as unknown[]).filter((v): v is string => typeof v === "string")
+        : [];
+      const next = existing.includes(id) ? existing : [...existing, id];
+      await kvService.set("user", ownerId, KV_NAMESPACE, QUESTS_DISMISSED_KEY, next);
+      return reply.send({ id, dismissed: true });
     }
   );
 }

--- a/apps/api/src/setup/routes.ts
+++ b/apps/api/src/setup/routes.ts
@@ -147,6 +147,7 @@ export function registerSetupRoutes(app: FastifyInstance, deps: SetupDeps): void
           type: "object",
           required: ["email", "password"],
           properties: {
+            name: { type: "string", maxLength: 200 },
             email: { type: "string", format: "email" },
             password: {
               type: "string",
@@ -163,7 +164,8 @@ export function registerSetupRoutes(app: FastifyInstance, deps: SetupDeps): void
       },
     },
     async (req, reply) => {
-      const body = (req.body ?? {}) as { email?: unknown; password?: unknown };
+      const body = (req.body ?? {}) as { name?: unknown; email?: unknown; password?: unknown };
+      const name = typeof body.name === "string" ? body.name.trim() : "";
       const email = typeof body.email === "string" ? body.email : "";
       const password = typeof body.password === "string" ? body.password : "";
       if (!email) {
@@ -178,6 +180,7 @@ export function registerSetupRoutes(app: FastifyInstance, deps: SetupDeps): void
       try {
         user = await createUser(userRepo, email, password, "admin", {
           setupBootstrap: true,
+          ...(name ? { name } : {}),
           ...(setupAdminCreator ? { insert: (record) => setupAdminCreator.create(record) } : {}),
         });
       } catch (err) {

--- a/apps/docs/content/docs/concepts/setup.mdx
+++ b/apps/docs/content/docs/concepts/setup.mdx
@@ -3,41 +3,44 @@ title: First-run setup and boot modes
 description: How TulipFarm opens the setup wizard or seeds a fresh instance from environment variables.
 ---
 
-A fresh TulipFarm instance needs an admin user, a business profile, and usually an LLM provider
-before it is useful. Setup can happen through the web wizard or through environment-driven headless
-bootstrap.
+A fresh TulipFarm instance needs an admin user before it is useful. Everything else — an LLM
+provider, the business profile — is gathered afterwards, inside the app. Setup can happen through
+the web wizard or through environment-driven headless bootstrap.
 
 ## Wizard mode
 
 Wizard mode is the default when no users exist and no headless admin seed is present — the shape
 `curl | bash` self-hosted installs and local development land in, with no environment variables set.
 When `GET /api/v1/setup/status` returns `needsSetup: true`, the web app redirects to `/setup` and
-walks the operator through three steps: the first admin account, the business profile, and an
-optional LLM provider.
+asks one question at a time — name, email, then password, no step count shown — to create the
+first admin. It stays open only until a user exists, so it cannot mint a second admin.
 
-The admin step creates the first user and logs them in; it stays open only until a user exists, so
-it cannot mint a second admin. The business step records `businessName`, `businessDescription`, and
-the optional `businessWebsite` in `soul.yaml`, and all three become static business context in every
-Agent's system prompt. That profile is not working [memory](/docs/concepts/memory). The LLM step
-stores the provider credentials as [secrets](/docs/concepts/secrets) and writes a default
-`llm` block in `soul.yaml` with all three provider chains pointing at the chosen model and
-**Auto** resolving to **Balanced**; skipping it leaves that to **Operate → Business → Models**.
-
-The LLM step accepts a Claude or ChatGPT
-[subscription](/docs/concepts/llm#subscription-providers) in place of an API key, so an operator
-with a paid plan and no API budget can finish setup. Whichever kind is chosen, the credential is
-validated with one real model call before it is stored — a credential that cannot answer is
-rejected in the wizard rather than kept and discovered at the first chat message.
-
-Finishing calls `POST /api/v1/setup/complete`, which writes `setupComplete: true` to `soul.yaml`.
-The wizard step routes return `403` from then on, while `GET /api/v1/setup/status` remains available
-so the web app can decide whether setup is still open.
+Finishing calls `POST /api/v1/setup/admin` then `POST /api/v1/setup/complete`, which writes
+`setupComplete: true` to `soul.yaml`. The wizard step routes return `403` from then on, while
+`GET /api/v1/setup/status` remains available so the web app can decide whether setup is still open.
 
 <Callout type="info">
 Soul git backup is not part of the wizard. Configure the remote after setup in
 **Operate → Business → Soul**, or seed it at boot with `SOUL_GIT_REMOTE_URL` /
 `SOUL_GIT_CREDENTIAL`.
 </Callout>
+
+## The Companion
+
+Once inside the app, a floating **Companion** — a tulip icon, bottom-right on desktop and a
+top-bar icon on mobile — surfaces what setup used to front-load, one small question at a time. Its
+first quest is an LLM provider: it opens **Operate → Business → Secrets** to add a key, validated
+with one real model call before it is stored, same as the old wizard step, and accepts a Claude or
+ChatGPT [subscription](/docs/concepts/llm#subscription-providers) in place of an API key. Its next
+two quests are the business profile: `businessName` and `businessDescription`, answered inline and
+written straight to `soul.yaml` as static business context in every Agent's system prompt — not
+working [memory](/docs/concepts/memory). Only once those three are answered does the Companion
+unlock further quests: a deterministic setup checklist, then AI-suggested profile gaps answered
+through chat.
+
+A provider key also lets you assign models to the **Fast**, **Balanced**, and **Thorough** chains
+in **Operate → Business → Models**, and choose which profile **Auto** resolves to — the Companion
+does not do this for you.
 
 ## Headless mode
 

--- a/apps/docs/content/docs/getting-started.mdx
+++ b/apps/docs/content/docs/getting-started.mdx
@@ -17,18 +17,11 @@ actually does work for you — about twenty minutes, all of it in the browser.
 ### Create your admin account
 
 Open your instance's URL. Because no admin exists yet, the app redirects to the setup wizard
-at `/setup`. Work through the three steps:
+at `/setup`. It asks one question at a time — your name, your email, then a password — and
+locks after you finish, so a second browser visitor cannot create another admin through it.
 
-1. **Admin account** — enter an email and password. This creates the first admin and logs
-   you in.
-2. **Business profile** — give your instance a name and optional description. Agents read
-   this, so a real sentence about what your business does is worth more than a placeholder.
-3. **LLM provider** — choose a provider (Anthropic, OpenAI, Azure Foundry, or an
-   OpenAI-compatible endpoint), enter the credentials, and pick a model. You can skip this
-   and configure it later.
-
-After step 3 the wizard redirects to the main workspace and the setup route locks — a second
-browser visitor cannot create another admin through it.
+That is all setup collects up front. A provider key and your business's name and description
+come next, inside the app, from the onboarding **Companion** — see the next step.
 
 <Callout type="warn">
   Until an admin exists, `/setup` is unauthenticated: on an internet-reachable instance,
@@ -42,13 +35,17 @@ browser visitor cannot create another admin through it.
 
 ### Give the assistant a model
 
-You build everything else by talking to the assistant, so it needs a model to run. If you
-skipped step 3 of the wizard, nothing below will work until you finish this one.
+You build everything else by talking to the assistant, so it needs a model to run. A tulip
+icon in the corner of the app — the Companion — opens with this as its first quest; answering
+it there takes you straight to the right screen. Nothing below works until it is done.
 
 Open **Operate → Business → Secrets**, add an API key for a provider, then open
 **Operate → Business → Models** and assign models to the **Fast**, **Balanced**, and **Thorough**
 chains. In **What each effort means**, choose which profile **Auto** resolves to when nobody picks
 an effort.
+
+The Companion also asks for your business's name and a short description of what it does —
+agents read that description, so answering it is worth doing before you build much else.
 
 The walkthrough is in
 [Configure LLM providers](/docs/guides/configure-llm-providers). No API key? A Claude or ChatGPT

--- a/apps/docs/content/docs/installation.mdx
+++ b/apps/docs/content/docs/installation.mdx
@@ -68,19 +68,13 @@ volume. See [Docker Compose](/docs/deploy/docker-compose) for what to back up, a
 
 ## Finish setup
 
-Open the printed URL. The app redirects to the setup wizard at `/setup`. Work through
-the three steps:
+Open the printed URL. The app redirects to the setup wizard at `/setup`, which asks one
+question at a time — your name, your email, then a password — to create the admin account.
+This is the only unauthenticated route; it locks once any admin exists.
 
-1. **Admin account** — enter an email and password. This is the only step that requires
-   no authentication; the route locks once any admin exists.
-2. **Business profile** — give your instance a name and optional description.
-3. **LLM provider** — choose a provider (Anthropic, OpenAI, Azure Foundry, or an
-   OpenAI-compatible endpoint), enter your credentials, and pick a model. You can skip
-   this step and configure it later in **Operate → Business → Models**.
-
-After step 3, the wizard marks setup complete in `soul.yaml` and redirects to the main
-workspace. The setup routes lock — no second visitor can claim the instance through the
-wizard.
+Finishing marks setup complete in `soul.yaml` and redirects to the main workspace. An LLM
+provider and your business's name and description come next, inside the app, as the first
+quests from the onboarding Companion — see [Get started](/docs/getting-started).
 
 <Callout type="warn">
   If the installer detected a public IP it prints a TLS warning: the instance is

--- a/apps/web/app/app.css
+++ b/apps/web/app/app.css
@@ -91,6 +91,9 @@
   --color-code-boolean: var(--code-boolean);
   --color-code-null: var(--code-null);
   --color-code-redacted: var(--code-redacted);
+
+  --color-tulip-stem: var(--tulip-stem);
+  --color-tulip-seed: var(--tulip-seed);
 }
 
 @layer base {
@@ -276,6 +279,79 @@
     stroke-dasharray: none !important;
     stroke-dashoffset: 0 !important;
   }
+}
+
+/*
+ * Onboarding tulip growth. `data-stage` on `.tulip-growth` (0-3) decides which parts *render* —
+ * the animations below are only the transition between stages, never the sole reason a part is
+ * visible. That split matters because the global reduced-motion guard further down flattens every
+ * animation/transition to 0.01ms: a state-driven part still snaps to the right stage, while a
+ * part that depended on its animation to appear would stay invisible forever.
+ */
+.tulip-growth .tulip-stem-path {
+  stroke-dasharray: 1 1;
+  stroke-dashoffset: 1;
+}
+.tulip-growth[data-stage="1"] .tulip-stem-path,
+.tulip-growth[data-stage="2"] .tulip-stem-path,
+.tulip-growth[data-stage="3"] .tulip-stem-path {
+  animation: glyph-sweep 600ms var(--ease-snappy) forwards;
+}
+.tulip-growth .tulip-grow {
+  transform-box: fill-box;
+  transform-origin: bottom center;
+  transform: scaleY(0);
+  opacity: 0;
+  transition:
+    transform 500ms var(--ease-snappy),
+    opacity 500ms var(--ease-snappy);
+}
+.tulip-growth[data-stage="1"] .tulip-grow[data-from="1"],
+.tulip-growth[data-stage="2"] .tulip-grow[data-from="1"],
+.tulip-growth[data-stage="2"] .tulip-grow[data-from="2"],
+.tulip-growth[data-stage="3"] .tulip-grow[data-from="1"],
+.tulip-growth[data-stage="3"] .tulip-grow[data-from="3"] {
+  transform: scaleY(1);
+  opacity: 1;
+}
+/* The closed bud is stage 2 only — the open bloom (data-from="3") replaces it, not stacks on it. */
+.tulip-growth[data-stage="3"] .tulip-bud {
+  transform: scaleY(0);
+  opacity: 0;
+}
+.tulip-growth .tulip-eyes {
+  opacity: 0;
+  transition: opacity 240ms var(--ease-snappy) 260ms;
+}
+.tulip-growth[data-stage="3"] .tulip-eyes {
+  opacity: 1;
+}
+
+/* Same failure mode as the glyph dash above: a neutralized dash must not freeze half-drawn, and
+   a neutralized transform/opacity must not leave a stage's parts stuck invisible. */
+@media (prefers-reduced-motion: reduce) {
+  .tulip-growth .tulip-stem-path {
+    stroke-dasharray: none !important;
+    stroke-dashoffset: 0 !important;
+  }
+}
+
+/* Companion pending-quest dot: one ambient breathe, same family as glyph-breathe. The badge is
+   fully opaque at rest, so the global reduced-motion guard flattening this to 0.01ms just removes
+   the pulse — it never hides the badge itself. */
+@keyframes companion-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(1.15);
+    opacity: 0.7;
+  }
+}
+.companion-badge-pulse {
+  animation: companion-pulse 2.4s ease-in-out infinite;
 }
 
 /*

--- a/apps/web/app/components/app-sidebar.tsx
+++ b/apps/web/app/components/app-sidebar.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import { type ReactNode, useEffect, useRef, useState } from "react";
 import { KnowledgeTree } from "~/components/knowledge/space-tree";
+import { CompanionMobileTrigger } from "~/components/onboarding/companion";
 import { ThemeToggle } from "~/components/theme-toggle";
 import { Badge } from "~/components/ui/badge";
 import { Separator } from "~/components/ui/separator";
@@ -498,6 +499,9 @@ export function AppShell({
           <Separator orientation="vertical" className="mx-1 hidden h-5 lg:block" />
           <Breadcrumb pathname={pathname} pageTitle={pageTitle} />
           <div className="ml-auto flex shrink-0 items-center gap-1 pl-2">
+            <span className="sm:hidden">
+              <CompanionMobileTrigger />
+            </span>
             <AccountChip user={user} />
             <span className="flex items-center lg:hidden">
               <ThemeToggle iconOnly />

--- a/apps/web/app/components/chat/chat-panel.tsx
+++ b/apps/web/app/components/chat/chat-panel.tsx
@@ -85,6 +85,7 @@ export function ChatPanel({
   initialConversationId,
   initialMessages,
   onConversationChange,
+  initialDraft,
 }: {
   agentId?: string;
   defaultModel?: ChatModelSelector;
@@ -95,6 +96,8 @@ export function ChatPanel({
   initialConversationId?: string;
   initialMessages?: ChatMessage[];
   onConversationChange?: (conversationId: string | undefined) => void;
+  /** A prompt to draft into the composer once, seeded by the onboarding Companion. */
+  initialDraft?: string;
 }) {
   const {
     messages,
@@ -219,6 +222,7 @@ export function ChatPanel({
             : undefined
         }
         suggestions={hasMessages ? [] : suggestions}
+        initialDraft={initialDraft}
         // A `@agent` mention in the composer overrides the panel's active agent for that turn.
         onSend={(text, opts) => send(text, { ...opts, agentId: opts.agentId ?? agentId })}
       />

--- a/apps/web/app/components/chat/composer.tsx
+++ b/apps/web/app/components/chat/composer.tsx
@@ -56,6 +56,7 @@ export function Composer({
   presetById,
   activeAgent,
   suggestions = [],
+  initialDraft,
 }: {
   onSend: (text: string, opts: ComposerSendOptions) => void;
   onStop?: () => void;
@@ -65,6 +66,8 @@ export function Composer({
   presetById?: (id: string) => ChatModelSelector | undefined;
   activeAgent?: ComposerAgent;
   suggestions?: Suggestion[];
+  /** A prompt to draft into the box once, e.g. seeded by the onboarding Companion. Never sent. */
+  initialDraft?: string;
 }) {
   const [model, setModel] = useState<ChatModelSelector>(defaultModel);
   const getItems = useMentionData();
@@ -176,6 +179,16 @@ export function Composer({
     editor.commands.selectTextblockEnd();
     editor.view.focus();
   }
+
+  // Applies `initialDraft` once the editor exists, and only once per distinct value — a route-level
+  // seed (Companion "chat" quest), not a live-typing sync back to the box.
+  const draftedRef = useRef<string | undefined>(undefined);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: draftSuggestion closes over editor/busy already in deps.
+  useEffect(() => {
+    if (!editor || !initialDraft || draftedRef.current === initialDraft) return;
+    draftedRef.current = initialDraft;
+    draftSuggestion(initialDraft);
+  }, [editor, initialDraft]);
 
   return (
     <div className="shrink-0 border-t border-border/70 bg-background">

--- a/apps/web/app/components/onboarding/companion-panel.tsx
+++ b/apps/web/app/components/onboarding/companion-panel.tsx
@@ -1,0 +1,172 @@
+import { useNavigate } from "@remix-run/react";
+import { ArrowRight, MessageCircle, X } from "lucide-react";
+import { useState } from "react";
+import { ApiError } from "~/lib/api";
+import type { Quest } from "~/lib/onboarding";
+import { answerQuest } from "~/lib/onboarding";
+
+const TIER_LABEL: Record<Quest["tier"], string> = {
+  1: "Get set up",
+  2: "Build your system",
+  3: "Tell us more",
+};
+
+/** Inline form for a tier-1 `form` quest — answers land in soul.yaml, no chat round-trip. */
+function FormQuest({ quest, onAnswered }: { quest: Quest; onAnswered: () => void }) {
+  const [value, setValue] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = value.trim();
+    if (!trimmed || busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await answerQuest(quest.id, trimmed);
+      onAnswered();
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : "Couldn't save that — try again.");
+      setBusy(false);
+    }
+  }
+
+  return (
+    <form onSubmit={submit} className="flex flex-col gap-1.5">
+      <label htmlFor={`quest-${quest.id}`} className="text-sm font-medium text-foreground">
+        {quest.label}
+      </label>
+      {quest.hint ? <p className="text-xs text-muted-foreground">{quest.hint}</p> : null}
+      <div className="flex gap-1.5">
+        <input
+          id={`quest-${quest.id}`}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          disabled={busy}
+          className="h-9 min-w-0 flex-1 rounded-md border border-input bg-background px-2.5 text-sm text-foreground outline-none focus-visible:ring-[3px] focus-visible:ring-ring/25"
+        />
+        <button
+          type="submit"
+          disabled={busy || !value.trim()}
+          className="inline-flex h-9 shrink-0 items-center rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground transition hover:bg-primary/90 disabled:opacity-40"
+        >
+          Save
+        </button>
+      </div>
+      {error ? (
+        <p role="alert" className="text-xs text-destructive">
+          {error}
+        </p>
+      ) : null}
+    </form>
+  );
+}
+
+function QuestRow({
+  quest,
+  onDismiss,
+  onAnswered,
+  onClose,
+}: {
+  quest: Quest;
+  onDismiss: (id: string) => void;
+  onAnswered: () => void;
+  onClose: () => void;
+}) {
+  const navigate = useNavigate();
+
+  return (
+    <li className="flex items-start gap-2 rounded-md border border-border bg-background p-3">
+      <div className="min-w-0 flex-1">
+        {quest.action.kind === "form" ? (
+          <FormQuest quest={quest} onAnswered={onAnswered} />
+        ) : (
+          <>
+            <p className="text-sm font-medium text-foreground">{quest.label}</p>
+            {quest.hint ? (
+              <p className="mt-0.5 text-xs text-muted-foreground">{quest.hint}</p>
+            ) : null}
+            <button
+              type="button"
+              onClick={() => {
+                const action = quest.action;
+                if (action.kind === "link") {
+                  navigate(action.href);
+                } else if (action.kind === "chat") {
+                  navigate(`/?draft=${encodeURIComponent(action.prompt)}`);
+                }
+                onClose();
+              }}
+              className="mt-2 inline-flex h-8 items-center gap-1.5 rounded-md border border-input bg-background px-2.5 text-xs font-medium text-muted-foreground transition hover:border-primary/60 hover:bg-accent hover:text-foreground active:translate-y-px"
+            >
+              {quest.action.kind === "chat" ? (
+                <MessageCircle className="size-3.5 text-primary" aria-hidden />
+              ) : (
+                <ArrowRight className="size-3.5 text-primary" aria-hidden />
+              )}
+              {quest.action.kind === "chat" ? "Ask in chat" : "Go"}
+            </button>
+          </>
+        )}
+      </div>
+      <button
+        type="button"
+        onClick={() => onDismiss(quest.id)}
+        aria-label={`Dismiss "${quest.label}"`}
+        className="-mr-1 -mt-1 inline-flex size-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition hover:bg-accent hover:text-foreground"
+      >
+        <X className="size-3.5" aria-hidden />
+      </button>
+    </li>
+  );
+}
+
+export function CompanionPanel({
+  quests,
+  loading,
+  onDismiss,
+  onAnswered,
+  onClose,
+}: {
+  quests: Quest[];
+  loading: boolean;
+  onDismiss: (id: string) => void;
+  onAnswered: () => void;
+  onClose: () => void;
+}) {
+  if (loading && quests.length === 0) {
+    return <p className="p-4 text-sm text-muted-foreground">Loading…</p>;
+  }
+  if (quests.length === 0) {
+    return <p className="p-4 text-sm text-muted-foreground">You're all caught up.</p>;
+  }
+
+  const groups = new Map<Quest["tier"], Quest[]>();
+  for (const quest of quests) {
+    const list = groups.get(quest.tier) ?? [];
+    list.push(quest);
+    groups.set(quest.tier, list);
+  }
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      {[...groups.entries()].map(([tier, tierQuests]) => (
+        <section key={tier}>
+          <p className="mb-2 text-xs font-medium text-muted-foreground">{TIER_LABEL[tier]}</p>
+          <ul className="flex flex-col gap-2">
+            {tierQuests.map((quest) => (
+              <QuestRow
+                key={quest.id}
+                quest={quest}
+                onDismiss={onDismiss}
+                onAnswered={onAnswered}
+                onClose={onClose}
+              />
+            ))}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/app/components/onboarding/companion.tsx
+++ b/apps/web/app/components/onboarding/companion.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useRef } from "react";
+import { Sheet } from "~/components/ui/sheet";
+import { useCompanion } from "~/lib/companion-context";
+import { CompanionPanel } from "./companion-panel";
+
+/* The brand mark (public/logo-*.png) is a rounder, tighter three-petal face than the growth
+   illustration's four pointed petals, and is already tuned to read at small/app-icon sizes — the
+   growth SVG's bloom, cropped down to avatar size, collapses into an unreadable blob instead of a
+   face. So the collapsed trigger uses the brand mark, not `TulipGrowth`. */
+const AVATAR_SRC = "/logo-128.png";
+
+/**
+ * The persistent onboarding Companion (`sm`+ only — see `CompanionMobileTrigger` for the
+ * collapsed top-bar icon below `sm`). Never auto-opens; a pending quest only adds a dot badge
+ * and a gentle breathe, never a popup.
+ */
+export function OnboardingCompanion() {
+  const { quests, loading, open, setOpen, refresh, dismiss } = useCompanion();
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
+    }
+    function onPointerDown(e: PointerEvent) {
+      const target = e.target as Node;
+      if (panelRef.current?.contains(target) || triggerRef.current?.contains(target)) return;
+      setOpen(false);
+    }
+    document.addEventListener("keydown", onKeyDown);
+    document.addEventListener("pointerdown", onPointerDown);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      document.removeEventListener("pointerdown", onPointerDown);
+    };
+  }, [open, setOpen]);
+
+  if (!loading && quests.length === 0 && !open) return null;
+
+  return (
+    <div className="fixed bottom-4 right-4 z-40 hidden sm:block">
+      {open ? (
+        <div
+          ref={panelRef}
+          role="dialog"
+          aria-label="Onboarding companion"
+          className="absolute bottom-14 right-0 max-h-[70vh] w-80 overflow-y-auto rounded-md border border-border bg-card shadow-lg"
+        >
+          <CompanionPanel
+            quests={quests}
+            loading={loading}
+            onDismiss={dismiss}
+            onAnswered={refresh}
+            onClose={() => setOpen(false)}
+          />
+        </div>
+      ) : null}
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-label={
+          quests.length > 0
+            ? `Onboarding companion, ${quests.length} suggestion`
+            : "Onboarding companion"
+        }
+        aria-expanded={open}
+        onClick={() => setOpen(!open)}
+        className="relative flex size-12 items-center justify-center rounded-full border border-border bg-card shadow-md transition hover:border-primary/60 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/30"
+      >
+        <img src={AVATAR_SRC} alt="" width={32} height={32} className="size-8" />
+        {quests.length > 0 ? (
+          <span
+            aria-hidden
+            className="companion-badge-pulse absolute right-0.5 top-0.5 size-2.5 rounded-full bg-primary"
+          />
+        ) : null}
+      </button>
+    </div>
+  );
+}
+
+/**
+ * Below `sm`, the Companion collapses into a top-bar icon (mounted in `app-sidebar.tsx`'s
+ * header) instead of floating, so it never overlaps the chat composer. Panel reuses `Sheet`.
+ */
+export function CompanionMobileTrigger() {
+  const { quests, loading, open, setOpen, refresh, dismiss } = useCompanion();
+
+  if (!loading && quests.length === 0 && !open) return null;
+
+  return (
+    <>
+      <button
+        type="button"
+        aria-label={
+          quests.length > 0
+            ? `Onboarding companion, ${quests.length} suggestion`
+            : "Onboarding companion"
+        }
+        aria-expanded={open}
+        onClick={() => setOpen(true)}
+        className="relative flex size-10 shrink-0 items-center justify-center rounded-md transition-colors duration-150 hover:bg-accent"
+      >
+        <img src={AVATAR_SRC} alt="" width={22} height={22} className="size-[22px]" />
+        {quests.length > 0 ? (
+          <span
+            aria-hidden
+            className="companion-badge-pulse absolute right-1 top-1.5 size-2.5 rounded-full bg-primary"
+          />
+        ) : null}
+      </button>
+      <Sheet open={open} onClose={() => setOpen(false)} title="Onboarding companion">
+        <CompanionPanel
+          quests={quests}
+          loading={loading}
+          onDismiss={dismiss}
+          onAnswered={refresh}
+          onClose={() => setOpen(false)}
+        />
+      </Sheet>
+    </>
+  );
+}

--- a/apps/web/app/components/onboarding/prompt-field.tsx
+++ b/apps/web/app/components/onboarding/prompt-field.tsx
@@ -1,0 +1,85 @@
+import { Eye, EyeOff } from "lucide-react";
+import { type Ref, useId, useState } from "react";
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
+import { cn } from "~/lib/utils";
+
+export interface PromptFieldProps {
+  label: string;
+  hint?: string;
+  error?: string;
+  type?: "text" | "email" | "password";
+  value: string;
+  onChange: (value: string) => void;
+  autoComplete?: string;
+  /** Mobile keeps a 44px target and 16px text so iOS does not zoom on focus. */
+  controlClassName?: string;
+  ref?: Ref<HTMLInputElement>;
+}
+
+/**
+ * One question, one input — the unit the pre-login tulip flow advances by. Enter submits because
+ * each question is its own `<form>`; this component owns only the field, not the form or the
+ * Continue action, so the caller controls submit/back/skip.
+ */
+export function PromptField({
+  label,
+  hint,
+  error,
+  type = "text",
+  value,
+  onChange,
+  autoComplete,
+  controlClassName,
+  ref,
+}: PromptFieldProps) {
+  const id = useId();
+  const [reveal, setReveal] = useState(false);
+  const isPassword = type === "password";
+  const note = error ?? hint;
+
+  return (
+    <div className="grid gap-1.5">
+      <label htmlFor={id} className="text-sm font-medium text-foreground">
+        {label}
+      </label>
+      <div className="relative">
+        <Input
+          id={id}
+          ref={ref}
+          type={isPassword && reveal ? "text" : type}
+          autoComplete={autoComplete}
+          className={cn(controlClassName, isPassword && "pr-11")}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          aria-invalid={error ? true : undefined}
+          aria-describedby={note ? `${id}-note` : undefined}
+          required
+        />
+        {isPassword ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="absolute right-0.5 top-0.5 size-8"
+            onClick={() => setReveal((v) => !v)}
+            aria-label={reveal ? "Hide password" : "Show password"}
+          >
+            {reveal ? <EyeOff aria-hidden /> : <Eye aria-hidden />}
+          </Button>
+        ) : null}
+      </div>
+      {note ? (
+        <span
+          id={`${id}-note`}
+          className={cn(
+            "text-xs font-normal",
+            error ? "text-destructive" : "text-muted-foreground"
+          )}
+        >
+          {note}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/app/components/onboarding/tulip-growth.tsx
+++ b/apps/web/app/components/onboarding/tulip-growth.tsx
@@ -1,0 +1,78 @@
+import { cn } from "~/lib/utils";
+
+export type TulipStage = 0 | 1 | 2 | 3;
+
+export interface TulipGrowthProps {
+  /** How many of the three setup questions are answered. Drives which parts render. */
+  stage: TulipStage;
+  className?: string;
+  /** Rendered size in px; keeps the 120x160 aspect ratio. Defaults to the full pre-login size. */
+  width?: number;
+  height?: number;
+}
+
+/**
+ * Growth reports real progress through setup — one answered question, one stage — so it stays
+ * inside the "motion reports real state" rule rather than being ornamental. `stage` decides which
+ * parts *render*; CSS in app.css only animates the transition between them, so a reduced-motion
+ * visitor still lands on the correct stage instead of an animation that never completes.
+ */
+export function TulipGrowth({ stage, className, width = 120, height = 160 }: TulipGrowthProps) {
+  return (
+    <svg
+      viewBox="0 0 120 160"
+      className={cn("tulip-growth", className)}
+      data-stage={stage}
+      width={width}
+      height={height}
+      aria-hidden="true"
+    >
+      <line x1={30} y1={148} x2={90} y2={148} stroke="var(--border)" strokeWidth={1} />
+      <ellipse cx={60} cy={142} rx={7} ry={5} fill="var(--tulip-seed)" />
+
+      <path
+        className="tulip-stem-path"
+        d="M60,140 L60,70"
+        pathLength={1}
+        fill="none"
+        stroke="var(--tulip-stem)"
+        strokeWidth={3}
+        strokeLinecap="round"
+      />
+
+      <path
+        className="tulip-grow"
+        data-from={1}
+        d="M60,118 C42,113 36,98 45,86 C56,100 60,110 60,118 Z"
+        fill="var(--tulip-stem)"
+      />
+      <path
+        className="tulip-grow"
+        data-from={1}
+        d="M60,124 C78,120 85,105 77,92 C65,106 60,116 60,124 Z"
+        fill="var(--tulip-stem)"
+      />
+
+      <ellipse
+        className="tulip-grow tulip-bud"
+        data-from={2}
+        cx={60}
+        cy={58}
+        rx={12}
+        ry={18}
+        fill="var(--primary)"
+      />
+
+      <g className="tulip-grow" data-from={3}>
+        <path d="M60,72 L48,36 C48,20 60,10 60,26 Z" fill="var(--primary)" />
+        <path d="M60,72 L72,36 C72,20 60,10 60,26 Z" fill="var(--primary)" />
+        <path d="M60,72 L60,20 C68,10 74,20 74,32 C74,52 66,66 60,72 Z" fill="var(--primary)" />
+        <path d="M60,72 L60,20 C52,10 46,20 46,32 C46,52 54,66 60,72 Z" fill="var(--primary)" />
+        <g className="tulip-eyes">
+          <ellipse cx={53} cy={46} rx={4} ry={5} fill="var(--primary-foreground)" />
+          <ellipse cx={67} cy={46} rx={4} ry={5} fill="var(--primary-foreground)" />
+        </g>
+      </g>
+    </svg>
+  );
+}

--- a/apps/web/app/lib/companion-context.tsx
+++ b/apps/web/app/lib/companion-context.tsx
@@ -1,0 +1,79 @@
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { dismissQuest, listQuests, type Quest } from "~/lib/onboarding";
+
+/* The Companion's quest ladder: poll every ~60s (low-urgency, unlike Approvals) so a quest
+   answered elsewhere (chat, Settings) clears itself out within a minute without a hard refresh. */
+
+const POLL_INTERVAL_MS = 60_000;
+
+type CompanionContextValue = {
+  quests: Quest[];
+  loading: boolean;
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  refresh: () => Promise<void>;
+  dismiss: (id: string) => Promise<void>;
+};
+
+const CompanionContext = createContext<CompanionContextValue | null>(null);
+
+export function CompanionProvider({ children }: { children: ReactNode }) {
+  const [quests, setQuests] = useState<Quest[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [open, setOpen] = useState(false);
+  const inFlight = useRef(false);
+  const mounted = useRef(true);
+
+  const refresh = useCallback(async () => {
+    if (inFlight.current) return;
+    inFlight.current = true;
+    try {
+      const items = await listQuests();
+      if (mounted.current) setQuests(items);
+    } catch {
+      // Keep the last-known list on a transient failure; retry next tick.
+    } finally {
+      if (mounted.current) setLoading(false);
+      inFlight.current = false;
+    }
+  }, []);
+
+  useEffect(() => {
+    mounted.current = true;
+    void refresh();
+    const id = setInterval(() => void refresh(), POLL_INTERVAL_MS);
+    return () => {
+      mounted.current = false;
+      clearInterval(id);
+    };
+  }, [refresh]);
+
+  const dismiss = useCallback(async (id: string) => {
+    setQuests((current) => current.filter((q) => q.id !== id));
+    await dismissQuest(id).catch(() => {});
+  }, []);
+
+  const value: CompanionContextValue = { quests, loading, open, setOpen, refresh, dismiss };
+  return <CompanionContext.Provider value={value}>{children}</CompanionContext.Provider>;
+}
+
+const INERT: CompanionContextValue = {
+  quests: [],
+  loading: false,
+  open: false,
+  setOpen: () => {},
+  refresh: async () => {},
+  dismiss: async () => {},
+};
+
+export function useCompanion(): CompanionContextValue {
+  return useContext(CompanionContext) ?? INERT;
+}

--- a/apps/web/app/lib/onboarding.ts
+++ b/apps/web/app/lib/onboarding.ts
@@ -35,3 +35,34 @@ export async function getOnboardingChecklist(): Promise<OnboardingChecklist> {
 export async function dismissOnboardingChecklist(): Promise<void> {
   await apiWrite("PUT", "/api/v1/kv/onboarding/checklist", { value: { dismissed: true } });
 }
+
+/*
+ * The Companion's quest ladder (ONB-V2): tier 1 (hardcoded gate), tier 2 (checklist), tier 3
+ * (AI profile gaps). `answer` only accepts tier-1 form quests; tier 2/3 route through chat.
+ */
+
+export type QuestAction =
+  | { kind: "form"; field: "name" | "description" }
+  | { kind: "link"; href: string }
+  | { kind: "chat"; prompt: string };
+
+export type Quest = {
+  id: string;
+  tier: 1 | 2 | 3;
+  label: string;
+  hint?: string;
+  action: QuestAction;
+};
+
+export async function listQuests(): Promise<Quest[]> {
+  const body = await apiGet<{ quests: Quest[] }>("/api/v1/onboarding/quests");
+  return body.quests;
+}
+
+export async function answerQuest(id: string, value: string): Promise<void> {
+  await apiWrite("POST", `/api/v1/onboarding/quests/${encodeURIComponent(id)}/answer`, { value });
+}
+
+export async function dismissQuest(id: string): Promise<void> {
+  await apiWrite("POST", `/api/v1/onboarding/quests/${encodeURIComponent(id)}/dismiss`, {});
+}

--- a/apps/web/app/lib/setup.ts
+++ b/apps/web/app/lib/setup.ts
@@ -6,9 +6,9 @@ export async function getSetupStatus(): Promise<SetupStatus> {
   return apiGet<SetupStatus>("/api/v1/setup/status");
 }
 
-export async function setupAdmin(email: string, password: string): Promise<void> {
+export async function setupAdmin(name: string, email: string, password: string): Promise<void> {
   // 201 with user body — use apiWrite; we don't need the response body
-  await apiWrite("POST", "/api/v1/setup/admin", { email, password });
+  await apiWrite("POST", "/api/v1/setup/admin", { name, email, password });
 }
 
 export async function setupBusiness(

--- a/apps/web/app/routes/_app._index.tsx
+++ b/apps/web/app/routes/_app._index.tsx
@@ -20,9 +20,13 @@ export const meta: MetaFunction = () => [{ title: "Chat · tulipfarm" }];
 // Deliberately does no fetching: a clientLoader gates the first paint of the app's landing route,
 // so anything awaited here is blank-screen time. Onboarding is fetched after mount instead.
 export async function clientLoader({ request }: ClientLoaderFunctionArgs) {
-  const agentId = new URL(request.url).searchParams.get("agent") || undefined;
+  const url = new URL(request.url);
+  const agentId = url.searchParams.get("agent") || undefined;
+  // Seeded by the onboarding Companion (a tier-2/3 quest's "chat" action) — drafted into the
+  // composer, never auto-sent.
+  const draft = url.searchParams.get("draft") || undefined;
   const defaultModel: ChatModelSelector = DEFAULT_CHAT_MODEL_SELECTOR;
-  return { agentId, defaultModel };
+  return { agentId, defaultModel, draft };
 }
 
 /*
@@ -62,7 +66,14 @@ function useOnboarding(newChatNonce: number) {
 }
 
 export default function ChatRoute() {
-  const { agentId, defaultModel } = useLoaderData<typeof clientLoader>();
+  const { agentId, defaultModel, draft } = useLoaderData<typeof clientLoader>();
+  // Strip `?draft=` once applied so a reload or Back doesn't redraft over the user's own typing.
+  useEffect(() => {
+    if (!draft) return;
+    const url = new URL(window.location.href);
+    url.searchParams.delete("draft");
+    window.history.replaceState(null, "", `${url.pathname}${url.search}`);
+  }, [draft]);
   const { refresh, setActiveChatId, newChatNonce } = useConversations();
   // Dismissal lives here, ABOVE the `newChatNonce`-keyed ChatPanel, so "+ new chat" (which remounts
   // ChatPanel) doesn't resurrect a card the user already dismissed.
@@ -98,6 +109,7 @@ export default function ChatRoute() {
         void dismissOnboardingChecklist().catch(() => {});
       }}
       onConversationChange={onConversationChange}
+      initialDraft={draft}
     />
   );
 }

--- a/apps/web/app/routes/_app.design-guide.tsx
+++ b/apps/web/app/routes/_app.design-guide.tsx
@@ -7,6 +7,8 @@ import { ToolRun } from "~/components/chat/tool-call";
 import { Transcript } from "~/components/chat/transcript";
 import { FormStatus } from "~/components/form-status";
 import { IntegrationIcon } from "~/components/integrations/integration-icon";
+import { CompanionPanel } from "~/components/onboarding/companion-panel";
+import { TulipGrowth, type TulipStage } from "~/components/onboarding/tulip-growth";
 import { PriorityBadge, StatusBadge } from "~/components/status-badge";
 import { Badge } from "~/components/ui/badge";
 import { Button } from "~/components/ui/button";
@@ -94,6 +96,34 @@ const TIER_TOKENS = [
   ["integration", "bg-tool-tier-integration"],
   ["mutating", "bg-tool-mutating"],
 ] as const;
+
+const TULIP_STAGES: readonly TulipStage[] = [0, 1, 2, 3];
+
+/** Static specimen quests — one per tier — for the Companion panel showcase. Never wired live. */
+const GUIDE_QUESTS = [
+  {
+    id: "provider-key",
+    tier: 1 as const,
+    label: "Plant your model key",
+    hint: "Agents need one provider connected before they can do anything.",
+    action: { kind: "link" as const, href: "/settings/secrets" },
+  },
+  {
+    id: "checklist-resource",
+    tier: 2 as const,
+    label: "Create your first resource type",
+    action: { kind: "chat" as const, prompt: "Help me create a resource type." },
+  },
+  {
+    id: "profile-employee-count",
+    tier: 3 as const,
+    label: "How many people work here?",
+    action: {
+      kind: "chat" as const,
+      prompt: "Help me record how many employees the business has.",
+    },
+  },
+];
 
 const TOOL_SPECIMENS: { caption: string; part: Extract<TimelinePart, { kind: "tool" }> }[] = [
   {
@@ -201,6 +231,7 @@ const GUIDE_LINKS = [
   ["status-priority", "Status & priority systems"],
   ["agent-run", "Agent run vocabulary"],
   ["brand-marks", "Brand marks"],
+  ["onboarding", "Onboarding: tulip & Companion"],
   ["copy-field", "Copyable values"],
   ["hierarchy", "Component hierarchy"],
   ["composition", "Composition patterns"],
@@ -510,6 +541,36 @@ export default function DesignGuideRoute() {
           on the dark canvas and a pale brand is invisible on the light one. Both corrections ship
           as custom properties so the <code>dark:</code> variant switches them without JavaScript.
         </p>
+      </GuideSection>
+
+      <GuideSection
+        id="onboarding"
+        title="Onboarding: tulip & Companion"
+        description="Growth reports real answered-input count, not decoration — stage is state, motion is only the transition between stages. The same bloom face, eyes open, is the persistent in-app Companion."
+      >
+        <div className="flex flex-wrap items-end gap-6">
+          {TULIP_STAGES.map((stage) => (
+            <div key={stage} className="flex flex-col items-center gap-2">
+              <TulipGrowth stage={stage} width={60} height={80} />
+              <span className="font-mono text-xs text-muted-foreground">stage {stage}</span>
+            </div>
+          ))}
+        </div>
+        <p className="mt-4 max-w-2xl text-sm text-muted-foreground">
+          Pre-login (<code>/setup</code>) drives this with answered-question count, no step number
+          shown. In-app, stage 3 is fixed — it is the Companion's collapsed glyph, bottom right on{" "}
+          <code>sm</code>+ and a top-bar icon below it, with a pulsing dot badge (never a popup)
+          when a quest is pending.
+        </p>
+        <div className="mt-5 max-w-sm rounded-md border border-border bg-card">
+          <CompanionPanel
+            quests={GUIDE_QUESTS}
+            loading={false}
+            onDismiss={() => {}}
+            onAnswered={() => {}}
+            onClose={() => {}}
+          />
+        </div>
       </GuideSection>
 
       <GuideSection

--- a/apps/web/app/routes/_app.tsx
+++ b/apps/web/app/routes/_app.tsx
@@ -1,8 +1,10 @@
 import { Outlet, redirect, useLoaderData } from "@remix-run/react";
 import { AppShell } from "~/components/app-sidebar";
+import { OnboardingCompanion } from "~/components/onboarding/companion";
 import { GlobalConnectionStatus } from "~/components/shell/states";
 import { ApiError, getSession } from "~/lib/api";
 import { ApprovalsProvider } from "~/lib/approvals-context";
+import { CompanionProvider } from "~/lib/companion-context";
 import { ConversationsProvider } from "~/lib/conversations-context";
 import { getSetupStatus } from "~/lib/setup";
 
@@ -42,16 +44,19 @@ export default function AppLayout() {
   return (
     <ApprovalsProvider>
       <ConversationsProvider>
-        <AppShell isAdmin={user.role === "admin"} user={user}>
-          <a
-            href="#main-content"
-            className="fixed left-2 top-2 z-[100] -translate-y-16 bg-background px-3 py-2 text-sm focus:translate-y-0"
-          >
-            Skip to main content
-          </a>
-          <Outlet />
-          <GlobalConnectionStatus />
-        </AppShell>
+        <CompanionProvider>
+          <AppShell isAdmin={user.role === "admin"} user={user}>
+            <a
+              href="#main-content"
+              className="fixed left-2 top-2 z-[100] -translate-y-16 bg-background px-3 py-2 text-sm focus:translate-y-0"
+            >
+              Skip to main content
+            </a>
+            <Outlet />
+            <GlobalConnectionStatus />
+            <OnboardingCompanion />
+          </AppShell>
+        </CompanionProvider>
       </ConversationsProvider>
     </ApprovalsProvider>
   );

--- a/apps/web/app/routes/setup.test.tsx
+++ b/apps/web/app/routes/setup.test.tsx
@@ -1,174 +1,104 @@
 import { createRemixStub } from "@remix-run/testing";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { deriveModelProfiles, resolveEffortPreset, validateLlmConfig } from "@tulipfarm/schema";
 import { afterEach, expect, test, vi } from "vitest";
-import * as settingsLib from "~/lib/settings";
+import { ApiError } from "~/lib/api";
 import * as setupLib from "~/lib/setup";
-import SetupRoute, { buildSetupLlmConfig } from "./setup";
+import SetupRoute from "./setup";
 
 vi.mock("~/lib/setup", () => ({
   getSetupStatus: vi.fn(),
   setupAdmin: vi.fn(),
-  setupBusiness: vi.fn(),
   completeSetup: vi.fn(),
-}));
-vi.mock("~/lib/settings", () => ({
-  listProviders: vi.fn().mockResolvedValue([]),
-  putLlmConfig: vi.fn(),
-  putSecret: vi.fn(),
 }));
 
 const setupAdmin = vi.mocked(setupLib.setupAdmin);
-const setupBusiness = vi.mocked(setupLib.setupBusiness);
 const completeSetup = vi.mocked(setupLib.completeSetup);
-const listProviders = vi.mocked(settingsLib.listProviders);
-const putLlmConfig = vi.mocked(settingsLib.putLlmConfig);
-const putSecret = vi.mocked(settingsLib.putSecret);
 
 afterEach(() => {
   vi.clearAllMocks();
-  listProviders.mockResolvedValue([]);
 });
 
-function renderWizard() {
+function renderRoute() {
   const Stub = createRemixStub([{ path: "/", Component: () => <SetupRoute /> }]);
   render(<Stub initialEntries={["/"]} />);
 }
 
-/** Complete steps 1 (admin) and 2 (business), landing on the LLM step. */
-async function advanceToLlmStep(
-  user: ReturnType<typeof userEvent.setup>,
-  business: { website?: string } = {}
-) {
-  setupAdmin.mockResolvedValue(undefined as never);
-  setupBusiness.mockResolvedValue(undefined as never);
-
-  await user.type(screen.getByLabelText(/email/i), "admin@example.com");
-  await user.type(screen.getByLabelText(/^password/i), "mypassword");
-  await user.type(screen.getByLabelText(/confirm password/i), "mypassword");
+async function answerAll(user: ReturnType<typeof userEvent.setup>) {
+  await user.type(screen.getByLabelText(/what should we call you/i), "Ada Lovelace");
   await user.click(screen.getByRole("button", { name: "Continue" }));
 
-  await user.type(await screen.findByLabelText(/business name/i), "Oscorp");
-  if (business.website) await user.type(screen.getByLabelText(/website/i), business.website);
+  await user.type(await screen.findByLabelText(/^email/i), "admin@example.com");
   await user.click(screen.getByRole("button", { name: "Continue" }));
 
-  await screen.findByRole("heading", { name: "LLM setup" });
+  await user.type(await screen.findByLabelText(/^password/i), "mypassword");
 }
 
-test("finishes setup when the final LLM step is skipped", async () => {
-  const user = userEvent.setup();
-  completeSetup.mockResolvedValue(undefined as never);
-  renderWizard();
-
-  await advanceToLlmStep(user);
-  await user.click(screen.getByRole("button", { name: /Skip for now/ }));
-
-  await waitFor(() => expect(completeSetup).toHaveBeenCalledTimes(1));
-});
-
-test("sends the optional website with the business profile", async () => {
-  const user = userEvent.setup();
-  renderWizard();
-
-  await advanceToLlmStep(user, { website: "https://oscorp.example" });
-
-  expect(setupBusiness).toHaveBeenCalledWith("Oscorp", "", "https://oscorp.example");
-});
-
-test("omits the website when it is left blank", async () => {
-  const user = userEvent.setup();
-  renderWizard();
-
-  await advanceToLlmStep(user);
-
-  expect(setupBusiness).toHaveBeenCalledWith("Oscorp", "", "");
-});
-
-test("steps back to an earlier step without losing what was already typed", async () => {
-  const user = userEvent.setup();
-  renderWizard();
-
-  await advanceToLlmStep(user);
-  const model = screen.getByLabelText(/^model/i);
-  await user.clear(model);
-  await user.type(model, "claude-haiku-4-5");
-
-  await user.click(screen.getByRole("button", { name: "Back" }));
-
-  expect(await screen.findByRole("heading", { name: "Business profile" })).toBeInTheDocument();
-  expect(screen.getByLabelText(/business name/i)).toHaveValue("Oscorp");
-
-  await user.click(screen.getByRole("button", { name: "Continue" }));
-
-  await screen.findByRole("heading", { name: "LLM setup" });
-  expect(screen.getByLabelText(/^model/i)).toHaveValue("claude-haiku-4-5");
-}, 15_000);
-
-test("submits tiers and an explicit default effort preset map from LLM setup", async () => {
-  const user = userEvent.setup();
-  const seededConfig = buildSetupLlmConfig("anthropic", "claude-sonnet-4-6");
-  listProviders.mockResolvedValue([
-    {
-      id: "anthropic",
-      label: "Anthropic",
-      fields: [
-        {
-          key: "ANTHROPIC_API_KEY",
-          label: "Anthropic API key",
-          role: "api_key",
-          kind: "secret",
-        },
-      ],
-    },
-  ]);
-  putLlmConfig.mockResolvedValue(seededConfig);
-  putSecret.mockResolvedValue(undefined as never);
-  completeSetup.mockResolvedValue(undefined as never);
-  renderWizard();
-
-  await advanceToLlmStep(user);
-  await user.type(await screen.findByLabelText(/anthropic api key/i), "sk-test");
-  await user.click(screen.getByRole("button", { name: "Continue" }));
-
-  await waitFor(() => expect(putLlmConfig).toHaveBeenCalledTimes(1));
-  expect(putLlmConfig).toHaveBeenCalledWith({
-    tiers: {
-      quick: { providers: [{ provider: "anthropic", model: "claude-sonnet-4-6" }] },
-      standard: { providers: [{ provider: "anthropic", model: "claude-sonnet-4-6" }] },
-      complex: { providers: [{ provider: "anthropic", model: "claude-sonnet-4-6" }] },
-    },
-    presets: { default: "balanced" },
-  });
-});
-
-test("seeds a schema-valid LLM config where auto resolves to a derived profile", () => {
-  const config = validateLlmConfig(buildSetupLlmConfig("anthropic", "claude-sonnet-4-6"));
-  const profiles = deriveModelProfiles(config);
-  const available = new Set(profiles.map((profile) => profile.profileId));
-  const resolved = resolveEffortPreset("auto", config, (profileId) => available.has(profileId));
-
-  expect(resolved).toBe("balanced");
-  expect(profiles.find((profile) => profile.profileId === resolved)).toMatchObject({
-    profileId: "balanced",
-    provider: "anthropic",
-    model: "claude-sonnet-4-6",
-  });
-});
-
-/* Browser smoke fills by id, so renames must fail here before the slow installer stage. */
-test("keeps the business-name field id the installer browser smoke drives", async () => {
+test("creates the admin, then completes setup, on the final answer", async () => {
   const user = userEvent.setup();
   setupAdmin.mockResolvedValue(undefined as never);
-  renderWizard();
+  completeSetup.mockResolvedValue(undefined as never);
+  renderRoute();
 
-  await user.type(screen.getByLabelText(/email/i), "admin@example.com");
-  await user.type(screen.getByLabelText(/^password/i), "mypassword");
-  await user.type(screen.getByLabelText(/confirm password/i), "mypassword");
+  await answerAll(user);
+  await user.click(screen.getByRole("button", { name: "Finish" }));
+
+  await waitFor(() =>
+    expect(setupAdmin).toHaveBeenCalledWith("Ada Lovelace", "admin@example.com", "mypassword")
+  );
+  expect(completeSetup).toHaveBeenCalledTimes(1);
+});
+
+test("does not call the API until the last question is answered", async () => {
+  const user = userEvent.setup();
+  renderRoute();
+
+  await answerAll(user);
+
+  expect(setupAdmin).not.toHaveBeenCalled();
+});
+
+test("steps back to an earlier question without losing what was already typed", async () => {
+  const user = userEvent.setup();
+  renderRoute();
+
+  await user.type(screen.getByLabelText(/what should we call you/i), "Ada Lovelace");
   await user.click(screen.getByRole("button", { name: "Continue" }));
 
-  expect(await screen.findByLabelText(/business name/i)).toHaveAttribute(
-    "id",
-    "setup-business-name"
-  );
+  await screen.findByLabelText(/^email/i);
+  await user.click(screen.getByRole("button", { name: "Back" }));
+
+  expect(await screen.findByLabelText(/what should we call you/i)).toHaveValue("Ada Lovelace");
+});
+
+test("disables Continue until the current question has a value", async () => {
+  renderRoute();
+
+  expect(screen.getByRole("button", { name: "Continue" })).toBeDisabled();
+});
+
+test("requires at least 8 characters for the password", async () => {
+  const user = userEvent.setup();
+  renderRoute();
+
+  await user.type(screen.getByLabelText(/what should we call you/i), "Ada Lovelace");
+  await user.click(screen.getByRole("button", { name: "Continue" }));
+  await user.type(await screen.findByLabelText(/^email/i), "admin@example.com");
+  await user.click(screen.getByRole("button", { name: "Continue" }));
+
+  await user.type(await screen.findByLabelText(/^password/i), "short");
+
+  expect(screen.getByRole("button", { name: "Finish" })).toBeDisabled();
+});
+
+test("rewinds to the question named by a 422's field path", async () => {
+  const user = userEvent.setup();
+  setupAdmin.mockRejectedValue(new ApiError(422, "email is already taken", "email"));
+  renderRoute();
+
+  await answerAll(user);
+  await user.click(screen.getByRole("button", { name: "Finish" }));
+
+  expect(await screen.findByText("email is already taken")).toBeInTheDocument();
+  expect(screen.getByLabelText(/^email/i)).toBeInTheDocument();
 });

--- a/apps/web/app/routes/setup.tsx
+++ b/apps/web/app/routes/setup.tsx
@@ -1,20 +1,11 @@
 import { type MetaFunction, redirect, useNavigate } from "@remix-run/react";
-import { AlertCircle, ArrowLeft, Check, Loader2 } from "lucide-react";
-import { type FormEvent, type ReactNode, useRef, useState } from "react";
-import { Badge } from "~/components/ui/badge";
+import { AlertCircle, ArrowLeft, Loader2 } from "lucide-react";
+import { type FormEvent, useRef, useState } from "react";
+import { PromptField } from "~/components/onboarding/prompt-field";
+import { TulipGrowth, type TulipStage } from "~/components/onboarding/tulip-growth";
 import { Button } from "~/components/ui/button";
-import { Input } from "~/components/ui/input";
-import { Select } from "~/components/ui/select";
-import { Textarea } from "~/components/ui/textarea";
 import { ApiError } from "~/lib/api";
-import {
-  type LlmConfig,
-  type LlmProviderInfo,
-  listProviders,
-  putLlmConfig,
-  putSecret,
-} from "~/lib/settings";
-import { completeSetup, getSetupStatus, setupAdmin, setupBusiness } from "~/lib/setup";
+import { completeSetup, getSetupStatus, setupAdmin } from "~/lib/setup";
 import { cn } from "~/lib/utils";
 
 export const meta: MetaFunction = () => [{ title: "Setup · tulipfarm" }];
@@ -26,64 +17,32 @@ export async function clientLoader() {
   return null;
 }
 
-type StepMeta = { label: string; description: string; optional?: boolean };
-
-const STEPS = [
-  {
-    label: "Admin account",
-    description:
-      "This account owns the workspace. You can add more people from Settings once setup is done.",
-  },
-  {
-    label: "Business profile",
-    description:
-      "Every Agent reads this to work out who it works for, so be specific about what you actually do.",
-  },
-  {
-    label: "LLM setup",
-    description:
-      "Use one provider and Model ID for every effort preset. You can split them later in Settings.",
-    optional: true,
-  },
-] as const satisfies readonly StepMeta[];
-
-type Step = 0 | 1 | 2;
-
 // Mobile keeps a 44px target and 16px text (below 16px iOS zooms the page on focus); desktop
 // drops to the 36px control height the rest of the app uses.
 const controlClass = "h-11 text-base sm:h-9 sm:text-sm";
 
-function Field({
-  id,
-  label,
-  hint,
-  error,
-  children,
-}: {
-  id: string;
+type Question = 0 | 1 | 2;
+
+const QUESTIONS: readonly {
   label: string;
   hint?: string;
-  error?: string;
-  children: ReactNode;
-}) {
-  const note = error ?? hint;
-  return (
-    <label htmlFor={id} className="grid gap-1.5 text-sm font-medium text-foreground">
-      {label}
-      {children}
-      {note ? (
-        <span
-          className={cn(
-            "text-xs font-normal",
-            error ? "text-destructive" : "text-muted-foreground"
-          )}
-        >
-          {note}
-        </span>
-      ) : null}
-    </label>
-  );
-}
+  type: "text" | "email" | "password";
+  autoComplete: string;
+}[] = [
+  { label: "What should we call you?", type: "text", autoComplete: "name" },
+  {
+    label: "Email",
+    hint: "You will sign in with this address.",
+    type: "email",
+    autoComplete: "username",
+  },
+  {
+    label: "Password",
+    hint: "At least 8 characters.",
+    type: "password",
+    autoComplete: "new-password",
+  },
+];
 
 function ErrorAlert({ message }: { message: string }) {
   return (
@@ -97,543 +56,140 @@ function ErrorAlert({ message }: { message: string }) {
   );
 }
 
-// Desktop rail: the full step list, so the shape of the whole wizard stays visible.
-function StepList({ steps, current }: { steps: readonly StepMeta[]; current: Step }) {
-  return (
-    <nav aria-label="Setup progress" className="hidden lg:block">
-      <ol className="flex flex-col gap-0.5">
-        {steps.map((s, i) => {
-          const done = i < current;
-          const active = i === current;
-          return (
-            <li
-              key={s.label}
-              aria-current={active ? "step" : undefined}
-              className={cn(
-                "flex items-center gap-2.5 rounded-md px-2 py-1.5 text-sm transition-colors",
-                active ? "bg-secondary font-medium text-foreground" : "text-muted-foreground"
-              )}
-            >
-              <span
-                className={cn(
-                  "flex size-5 shrink-0 items-center justify-center rounded-full border text-[0.625rem] tabular-nums",
-                  done && "border-primary bg-primary text-primary-foreground",
-                  active && "border-primary text-primary",
-                  !done && !active && "border-border"
-                )}
-              >
-                {done ? <Check aria-hidden className="size-3" /> : i + 1}
-              </span>
-              {s.label}
-              {done ? <span className="sr-only">completed</span> : null}
-            </li>
-          );
-        })}
-      </ol>
-    </nav>
-  );
-}
-
-// Below lg there is no room for four labelled markers, so state is carried by text plus a bar.
-function StepProgress({ steps, current }: { steps: readonly StepMeta[]; current: Step }) {
-  return (
-    <div className="lg:hidden">
-      <p className="text-xs text-muted-foreground">
-        Step <span className="tabular-nums">{current + 1}</span> of{" "}
-        <span className="tabular-nums">{steps.length}</span>
-      </p>
-      <ol aria-hidden className="mt-2 flex gap-1.5">
-        {steps.map((s, i) => (
-          <li
-            key={s.label}
-            className={cn("h-1 flex-1 rounded-full", i <= current ? "bg-primary" : "bg-border")}
-          />
-        ))}
-      </ol>
-    </div>
-  );
-}
-
-function Actions({
-  busy,
-  disabled,
-  busyLabel,
-  onBack,
-  onSkip,
-}: {
-  busy: boolean;
-  disabled: boolean;
-  busyLabel: string;
-  onBack?: () => void;
-  onSkip?: () => void;
-}) {
-  return (
-    <div className="mt-2 flex flex-col gap-2">
-      <div className="flex gap-2">
-        {onBack ? (
-          <Button
-            type="button"
-            variant="outline"
-            className="h-11 px-4 active:translate-y-px sm:h-10"
-            onClick={onBack}
-            disabled={busy}
-          >
-            <ArrowLeft aria-hidden />
-            Back
-          </Button>
-        ) : null}
-        <Button
-          type="submit"
-          className="h-11 flex-1 active:translate-y-px sm:h-10"
-          disabled={busy || disabled}
-        >
-          {busy ? busyLabel : "Continue"}
-        </Button>
-      </div>
-      {onSkip ? (
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          className="mx-auto font-normal text-muted-foreground"
-          onClick={onSkip}
-          disabled={busy}
-        >
-          Skip for now
-        </Button>
-      ) : null}
-    </div>
-  );
-}
-
-// Step 1: admin account
-function AdminStep({ onNext }: { onNext: () => void }) {
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [confirm, setConfirm] = useState("");
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [mismatch, setMismatch] = useState(false);
-  const confirmRef = useRef<HTMLInputElement>(null);
-
-  async function onSubmit(e: FormEvent) {
-    e.preventDefault();
-    if (password !== confirm) {
-      setMismatch(true);
-      confirmRef.current?.focus();
-      return;
-    }
-    setBusy(true);
-    setError(null);
-    try {
-      await setupAdmin(email.trim(), password);
-      onNext();
-    } catch (err) {
-      setError(err instanceof ApiError ? err.message : "Setup failed — is the API reachable?");
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  return (
-    <form onSubmit={onSubmit} className="flex flex-col gap-4">
-      {error && <ErrorAlert message={error} />}
-      <Field id="setup-email" label="Email" hint="You will sign in with this address.">
-        <Input
-          id="setup-email"
-          type="email"
-          autoComplete="username"
-          className={controlClass}
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          required
-        />
-      </Field>
-      <Field id="setup-password" label="Password" hint="At least 8 characters.">
-        <Input
-          id="setup-password"
-          type="password"
-          autoComplete="new-password"
-          className={controlClass}
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          minLength={8}
-          required
-        />
-      </Field>
-      <Field
-        id="setup-confirm"
-        label="Confirm password"
-        error={mismatch ? "Both passwords must match." : undefined}
-      >
-        <Input
-          id="setup-confirm"
-          ref={confirmRef}
-          type="password"
-          autoComplete="new-password"
-          className={controlClass}
-          aria-invalid={mismatch || undefined}
-          value={confirm}
-          onChange={(e) => {
-            setConfirm(e.target.value);
-            setMismatch(false);
-          }}
-          required
-        />
-      </Field>
-      <Actions
-        busy={busy}
-        busyLabel="Creating account…"
-        disabled={!email || password.length < 8 || !confirm}
-      />
-    </form>
-  );
-}
-
-type BusinessDraft = { name: string; description: string; website: string };
-
-// Step 2: business profile
-function BusinessStep({
-  draft,
-  onDraft,
-  onBack,
-  onNext,
-}: {
-  draft: BusinessDraft;
-  onDraft: (next: BusinessDraft) => void;
-  onBack: () => void;
-  onNext: () => void;
-}) {
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  async function onSubmit(e: FormEvent) {
-    e.preventDefault();
-    setBusy(true);
-    setError(null);
-    try {
-      await setupBusiness(draft.name.trim(), draft.description.trim(), draft.website.trim());
-      onNext();
-    } catch (err) {
-      setError(err instanceof ApiError ? err.message : "Failed to save business profile.");
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  return (
-    <form onSubmit={onSubmit} className="flex flex-col gap-4">
-      {error && <ErrorAlert message={error} />}
-      <Field id="setup-business-name" label="Business name">
-        <Input
-          id="setup-business-name"
-          type="text"
-          className={controlClass}
-          value={draft.name}
-          onChange={(e) => onDraft({ ...draft, name: e.target.value })}
-          placeholder="Northgate Dental"
-          required
-        />
-      </Field>
-      <Field
-        id="setup-business-description"
-        label="What your business does"
-        hint="Two or three sentences is plenty."
-      >
-        <Textarea
-          id="setup-business-description"
-          className="text-base sm:text-sm"
-          value={draft.description}
-          onChange={(e) => onDraft({ ...draft, description: e.target.value })}
-          placeholder="Family dental practice in Portland. Mostly preventive care, with some implant work."
-        />
-      </Field>
-      <Field
-        id="setup-business-website"
-        label="Website (optional)"
-        hint="Agents use this when they need to reference or link to your site."
-      >
-        <Input
-          id="setup-business-website"
-          type="url"
-          inputMode="url"
-          className={controlClass}
-          value={draft.website}
-          onChange={(e) => onDraft({ ...draft, website: e.target.value })}
-          placeholder="https://northgatedental.com"
-        />
-      </Field>
-      <Actions busy={busy} busyLabel="Saving…" disabled={!draft.name.trim()} onBack={onBack} />
-    </form>
-  );
-}
-
-const DEFAULT_MODEL: Record<string, string> = {
-  anthropic: "claude-sonnet-4-6",
-  openai: "gpt-4o",
-  azure: "gpt-4o",
-  "openai-compatible": "",
-  "claude-code": "sonnet",
-  codex: "gpt-5.6-terra",
-};
-
-type LlmDraft = { providerId: string; model: string; fieldValues: Record<string, string> };
-export function buildSetupLlmConfig(providerId: string, model: string): LlmConfig {
-  const entry = { provider: providerId, model: model.trim() };
-  return {
-    tiers: {
-      quick: { providers: [entry] },
-      standard: { providers: [entry] },
-      complex: { providers: [entry] },
-    },
-    // One provider seeds every preset; Settings splits them once more models are configured.
-    presets: { default: "balanced" },
-  };
-}
-
-// Step 3: LLM setup — uses the same registry and storage endpoints as Settings › Secrets + LLM Config.
-function LlmStep({
-  providers,
-  draft,
-  onDraft,
-  onBack,
-  onNext,
-}: {
-  providers: LlmProviderInfo[];
-  draft: LlmDraft;
-  onDraft: (next: LlmDraft) => void;
-  onBack: () => void;
-  onNext: () => void;
-}) {
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const selected = providers.find((p) => p.id === draft.providerId);
-
-  function setVal(key: string, v: string) {
-    onDraft({ ...draft, fieldValues: { ...draft.fieldValues, [key]: v } });
-  }
-
-  function onProviderChange(id: string) {
-    onDraft({ providerId: id, model: DEFAULT_MODEL[id] ?? "", fieldValues: {} });
-  }
-
-  const canSubmit =
-    !!selected &&
-    selected.fields
-      .filter((f) => !f.optional)
-      .every((f) => (draft.fieldValues[f.key] ?? "").trim().length > 0) &&
-    draft.model.trim().length > 0;
-
-  async function onSubmit(e: FormEvent) {
-    e.preventDefault();
-    if (!selected) return;
-    setBusy(true);
-    setError(null);
-    try {
-      const filled = selected.fields.filter(
-        (f) => (draft.fieldValues[f.key] ?? "").trim().length > 0
-      );
-      await Promise.all(
-        filled.map((f) => putSecret(f.key, (draft.fieldValues[f.key] ?? "").trim()))
-      );
-      await putLlmConfig(buildSetupLlmConfig(draft.providerId, draft.model));
-      onNext();
-    } catch (err) {
-      setError(err instanceof ApiError ? err.message : "Failed to save LLM configuration.");
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  return (
-    <form onSubmit={onSubmit} className="flex flex-col gap-4">
-      {error && <ErrorAlert message={error} />}
-      <Field id="setup-provider" label="LLM provider">
-        <Select
-          id="setup-provider"
-          className={controlClass}
-          value={draft.providerId}
-          onChange={(e) => onProviderChange(e.target.value)}
-        >
-          {providers.length > 0 ? (
-            providers.map((p) => (
-              <option key={p.id} value={p.id}>
-                {p.label}
-              </option>
-            ))
-          ) : (
-            <>
-              <option value="anthropic">Anthropic</option>
-              <option value="openai">OpenAI</option>
-            </>
-          )}
-        </Select>
-      </Field>
-      {selected?.fields.map((field) => (
-        <Field
-          key={field.key}
-          id={`setup-${field.key}`}
-          label={`${field.label}${field.optional ? " (optional)" : ""}`}
-          hint={field.hint ?? (field.kind === "secret" ? "Stored encrypted." : undefined)}
-        >
-          <Input
-            id={`setup-${field.key}`}
-            className={controlClass}
-            type={field.kind === "secret" ? "password" : "text"}
-            value={draft.fieldValues[field.key] ?? ""}
-            onChange={(e) => setVal(field.key, e.target.value)}
-            placeholder={field.placeholder ?? (field.kind === "secret" ? "sk-…" : "")}
-            autoComplete="off"
-          />
-        </Field>
-      ))}
-      <Field
-        id="setup-model"
-        label="Model ID"
-        hint="The provider's exact model identifier. Setup uses it for every effort preset."
-      >
-        <Input
-          id="setup-model"
-          className={controlClass}
-          value={draft.model}
-          onChange={(e) => onDraft({ ...draft, model: e.target.value })}
-          placeholder={DEFAULT_MODEL[draft.providerId] ?? "e.g. gpt-4o"}
-          autoComplete="off"
-        />
-      </Field>
-      <Actions
-        busy={busy}
-        busyLabel="Saving…"
-        disabled={!canSubmit}
-        onBack={onBack}
-        onSkip={onNext}
-      />
-    </form>
-  );
-}
-
 export default function SetupRoute() {
   const navigate = useNavigate();
-  const [step, setStep] = useState<Step>(0);
-  const [finishing, setFinishing] = useState(false);
-  const [finishError, setFinishError] = useState<string | null>(null);
-  const [providers, setProviders] = useState<LlmProviderInfo[]>([]);
-  // Drafts live here, not in the step components, so stepping back preserves what was typed.
-  const [business, setBusiness] = useState<BusinessDraft>({
-    name: "",
-    description: "",
-    website: "",
-  });
-  const [llm, setLlm] = useState<LlmDraft>({
-    providerId: "anthropic",
-    model: DEFAULT_MODEL.anthropic ?? "",
-    fieldValues: {},
-  });
+  const [question, setQuestion] = useState<Question>(0);
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const headingRef = useRef<HTMLHeadingElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
-  const current: StepMeta = STEPS[step] ?? STEPS[0];
+  // Stage mirrors how many of the three answers are already committed — the tulip's growth is the
+  // question index itself while an answer is being typed, and only reaches 3 once setup finishes.
+  const stage: TulipStage = busy ? 3 : question;
 
-  async function finish() {
-    setFinishing(true);
-    setFinishError(null);
-    try {
-      await completeSetup();
-      navigate("/", { replace: true });
-    } catch (err) {
-      setFinishError(err instanceof ApiError ? err.message : "Failed to complete setup.");
-      setFinishing(false);
-    }
-  }
+  const values = [name, email, password];
+  const setValue = (v: string) => {
+    if (question === 0) setName(v);
+    else if (question === 1) setEmail(v);
+    else setPassword(v);
+  };
 
-  const goTo = (next: Step) => {
-    setStep(next);
-    // The whole form swaps on step change, which would otherwise drop focus to <body>.
+  const goTo = (next: Question) => {
+    setQuestion(next);
+    setError(null);
+    // The whole question swaps, which would otherwise drop focus to <body>.
     headingRef.current?.focus();
   };
 
-  const advance = () => {
-    if (step < STEPS.length - 1) {
-      goTo((step + 1) as Step);
+  const back = () => goTo(Math.max(0, question - 1) as Question);
+
+  async function finish() {
+    setBusy(true);
+    setError(null);
+    try {
+      await setupAdmin(name.trim(), email.trim(), password);
+      await completeSetup();
+      navigate("/", { replace: true });
+    } catch (err) {
+      setBusy(false);
+      const message =
+        err instanceof ApiError ? err.message : "Setup failed — is the API reachable?";
+      // A 422 names the offending field — rewind to the question that owns it.
+      const owner =
+        err instanceof ApiError
+          ? err.path === "email"
+            ? 1
+            : err.path === "password"
+              ? 2
+              : err.path === "name"
+                ? 0
+                : null
+          : null;
+      if (owner !== null && owner !== question) {
+        setQuestion(owner as Question);
+      }
+      setError(message);
+      headingRef.current?.focus();
+      inputRef.current?.focus();
+    }
+  }
+
+  function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (question < 2) {
+      goTo((question + 1) as Question);
     } else {
       void finish();
     }
-  };
+  }
 
-  const back = () => goTo(Math.max(0, step - 1) as Step);
-
-  // The admin step's auto-login is what makes the (authenticated) provider list readable: fetch it
-  // once, then advance. A failed read leaves the static Anthropic/OpenAI fallback in place.
-  const advanceFromAdmin = () => {
-    listProviders()
-      .then((list) => {
-        setProviders(list);
-        const first = list[0];
-        if (!first) return;
-        setLlm((draft) =>
-          list.some((p) => p.id === draft.providerId)
-            ? draft
-            : { providerId: first.id, model: DEFAULT_MODEL[first.id] ?? "", fieldValues: {} }
-        );
-      })
-      .catch(() => {});
-    advance();
-  };
+  const current = QUESTIONS[question];
+  const disabled = question === 2 ? password.length < 8 : values[question]?.trim().length === 0;
 
   return (
-    <main className="min-h-svh px-6 py-12 sm:py-16 lg:py-24">
-      <div className="mx-auto grid w-full max-w-md items-start gap-10 lg:max-w-3xl lg:grid-cols-[13rem_minmax(0,1fr)] lg:gap-12">
-        <aside className="flex flex-col gap-8">
-          <div>
-            <p className="text-[0.625rem] font-medium uppercase tracking-[0.2em] text-primary">
-              [ SETUP ]
-            </p>
-            <p className="mt-1 text-2xl font-semibold text-foreground">tulipfarm</p>
-          </div>
-          <StepList steps={STEPS} current={step} />
-        </aside>
+    <main className="flex min-h-svh flex-col items-center justify-center gap-10 px-6 py-12">
+      <TulipGrowth stage={stage} />
+      <p role="status" className="sr-only">
+        {Math.min(question, 3)} of 3 answered
+      </p>
 
-        <div className="flex flex-col gap-6">
-          <div>
-            <StepProgress steps={STEPS} current={step} />
-            <div className="mt-4 flex items-center gap-2 lg:mt-0">
-              <h1
-                ref={headingRef}
-                tabIndex={-1}
-                className="text-xl font-semibold text-foreground outline-none"
+      <div className="flex w-full max-w-sm flex-col gap-6">
+        <h1
+          ref={headingRef}
+          tabIndex={-1}
+          className="text-center text-xl font-semibold text-foreground outline-none"
+        >
+          Let's get your account set up
+        </h1>
+
+        {error && <ErrorAlert message={error} />}
+
+        <form onSubmit={onSubmit} className="flex flex-col gap-4">
+          <PromptField
+            ref={inputRef}
+            label={current.label}
+            hint={current.hint}
+            type={current.type}
+            autoComplete={current.autoComplete}
+            controlClassName={controlClass}
+            value={values[question] ?? ""}
+            onChange={setValue}
+          />
+          <div className={cn("flex gap-2", question === 0 && "justify-end")}>
+            {question > 0 ? (
+              <Button
+                type="button"
+                variant="outline"
+                className="h-11 px-4 active:translate-y-px sm:h-10"
+                onClick={back}
+                disabled={busy}
               >
-                {current.label}
-              </h1>
-              {current.optional ? <Badge>Optional</Badge> : null}
-            </div>
-            <p className="mt-2 text-sm leading-6 text-pretty text-muted-foreground">
-              {current.description}
-            </p>
+                <ArrowLeft aria-hidden />
+                Back
+              </Button>
+            ) : null}
+            <Button
+              type="submit"
+              className="h-11 flex-1 active:translate-y-px sm:h-10"
+              disabled={busy || disabled}
+            >
+              {busy ? (
+                <>
+                  <Loader2 aria-hidden className="size-4 motion-safe:animate-spin" />
+                  Creating account…
+                </>
+              ) : question === 2 ? (
+                "Finish"
+              ) : (
+                "Continue"
+              )}
+            </Button>
           </div>
-
-          {finishError && <ErrorAlert message={finishError} />}
-
-          {step === 0 && <AdminStep onNext={advanceFromAdmin} />}
-          {step === 1 && (
-            <BusinessStep draft={business} onDraft={setBusiness} onBack={back} onNext={advance} />
-          )}
-          {step === 2 && (
-            <LlmStep
-              providers={providers}
-              draft={llm}
-              onDraft={setLlm}
-              onBack={back}
-              onNext={advance}
-            />
-          )}
-
-          {finishing && (
-            <p role="status" className="flex items-center gap-2 text-sm text-muted-foreground">
-              <Loader2 aria-hidden className="size-4 motion-safe:animate-spin" />
-              Finishing setup…
-            </p>
-          )}
-        </div>
+        </form>
       </div>
     </main>
   );

--- a/apps/web/app/tokens.css
+++ b/apps/web/app/tokens.css
@@ -102,6 +102,11 @@
   --code-boolean: oklch(0.5 0.13 30);
   --code-null: oklch(0.58 0 0);
   --code-redacted: oklch(0.6 0.05 75);
+
+  /* Onboarding growth. Not in the categorical/status/run families: a seed and a stem are not
+     data, content status, or execution state — just what the tulip is made of. */
+  --tulip-stem: oklch(0.5 0.11 150);
+  --tulip-seed: oklch(0.52 0.04 75);
 }
 
 [data-sidebar="collapsed"] {
@@ -190,4 +195,7 @@
   --code-boolean: oklch(0.75 0.12 30);
   --code-null: oklch(0.6 0 0);
   --code-redacted: oklch(0.72 0.06 75);
+
+  --tulip-stem: oklch(0.68 0.1 150);
+  --tulip-seed: oklch(0.62 0.03 75);
 }

--- a/metadata/terminologies.md
+++ b/metadata/terminologies.md
@@ -99,7 +99,9 @@ Never let these bleed: UI/URL never say "conversation"; domain/DB never say "cha
 | Closing a stored Assertion's validity because a newer one replaced it | **Contradiction** | `MemoryContradictionPort` | — | — | closes `valid_to`, never deletes; scoped, trust-ranked, and offered-ids-only; ⛔ "overwrite", "conflict resolution" |
 | Asking what was true at a past moment | **Point-in-time Recall** | `validAt` | — | — | includes superseded Assertions whose valid interval covers the moment; ⛔ "time travel", "history query" |
 | Assembled model-input window for a turn | **Context** | `Context` | — | — | the Context Engine (assembly, compaction); ≠ Memory |
-| First-run setup wizard | **Onboarding** | `Onboarding` | `/onboarding` | "Onboarding" | |
+| First-run setup wizard | **Onboarding** | `Onboarding` | `/onboarding` | "Onboarding" | route rename from `/setup` deferred — `/setup` is still named in ~10 published docs pages and `apps/web/app/routes/_app.tsx`; tracked in Rename backlog below |
+| The persistent post-login onboarding assistant | **Companion** | `OnboardingCompanion` | — | "Companion" | floating bottom-right ≥`sm`, top-bar icon button below it; never auto-opens; ⛔ "clippy", "mascot", "tour", "walkthrough" |
+| One thing the Companion asks the operator or a user to supply | **Quest** | `Quest` | `/api/v1/onboarding/quests` | "Quest" | tiered: hardcoded gate, derived checklist, AI-generated profile gap; dismissal is per-quest, never global |
 | Model Context Protocol (external tool servers) | **MCP** | `MCP` | — | "MCP" | acronym, verbatim |
 | A governed model routing record derived from Soul Config | **ModelProfile** | `ModelProfile` | `/api/v1/model-profiles` | "Model profile" | one word, `PascalCase` — synthesized deterministically from `soul.yaml#llm` and pinned into immutable bundles; holds provider/model, capability, modality, constraints, budgets, fallbacks. There is no authored `models/` directory. ⛔ "tier" as the routing unit — retired |
 | A named effort level a participant may pick | **Effort Preset** | `EffortPreset` | — | "Auto"/"Fast"/"Balanced"/"Thorough" | the ONLY model concept a user sees; maps to a ModelProfile ref, one marked default. ⛔ "quick"/"standard"/"complex" — retired |
@@ -165,3 +167,12 @@ URL, UI, and docs. Migration `v18` renamed the physical Knowledge tables/columns
 5. **Integration**: `SoulIntegration.connection`→`config` (file `connection.yaml`→
    `config.yaml`). "connection" now means only a DB pool / SSE stream.
 6. **Skill**: `capability`-as-synonym removed from Skill Forge copy.
+
+## Rename backlog
+
+1. **`/setup` → `/onboarding`**: canonical route decided above but not yet applied. The route,
+   its file (`apps/web/app/routes/setup.tsx`), and its redirect target
+   (`apps/web/app/routes/_app.tsx`) still say `setup`, as do ~10 published `apps/docs` pages
+   (installation, deploy/coolify, deploy/headless, deploy/tls, getting-started, troubleshooting,
+   concepts/setup, production-checklist). Rename is a docs sweep, not just a route change —
+   scope it as its own change.

--- a/packages/llm/src/llm-service.ts
+++ b/packages/llm/src/llm-service.ts
@@ -159,6 +159,11 @@ export class LlmService {
     return this.byModelId.has(id);
   }
 
+  /** Whether any provider built at all, e.g. to gate a "add a provider key" onboarding quest. */
+  isConfigured(): boolean {
+    return this.configured;
+  }
+
   /** The pinned spec for a configured model id, for cost attribution and capability derivation. */
   specFor(id: string): ModelSpec | undefined {
     return this.entryByModelId.get(id)?.spec;

--- a/scripts/test/browser-smoke.mjs
+++ b/scripts/test/browser-smoke.mjs
@@ -101,22 +101,13 @@ try {
   if (onSetup) {
     log("running the setup wizard");
 
-    // Step 1 — admin account (email, password, confirm).
+    // One question per screen: name, then email, then password, then Finish.
+    await page.locator('input[type="text"]').fill("Smoke Test");
+    await page.getByRole("button", { name: "Continue" }).click();
     await page.locator('input[type="email"]').fill(EMAIL);
-    await page.locator('input[type="password"]').nth(0).fill(PASSWORD);
-    await page.locator('input[type="password"]').nth(1).fill(PASSWORD);
     await page.getByRole("button", { name: "Continue" }).click();
-
-    // Step 2 — business profile. The description is optional; the name is not. Anchored to the
-    // field id (the label's htmlFor target), not the placeholder: placeholder text is example
-    // copy, and rewriting it is what silently broke this step once already.
-    await page.locator("#setup-business-name").fill("Smoke Test Co");
-    await page.getByRole("button", { name: "Continue" }).click();
-
-    // Step 3 — LLM config, and the last step. Skipped: no API key in CI, and the chat crash we
-    // are hunting happens client-side before any model call. Skipping the final step is what
-    // completes setup, so there is nothing to click after this.
-    await page.getByRole("button", { name: /Skip for now/i }).click();
+    await page.locator('input[type="password"]').fill(PASSWORD);
+    await page.getByRole("button", { name: "Finish" }).click();
   } else {
     log("instance already configured — signing in");
     await page.getByLabel("email").fill(EMAIL);

--- a/scripts/test/browser/fixtures.ts
+++ b/scripts/test/browser/fixtures.ts
@@ -98,16 +98,13 @@ export async function completeOrSignIn(page: Page): Promise<void> {
   const password = "smoke-password-123";
 
   if (onSetup) {
+    // One question per screen: name, then email, then password, then Finish.
+    await page.locator('input[type="text"]').fill("Smoke Test");
+    await page.getByRole("button", { name: "Continue" }).click();
     await page.locator('input[type="email"]').fill(email);
-    await page.locator('input[type="password"]').nth(0).fill(password);
-    await page.locator('input[type="password"]').nth(1).fill(password);
     await page.getByRole("button", { name: "Continue" }).click();
-    // Anchored to the field id (the label's htmlFor target), not the placeholder: placeholder
-    // text is example copy, and rewriting it is what silently broke this step once already.
-    await page.locator("#setup-business-name").fill("Smoke Test Co");
-    await page.getByRole("button", { name: "Continue" }).click();
-    // The LLM step is the last one — skipping it completes setup.
-    await page.getByRole("button", { name: /Skip for now/i }).click();
+    await page.locator('input[type="password"]').fill(password);
+    await page.getByRole("button", { name: "Finish" }).click();
   } else {
     await page.getByLabel("email").fill(email);
     await page.getByLabel("password").fill(password);


### PR DESCRIPTION
## Summary
- Rewrites pre-login `/setup` as a one-question-at-a-time flow (name, email, password), with a growth-stage tulip illustration replacing the step counter.
- Adds a persistent in-app Companion that collects everything else — provider key, business name (required)/description (optional, skippable), setup checklist, AI-suggested profile gaps — as small dismissible quests instead of front-loading it before first login.
- Companion trigger uses the existing brand mark for its avatar (the growth SVG's bloom doesn't read at avatar size).

## Test plan
- [x] `pnpm exec biome check --write` on changed dirs
- [x] `pnpm --filter @tulipfarm/api typecheck` / `test src/onboarding src/setup`
- [x] `pnpm --filter @tulipfarm/web typecheck` / `test app/routes/setup.test.tsx app/components/onboarding`
- [x] Manual QA in Chrome: quest gate (provider key + business name only), Companion avatar legibility, tulip growth rendering at each stage
- [x] Subagent code review — fixed missing admin-role check and business-name length cap on the quest-answer route; fixed generic error message swallowing server detail