### PR TITLE
fix(models): require fallback model ids

### DIFF
--- a/apps/web/app/components/model-chains.test.tsx
+++ b/apps/web/app/components/model-chains.test.tsx
@@ -261,6 +261,27 @@ test("adding a fallback creates a numbered profile the presets can target", asyn
   });
 });
 
+test("an empty fallback Model ID stays in the sheet and is not offered to presets", async () => {
+  renderChains();
+
+  const fast = screen.getByRole("heading", { name: "Fast" }).closest("section");
+  await userEvent.click(within(fast as HTMLElement).getByRole("button", { name: /add fallback/i }));
+  await userEvent.click(screen.getByRole("button", { name: /^done$/i }));
+
+  expect(screen.getByText("Enter a Model ID.")).toBeInTheDocument();
+  expect(screen.getByLabelText("Model ID")).toBeInTheDocument();
+  expect(
+    within(screen.getByLabelText("Fast")).queryByRole("option", { name: /fast-fallback-1/ })
+  ).not.toBeInTheDocument();
+
+  await userEvent.type(screen.getByLabelText("Model ID"), "gpt-4o-mini");
+  await userEvent.click(screen.getByRole("button", { name: /^done$/i }));
+
+  expect(
+    within(screen.getByLabelText("Fast")).getByRole("option", { name: /fast-fallback-1/ })
+  ).toBeInTheDocument();
+});
+
 test("Auto is shown as the profile it resolves to", async () => {
   const onSubmit = renderChains();
 

--- a/apps/web/app/components/model-chains.tsx
+++ b/apps/web/app/components/model-chains.tsx
@@ -113,6 +113,7 @@ export function ModelChains({
     const ids: { id: string; label: string }[] = [];
     for (const tier of TIERS) {
       chains[tier.wire].forEach((row, index) => {
+        if (!row.model.trim()) return;
         const id = profileIdFor(tier.preset, index);
         ids.push({
           id,

--- a/apps/web/app/components/model-chains/model-sheet.tsx
+++ b/apps/web/app/components/model-chains/model-sheet.tsx
@@ -35,6 +35,7 @@ export function ModelSheet({
   const [resolving, setResolving] = useState(false);
   const [candidates, setCandidates] = useState<string[]>([]);
   const [unmatched, setUnmatched] = useState(false);
+  const [modelError, setModelError] = useState<string | null>(null);
   const provider = row?.provider;
   const model = row?.model;
 
@@ -98,6 +99,14 @@ export function ModelSheet({
   const modelFieldId = useId();
   const modelHelpId = `${modelFieldId}-help`;
 
+  function finish() {
+    if (!row?.model.trim()) {
+      setModelError("Enter a Model ID.");
+      return;
+    }
+    onClose();
+  }
+
   return (
     <Sheet open={open} onClose={onClose} title="Model">
       {row ? (
@@ -120,6 +129,7 @@ export function ModelSheet({
           <Field
             label="Model ID"
             htmlFor={modelFieldId}
+            error={modelError}
             help={
               options?.source === "live"
                 ? "Listed from your configured endpoint."
@@ -136,6 +146,7 @@ export function ModelSheet({
                 value={isSuggested ? row.model : CUSTOM_MODEL}
                 onChange={(e) => {
                   const value = e.target.value;
+                  setModelError(null);
                   setCandidates([]);
                   setUnmatched(false);
                   if (value === CUSTOM_MODEL) {
@@ -161,6 +172,7 @@ export function ModelSheet({
                 value={row.model}
                 onChange={(e) => {
                   onChange({ model: e.target.value, spec: undefined });
+                  setModelError(null);
                   setCandidates([]);
                   setUnmatched(false);
                 }}
@@ -266,7 +278,7 @@ export function ModelSheet({
           </details>
 
           <div className={cn("flex justify-end")}>
-            <Button size="sm" onClick={onClose}>
+            <Button size="sm" onClick={finish}>
               Done
             </Button>
           </div>


### PR DESCRIPTION
## Summary
- keep the model sheet open and show inline validation when Model ID is empty
- omit incomplete fallback rows from effort-preset choices
- add a regression covering the empty fallback flow

## Test plan
- [x] pnpm exec biome check --write apps/web/app/components/model-chains.tsx apps/web/app/components/model-chains/model-sheet.tsx apps/web/app/components/model-chains.test.tsx
- [x] pnpm --filter @tulipfarm/web test app/components/model-chains.test.tsx
- [x] pnpm --filter @tulipfarm/web typecheck