### PR TITLE
fix(chat): show knowledge mention states

### DIFF
--- a/apps/web/app/components/chat/editor/mention-list.test.tsx
+++ b/apps/web/app/components/chat/editor/mention-list.test.tsx
@@ -1,0 +1,43 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { createRef } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { MentionList, type MentionListRef } from "./mention-list";
+
+describe("MentionList", () => {
+  it("renders a loading state while Knowledge search is pending", () => {
+    render(<MentionList command={vi.fn()} items={[]} kind="knowledge" loading />);
+
+    expect(screen.getByRole("status")).toHaveTextContent("Searching Knowledge…");
+  });
+
+  it("renders an empty state when Knowledge search finds no matches", () => {
+    render(<MentionList command={vi.fn()} items={[]} kind="knowledge" />);
+
+    expect(screen.getByText("No matching Knowledge.")).toBeInTheDocument();
+  });
+
+  it("keeps selecting returned Knowledge items with keyboard navigation", () => {
+    const command = vi.fn();
+    const ref = createRef<MentionListRef>();
+    render(
+      <MentionList
+        ref={ref}
+        command={command}
+        items={[
+          { id: "page-1", label: "Operating profile", description: "Autonomy choices" },
+          { id: "page-2", label: "Support policy", description: "Response guidelines" },
+        ]}
+        kind="knowledge"
+      />
+    );
+
+    act(() => {
+      ref.current?.onKeyDown({ event: new KeyboardEvent("keydown", { key: "ArrowDown" }) });
+    });
+    ref.current?.onKeyDown({ event: new KeyboardEvent("keydown", { key: "Enter" }) });
+
+    expect(command).toHaveBeenCalledWith({ id: "page-2", label: "Support policy" });
+    fireEvent.mouseDown(screen.getByRole("button", { name: /Operating profile/i }));
+    expect(command).toHaveBeenCalledWith({ id: "page-1", label: "Operating profile" });
+  });
+});

--- a/apps/web/app/components/chat/editor/mention-list.tsx
+++ b/apps/web/app/components/chat/editor/mention-list.tsx
@@ -16,8 +16,10 @@ export const MentionList = forwardRef<
     command: (item: { id: string; label: string }) => void;
     /** Trigger kind — agent rows render a glyph avatar; skill/resource rows don't. */
     kind?: MentionKind;
+    /** Async Knowledge search is pending; render feedback instead of hiding the menu. */
+    loading?: boolean;
   }
->(({ items, command, kind }, ref) => {
+>(({ items, command, kind, loading = false }, ref) => {
   const [selected, setSelected] = useState(0);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: a fresh query yields a fresh list — reset the highlight to the top.
@@ -47,7 +49,16 @@ export const MentionList = forwardRef<
     [items, selected, command]
   );
 
-  if (items.length === 0) return null;
+  if (items.length === 0) {
+    if (!loading && kind !== "knowledge") return null;
+    return (
+      <div className="w-64 rounded-sm border border-border bg-card p-2 text-sm shadow-md">
+        <p className="text-muted-foreground" role={loading ? "status" : undefined}>
+          {loading ? "Searching Knowledge…" : "No matching Knowledge."}
+        </p>
+      </div>
+    );
+  }
 
   return (
     <div className="max-h-64 w-64 overflow-y-auto rounded-sm border border-border bg-card p-1 text-sm shadow-md">


### PR DESCRIPTION
## Summary

- keep the Knowledge mention menu visible while its server-side search is pending
- show a clear empty state when Knowledge search returns no matches
- cover loading, empty, keyboard, and pointer selection behavior

## Test plan

- [x] `pnpm exec biome check apps/web/app/components/chat/editor/mention-list.tsx apps/web/app/components/chat/editor/mention-list.test.tsx`
- [x] TypeScript check
- [x] `pnpm --filter @tulipfarm/web test app/components/chat/editor/mention-list.test.tsx`