### PR TITLE
fix(sandbox): drain hook workers before termination

### DIFF
--- a/packages/sandbox/src/hooks/executor.test.ts
+++ b/packages/sandbox/src/hooks/executor.test.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { Worker } from "node:worker_threads";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
 // isolated-vm 7.x ships prebuilds for Node 24 (abi137) and Node 26 (abi147) but not Node 25 (abi141).
 // Tests that require the isolate to actually execute and return a successful result must be
@@ -169,6 +169,24 @@ describe("HookExecutor", () => {
       // Structural verification: executor spawns a Worker
       // biome-ignore lint/complexity/useLiteralKeys: accessing private property in test
       expect(executor["worker"]).toBeInstanceOf(Worker);
+    });
+  });
+
+  describe("close()", () => {
+    it("asks the worker to shut down gracefully instead of hard-terminating it", async () => {
+      const postSpy = vi.spyOn(Worker.prototype, "postMessage");
+      const terminateSpy = vi.spyOn(Worker.prototype, "terminate");
+      const closingExecutor = new HookExecutor({ workerPath: WORKER_PATH });
+
+      await closingExecutor.close();
+
+      expect(
+        postSpy.mock.calls.some(([message]) => (message as { type?: string })?.type === "shutdown")
+      ).toBe(true);
+      expect(terminateSpy).not.toHaveBeenCalled();
+
+      postSpy.mockRestore();
+      terminateSpy.mockRestore();
     });
   });
 

--- a/packages/sandbox/src/hooks/executor.ts
+++ b/packages/sandbox/src/hooks/executor.ts
@@ -256,10 +256,39 @@ export class HookExecutor {
   }
 
   async close(): Promise<void> {
-    await this.worker.terminate();
     for (const [id, p] of this.pending) {
       p.reject(new Error("executor closed"));
       this.pending.delete(id);
     }
+    await this.shutdownWorker();
+  }
+
+  private shutdownWorker(): Promise<void> {
+    return new Promise((resolve) => {
+      let settled = false;
+      const hardTerminate = () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        this.worker
+          .terminate()
+          .catch(() => {})
+          .finally(resolve);
+      };
+      const timer = setTimeout(hardTerminate, 2000);
+
+      this.worker.once("exit", () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve();
+      });
+
+      try {
+        this.worker.postMessage({ type: "shutdown" });
+      } catch {
+        hardTerminate();
+      }
+    });
   }
 }


### PR DESCRIPTION
## Summary

- send the existing shutdown message before terminating a hook worker
- retain a bounded 2-second hard-termination fallback
- cover graceful worker shutdown with a regression test

## Test plan

- [x] `pnpm exec biome check --write packages/sandbox/src/hooks/executor.ts packages/sandbox/src/hooks/executor.test.ts`
- [x] `pnpm --filter @tulipfarm/sandbox typecheck`
- [x] `pnpm --filter @tulipfarm/sandbox test src/hooks/executor.test.ts`