### PR TITLE
fix(llm): classify shed provider calls as unavailable 

### DIFF
--- a/apps/worker/AGENTS.md
+++ b/apps/worker/AGENTS.md
@@ -62,6 +62,8 @@ reconciliation, turn execution, delivery classification, projections, and outbox
 - Delivery classifier isolate gets no grants; keep API and worker hook bundle basenames distinct.
 - Bind links and reply text never cross from API to worker; replies are at-least-once.
 - Effort inference happens once per Run for `auto`; classifier tokens are unmetered.
+- Gate rejections throw `ProviderUnavailableError` from `@tulipfarm/llm`; a worker-local error
+  class classifies as a generic `model_error` and the participant is told nothing useful.
 - `test/process/` boots the bundled worker; run these tests with `--maxWorkers=1`.
 - Worker process tests can leak dev env through `apps/worker/.env.local`; check before blaming code.
 - May import listed `@tulipfarm/*` packages, never another app; see dependency rules below.

--- a/apps/worker/src/model-gate.test.ts
+++ b/apps/worker/src/model-gate.test.ts
@@ -1,5 +1,6 @@
+import { ProviderUnavailableError } from "@tulipfarm/llm";
 import { describe, expect, it, vi } from "vitest";
-import { ProviderGate, ProviderUnavailableError } from "./model-gate";
+import { ProviderGate } from "./model-gate";
 
 const settled = () => new Promise((resolve) => setImmediate(resolve));
 

--- a/apps/worker/src/model-gate.ts
+++ b/apps/worker/src/model-gate.ts
@@ -1,3 +1,4 @@
+import { ProviderUnavailableError } from "@tulipfarm/llm";
 import { CircuitBreaker } from "@tulipfarm/observability";
 
 /** Parallel in-flight calls allowed against one provider before further turns queue. */
@@ -18,16 +19,6 @@ const INFRASTRUCTURE_FAILURES = new Set([
   "model_rate_limited",
   "model_error",
 ]);
-
-export class ProviderUnavailableError extends Error {
-  constructor(
-    readonly provider: string,
-    reason: string
-  ) {
-    super(`provider ${provider} is not accepting calls: ${reason}`);
-    this.name = "ProviderUnavailableError";
-  }
-}
 
 /** A held slot. `release` must run exactly once, or the provider leaks capacity. */
 export interface ModelCallLease {

--- a/apps/worker/src/model.test.ts
+++ b/apps/worker/src/model.test.ts
@@ -1245,16 +1245,24 @@ describe("LlmModelPort — a call the provider gate refused", () => {
   });
 
   it("reports a call that never got a slot as unavailable", async () => {
-    const gate = new ProviderGate({ maxConcurrency: 1, queueTimeoutMs: 5 });
-    // Another turn holds the only slot for longer than this one is willing to queue.
-    await gate.acquire("openai");
-    const queued = healthyModel();
+    vi.useFakeTimers();
+    try {
+      const gate = new ProviderGate({ maxConcurrency: 1, queueTimeoutMs: 1_000 });
+      // Another turn holds the only slot for longer than this one is willing to queue.
+      await gate.acquire("openai");
+      const queued = healthyModel();
 
-    await expect(gatedPort(gate, queued).invoke(request())).rejects.toMatchObject({
-      name: "ModelInvocationError",
-      reason: "model_provider_unavailable",
-    });
-    expect(queued.doStreamCalls).toHaveLength(0);
+      const assertion = expect(gatedPort(gate, queued).invoke(request())).rejects.toMatchObject({
+        name: "ModelInvocationError",
+        reason: "model_provider_unavailable",
+      });
+      await vi.advanceTimersByTimeAsync(1_001);
+      await assertion;
+
+      expect(queued.doStreamCalls).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("is the reason the Turn reports, so the participant is told the provider is down", async () => {

--- a/apps/worker/src/model.test.ts
+++ b/apps/worker/src/model.test.ts
@@ -1,18 +1,24 @@
 import type {
+  AgentLoopInput,
   ModelInvocationRequest,
   ModelRequirements,
   ModelRequirementsPolicy,
   ModelStreamChunk,
 } from "@tulipfarm/agent-runtime";
-import { ModelInvocationError } from "@tulipfarm/agent-runtime";
+import {
+  AgentLoop,
+  InMemoryLoopCheckpointStore,
+  ModelInvocationError,
+} from "@tulipfarm/agent-runtime";
 import { type CostBasis, LlmProviderError } from "@tulipfarm/llm";
 import type { EffortRung, RunEventEffortInference } from "@tulipfarm/schema";
-import type { LanguageModel } from "ai";
+import { APICallError, type LanguageModel } from "ai";
 import { MockLanguageModelV4, simulateReadableStream } from "ai/test";
 import { describe, expect, it, vi } from "vitest";
 import type { EffortInferencePort } from "./effort-inference";
 import type { LlmModelResolution } from "./llm";
 import { LlmModelPort } from "./model";
+import { type ModelCallGate, ProviderGate } from "./model-gate";
 import type { SpendSink } from "./observability";
 
 /**
@@ -1169,5 +1175,114 @@ describe("LlmModelPort prompt caching", () => {
   it("still delivers the instructions when nothing is cached", async () => {
     const prompt = await promptFor({ cacheAllowed: false });
     expect(prompt.find((m) => m.role === "system")?.content).toBe(LONG_SYSTEM);
+  });
+});
+
+/**
+ * The gate refuses a call before the provider is ever dialled, so nothing in the stream's own
+ * failure handling sees it. These pin the whole chain — gate to Turn — because the participant
+ * copy for a shed provider already existed and this path could never reach it.
+ */
+describe("LlmModelPort — a call the provider gate refused", () => {
+  const gatedPort = (gate: ModelCallGate, mock: MockLanguageModelV4): LlmModelPort =>
+    new LlmModelPort({
+      gate,
+      model: async (selector): Promise<LlmModelResolution> => ({
+        kind: "available",
+        price: TEST_PRICE,
+        provider: "openai",
+        model: mock as unknown as LanguageModel,
+        routing: {
+          outcome: "raw_model",
+          selector,
+          resolution: "raw_model_id",
+          modelId: selector,
+        },
+      }),
+    });
+
+  /** Not retryable, so the call fails once and opens the breaker at a known count. */
+  const rateLimited = (): APICallError =>
+    new APICallError({
+      message: "http 429",
+      url: "https://provider.test/v1/responses",
+      requestBodyValues: {},
+      statusCode: 429,
+      responseBody: "{}",
+      isRetryable: false,
+    });
+
+  const failingModel = (): MockLanguageModelV4 =>
+    new MockLanguageModelV4({
+      doStream: async () => {
+        throw rateLimited();
+      },
+    });
+
+  const healthyModel = (): MockLanguageModelV4 =>
+    new MockLanguageModelV4({
+      doStream: async () => ({
+        stream: simulateReadableStream<StreamPart>({
+          chunks: [...textParts("t1", ["hi"]), FINISH],
+        }),
+      }),
+    });
+
+  it("reports a shed provider as unavailable, not as a generic model failure", async () => {
+    const gate = new ProviderGate({ failureThreshold: 1, recoveryAfterMs: 60_000 });
+
+    await expect(gatedPort(gate, failingModel()).invoke(request())).rejects.toMatchObject({
+      name: "ModelInvocationError",
+      reason: "model_rate_limited",
+    });
+
+    const healthy = healthyModel();
+    await expect(gatedPort(gate, healthy).invoke(request())).rejects.toMatchObject({
+      name: "ModelInvocationError",
+      reason: "model_provider_unavailable",
+    });
+    expect(healthy.doStreamCalls).toHaveLength(0);
+  });
+
+  it("reports a call that never got a slot as unavailable", async () => {
+    const gate = new ProviderGate({ maxConcurrency: 1, queueTimeoutMs: 5 });
+    // Another turn holds the only slot for longer than this one is willing to queue.
+    await gate.acquire("openai");
+    const queued = healthyModel();
+
+    await expect(gatedPort(gate, queued).invoke(request())).rejects.toMatchObject({
+      name: "ModelInvocationError",
+      reason: "model_provider_unavailable",
+    });
+    expect(queued.doStreamCalls).toHaveLength(0);
+  });
+
+  it("is the reason the Turn reports, so the participant is told the provider is down", async () => {
+    const gate = new ProviderGate({ failureThreshold: 1, recoveryAfterMs: 60_000 });
+    const turn = (port: LlmModelPort): AgentLoop =>
+      new AgentLoop({
+        model: port,
+        tools: { dispatch: async () => ({ status: "succeeded", callId: "call-1", output: {} }) },
+        checkpoints: new InMemoryLoopCheckpointStore(),
+        events: { append: async () => {} },
+        budget: { consume: async () => ({ outcome: "allowed" }) },
+        isCancelled: async () => false,
+      });
+    const loopInput: AgentLoopInput = {
+      businessId: "biz-1",
+      runId: "run-1",
+      stateId: "state-1",
+      modelProfileId: "balanced",
+      contextDigest: "sha256:context",
+      guardrailDigest: "sha256:guardrail",
+      messages: [{ role: "user", content: "hello" }],
+      tools: [],
+      limits: { maxIterations: 1, maxToolCalls: 1, maxRepairAttempts: 1 },
+    };
+
+    await turn(gatedPort(gate, failingModel())).run(loopInput);
+    const outcome = await turn(gatedPort(gate, healthyModel())).run(loopInput);
+
+    expect(outcome).toMatchObject({ status: "failed", reason: "model_provider_unavailable" });
   });
 });

--- a/packages/llm/AGENTS.md
+++ b/packages/llm/AGENTS.md
@@ -28,6 +28,8 @@ subscription-CLI model adapters.
 - `chainModel(ids)` must execute the whole selected chain; do not collapse fallback to the head.
 - API-keyed providers read `entry.api_key_ref`: `env://VAR` from env, else `secrets.get(ref)`.
 - Fallback hard failures propagate: auth, `404`, abort. `429`, `5xx`, timeout fall through.
+- A call shed by admission control throws `ProviderUnavailableError`, never `LlmProviderError`:
+  that type means permanent, and a shed provider must stay retryable.
 - Bad Subscription Provider credentials throw `LlmProviderError("model_authentication_failed")`.
 - CLI usage reports are running totals, not deltas; never sum them.
 - Embedding failover is width-scoped: a standby may answer only if it declares the *same*

--- a/packages/llm/AGENTS.md
+++ b/packages/llm/AGENTS.md
@@ -28,8 +28,6 @@ subscription-CLI model adapters.
 - `chainModel(ids)` must execute the whole selected chain; do not collapse fallback to the head.
 - API-keyed providers read `entry.api_key_ref`: `env://VAR` from env, else `secrets.get(ref)`.
 - Fallback hard failures propagate: auth, `404`, abort. `429`, `5xx`, timeout fall through.
-- A call shed by admission control throws `ProviderUnavailableError`, never `LlmProviderError`:
-  that type means permanent, and a shed provider must stay retryable.
 - Bad Subscription Provider credentials throw `LlmProviderError("model_authentication_failed")`.
 - CLI usage reports are running totals, not deltas; never sum them.
 - Embedding failover is width-scoped: a standby may answer only if it declares the *same*

--- a/packages/llm/src/index.ts
+++ b/packages/llm/src/index.ts
@@ -56,4 +56,5 @@ export {
   classifyProviderError,
   LlmProviderError,
   type LlmProviderFailureReason,
+  ProviderUnavailableError,
 } from "./provider-error";

--- a/packages/llm/src/provider-error.test.ts
+++ b/packages/llm/src/provider-error.test.ts
@@ -1,7 +1,12 @@
 import type { LanguageModelV4, LanguageModelV4CallOptions } from "@ai-sdk/provider";
 import { APICallError, generateText, RetryError } from "ai";
 import { describe, expect, it, vi } from "vitest";
-import { ClassifiedLanguageModel, classifyProviderError, LlmProviderError } from "./provider-error";
+import {
+  ClassifiedLanguageModel,
+  classifyProviderError,
+  LlmProviderError,
+  ProviderUnavailableError,
+} from "./provider-error";
 
 function apiError(
   statusCode: number,
@@ -57,6 +62,12 @@ describe("classifyProviderError", () => {
     expect(classifyProviderError(apiError(429, {}))).toBe("model_rate_limited");
     expect(classifyProviderError(apiError(503, {}))).toBe("model_provider_unavailable");
     expect(classifyProviderError(new Error("secret provider detail"))).toBe("model_error");
+  });
+
+  it("classifies a call shed before it reached the provider as an outage", () => {
+    expect(classifyProviderError(new ProviderUnavailableError("openai", "circuit open"))).toBe(
+      "model_provider_unavailable"
+    );
   });
 });
 

--- a/packages/llm/src/provider-error.ts
+++ b/packages/llm/src/provider-error.ts
@@ -27,6 +27,25 @@ export class LlmProviderError extends Error {
   }
 }
 
+/**
+ * A call shed before it ever reached the provider: local admission control — the per-provider
+ * concurrency queue or its circuit breaker — refused to dial out.
+ *
+ * Deliberately not an `LlmProviderError`, which marks permanent failures the SDK must stop
+ * retrying. A shed call is transient by construction. It lives here rather than beside the gate
+ * that throws it because `classifyProviderError` is the only classification authority, and a
+ * package may not import from an application.
+ */
+export class ProviderUnavailableError extends Error {
+  constructor(
+    readonly provider: string,
+    reason: string
+  ) {
+    super(`provider ${provider} is not accepting calls: ${reason}`);
+    this.name = "ProviderUnavailableError";
+  }
+}
+
 function lastProviderError(error: unknown): unknown {
   return RetryError.isInstance(error) ? lastProviderError(error.lastError) : error;
 }
@@ -54,6 +73,7 @@ function errorCodes(error: APICallError): Set<string> {
 export function classifyProviderError(error: unknown): LlmProviderFailureReason {
   const providerError = lastProviderError(error);
   if (providerError instanceof LlmProviderError) return providerError.reason;
+  if (providerError instanceof ProviderUnavailableError) return "model_provider_unavailable";
   if (LoadAPIKeyError.isInstance(providerError)) return "model_authentication_failed";
   if (NoSuchModelError.isInstance(providerError)) return "model_not_found";
   if (!APICallError.isInstance(providerError)) return "model_error";


### PR DESCRIPTION
## Summary

<!-- What changed, and why. Link the driving issue if one exists. -->

## Test plan

<!-- Commands you ran, or manual steps / screenshots for UI changes. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (or the scoped `--filter` you actually ran)

## Checklist

- [ ] PR title follows Conventional Commits (`type(scope): subject`) — CI checks this
- [ ] Scoped to one logical change
- [ ] Tests added/updated for the behavior that changed
