### PR TITLE
fix(api): treat malformed record ids as missing

### DIFF
--- a/apps/api/src/resources/repo.pg.test.ts
+++ b/apps/api/src/resources/repo.pg.test.ts
@@ -61,6 +61,10 @@ describe("PgResourceRepo", () => {
     expect(await repo.findById(randomUUID())).toBeNull();
   });
 
+  it("returns null for a malformed id without querying the UUID column", async () => {
+    expect(await repo.findById("qa-does-not-exist-id")).toBeNull();
+  });
+
   it("list excludes soft-deleted by default and includes them on demand", async () => {
     await repo.insert(doc({ title: "live" }));
     await repo.insert(doc({ title: "gone", version: 2, deletedAt: new Date() }));
@@ -87,6 +91,13 @@ describe("PgResourceRepo", () => {
     const found = await repo.findById(d._id);
     expect(found?.version).toBe(2);
     expect(found?.title).toBe("updated");
+  });
+
+  it("replaceOne rejects a malformed id without querying the UUID column", async () => {
+    const d = doc();
+    await repo.insert(d);
+
+    expect(await repo.replaceOne("qa-does-not-exist-id", 1, d)).toBe(false);
   });
 
   it("appendHistory writes a snapshot row", async () => {

--- a/apps/api/src/resources/repo.ts
+++ b/apps/api/src/resources/repo.ts
@@ -4,6 +4,8 @@ import { type PaginatedResult, toPage } from "@tulipfarm/storage";
 import type { Queryable } from "../db";
 import { historyTableName, rowToResourceDoc, tableName } from "./schema";
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export interface ResourceDoc {
   _id: string;
   version: number;
@@ -73,6 +75,7 @@ export class PgResourceRepo implements ResourceRepo {
   }
 
   async findById(id: string): Promise<ResourceDoc | null> {
+    if (!UUID_RE.test(id)) return null;
     const { rows } = await this.q.query(
       `SELECT id, version, created_at, updated_at, deleted_at, data FROM ${this.table} WHERE id = $1`,
       [id]
@@ -121,6 +124,7 @@ export class PgResourceRepo implements ResourceRepo {
   }
 
   async replaceOne(id: string, expectedVersion: number, doc: ResourceDoc): Promise<boolean> {
+    if (!UUID_RE.test(id)) return false;
     const { _id, version, createdAt, updatedAt, deletedAt, ...data } = doc;
     const { rows } = await this.q.query(
       `UPDATE ${this.table}


### PR DESCRIPTION
## Summary
- reject malformed resource record IDs before PostgreSQL UUID coercion
- preserve normal 404 behavior for resource detail and edit routes
- cover malformed ID reads and writes in the PostgreSQL repository

## Test plan
- [x] pnpm exec biome check --write apps/api/src/resources
- [x] pnpm --filter @tulipfarm/api run typecheck
- [x] pnpm --filter @tulipfarm/api test src/resources/repo.pg.test.ts

Closes #404