### PR TITLE
fix(chat): run mentions as resolved agents

### DIFF
--- a/apps/api/src/chat/durable-submission.pg.test.ts
+++ b/apps/api/src/chat/durable-submission.pg.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import type { LanguageModelV3 } from "@ai-sdk/provider";
 import type { PGlite } from "@electric-sql/pglite";
 import type { LlmService } from "@tulipfarm/llm";
@@ -28,6 +29,7 @@ import { ambientTransactionPort, type Queryable, transactionPort } from "../db";
 
 import { runCanceller } from "../runs/cancel";
 import { makeMigratedPglite } from "../test/pglite";
+import type { ConversationDoc } from "./conversations";
 import { PgConversationRepo } from "./conversations";
 import { PgMessageRepo } from "./messages";
 
@@ -114,6 +116,7 @@ describe("durable chat submission over HTTP", () => {
   let sid: string;
   let otherSid: string;
   let validator: TypedOutputValidator;
+  let conversationRepo: PgConversationRepo;
   /** Flipped by the budget test; every other test runs with the budget open. */
   let withinBudget: boolean;
 
@@ -142,6 +145,7 @@ describe("durable chat submission over HTTP", () => {
 
     const runTransactions = transactionPort(queryable);
     const runStore = new RunStore(runTransactions);
+    conversationRepo = new PgConversationRepo(queryable);
 
     app = await buildApp({
       sessionStore,
@@ -155,7 +159,7 @@ describe("durable chat submission over HTTP", () => {
           chain: [{ provider: "test", modelId: "test-model" }],
         })),
       } as unknown as LlmService,
-      conversationRepo: new PgConversationRepo(queryable),
+      conversationRepo,
       messageRepo: new PgMessageRepo(queryable),
       invocations,
       conversationStore: new PgConversationStore(queryable),
@@ -283,14 +287,52 @@ describe("durable chat submission over HTTP", () => {
     );
     expect(artifact.rows).toHaveLength(1);
     expect(artifact.rows[0]?.id).toBe(`${runId}:request`);
-    // Verbatim: what the Worker replays must be the request as received, not a re-derived shape.
-    expect(artifact.rows[0]?.content).toEqual(BODY);
-    expect(artifact.rows[0]?.content_hash).toBe(canonicalHash(BODY));
+    const resolvedBody = { ...BODY, agentId: "__tulipfarm_default__" };
+    expect(artifact.rows[0]?.content).toEqual(resolvedBody);
+    expect(artifact.rows[0]?.content_hash).toBe(canonicalHash(resolvedBody));
 
     const states = await db.query<{ resolved_input: { payloadRef: string } }>(
       "SELECT resolved_input FROM run_states"
     );
     expect(states.rows[0]?.resolved_input.payloadRef).toBe(`artifact:${runId}:request`);
+  });
+
+  it("mints a Run for the Conversation's resolved Agent on a follow-up turn", async () => {
+    const conversation: ConversationDoc = {
+      _id: randomUUID(),
+      userId,
+      agentId: "support-triage",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    await conversationRepo.create(conversation);
+
+    const response = app.inject({
+      method: "POST",
+      url: "/api/v1/chat",
+      cookies: { [SESSION_COOKIE]: sid, [CSRF_COOKIE]: CSRF },
+      headers: { "x-csrf-token": CSRF, "idempotency-key": "follow-up-agent-key" },
+      payload: { ...BODY, conversationId: conversation._id },
+    });
+    const run = await awaitRun();
+    await db.query("UPDATE runs SET status = 'succeeded' WHERE id = $1", [run.id]);
+
+    expect((await response).statusCode).toBe(200);
+    expect(
+      (
+        await db.query<{ definition_ref: string }>(
+          "SELECT definition_ref FROM run_states WHERE run_id = $1",
+          [run.id]
+        )
+      ).rows[0]?.definition_ref
+    ).toBe("published:agent:support-triage");
+    expect(
+      (
+        await db.query<{ content: unknown }>("SELECT content FROM artifacts WHERE id = $1", [
+          `${run.id}:request`,
+        ])
+      ).rows[0]?.content
+    ).toEqual({ ...BODY, conversationId: conversation._id, agentId: "support-triage" });
   });
 
   it("lets the Run executor reconstruct the request, and denies a reader outside the ACL", async () => {

--- a/apps/api/src/chat/routes.ts
+++ b/apps/api/src/chat/routes.ts
@@ -144,7 +144,16 @@ export function registerChatRoutes(
         return reply.code(entry.status).send({ error: entry.error });
       }
 
-      const submission = await submitter.submit({
+      const resolvedSubmitter = durableTurnSubmitter({
+        store: options.conversationStore,
+        invocations: options.invocations,
+        principal: { kind: principal.kind, id: principal.id, businessId: principal.businessId },
+        payload: { ...body, agentId: entry.agentId },
+        agentId: entry.agentId,
+        idempotencyKey: `${principal.kind}:${principal.id}:${clientKey}`,
+        log: req.log,
+      });
+      const submission = await resolvedSubmitter.submit({
         conversationId: entry.conversation._id,
         content: body.message.content,
       });

--- a/apps/api/src/chat/turn-submit.ts
+++ b/apps/api/src/chat/turn-submit.ts
@@ -30,7 +30,7 @@ export interface DurableTurnSubmitterDeps {
   readonly store: ConversationStore;
   readonly invocations: DurableInvocationGateway;
   readonly principal: ChatTurnPrincipal;
-  /** The request body verbatim; published as the Run's immutable request Artifact. */
+  /** The request body normalized with the resolved Agent; published as the immutable request Artifact. */
   readonly payload: unknown;
   readonly agentId: string;
   readonly idempotencyKey: string;

--- a/apps/api/src/conversations/chat-turns.ts
+++ b/apps/api/src/conversations/chat-turns.ts
@@ -16,7 +16,7 @@ export interface ChatTurnPrincipal {
 
 export interface ChatTurnSubmission {
   readonly principal: ChatTurnPrincipal;
-  /** The request body as accepted by the route; stored verbatim as the Run's request Artifact. */
+  /** The request body normalized by the route with its resolved Agent identity. */
   readonly payload: unknown;
   readonly agentId: string;
 }

--- a/apps/api/src/platform/tools.test.ts
+++ b/apps/api/src/platform/tools.test.ts
@@ -1,7 +1,7 @@
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { assembleSystemPrompt, DelegationError } from "@tulipfarm/agent-runtime";
+import { DelegationError } from "@tulipfarm/agent-runtime";
 import type { BundledSkill, SoulAgent, SoulRoutine, SoulSkill, SoulWriter } from "@tulipfarm/soul";
 import { describe, expect, it, vi } from "vitest";
 import { delegateToAgentTool } from "./delegate-tool";
@@ -633,7 +633,6 @@ describe("PLATFORM_TOOLS registry", () => {
     expect(names).toEqual([
       "load_skill",
       "load_skill_reference",
-      "transfer_to_agent",
       "delegate_to_agent",
       "trigger_routine",
       "routine_forge",

--- a/apps/api/src/platform/tools.test.ts
+++ b/apps/api/src/platform/tools.test.ts
@@ -14,7 +14,6 @@ import {
   routineForgeTool,
   routinePickerTool,
   soulRepoPushTool,
-  transferToAgentTool,
   triggerRoutineTool,
 } from "./tools";
 
@@ -112,9 +111,6 @@ describe("platform authorization declarations", () => {
     expect(callSkillTool.targetsFor({ name: "research" })).toEqual([
       { type: "soul.skill", id: "research" },
     ]);
-    expect(transferToAgentTool.targetsFor({ agentId: "planner" })).toEqual([
-      { type: "platform.agent", id: "planner" },
-    ]);
     expect(delegateToAgentTool.targetsFor({ agentId: "planner", task: "plan" })).toEqual([
       { type: "platform.agent", id: "planner" },
     ]);
@@ -149,7 +145,6 @@ describe("platform authorization declarations", () => {
       loadSkillTool,
       loadSkillReferenceTool,
       callSkillTool,
-      transferToAgentTool,
       delegateToAgentTool,
       triggerRoutineTool,
       routineForgeTool,
@@ -320,53 +315,6 @@ describe("loadSkillReferenceTool", () => {
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
-  });
-});
-
-// ── validate_artifact ─────────────────────────────────────────────────────────
-
-describe("transferToAgentTool", () => {
-  it("returns transferred status and agentName", async () => {
-    const ctx = makeCtx({}, { support: makeAgent("support", "Support Bot") });
-    const res = await transferToAgentTool.handler(
-      { agentId: "support", message: "User needs billing help" },
-      ctx
-    );
-    expect(res).toEqual({
-      success: true,
-      data: {
-        agentId: "support",
-        agentName: "Support Bot",
-        status: "transferred",
-        message: "User needs billing help",
-      },
-    });
-  });
-
-  it("sets message to null when not provided", async () => {
-    const ctx = makeCtx({}, { support: makeAgent("support") });
-    const res = await transferToAgentTool.handler({ agentId: "support" }, ctx);
-    expect(res).toMatchObject({ success: true, data: { message: null } });
-  });
-
-  it("returns not_found for unknown agent", async () => {
-    const res = await transferToAgentTool.handler({ agentId: "ghost" }, makeCtx());
-    expect(res).toMatchObject({ success: false, error: { code: "not_found" } });
-  });
-
-  it("accepts the built-in platform assistant as a transfer target", async () => {
-    const ctx: PlatformToolContext = {
-      soulWriter: makeSoulWriter(),
-      platformAgentNames: new Set(["GeneralAssistant"]),
-    };
-    const res = await transferToAgentTool.handler(
-      { agentId: "GeneralAssistant", message: "resume the default assistant" },
-      ctx
-    );
-    expect(res).toMatchObject({
-      success: true,
-      data: { agentId: "GeneralAssistant", status: "transferred" },
-    });
   });
 });
 

--- a/apps/api/src/platform/tools.ts
+++ b/apps/api/src/platform/tools.ts
@@ -22,13 +22,7 @@ import { stringify as stringifyYaml } from "yaml";
 import { SYSTEM_SOUL_COMMIT_ACTOR } from "../runtime/soul-writer";
 import { soulCommitError } from "../tools/soul-faults";
 import { delegateToAgentTool } from "./delegate-tool";
-import {
-  firstError,
-  SOUL_AGENT_TARGET,
-  SOUL_ROUTINE_TARGET,
-  SOUL_SKILL_TARGET,
-  soulTarget,
-} from "./tool-args";
+import { firstError, SOUL_ROUTINE_TARGET, SOUL_SKILL_TARGET, soulTarget } from "./tool-args";
 import { err, ok, type ToolCallResult } from "./tool-result";
 
 export interface PlatformToolContext {
@@ -178,48 +172,6 @@ export const loadSkillReferenceTool = defineApiTool<PlatformToolContext>({
     } catch {
       return err("not_found", `Reference "${reference}" not found for skill "${skill}".`);
     }
-  },
-});
-
-const TRANSFER_TO_AGENT_SCHEMA: Record<string, unknown> = {
-  type: "object",
-  additionalProperties: false,
-  required: ["agentId"],
-  properties: {
-    agentId: { type: "string", minLength: 1, description: "Soul name of the target agent." },
-    message: {
-      type: "string",
-      description: "Optional handoff context to give the receiving agent.",
-    },
-  },
-};
-const validateTransfer = ajv.compile(TRANSFER_TO_AGENT_SCHEMA);
-
-export const transferToAgentTool = defineApiTool<PlatformToolContext>({
-  name: "transfer_to_agent",
-  requiresAmbient: ["soul"],
-  description:
-    "Hand the conversation off to another configured agent. The conversation's active agent switches and future turns are handled by the target. Validates that the target is a known platform or Soul agent.",
-  mutating: false,
-  tier: "platform",
-  inputSchema: TRANSFER_TO_AGENT_SCHEMA,
-  authorization: {
-    action: "platform.agent.transfer",
-    resources: ["platform.agent"],
-    targets: (args) => soulTarget(SOUL_AGENT_TARGET, args, "agentId"),
-    dataClasses: ["operational"],
-  },
-  handler: async (args, ctx) => {
-    if (!validateTransfer(args))
-      return err("validation_error", firstError(validateTransfer.errors));
-    const { agentId, message } = args as { agentId: string; message?: string };
-    if (ctx.platformAgentNames?.has(agentId)) {
-      return ok({ agentId, agentName: agentId, status: "transferred", message: message ?? null });
-    }
-    const agent = ctx.soulLoader?.agents.get(agentId);
-    if (!agent) return err("not_found", `Agent "${agentId}" not found.`);
-    const agentName = typeof agent.frontmatter.name === "string" ? agent.frontmatter.name : agentId;
-    return ok({ agentId, agentName, status: "transferred", message: message ?? null });
   },
 });
 

--- a/apps/api/src/platform/tools.ts
+++ b/apps/api/src/platform/tools.ts
@@ -2,10 +2,8 @@ import type { EventEmitter } from "node:events";
 import { readFile } from "node:fs/promises";
 import { isAbsolute, relative, resolve, sep } from "node:path";
 import type { DelegateToAgentInput, DelegationOutcome } from "@tulipfarm/agent-runtime";
-import { DelegationError } from "@tulipfarm/agent-runtime";
 import { DEPLOYMENT_BUSINESS_ID } from "@tulipfarm/constants";
 import { PLATFORM_RUNTIME_TOOLS } from "@tulipfarm/platform-tools";
-import { ChildRunError } from "@tulipfarm/run-kernel";
 import { ajv, TulipFarmValidationError, validateRoutineDefinition } from "@tulipfarm/schema";
 import type { BundledSkill } from "@tulipfarm/soul";
 import {
@@ -542,7 +540,6 @@ export const callSkillTool = defineApiTool<PlatformToolContext>({
 export const PLATFORM_TOOLS: ApiToolDefinition<PlatformToolContext>[] = [
   loadSkillTool,
   loadSkillReferenceTool,
-  transferToAgentTool,
   delegateToAgentTool,
   triggerRoutineTool,
   routineForgeTool,

--- a/apps/api/src/tools/contract-coverage.test.ts
+++ b/apps/api/src/tools/contract-coverage.test.ts
@@ -125,7 +125,6 @@ const EXPECTED_FAMILY_TOOL_NAMES = [
       "routine_forge",
       "routine_picker",
       "soul_repo_push",
-      "transfer_to_agent",
       "trigger_routine",
       "validate_artifact",
     ],


### PR DESCRIPTION
## Summary
- mint chat Runs and request Artifacts with the Conversation's resolved Agent
- remove the cosmetic transfer_to_agent tool from the model-visible platform registry
- cover Agent-targeted follow-up turns and the platform registry

## Test plan
- [x] pnpm exec biome check --write apps/api/src/chat/routes.ts apps/api/src/chat/turn-submit.ts apps/api/src/chat/durable-submission.pg.test.ts apps/api/src/conversations/chat-turns.ts apps/api/src/platform/tools.ts apps/api/src/platform/tools.test.ts
- [x] pnpm --filter @tulipfarm/api test src/chat/durable-submission.pg.test.ts src/platform/tools.test.ts
- [x] pnpm --filter @tulipfarm/api typecheck