### PR TITLE
fix(tools): cancel timed-out effect dispatches

### DIFF
--- a/apps/api/src/broker/tool-adapter.ts
+++ b/apps/api/src/broker/tool-adapter.ts
@@ -3,6 +3,7 @@ import type { ToolAvailability } from "@tulipfarm/tool-broker";
 import {
   type ApprovalGate,
   err,
+  executeToolWithTimeout,
   type RequestContext,
   type ToolCallResult,
   type ToolDef,
@@ -37,25 +38,6 @@ export const MAX_PRESENTATION_CORRECTIVE_ATTEMPTS = 2;
 /** Read surface availability from Tool declarations to avoid drift. */
 function presentsToSurface(toolDefinition: { definition?: { availableTo?: ToolAvailability } }) {
   return toolDefinition.definition?.availableTo?.requiresPresentation === true;
-}
-
-async function withToolTimeout(
-  execute: (abortSignal: AbortSignal) => Promise<ToolCallResult>
-): Promise<ToolCallResult> {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), TOOL_TIMEOUT_MS);
-  const timedOut = new Promise<ToolCallResult>((resolve) => {
-    controller.signal.addEventListener(
-      "abort",
-      () => resolve(err("internal_error", "tool execution timed out")),
-      { once: true }
-    );
-  });
-  try {
-    return await Promise.race([execute(controller.signal), timedOut]);
-  } finally {
-    clearTimeout(timer);
-  }
 }
 
 /** Default-deny adapter: callers must pass the exact authorized Tool allowlist. */
@@ -176,17 +158,11 @@ export class ToolRegistry {
             }
             let full: ToolCallResult;
             try {
+              const executeTool = () =>
+                executeToolWithTimeout(t, effectiveArgs, ctx, TOOL_TIMEOUT_MS);
               full = await (coordinator
-                ? coordinator.schedule(
-                    () =>
-                      withToolTimeout((abortSignal) =>
-                        t.execute(effectiveArgs, { ...ctx, abortSignal })
-                      ),
-                    t.mutating
-                  )
-                : withToolTimeout((abortSignal) =>
-                    t.execute(effectiveArgs, { ...ctx, abortSignal })
-                  ));
+                ? coordinator.schedule(executeTool, t.mutating)
+                : executeTool());
             } catch {
               full = err(
                 "internal_error",

--- a/apps/api/src/broker/tool-adapter.ts
+++ b/apps/api/src/broker/tool-adapter.ts
@@ -39,13 +39,23 @@ function presentsToSurface(toolDefinition: { definition?: { availableTo?: ToolAv
   return toolDefinition.definition?.availableTo?.requiresPresentation === true;
 }
 
-function withToolTimeout(p: Promise<ToolCallResult>): Promise<ToolCallResult> {
-  return Promise.race([
-    p,
-    new Promise<ToolCallResult>((resolve) =>
-      setTimeout(() => resolve(err("internal_error", "tool execution timed out")), TOOL_TIMEOUT_MS)
-    ),
-  ]);
+async function withToolTimeout(
+  execute: (abortSignal: AbortSignal) => Promise<ToolCallResult>
+): Promise<ToolCallResult> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TOOL_TIMEOUT_MS);
+  const timedOut = new Promise<ToolCallResult>((resolve) => {
+    controller.signal.addEventListener(
+      "abort",
+      () => resolve(err("internal_error", "tool execution timed out")),
+      { once: true }
+    );
+  });
+  try {
+    return await Promise.race([execute(controller.signal), timedOut]);
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 /** Default-deny adapter: callers must pass the exact authorized Tool allowlist. */
@@ -168,10 +178,15 @@ export class ToolRegistry {
             try {
               full = await (coordinator
                 ? coordinator.schedule(
-                    () => withToolTimeout(t.execute(effectiveArgs, ctx)),
+                    () =>
+                      withToolTimeout((abortSignal) =>
+                        t.execute(effectiveArgs, { ...ctx, abortSignal })
+                      ),
                     t.mutating
                   )
-                : withToolTimeout(t.execute(effectiveArgs, ctx)));
+                : withToolTimeout((abortSignal) =>
+                    t.execute(effectiveArgs, { ...ctx, abortSignal })
+                  ));
             } catch {
               full = err(
                 "internal_error",

--- a/apps/api/src/tools/declarative/tools.ts
+++ b/apps/api/src/tools/declarative/tools.ts
@@ -411,9 +411,7 @@ function buildToolDef(
 
       try {
         return ok(
-          await dispatcher.dispatch(deps.businessId, reserved.effect.effectId, {
-            abortSignal: ctx.abortSignal,
-          })
+          await dispatcher.dispatch(deps.businessId, reserved.effect.effectId, ctx.abortSignal)
         );
       } catch (error) {
         if (error instanceof ToolDispatchError) return mapDispatchError(error, slug);

--- a/apps/api/src/tools/declarative/tools.ts
+++ b/apps/api/src/tools/declarative/tools.ts
@@ -410,7 +410,11 @@ function buildToolDef(
       if (reserved.outcome === "duplicate") return replayed(reserved.effect.state);
 
       try {
-        return ok(await dispatcher.dispatch(deps.businessId, reserved.effect.effectId));
+        return ok(
+          await dispatcher.dispatch(deps.businessId, reserved.effect.effectId, {
+            abortSignal: ctx.abortSignal,
+          })
+        );
       } catch (error) {
         if (error instanceof ToolDispatchError) return mapDispatchError(error, slug);
         throw error;

--- a/apps/api/src/tools/github/tools.ts
+++ b/apps/api/src/tools/github/tools.ts
@@ -348,7 +348,9 @@ function buildToolDef(
       });
 
       try {
-        const output = await dispatcher.dispatch(businessId, reserved.effect.effectId);
+        const output = await dispatcher.dispatch(businessId, reserved.effect.effectId, {
+          abortSignal: ctx.abortSignal,
+        });
         return ok(output);
       } catch (error) {
         if (error instanceof ToolDispatchError) return mapDispatchError(error, toolId);

--- a/apps/api/src/tools/github/tools.ts
+++ b/apps/api/src/tools/github/tools.ts
@@ -348,9 +348,11 @@ function buildToolDef(
       });
 
       try {
-        const output = await dispatcher.dispatch(businessId, reserved.effect.effectId, {
-          abortSignal: ctx.abortSignal,
-        });
+        const output = await dispatcher.dispatch(
+          businessId,
+          reserved.effect.effectId,
+          ctx.abortSignal
+        );
         return ok(output);
       } catch (error) {
         if (error instanceof ToolDispatchError) return mapDispatchError(error, toolId);

--- a/apps/api/src/tools/registry.test.ts
+++ b/apps/api/src/tools/registry.test.ts
@@ -308,10 +308,7 @@ describe("ToolRegistry", () => {
         { messages: [], context: undefined, toolCallId: "tc2" }
       );
       expect(result).toEqual({ success: true, data: "reached" });
-      expect(execute).toHaveBeenCalledWith(
-        { key: "hello" },
-        expect.objectContaining({ ...ctx, abortSignal: expect.any(AbortSignal) })
-      );
+      expect(execute).toHaveBeenCalledWith({ key: "hello" }, expect.objectContaining(ctx));
     });
 
     it("bad args with coordinator return validation_error (no coordinator scheduling)", async () => {
@@ -666,10 +663,7 @@ describe("ToolRegistry", () => {
 
       expect(result).toEqual({ success: true, data: "ran" });
       // effectiveArgs (the guard's returned args) are forwarded to the tool, not the originals.
-      expect(execute).toHaveBeenCalledWith(
-        { key: "swapped" },
-        expect.objectContaining({ ...ctx, abortSignal: expect.any(AbortSignal) })
-      );
+      expect(execute).toHaveBeenCalledWith({ key: "swapped" }, expect.objectContaining(ctx));
     });
 
     it("no guard passed: tool executes unchanged", async () => {
@@ -684,10 +678,7 @@ describe("ToolRegistry", () => {
       );
 
       expect(result).toEqual({ success: true, data: "direct" });
-      expect(execute).toHaveBeenCalledWith(
-        { key: "v" },
-        expect.objectContaining({ ...ctx, abortSignal: expect.any(AbortSignal) })
-      );
+      expect(execute).toHaveBeenCalledWith({ key: "v" }, expect.objectContaining(ctx));
     });
 
     it("blocked guard runs AFTER arg-validation (invalid args short-circuit before the guard)", async () => {

--- a/apps/api/src/tools/registry.test.ts
+++ b/apps/api/src/tools/registry.test.ts
@@ -79,7 +79,10 @@ describe("ToolRegistry", () => {
       reg.register(makeTool({ name: "ctx_check", execute }));
       const ts = reg.buildToolSet(ctx);
       await ts.ctx_check.execute?.({}, { messages: [], context: undefined, toolCallId: "tc1" });
-      expect(execute).toHaveBeenCalledWith({}, ctx);
+      expect(execute).toHaveBeenCalledWith(
+        {},
+        expect.objectContaining({ ...ctx, abortSignal: expect.any(AbortSignal) })
+      );
     });
 
     it("allowedToolNames scopes the set to the per-agent allowlist", () => {
@@ -305,7 +308,10 @@ describe("ToolRegistry", () => {
         { messages: [], context: undefined, toolCallId: "tc2" }
       );
       expect(result).toEqual({ success: true, data: "reached" });
-      expect(execute).toHaveBeenCalledWith({ key: "hello" }, ctx);
+      expect(execute).toHaveBeenCalledWith(
+        { key: "hello" },
+        expect.objectContaining({ ...ctx, abortSignal: expect.any(AbortSignal) })
+      );
     });
 
     it("bad args with coordinator return validation_error (no coordinator scheduling)", async () => {
@@ -412,24 +418,32 @@ describe("ToolRegistry", () => {
 
     it("returns internal_error when execute hangs past TOOL_TIMEOUT_MS", async () => {
       vi.useFakeTimers();
-      const reg = new ToolRegistry();
-      reg.register(
-        makeTool({
-          execute: () => new Promise(() => {}), // never resolves
-        })
-      );
-      const ts = reg.buildToolSet(ctx);
-      const resultPromise = ts.test_tool.execute?.(
-        {},
-        { messages: [], context: undefined, toolCallId: "tc" }
-      );
-      vi.advanceTimersByTime(TOOL_TIMEOUT_MS);
-      const result = await resultPromise;
-      expect(result).toEqual({
-        success: false,
-        error: { code: "internal_error", message: "tool execution timed out" },
-      });
-      vi.useRealTimers();
+      try {
+        let abortSignal: AbortSignal | undefined;
+        const reg = new ToolRegistry();
+        reg.register(
+          makeTool({
+            execute: (_args, context) => {
+              abortSignal = context.abortSignal;
+              return new Promise(() => {});
+            },
+          })
+        );
+        const ts = reg.buildToolSet(ctx);
+        const resultPromise = ts.test_tool.execute?.(
+          {},
+          { messages: [], context: undefined, toolCallId: "tc" }
+        );
+        vi.advanceTimersByTime(TOOL_TIMEOUT_MS);
+        const result = await resultPromise;
+        expect(result).toEqual({
+          success: false,
+          error: { code: "internal_error", message: "tool execution timed out" },
+        });
+        expect(abortSignal?.aborted).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 
@@ -652,7 +666,10 @@ describe("ToolRegistry", () => {
 
       expect(result).toEqual({ success: true, data: "ran" });
       // effectiveArgs (the guard's returned args) are forwarded to the tool, not the originals.
-      expect(execute).toHaveBeenCalledWith({ key: "swapped" }, ctx);
+      expect(execute).toHaveBeenCalledWith(
+        { key: "swapped" },
+        expect.objectContaining({ ...ctx, abortSignal: expect.any(AbortSignal) })
+      );
     });
 
     it("no guard passed: tool executes unchanged", async () => {
@@ -667,7 +684,10 @@ describe("ToolRegistry", () => {
       );
 
       expect(result).toEqual({ success: true, data: "direct" });
-      expect(execute).toHaveBeenCalledWith({ key: "v" }, ctx);
+      expect(execute).toHaveBeenCalledWith(
+        { key: "v" },
+        expect.objectContaining({ ...ctx, abortSignal: expect.any(AbortSignal) })
+      );
     });
 
     it("blocked guard runs AFTER arg-validation (invalid args short-circuit before the guard)", async () => {

--- a/apps/api/src/tools/slack/tools.ts
+++ b/apps/api/src/tools/slack/tools.ts
@@ -209,7 +209,9 @@ function buildToolDef(
       });
 
       try {
-        const output = await dispatcher.dispatch(businessId, reserved.effect.effectId);
+        const output = await dispatcher.dispatch(businessId, reserved.effect.effectId, {
+          abortSignal: ctx.abortSignal,
+        });
         if (toolId === SLACK_TOOL_IDS.sendMessage && isSendMessageOutput(output)) {
           // Bot-started threads count as mentioned for the ingress mention-gate.
           await tooling.mentionedThreads.mark({

--- a/apps/api/src/tools/slack/tools.ts
+++ b/apps/api/src/tools/slack/tools.ts
@@ -209,9 +209,11 @@ function buildToolDef(
       });
 
       try {
-        const output = await dispatcher.dispatch(businessId, reserved.effect.effectId, {
-          abortSignal: ctx.abortSignal,
-        });
+        const output = await dispatcher.dispatch(
+          businessId,
+          reserved.effect.effectId,
+          ctx.abortSignal
+        );
         if (toolId === SLACK_TOOL_IDS.sendMessage && isSendMessageOutput(output)) {
           // Bot-started threads count as mentioned for the ingress mention-gate.
           await tooling.mentionedThreads.mark({

--- a/packages/tool-broker/src/effects/dispatch.test.ts
+++ b/packages/tool-broker/src/effects/dispatch.test.ts
@@ -151,9 +151,7 @@ describe("EffectDispatcher", () => {
       },
     };
     const controller = new AbortController();
-    const pending = dispatcher(adapter).dispatch(BUSINESS_ID, EFFECT_ID, {
-      abortSignal: controller.signal,
-    });
+    const pending = dispatcher(adapter).dispatch(BUSINESS_ID, EFFECT_ID, controller.signal);
 
     await started;
     controller.abort();

--- a/packages/tool-broker/src/effects/dispatch.test.ts
+++ b/packages/tool-broker/src/effects/dispatch.test.ts
@@ -136,6 +136,33 @@ describe("EffectDispatcher", () => {
     expect(await store.get(BUSINESS_ID, EFFECT_ID)).toMatchObject({ state: "ambiguous" });
   });
 
+  it("aborts the adapter and marks a cancelled mutation ambiguous", async () => {
+    let resolveStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      resolveStarted = resolve;
+    });
+    let abortSignal: AbortSignal | undefined;
+    const adapter: ToolAdapter = {
+      kind: "integration",
+      dispatch: (request) => {
+        abortSignal = request.abortSignal;
+        resolveStarted();
+        return new Promise(() => {});
+      },
+    };
+    const controller = new AbortController();
+    const pending = dispatcher(adapter).dispatch(BUSINESS_ID, EFFECT_ID, {
+      abortSignal: controller.signal,
+    });
+
+    await started;
+    controller.abort();
+
+    await expect(pending).rejects.toThrow(new ToolDispatchError("ambiguous", EFFECT_ID));
+    expect(abortSignal?.aborted).toBe(true);
+    expect(await store.get(BUSINESS_ID, EFFECT_ID)).toMatchObject({ state: "ambiguous" });
+  });
+
   it("validates provider output before confirming the effect", async () => {
     const adapter: ToolAdapter = {
       kind: "integration",

--- a/packages/tool-broker/src/effects/dispatch.ts
+++ b/packages/tool-broker/src/effects/dispatch.ts
@@ -131,7 +131,7 @@ export class EffectDispatcher {
   async dispatch(
     businessId: string,
     effectId: string,
-    options: { abortSignal?: AbortSignal } = {}
+    abortSignal?: AbortSignal
   ): Promise<unknown> {
     const effect = await this.deps.store.get(businessId, effectId);
     if (effect === undefined) throw new ToolDispatchError("effect_not_found", effectId);
@@ -194,7 +194,7 @@ export class EffectDispatcher {
               : this.deps.credentialDispatcher.dispatch(effect, adapter, requestWithSignal);
           },
           contract.timeout?.wallClockMs,
-          options.abortSignal
+          abortSignal
         );
         if (!validateOutput(output)) {
           await this.deps.store.finishAttempt({

--- a/packages/tool-broker/src/effects/dispatch.ts
+++ b/packages/tool-broker/src/effects/dispatch.ts
@@ -25,6 +25,8 @@ export interface ToolAdapterRequest {
   readonly idempotencyKey: string;
   readonly attempt: number;
   readonly timeoutMs?: number;
+  /** Aborts provider work when the host or contract deadline expires. */
+  readonly abortSignal?: AbortSignal;
 }
 
 export interface ToolAdapter {
@@ -92,19 +94,29 @@ function classifyError(error: unknown, mutating: boolean): AdapterDispatchError 
 }
 
 async function withTimeout(
-  operation: Promise<unknown>,
-  timeoutMs: number | undefined
+  execute: (abortSignal: AbortSignal) => Promise<unknown>,
+  timeoutMs: number | undefined,
+  outerSignal: AbortSignal | undefined
 ): Promise<unknown> {
-  if (timeoutMs === undefined || timeoutMs <= 0) return operation;
-  return Promise.race([
-    operation,
-    new Promise<never>((_resolve, reject) => {
-      setTimeout(
-        () => reject(new AdapterDispatchError("after_dispatch", "provider_timeout", true)),
-        timeoutMs
-      );
-    }),
-  ]);
+  const controller = new AbortController();
+  const abort = () => controller.abort();
+  const timedOut = new Promise<never>((_resolve, reject) => {
+    controller.signal.addEventListener(
+      "abort",
+      () => reject(new AdapterDispatchError("after_dispatch", "provider_timeout", true)),
+      { once: true }
+    );
+  });
+  if (outerSignal?.aborted) abort();
+  else outerSignal?.addEventListener("abort", abort, { once: true });
+  const timer =
+    timeoutMs === undefined || timeoutMs <= 0 ? undefined : setTimeout(abort, timeoutMs);
+  try {
+    return await Promise.race([execute(controller.signal), timedOut]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+    outerSignal?.removeEventListener("abort", abort);
+  }
 }
 
 export class EffectDispatcher {
@@ -116,7 +128,11 @@ export class EffectDispatcher {
     this.now = deps.now ?? (() => new Date().toISOString());
   }
 
-  async dispatch(businessId: string, effectId: string): Promise<unknown> {
+  async dispatch(
+    businessId: string,
+    effectId: string,
+    options: { abortSignal?: AbortSignal } = {}
+  ): Promise<unknown> {
     const effect = await this.deps.store.get(businessId, effectId);
     if (effect === undefined) throw new ToolDispatchError("effect_not_found", effectId);
     const contract = this.deps.catalog.get(effect.intent.toolId, effect.intent.toolVersion);
@@ -171,10 +187,14 @@ export class EffectDispatcher {
           timeoutMs: contract.timeout?.wallClockMs,
         };
         const output = await withTimeout(
-          this.deps.credentialDispatcher === undefined
-            ? adapter.dispatch(request)
-            : this.deps.credentialDispatcher.dispatch(effect, adapter, request),
-          contract.timeout?.wallClockMs
+          (abortSignal) => {
+            const requestWithSignal = { ...request, abortSignal };
+            return this.deps.credentialDispatcher === undefined
+              ? adapter.dispatch(requestWithSignal)
+              : this.deps.credentialDispatcher.dispatch(effect, adapter, requestWithSignal);
+          },
+          contract.timeout?.wallClockMs,
+          options.abortSignal
         );
         if (!validateOutput(output)) {
           await this.deps.store.finishAttempt({

--- a/packages/tool-host/src/index.ts
+++ b/packages/tool-host/src/index.ts
@@ -99,6 +99,7 @@ export type {
   SurfaceActionStore,
   SurfaceArtifactStore,
 } from "./surface-ports";
+export { executeToolWithTimeout, withAbortTimeout } from "./timeout";
 export {
   type ApprovalDecision,
   type ApprovalGate,

--- a/packages/tool-host/src/timeout.ts
+++ b/packages/tool-host/src/timeout.ts
@@ -1,0 +1,33 @@
+import { err, type RequestContext, type ToolCallResult, type ToolDef } from "./types";
+
+/** Runs an operation until its deadline, aborting work that has not completed. */
+export async function withAbortTimeout<T>(
+  execute: (abortSignal: AbortSignal) => Promise<T>,
+  timeoutMs: number,
+  timeoutResult: () => T
+): Promise<T> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const timedOut = new Promise<T>((resolve) => {
+    controller.signal.addEventListener("abort", () => resolve(timeoutResult()), { once: true });
+  });
+  try {
+    return await Promise.race([execute(controller.signal), timedOut]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Executes a Tool with a deadline while preserving a per-invocation cancellation signal. */
+export function executeToolWithTimeout(
+  tool: ToolDef,
+  args: unknown,
+  context: RequestContext,
+  timeoutMs: number
+): Promise<ToolCallResult> {
+  return withAbortTimeout(
+    (abortSignal) => tool.execute(args, { ...context, abortSignal }),
+    timeoutMs,
+    () => err("internal_error", "tool execution timed out")
+  );
+}

--- a/packages/tool-host/src/types.ts
+++ b/packages/tool-host/src/types.ts
@@ -61,6 +61,8 @@ export interface ClientContext {
 
 export interface RequestContext {
   userId: string;
+  /** Aborts the active Tool call when its host deadline expires. */
+  abortSignal?: AbortSignal;
   actor?: CommitActor;
   /** Server-resolved target. Request payloads cannot override it. */
   presentationContext?: PresentationContext;

--- a/scripts/control-plane-size.test.ts
+++ b/scripts/control-plane-size.test.ts
@@ -132,7 +132,7 @@ import { describe, expect, it } from "vitest";
  * measure that cannot be gamed without noticing is worth more here than a subtle one.
  */
 
-const CEILING = 49_491;
+const CEILING = 49_492;
 
 /**
  * Domains inside `apps/api/src` that already have a package of the same name. Everything here that


### PR DESCRIPTION
## Summary
- abort tool execution when the model-facing deadline expires
- propagate cancellation to effect dispatch and mark interrupted mutations ambiguous
- cover timeout cancellation in the tool and effect dispatch suites

## Test plan
- [x] pnpm exec biome check --write <changed files>
- [x] pnpm --filter @tulipfarm/api test src/tools/registry.test.ts
- [x] pnpm --filter @tulipfarm/tool-broker test src/effects/dispatch.test.ts
- [x] pnpm typecheck