### PR TITLE
fix(web): expose degraded health details

### DIFF
--- a/apps/web/app/components/operations/operations-console.test.tsx
+++ b/apps/web/app/components/operations/operations-console.test.tsx
@@ -6,7 +6,14 @@ import type { OperationsModel } from "~/lib/operations";
 import { OperationsConsole } from "./operations-console";
 
 const model = {
-  health: [{ component: "worker", status: "degraded" }],
+  health: [
+    {
+      component: "worker",
+      status: "degraded" as const,
+      detail: "worker heartbeat is overdue",
+      checkedAt: "2026-07-26T00:00:00Z",
+    },
+  ],
   incidents: [
     {
       id: "incident-1",
@@ -33,11 +40,13 @@ const model = {
   recovery: { supportBundleAvailable: true, lastBackupAt: "2026-07-26T00:00:00Z" },
 };
 
-function renderConsole(consoleModel: OperationsModel, onCommand = vi.fn()) {
+function renderConsole(consoleModel: OperationsModel, onCommand = vi.fn(), onRefresh = vi.fn()) {
   const Stub = createRemixStub([
     {
       path: "/",
-      Component: () => <OperationsConsole model={consoleModel} onCommand={onCommand} />,
+      Component: () => (
+        <OperationsConsole model={consoleModel} onCommand={onCommand} onRefresh={onRefresh} />
+      ),
     },
     { path: "/business/activities", Component: () => null },
   ]);
@@ -50,6 +59,7 @@ describe("OperationsConsole", () => {
     expect(screen.getByRole("heading", { name: "Queue stalled" })).toBeInTheDocument();
     expect(screen.getByText("worker")).toBeInTheDocument();
     expect(screen.getByText("Degraded")).toBeInTheDocument();
+    expect(screen.getByText("worker heartbeat is overdue")).toBeInTheDocument();
     expect(screen.getByText("High")).toBeInTheDocument();
     expect(screen.getByRole("table", { name: "Recent operational activity" })).toBeInTheDocument();
     expect(screen.getByRole("columnheader", { name: "Event" })).toBeInTheDocument();
@@ -61,6 +71,18 @@ describe("OperationsConsole", () => {
     expect(screen.getByTitle("0f5a23e8-42d7-7556-88d4-b544f361718b")).toHaveTextContent("0f5a23e8");
     expect(screen.queryByText(/"component":/)).not.toBeInTheDocument();
     expect(screen.queryByText("must-not-render")).not.toBeInTheDocument();
+  });
+
+  it("refreshes health without issuing an operational command", async () => {
+    const user = userEvent.setup();
+    const onCommand = vi.fn();
+    const onRefresh = vi.fn();
+    renderConsole(model, onCommand, onRefresh);
+
+    await user.click(screen.getByRole("button", { name: "Refresh status" }));
+
+    expect(onRefresh).toHaveBeenCalledOnce();
+    expect(onCommand).not.toHaveBeenCalled();
   });
 
   it("uses compact, descriptive empty states", () => {

--- a/apps/web/app/components/operations/operations-console.tsx
+++ b/apps/web/app/components/operations/operations-console.tsx
@@ -5,6 +5,7 @@ import {
   Ban,
   CheckCircle2,
   DatabaseBackup,
+  RefreshCw,
   Search,
   ShieldAlert,
 } from "lucide-react";
@@ -96,7 +97,7 @@ function EmptyPanel({ children }: { children: ReactNode }) {
   );
 }
 
-function HealthPanel({ items }: { items: readonly OperationalItem[] }) {
+function HealthPanel({ items }: { items: OperationsModel["health"] }) {
   return (
     <Section
       title="Health"
@@ -110,14 +111,25 @@ function HealthPanel({ items }: { items: readonly OperationalItem[] }) {
           {items.map((item, index) => {
             const component = text(item, "component", "name", "id") ?? "Unknown component";
             const status = statusValue(item, "unknown");
+            const detail = text(item, "detail");
             return (
               <li
                 key={itemKey(item, index)}
-                className="flex min-h-12 items-center gap-3 px-3 py-2 text-xs"
+                className="flex min-h-12 items-start gap-3 px-3 py-2 text-xs"
               >
-                <span className="min-w-0 flex-1 truncate font-medium" title={component}>
-                  {component}
-                </span>
+                <div className="min-w-0 flex-1">
+                  <p className="truncate font-medium" title={component}>
+                    {component}
+                  </p>
+                  {status !== "ok" && detail ? (
+                    <p className="mt-0.5 text-muted-foreground">{detail}</p>
+                  ) : null}
+                  {status !== "ok" ? (
+                    <p className="mt-0.5 text-[0.625rem] text-muted-foreground">
+                      Last checked {formatIso(item.checkedAt)}
+                    </p>
+                  ) : null}
+                </div>
                 <StatusBadge status={status} />
               </li>
             );
@@ -405,10 +417,12 @@ export function OperationsConsole({
   model,
   busy = false,
   onCommand,
+  onRefresh,
 }: {
   model: OperationsModel;
   busy?: boolean;
   onCommand: (action: OperationAction, input: Record<string, unknown>) => void;
+  onRefresh?: () => void;
 }) {
   const [previewSupport, setPreviewSupport] = useState(false);
   const attentionCount = attentionItems(model);
@@ -448,6 +462,14 @@ export function OperationsConsole({
             Create support bundle
           </button>
         ) : null}
+        <button
+          type="button"
+          onClick={onRefresh}
+          className="inline-flex items-center gap-1.5 rounded-sm border border-border px-2.5 py-1.5 text-xs hover:bg-muted disabled:opacity-60"
+        >
+          <RefreshCw aria-hidden="true" className="size-3.5" />
+          Refresh status
+        </button>
       </header>
 
       {previewSupport ? (

--- a/apps/web/app/lib/operations.ts
+++ b/apps/web/app/lib/operations.ts
@@ -49,6 +49,13 @@ export type RunBudget = {
   exhaustionPolicy: "failure_path" | "attention_required";
 };
 
+export type OperationalHealth = {
+  component: string;
+  status: "ok" | "degraded" | "down";
+  detail?: string;
+  checkedAt: string;
+};
+
 /** Reads the enforced write-once `run_budgets` ledger for one Run — not a recomputation. */
 export function getRunBudgets(id: string): Promise<{ runId: string; budgets: RunBudget[] }> {
   return apiGet<{ runId: string; budgets: RunBudget[] }>(
@@ -69,7 +76,7 @@ export function commandRun(
 }
 
 export type OperationsModel = {
-  health: Array<Record<string, unknown>>;
+  health: OperationalHealth[];
   incidents: Array<Record<string, unknown>>;
   quarantine: Array<Record<string, unknown>>;
   killSwitches: Array<Record<string, unknown>>;

--- a/apps/web/app/routes/_app.operations.tsx
+++ b/apps/web/app/routes/_app.operations.tsx
@@ -36,7 +36,12 @@ export default function OperationsRoute() {
       {killSwitches ? (
         <KillSwitchPanel model={killSwitches} onChanged={() => revalidator.revalidate()} />
       ) : null}
-      <OperationsConsole model={model} busy={busy} onCommand={command} />
+      <OperationsConsole
+        model={model}
+        busy={busy}
+        onCommand={command}
+        onRefresh={() => revalidator.revalidate()}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- type Operations health data including diagnostic detail and last check time
- show degraded health detail and provide a non-mutating refresh control
- cover the detail and refresh behavior

## Test plan
- [x] pnpm exec biome check --write apps/web/app/components/operations apps/web/app/lib/operations.ts apps/web/app/routes/_app.operations.tsx
- [x] pnpm --filter @tulipfarm/web run typecheck
- [x] pnpm --filter @tulipfarm/web test app/components/operations/operations-console.test.tsx

Closes #412