### PR TITLE
fix(chat): pause turns for requested input

### DIFF
--- a/apps/api/src/surfaces/tools.ts
+++ b/apps/api/src/surfaces/tools.ts
@@ -340,9 +340,10 @@ export const updatePresentationTool: ToolDef = toToolDef(
 const requestInputToolDefinition = defineApiTool<RequestContext>({
   name: "request_input",
   tier: "platform",
-  mutating: false,
+  // It makes no external change, but it is a control-flow barrier for the Tool loop.
+  mutating: true,
   description:
-    "Ask the user for a choice or typed response. This is the only Tool to use when the response must wait for user input; it presents the interactive component and suspends the same Run.",
+    "Ask the user for a choice or typed response. This is the only Tool to use when the response must wait for user input; it presents the interactive component and pauses agent work until the response starts a later Chat Turn.",
   inputSchema: {
     ...PRESENT_SCHEMA,
   },

--- a/apps/eval/corpus/l3-request-input-pauses-before-agent-create.json
+++ b/apps/eval/corpus/l3-request-input-pauses-before-agent-create.json
@@ -1,0 +1,91 @@
+{
+  "id": "l3-request-input-pauses-before-agent-create",
+  "tier": "l3",
+  "agent": "support",
+  "context": {
+    "memoryDocument": "## Operating profile\nThe operator must choose the operating profile before an Agent is created.",
+    "governancePages": []
+  },
+  "input": [
+    {
+      "role": "user",
+      "content": "Ask me to choose an operating profile with request_input, then create the Agent only after I answer."
+    }
+  ],
+  "tools": [
+    {
+      "name": "request_input",
+      "description": "Ask the operator to choose before continuing.",
+      "inputSchema": { "type": "object" },
+      "mutating": true
+    },
+    {
+      "name": "agent_create",
+      "description": "Create an Agent.",
+      "inputSchema": { "type": "object" },
+      "mutating": true
+    }
+  ],
+  "toolResults": [
+    {
+      "name": "request_input",
+      "output": { "suspendRun": true }
+    },
+    {
+      "name": "agent_create",
+      "output": { "id": "agent-1" }
+    }
+  ],
+  "script": [
+    {
+      "kind": "tool_calls",
+      "calls": [
+        {
+          "callId": "input-1",
+          "name": "request_input",
+          "arguments": { "component": { "name": "Choices" } }
+        }
+      ]
+    },
+    {
+      "kind": "tool_calls",
+      "calls": [
+        {
+          "callId": "create-1",
+          "name": "agent_create",
+          "arguments": { "name": "Support Agent" }
+        }
+      ]
+    },
+    {
+      "kind": "text",
+      "text": "Created the Agent."
+    }
+  ],
+  "expect": [
+    {
+      "kind": "tool_called",
+      "name": "request_input"
+    },
+    {
+      "kind": "tool_not_called",
+      "name": "agent_create"
+    },
+    {
+      "kind": "run_status",
+      "status": "succeeded"
+    },
+    {
+      "kind": "state_status",
+      "status": "succeeded"
+    },
+    {
+      "kind": "turn_status",
+      "status": "succeeded"
+    },
+    {
+      "kind": "run_event_emitted",
+      "eventType": "turn.finished"
+    }
+  ]
+}

--- a/apps/worker/src/routine/agent-port.ts
+++ b/apps/worker/src/routine/agent-port.ts
@@ -386,6 +386,10 @@ export class BundleRoutineAgentPort implements RoutineAgentPort {
     if (outcome.status === "awaiting_approval") {
       return { kind: "awaiting_approval", reason: "approval_required" };
     }
+    if (outcome.status === "input_required") {
+      // Routine Agents expose no Surface-capable Tools, so this outcome cannot be resumed here.
+      return { kind: "failed", reason: "input_required_without_surface", retryable: false };
+    }
 
     // Last zero-cost refusal point: no State is settled and no downstream effect has run.
     const guardedOutput = await guardrails.runOutput(answerText(outcome.output), guardContext);

--- a/packages/agent-runtime/src/loop/contract.ts
+++ b/packages/agent-runtime/src/loop/contract.ts
@@ -132,6 +132,14 @@ export type AgentLoopOutcome =
       readonly repairs: number;
     }
   | {
+      /** A `request_input` Surface is durable; a later Chat Turn receives the answer. */
+      readonly status: "input_required";
+      readonly callId: string;
+      readonly iterations: number;
+      readonly toolCalls: number;
+      readonly repairs: number;
+    }
+  | {
       readonly status: "cancelled";
       readonly iterations: number;
       readonly toolCalls: number;

--- a/packages/agent-runtime/src/loop/loop.test.ts
+++ b/packages/agent-runtime/src/loop/loop.test.ts
@@ -439,6 +439,31 @@ describe("AgentLoop", () => {
     expect(outcome).toMatchObject({ status: "awaiting_approval", approvalId: "appr-1" });
   });
 
+  it("stops after request_input before asking the model to continue", async () => {
+    const model = scriptedModel(
+      toolCallResult([{ callId: "input-1", name: "request_input", arguments: { component: {} } }]),
+      toolCallResult([{ callId: "create-1", name: "agent_create", arguments: {} }])
+    );
+    const tools = dispatcher({
+      status: "succeeded",
+      callId: "input-1",
+      output: { suspendRun: true },
+    });
+
+    const outcome = await loop({ model, tools }).run(
+      input({
+        tools: [
+          { name: "request_input", inputSchema: {}, mutating: true },
+          { name: "agent_create", inputSchema: {}, mutating: true },
+        ],
+      })
+    );
+
+    expect(outcome).toMatchObject({ status: "input_required", callId: "input-1" });
+    expect(model.requests).toBe(1);
+    expect(tools.calls).toEqual([{ name: "request_input", arguments: { component: {} } }]);
+  });
+
   it("AJV-validates structured output and repairs an invalid one", async () => {
     const outcome = await loop({
       model: scriptedModel(

--- a/packages/agent-runtime/src/loop/loop.ts
+++ b/packages/agent-runtime/src/loop/loop.ts
@@ -200,6 +200,7 @@ export class AgentLoop {
       ): Promise<
         | { kind: "continue" }
         | { kind: "approval"; approvalId: string; call: NormalizedToolCall }
+        | { kind: "input_required"; call: NormalizedToolCall }
         | { kind: "fail"; reason: AgentLoopFailureReason }
       > => {
         await emit("tool_call_dispatched", {
@@ -225,6 +226,9 @@ export class AgentLoop {
 
         if (dispatched.status === "succeeded") {
           messages.push(toolMessage(call.callId, { output: dispatched.output }));
+          if (isInputRequired(call.name, dispatched.output)) {
+            return { kind: "input_required", call };
+          }
           if (call.name === "load_skill") {
             const loaded = extractSkillName(call.arguments);
             if (loaded !== undefined) activeSkillName = loaded;
@@ -280,6 +284,12 @@ export class AgentLoop {
             approval = { approvalId: outcome.approvalId, call: outcome.call };
             break;
           }
+          if (outcome.kind === "input_required") {
+            return finish(
+              { status: "input_required", callId: outcome.call.callId, ...counters },
+              "completed"
+            );
+          }
           index += 1;
           continue;
         }
@@ -326,6 +336,7 @@ export class AgentLoop {
         // in call order wins, matching what a sequential batch would have produced.
         let decision:
           | { kind: "approval"; approvalId: string; call: NormalizedToolCall }
+          | { kind: "input_required"; call: NormalizedToolCall }
           | { kind: "fail"; reason: AgentLoopFailureReason }
           | undefined;
         for (let i = 0; i < runBatch.length; i += 1) {
@@ -359,6 +370,12 @@ export class AgentLoop {
         }
         if (decision?.kind === "fail") {
           return finish({ status: "failed", reason: decision.reason, ...counters }, "failed");
+        }
+        if (decision?.kind === "input_required") {
+          return finish(
+            { status: "input_required", callId: decision.call.callId, ...counters },
+            "completed"
+          );
         }
         if (decision !== undefined) {
           approval = { approvalId: decision.approvalId, call: decision.call };
@@ -550,4 +567,13 @@ export class AgentLoop {
       return finish({ status: "completed", output, ...counters }, "completed");
     }
   }
+}
+
+function isInputRequired(name: string, output: unknown): boolean {
+  return (
+    name === "request_input" &&
+    typeof output === "object" &&
+    output !== null &&
+    (output as { suspendRun?: unknown }).suspendRun === true
+  );
 }

--- a/packages/turn-executor/src/agent-state.test.ts
+++ b/packages/turn-executor/src/agent-state.test.ts
@@ -94,6 +94,17 @@ describe("AgentStateRunner", () => {
     expect(result).toMatchObject({ status: "waiting", waitId: "wait-1" });
   });
 
+  it("settles the State when input is required for a later Chat Turn", async () => {
+    const harness = runner({ status: "input_required", callId: "input-1", ...counters });
+    const result = await harness.agentState.execute(request(), LOOP_INPUT);
+
+    expect(harness.transitions).toEqual([
+      { from: "claimed", to: "running" },
+      { from: "running", to: "succeeded" },
+    ]);
+    expect(result).toEqual({ status: "input_required" });
+  });
+
   it("takes a cancelled loop through cancelling to cancelled", async () => {
     const harness = runner({ status: "cancelled", ...counters });
     const result = await harness.agentState.execute(request(), LOOP_INPUT);

--- a/packages/turn-executor/src/agent-state.ts
+++ b/packages/turn-executor/src/agent-state.ts
@@ -52,6 +52,7 @@ export type AgentStateResult =
       /** The Tool call being held, so a reader can show the decision against that call. */
       readonly callId: string;
     }
+  | { readonly status: "input_required" }
   | { readonly status: "cancelled" }
   | { readonly status: "needs_reconciliation" };
 
@@ -98,6 +99,10 @@ export class AgentStateRunner {
           callId: outcome.callId,
         };
       }
+
+      case "input_required":
+        await this.move(request, "running", "succeeded");
+        return { status: "input_required" };
 
       case "cancelled":
         // `RunCancellationManager` is walking this State down the same two steps from the other

--- a/packages/turn-executor/src/conversation-turn.test.ts
+++ b/packages/turn-executor/src/conversation-turn.test.ts
@@ -109,6 +109,22 @@ describe("ConversationTurnCompleter", () => {
     expect(result).toMatchObject({ status: "failed", reason: "iteration_limit" });
   });
 
+  it("completes an input-required Turn without inventing an assistant Message", async () => {
+    const store = new FakeStore();
+    const completer = new ConversationTurnCompleter({ store });
+
+    const result = await completer.complete({
+      ...request,
+      outcome: { status: "input_required" },
+    });
+
+    expect(store.appended).toEqual([]);
+    expect(store.completed).toEqual([
+      { turnId: "turn-1", attempt: 1, status: "succeeded", cursor: 12 },
+    ]);
+    expect(result).toEqual({ status: "succeeded", messageId: null });
+  });
+
   it("leaves a waiting Turn open so the Approval can resume it", async () => {
     const store = new FakeStore();
     const completer = new ConversationTurnCompleter({ store });

--- a/packages/turn-executor/src/conversation-turn.ts
+++ b/packages/turn-executor/src/conversation-turn.ts
@@ -40,6 +40,7 @@ export interface TurnCompletionStore {
 export type TurnOutcome =
   | { readonly status: "succeeded"; readonly text: string }
   | { readonly status: "failed"; readonly reason: string }
+  | { readonly status: "input_required" }
   | { readonly status: "waiting"; readonly waitId: string };
 
 export interface CompleteTurnInput {
@@ -57,7 +58,7 @@ export interface CompleteTurnInput {
 }
 
 export type CompleteTurnResult =
-  | { readonly status: "succeeded"; readonly messageId: string }
+  | { readonly status: "succeeded"; readonly messageId: string | null }
   | { readonly status: "failed"; readonly reason: string }
   | { readonly status: "waiting"; readonly waitId: string }
   | { readonly status: "stale" };
@@ -92,7 +93,7 @@ export class ConversationTurnCompleter {
     const existing = await this.options.store.findCompletion(ref);
     if (existing !== undefined) {
       return existing.status === "succeeded"
-        ? { status: "succeeded", messageId: existing.messageId ?? "" }
+        ? { status: "succeeded", messageId: existing.messageId }
         : {
             status: "failed",
             reason: input.outcome.status === "failed" ? input.outcome.reason : "",
@@ -107,6 +108,16 @@ export class ConversationTurnCompleter {
         messageId: null,
       });
       return { status: "failed", reason: input.outcome.reason };
+    }
+
+    if (input.outcome.status === "input_required") {
+      await this.options.store.completeTurn({
+        ...ref,
+        status: "succeeded",
+        cursor: input.cursor,
+        messageId: null,
+      });
+      return { status: "succeeded", messageId: null };
     }
 
     const { messageId } = await this.options.store.appendAssistantMessage({

--- a/packages/turn-executor/src/driver.test.ts
+++ b/packages/turn-executor/src/driver.test.ts
@@ -340,6 +340,23 @@ describe("TurnDriver", () => {
     });
   });
 
+  it("settles for input without appending an assistant Message", async () => {
+    const { driver, events, store } = harness({
+      status: "input_required",
+      callId: "input-1",
+      ...counters,
+    });
+    const outcome = await driver.run(request());
+
+    expect(outcome).toBe("succeeded");
+    expect(store.messages).toEqual([]);
+    expect(store.completed).toEqual([{ status: "succeeded", cursor: 2, messageId: null }]);
+    expect(events.appended.at(-1)).toEqual({
+      eventType: "turn.finished",
+      payload: { status: "succeeded", messageId: null },
+    });
+  });
+
   it("reports a failed loop as a finished turn with no Message", async () => {
     const { driver, events, store } = harness({
       status: "failed",

--- a/packages/turn-executor/src/driver.ts
+++ b/packages/turn-executor/src/driver.ts
@@ -221,7 +221,7 @@ export class TurnDriver {
   private async complete(
     request: TurnRequest,
     events: TurnEventWriter,
-    result: Extract<AgentStateResult, { status: "succeeded" | "failed" }>,
+    result: Extract<AgentStateResult, { status: "succeeded" | "failed" | "input_required" }>,
     spend: TurnSpendScope
   ): Promise<RunOutcome> {
     const completion = await this.options.completer.complete({
@@ -294,9 +294,10 @@ export class TurnDriver {
 
 /** Serialize structured output; empty output fails instead of writing a blank Message. */
 function turnOutcome(
-  result: Extract<AgentStateResult, { status: "succeeded" | "failed" }>
+  result: Extract<AgentStateResult, { status: "succeeded" | "failed" | "input_required" }>
 ): TurnOutcome {
   if (result.status === "failed") return { status: "failed", reason: result.reason };
+  if (result.status === "input_required") return { status: "input_required" };
   const text = renderAnswer(result.output);
   if (text.length === 0) return { status: "failed", reason: "empty_model_output" };
   return { status: "succeeded", text };


### PR DESCRIPTION
## Summary

- stop the Agent loop immediately after `request_input` emits its interactive Surface
- settle the original Turn without fabricating an assistant Message, so the selected response can start the existing follow-up Chat Turn
- add loop, executor, and L3 eval coverage preventing `agent_create` before input

## Test plan

- [x] `pnpm exec biome check …`
- [x] root TypeScript check
- [x] `pnpm --filter @tulipfarm/agent-runtime test src/loop/loop.test.ts`
- [x] `pnpm --filter @tulipfarm/turn-executor test src/agent-state.test.ts src/conversation-turn.test.ts src/driver.test.ts`
- [x] `pnpm --filter @tulipfarm/eval test`

Corpus update changes `corpusHash`; existing baselines require re-promotion before the eval gate can compare against them.