### PR TITLE
refactor(runtime): enforce controls that validated but never ran

### DIFF
--- a/apps/api/src/admin/runtime.test.ts
+++ b/apps/api/src/admin/runtime.test.ts
@@ -61,6 +61,10 @@ function runtime() {
               resolvedAt: null,
               consumedAt: null,
               consumedByCallId: null,
+              requesterPrincipalId: null,
+              guardrailEvidence: null,
+              guardrailEvidenceDigest: null,
+              approverPrincipalId: null,
             },
           ]
         : []

--- a/apps/api/src/admin/runtime.ts
+++ b/apps/api/src/admin/runtime.ts
@@ -1,8 +1,12 @@
 import { createHash } from "node:crypto";
-import type { ApprovalsRepo, ToolApprovalService } from "@tulipfarm/tool-host";
+import {
+  type ApprovalsRepo,
+  listPendingToolApprovals,
+  type PendingToolApproval,
+  type ToolApprovalService,
+} from "@tulipfarm/tool-host";
 import type { FastifyRequest } from "fastify";
 import type { ActivityService } from "../activity/service";
-import { listPendingToolApprovals, type PendingToolApproval } from "../approvals/pending";
 import type { AuthorizationCheck, RouteAuthorization } from "../authz/route-gate";
 import { makeAuthorizationCheck } from "../authz/route-gate";
 import { describeDeploymentRoles } from "../identity/roles";

--- a/apps/api/src/approvals/repo.pg.test.ts
+++ b/apps/api/src/approvals/repo.pg.test.ts
@@ -1,8 +1,19 @@
 import { randomUUID } from "node:crypto";
 import type { PGlite } from "@electric-sql/pglite";
-import { ApprovalsRepo } from "@tulipfarm/tool-host";
+import { type ApprovalGuardrailEvidence, ApprovalsRepo } from "@tulipfarm/tool-host";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { makeMigratedPglite } from "../test/pglite";
+
+/** Every `tool_call` row carries the Guardrail evidence that demanded it; the table requires it. */
+const EVIDENCE: ApprovalGuardrailEvidence = {
+  demandedBy: "guardrail_rule",
+  guardrailRevision: "gr-1",
+  reason: "approval_required",
+  ruleId: "rule-1",
+  toolName: "write_x",
+  intentDigest: "sha256:intent",
+  demandedAt: "2026-08-16T00:00:00.000Z",
+};
 
 describe("ApprovalsRepo (PGlite)", () => {
   let db: PGlite;
@@ -25,6 +36,8 @@ describe("ApprovalsRepo (PGlite)", () => {
       kind: "tool_call",
       payload: { toolName: "write_x", args: { a: 1 } },
       expiresAt,
+      requesterPrincipalId: "user:requester-1",
+      evidence: EVIDENCE,
     });
 
     const row = await repo.findById(id);
@@ -42,6 +55,8 @@ describe("ApprovalsRepo (PGlite)", () => {
       kind: "tool_call",
       payload: {},
       expiresAt: new Date(Date.now() + 300_000),
+      requesterPrincipalId: "user:requester-1",
+      evidence: EVIDENCE,
     });
 
     await repo.settle(id, "approved");
@@ -58,6 +73,8 @@ describe("ApprovalsRepo (PGlite)", () => {
       kind: "tool_call",
       payload: {},
       expiresAt: new Date(Date.now() + 300_000),
+      requesterPrincipalId: "user:requester-1",
+      evidence: EVIDENCE,
     });
 
     await repo.settle(id, "denied");
@@ -72,6 +89,8 @@ describe("ApprovalsRepo (PGlite)", () => {
       kind: "tool_call",
       payload: {},
       expiresAt: new Date(Date.now() + 300_000),
+      requesterPrincipalId: "user:requester-1",
+      evidence: EVIDENCE,
     });
 
     expect(await repo.settlePending(id, "approved")).toBe(true);
@@ -91,6 +110,8 @@ describe("ApprovalsRepo (PGlite)", () => {
       kind: "tool_call",
       payload,
       expiresAt: new Date(Date.now() + 300_000),
+      requesterPrincipalId: "user:requester-1",
+      evidence: EVIDENCE,
     });
 
     const row = await repo.findById(id);

--- a/apps/api/src/approvals/routes.test.ts
+++ b/apps/api/src/approvals/routes.test.ts
@@ -190,7 +190,6 @@ describe("approval routes — durable tool_call kind", () => {
         effectiveSubject: { kind: "user", id: subjectId },
         guardrailContextRef: "guardrails:1",
       },
-      bounds: { wallTimeMs: 60_000, activeTimeMs: 60_000, attempts: 1, sideEffects: 8 },
       states: [
         {
           key: "invoke",
@@ -206,6 +205,13 @@ describe("approval routes — durable tool_call kind", () => {
       toolCallId: "call-1",
       toolName: "record_delete",
       args: { id: "record-1" },
+      requesterPrincipalId: `user:${subjectId}`,
+      demand: {
+        demandedBy: "guardrail_rule",
+        guardrailRevision: "gr-1",
+        reason: "approval_required",
+        ruleId: "rule-1",
+      },
     });
     if (decision.status !== "pending") throw new Error("expected a pending approval");
 
@@ -366,7 +372,6 @@ describe("approval routes — routine_state kind, decided by role", () => {
         effectiveSubject: { kind: "user", id: "author" },
         guardrailContextRef: "guardrails:1",
       },
-      bounds: { wallTimeMs: 60_000, activeTimeMs: 60_000, attempts: 1, sideEffects: 8 },
       states: [
         {
           key: "Approve",

--- a/apps/api/src/approvals/routes.ts
+++ b/apps/api/src/approvals/routes.ts
@@ -1,8 +1,11 @@
 import { DEPLOYMENT_BUSINESS_ID } from "@tulipfarm/constants";
-import type { ApprovalsRepo, ToolApprovalService } from "@tulipfarm/tool-host";
+import {
+  type ApprovalsRepo,
+  listPendingToolApprovals,
+  type ToolApprovalService,
+} from "@tulipfarm/tool-host";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { ErrorSchema } from "../auth/schemas";
-import { listPendingToolApprovals } from "./pending";
 import type { RoutineApprovalService } from "./routine-approvals";
 
 type PreHandler = (req: FastifyRequest, reply: FastifyReply) => Promise<void>;

--- a/apps/api/src/approvals/tool-approvals.pg.test.ts
+++ b/apps/api/src/approvals/tool-approvals.pg.test.ts
@@ -123,6 +123,13 @@ describe("tool approvals as durable waits", () => {
       toolCallId,
       toolName: "record_delete",
       args: { id: "record-1" },
+      requesterPrincipalId: "user:requester-1",
+      demand: {
+        demandedBy: "guardrail_rule",
+        guardrailRevision: "gr-1",
+        reason: "approval_required",
+        ruleId: "rule-1",
+      },
     });
     if (decision.status !== "pending") throw new Error(`expected pending, got ${decision.status}`);
     return { approvalId: decision.approvalId };
@@ -182,6 +189,13 @@ describe("tool approvals as durable waits", () => {
         toolCallId: "call-2",
         toolName: "record_delete",
         args: { id: "record-1" },
+        requesterPrincipalId: "user:requester-1",
+        demand: {
+          demandedBy: "guardrail_rule",
+          guardrailRevision: "gr-1",
+          reason: "approval_required",
+          ruleId: "rule-1",
+        },
       })
     ).toEqual({ status: "approved", approvalId });
 
@@ -213,6 +227,13 @@ describe("tool approvals as durable waits", () => {
       toolCallId: "call-2",
       toolName: "record_delete",
       args: { id: "record-1" },
+      requesterPrincipalId: "user:requester-1",
+      demand: {
+        demandedBy: "guardrail_rule",
+        guardrailRevision: "gr-1",
+        reason: "approval_required",
+        ruleId: "rule-1",
+      },
     });
     expect(repeat.status).toBe("pending");
     expect(repeat).not.toMatchObject({ approvalId });
@@ -226,6 +247,13 @@ describe("tool approvals as durable waits", () => {
         toolCallId: "call-1",
         toolName: "record_delete",
         args: { id: "record-1" },
+        requesterPrincipalId: "user:requester-1",
+        demand: {
+          demandedBy: "guardrail_rule",
+          guardrailRevision: "gr-1",
+          reason: "approval_required",
+          ruleId: "rule-1",
+        },
       })
     ).toEqual({ status: "approved", approvalId });
   });
@@ -249,6 +277,13 @@ describe("tool approvals as durable waits", () => {
         toolCallId: "call-2",
         toolName: "record_delete",
         args: { id: "record-1" },
+        requesterPrincipalId: "user:requester-1",
+        demand: {
+          demandedBy: "guardrail_rule",
+          guardrailRevision: "gr-1",
+          reason: "approval_required",
+          ruleId: "rule-1",
+        },
       })
     ).toEqual({ status: "denied", reason: "denied by operator" });
   });
@@ -263,6 +298,13 @@ describe("tool approvals as durable waits", () => {
       toolCallId: "call-2",
       toolName: "record_delete",
       args: { id: "record-2" },
+      requesterPrincipalId: "user:requester-1",
+      demand: {
+        demandedBy: "guardrail_rule",
+        guardrailRevision: "gr-1",
+        reason: "approval_required",
+        ruleId: "rule-1",
+      },
     });
 
     expect(other.status).toBe("pending");
@@ -290,6 +332,13 @@ describe("tool approvals as durable waits", () => {
         toolCallId: "call-2",
         toolName: "record_delete",
         args: { id: "record-1" },
+        requesterPrincipalId: "user:requester-1",
+        demand: {
+          demandedBy: "guardrail_rule",
+          guardrailRevision: "gr-1",
+          reason: "approval_required",
+          ruleId: "rule-1",
+        },
       })
     ).toEqual({ status: "denied", reason: "denied by operator" });
   });

--- a/apps/api/src/internal/channel-routes.test.ts
+++ b/apps/api/src/internal/channel-routes.test.ts
@@ -689,6 +689,13 @@ describe("/api/v1/internal/channels", () => {
         toolCallId: "call-1",
         toolName: "record_delete",
         args: { id: "record-1" },
+        requesterPrincipalId: "user:requester-1",
+        demand: {
+          demandedBy: "guardrail_rule",
+          guardrailRevision: "gr-1",
+          reason: "approval_required",
+          ruleId: "rule-1",
+        },
       });
       if (decision.status !== "pending") throw new Error("expected a pending approval");
 
@@ -732,7 +739,6 @@ describe("/api/v1/internal/channels", () => {
           effectiveSubject: { kind: "user", id: slackUser._id },
           guardrailContextRef: "guardrails:1",
         },
-        bounds: { wallTimeMs: 60_000, activeTimeMs: 60_000, attempts: 1, sideEffects: 8 },
         states: [
           {
             key: "invoke",
@@ -747,6 +753,13 @@ describe("/api/v1/internal/channels", () => {
         toolCallId: "call-1",
         toolName: "record_delete",
         args: { id: "record-1" },
+        requesterPrincipalId: "user:requester-1",
+        demand: {
+          demandedBy: "guardrail_rule",
+          guardrailRevision: "gr-1",
+          reason: "approval_required",
+          ruleId: "rule-1",
+        },
       });
       if (decision.status !== "pending") throw new Error("expected a pending approval");
       await toolApprovals.registerWait({

--- a/apps/api/src/pg-migrations/index.ts
+++ b/apps/api/src/pg-migrations/index.ts
@@ -19,6 +19,7 @@ import {
   INTEGRATION_STORAGE_STATEMENTS,
   KILL_SWITCH_STORAGE_STATEMENTS,
   LOOP_CHECKPOINT_STORAGE_STATEMENTS,
+  RUN_BOUNDS_REMOVAL_STATEMENTS,
   RUN_BROWSE_STORAGE_STATEMENTS,
   RUN_EVENT_NOTIFY_STATEMENTS,
   RUN_EVENT_STORAGE_STATEMENTS,
@@ -32,6 +33,7 @@ import {
   WAIT_STORAGE_STATEMENTS,
 } from "@tulipfarm/storage";
 import { EFFECT_STORAGE_STATEMENTS } from "@tulipfarm/tool-broker";
+import { APPROVAL_EVIDENCE_STORAGE_STATEMENTS } from "@tulipfarm/tool-host";
 import type { Queryable } from "../db";
 
 export interface PgMigration {
@@ -2055,6 +2057,24 @@ export const PG_MIGRATIONS: PgMigration[] = [
     up: async (q) => {
       await q.query("ALTER TABLE approvals ADD COLUMN IF NOT EXISTS consumed_at timestamptz");
       await q.query("ALTER TABLE approvals ADD COLUMN IF NOT EXISTS consumed_by_call_id text");
+    },
+  },
+  {
+    version: 60,
+    description: "approvals: immutable Guardrail evidence, requester, approver (I-13)",
+    up: async (q) => {
+      for (const sql of APPROVAL_EVIDENCE_STORAGE_STATEMENTS) {
+        await q.query(sql);
+      }
+    },
+  },
+  {
+    version: 61,
+    description: "runs.bounds: drop the required Run bounds no reader ever consulted (L3-10)",
+    up: async (q) => {
+      for (const sql of RUN_BOUNDS_REMOVAL_STATEMENTS) {
+        await q.query(sql);
+      }
     },
   },
 ];

--- a/apps/worker/src/executors.test.ts
+++ b/apps/worker/src/executors.test.ts
@@ -17,7 +17,6 @@ function persistedRun(overrides: Partial<PersistedRun> = {}): PersistedRun {
       effectiveSubject: { kind: "agent", id: "agent-1" },
       guardrailContextRef: "guardrail-context-1",
     },
-    bounds: { wallTimeMs: 60_000, activeTimeMs: 30_000, attempts: 3, sideEffects: 2 },
     status: "claimed",
     version: 1,
     createdAt: "2026-07-24T10:00:00.000Z",

--- a/apps/worker/src/recovery/run-dispatch.test.ts
+++ b/apps/worker/src/recovery/run-dispatch.test.ts
@@ -21,7 +21,6 @@ function run(overrides: Partial<PersistedRun> = {}): PersistedRun {
       effectiveSubject: { kind: "agent", id: "agent-1" },
       guardrailContextRef: "guardrail-context-1",
     },
-    bounds: { wallTimeMs: 60_000, activeTimeMs: 30_000, attempts: 3, sideEffects: 2 },
     status: "queued",
     version: 0,
     createdAt: "2026-07-25T09:00:00.000Z",

--- a/apps/worker/src/routine/definition-loader.test.ts
+++ b/apps/worker/src/routine/definition-loader.test.ts
@@ -52,12 +52,6 @@ function run(override: Partial<PersistedRun> = {}): PersistedRun {
       effectiveSubject: { kind: "agent", id: "assistant" },
       guardrailContextRef: "guardrail:default",
     },
-    bounds: {
-      wallTimeMs: 60_000,
-      activeTimeMs: 30_000,
-      attempts: 3,
-      sideEffects: 0,
-    },
     status: "claimed",
     version: 1,
     createdAt: "2026-08-02T00:00:00.000Z",

--- a/apps/worker/src/routine/executor.test.ts
+++ b/apps/worker/src/routine/executor.test.ts
@@ -57,12 +57,6 @@ function run(): PersistedRun {
       effectiveSubject: { kind: "agent", id: "assistant" },
       guardrailContextRef: "guardrail:default",
     },
-    bounds: {
-      wallTimeMs: 60_000,
-      activeTimeMs: 30_000,
-      attempts: 3,
-      sideEffects: 0,
-    },
     status: "running",
     version: 2,
     createdAt: STARTED_AT,

--- a/apps/worker/src/run-dispatcher.test.ts
+++ b/apps/worker/src/run-dispatcher.test.ts
@@ -16,7 +16,6 @@ function persistedRun(overrides: Partial<PersistedRun> = {}): PersistedRun {
       effectiveSubject: { kind: "agent", id: "agent-1" },
       guardrailContextRef: "guardrail-context-1",
     },
-    bounds: { wallTimeMs: 60_000, activeTimeMs: 30_000, attempts: 3, sideEffects: 2 },
     status: "claimed",
     version: 1,
     createdAt: "2026-07-24T10:00:00.000Z",

--- a/apps/worker/src/turn/chat-executor.checkpoint.test.ts
+++ b/apps/worker/src/turn/chat-executor.checkpoint.test.ts
@@ -32,7 +32,6 @@ const RUN: PersistedRun = {
     effectiveSubject: { kind: "user", id: "user-1" },
     guardrailContextRef: "sha256:guardrail",
   },
-  bounds: { wallTimeMs: 60_000, activeTimeMs: 30_000, attempts: 3, sideEffects: 10 },
   status: "running",
   version: 2,
   createdAt: "2026-01-01T00:00:00.000Z",

--- a/apps/worker/src/turn/chat-executor.test.ts
+++ b/apps/worker/src/turn/chat-executor.test.ts
@@ -24,7 +24,6 @@ const RUN: PersistedRun = {
     effectiveSubject: { kind: "user", id: "user-1" },
     guardrailContextRef: "sha256:guardrail",
   },
-  bounds: { wallTimeMs: 60_000, activeTimeMs: 30_000, attempts: 3, sideEffects: 10 },
   status: "running",
   version: 2,
   createdAt: "2026-01-01T00:00:00.000Z",

--- a/apps/worker/src/turn/integration-executor.test.ts
+++ b/apps/worker/src/turn/integration-executor.test.ts
@@ -19,7 +19,6 @@ const RUN: PersistedRun = {
     effectiveSubject: { kind: "integration", id: "chatapp" },
     guardrailContextRef: "sha256:guardrail",
   },
-  bounds: { wallTimeMs: 60_000, activeTimeMs: 30_000, attempts: 3, sideEffects: 10 },
   status: "running",
   version: 2,
   createdAt: "2026-01-01T00:00:00.000Z",

--- a/apps/worker/test/process/scratch-database.ts
+++ b/apps/worker/test/process/scratch-database.ts
@@ -103,7 +103,6 @@ export async function insertQueuedRun(
       effectiveSubject: { kind: "user", id: "user-1" },
       guardrailContextRef: "identity:user",
     },
-    bounds: { wallTimeMs: 3_600_000, activeTimeMs: 900_000, attempts: 3, sideEffects: 100 },
     createdAt: new Date().toISOString(),
     states: [
       {

--- a/docs/architecture/legacy-inventory.md
+++ b/docs/architecture/legacy-inventory.md
@@ -44,7 +44,7 @@ parse the table below and assert every legacy path is absent from the current tr
 | LB-08 | config-write | `packages/soul/src/soul-loader.ts` | The Soul loader reads and can skip invalid entries at load time; it acts as an alternate, fail-open write/read path rather than the single fail-closed changeset and publication gateway | I-05 | high |
 | LB-09 | secret-resolution | `packages/secrets/src/service.ts` | Secret resolution has no scoped Secret Broker lease, rotation, or revocation semantics; stale plaintext can remain usable and is not bound to an authorized Tool dispatch | I-10 | high |
 | LB-10 | auth | `apps/api/src/auth/users.ts` | Only fixed `admin` and `member` roles exist; there are no custom user/Agent roles or scoped AccessGrants, so authority cannot narrow through delegation or Run Context | I-03 | high |
-| LB-11 | approval-persistence | `apps/api/src/approvals/repo.ts` | The approvals table lacks Guardrail evidence binding and four-eyes enforcement. Decisions are digest-bound and one-use as of the `consumed_at`/`consumed_by_call_id` columns (migration 59): the dispatch that executes spends the decision, so an identical repeat in the same Run asks again | I-13 | medium |
+| LB-11 | approval-persistence | `apps/api/src/approvals/repo.ts` | The approvals repository moved to `packages/tool-host`, where the durable path now lives. What remains is that it is a second approval authority beside `packages/tool-broker`'s `ApprovalRepo`, and carries none of its risk-tiered quorum or per-approval approver roles: every decision needs exactly one approver, and eligibility is the deployment's `approval` surface grant rather than anything the demanding Guardrail names. Digest-bound and one-use since migration 59; Guardrail evidence is immutable and write-once, the requesting principal is recorded, and four-eyes holds wherever a second principal could decide, since migration 60 | I-13 | low |
 | LB-12 | direct-effect | `apps/api/src/routines/driver.ts` | The Routine driver dispatches effects with CAS/persist-first patterns but no effect ledger, idempotency key, or ambiguity reconciliation; retries can double-apply external effects | I-09 | medium |
 | LB-13 | table | `apps/api/src/routines/repo.ts` | Routine persistence snapshots definitions but stores a mutable Context and a limited status model; it is superseded by Runs, States, attempts, waits, and effect records | I-08 | medium |
 | LB-14 | surface | `apps/api/src/surface/surface-store.ts` | Tulip Surface Protocol surfaces are process/local store rows rather than immutable authorized Artifacts with signed, expiring action descriptors; client actions are not re-authorized against a signed intent | I-14 | medium |
@@ -73,8 +73,9 @@ keep confirming none returns as a shadow authority:
 
 - A second Tool-exposure path that skips the broker (any direct `buildToolSet`/`registry.register`
   outside `packages/tool-broker`) re-creates LB-02/LB-04.
-- Any in-process approval `Map`, non-digest-bound decision, or approval that survives the dispatch
-  it authorized re-creates LB-03/LB-11.
+- Any in-process approval `Map`, non-digest-bound decision, approval created without the Guardrail
+  evidence that demanded it, or approval that survives the dispatch it authorized re-creates
+  LB-03/LB-11.
 - Any ingress or channel path that borrows a Conversation owner's identity re-creates LB-01.
 - Any Soul read/write outside the changeset gateway re-creates LB-08.
 - Any retrieval that ranks before an ACL check re-creates LB-05.

--- a/packages/run-kernel/AGENTS.md
+++ b/packages/run-kernel/AGENTS.md
@@ -32,10 +32,12 @@ typed outputs, Artifacts, limits, budgets, and concurrency.
   target admission (per Run, no expiry); `routine/concurrency-lease.ts` is per-State
   `concurrencyKey` exclusion (per State occurrence, expiry-bounded so a crash cannot wedge a key),
   with a durable, jittered, bounded backoff budget for contenders.
-- Authored `limits` reach `LimitSet` only through `routine/authored-limits.ts`; three keys are
+- Authored `limits` reach `LimitSet` only through `routine/authored-limits.ts`; two keys are
   renamed and `costUsd` is converted to micro-USD. Never cast an authored block to `LimitSet`.
-- `routine/limit-enforcement.ts` is the only place authored limits become enforcement: structural
-  keys narrow `CompiledState.bounds` at compile time, metered keys reach the Run budget ledger at
-  Routine scope. Never open a second ceiling on a quantity `bounds` or the ledger already bounds.
+- `routine/limit-enforcement.ts` is the only place authored limits become enforcement, and every
+  `LIMIT_KEYS` entry must name its surface there or the file stops compiling: `bounds`, `retry` or
+  the Routine-scope budget ledger. Never open a second ceiling on a bounded quantity, and give a
+  quantity nothing meters no key at all, so authoring it fails validation instead of bounding
+  nothing (`scripts/routine-limit-coverage.test.ts`).
 - Child authority never broadens; detach must be explicit. Cancellation parks in-flight effects.
   Ambiguous effect evidence never becomes `cancelled`.

--- a/packages/run-kernel/src/budgets.test.ts
+++ b/packages/run-kernel/src/budgets.test.ts
@@ -69,7 +69,7 @@ describe("RunBudgetManager", () => {
     const store = new FakeBudgetStore();
     const resolved = resolveLimits([
       { scope: "deployment", limits: { tokens: 1_000 } },
-      { scope: "agent", limits: { tokens: 100, sideEffects: 2 } },
+      { scope: "agent", limits: { tokens: 100, fanOut: 2 } },
     ]);
 
     await manager(store).open({
@@ -80,7 +80,7 @@ describe("RunBudgetManager", () => {
     });
 
     expect(store.budgets.get(`${BUSINESS_ID}:${RUN_ID}:tokens`)?.limit).toBe(100);
-    expect(store.budgets.get(`${BUSINESS_ID}:${RUN_ID}:sideEffects`)?.limit).toBe(2);
+    expect(store.budgets.get(`${BUSINESS_ID}:${RUN_ID}:fanOut`)?.limit).toBe(2);
   });
 
   it("allows consumption up to the ceiling and reports remaining budget", async () => {
@@ -149,7 +149,7 @@ describe("RunBudgetManager", () => {
     const result = await budgets.consume({
       businessId: BUSINESS_ID,
       runId: RUN_ID,
-      key: "networkBytes",
+      key: "costMicros",
       amount: 4_096,
     });
 

--- a/packages/run-kernel/src/invocation/store.pg.ts
+++ b/packages/run-kernel/src/invocation/store.pg.ts
@@ -57,8 +57,8 @@ export class PgDurableInvocationStore implements DurableInvocationStore {
       await this.artifacts(transaction).publish(record.requestArtifact);
 
       await transaction.query(
-        `INSERT INTO runs (id, business_id, source, bundle, identity, bounds, created_at)
-         VALUES ($1, $2, $3, $4::jsonb, $5::jsonb, $6::jsonb, $7::timestamptz)`,
+        `INSERT INTO runs (id, business_id, source, bundle, identity, created_at)
+         VALUES ($1, $2, $3, $4::jsonb, $5::jsonb, $6::timestamptz)`,
         [
           record.runId,
           record.businessId,
@@ -69,12 +69,6 @@ export class PgDurableInvocationStore implements DurableInvocationStore {
             effectiveSubject: record.effectiveSubject,
             guardrailContextRef:
               record.identityMappingEvidenceRef ?? `identity:${record.initiator.kind}`,
-          }),
-          JSON.stringify({
-            wallTimeMs: 3_600_000,
-            activeTimeMs: 900_000,
-            attempts: 3,
-            sideEffects: 100,
           }),
           record.createdAt,
         ]

--- a/packages/run-kernel/src/lease.test.ts
+++ b/packages/run-kernel/src/lease.test.ts
@@ -17,7 +17,6 @@ function persistedRun(overrides: Partial<PersistedRun> = {}): PersistedRun {
       effectiveSubject: { kind: "agent", id: "agent-1" },
       guardrailContextRef: "guardrail-context-1",
     },
-    bounds: { wallTimeMs: 60_000, activeTimeMs: 30_000, attempts: 3, sideEffects: 2 },
     status: "claimed",
     version: 1,
     createdAt: "2026-07-24T10:00:00.000Z",

--- a/packages/run-kernel/src/limits.test.ts
+++ b/packages/run-kernel/src/limits.test.ts
@@ -42,11 +42,11 @@ describe("resolveLimits", () => {
 describe("narrowestWins", () => {
   it("returns the effective numeric ceiling for a key", () => {
     const resolved = resolveLimits([
-      { scope: "deployment", limits: { sideEffects: 9 } },
-      { scope: "tool", limits: { sideEffects: 2 } },
+      { scope: "deployment", limits: { retries: 9 } },
+      { scope: "tool", limits: { retries: 2 } },
     ]);
 
-    expect(narrowestWins(resolved, "sideEffects")).toBe(2);
+    expect(narrowestWins(resolved, "retries")).toBe(2);
     expect(narrowestWins(resolved, "tokens")).toBeNull();
   });
 });

--- a/packages/run-kernel/src/limits.ts
+++ b/packages/run-kernel/src/limits.ts
@@ -18,19 +18,20 @@ export const LIMIT_SCOPES = [
 
 export type LimitScope = (typeof LIMIT_SCOPES)[number];
 
+/**
+ * Every limit an author may declare, and every one the runtime enforces — the two sets are the
+ * same set on purpose. A key here that no meter reaches would read as a live safety control and
+ * stop nothing, so a quantity nothing counts is left out of the schema entirely and the author is
+ * told at validation time. `scripts/routine-limit-coverage.test.ts` holds the two sides together.
+ */
 export const LIMIT_KEYS = [
   "wallTimeMs",
-  "activeTimeMs",
   "tokens",
   "costMicros",
   "retries",
   "iterations",
   "fanOut",
   "parallelism",
-  "artifactBytes",
-  "resultRows",
-  "networkBytes",
-  "sideEffects",
 ] as const;
 
 export type LimitKey = (typeof LIMIT_KEYS)[number];

--- a/packages/run-kernel/src/resilience/simulator.ts
+++ b/packages/run-kernel/src/resilience/simulator.ts
@@ -36,7 +36,6 @@ function baseRun(overrides: Partial<PersistedRun>): PersistedRun {
       effectiveSubject: { kind: "agent", id: "agent-1" },
       guardrailContextRef: "guardrail-context-1",
     },
-    bounds: { wallTimeMs: 60_000, activeTimeMs: 30_000, attempts: 3, sideEffects: 2 },
     status: "queued",
     version: 0,
     createdAt: "2026-07-25T09:00:00.000Z",

--- a/packages/run-kernel/src/routine/authored-limits.test.ts
+++ b/packages/run-kernel/src/routine/authored-limits.test.ts
@@ -3,10 +3,10 @@ import { LimitError } from "../limits";
 import { mapAuthoredLimits } from "./authored-limits";
 
 describe("mapAuthoredLimits", () => {
-  it("renames the three keys the runtime spells differently", () => {
-    expect(mapAuthoredLimits({ wallClockMs: 60_000, activeMs: 30_000 })).toEqual({
+  it("renames the two keys the runtime spells differently", () => {
+    expect(mapAuthoredLimits({ wallClockMs: 60_000, costUsd: 1 })).toEqual({
       wallTimeMs: 60_000,
-      activeTimeMs: 30_000,
+      costMicros: 1_000_000,
     });
   });
 
@@ -20,16 +20,13 @@ describe("mapAuthoredLimits", () => {
     expect(mapAuthoredLimits({ costUsd: 0.0000001 })).toEqual({ costMicros: 1 });
   });
 
-  it("passes the eight identically spelled keys through unchanged", () => {
+  it("passes the five identically spelled keys through unchanged", () => {
     const authored = {
       tokens: 1_000,
       iterations: 5,
       fanOut: 3,
       parallelism: 2,
-      artifactBytes: 4_096,
-      resultRows: 100,
-      networkBytes: 8_192,
-      sideEffects: 0,
+      retries: 0,
     };
     expect(mapAuthoredLimits(authored)).toEqual(authored);
   });
@@ -41,6 +38,8 @@ describe("mapAuthoredLimits", () => {
   it("refuses a key it cannot map instead of dropping it", () => {
     expect(() => mapAuthoredLimits({ wallTimeMs: 60_000 })).toThrow(LimitError);
     expect(() => mapAuthoredLimits({ wallTimeMs: 60_000 })).toThrow("invalid_limit:wallTimeMs");
+    // A quantity nothing meters is refused rather than accepted and left inert (L3-10).
+    expect(() => mapAuthoredLimits({ networkBytes: 5_000 })).toThrow("invalid_limit:networkBytes");
   });
 
   it("refuses values the runtime cannot enforce", () => {

--- a/packages/run-kernel/src/routine/authored-limits.ts
+++ b/packages/run-kernel/src/routine/authored-limits.ts
@@ -22,16 +22,12 @@ const sameUnit = (authored: number): number => authored;
 
 const AUTHORED_LIMIT_MAPPINGS = {
   wallClockMs: { key: "wallTimeMs", toRuntimeValue: sameUnit },
-  activeMs: { key: "activeTimeMs", toRuntimeValue: sameUnit },
   costUsd: { key: "costMicros", toRuntimeValue: usdToCostMicros },
   tokens: { key: "tokens", toRuntimeValue: sameUnit },
   iterations: { key: "iterations", toRuntimeValue: sameUnit },
   fanOut: { key: "fanOut", toRuntimeValue: sameUnit },
   parallelism: { key: "parallelism", toRuntimeValue: sameUnit },
-  artifactBytes: { key: "artifactBytes", toRuntimeValue: sameUnit },
-  resultRows: { key: "resultRows", toRuntimeValue: sameUnit },
-  networkBytes: { key: "networkBytes", toRuntimeValue: sameUnit },
-  sideEffects: { key: "sideEffects", toRuntimeValue: sameUnit },
+  retries: { key: "retries", toRuntimeValue: sameUnit },
 } satisfies Record<AuthoredLimitKey, AuthoredLimitMapping>;
 
 const MAPPING_BY_AUTHORED_KEY: ReadonlyMap<string, AuthoredLimitMapping> = new Map(

--- a/packages/run-kernel/src/routine/compiler.test.ts
+++ b/packages/run-kernel/src/routine/compiler.test.ts
@@ -291,7 +291,7 @@ describe("compileRoutine", () => {
       name: "Classify",
       agentRef: { name: "triage", version: "1.0.0" },
       end: true,
-      limits: { wallClockMs: 60_000, activeMs: 30_000, costUsd: 5, tokens: 1_000 },
+      limits: { wallClockMs: 60_000, retries: 2, costUsd: 5, tokens: 1_000 },
     };
 
     const compiled = compileRoutine(
@@ -302,7 +302,7 @@ describe("compileRoutine", () => {
     expect(compiled.limits).toEqual({ costMicros: 2_500_000, wallTimeMs: 120_000 });
     expect(compiled.states.get("Classify")?.limits).toEqual({
       wallTimeMs: 60_000,
-      activeTimeMs: 30_000,
+      retries: 2,
       costMicros: 5_000_000,
       tokens: 1_000,
     });

--- a/packages/run-kernel/src/routine/compiler.ts
+++ b/packages/run-kernel/src/routine/compiler.ts
@@ -4,7 +4,7 @@ import { type LimitSet, resolveLimits } from "../limits";
 import type { JsonObject, OutputSchemaRegistration } from "../outputs";
 import { mapAuthoredLimits } from "./authored-limits";
 import { type CompiledExpression, compileExpression, ExpressionError } from "./expressions";
-import { narrowBoundsByLimits } from "./limit-enforcement";
+import { narrowBoundsByLimits, narrowRetryByLimits } from "./limit-enforcement";
 
 /**
  * Compiles valid Routine shapes into one graph after proving termination, reference order,
@@ -556,7 +556,7 @@ export function compileRoutine(
         ),
         bounds: narrowBoundsByLimits(checkBounds(state, path), boundCeilings),
         join: (readString(state, "join") as CompiledState["join"]) ?? null,
-        retry: compileRetry(state, path),
+        retry: narrowRetryByLimits(compileRetry(state, path), boundCeilings),
         limits: stateLimits,
         identity: {
           principalKind: ceiling.principalKind,

--- a/packages/run-kernel/src/routine/limit-enforcement.test.ts
+++ b/packages/run-kernel/src/routine/limit-enforcement.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { resolveLimits } from "../limits";
-import type { CompiledBounds } from "./compiler";
-import { narrowBoundsByLimits, routineBudgetScopedLimits } from "./limit-enforcement";
+import type { CompiledBounds, CompiledRetryPolicy } from "./compiler";
+import {
+  narrowBoundsByLimits,
+  narrowRetryByLimits,
+  routineBudgetScopedLimits,
+} from "./limit-enforcement";
 
 const UNBOUNDED: CompiledBounds = {
   maxItems: null,
@@ -73,8 +77,36 @@ describe("routineBudgetScopedLimits", () => {
   it("drops keys the Run budget ledger never charges", () => {
     expect(
       routineBudgetScopedLimits({
-        limits: { tokens: 10, wallTimeMs: 1, activeTimeMs: 1, sideEffects: 1, networkBytes: 1 },
+        limits: { tokens: 10, wallTimeMs: 1, retries: 1, fanOut: 1 },
       })
     ).toEqual({ scope: "routine", limits: { tokens: 10 } });
+  });
+});
+
+describe("narrowRetryByLimits", () => {
+  const policy: CompiledRetryPolicy = { maxAttempts: 5, backoffMs: 100, multiplier: 2 };
+
+  it("leaves the policy alone when no limit names retries", () => {
+    expect(narrowRetryByLimits(policy, resolveLimits([]))).toBe(policy);
+  });
+
+  it("caps attempts at one first attempt plus the allowed retries", () => {
+    const resolved = resolveLimits([{ scope: "routine", limits: { retries: 1 } }]);
+    expect(narrowRetryByLimits(policy, resolved)).toEqual({ ...policy, maxAttempts: 2 });
+  });
+
+  it("never raises attempts above the authored policy", () => {
+    const resolved = resolveLimits([{ scope: "routine", limits: { retries: 99 } }]);
+    expect(narrowRetryByLimits(policy, resolved)).toBe(policy);
+  });
+
+  it("leaves a State with no policy at its single attempt rather than granting retries", () => {
+    const resolved = resolveLimits([{ scope: "routine", limits: { retries: 3 } }]);
+    expect(narrowRetryByLimits(null, resolved)).toBeNull();
+  });
+
+  it("denies every retry when the ceiling is zero", () => {
+    const resolved = resolveLimits([{ scope: "state", limits: { retries: 0 } }]);
+    expect(narrowRetryByLimits(policy, resolved)?.maxAttempts).toBe(1);
   });
 });

--- a/packages/run-kernel/src/routine/limit-enforcement.ts
+++ b/packages/run-kernel/src/routine/limit-enforcement.ts
@@ -1,15 +1,18 @@
 import type { LimitKey, LimitSet, ResolvedLimits, ScopedLimits } from "../limits";
-import type { CompiledBounds, CompiledRoutine } from "./compiler";
+import type { CompiledBounds, CompiledRetryPolicy, CompiledRoutine } from "./compiler";
 
 /**
  * Where an authored `limits` key is actually enforced.
  *
- * Two enforcement surfaces already exist and neither was reading `limits`: a State's structural
- * `bounds`, checked by the `foreach`/`parallel`/`repeat_until` processors, and the Run budget
- * ledger, charged by the Agent loop. Rather than open a third ceiling on quantities those two
- * already bound — two ceilings that can disagree is worse than one that is missing — each
- * authored key is routed into whichever of the two already meters it, and the keys neither meters
- * stay unenforced instead of pretending.
+ * Three enforcement surfaces already exist and none was reading `limits`: a State's structural
+ * `bounds`, checked by the `foreach`/`parallel`/`repeat_until` processors; the Run budget ledger,
+ * charged by the Agent loop; and the State `retry` policy, spent against the durable attempt
+ * counter by the executor. Rather than open a fourth ceiling on quantities those already bound —
+ * two ceilings that can disagree is worse than one that is missing — each authored key is routed
+ * into whichever of the three already meters it.
+ *
+ * A key no surface meters is not accepted and left inert: it is absent from `LIMIT_KEYS` and from
+ * the authored schema, so declaring it fails validation loudly instead of bounding nothing.
  */
 
 /**
@@ -18,19 +21,53 @@ import type { CompiledBounds, CompiledRoutine } from "./compiler";
  * ceiling per quantity. A key whose bound is absent supplies it, which is why `foreach`,
  * `parallel` and `repeat_until` can now be bounded from `limits` alone.
  */
-const BOUND_BY_LIMIT_KEY = {
+export const BOUND_BY_LIMIT_KEY = {
   fanOut: "maxItems",
   parallelism: "maxConcurrency",
   iterations: "maxIterations",
   wallTimeMs: "maxDurationMs",
 } as const satisfies Partial<Record<LimitKey, keyof CompiledBounds>>;
 
+/** The enforcement surface that meters each limit key. */
+export type LimitEnforcementSurface = "bounds" | "ledger" | "retry";
+
 /**
- * Limit keys the Run budget ledger charges. The Agent loop debits exactly these two, so they are
- * the only keys for which opening a budget row creates a ceiling that anything can reach; a row
- * for an unmetered key would read as a live control and stop nothing.
+ * Every limit key and the one surface that meters it.
+ *
+ * `satisfies Record<LimitKey, ...>` is the compile-time half of the L3-10 control: adding a key to
+ * `LIMIT_KEYS` without naming where it is enforced stops this file compiling, and
+ * `scripts/routine-limit-coverage.test.ts` checks the named surface actually carries it.
  */
-const LEDGER_METERED_LIMIT_KEYS: readonly LimitKey[] = ["tokens", "costMicros"];
+export const ENFORCEMENT_SURFACE_BY_LIMIT_KEY = {
+  fanOut: "bounds",
+  parallelism: "bounds",
+  iterations: "bounds",
+  wallTimeMs: "bounds",
+  tokens: "ledger",
+  costMicros: "ledger",
+  retries: "retry",
+} as const satisfies Record<LimitKey, LimitEnforcementSurface>;
+
+function limitKeysMeteredBy(surface: LimitEnforcementSurface): readonly LimitKey[] {
+  const entries = Object.entries(ENFORCEMENT_SURFACE_BY_LIMIT_KEY) as readonly [
+    LimitKey,
+    LimitEnforcementSurface,
+  ][];
+  return entries.filter(([, declared]) => declared === surface).map(([key]) => key);
+}
+
+/**
+ * Limit keys the Run budget ledger charges. The Agent loop debits exactly these, so they are the
+ * only keys for which opening a budget row creates a ceiling that anything can reach; a row for an
+ * unmetered key would read as a live control and stop nothing.
+ */
+export const LEDGER_METERED_LIMIT_KEYS: readonly LimitKey[] = limitKeysMeteredBy("ledger");
+
+/**
+ * Limit keys enforced against a State's `retry` policy, whose attempts the executor spends against
+ * a durable per-occurrence counter.
+ */
+export const RETRY_METERED_LIMIT_KEYS: readonly LimitKey[] = limitKeysMeteredBy("retry");
 
 /**
  * Narrows a State's structural bounds by the resolved limit ceilings.
@@ -51,6 +88,26 @@ export function narrowBoundsByLimits(
     if (current === null || ceiling.value < current) narrowed[boundKey] = ceiling.value;
   }
   return narrowed;
+}
+
+/**
+ * Narrows a State's `retry` policy by the resolved `retries` ceiling.
+ *
+ * A State with no policy makes exactly one attempt, which is already under every ceiling, so a
+ * limit never supplies a policy — it can only take attempts away, never grant them.
+ */
+export function narrowRetryByLimits(
+  retry: CompiledRetryPolicy | null,
+  resolved: ResolvedLimits
+): CompiledRetryPolicy | null {
+  if (retry === null) return retry;
+  let maxAttempts = retry.maxAttempts;
+  for (const key of RETRY_METERED_LIMIT_KEYS) {
+    const ceiling = resolved[key];
+    // A ceiling counts re-attempts, so it allows one first attempt plus that many more.
+    if (ceiling !== undefined) maxAttempts = Math.min(maxAttempts, ceiling.value + 1);
+  }
+  return maxAttempts === retry.maxAttempts ? retry : { ...retry, maxAttempts };
 }
 
 /**

--- a/packages/run-kernel/src/routine/scheduling.test.ts
+++ b/packages/run-kernel/src/routine/scheduling.test.ts
@@ -27,7 +27,6 @@ const RUN: PersistedRun = {
     effectiveSubject: { kind: "agent", id: "agent-1" },
     guardrailContextRef: "guardrail-context-1",
   },
-  bounds: { wallTimeMs: 60_000, activeTimeMs: 30_000, attempts: 3, sideEffects: 2 },
   status: "running",
   version: 2,
   createdAt: "2026-08-02T10:00:00.000Z",

--- a/packages/schema/src/definitions/__schemas__/Routine.json
+++ b/packages/schema/src/definitions/__schemas__/Routine.json
@@ -115,14 +115,6 @@
         "limits": {
           "additionalProperties": false,
           "properties": {
-            "activeMs": {
-              "minimum": 1,
-              "type": "integer"
-            },
-            "artifactBytes": {
-              "minimum": 1,
-              "type": "integer"
-            },
             "costUsd": {
               "minimum": 0,
               "type": "number"
@@ -135,19 +127,11 @@
               "minimum": 1,
               "type": "integer"
             },
-            "networkBytes": {
-              "minimum": 1,
-              "type": "integer"
-            },
             "parallelism": {
               "minimum": 1,
               "type": "integer"
             },
-            "resultRows": {
-              "minimum": 1,
-              "type": "integer"
-            },
-            "sideEffects": {
+            "retries": {
               "minimum": 0,
               "type": "integer"
             },
@@ -255,14 +239,6 @@
                   "limits": {
                     "additionalProperties": false,
                     "properties": {
-                      "activeMs": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
-                      "artifactBytes": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
                       "costUsd": {
                         "minimum": 0,
                         "type": "number"
@@ -275,19 +251,11 @@
                         "minimum": 1,
                         "type": "integer"
                       },
-                      "networkBytes": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
                       "parallelism": {
                         "minimum": 1,
                         "type": "integer"
                       },
-                      "resultRows": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
-                      "sideEffects": {
+                      "retries": {
                         "minimum": 0,
                         "type": "integer"
                       },
@@ -457,14 +425,6 @@
                   "limits": {
                     "additionalProperties": false,
                     "properties": {
-                      "activeMs": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
-                      "artifactBytes": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
                       "costUsd": {
                         "minimum": 0,
                         "type": "number"
@@ -477,19 +437,11 @@
                         "minimum": 1,
                         "type": "integer"
                       },
-                      "networkBytes": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
                       "parallelism": {
                         "minimum": 1,
                         "type": "integer"
                       },
-                      "resultRows": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
-                      "sideEffects": {
+                      "retries": {
                         "minimum": 0,
                         "type": "integer"
                       },
@@ -703,14 +655,6 @@
                   "limits": {
                     "additionalProperties": false,
                     "properties": {
-                      "activeMs": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
-                      "artifactBytes": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
                       "costUsd": {
                         "minimum": 0,
                         "type": "number"
@@ -723,19 +667,11 @@
                         "minimum": 1,
                         "type": "integer"
                       },
-                      "networkBytes": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
                       "parallelism": {
                         "minimum": 1,
                         "type": "integer"
                       },
-                      "resultRows": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
-                      "sideEffects": {
+                      "retries": {
                         "minimum": 0,
                         "type": "integer"
                       },
@@ -904,14 +840,6 @@
                   "limits": {
                     "additionalProperties": false,
                     "properties": {
-                      "activeMs": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
-                      "artifactBytes": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
                       "costUsd": {
                         "minimum": 0,
                         "type": "number"
@@ -924,19 +852,11 @@
                         "minimum": 1,
                         "type": "integer"
                       },
-                      "networkBytes": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
                       "parallelism": {
                         "minimum": 1,
                         "type": "integer"
                       },
-                      "resultRows": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
-                      "sideEffects": {
+                      "retries": {
                         "minimum": 0,
                         "type": "integer"
                       },
@@ -1102,14 +1022,6 @@
                   "limits": {
                     "additionalProperties": false,
                     "properties": {
-                      "activeMs": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
-                      "artifactBytes": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
                       "costUsd": {
                         "minimum": 0,
                         "type": "number"
@@ -1122,19 +1034,11 @@
                         "minimum": 1,
                         "type": "integer"
                       },
-                      "networkBytes": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
                       "parallelism": {
                         "minimum": 1,
                         "type": "integer"
                       },
-                      "resultRows": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
-                      "sideEffects": {
+                      "retries": {
                         "minimum": 0,
                         "type": "integer"
                       },
@@ -1305,14 +1209,6 @@
                   "limits": {
                     "additionalProperties": false,
                     "properties": {
-                      "activeMs": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
-                      "artifactBytes": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
                       "costUsd": {
                         "minimum": 0,
                         "type": "number"
@@ -1325,19 +1221,11 @@
                         "minimum": 1,
                         "type": "integer"
                       },
-                      "networkBytes": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
                       "parallelism": {
                         "minimum": 1,
                         "type": "integer"
                       },
-                      "resultRows": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
-                      "sideEffects": {
+                      "retries": {
                         "minimum": 0,
                         "type": "integer"
                       },
@@ -1499,14 +1387,6 @@
                   "limits": {
                     "additionalProperties": false,
                     "properties": {
-                      "activeMs": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
-                      "artifactBytes": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
                       "costUsd": {
                         "minimum": 0,
                         "type": "number"
@@ -1519,19 +1399,11 @@
                         "minimum": 1,
                         "type": "integer"
                       },
-                      "networkBytes": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
                       "parallelism": {
                         "minimum": 1,
                         "type": "integer"
                       },
-                      "resultRows": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
-                      "sideEffects": {
+                      "retries": {
                         "minimum": 0,
                         "type": "integer"
                       },
@@ -1732,14 +1604,6 @@
                   "limits": {
                     "additionalProperties": false,
                     "properties": {
-                      "activeMs": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
-                      "artifactBytes": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
                       "costUsd": {
                         "minimum": 0,
                         "type": "number"
@@ -1752,19 +1616,11 @@
                         "minimum": 1,
                         "type": "integer"
                       },
-                      "networkBytes": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
                       "parallelism": {
                         "minimum": 1,
                         "type": "integer"
                       },
-                      "resultRows": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
-                      "sideEffects": {
+                      "retries": {
                         "minimum": 0,
                         "type": "integer"
                       },
@@ -1924,14 +1780,6 @@
                   "limits": {
                     "additionalProperties": false,
                     "properties": {
-                      "activeMs": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
-                      "artifactBytes": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
                       "costUsd": {
                         "minimum": 0,
                         "type": "number"
@@ -1944,19 +1792,11 @@
                         "minimum": 1,
                         "type": "integer"
                       },
-                      "networkBytes": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
                       "parallelism": {
                         "minimum": 1,
                         "type": "integer"
                       },
-                      "resultRows": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
-                      "sideEffects": {
+                      "retries": {
                         "minimum": 0,
                         "type": "integer"
                       },
@@ -2130,14 +1970,6 @@
                   "limits": {
                     "additionalProperties": false,
                     "properties": {
-                      "activeMs": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
-                      "artifactBytes": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
                       "costUsd": {
                         "minimum": 0,
                         "type": "number"
@@ -2150,19 +1982,11 @@
                         "minimum": 1,
                         "type": "integer"
                       },
-                      "networkBytes": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
                       "parallelism": {
                         "minimum": 1,
                         "type": "integer"
                       },
-                      "resultRows": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
-                      "sideEffects": {
+                      "retries": {
                         "minimum": 0,
                         "type": "integer"
                       },
@@ -2314,14 +2138,6 @@
                   "limits": {
                     "additionalProperties": false,
                     "properties": {
-                      "activeMs": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
-                      "artifactBytes": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
                       "costUsd": {
                         "minimum": 0,
                         "type": "number"
@@ -2334,19 +2150,11 @@
                         "minimum": 1,
                         "type": "integer"
                       },
-                      "networkBytes": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
                       "parallelism": {
                         "minimum": 1,
                         "type": "integer"
                       },
-                      "resultRows": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
-                      "sideEffects": {
+                      "retries": {
                         "minimum": 0,
                         "type": "integer"
                       },
@@ -2533,14 +2341,6 @@
                   "limits": {
                     "additionalProperties": false,
                     "properties": {
-                      "activeMs": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
-                      "artifactBytes": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
                       "costUsd": {
                         "minimum": 0,
                         "type": "number"
@@ -2553,19 +2353,11 @@
                         "minimum": 1,
                         "type": "integer"
                       },
-                      "networkBytes": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
                       "parallelism": {
                         "minimum": 1,
                         "type": "integer"
                       },
-                      "resultRows": {
-                        "minimum": 1,
-                        "type": "integer"
-                      },
-                      "sideEffects": {
+                      "retries": {
                         "minimum": 0,
                         "type": "integer"
                       },

--- a/packages/schema/src/definitions/routine.ts
+++ b/packages/schema/src/definitions/routine.ts
@@ -75,16 +75,12 @@ const retryPolicy = Type.Object(
 const stateLimits = Type.Object(
   {
     wallClockMs: Type.Optional(positiveInteger),
-    activeMs: Type.Optional(positiveInteger),
     tokens: Type.Optional(positiveInteger),
     costUsd: Type.Optional(Type.Number({ minimum: 0 })),
     iterations: Type.Optional(positiveInteger),
     fanOut: Type.Optional(positiveInteger),
     parallelism: Type.Optional(positiveInteger),
-    artifactBytes: Type.Optional(positiveInteger),
-    resultRows: Type.Optional(positiveInteger),
-    networkBytes: Type.Optional(positiveInteger),
-    sideEffects: Type.Optional(Type.Integer({ minimum: 0 })),
+    retries: Type.Optional(Type.Integer({ minimum: 0 })),
   },
   { additionalProperties: false }
 );

--- a/packages/storage/src/runs/budget-store.pg.test.ts
+++ b/packages/storage/src/runs/budget-store.pg.test.ts
@@ -26,7 +26,6 @@ function run(): StartRunInput {
       effectiveSubject: { kind: "agent", id: "agent-1" },
       guardrailContextRef: "guardrail-context-1",
     },
-    bounds: { wallTimeMs: 60_000, activeTimeMs: 30_000, attempts: 3, sideEffects: 2 },
     createdAt: CREATED_AT,
     states: [{ key: "apply", definitionRef: "sha256:bundle-1#/states/apply", resolvedInput: {} }],
   };

--- a/packages/storage/src/runs/child-store.pg.test.ts
+++ b/packages/storage/src/runs/child-store.pg.test.ts
@@ -35,7 +35,6 @@ function run(id: string): StartRunInput {
       effectiveSubject: { kind: "agent", id: "agent-1" },
       guardrailContextRef: "guardrail-context-1",
     },
-    bounds: { wallTimeMs: 60_000, activeTimeMs: 30_000, attempts: 3, sideEffects: 2 },
     createdAt: CREATED_AT,
     states: [{ key: "apply", definitionRef: "sha256:bundle-1#/states/apply", resolvedInput: {} }],
   };

--- a/packages/storage/src/runs/concurrency-store.pg.test.ts
+++ b/packages/storage/src/runs/concurrency-store.pg.test.ts
@@ -33,7 +33,6 @@ function run(id: string): StartRunInput {
       effectiveSubject: { kind: "agent", id: "agent-1" },
       guardrailContextRef: "guardrail-context-1",
     },
-    bounds: { wallTimeMs: 60_000, activeTimeMs: 30_000, attempts: 3, sideEffects: 2 },
     createdAt: CREATED_AT,
     states: [{ key: "apply", definitionRef: "sha256:bundle-1#/states/apply", resolvedInput: {} }],
   };

--- a/packages/storage/src/runs/events.pg.test.ts
+++ b/packages/storage/src/runs/events.pg.test.ts
@@ -27,7 +27,6 @@ function run(id: string): StartRunInput {
       effectiveSubject: { kind: "agent", id: "agent-1" },
       guardrailContextRef: "guardrail-context-1",
     },
-    bounds: { wallTimeMs: 60_000, activeTimeMs: 30_000, attempts: 3, sideEffects: 2 },
     createdAt: OCCURRED_AT,
     states: [{ key: "apply", definitionRef: "sha256:bundle-1#/states/apply", resolvedInput: {} }],
   };

--- a/packages/storage/src/runs/index.ts
+++ b/packages/storage/src/runs/index.ts
@@ -56,7 +56,6 @@ export type {
   PersistedRunStatus,
   PersistedState,
   PersistedStateStatus,
-  RunBounds,
   RunBundle,
   RunIdentity,
   RunLineage,
@@ -71,6 +70,7 @@ export type {
 } from "./run-store";
 export {
   MAX_RUN_PAGE_SIZE,
+  RUN_BOUNDS_REMOVAL_STATEMENTS,
   RUN_BROWSE_STORAGE_STATEMENTS,
   RUN_STORAGE_STATEMENTS,
   RunPersistenceError,

--- a/packages/storage/src/runs/loop-checkpoint-store.pg.test.ts
+++ b/packages/storage/src/runs/loop-checkpoint-store.pg.test.ts
@@ -31,7 +31,6 @@ function run(id: string, businessId: string): StartRunInput {
       effectiveSubject: { kind: "user", id: "user-1" },
       guardrailContextRef: "guardrail-context-1",
     },
-    bounds: { wallTimeMs: 60_000, activeTimeMs: 30_000, attempts: 3, sideEffects: 2 },
     createdAt: CREATED_AT,
     states: [{ key: "invoke", definitionRef: "sha256:bundle-1#/states/invoke", resolvedInput: {} }],
   };

--- a/packages/storage/src/runs/run-lease-store.ts
+++ b/packages/storage/src/runs/run-lease-store.ts
@@ -50,7 +50,7 @@ export async function reclaimExpiredRunRows(
             lease_expires_at = NULL
        FROM candidates
       WHERE runs.id = candidates.id
-     RETURNING runs.id, runs.business_id, runs.source, runs.bundle, runs.identity, runs.bounds,
+     RETURNING runs.id, runs.business_id, runs.source, runs.bundle, runs.identity,
                runs.status, runs.version, runs.created_at, runs.started_at, runs.finished_at,
                runs.result_artifact_id, runs.error_evidence_ref, runs.lease_owner,
                runs.lease_expires_at`,
@@ -86,7 +86,7 @@ export async function claimNextQueuedRunRows(
             lease_expires_at = $3::timestamptz
        FROM candidates
       WHERE runs.id = candidates.id
-     RETURNING runs.id, runs.business_id, runs.source, runs.bundle, runs.identity, runs.bounds,
+     RETURNING runs.id, runs.business_id, runs.source, runs.bundle, runs.identity,
                runs.status, runs.version, runs.created_at, runs.started_at, runs.finished_at,
                runs.result_artifact_id, runs.error_evidence_ref, runs.lease_owner,
                runs.lease_expires_at`,

--- a/packages/storage/src/runs/run-row.ts
+++ b/packages/storage/src/runs/run-row.ts
@@ -1,10 +1,4 @@
-import type {
-  PersistedRun,
-  PersistedRunStatus,
-  RunBounds,
-  RunBundle,
-  RunIdentity,
-} from "./run-store";
+import type { PersistedRun, PersistedRunStatus, RunBundle, RunIdentity } from "./run-store";
 import { optionalTimestamp, timestamp } from "./timestamps";
 
 export interface RunRow {
@@ -13,7 +7,6 @@ export interface RunRow {
   source: string;
   bundle: RunBundle;
   identity: RunIdentity;
-  bounds: RunBounds;
   status: PersistedRunStatus;
   version: number;
   created_at: string | Date;
@@ -32,7 +25,6 @@ export function persistedRun(row: RunRow): PersistedRun {
     source: row.source,
     bundle: row.bundle,
     identity: row.identity,
-    bounds: row.bounds,
     status: row.status,
     version: row.version,
     createdAt: timestamp(row.created_at),

--- a/packages/storage/src/runs/run-store.pg.test.ts
+++ b/packages/storage/src/runs/run-store.pg.test.ts
@@ -33,12 +33,6 @@ function run(overrides: Partial<StartRunInput> = {}): StartRunInput {
       effectiveSubject: { kind: "agent", id: "agent-1" },
       guardrailContextRef: "guardrail-context-1",
     },
-    bounds: {
-      wallTimeMs: 60_000,
-      activeTimeMs: 30_000,
-      attempts: 3,
-      sideEffects: 2,
-    },
     createdAt: CREATED_AT,
     states: [
       {
@@ -76,7 +70,7 @@ describe("RunStore (PostgreSQL)", () => {
     await database.close();
   });
 
-  it("atomically persists immutable bundle, identity, bounds, and typed States", async () => {
+  it("atomically persists immutable bundle, identity, and typed States", async () => {
     const persisted = await store.start(run());
 
     expect(persisted).toMatchObject({
@@ -86,7 +80,6 @@ describe("RunStore (PostgreSQL)", () => {
       version: 0,
       bundle: run().bundle,
       identity: run().identity,
-      bounds: run().bounds,
     });
     expect(await store.listStates("business-1", persisted.id)).toEqual([
       expect.objectContaining({

--- a/packages/storage/src/runs/run-store.ts
+++ b/packages/storage/src/runs/run-store.ts
@@ -79,13 +79,6 @@ export interface RunIdentity {
   readonly guardrailContextRef: string;
 }
 
-export interface RunBounds {
-  readonly wallTimeMs: number;
-  readonly activeTimeMs: number;
-  readonly attempts: number;
-  readonly sideEffects: number;
-}
-
 export interface StartRunInput {
   readonly id: string;
   readonly businessId: string;
@@ -93,7 +86,6 @@ export interface StartRunInput {
   readonly source: string;
   readonly bundle: RunBundle;
   readonly identity: RunIdentity;
-  readonly bounds: RunBounds;
   readonly createdAt: string;
   readonly states: readonly StartStateInput[];
   readonly parentRunId?: string;
@@ -107,7 +99,6 @@ export interface PersistedRun {
   readonly source: string;
   readonly bundle: RunBundle;
   readonly identity: RunIdentity;
-  readonly bounds: RunBounds;
   readonly status: PersistedRunStatus;
   readonly version: number;
   readonly createdAt: string;
@@ -173,6 +164,21 @@ export const RUN_BROWSE_STORAGE_STATEMENTS: readonly string[] = [
     ON runs (business_id, created_at DESC, id DESC)`,
 ];
 
+/** Immutable Run identity. Kept separate because the bounds removal must replace it in place. */
+const RUN_IDENTITY_IMMUTABLE_FUNCTION = `CREATE OR REPLACE FUNCTION reject_run_identity_change()
+    RETURNS trigger LANGUAGE plpgsql AS $$
+    BEGIN
+      IF OLD.id IS DISTINCT FROM NEW.id
+        OR OLD.business_id IS DISTINCT FROM NEW.business_id
+        OR OLD.bundle IS DISTINCT FROM NEW.bundle
+        OR OLD.identity IS DISTINCT FROM NEW.identity
+        OR OLD.created_at IS DISTINCT FROM NEW.created_at THEN
+        RAISE EXCEPTION 'run_identity_immutable';
+      END IF;
+      RETURN NEW;
+    END;
+    $$`;
+
 export const RUN_STORAGE_STATEMENTS: readonly string[] = [
   `CREATE TABLE IF NOT EXISTS runs (
     id                    uuid PRIMARY KEY,
@@ -180,14 +186,6 @@ export const RUN_STORAGE_STATEMENTS: readonly string[] = [
     source                text NOT NULL CHECK (length(source) > 0),
     bundle                jsonb NOT NULL CHECK (jsonb_typeof(bundle) = 'object'),
     identity              jsonb NOT NULL CHECK (jsonb_typeof(identity) = 'object'),
-    bounds                jsonb NOT NULL CHECK (
-      jsonb_typeof(bounds) = 'object'
-      AND bounds ?& ARRAY['wallTimeMs', 'activeTimeMs', 'attempts', 'sideEffects']
-      AND (bounds->>'wallTimeMs')::bigint > 0
-      AND (bounds->>'activeTimeMs')::bigint > 0
-      AND (bounds->>'attempts')::integer >= 0
-      AND (bounds->>'sideEffects')::integer >= 0
-    ),
     status                text NOT NULL DEFAULT 'queued'
       CHECK (status IN (${RUN_STATUS_SQL})),
     version               integer NOT NULL DEFAULT 0 CHECK (version >= 0),
@@ -272,20 +270,7 @@ export const RUN_STORAGE_STATEMENTS: readonly string[] = [
   `CREATE TRIGGER run_lineage_append_only
     BEFORE UPDATE OR DELETE ON run_lineage
     FOR EACH ROW EXECUTE FUNCTION reject_run_append_only_change()`,
-  `CREATE OR REPLACE FUNCTION reject_run_identity_change()
-    RETURNS trigger LANGUAGE plpgsql AS $$
-    BEGIN
-      IF OLD.id IS DISTINCT FROM NEW.id
-        OR OLD.business_id IS DISTINCT FROM NEW.business_id
-        OR OLD.bundle IS DISTINCT FROM NEW.bundle
-        OR OLD.identity IS DISTINCT FROM NEW.identity
-        OR OLD.bounds IS DISTINCT FROM NEW.bounds
-        OR OLD.created_at IS DISTINCT FROM NEW.created_at THEN
-        RAISE EXCEPTION 'run_identity_immutable';
-      END IF;
-      RETURN NEW;
-    END;
-    $$`,
+  RUN_IDENTITY_IMMUTABLE_FUNCTION,
   "DROP TRIGGER IF EXISTS runs_identity_immutable ON runs",
   `CREATE TRIGGER runs_identity_immutable
     BEFORE UPDATE ON runs
@@ -323,6 +308,19 @@ export const RUN_STORAGE_STATEMENTS: readonly string[] = [
   ...RUN_BROWSE_STORAGE_STATEMENTS,
 ];
 
+/**
+ * Drops the `runs.bounds` column, whose four fields no reader ever consulted (L3-10).
+ *
+ * A Run's real ceilings live in the compiled Routine — `bounds`/`retry` per State — and in the Run
+ * budget ledger; the column only ever held constants a single writer invented. The immutability
+ * trigger names its columns, so its function must stop naming `bounds` before the column goes,
+ * or the next `UPDATE` on a Run would raise inside the trigger.
+ */
+export const RUN_BOUNDS_REMOVAL_STATEMENTS: readonly string[] = [
+  RUN_IDENTITY_IMMUTABLE_FUNCTION,
+  "ALTER TABLE runs DROP COLUMN IF EXISTS bounds",
+];
+
 interface RunCursor {
   readonly createdAt: string;
   readonly id: string;
@@ -349,7 +347,7 @@ function decodeRunCursor(decoded: string | undefined): RunCursor | null {
 }
 
 /** PostgreSQL persistence for business-scoped Runs, States, attempts, and lineage. */
-export const RUN_COLUMNS = `id, business_id, source, bundle, identity, bounds, status, version, created_at,
+export const RUN_COLUMNS = `id, business_id, source, bundle, identity, status, version, created_at,
   started_at, finished_at, result_artifact_id, error_evidence_ref, lease_owner, lease_expires_at`;
 
 export class RunStore {
@@ -358,8 +356,8 @@ export class RunStore {
   async start(input: StartRunInput): Promise<PersistedRun> {
     return this.transactions.withTransaction(async (transaction) => {
       const inserted = await transaction.query<RunRow>(
-        `INSERT INTO runs (id, business_id, source, bundle, identity, bounds, created_at)
-         VALUES ($1, $2, $3, $4::jsonb, $5::jsonb, $6::jsonb, $7::timestamptz)
+        `INSERT INTO runs (id, business_id, source, bundle, identity, created_at)
+         VALUES ($1, $2, $3, $4::jsonb, $5::jsonb, $6::timestamptz)
          RETURNING ${RUN_COLUMNS}`,
         [
           input.id,
@@ -367,7 +365,6 @@ export class RunStore {
           input.source,
           JSON.stringify(input.bundle),
           JSON.stringify(input.identity),
-          JSON.stringify(input.bounds),
           input.createdAt,
         ]
       );

--- a/packages/storage/src/runs/state-concurrency-store.pg.test.ts
+++ b/packages/storage/src/runs/state-concurrency-store.pg.test.ts
@@ -36,7 +36,6 @@ function run(id: string, businessId: string): StartRunInput {
       effectiveSubject: { kind: "user", id: "user-1" },
       guardrailContextRef: "guardrail-context-1",
     },
-    bounds: { wallTimeMs: 60_000, activeTimeMs: 30_000, attempts: 3, sideEffects: 2 },
     createdAt: CREATED_AT,
     states: [{ key: "Notify", definitionRef: "sha256:bundle-1#/states/Notify", resolvedInput: {} }],
   };

--- a/packages/storage/src/runs/state-retry-store.pg.test.ts
+++ b/packages/storage/src/runs/state-retry-store.pg.test.ts
@@ -28,7 +28,6 @@ function run(id: string, businessId: string): StartRunInput {
       effectiveSubject: { kind: "user", id: "user-1" },
       guardrailContextRef: "guardrail-context-1",
     },
-    bounds: { wallTimeMs: 60_000, activeTimeMs: 30_000, attempts: 3, sideEffects: 2 },
     createdAt: CREATED_AT,
     states: [{ key: "Notify", definitionRef: "sha256:bundle-1#/states/Notify", resolvedInput: {} }],
   };

--- a/packages/storage/src/runs/wait-store.pg.test.ts
+++ b/packages/storage/src/runs/wait-store.pg.test.ts
@@ -34,7 +34,6 @@ function run(): StartRunInput {
       effectiveSubject: { kind: "agent", id: "agent-1" },
       guardrailContextRef: "guardrail-context-1",
     },
-    bounds: { wallTimeMs: 60_000, activeTimeMs: 30_000, attempts: 3, sideEffects: 2 },
     createdAt: CREATED_AT,
     states: [
       {

--- a/packages/tool-broker/src/authorize.ts
+++ b/packages/tool-broker/src/authorize.ts
@@ -4,6 +4,7 @@ import {
   type DlpRule,
   decideEffectivePermission,
   evaluateGuardrail,
+  type GuardrailDecisionReason,
   type GuardrailRule,
 } from "@tulipfarm/authz";
 import type { PublishedToolContract } from "./contract";
@@ -32,9 +33,21 @@ export type ToolAuthorizationDenialReason =
   | "destination_denied"
   | "missing_guardrail_revision";
 
+/**
+ * Why this policy evaluation demanded a human. Carried out of the decision so the approval a
+ * caller then creates can be bound to the evaluation that caused it, rather than to the bare fact
+ * that something did (I-13).
+ */
+export interface ApprovalDemandEvidence {
+  readonly requiredBy: "guardrail_rule" | "sandbox_contract";
+  readonly reason: GuardrailDecisionReason | "sandbox_mutating_adapter";
+  /** Id of the Guardrail rule whose `require_approval` effect decided; absent for the contract. */
+  readonly ruleId?: string;
+}
+
 export type ToolPolicyOutcome =
   | { readonly outcome: "authorized" }
-  | { readonly outcome: "awaiting_approval" }
+  | { readonly outcome: "awaiting_approval"; readonly demand?: ApprovalDemandEvidence }
   | { readonly outcome: "denied"; readonly reason: ToolAuthorizationDenialReason };
 
 function protectedRequests(intent: ToolIntent, contract: PublishedToolContract) {
@@ -74,7 +87,10 @@ export function authorizeToolIntent(
 
   // A sandbox script may perform an opaque provider mutation. Its source and exact intent must be
   // approved even when a broader Guardrail would normally allow unattended low-risk execution.
-  let approvalRequired = contract.adapter.kind === "sandbox" && contract.mutating;
+  let demand: ApprovalDemandEvidence | undefined =
+    contract.adapter.kind === "sandbox" && contract.mutating
+      ? { requiredBy: "sandbox_contract", reason: "sandbox_mutating_adapter" }
+      : undefined;
   for (const request of protectedRequests(intent, contract)) {
     const authz = decideEffectivePermission(context.authorityLayers, request, context.now);
     if (!authz.allowed) return { outcome: "denied", reason: "authorization_denied" };
@@ -88,7 +104,15 @@ export function authorizeToolIntent(
     if (guardrail.effect === "deny") {
       return { outcome: "denied", reason: "guardrail_denied" };
     }
-    approvalRequired ||= guardrail.effect === "require_approval";
+    // The first rule that demands a human is the one the approver is shown; a later rule saying
+    // the same thing adds no evidence, and overwriting would attribute the ask to the wrong rule.
+    if (guardrail.effect === "require_approval" && demand === undefined) {
+      demand = {
+        requiredBy: "guardrail_rule",
+        reason: guardrail.reason,
+        ...(guardrail.ruleId === undefined ? {} : { ruleId: guardrail.ruleId }),
+      };
+    }
   }
 
   const dlp = checkDlpBoundary(context.dlpRules, {
@@ -98,5 +122,7 @@ export function authorizeToolIntent(
     secretDetected: context.secretDetected,
   });
   if (dlp.effect === "deny") return { outcome: "denied", reason: "dlp_denied" };
-  return approvalRequired ? { outcome: "awaiting_approval" } : { outcome: "authorized" };
+  return demand === undefined
+    ? { outcome: "authorized" }
+    : { outcome: "awaiting_approval", demand };
 }

--- a/packages/tool-broker/src/broker.ts
+++ b/packages/tool-broker/src/broker.ts
@@ -1,5 +1,6 @@
 import { ajv } from "@tulipfarm/schema";
 import {
+  type ApprovalDemandEvidence,
   authorizeToolIntent,
   type ToolAuthorizationContext,
   type ToolAuthorizationDenialReason,
@@ -26,7 +27,10 @@ interface ToolBrokerOutcomeBase {
 
 export type ToolBrokerOutcome =
   | (ToolBrokerOutcomeBase & { readonly outcome: "authorized" })
-  | (ToolBrokerOutcomeBase & { readonly outcome: "awaiting_approval" })
+  | (ToolBrokerOutcomeBase & {
+      readonly outcome: "awaiting_approval";
+      readonly demand?: ApprovalDemandEvidence;
+    })
   | (Partial<ToolBrokerOutcomeBase> & {
       readonly outcome: "denied";
       readonly reason: ToolBrokerDenialReason;
@@ -63,7 +67,6 @@ export class ToolBroker {
     }
 
     const policy = authorizeToolIntent(intent, contract, context);
-    if (policy.outcome === "denied") return { ...base, ...policy };
-    return { ...base, outcome: policy.outcome };
+    return { ...base, ...policy };
   }
 }

--- a/packages/tool-broker/src/index.ts
+++ b/packages/tool-broker/src/index.ts
@@ -5,6 +5,7 @@ export type {
 } from "./approval-gate";
 export { ToolApprovalDecisions, ToolApprovalGate, ToolApprovalGateError } from "./approval-gate";
 export type {
+  ApprovalDemandEvidence,
   ToolAuthorizationContext,
   ToolAuthorizationDenialReason,
   ToolPolicyOutcome,

--- a/packages/tool-host/src/approvals/evidence.ts
+++ b/packages/tool-host/src/approvals/evidence.ts
@@ -1,0 +1,75 @@
+/** Guardrail evidence for one approval: what demanded a human, recorded at the instant it did. */
+
+import { canonicalHash } from "@tulipfarm/schema";
+import type { ApprovalDemandEvidence } from "@tulipfarm/tool-broker";
+
+/**
+ * Why an approval was asked for, as the policy evaluation that asked stated it (I-13).
+ *
+ * `autonomy_policy` is the third producer: the Turn declared `approval-required` autonomy, so a
+ * mutating Tool needs a human even where no Guardrail rule and no contract demanded one. It is
+ * named rather than folded into the Guardrail cases so the record never claims a rule fired.
+ */
+export interface ApprovalGuardrailEvidence {
+  readonly demandedBy: ApprovalDemandEvidence["requiredBy"] | "autonomy_policy";
+  /** Guardrail revision the demanding evaluation ran against; "none" when none was bound. */
+  readonly guardrailRevision: string;
+  readonly reason: string;
+  /** The Guardrail rule that decided, when a rule did. */
+  readonly ruleId?: string;
+  readonly toolName: string;
+  /** The exact intent the approver is being asked about, as {@link intentOf} computes it. */
+  readonly intentDigest: string;
+  readonly demandedAt: string;
+}
+
+/** What a caller knows about the demand before the intent is digested. */
+export type ApprovalDemand = Pick<
+  ApprovalGuardrailEvidence,
+  "demandedBy" | "guardrailRevision" | "reason" | "ruleId"
+>;
+
+/** The demand a Turn's own autonomy setting makes, where no rule and no contract made one. */
+export const AUTONOMY_APPROVAL_DEMAND: Pick<ApprovalDemand, "demandedBy" | "reason"> = {
+  demandedBy: "autonomy_policy",
+  reason: "autonomy_requires_approval",
+};
+
+/**
+ * The demand a gate reported without attributing it. Recorded verbatim rather than guessed at: an
+ * approval that names a rule which never fired is worse evidence than one that names nothing.
+ */
+export const UNATTRIBUTED_APPROVAL_DEMAND: Pick<ApprovalDemand, "demandedBy" | "reason"> = {
+  demandedBy: "guardrail_rule",
+  reason: "unattributed",
+};
+
+/** Content address of the evidence; recomputed before any decision to detect substitution. */
+export function approvalEvidenceDigest(evidence: ApprovalGuardrailEvidence): string {
+  return canonicalHash({
+    demandedBy: evidence.demandedBy,
+    guardrailRevision: evidence.guardrailRevision,
+    reason: evidence.reason,
+    ruleId: evidence.ruleId ?? null,
+    toolName: evidence.toolName,
+    intentDigest: evidence.intentDigest,
+    demandedAt: evidence.demandedAt,
+  });
+}
+
+/** Reads a stored evidence value back, or `null` when the row holds nothing usable. */
+export function readApprovalEvidence(value: unknown): ApprovalGuardrailEvidence | null {
+  if (typeof value !== "object" || value === null) return null;
+  const candidate = value as Partial<ApprovalGuardrailEvidence>;
+  if (
+    typeof candidate.demandedBy !== "string" ||
+    typeof candidate.guardrailRevision !== "string" ||
+    typeof candidate.reason !== "string" ||
+    typeof candidate.toolName !== "string" ||
+    typeof candidate.intentDigest !== "string" ||
+    typeof candidate.demandedAt !== "string"
+  ) {
+    return null;
+  }
+  return candidate as ApprovalGuardrailEvidence;
+}

--- a/packages/tool-host/src/approvals/pending.ts
+++ b/packages/tool-host/src/approvals/pending.ts
@@ -1,4 +1,4 @@
-import type { ApprovalsRepo } from "@tulipfarm/tool-host";
+import type { ApprovalsRepo } from "./repo";
 
 /** Pending Tool approval projected from durable rows, not in-process Worker state. */
 export interface PendingToolApproval {

--- a/packages/tool-host/src/approvals/repo.ts
+++ b/packages/tool-host/src/approvals/repo.ts
@@ -1,3 +1,5 @@
+import { type ApprovalGuardrailEvidence, approvalEvidenceDigest } from "./evidence";
+
 /**
  * Narrower than `@tulipfarm/storage`'s `Queryable` on purpose: this repo runs against a pg Pool,
  * a PGlite test client and a storage transaction alike, and only the non-generic call site is
@@ -22,6 +24,14 @@ export interface ApprovalRow {
   consumedAt: Date | null;
   /** The Tool call that spent it, so only a redelivery of that same call may ride it again. */
   consumedByCallId: string | null;
+  /** The principal whose Turn asked for this effect; four-eyes is enforced against it (I-13). */
+  requesterPrincipalId: string | null;
+  /** The policy evaluation that demanded a human, exactly as it was recorded at that instant. */
+  guardrailEvidence: unknown;
+  /** Content address of {@link guardrailEvidence}, written once with it. */
+  guardrailEvidenceDigest: string | null;
+  /** Who decided. Compared against {@link requesterPrincipalId} to audit four-eyes after the fact. */
+  approverPrincipalId: string | null;
 }
 
 function rowToApproval(row: Record<string, unknown>): ApprovalRow {
@@ -35,26 +45,87 @@ function rowToApproval(row: Record<string, unknown>): ApprovalRow {
     resolvedAt: (row.resolved_at as Date | null) ?? null,
     consumedAt: (row.consumed_at as Date | null) ?? null,
     consumedByCallId: (row.consumed_by_call_id as string | null) ?? null,
+    requesterPrincipalId: (row.requester_principal_id as string | null) ?? null,
+    guardrailEvidence: row.guardrail_evidence ?? null,
+    guardrailEvidenceDigest: (row.guardrail_evidence_digest as string | null) ?? null,
+    approverPrincipalId: (row.approver_principal_id as string | null) ?? null,
   };
 }
 
 const APPROVAL_COLUMNS =
-  "id, kind, status, payload, expires_at, created_at, resolved_at, consumed_at, consumed_by_call_id";
+  "id, kind, status, payload, expires_at, created_at, resolved_at, consumed_at, consumed_by_call_id, " +
+  "requester_principal_id, guardrail_evidence, guardrail_evidence_digest, approver_principal_id";
+
+/**
+ * Migration v60. Guardrail evidence and the requesting principal are stored on the approval row
+ * itself, not referenced: an approval that points at a row someone can still edit proves nothing
+ * about what the approver was shown. `approvals_evidence_immutable` makes the columns write-once
+ * so the row is its own evidence, and `approvals_tool_call_evidence` makes an approval that
+ * carries none impossible to create rather than merely unusual (I-13).
+ *
+ * The CHECK is added NOT VALID on purpose: rows written before this migration legitimately have
+ * no evidence, and rewriting history to satisfy a constraint would fabricate the very thing the
+ * constraint exists to guarantee. Those rows expire within the approval TTL, and
+ * `ToolApprovalService.signal` refuses them meanwhile.
+ */
+export const APPROVAL_EVIDENCE_STORAGE_STATEMENTS: readonly string[] = [
+  "ALTER TABLE approvals ADD COLUMN IF NOT EXISTS requester_principal_id text",
+  "ALTER TABLE approvals ADD COLUMN IF NOT EXISTS guardrail_evidence jsonb",
+  "ALTER TABLE approvals ADD COLUMN IF NOT EXISTS guardrail_evidence_digest text",
+  "ALTER TABLE approvals ADD COLUMN IF NOT EXISTS approver_principal_id text",
+  `DO $$ BEGIN
+     ALTER TABLE approvals ADD CONSTRAINT approvals_tool_call_evidence CHECK (
+       kind <> 'tool_call' OR (
+         requester_principal_id IS NOT NULL
+         AND guardrail_evidence IS NOT NULL
+         AND guardrail_evidence_digest IS NOT NULL
+       )
+     ) NOT VALID;
+   EXCEPTION WHEN duplicate_object THEN NULL; END $$`,
+  `CREATE OR REPLACE FUNCTION approvals_reject_evidence_change() RETURNS trigger AS $$
+   BEGIN
+     IF NEW.requester_principal_id IS DISTINCT FROM OLD.requester_principal_id
+       OR NEW.guardrail_evidence IS DISTINCT FROM OLD.guardrail_evidence
+       OR NEW.guardrail_evidence_digest IS DISTINCT FROM OLD.guardrail_evidence_digest THEN
+       RAISE EXCEPTION 'approval % has immutable Guardrail evidence', OLD.id;
+     END IF;
+     RETURN NEW;
+   END $$ LANGUAGE plpgsql`,
+  "DROP TRIGGER IF EXISTS approvals_evidence_immutable ON approvals",
+  `CREATE TRIGGER approvals_evidence_immutable BEFORE UPDATE ON approvals
+     FOR EACH ROW EXECUTE FUNCTION approvals_reject_evidence_change()`,
+];
 
 /** DB-backed approvals settle pending rows atomically to prevent replayed decisions. */
 export class ApprovalsRepo {
   constructor(private readonly db: ApprovalsQueryable) {}
 
+  /**
+   * A `tool_call` approval cannot be created without the evidence that demanded it or the
+   * principal that requested it — both are required arguments, and the row constraint rejects the
+   * write if a caller reaches this table another way.
+   */
   async insert(row: {
     id: string;
     kind: ApprovalKind;
     payload: unknown;
     expiresAt: Date;
+    requesterPrincipalId?: string;
+    evidence?: ApprovalGuardrailEvidence;
   }): Promise<void> {
     await this.db.query(
-      `INSERT INTO approvals (id, kind, status, payload, expires_at, created_at)
-       VALUES ($1, $2, 'pending', $3, $4, now())`,
-      [row.id, row.kind, JSON.stringify(row.payload), row.expiresAt]
+      `INSERT INTO approvals (id, kind, status, payload, expires_at, created_at,
+                              requester_principal_id, guardrail_evidence, guardrail_evidence_digest)
+       VALUES ($1, $2, 'pending', $3, $4, now(), $5, $6, $7)`,
+      [
+        row.id,
+        row.kind,
+        JSON.stringify(row.payload),
+        row.expiresAt,
+        row.requesterPrincipalId ?? null,
+        row.evidence === undefined ? null : JSON.stringify(row.evidence),
+        row.evidence === undefined ? null : approvalEvidenceDigest(row.evidence),
+      ]
     );
   }
 
@@ -65,15 +136,44 @@ export class ApprovalsRepo {
     ]);
   }
 
-  async settlePending(id: string, status: Exclude<ApprovalStatus, "pending">): Promise<boolean> {
+  async settlePending(
+    id: string,
+    status: Exclude<ApprovalStatus, "pending">,
+    approverPrincipalId?: string
+  ): Promise<boolean> {
     const { rows } = await this.db.query(
       `UPDATE approvals
-       SET status = $2, resolved_at = now()
+       SET status = $2, resolved_at = now(), approver_principal_id = COALESCE($3, approver_principal_id)
        WHERE id = $1 AND status = 'pending'
        RETURNING id`,
-      [id, status]
+      [id, status, approverPrincipalId ?? null]
     );
     return rows.length === 1;
+  }
+
+  /**
+   * Principals other than `excludingPrincipalId` who could decide an approval. Only active users
+   * can: the approval surface is granted to the `admin` and `member` Roles both, and a service
+   * principal has no way to reach it. Four-eyes turns on this count being non-zero.
+   */
+  async countOtherEligibleApprovers(excludingPrincipalId: string): Promise<number> {
+    const { rows } = await this.db.query(
+      `SELECT count(*)::int AS eligible
+       FROM users
+       WHERE status = 'active' AND ('user:' || id::text) <> $1`,
+      [excludingPrincipalId]
+    );
+    const value = rows[0]?.eligible;
+    return typeof value === "number" ? value : Number(value ?? 0);
+  }
+
+  /** The Role principals a deciding principal holds, in the form a durable wait allows. */
+  async rolesForPrincipal(principalId: string): Promise<readonly string[]> {
+    const { rows } = await this.db.query(
+      `SELECT role FROM users WHERE status = 'active' AND ('user:' || id::text) = $1`,
+      [principalId]
+    );
+    return rows.map((row) => `role:${row.role as string}`);
   }
 
   /**

--- a/packages/tool-host/src/approvals/tool-approvals.ts
+++ b/packages/tool-host/src/approvals/tool-approvals.ts
@@ -3,6 +3,12 @@ import type { InvocationPrincipal } from "@tulipfarm/run-kernel";
 import { DurableWaitError, type DurableWaitManager } from "@tulipfarm/run-kernel";
 import { canonicalHash } from "@tulipfarm/schema";
 import type { ToolApprovalDecision, ToolApprovalPort } from "../ports";
+import {
+  type ApprovalDemand,
+  type ApprovalGuardrailEvidence,
+  approvalEvidenceDigest,
+  readApprovalEvidence,
+} from "./evidence";
 import type { ApprovalRow, ApprovalsRepo } from "./repo";
 
 /** Durable Tool approvals: intent-keyed rows park the Run; one-use wait tokens resume it.
@@ -31,6 +37,9 @@ export interface ToolApprovalPayload {
   /** Present once the Run actually parked; absent while the loop is still deciding to. */
   readonly waitId?: string;
 }
+
+/** Roles whose holders may decide a Tool approval, mirroring the `approval` surface grant. */
+export const APPROVAL_DECIDER_ROLES: readonly string[] = ["role:admin", "role:member"];
 
 export interface ToolApprovalServiceOptions {
   readonly repo: ApprovalsRepo;
@@ -78,6 +87,10 @@ export class ToolApprovalService implements ToolApprovalPort {
     toolCallId: string;
     toolName: string;
     args: unknown;
+    /** The principal whose Turn is asking. Four-eyes has nothing to check without it. */
+    requesterPrincipalId: string;
+    /** What demanded a human, from the evaluation that demanded it. */
+    demand: ApprovalDemand;
   }): Promise<ToolApprovalDecision> {
     const intentDigest = intentOf(input.runId, input.toolName, input.args);
     const existing = await this.options.repo.findByIntent(
@@ -95,11 +108,19 @@ export class ToolApprovalService implements ToolApprovalPort {
       toolName: input.toolName,
       args: input.args,
     };
+    const evidence: ApprovalGuardrailEvidence = {
+      ...input.demand,
+      toolName: input.toolName,
+      intentDigest,
+      demandedAt: this.now().toISOString(),
+    };
     await this.options.repo.insert({
       id: approvalId,
       kind: "tool_call",
       payload,
       expiresAt: new Date(this.now().getTime() + this.ttlMs),
+      requesterPrincipalId: input.requesterPrincipalId,
+      evidence,
     });
     return { status: "pending", approvalId };
   }
@@ -133,9 +154,11 @@ export class ToolApprovalService implements ToolApprovalPort {
       kind: "approval",
       aggregation: "first",
       schemaRef: APPROVAL_SIGNAL_SCHEMA_REF,
-      // The person the turn acts as is the person who decides its approvals. Recorded on the wait
-      // so the kernel enforces it under the row lock, rather than a route deciding case by case.
-      allowedPrincipals: [`${input.subject.kind}:${input.subject.id}`],
+      // Four-eyes (I-13) needs somebody other than the requester to be able to decide, so the
+      // wait admits the Roles that hold the `approval` surface as well as the requester. The
+      // requester is kept because a deployment with no other eligible approver must not be unable
+      // to decide at all; `signal` is what refuses self-approval when someone else could decide.
+      allowedPrincipals: [`${input.subject.kind}:${input.subject.id}`, ...APPROVAL_DECIDER_ROLES],
       expectedSignals: 1,
       quorum: null,
       deadlineAt: row.expiresAt.toISOString(),
@@ -162,7 +185,16 @@ export class ToolApprovalService implements ToolApprovalPort {
     };
   }
 
-  /** Checks principal, settles row, then signals wait so resumed dispatch does not re-park. */
+  /**
+   * Checks evidence and approver, settles the row, then signals the wait.
+   *
+   * Four-eyes (I-13): the principal that asked for an effect may not be the principal that
+   * authorizes it, whenever any other principal could. Where nobody else could — a deployment
+   * with exactly one active user — the requester decides and the row records them as the
+   * approver, so the exemption is visible in the audit trail rather than silent. Refusing outright
+   * would leave a solo deployment unable to run any approved Tool at all, which is a worse
+   * failure than the one four-eyes prevents.
+   */
   async signal(input: {
     businessId: string;
     approvalId: string;
@@ -182,9 +214,34 @@ export class ToolApprovalService implements ToolApprovalPort {
 
     const wait = await this.options.waits.find(input.businessId, waitId);
     if (wait === null) return "not_found";
-    if (!wait.allowedPrincipals.includes(input.principal)) return "forbidden";
 
-    if (!(await this.options.repo.settlePending(input.approvalId, input.decision))) {
+    // Evidence first: a decision on an approval whose recorded Guardrail evidence is missing or no
+    // longer matches its digest is a decision about something other than what was asked.
+    const evidence = readApprovalEvidence(row.guardrailEvidence);
+    if (
+      evidence === null ||
+      row.guardrailEvidenceDigest === null ||
+      approvalEvidenceDigest(evidence) !== row.guardrailEvidenceDigest
+    ) {
+      return "forbidden";
+    }
+
+    const requester = row.requesterPrincipalId;
+    // A row that never recorded who asked cannot be four-eyes checked, so it is not decidable.
+    if (requester === null) return "forbidden";
+
+    const principalAs = await this.approverPrincipal(wait.allowedPrincipals, input.principal);
+    if (principalAs === null) return "forbidden";
+    if (
+      input.principal === requester &&
+      (await this.options.repo.countOtherEligibleApprovers(requester)) > 0
+    ) {
+      return "forbidden";
+    }
+
+    if (
+      !(await this.options.repo.settlePending(input.approvalId, input.decision, input.principal))
+    ) {
       return "already_settled";
     }
 
@@ -194,11 +251,15 @@ export class ToolApprovalService implements ToolApprovalPort {
         businessId: input.businessId,
         runId,
         token: resumeToken,
-        principal: input.principal,
+        principal: principalAs,
         schemaRef: APPROVAL_SIGNAL_SCHEMA_REF,
         // One decision per approval: a replayed request redeems nothing a second time.
         correlationKey: `approval:${input.approvalId}`,
-        signalDigest: canonicalHash({ approvalId: input.approvalId, decision: input.decision }),
+        signalDigest: canonicalHash({
+          approvalId: input.approvalId,
+          decision: input.decision,
+          decidedBy: input.principal,
+        }),
         receivedAt: this.now().toISOString(),
       });
     } catch (error) {
@@ -208,6 +269,19 @@ export class ToolApprovalService implements ToolApprovalPort {
       return "already_settled";
     }
     return "resumed";
+  }
+
+  /**
+   * The principal form this decider may signal as: itself when the wait names it, otherwise a Role
+   * it holds that the wait allows. `null` means the wait admits nothing this decider has.
+   */
+  private async approverPrincipal(
+    allowedPrincipals: readonly string[],
+    principal: string
+  ): Promise<string | null> {
+    if (allowedPrincipals.includes(principal)) return principal;
+    const held = await this.options.repo.rolesForPrincipal(principal);
+    return allowedPrincipals.find((allowed) => held.includes(allowed)) ?? null;
   }
 }
 

--- a/packages/tool-host/src/dispatcher.ts
+++ b/packages/tool-host/src/dispatcher.ts
@@ -12,6 +12,11 @@ import {
   type ToolAuthorizationDenialReason,
   type ToolTargetRef,
 } from "@tulipfarm/tool-broker";
+import {
+  type ApprovalDemand,
+  AUTONOMY_APPROVAL_DEMAND,
+  UNATTRIBUTED_APPROVAL_DEMAND,
+} from "./approvals/evidence";
 import type {
   HostedToolCall,
   HostedToolResult,
@@ -85,7 +90,7 @@ export interface RegistryToolDispatcherOptions {
 
 type AuthorizeVerdict =
   | { readonly decision: "proceed" }
-  | { readonly decision: "approval" }
+  | { readonly decision: "approval"; readonly demand: ApprovalDemand }
   | { readonly decision: "denied"; readonly result: HostedToolResult };
 
 /** Worker approvals mirror the web path: mutating, `approval-required`, and not opted out. */
@@ -179,7 +184,21 @@ export class RegistryToolDispatcher implements TurnToolDispatcher {
 
     if (outcome.outcome === "authorized") return { decision: "proceed" };
     // Policy-level approval is not a pass; it must park even outside `approval-required`.
-    if (outcome.outcome === "awaiting_approval") return { decision: "approval" };
+    if (outcome.outcome === "awaiting_approval") {
+      return {
+        decision: "approval",
+        demand: {
+          ...(outcome.demand === undefined
+            ? UNATTRIBUTED_APPROVAL_DEMAND
+            : {
+                demandedBy: outcome.demand.requiredBy,
+                reason: outcome.demand.reason,
+                ...(outcome.demand.ruleId === undefined ? {} : { ruleId: outcome.demand.ruleId }),
+              }),
+          guardrailRevision: this.options.guardrails?.revision ?? "none",
+        },
+      };
+    }
     return {
       decision: "denied",
       result: { status: "denied", reason: denialReason(call.name, outcome.reason) },
@@ -357,6 +376,16 @@ export class RegistryToolDispatcher implements TurnToolDispatcher {
         toolCallId: call.callId,
         toolName: definition.name,
         args: call.arguments,
+        requesterPrincipalId: `${authority.subject.kind}:${authority.subject.id}`,
+        // The Guardrail evaluation's own account of why, or the Turn's autonomy where policy
+        // allowed the call and only the declared autonomy demanded a human.
+        demand:
+          verdict.decision === "approval"
+            ? verdict.demand
+            : {
+                ...AUTONOMY_APPROVAL_DEMAND,
+                guardrailRevision: this.options.guardrails?.revision ?? "none",
+              },
       });
       if (decision.status === "pending") {
         return { status: "awaiting_approval", approvalId: decision.approvalId };

--- a/packages/tool-host/src/index.ts
+++ b/packages/tool-host/src/index.ts
@@ -1,4 +1,17 @@
 export {
+  type ApprovalDemand,
+  type ApprovalGuardrailEvidence,
+  AUTONOMY_APPROVAL_DEMAND,
+  approvalEvidenceDigest,
+  readApprovalEvidence,
+  UNATTRIBUTED_APPROVAL_DEMAND,
+} from "./approvals/evidence";
+export {
+  listPendingToolApprovals,
+  type PendingToolApproval,
+} from "./approvals/pending";
+export {
+  APPROVAL_EVIDENCE_STORAGE_STATEMENTS,
   type ApprovalKind,
   type ApprovalRow,
   type ApprovalStatus,
@@ -6,6 +19,7 @@ export {
   ApprovalsRepo,
 } from "./approvals/repo";
 export {
+  APPROVAL_DECIDER_ROLES,
   APPROVAL_SIGNAL_SCHEMA_REF,
   APPROVAL_WAIT_TTL_MS,
   type ApprovalSignalOutcome,

--- a/packages/tool-host/src/ports.ts
+++ b/packages/tool-host/src/ports.ts
@@ -5,6 +5,7 @@ import type {
   SurfaceRendererManifest,
   SurfaceTarget,
 } from "@tulipfarm/surface";
+import type { ApprovalDemand } from "./approvals/evidence";
 
 /**
  * Ports the Tool host needs but must not own. Each one is something a process may legitimately
@@ -77,6 +78,10 @@ export interface ToolApprovalPort {
     toolCallId: string;
     toolName: string;
     args: unknown;
+    /** Who is asking. An approval that does not record it cannot be four-eyes checked (I-13). */
+    requesterPrincipalId: string;
+    /** The policy evaluation that demanded a human, bound to the approval it creates. */
+    demand: ApprovalDemand;
   }): Promise<ToolApprovalDecision>;
   /**
    * Spends an approved decision at the dispatch that will execute it. `false` means the decision

--- a/scripts/approval-evidence-four-eyes.test.ts
+++ b/scripts/approval-evidence-four-eyes.test.ts
@@ -1,0 +1,401 @@
+import type { PGlite } from "@electric-sql/pglite";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ambientTransactionPort, type Queryable, transactionPort } from "../apps/api/src/db";
+import { makeMigratedPglite } from "../apps/api/src/test/pglite";
+import { DEPLOYMENT_BUSINESS_ID } from "../packages/constants/src/index";
+import {
+  ArtifactService,
+  DurableInvocationGateway,
+  DurableWaitManager,
+  PgDurableInvocationStore,
+  RunResumeGateway,
+  TypedOutputValidator,
+} from "../packages/run-kernel/src/index";
+import { CHAT_REQUEST_SCHEMA_REF, INVOCATION_REQUEST_SCHEMAS } from "../packages/schema/src/index";
+import { ArtifactStore } from "../packages/storage/src/artifacts/artifact-store";
+import { RunStore } from "../packages/storage/src/runs/run-store";
+import { WaitStore } from "../packages/storage/src/runs/wait-store";
+import {
+  type ApprovalGuardrailEvidence,
+  approvalEvidenceDigest,
+  readApprovalEvidence,
+} from "../packages/tool-host/src/approvals/evidence";
+import { ApprovalsRepo } from "../packages/tool-host/src/approvals/repo";
+import { ToolApprovalService } from "../packages/tool-host/src/approvals/tool-approvals";
+import type { TurnAuthority } from "../packages/tool-host/src/authority";
+import { InMemoryToolCatalog } from "../packages/tool-host/src/catalog";
+import { defineApiTool, toToolDef } from "../packages/tool-host/src/define";
+import { RegistryToolDispatcher } from "../packages/tool-host/src/dispatcher";
+import type { ToolGate } from "../packages/tool-host/src/gate";
+import { ok, type ToolDef } from "../packages/tool-host/src/types";
+
+/**
+ * Fitness function for L6-7, the residual half of LB-11 against invariant I-13.
+ *
+ * Two properties were missing after the one-use half landed, and both are properties of the
+ * *composition*, not of a method: an approval could be created carrying no record of the policy
+ * evaluation that demanded it, and the principal who asked for an effect could authorize it.
+ * Neither had anything standing over the production wiring, which is why LB-11 stayed open while
+ * the digest binding beside it was already enforced.
+ *
+ * So this drives the real pieces — `RegistryToolDispatcher`, `ToolApprovalService`, the real
+ * `DurableWaitManager` over a migrated PostgreSQL — from the dispatch that asks for a human to the
+ * request that decides, and asserts:
+ *
+ *  1. Every approval the composition creates carries the Guardrail evidence that demanded it,
+ *     bound to the intent and content-addressed, and names the principal that requested it.
+ *  2. The table refuses an approval without that evidence and refuses to let it change afterwards,
+ *     so the record proves what the approver was shown rather than merely asserting it.
+ *  3. A requester cannot decide their own approval while any other principal could decide it, and
+ *     the one principal in a solo deployment still can — a four-eyes rule that bricks a
+ *     single-admin instance is a worse failure than the self-approval it prevents.
+ */
+
+const SUBJECT = { kind: "user", id: "11111111-1111-4111-8111-111111111111" } as const;
+const REQUESTER = `${SUBJECT.kind}:${SUBJECT.id}`;
+const APPROVER_ID = "22222222-2222-4222-8222-222222222222";
+const STATE_KEY = "invoke";
+const WRITE_TOOL = "customer_delete";
+const WRITE_ARGS = { id: "cust-1" };
+
+/** A gate that demands a human and attributes it, as `authorizeToolIntent` does. */
+const RULE_GATE: ToolGate = {
+  authorize: () => ({
+    outcome: "awaiting_approval",
+    demand: { requiredBy: "guardrail_rule", reason: "approval_required", ruleId: "no-bulk-delete" },
+  }),
+};
+
+describe("approvals bind Guardrail evidence and enforce four eyes (L6-7)", () => {
+  let database: PGlite;
+  let runs: RunStore;
+  let repo: ApprovalsRepo;
+  let approvals: ToolApprovalService;
+  let waits: DurableWaitManager;
+  let invocations: DurableInvocationGateway;
+  let executed: unknown[];
+
+  beforeEach(async () => {
+    database = await makeMigratedPglite();
+    const queryable = database as unknown as Queryable;
+    const transactions = transactionPort(queryable);
+    const validator = new TypedOutputValidator(INVOCATION_REQUEST_SCHEMAS);
+    invocations = new DurableInvocationGateway({
+      store: new PgDurableInvocationStore(
+        transactions,
+        (transaction) =>
+          new ArtifactService(new ArtifactStore(ambientTransactionPort(transaction)), validator)
+      ),
+      validator,
+    });
+    runs = new RunStore(transactions);
+    repo = new ApprovalsRepo(queryable);
+    waits = new DurableWaitManager(new WaitStore(transactions), new RunResumeGateway(runs));
+    approvals = new ToolApprovalService({ repo, waits });
+    executed = [];
+    await addUser(SUBJECT.id, "requester@example.com", "admin");
+  });
+
+  afterEach(async () => {
+    await database.close();
+  });
+
+  async function addUser(id: string, email: string, role: string): Promise<void> {
+    await database.query(
+      `INSERT INTO users (id, email, password_hash, role, created_at, status)
+       VALUES ($1, $2, 'x', $3, now(), 'active')`,
+      [id, email, role]
+    );
+  }
+
+  function dispatcher(gate?: ToolGate): RegistryToolDispatcher {
+    const registry = new InMemoryToolCatalog();
+    const schema = {
+      type: "object",
+      required: ["id"],
+      additionalProperties: false,
+      properties: { id: { type: "string" } },
+    };
+    const run = async (args: unknown) => {
+      executed.push(args);
+      return ok({ deleted: true });
+    };
+    // A gated dispatch needs the authorization contract the gate decides against; the ungated one
+    // is the plain registry Tool the autonomy path sees.
+    const definition: ToolDef =
+      gate === undefined
+        ? {
+            name: WRITE_TOOL,
+            tier: "platform",
+            mutating: true,
+            description: "deletes a customer",
+            inputSchema: schema,
+            execute: run,
+          }
+        : toToolDef(
+            defineApiTool({
+              name: WRITE_TOOL,
+              tier: "platform",
+              mutating: true,
+              description: "deletes a customer",
+              inputSchema: schema as unknown as Record<string, unknown>,
+              authorization: {
+                action: "record.delete",
+                resources: ["record"],
+                dataClasses: ["business_record"],
+              },
+              handler: run,
+            }),
+            (context) => context
+          );
+    registry.register(definition);
+    return new RegistryToolDispatcher({
+      registry,
+      // The Turn asked to be supervised; that is what makes this Tool need a human at all.
+      artifacts: {
+        read: async () => ({ content: { autonomy: "approval-required" } }),
+      } as unknown as ArtifactService,
+      approvals,
+      ...(gate === undefined
+        ? {}
+        : {
+            gate,
+            authorityLayers: {
+              resolvePrincipalLayer: async (name: string) => ({ name, grants: [] }),
+            },
+          }),
+    });
+  }
+
+  /** Mints a chat Run and drives it to `running`, where a turn asks for an approval. */
+  async function startRunningRun(): Promise<string> {
+    const started = await invocations.start({
+      source: "chat",
+      runSource: "chat",
+      businessId: DEPLOYMENT_BUSINESS_ID,
+      initiator: SUBJECT,
+      effectiveSubject: SUBJECT,
+      definitionRef: "published:agent:assistant",
+      payload: {
+        conversationId: "conversation-1",
+        message: { role: "user", content: "delete cust-1" },
+        autonomy: "approval-required",
+      },
+      payloadSchemaRef: CHAT_REQUEST_SCHEMA_REF,
+      idempotencyKey: "key-1",
+    });
+    await runs.transitionRun(DEPLOYMENT_BUSINESS_ID, started.runId, {
+      expectedVersion: 0,
+      expectedStatus: "queued",
+      status: "claimed",
+      leaseOwner: "worker-1",
+      leaseExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    await runs.transitionRun(DEPLOYMENT_BUSINESS_ID, started.runId, {
+      expectedVersion: 1,
+      expectedStatus: "claimed",
+      status: "running",
+      leaseOwner: "worker-1",
+      leaseExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    return started.runId;
+  }
+
+  function authorityFor(runId: string): TurnAuthority {
+    return {
+      businessId: DEPLOYMENT_BUSINESS_ID,
+      runId,
+      turn: { id: "turn-1", conversationId: "conversation-1", attempt: 1 },
+      subject: SUBJECT,
+      source: "chat",
+      bundleDigest: "sha256:bundle-1",
+    };
+  }
+
+  /** The production ask: a real dispatch of a mutating Tool that a human has to authorize. */
+  async function ask(runId: string, gate?: ToolGate): Promise<string> {
+    const result = await dispatcher(gate).dispatch(authorityFor(runId), {
+      callId: "c1",
+      name: WRITE_TOOL,
+      arguments: WRITE_ARGS,
+    });
+    if (result.status !== "awaiting_approval") {
+      throw new Error(`expected the dispatch to ask for approval, got ${result.status}`);
+    }
+    expect(executed, "nothing may run before a human decides").toEqual([]);
+    return result.approvalId;
+  }
+
+  /** What the Agent State runner does once the loop reports it parked. */
+  async function park(runId: string, approvalId: string): Promise<void> {
+    await approvals.registerWait({
+      businessId: DEPLOYMENT_BUSINESS_ID,
+      runId,
+      stateKey: STATE_KEY,
+      approvalId,
+      subject: SUBJECT,
+    });
+    const state = await runs.findState(DEPLOYMENT_BUSINESS_ID, runId, STATE_KEY);
+    await runs.transitionState(DEPLOYMENT_BUSINESS_ID, runId, STATE_KEY, {
+      expectedVersion: state?.version ?? 0,
+      expectedStatus: state?.status ?? "ready",
+      status: "waiting",
+    });
+    await runs.transitionRun(DEPLOYMENT_BUSINESS_ID, runId, {
+      expectedVersion: 2,
+      expectedStatus: "running",
+      status: "waiting",
+      leaseOwner: null,
+      leaseExpiresAt: null,
+    });
+  }
+
+  async function evidenceOf(approvalId: string): Promise<ApprovalGuardrailEvidence> {
+    const row = await repo.findById(approvalId);
+    const evidence = readApprovalEvidence(row?.guardrailEvidence);
+    if (evidence === null) throw new Error("the approval carries no Guardrail evidence at all");
+    return evidence;
+  }
+
+  it("binds the evidence that demanded the approval to the approval it created", async () => {
+    const runId = await startRunningRun();
+    const approvalId = await ask(runId);
+
+    const row = await repo.findById(approvalId);
+    const evidence = await evidenceOf(approvalId);
+
+    // The Turn's declared autonomy is what demanded a human here, and the record says so rather
+    // than naming a Guardrail rule that never fired.
+    expect(evidence.demandedBy).toBe("autonomy_policy");
+    expect(evidence.reason).toBe("autonomy_requires_approval");
+    expect(evidence.toolName).toBe(WRITE_TOOL);
+    expect(evidence.intentDigest).toMatch(/^[a-z0-9:]+/);
+
+    // Content-addressed, so a later substitution is detectable without trusting the row.
+    expect(row?.guardrailEvidenceDigest).toBe(approvalEvidenceDigest(evidence));
+
+    // And the approval knows who asked, which is the only thing four-eyes can be checked against.
+    expect(row?.requesterPrincipalId).toBe(REQUESTER);
+  });
+
+  it("names the Guardrail rule when policy, not autonomy, demanded the human", async () => {
+    const runId = await startRunningRun();
+    const evidence = await evidenceOf(await ask(runId, RULE_GATE));
+
+    expect(evidence.demandedBy).toBe("guardrail_rule");
+    expect(evidence.ruleId).toBe("no-bulk-delete");
+  });
+
+  it("refuses to create a tool_call approval that carries no evidence", async () => {
+    await expect(
+      repo.insert({
+        id: "33333333-3333-4333-8333-333333333333",
+        kind: "tool_call",
+        payload: { runId: "r-1", toolName: WRITE_TOOL },
+        expiresAt: new Date(Date.now() + 60_000),
+      })
+    ).rejects.toThrow(/approvals_tool_call_evidence/);
+  });
+
+  it("refuses to change the evidence an approval already recorded", async () => {
+    const runId = await startRunningRun();
+    const approvalId = await ask(runId);
+
+    await expect(
+      database.query("UPDATE approvals SET guardrail_evidence = $2 WHERE id = $1", [
+        approvalId,
+        JSON.stringify({ demandedBy: "autonomy_policy", reason: "something else" }),
+      ])
+    ).rejects.toThrow(/immutable Guardrail evidence/);
+    await expect(
+      database.query("UPDATE approvals SET requester_principal_id = $2 WHERE id = $1", [
+        approvalId,
+        `user:${APPROVER_ID}`,
+      ])
+    ).rejects.toThrow(/immutable Guardrail evidence/);
+  });
+
+  it("refuses the requester's own decision while another principal could decide", async () => {
+    await addUser(APPROVER_ID, "approver@example.com", "member");
+    const runId = await startRunningRun();
+    const approvalId = await ask(runId);
+    await park(runId, approvalId);
+
+    expect(
+      await approvals.signal({
+        businessId: DEPLOYMENT_BUSINESS_ID,
+        approvalId,
+        decision: "approved",
+        principal: REQUESTER,
+      }),
+      "the principal that asked for the effect authorized it"
+    ).toBe("forbidden");
+    expect((await repo.findById(approvalId))?.status).toBe("pending");
+
+    // The second pair of eyes decides, and the row records whose they were.
+    expect(
+      await approvals.signal({
+        businessId: DEPLOYMENT_BUSINESS_ID,
+        approvalId,
+        decision: "approved",
+        principal: `user:${APPROVER_ID}`,
+      })
+    ).toBe("resumed");
+    const settled = await repo.findById(approvalId);
+    expect(settled?.status).toBe("approved");
+    expect(settled?.approverPrincipalId).toBe(`user:${APPROVER_ID}`);
+  });
+
+  it("lets the only principal in a solo deployment decide, and records that it did", async () => {
+    const runId = await startRunningRun();
+    const approvalId = await ask(runId);
+    await park(runId, approvalId);
+
+    expect(
+      await approvals.signal({
+        businessId: DEPLOYMENT_BUSINESS_ID,
+        approvalId,
+        decision: "approved",
+        principal: REQUESTER,
+      }),
+      "a four-eyes rule that leaves a single-user deployment unable to decide anything is a bug"
+    ).toBe("resumed");
+
+    const settled = await repo.findById(approvalId);
+    expect(settled?.status).toBe("approved");
+    // Requester and approver are the same principal, so the exemption is visible afterwards.
+    expect(settled?.approverPrincipalId).toBe(settled?.requesterPrincipalId);
+  });
+
+  it("refuses a decision on evidence that no longer matches what was recorded", async () => {
+    await addUser(APPROVER_ID, "approver@example.com", "member");
+    const runId = await startRunningRun();
+    const approvalId = await ask(runId);
+    await park(runId, approvalId);
+
+    // Simulates evidence substituted past the trigger — a restored dump, a disabled trigger, a
+    // migration run by hand. The decision path must not trust the row it is handed.
+    await database.query("ALTER TABLE approvals DISABLE TRIGGER approvals_evidence_immutable");
+    await database.query("UPDATE approvals SET guardrail_evidence = $2 WHERE id = $1", [
+      approvalId,
+      JSON.stringify({
+        demandedBy: "autonomy_policy",
+        guardrailRevision: "none",
+        reason: "something the approver was never shown",
+        toolName: WRITE_TOOL,
+        intentDigest: "sha256:not-the-intent",
+        demandedAt: "2026-08-16T00:00:00.000Z",
+      }),
+    ]);
+
+    expect(
+      await approvals.signal({
+        businessId: DEPLOYMENT_BUSINESS_ID,
+        approvalId,
+        decision: "approved",
+        principal: `user:${APPROVER_ID}`,
+      })
+    ).toBe("forbidden");
+    expect((await repo.findById(approvalId))?.status).toBe("pending");
+  });
+});

--- a/scripts/approval-one-use.test.ts
+++ b/scripts/approval-one-use.test.ts
@@ -48,6 +48,13 @@ const RUN_ID = "00000000-0000-4000-8000-0000000000b1";
 const CONVERSATION_ID = "00000000-0000-4000-8000-0000000000b2";
 const TURN_ID = "00000000-0000-4000-8000-0000000000b3";
 const USER_ID = "00000000-0000-4000-8000-0000000000b4";
+/** Every approval records who asked and what demanded a human; the table requires both (I-13). */
+const APPROVAL_REQUESTER = `user:${USER_ID}`;
+const APPROVAL_DEMAND = {
+  demandedBy: "autonomy_policy",
+  guardrailRevision: "none",
+  reason: "autonomy_requires_approval",
+} as const;
 const STATE_KEY = "invoke";
 const CREATED_AT = new Date("2026-08-16T00:00:00.000Z");
 
@@ -65,7 +72,6 @@ function startRun(): StartRunInput {
       effectiveSubject: { kind: "user", id: USER_ID },
       guardrailContextRef: "guardrail-context-1",
     },
-    bounds: { wallTimeMs: 60_000, activeTimeMs: 30_000, attempts: 3, sideEffects: 4 },
     createdAt: CREATED_AT.toISOString(),
     states: [
       { key: STATE_KEY, definitionRef: "sha256:bundle-1#/states/invoke", resolvedInput: {} },
@@ -260,6 +266,8 @@ describe("one approval authorizes one dispatch (L6-6)", () => {
         toolCallId: "c3",
         toolName: WRITE_TOOL,
         args: WRITE_ARGS,
+        requesterPrincipalId: APPROVAL_REQUESTER,
+        demand: APPROVAL_DEMAND,
       })
     ).toMatchObject({ status: "pending" });
 
@@ -272,6 +280,8 @@ describe("one approval authorizes one dispatch (L6-6)", () => {
         toolCallId: "c1",
         toolName: WRITE_TOOL,
         args: WRITE_ARGS,
+        requesterPrincipalId: APPROVAL_REQUESTER,
+        demand: APPROVAL_DEMAND,
       })
     ).toEqual({ status: "approved", approvalId });
   });

--- a/scripts/approval-transcript-durability.test.ts
+++ b/scripts/approval-transcript-durability.test.ts
@@ -42,6 +42,13 @@ const RUN_ID = "00000000-0000-4000-8000-0000000000a1";
 const CONVERSATION_ID = "00000000-0000-4000-8000-0000000000a2";
 const TURN_ID = "00000000-0000-4000-8000-0000000000a3";
 const USER_ID = "00000000-0000-4000-8000-0000000000a4";
+/** Every approval records who asked and what demanded a human; the table requires both (I-13). */
+const APPROVAL_REQUESTER = `user:${USER_ID}`;
+const APPROVAL_DEMAND = {
+  demandedBy: "autonomy_policy",
+  guardrailRevision: "none",
+  reason: "autonomy_requires_approval",
+} as const;
 const MESSAGE_ID = "00000000-0000-4000-8000-0000000000a5";
 const STATE_KEY = "invoke";
 const CREATED_AT = new Date("2026-08-16T00:00:00.000Z");
@@ -57,7 +64,6 @@ function startRun(): StartRunInput {
       effectiveSubject: { kind: "user", id: USER_ID },
       guardrailContextRef: "guardrail-context-1",
     },
-    bounds: { wallTimeMs: 60_000, activeTimeMs: 30_000, attempts: 3, sideEffects: 4 },
     createdAt: CREATED_AT.toISOString(),
     states: [
       { key: STATE_KEY, definitionRef: "sha256:bundle-1#/states/invoke", resolvedInput: {} },
@@ -127,6 +133,8 @@ function dispatcher(approvals: ToolApprovalService): ToolDispatchPort & {
           toolCallId: request.callId,
           toolName: request.name,
           args: request.arguments,
+          requesterPrincipalId: APPROVAL_REQUESTER,
+          demand: APPROVAL_DEMAND,
         });
         if (decision.status === "pending") {
           return {

--- a/scripts/file-size.test.ts
+++ b/scripts/file-size.test.ts
@@ -71,7 +71,7 @@ const IGNORED_DIRS = new Set([
  * which remains forbidden.
  */
 const OVERSIZED: Readonly<Record<string, number>> = {
-  "apps/api/src/pg-migrations/index.ts": 2061,
+  "apps/api/src/pg-migrations/index.ts": 2081,
   "apps/api/src/index.ts": 1314,
 };
 

--- a/scripts/routine-limit-coverage.test.ts
+++ b/scripts/routine-limit-coverage.test.ts
@@ -1,0 +1,172 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { LIMIT_KEYS, type LimitKey } from "../packages/run-kernel/src/limits";
+import { ROUTINE_BOUND_CEILINGS } from "../packages/run-kernel/src/routine/compiler";
+import {
+  BOUND_BY_LIMIT_KEY,
+  ENFORCEMENT_SURFACE_BY_LIMIT_KEY,
+  LEDGER_METERED_LIMIT_KEYS,
+  RETRY_METERED_LIMIT_KEYS,
+} from "../packages/run-kernel/src/routine/limit-enforcement";
+
+/**
+ * Fitness function for L3-10: no limit key may exist that nothing meters.
+ *
+ * Six of the twelve declared keys were validated, resolved, non-amplification-checked, and then
+ * reached nothing at all — an author could bound `networkBytes` and receive no bound. Unit tests
+ * on each piece stayed green throughout, because every piece worked; only the join was missing.
+ *
+ * These assertions fail if a key is ever added back to `LIMIT_KEYS` without landing on one of the
+ * three surfaces that actually count something, and if the authored schema and the runtime key
+ * set ever drift apart. A key nothing meters must be absent, so declaring it is a validation
+ * error the author sees, not silence.
+ */
+
+function repoRoot(): string {
+  let directory = __dirname;
+  for (;;) {
+    if (existsSync(join(directory, "pnpm-workspace.yaml"))) return directory;
+    const parent = dirname(directory);
+    if (parent === directory) throw new Error("pnpm-workspace.yaml not found");
+    directory = parent;
+  }
+}
+
+const ROOT = repoRoot();
+const AUTHORED_LIMITS = join(ROOT, "packages/run-kernel/src/routine/authored-limits.ts");
+const COMPILER = join(ROOT, "packages/run-kernel/src/routine/compiler.ts");
+const EXECUTOR = join(ROOT, "apps/worker/src/routine/executor.ts");
+
+const boundKeys = new Set<string>(Object.keys(BOUND_BY_LIMIT_KEY));
+const ledgerKeys = new Set<string>(LEDGER_METERED_LIMIT_KEYS);
+const retryKeys = new Set<string>(RETRY_METERED_LIMIT_KEYS);
+
+/** The surfaces that carry a key, read from the maps production actually applies. */
+function enforcingSurfaces(key: LimitKey): readonly string[] {
+  return [
+    ...(boundKeys.has(key) ? ["bounds"] : []),
+    ...(ledgerKeys.has(key) ? ["ledger"] : []),
+    ...(retryKeys.has(key) ? ["retry"] : []),
+  ];
+}
+
+describe("every limit key reaches an enforcement surface (L3-10)", () => {
+  it.each(LIMIT_KEYS)("enforces %s on exactly one surface", (key) => {
+    // One surface, not zero (the L3-10 bug) and not two (two ceilings that can disagree).
+    const surfaces = enforcingSurfaces(key);
+    expect(
+      surfaces,
+      `limit key "${key}" is metered by ${surfaces.length} surfaces; enforce it on exactly one ` +
+        "of bounds/ledger/retry, or delete the key so authoring it fails validation"
+    ).toHaveLength(1);
+    expect(surfaces[0]).toBe(ENFORCEMENT_SURFACE_BY_LIMIT_KEY[key]);
+  });
+
+  it("declares an enforcement surface for exactly the keys that exist", () => {
+    expect(Object.keys(ENFORCEMENT_SURFACE_BY_LIMIT_KEY).sort()).toEqual([...LIMIT_KEYS].sort());
+  });
+
+  it("routes every surface's keys to a target the runtime reads", () => {
+    // A bound key must name a real `CompiledBounds` field, which is what the processors check.
+    for (const bound of Object.values(BOUND_BY_LIMIT_KEY)) {
+      expect(Object.keys(ROUTINE_BOUND_CEILINGS)).toContain(bound);
+    }
+    for (const key of [...boundKeys, ...ledgerKeys, ...retryKeys]) {
+      expect(LIMIT_KEYS).toContain(key);
+    }
+  });
+
+  it("applies each surface's narrowing at the site that owns it", () => {
+    const compiler = readFileSync(COMPILER, "utf8");
+    expect(compiler).toMatch(/bounds:\s*narrowBoundsByLimits\(/);
+    expect(compiler).toMatch(/retry:\s*narrowRetryByLimits\(/);
+
+    // The ledger keys are the ones the Agent loop debits; the executor opens them per Run.
+    const executor = readFileSync(EXECUTOR, "utf8");
+    expect(executor).toMatch(/routineBudgetScopedLimits\(this\.ctx\.routine\)/);
+  });
+
+  it("enforces the State retry ceiling the `retries` limit narrows", () => {
+    const executor = readFileSync(EXECUTOR, "utf8");
+    expect(executor).toMatch(/made\s*>=\s*policy\.maxAttempts/);
+  });
+
+  it("keeps the authored vocabulary and the runtime key set in step", () => {
+    // Every authored key maps to a runtime key, so nothing authorable is left unmetered.
+    const authored = readFileSync(AUTHORED_LIMITS, "utf8");
+    const mapped = [...authored.matchAll(/key:\s*"([a-zA-Z]+)"/g)].map(([, key]) => key);
+    expect(mapped.length).toBeGreaterThan(0);
+    for (const key of mapped) expect(LIMIT_KEYS).toContain(key);
+  });
+});
+
+const RUN_STORE = join(ROOT, "packages/storage/src/runs/run-store.ts");
+
+/** Every non-test `.ts` file under `directory`, read as source. */
+function productionSources(directory: string): readonly { path: string; source: string }[] {
+  const out: { path: string; source: string }[] = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    if (entry.name === "node_modules" || entry.name === "dist") continue;
+    const full = join(directory, entry.name);
+    if (entry.isDirectory()) out.push(...productionSources(full));
+    else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts"))
+      out.push({ path: full, source: readFileSync(full, "utf8") });
+  }
+  return out;
+}
+
+function workspaceSources(): readonly { path: string; source: string }[] {
+  const out: { path: string; source: string }[] = [];
+  for (const workspace of ["packages", "apps"]) {
+    for (const entry of readdirSync(join(ROOT, workspace), { withFileTypes: true })) {
+      const src = join(ROOT, workspace, entry.name, "src");
+      if (entry.isDirectory() && existsSync(src)) out.push(...productionSources(src));
+    }
+  }
+  return out;
+}
+
+/**
+ * A Run bound is only readable through the `bounds` value it lives in, so that is what a reader
+ * has to name. Matching the bare field name would count `job.attempts` in an unrelated queue as
+ * proof that `bounds.attempts` is enforced, which is the very illusion this file exists to stop.
+ */
+function hasBoundsReader(sources: readonly { path: string; source: string }[], field: string) {
+  const reader = new RegExp(`(^|[^A-Za-z])bounds\\??\\.${field}\\b`, "m");
+  return sources.some(({ path, source }) => path !== RUN_STORE && reader.test(source));
+}
+
+/** Keys a `jsonb` column's `?& ARRAY[...]` presence check makes mandatory on every row. */
+function requiredJsonbKeys(sql: string): readonly string[] {
+  return [...sql.matchAll(/\?&\s*ARRAY\[([^\]]*)\]/g)].flatMap(([, list]) =>
+    [...list.matchAll(/'([^']+)'/g)].map(([, key]) => key)
+  );
+}
+
+/** Fields of any `*Bounds` interface the Run store declares. */
+function declaredBoundsFields(source: string): readonly string[] {
+  return [...source.matchAll(/interface\s+\w*Bounds\s*\{([^}]*)\}/g)].flatMap(([, body]) =>
+    [...body.matchAll(/(?:readonly\s+)?(\w+)\s*[?:]/g)].map(([, field]) => field)
+  );
+}
+
+describe("no Run field is required without a reader (L3-10)", () => {
+  const runStore = readFileSync(RUN_STORE, "utf8");
+
+  it("requires no `bounds` JSONB key that nothing reads", () => {
+    const sources = workspaceSources();
+    const unread = requiredJsonbKeys(runStore).filter((key) => !hasBoundsReader(sources, key));
+    expect(
+      unread,
+      `the runs table makes ${unread.join(", ")} mandatory, but no production module reads them; ` +
+        "give each a reader or drop it from the interface, the CHECK, and every fixture"
+    ).toEqual([]);
+  });
+
+  it("declares no bounds field that nothing reads", () => {
+    const sources = workspaceSources();
+    const unread = declaredBoundsFields(runStore).filter((f) => !hasBoundsReader(sources, f));
+    expect(unread).toEqual([]);
+  });
+});

--- a/scripts/state-contention-queueing.test.ts
+++ b/scripts/state-contention-queueing.test.ts
@@ -93,7 +93,6 @@ function run(id: string): PersistedRun {
       effectiveSubject: { kind: "agent", id: "assistant" },
       guardrailContextRef: "guardrail:default",
     },
-    bounds: { wallTimeMs: 60_000, activeTimeMs: 30_000, attempts: 3, sideEffects: 0 },
     status: "running",
     version: 2,
     createdAt: AT,

--- a/scripts/turn-event-key-collision.test.ts
+++ b/scripts/turn-event-key-collision.test.ts
@@ -50,6 +50,13 @@ import { ToolApprovalService } from "../packages/tool-host/src/approvals/tool-ap
 const RUN_ID = "00000000-0000-4000-8000-0000000000b1";
 const TURN_ID = "00000000-0000-4000-8000-0000000000b3";
 const USER_ID = "00000000-0000-4000-8000-0000000000b4";
+/** Every approval records who asked and what demanded a human; the table requires both (I-13). */
+const APPROVAL_REQUESTER = `user:${USER_ID}`;
+const APPROVAL_DEMAND = {
+  demandedBy: "autonomy_policy",
+  guardrailRevision: "none",
+  reason: "autonomy_requires_approval",
+} as const;
 const STATE_KEY = "invoke";
 const CREATED_AT = new Date("2026-08-16T00:00:00.000Z");
 
@@ -74,7 +81,6 @@ function startRun(): StartRunInput {
       effectiveSubject: { kind: "user", id: USER_ID },
       guardrailContextRef: "guardrail-context-1",
     },
-    bounds: { wallTimeMs: 60_000, activeTimeMs: 30_000, attempts: 3, sideEffects: 4 },
     createdAt: CREATED_AT.toISOString(),
     states: [
       { key: STATE_KEY, definitionRef: "sha256:bundle-1#/states/invoke", resolvedInput: {} },
@@ -125,6 +131,8 @@ function dispatcher(approvals: ToolApprovalService): ToolDispatchPort {
         toolCallId: request.callId,
         toolName: request.name,
         args: request.arguments,
+        requesterPrincipalId: APPROVAL_REQUESTER,
+        demand: APPROVAL_DEMAND,
       });
       if (decision.status === "pending") {
         return {


### PR DESCRIPTION
Closes 18 architecture-queue issues. The common defect: config that parsed
cleanly, resolved, and then reached no enforcement — limits, approvals,
delegated authority, concurrency, retention and Run bounds all validated
and did nothing.

- **Enforced or deleted, never left inert.** Authored limit keys went 12 → 7
  (`retries` gained an enforcement surface; five with no meter were removed, so
  authoring one now fails validation). `RunBounds` lost all four fields — none
  had a reader, and `bounds.attempts` was a silent second retry ceiling
  hardcoded to 3 while the executor obeyed `policy.maxAttempts`.
- **Approvals are now accountable.** Digest-bound and one-use, with write-once
  Guardrail evidence and four-eyes (recorded, not skipped, on single-admin
  deployments). Child Runs are bounded by their link row at both dispatch seams.
- **14 new fitness functions**, each mutation-tested against a source with the
  fix removed. Oversized files 22 → 2; no ratchet raised except the append-only
  migration ledger the file explicitly sanctions.

Migrations v56–v61, applied on boot.

## Test plan

- [ ] `pnpm lint` and `pnpm typecheck` — 31/31
- [ ] `pnpm architecture:test` — 507 passing
- [ ] `pnpm reachability:check` — OK
- [ ] `pnpm --filter @tulipfarm/api test` — 2645
- [ ] `pnpm --filter @tulipfarm/worker test` — 493
- [ ] `pnpm --filter @tulipfarm/web test` — 834
- [ ] `pnpm --filter @tulipfarm/run-kernel test` — 448
- [ ] `pnpm --filter @tulipfarm/storage test` — 265
- [ ] Migrations v56–v61 apply cleanly on a fresh boot (`pnpm reset:dev`)