### PR TITLE
feat(llm): request the prompt caching the model path already meters

### DIFF
--- a/apps/worker/src/model.test.ts
+++ b/apps/worker/src/model.test.ts
@@ -1089,3 +1089,85 @@ describe("LlmModelPort — the zero-output diagnostic is not a content leak", ()
     expect(digest(a)).toBeDefined();
   });
 });
+
+/**
+ * The metering half of prompt caching shipped long before the asking half. These pin the ask
+ * itself: the decision is unit-tested in `@tulipfarm/llm`, so what matters here is that it reaches
+ * the provider wire, and that routing's refusal survives the trip.
+ */
+describe("LlmModelPort prompt caching", () => {
+  const LONG_SYSTEM = "s".repeat(1024 * 5);
+
+  async function promptFor(overrides: {
+    cacheAllowed?: boolean;
+    provider?: string;
+    system?: string;
+    raw?: boolean;
+  }): Promise<Record<string, unknown>[]> {
+    const mock = new MockLanguageModelV4({
+      doStream: async () => ({
+        stream: simulateReadableStream<StreamPart>({
+          chunks: [...textParts("t1", ["ok"]), FINISH],
+        }),
+      }),
+    });
+    const port = new LlmModelPort({
+      model: async (selector): Promise<LlmModelResolution> => ({
+        kind: "available",
+        price: TEST_PRICE,
+        model: mock as unknown as LanguageModel,
+        provider: overrides.provider ?? "anthropic",
+        routing: overrides.raw
+          ? { outcome: "raw_model", selector, resolution: "raw_model_id", modelId: selector }
+          : {
+              outcome: "selected",
+              selector,
+              resolution: "effort_preset",
+              profileId: "primary",
+              chain: [{ profileId: "primary", modelId: "claude-sonnet-5" }],
+              cacheAllowed: overrides.cacheAllowed ?? true,
+              rejectedFallbacks: [],
+            },
+      }),
+    });
+    await port.invoke(
+      request({
+        messages: [
+          { role: "system", content: overrides.system ?? LONG_SYSTEM },
+          { role: "user", content: "hello" },
+        ],
+      })
+    );
+    return mock.doStreamCalls[0]?.prompt as unknown as Record<string, unknown>[];
+  }
+
+  const breakpointOn = (prompt: Record<string, unknown>[]): unknown =>
+    prompt.find((m) => m.role === "system")?.providerOptions;
+
+  it("asks the provider to cache a long, allowed instruction prefix", async () => {
+    expect(breakpointOn(await promptFor({}))).toEqual({
+      anthropic: { cacheControl: { type: "ephemeral" } },
+    });
+  });
+
+  it("sends no breakpoint when routing withheld caching, which is how sensitive prompts stay out", async () => {
+    expect(breakpointOn(await promptFor({ cacheAllowed: false }))).toBeUndefined();
+  });
+
+  it("sends no breakpoint for a raw model id, because no profile checked sensitivity", async () => {
+    expect(breakpointOn(await promptFor({ raw: true }))).toBeUndefined();
+  });
+
+  it("sends no breakpoint to a provider that caches without being asked", async () => {
+    expect(breakpointOn(await promptFor({ provider: "openai" }))).toBeUndefined();
+  });
+
+  it("sends no breakpoint on a prefix too short for the provider to cache", async () => {
+    expect(breakpointOn(await promptFor({ system: "you are helpful" }))).toBeUndefined();
+  });
+
+  it("still delivers the instructions when nothing is cached", async () => {
+    const prompt = await promptFor({ cacheAllowed: false });
+    expect(prompt.find((m) => m.role === "system")?.content).toBe(LONG_SYSTEM);
+  });
+});

--- a/apps/worker/src/model.ts
+++ b/apps/worker/src/model.ts
@@ -11,8 +11,8 @@ import type {
   ModelUsage,
 } from "@tulipfarm/agent-runtime";
 import { deriveModelRequirements, ModelInvocationError } from "@tulipfarm/agent-runtime";
-import type { CostBasis, PrincipalRef } from "@tulipfarm/llm";
-import { classifyProviderError } from "@tulipfarm/llm";
+import type { CostBasis, PrincipalRef, PromptCacheDecision } from "@tulipfarm/llm";
+import { classifyProviderError, decidePromptCache } from "@tulipfarm/llm";
 import type { ResolvedLimits } from "@tulipfarm/run-kernel";
 import {
   asEffortPreset,
@@ -179,6 +179,17 @@ export class LlmModelPort implements ModelPort, ModelCallReceiptSource {
     resolution: Extract<LlmModelResolution, { kind: "available" }>
   ): AsyncIterable<ModelStreamChunk> {
     const { instructions, messages } = splitPrompt(request.messages);
+    // Caching is charged on this path whether or not it was asked for, so the ask happens here
+    // rather than being left to whatever each provider does by default.
+    const prompt = withCacheBreakpoint(
+      instructions,
+      decidePromptCache({
+        provider: resolution.provider,
+        modelId: routedModelId(resolution.routing),
+        cacheAllowed: routedCacheAllowed(resolution.routing),
+        prefixChars: stablePrefixChars(instructions, request.tools),
+      })
+    );
     const startedAt = this.now();
     // Held for the whole call: releasing early would let the next turn in while this one is
     // still occupying a provider connection.
@@ -208,7 +219,7 @@ export class LlmModelPort implements ModelPort, ModelCallReceiptSource {
       result = streamText({
         model: resolution.model,
         messages,
-        ...(instructions.length === 0 ? {} : { instructions }),
+        ...(prompt.length === 0 ? {} : { instructions: prompt }),
         ...(request.tools === undefined || request.tools.length === 0
           ? {}
           : { tools: toToolSet(request.tools) }),
@@ -492,6 +503,49 @@ function toOutput(
     };
   }
   return { kind: "text", text };
+}
+
+/** Routing's caching allowance; `undefined` when no profile decided, which is not the same as no. */
+function routedCacheAllowed(routing: RunEventPayloads["model.routed"]): boolean | undefined {
+  return routing.outcome === "selected" ? routing.cacheAllowed : undefined;
+}
+
+/**
+ * Size of the part of the prompt that repeats unchanged between turns.
+ *
+ * Tool declarations sit ahead of the instructions in the provider's cacheable prefix and are just
+ * as stable, so leaving them out would under-measure a prompt that is mostly tool schemas.
+ */
+function stablePrefixChars(
+  instructions: readonly SystemModelMessage[],
+  tools: ModelInvocationRequest["tools"]
+): number {
+  const instructionChars = instructions.reduce((total, m) => total + m.content.length, 0);
+  const toolChars = (tools ?? []).reduce(
+    (total, t) =>
+      total + t.name.length + (t.description?.length ?? 0) + JSON.stringify(t.inputSchema).length,
+    0
+  );
+  return instructionChars + toolChars;
+}
+
+/**
+ * Marks the end of the stable prefix so the provider caches everything up to it.
+ *
+ * Only the last instruction is marked: a breakpoint covers everything before it, so marking each
+ * block would spend the provider's limited breakpoints for no extra coverage. The annotation is
+ * namespaced by provider, so a chain that falls back across vendors carries an option the
+ * answering provider ignores rather than one it misreads.
+ */
+function withCacheBreakpoint(
+  instructions: readonly SystemModelMessage[],
+  decision: PromptCacheDecision
+): SystemModelMessage[] {
+  if (decision.kind === "skip") return [...instructions];
+  const last = instructions.length - 1;
+  return instructions.map((message, index) =>
+    index === last ? { ...message, providerOptions: decision.providerOptions } : message
+  );
 }
 
 /** Convert loop transcript to SDK prompt; tool results stay attributed to their tool calls. */

--- a/packages/llm/AGENTS.md
+++ b/packages/llm/AGENTS.md
@@ -17,6 +17,7 @@ subscription-CLI model adapters.
 | `src/fallback.ts`, `src/provider-error.ts` | Fallback order and hard/transient failures. |
 | `src/embeddings.ts`, `src/embedding-provider.ts` | Embedding providers and execution. |
 | `src/model-spec.ts`, `src/pricing.ts` | Model metadata and cost helpers. |
+| `src/prompt-cache.ts` | Whether a prompt prefix asks for provider-side caching. |
 | `src/cli/` | Subscription Provider adapters, jail, transcripts, JSON mode, specs. |
 
 ## Rules
@@ -37,6 +38,8 @@ subscription-CLI model adapters.
 - No direct `console.*`: every notice goes through the injected `LlmLogger`/`EmbeddingLogger`, or
   it misses the log viewer and redaction.
 - Cached input token semantics differ by vendor; report cache read as a breakdown, never an addend.
+- Prompt caching is requested only through `decidePromptCache`, which fails closed: an absent
+  `cacheAllowed` means no profile checked sensitivity, so it must never read as yes.
 - Do not pass ambient vendor env credentials through the CLI jail; only saved credentials.
 - Timed-out CLI turns must throw, not finish as a normal `stop`.
 - Subscription Providers are models only: disable shell, file tools, web, and ambient capability.

--- a/packages/llm/src/index.ts
+++ b/packages/llm/src/index.ts
@@ -40,6 +40,13 @@ export {
 } from "./pricing";
 export { SecretsPrincipalCredentials } from "./principal-credentials";
 export {
+  decidePromptCache,
+  type PromptCacheAnnotation,
+  type PromptCacheDecision,
+  type PromptCacheInput,
+  type PromptCacheSkip,
+} from "./prompt-cache";
+export {
   createModel,
   type PrincipalCredentialResolver,
   type PrincipalRef,

--- a/packages/llm/src/prompt-cache.test.ts
+++ b/packages/llm/src/prompt-cache.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { decidePromptCache, type PromptCacheInput } from "./prompt-cache";
+
+/** A prefix comfortably over Anthropic's 1024-token minimum at the pessimistic 5 chars/token. */
+const LONG_PREFIX = 1024 * 5;
+
+const input = (overrides: Partial<PromptCacheInput> = {}): PromptCacheInput => ({
+  provider: "anthropic",
+  modelId: "claude-sonnet-4-5",
+  cacheAllowed: true,
+  prefixChars: LONG_PREFIX,
+  ...overrides,
+});
+
+describe("decidePromptCache", () => {
+  it("asks an explicit provider to cache a long enough allowed prefix", () => {
+    expect(decidePromptCache(input())).toEqual({
+      kind: "annotate",
+      providerOptions: { anthropic: { cacheControl: { type: "ephemeral" } } },
+    });
+  });
+
+  it("honours routing's refusal, which is how a sensitive prompt stays out of a cache", () => {
+    expect(decidePromptCache(input({ cacheAllowed: false }))).toEqual({
+      kind: "skip",
+      reason: "routing_withheld",
+    });
+  });
+
+  it("fails closed when no profile decided, because nothing then checked sensitivity", () => {
+    expect(decidePromptCache(input({ cacheAllowed: undefined }))).toEqual({
+      kind: "skip",
+      reason: "routing_unknown",
+    });
+  });
+
+  it("leaves implicitly-caching providers alone rather than sending an inert option", () => {
+    for (const provider of ["openai", "azure", "claude-code", "codex"]) {
+      expect(decidePromptCache(input({ provider }))).toEqual({
+        kind: "skip",
+        reason: "provider_implicit",
+      });
+    }
+  });
+
+  it("refuses to guess a wire format for a provider with no known contract", () => {
+    for (const provider of ["openai-compatible", "something-new", undefined]) {
+      expect(decidePromptCache(input({ provider }))).toEqual({
+        kind: "skip",
+        reason: "provider_unknown",
+      });
+    }
+  });
+
+  it("will not pay the cache-write premium on a prefix too short to be cached", () => {
+    expect(decidePromptCache(input({ prefixChars: LONG_PREFIX - 1 }))).toEqual({
+      kind: "skip",
+      reason: "prefix_too_short",
+    });
+  });
+
+  it("applies Haiku's doubled minimum, so a Sonnet-sized prefix is not annotated for it", () => {
+    expect(decidePromptCache(input({ modelId: "claude-haiku-4-5" }))).toEqual({
+      kind: "skip",
+      reason: "prefix_too_short",
+    });
+    expect(
+      decidePromptCache(input({ modelId: "claude-haiku-4-5", prefixChars: 2048 * 5 }))
+    ).toEqual({
+      kind: "annotate",
+      providerOptions: { anthropic: { cacheControl: { type: "ephemeral" } } },
+    });
+  });
+
+  it("checks the allowance before the provider, so a refusal cannot be routed around", () => {
+    expect(decidePromptCache(input({ cacheAllowed: false, provider: "openai" }))).toEqual({
+      kind: "skip",
+      reason: "routing_withheld",
+    });
+  });
+});

--- a/packages/llm/src/prompt-cache.ts
+++ b/packages/llm/src/prompt-cache.ts
@@ -1,0 +1,110 @@
+/**
+ * Decides whether a prompt's stable prefix should ask the provider to cache it.
+ *
+ * Cache read, cache write and reasoning tokens were already captured, priced and charged on this
+ * path — but nothing ever *requested* caching, so hits were whatever the provider happened to do
+ * by default. Asking is not free in either direction, which is why the decision lives here rather
+ * than at the call site:
+ *
+ * - A cache **write** costs roughly 25% more than an ordinary input token, so annotating a prefix
+ *   too short for the provider to cache pays a premium for nothing.
+ * - A sensitive request must not have its prompt written into a provider-side cache at all. That
+ *   is already decided during routing; this module's job is to honour it rather than re-derive it.
+ */
+
+/** Why a prompt was left unannotated. Every branch is a deliberate no, never a default. */
+export type PromptCacheSkip =
+  /** Routing decided against it — the model declares no caching support, or the request is sensitive. */
+  | "routing_withheld"
+  /** No profile decided. A raw model id names a model without a governance posture, so nothing checked sensitivity. */
+  | "routing_unknown"
+  /** The provider caches without being asked; an annotation would be inert. */
+  | "provider_implicit"
+  /** No known caching contract for this provider, so the wire format is a guess. */
+  | "provider_unknown"
+  /** Below the provider's minimum cacheable prefix — the write premium could never be earned back. */
+  | "prefix_too_short";
+
+/** Provider options that mark the end of a cacheable prefix, in the shape the SDK passes through. */
+export type PromptCacheAnnotation = {
+  readonly anthropic: { readonly cacheControl: { readonly type: "ephemeral" } };
+};
+
+export type PromptCacheDecision =
+  | { readonly kind: "annotate"; readonly providerOptions: PromptCacheAnnotation }
+  | { readonly kind: "skip"; readonly reason: PromptCacheSkip };
+
+export interface PromptCacheInput {
+  /** The provider the head of the chain belongs to. */
+  readonly provider: string | undefined;
+  /** The model the head of the chain names; minimum cacheable length varies by model family. */
+  readonly modelId: string | undefined;
+  /**
+   * Routing's allowance, `primary.allowCaching && !requirements.sensitive`.
+   *
+   * `undefined` means no profile decided, which is not the same as `true`: it means nothing
+   * checked sensitivity, so the only safe answer is no.
+   */
+  readonly cacheAllowed: boolean | undefined;
+  /** Size of the stable prefix — instructions plus tool declarations — in characters. */
+  readonly prefixChars: number;
+}
+
+/** How a provider is asked to cache, if at all. */
+type CacheContract = "explicit" | "implicit" | "unknown";
+
+const PROVIDER_CACHE_CONTRACT: Readonly<Record<string, CacheContract>> = {
+  anthropic: "explicit",
+  openai: "implicit",
+  azure: "implicit",
+  // The subscription CLIs cache inside their own agent SDK and are handed a transcript, not a
+  // provider-options payload, so there is nothing here to annotate.
+  "claude-code": "implicit",
+  codex: "implicit",
+  // A compatible endpoint may proxy anything, so neither the contract nor the minimum is knowable.
+  "openai-compatible": "unknown",
+};
+
+/** Anthropic declines to cache a shorter prefix rather than erroring, so this must be respected. */
+const ANTHROPIC_MIN_CACHEABLE_TOKENS = 1024;
+/** Haiku models require twice the prefix before Anthropic will cache it. */
+const ANTHROPIC_HAIKU_MIN_CACHEABLE_TOKENS = 2048;
+
+/**
+ * Deliberately pessimistic characters-per-token.
+ *
+ * English averages closer to 4. Dividing by a larger number under-counts tokens, so a prefix has
+ * to be comfortably over the provider minimum before it is annotated. Erring the other way would
+ * pay the write premium on prompts the provider was never going to cache.
+ */
+const CHARS_PER_TOKEN = 5;
+
+const EPHEMERAL: PromptCacheAnnotation = { anthropic: { cacheControl: { type: "ephemeral" } } };
+
+/** The minimum cacheable prefix for a model, in characters. */
+function minCacheableChars(modelId: string | undefined): number {
+  const tokens = /haiku/i.test(modelId ?? "")
+    ? ANTHROPIC_HAIKU_MIN_CACHEABLE_TOKENS
+    : ANTHROPIC_MIN_CACHEABLE_TOKENS;
+  return tokens * CHARS_PER_TOKEN;
+}
+
+/**
+ * Whether to annotate the stable prompt prefix for provider-side caching.
+ *
+ * Fail-closed on every unknown: an un-annotated prompt costs full price, while a wrongly
+ * annotated one can write a sensitive prefix into a cache this deployment does not control.
+ */
+export function decidePromptCache(input: PromptCacheInput): PromptCacheDecision {
+  if (input.cacheAllowed === undefined) return { kind: "skip", reason: "routing_unknown" };
+  if (!input.cacheAllowed) return { kind: "skip", reason: "routing_withheld" };
+
+  const contract = PROVIDER_CACHE_CONTRACT[input.provider ?? ""] ?? "unknown";
+  if (contract === "implicit") return { kind: "skip", reason: "provider_implicit" };
+  if (contract === "unknown") return { kind: "skip", reason: "provider_unknown" };
+
+  if (input.prefixChars < minCacheableChars(input.modelId)) {
+    return { kind: "skip", reason: "prefix_too_short" };
+  }
+  return { kind: "annotate", providerOptions: EPHEMERAL };
+}

--- a/scripts/model-path-authz.test.ts
+++ b/scripts/model-path-authz.test.ts
@@ -184,4 +184,26 @@ describe("the embedding path is metered, bounded and structurally logged", () =>
     expect(model).toContain("lastMessage: describeMessage(messages.at(-1))");
     expect(model).not.toContain("lastMessage: messages.at(-1)");
   });
+
+  it("asks for the prompt caching it already meters, and only where routing allowed it", () => {
+    // Cache read and write tokens were captured, priced and charged long before anything requested
+    // caching, so the ledger reported a decision nobody had made. The annotation must reach the
+    // prompt actually sent — building it and passing `instructions` would look identical here.
+    const model = read("apps/worker/src/model.ts");
+    expect(model).toContain("decidePromptCache({");
+    expect(model).toContain("cacheAllowed: routedCacheAllowed(resolution.routing)");
+    expect(model).toContain("instructions: prompt");
+    expect(model).not.toMatch(/\binstructions: instructions\b|\binstructions,\s*\n\s*\.\.\.\(/);
+  });
+
+  it("refuses to cache a prompt no profile cleared, so sensitivity is never assumed", () => {
+    // `cacheAllowed` is `allowCaching && !sensitive`. A raw model id bypasses profile selection
+    // entirely, so `undefined` means nothing checked sensitivity — it must not read as yes.
+    const cache = read("packages/llm/src/prompt-cache.ts");
+    expect(cache).toContain('if (input.cacheAllowed === undefined) return { kind: "skip"');
+    const model = read("apps/worker/src/model.ts");
+    expect(model).toMatch(
+      /routedCacheAllowed[\s\S]{0,200}routing\.outcome === "selected" \? routing\.cacheAllowed : undefined/
+    );
+  });
 });


### PR DESCRIPTION
## Summary

<!-- What changed, and why. Link the driving issue if one exists. -->

## Test plan

<!-- Commands you ran, or manual steps / screenshots for UI changes. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (or the scoped `--filter` you actually ran)

## Checklist

- [ ] PR title follows Conventional Commits (`type(scope): subject`) — CI checks this
- [ ] Scoped to one logical change
- [ ] Tests added/updated for the behavior that changed
