### PR TITLE
fix(runtime): distinguish skill categories

### DIFF
--- a/apps/eval/corpus/support-sees-eager-skill-not-lazy-body.json
+++ b/apps/eval/corpus/support-sees-eager-skill-not-lazy-body.json
@@ -29,6 +29,10 @@
     },
     {
       "kind": "prompt_omits",
+      "text": "customer-service:"
+    },
+    {
+      "kind": "prompt_omits",
       "text": "A refund is approved by finance, never by an agent."
     },
     {

--- a/apps/eval/soul/skills/refund-policy/SKILL.md
+++ b/apps/eval/soul/skills/refund-policy/SKILL.md
@@ -1,5 +1,6 @@
 ---
 description: How Tulip Supply Co handles refund requests and who may approve one.
+category: customer-service
 ---
 
 A refund is approved by finance, never by an agent.

--- a/packages/agent-runtime/src/context/assemble.test.ts
+++ b/packages/agent-runtime/src/context/assemble.test.ts
@@ -319,7 +319,7 @@ describe("assembleSystemPrompt — available-skills (lazy L1)", () => {
     expect(out).toContain("\n\n- bare\n</available-skills>");
   });
 
-  it("keeps the self-improvement directive inside a deterministic, budgeted block", () => {
+  it("keeps categories distinct from loadable Skill names in a deterministic, budgeted block", () => {
     const context = baseCtx({
       availableSkills: [
         {
@@ -343,13 +343,13 @@ describe("assembleSystemPrompt — available-skills (lazy L1)", () => {
 
     expect(first).toBe(second);
     const blockStart = first.indexOf("<available-skills>");
-    const directive = first.indexOf("Before replying, scan this list");
+    const directive = first.indexOf("Before replying, scan the named Skills");
     const list = first.indexOf("- user-skill: A Soul Skill.");
     const blockEnd = first.indexOf("</available-skills>");
     expect(blockStart).toBeLessThan(directive);
     expect(directive).toBeLessThan(list);
     expect(list).toBeLessThan(blockEnd);
-    expect(first).toContain("load any Skill that is even partially relevant with load_skill");
+    expect(first).toContain("Category headings only group Skills; they are not Skill names");
     expect(first).toContain(
       "patch it immediately with skill_update using old_string and new_string"
     );
@@ -357,13 +357,14 @@ describe("assembleSystemPrompt — available-skills (lazy L1)", () => {
     expect(first).toContain(
       [
         "- user-skill: A Soul Skill.",
-        "core: Core workflows.",
+        "## Skill category: Core workflows.",
         "  - business-records: Work with Records.",
-        "forge: Author Soul artifacts.",
+        "## Skill category: Author Soul artifacts.",
         "  - resource-forge: Forge Resource types.",
         "</available-skills>",
       ].join("\n")
     );
+    expect(first).not.toContain("\ncore:");
   });
 
   it("omits the block when there are no skills (unset or empty)", () => {

--- a/packages/agent-runtime/src/context/assemble.ts
+++ b/packages/agent-runtime/src/context/assemble.ts
@@ -186,8 +186,9 @@ function renderEagerSkills(ctx: AssembleContext): string {
 const MAX_AVAILABLE_SKILLS_CHARS = 8000;
 
 const AVAILABLE_SKILLS_GUIDANCE = [
-  "Before replying, scan this list and load any Skill that is even partially relevant with",
-  "load_skill. If a loaded Skill is wrong, outdated, or incomplete, patch it immediately with",
+  "Before replying, scan the named Skills in this list and load any that are even partially",
+  "relevant with load_skill. Category headings only group Skills; they are not Skill names and",
+  "cannot be loaded. If a loaded Skill is wrong, outdated, or incomplete, patch it immediately with",
   "skill_update using old_string and new_string; do not wait to be asked. After a hard multi-step",
   "task, offer to save the reusable approach as a new Skill.",
 ].join(" ");
@@ -225,7 +226,7 @@ function renderAvailableSkills(ctx: AssembleContext): string {
     const categorySkills = categories.get(category) ?? [];
     const description =
       categorySkills.find((skill) => skill.categoryDescription)?.categoryDescription ?? "";
-    lines.push(description ? `${category}: ${description}` : `${category}:`);
+    lines.push(description ? `## Skill category: ${description}` : "## Skill category");
     for (const skill of categorySkills) {
       lines.push(
         skill.description ? `  - ${skill.name}: ${skill.description}` : `  - ${skill.name}`


### PR DESCRIPTION
## Summary
- render available-Skill categories as non-addressable headings
- clarify that only named Skills can be loaded
- add a categorized lazy-Skill eval regression

## Test plan
- [x] `pnpm exec biome check --write` (changed files)
- [x] `pnpm --filter @tulipfarm/agent-runtime test src/context/assemble.test.ts`
- [x] `pnpm eval`
- [x] `pnpm typecheck`

Corpus content changed, so the corpus hash changed and existing eval baselines must be re-promoted before comparison.