### PR TITLE
fix(skills): install Skill packages with companion files

### DIFF
--- a/apps/api/src/soul/skills/routes.test.ts
+++ b/apps/api/src/soul/skills/routes.test.ts
@@ -558,6 +558,7 @@ spec:
       expect(skills).toEqual([
         {
           name: "demo-skill",
+          skillPath: join("skills", "demo-skill", "SKILL.md"),
           description: "A demo skill.",
           installed: false,
           updateAvailable: false,
@@ -906,6 +907,163 @@ spec:
       expect(installRes.json().error).toMatch(/100,000 characters/);
       expect(commits).toEqual([]);
     });
+
+    // A real marketplace Skill is a package: reference material, helper scripts, and the licence
+    // and dependency files its author shipped. Every file has to reach the soul, or the operator
+    // installs a Skill whose `load_skill_reference` targets are simply missing.
+    it("installs a Skill package's references, scripts and root provenance files", async () => {
+      const remote = await makeRemoteRepo();
+      temps.push(remote);
+      const skillDir = join(remote, "skills", "demo-skill");
+      await mkdir(join(skillDir, "references"), { recursive: true });
+      await mkdir(join(skillDir, "scripts"), { recursive: true });
+      await writeFile(join(skillDir, "references", "playbook.md"), "# Playbook\n", "utf8");
+      await writeFile(join(skillDir, "scripts", "convert.py"), "print('convert')\n", "utf8");
+      await writeFile(join(skillDir, "LICENSE.txt"), "MIT\n", "utf8");
+      await writeFile(join(skillDir, "requirements.txt"), "pandas\n", "utf8");
+      await execFileP("git", ["add", "-A"], { cwd: remote });
+      await execFileP("git", ["commit", "-q", "-m", "add package files"], { cwd: remote });
+
+      const scanRes = await app.inject({
+        method: "POST",
+        url: "/api/v1/skills/scan",
+        cookies: auth(),
+        headers,
+        payload: { source: `file://${remote}` },
+      });
+      const { scanId } = scanRes.json();
+      buildAudit.mockResolvedValue({
+        riskRating: "low",
+        summary: "No issue found.",
+        toolsReach: [],
+        findings: [],
+        deterministicScan: CLEAN_DETERMINISTIC_SCAN,
+      });
+      await app.inject({
+        method: "POST",
+        url: "/api/v1/skills/audit",
+        cookies: auth(),
+        headers,
+        payload: { scanId, name: "demo-skill" },
+      });
+
+      const installRes = await app.inject({
+        method: "POST",
+        url: "/api/v1/skills/install",
+        cookies: auth(),
+        headers,
+        payload: { scanId, names: ["demo-skill"] },
+      });
+
+      expect(installRes.statusCode).toBe(200);
+      const installed = join(soulPath, "skills", "demo-skill");
+      await expect(readFile(join(installed, "references", "playbook.md"), "utf8")).resolves.toBe(
+        "# Playbook\n"
+      );
+      await expect(readFile(join(installed, "scripts", "convert.py"), "utf8")).resolves.toBe(
+        "print('convert')\n"
+      );
+      await expect(readFile(join(installed, "LICENSE.txt"), "utf8")).resolves.toBe("MIT\n");
+      await expect(readFile(join(installed, "requirements.txt"), "utf8")).resolves.toBe("pandas\n");
+    });
+
+    it("names the offending file when a package carries something the soul cannot store", async () => {
+      const remote = await makeRemoteRepo();
+      temps.push(remote);
+      await writeFile(join(remote, "skills", "demo-skill", "notes.rst"), "notes\n", "utf8");
+      await execFileP("git", ["add", "-A"], { cwd: remote });
+      await execFileP("git", ["commit", "-q", "-m", "add unstorable file"], { cwd: remote });
+
+      const scanRes = await app.inject({
+        method: "POST",
+        url: "/api/v1/skills/scan",
+        cookies: auth(),
+        headers,
+        payload: { source: `file://${remote}` },
+      });
+      const { scanId } = scanRes.json();
+      buildAudit.mockResolvedValue({
+        riskRating: "low",
+        summary: "No issue found.",
+        toolsReach: [],
+        findings: [],
+        deterministicScan: CLEAN_DETERMINISTIC_SCAN,
+      });
+      await app.inject({
+        method: "POST",
+        url: "/api/v1/skills/audit",
+        cookies: auth(),
+        headers,
+        payload: { scanId, name: "demo-skill" },
+      });
+
+      const installRes = await app.inject({
+        method: "POST",
+        url: "/api/v1/skills/install",
+        cookies: auth(),
+        headers,
+        payload: { scanId, names: ["demo-skill"] },
+      });
+
+      expect(installRes.statusCode).toBe(400);
+      expect(installRes.json().error).toContain("notes.rst");
+      expect(commits).toEqual([]);
+    });
+
+    // A Skill's name is its soul directory, so two same-named packages in one source cannot both
+    // be installed. Say so instead of installing whichever the scan happened to list first.
+    it("refuses an ambiguous install when one source defines two skills with the same name", async () => {
+      const remote = await makeRemoteRepo();
+      temps.push(remote);
+      const second = join(remote, "extra", "demo-skill");
+      await mkdir(second, { recursive: true });
+      await writeFile(
+        join(second, "SKILL.md"),
+        "---\nname: demo-skill\ndescription: A rival demo skill.\n---\nDo it differently.",
+        "utf8"
+      );
+      await execFileP("git", ["add", "-A"], { cwd: remote });
+      await execFileP("git", ["commit", "-q", "-m", "add duplicate name"], { cwd: remote });
+
+      const scanRes = await app.inject({
+        method: "POST",
+        url: "/api/v1/skills/scan",
+        cookies: auth(),
+        headers,
+        payload: { source: `file://${remote}` },
+      });
+      const { scanId, skills } = scanRes.json();
+      expect(skills).toHaveLength(2);
+      // The two rows are distinguishable, which is what lets a client key them apart.
+      expect(new Set(skills.map((s: { skillPath: string }) => s.skillPath)).size).toBe(2);
+
+      buildAudit.mockResolvedValue({
+        riskRating: "low",
+        summary: "No issue found.",
+        toolsReach: [],
+        findings: [],
+        deterministicScan: CLEAN_DETERMINISTIC_SCAN,
+      });
+      await app.inject({
+        method: "POST",
+        url: "/api/v1/skills/audit",
+        cookies: auth(),
+        headers,
+        payload: { scanId, name: "demo-skill" },
+      });
+
+      const installRes = await app.inject({
+        method: "POST",
+        url: "/api/v1/skills/install",
+        cookies: auth(),
+        headers,
+        payload: { scanId, names: ["demo-skill"] },
+      });
+
+      expect(installRes.statusCode).toBe(400);
+      expect(installRes.json().error).toContain("more than one skill with the same name");
+      expect(commits).toEqual([]);
+    });
   });
 
   describe("DELETE /api/v1/skills/:name", () => {
@@ -1029,6 +1187,7 @@ spec:
       expect(body.skills).toEqual([
         {
           name: "demo-skill",
+          skillPath: "skills/demo-skill/SKILL.md",
           skillId: "demo-skill",
           description: "A demo skill.",
           category: "productivity",
@@ -1054,6 +1213,7 @@ spec:
       expect(res.json().skills).toEqual([
         {
           name: "demo-skill",
+          skillPath: "skills/demo-skill/SKILL.md",
           description: "A demo skill.",
           installed: false,
           updateAvailable: false,
@@ -1076,6 +1236,7 @@ spec:
       expect(res.json().skills).toEqual([
         {
           name: "demo-skill",
+          skillPath: "productivity/demo-skill/SKILL.md",
           description: "A demo skill.",
           category: "productivity",
           installed: false,
@@ -1223,6 +1384,7 @@ spec:
       expect(updates.json().skills).toEqual([
         {
           name: "demo-skill",
+          skillPath: "skills/demo-skill/SKILL.md",
           skillId: "demo-skill",
           description: "A demo skill.",
           category: "productivity",

--- a/apps/api/src/soul/skills/routes.ts
+++ b/apps/api/src/soul/skills/routes.ts
@@ -10,6 +10,7 @@ import {
   LlmNotConfiguredError,
   SchemaRegistry,
   type SkillDefinition,
+  unstorableArtifactPaths,
   validateSkill,
 } from "@tulipfarm/schema";
 import {
@@ -323,6 +324,7 @@ async function loadMarketplace(gitSync: GitSyncService, soulLoader: SoulLoader, 
         const status = installStatus(skill, lock, soulLoader, bundledSkills, disabledBundledSkills);
         return {
           name: skill.name,
+          skillPath: skill.skillPath,
           skillId: asString(meta?.skillId),
           description: skill.description ?? asString(meta?.description),
           category: skill.category ?? asString(meta?.category),
@@ -469,7 +471,7 @@ export function registerSkillRoutes(app: FastifyInstance, soulLoader: SoulLoader
       const scanId = randomUUID();
       pruneScans(Date.now());
       scans.set(scanId, { source, ref: clone.ref, skills: discovered, audited: new Set(), expires: Date.now() + SCAN_TTL_MS });
-      return { scanId, skills: discovered.map((skill) => ({ name: skill.name, description: skill.description, ...installStatus(skill, lock, soulLoader, bundledSkills, disabledBundledSkills) })) };
+      return { scanId, skills: discovered.map((skill) => ({ name: skill.name, skillPath: skill.skillPath, description: skill.description, ...installStatus(skill, lock, soulLoader, bundledSkills, disabledBundledSkills) })) };
     } catch (error) {
       return reply.code(400).send({ error: `scan failed: ${error instanceof Error ? error.message : String(error)}` });
     } finally {
@@ -520,10 +522,15 @@ export function registerSkillRoutes(app: FastifyInstance, soulLoader: SoulLoader
     if (missing.length > 0) return reply.code(400).send({ error: `not in scan: ${missing.join(", ")}` });
     const unaudited = unique.filter((name) => !entry.audited.has(name));
     if (unaudited.length > 0) return reply.code(409).send({ error: `audit required before install: ${unaudited.join(", ")}` });
+    // A Skill name is its soul directory, so two discovered Skills sharing one name cannot both be installed. Refuse rather than install whichever the scan listed first: the operator reviewed two packages and would be given one.
+    const ambiguous = unique.map((name) => entry.skills.filter((skill) => skill.name === name)).filter((matches) => matches.length > 1);
+    if (ambiguous.length > 0) return reply.code(400).send({ error: `this source defines more than one skill with the same name, so the selection is ambiguous: ${ambiguous.map((matches) => `${matches[0].name} (${matches.map((skill) => skill.skillPath).join(", ")})`).join("; ")}` });
     for (const skill of chosen as DiscoveredSkill[]) {
       const { frontmatter, body } = parseFrontmatter(skill.content);
       const validation = validateSkill({ name: skill.name, frontmatter, body, content: skill.content });
       if (!validation.valid) return reply.code(400).send({ error: `invalid Skill "${skill.name}": ${validation.error}` });
+      const unstorable = unstorableArtifactPaths("Skill", skill.name, skill.files.filter((file) => file.symlinkTarget === undefined).map((file) => file.path));
+      if (unstorable.length > 0) return reply.code(400).send({ error: `Skill "${skill.name}" contains files the soul cannot store: ${unstorable.join(", ")}` });
       const blockers = scanSkill(skill.files).findings.filter((finding) => STRUCTURAL_INSTALL_BLOCKERS.has(finding.patternId));
       if (blockers.length > 0) {
         return reply.code(400).send({ error: `Skill "${skill.name}" contains unsupported package files: ${[...new Set(blockers.map((finding) => finding.patternId))].join(", ")}` });

--- a/apps/api/src/soul/skills/schemas.ts
+++ b/apps/api/src/soul/skills/schemas.ts
@@ -10,6 +10,7 @@ const SkillSummaryPropertiesSchema = {
 
 const MarketplaceSkillPropertiesSchema = {
   name: { type: "string" },
+  skillPath: { type: "string" },
   skillId: { type: "string" },
   description: { type: "string" },
   category: { type: "string" },
@@ -35,6 +36,8 @@ const SkillCommandPropertiesSchema = {
 
 const ScannedSkillPropertiesSchema = {
   name: { type: "string" },
+  /** Unique within one scan; `name` is not, so this is what a client keys a selection by. */
+  skillPath: { type: "string" },
   description: { type: "string" },
   installed: { type: "boolean" },
   updateAvailable: { type: "boolean" },

--- a/apps/eval/corpus/l3-a-committed-skill-package-is-visible-next-turn.json
+++ b/apps/eval/corpus/l3-a-committed-skill-package-is-visible-next-turn.json
@@ -1,0 +1,107 @@
+{
+  "id": "l3-a-committed-skill-package-is-visible-next-turn",
+  "tier": "l3",
+  "agent": "support",
+  "context": {
+    "governancePages": []
+  },
+  "input": [
+    {
+      "role": "user",
+      "content": "Add a skill called packing-notes that says how we pack bulbs, and keep the supplier licence beside it as LICENSE.txt. Call the soul_write tool now for each file, with kind \"Skill\" and slug \"packing-notes\". Do not ask me to confirm first."
+    }
+  ],
+  "tools": [
+    {
+      "name": "soul_write",
+      "description": "Commit a Soul artifact to the configuration repository. `kind` is a capitalised singular such as \"Skill\". `slug` is the artifact's directory name. `companion` names a file beside the definition, such as \"SKILL.md\", \"LICENSE.txt\" or \"references/notes.md\"; omit it to write the definition itself. `content` for a Skill's SKILL.md is YAML frontmatter with `name` and `description` keys, delimited by --- lines, followed by the skill's instructions in Markdown.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "type": "string"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "companion": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          }
+        },
+        "required": ["kind", "slug", "content"]
+      }
+    }
+  ],
+  "script": [
+    {
+      "kind": "tool_calls",
+      "calls": [
+        {
+          "callId": "c1",
+          "name": "soul_write",
+          "arguments": {
+            "kind": "Skill",
+            "slug": "packing-notes",
+            "companion": "SKILL.md",
+            "content": "---\nname: packing-notes\ndescription: How Tulip Supply Co packs bulbs for shipping.\n---\n\nPack bulbs in breathable paper, never in sealed plastic."
+          }
+        },
+        {
+          "callId": "c2",
+          "name": "soul_write",
+          "arguments": {
+            "kind": "Skill",
+            "slug": "packing-notes",
+            "companion": "LICENSE.txt",
+            "content": "Supplier packing guidance, reproduced with permission."
+          }
+        }
+      ]
+    },
+    {
+      "kind": "text",
+      "text": "I added the packing-notes skill and its licence."
+    }
+  ],
+  "journey": [
+    {
+      "input": [
+        {
+          "role": "user",
+          "content": "Which skills can you see now? Name every one."
+        }
+      ],
+      "script": [
+        {
+          "kind": "text",
+          "text": "Refund policy, ticket hygiene and packing-notes."
+        }
+      ]
+    }
+  ],
+  "expect": [
+    {
+      "kind": "soul_committed",
+      "path": "skills/packing-notes/SKILL.md"
+    },
+    {
+      "kind": "soul_committed",
+      "path": "skills/packing-notes/LICENSE.txt"
+    },
+    {
+      "kind": "prompt_contains",
+      "text": "packing-notes"
+    },
+    {
+      "kind": "run_status",
+      "status": "succeeded"
+    },
+    {
+      "kind": "output_contains",
+      "text": "packing-notes"
+    }
+  ]
+}

--- a/apps/eval/src/corpus.smoke.test.ts
+++ b/apps/eval/src/corpus.smoke.test.ts
@@ -31,7 +31,9 @@ describe("shipped corpus", () => {
     const bad = card.trials.filter((t) => !t.passed);
     expect(bad.map((t) => `${t.caseId}: ${t.error ?? JSON.stringify(t.expectations)}`)).toEqual([]);
     expect(card.errored).toBe(0);
-  });
+    // Each L3 Case drives a real Run against a real git-backed Soul, so the whole sweep outgrew
+    // the 5s default as soon as the Corpus did.
+  }, 60_000);
 
   it("has no vacuous Case, because one would pass without checking anything", async () => {
     const corpus = await loadCorpus(CORPUS_DIR, soul);

--- a/apps/eval/src/l3/soul-write.ts
+++ b/apps/eval/src/l3/soul-write.ts
@@ -51,6 +51,7 @@ interface WriteArguments {
   readonly kind?: unknown;
   readonly slug?: unknown;
   readonly content?: unknown;
+  readonly companion?: unknown;
   readonly definitionMode?: unknown;
   readonly subject?: unknown;
 }
@@ -58,9 +59,12 @@ interface WriteArguments {
 /**
  * The Tool the L3 tier exposes for Soul writes.
  *
- * Deliberately narrow: it puts one artifact's definition file. Reproducing the API's full Agent and
- * Skill Tool surface here would be a second implementation of the product's own Tools, and a Case
- * passing against it would prove nothing about the ones users reach.
+ * Deliberately narrow: it puts one artifact's definition file, or one companion file beside it.
+ * Reproducing the API's full Agent and Skill Tool surface here would be a second implementation of
+ * the product's own Tools, and a Case passing against it would prove nothing about the ones users
+ * reach. A companion is included because a Skill is a *package* — its prose, references and scripts
+ * are the artifact as much as its definition is, and a writer that can only address the definition
+ * cannot measure whether the rest of the package survives.
  */
 export function soulWriterTool(soul: EvalSoul): SoulWriterTool {
   const commits: SoulCommit[] = [];
@@ -95,6 +99,7 @@ export function soulWriterTool(soul: EvalSoul): SoulWriterTool {
         const kind = typeof args.kind === "string" ? args.kind : undefined;
         const slug = typeof args.slug === "string" ? args.slug : undefined;
         const content = typeof args.content === "string" ? args.content : undefined;
+        const companion = typeof args.companion === "string" ? args.companion : undefined;
         const definitionMode =
           args.definitionMode === "canonical" || args.definitionMode === "legacy"
             ? args.definitionMode
@@ -119,7 +124,10 @@ export function soulWriterTool(soul: EvalSoul): SoulWriterTool {
             changes: [
               {
                 op: "put",
-                target: { kind: kind as never, slug, definitionMode },
+                target:
+                  companion === undefined
+                    ? { kind: kind as never, slug, definitionMode }
+                    : { kind: kind as never, slug, companion },
                 content,
               },
             ],

--- a/apps/web/app/lib/skills.ts
+++ b/apps/web/app/lib/skills.ts
@@ -32,16 +32,32 @@ export type SkillDetail = SkillSummary & {
 // against the soul repo + skills-lock hash, so the UI can badge already-installed and stale skills.
 export type SkillInstallStatus = { installed: boolean; updateAvailable: boolean };
 
-export type ScannedSkill = { name: string; description?: string } & SkillInstallStatus;
+export type ScannedSkill = {
+  name: string;
+  skillPath?: string;
+  description?: string;
+} & SkillInstallStatus;
 export type ScanResult = { scanId: string; skills: ScannedSkill[] };
 
 export type MarketplaceSkill = {
   name: string;
+  skillPath?: string;
   skillId?: string;
   description?: string;
   category?: string;
   installs?: number;
 } & SkillInstallStatus;
+
+/**
+ * A stable identity for one scanned row.
+ *
+ * `name` is not unique within a source — one repo can define two different skills with the same
+ * directory name under different parents — so keying a React list or a selection by it merges two
+ * distinct rows into one.
+ */
+export function skillRowKey(skill: { name: string; skillPath?: string }): string {
+  return skill.skillPath ?? skill.name;
+}
 
 // The official curated catalog (SKL-V1-005). The scanId plugs into the same audit/install flow as a
 // manual git-URL scan, so the operator-confirm gate applies unchanged.

--- a/apps/web/app/routes/_app.skills.marketplace.tsx
+++ b/apps/web/app/routes/_app.skills.marketplace.tsx
@@ -14,6 +14,7 @@ import {
   type SkillAuditReport,
   type SkillInstallStatus,
   scanSkills,
+  skillRowKey,
 } from "~/lib/skills";
 
 export const meta: MetaFunction = () => [{ title: "Marketplace · tulipfarm" }];
@@ -180,10 +181,13 @@ export default function SkillsMarketplace() {
   const [reports, setReports] = useState<Record<string, SkillAuditReport>>({});
   const [busy, setBusy] = useState<null | "scan" | "audit" | "install">(null);
   const [error, setError] = useState<string | null>(null);
+  const [installError, setInstallError] = useState<string | null>(null);
   const [installed, setInstalled] = useState<string[] | null>(null);
 
-  const selectedNames = [...selected];
-  const allAudited = selectedNames.length > 0 && selectedNames.every((n) => reports[n]);
+  // Selection is keyed by row, not by name: a source may define two skills with the same name.
+  const selectedSkills = (scan?.skills ?? []).filter((s) => selected.has(skillRowKey(s)));
+  const selectedNames = selectedSkills.map((s) => s.name);
+  const allAudited = selectedSkills.length > 0 && selectedSkills.every((s) => reports[s.name]);
   const catalogGroups = new Map<string, MarketplaceCatalog["skills"]>();
   for (const skill of catalog?.skills ?? []) {
     const category = skill.category ?? "other";
@@ -197,16 +201,18 @@ export default function SkillsMarketplace() {
   // unchanged). Used by the per-row Install/Update buttons and the "Review all" button.
   function loadIntoPipeline(scanId: string, skills: ScannedSkill[]) {
     setError(null);
+    setInstallError(null);
     setReports({});
     setInstalled(null);
     setScan({ scanId, skills });
-    setSelected(new Set(skills.map((s) => s.name)));
+    setSelected(new Set(skills.map(skillRowKey)));
   }
 
   async function onScan() {
     if (!source.trim()) return;
     setBusy("scan");
     setError(null);
+    setInstallError(null);
     setReports({});
     setInstalled(null);
     // Clear any prior scan so stale results aren't shown/interactive during the new scan.
@@ -215,7 +221,7 @@ export default function SkillsMarketplace() {
     try {
       const result = await scanSkills(source.trim());
       setScan(result);
-      setSelected(new Set(result.skills.map((s) => s.name)));
+      setSelected(new Set(result.skills.map(skillRowKey)));
     } catch (e) {
       setScan(null);
       setError(errMessage(e));
@@ -224,11 +230,11 @@ export default function SkillsMarketplace() {
     }
   }
 
-  function toggle(name: string) {
+  function toggle(key: string) {
     setSelected((prev) => {
       const next = new Set(prev);
-      if (next.has(name)) next.delete(name);
-      else next.add(name);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
       return next;
     });
   }
@@ -237,6 +243,7 @@ export default function SkillsMarketplace() {
     if (!scan || selectedNames.length === 0) return;
     setBusy("audit");
     setError(null);
+    setInstallError(null);
     // Audit each selected skill independently so one failure does not discard the others' reports.
     const settled = await Promise.allSettled(
       selectedNames.map((name) => auditSkill(scan.scanId, name))
@@ -256,11 +263,14 @@ export default function SkillsMarketplace() {
     if (!scan || !allAudited) return;
     setBusy("install");
     setError(null);
+    setInstallError(null);
     try {
       const res = await installSkills(scan.scanId, selectedNames);
       setInstalled(res.installed);
     } catch (e) {
-      setError(errMessage(e));
+      // Kept beside the confirm button as well as in the page banner: the banner sits above a long
+      // scrolled report list, so on its own the failure reads as nothing having happened.
+      setInstallError(errMessage(e));
     } finally {
       setBusy(null);
     }
@@ -325,7 +335,7 @@ export default function SkillsMarketplace() {
                     </h2>
                     <ul className="flex flex-col divide-y divide-border rounded-sm border border-border">
                       {skills.map((s) => (
-                        <li key={s.name} className="flex items-center gap-3 px-3 py-2">
+                        <li key={skillRowKey(s)} className="flex items-center gap-3 px-3 py-2">
                           <span className="font-medium text-foreground">{s.name}</span>
                           {s.description ? (
                             <span className="min-w-0 flex-1 truncate text-muted-foreground">
@@ -408,6 +418,7 @@ export default function SkillsMarketplace() {
                     setScan(null);
                     setSelected(new Set());
                     setReports({});
+                    setInstallError(null);
                   }}
                 >
                   ← Back
@@ -415,13 +426,13 @@ export default function SkillsMarketplace() {
               </div>
               <ul className="flex max-h-96 flex-col divide-y divide-border overflow-y-auto rounded-sm border border-border">
                 {scan.skills.map((s) => (
-                  <li key={s.name}>
+                  <li key={skillRowKey(s)}>
                     <label className="flex cursor-pointer items-baseline gap-2 px-3 py-2 hover:bg-accent">
                       <input
                         type="checkbox"
                         className="accent-primary"
-                        checked={selected.has(s.name)}
-                        onChange={() => toggle(s.name)}
+                        checked={selected.has(skillRowKey(s))}
+                        onChange={() => toggle(skillRowKey(s))}
                         disabled={busy !== null}
                       />
                       <span className="font-medium text-foreground">{s.name}</span>
@@ -461,8 +472,8 @@ export default function SkillsMarketplace() {
           {/* Step 3 — advisory reports + explicit operator confirm. */}
           {allAudited ? (
             <div className="flex flex-col gap-3 border-t border-border pt-4">
-              {selectedNames.map((name) => (
-                <AuditReportCard key={name} name={name} report={reports[name]} />
+              {selectedSkills.map((s) => (
+                <AuditReportCard key={skillRowKey(s)} name={s.name} report={reports[s.name]} />
               ))}
               <p className="rounded-sm border border-border bg-muted px-3 py-2 text-xs text-muted-foreground">
                 SkillAudit is <span className="text-foreground">advisory, not a guarantee</span>. A
@@ -471,6 +482,14 @@ export default function SkillsMarketplace() {
                 with full tool access (no per-skill ACL in V1). Confirming installs these skills
                 into your soul repo.
               </p>
+              {installError ? (
+                <p
+                  role="alert"
+                  className="rounded-sm border border-destructive bg-destructive/10 px-3 py-2 text-destructive"
+                >
+                  install failed: {installError}
+                </p>
+              ) : null}
               <Button
                 size="sm"
                 className="self-start"

--- a/apps/web/app/routes/skills.marketplace.test.tsx
+++ b/apps/web/app/routes/skills.marketplace.test.tsx
@@ -9,6 +9,7 @@ vi.mock("~/lib/skills", () => ({
   auditSkill: vi.fn(),
   installSkills: vi.fn(),
   marketplaceSkills: vi.fn(),
+  skillRowKey: (skill: { name: string; skillPath?: string }) => skill.skillPath ?? skill.name,
 }));
 
 import { auditSkill, installSkills, type MarketplaceCatalog, scanSkills } from "~/lib/skills";
@@ -196,4 +197,80 @@ test("a scan failure surfaces an error banner", async () => {
   await user.click(screen.getByRole("button", { name: /^Scan$/ }));
 
   expect(await screen.findByText(/scan failed: no SKILL\.md files found/i)).toBeInTheDocument();
+});
+
+// A source may define two different skills under the same directory name. Keying rows by name
+// merged them into one selection, so the operator saw a checkbox they could not clear and the
+// install request carried a different set of names from the one on screen.
+test("two scanned skills sharing a name stay separately selectable", async () => {
+  const user = userEvent.setup();
+  vi.mocked(scanSkills).mockResolvedValue({
+    scanId: "s2",
+    skills: [
+      {
+        name: "review-contract",
+        skillPath: "legal/review-contract/SKILL.md",
+        description: "Legal review.",
+        installed: false,
+        updateAvailable: false,
+      },
+      {
+        name: "review-contract",
+        skillPath: "sales/review-contract/SKILL.md",
+        description: "Sales review.",
+        installed: false,
+        updateAvailable: false,
+      },
+    ],
+  });
+
+  renderInstall();
+  await user.type(await screen.findByLabelText(/git url/i), "owner/repo");
+  await user.click(screen.getByRole("button", { name: /^Scan$/ }));
+
+  const boxes = await screen.findAllByRole("checkbox");
+  expect(boxes).toHaveLength(2);
+  expect(screen.getByRole("button", { name: /Run SkillAudit \(2\)/ })).toBeInTheDocument();
+
+  await user.click(boxes[0]);
+
+  expect(boxes[0]).not.toBeChecked();
+  expect(boxes[1]).toBeChecked();
+  expect(screen.getByRole("button", { name: /Run SkillAudit \(1\)/ })).toBeInTheDocument();
+});
+
+test("an install failure is reported beside the confirm button, not only in the page banner", async () => {
+  const user = userEvent.setup();
+  vi.mocked(scanSkills).mockResolvedValue({
+    scanId: "s3",
+    skills: [
+      {
+        name: "demo-skill",
+        skillPath: "skills/demo-skill/SKILL.md",
+        description: "A demo.",
+        installed: false,
+        updateAvailable: false,
+      },
+    ],
+  });
+  vi.mocked(auditSkill).mockResolvedValue({
+    riskRating: "low",
+    summary: "Benign.",
+    toolsReach: [],
+    findings: [],
+    deterministicScan: { verdict: "safe", trustLevel: "trusted", findings: [] },
+  });
+  vi.mocked(installSkills).mockRejectedValue(new Error("invalid soul write target"));
+
+  renderInstall();
+  await user.type(await screen.findByLabelText(/git url/i), "owner/repo");
+  await user.click(screen.getByRole("button", { name: /^Scan$/ }));
+  await user.click(await screen.findByRole("button", { name: /Run SkillAudit/ }));
+  await user.click(await screen.findByRole("button", { name: /confirm install/i }));
+
+  const alert = await screen.findByRole("alert");
+  expect(alert).toHaveTextContent(/install failed: invalid soul write target/i);
+  // The confirm button is still there to retry, and nothing claims a successful install.
+  expect(screen.getByRole("button", { name: /confirm install/i })).toBeInTheDocument();
+  expect(screen.queryByText(/^Installed /)).not.toBeInTheDocument();
 });

--- a/packages/schema/src/artifacts.test.ts
+++ b/packages/schema/src/artifacts.test.ts
@@ -11,6 +11,7 @@ import {
   isLiveKind,
   isPinnedKind,
   temporalClassOf,
+  unstorableArtifactPaths,
   withinArtifactTree,
 } from "./artifacts";
 import { DEFINITION_KINDS } from "./definitions";
@@ -219,6 +220,57 @@ describe("path builders", () => {
     expect(() => definitionPath("Agent", "Not A Slug")).toThrow();
     expect(() => artifactDirectory("Agent", "../escape")).toThrow();
     expect(() => definitionPath("Settings", "slug")).not.toThrow();
+  });
+
+  // A Skill ships as a package, so every shape it ships has to be addressable — otherwise the
+  // installer cannot name the files it must write and the whole install is rejected.
+  it("addresses every file shape a Skill package ships", () => {
+    for (const companion of [
+      "SKILL.md",
+      "references/checklist.md",
+      "scripts/convert.py",
+      "assets/logo.png",
+      "schemas/output.json",
+      "LICENSE.txt",
+      "requirements.txt",
+      "README.md",
+    ]) {
+      expect(companionPath("Skill", "triage", companion), companion).toBe(
+        `skills/triage/${companion}`
+      );
+    }
+  });
+
+  // An installer has to know which files it cannot write before it writes any of them: the gateway
+  // rejects the whole changeset on the first unaddressable path, so a per-file answer is the only
+  // way the operator can be told which file is the problem.
+  it("reports which of a package's own files the layout cannot address", () => {
+    expect(
+      unstorableArtifactPaths("Skill", "triage", [
+        "SKILL.md",
+        "references/checklist.md",
+        "LICENSE.txt",
+        "notes.rst",
+        "src/index.ts",
+      ])
+    ).toEqual(["notes.rst", "src/index.ts"]);
+  });
+
+  it("treats every path as unstorable when the slug or kind cannot hold one", () => {
+    expect(unstorableArtifactPaths("Skill", "../escape", ["SKILL.md"])).toEqual(["SKILL.md"]);
+    expect(unstorableArtifactPaths("Settings", "any", ["notes.md"])).toEqual(["notes.md"]);
+  });
+
+  it("keeps refusing a Skill companion that leaves the Skill's own directory", () => {
+    for (const companion of [
+      "../escape.md",
+      "references/../../escape.md",
+      "/etc/passwd",
+      "..\\escape.txt",
+      "./LICENSE.txt",
+    ]) {
+      expect(() => companionPath("Skill", "triage", companion), companion).toThrow();
+    }
   });
 
   it("exposes layouts by kind", () => {

--- a/packages/schema/src/artifacts.ts
+++ b/packages/schema/src/artifacts.ts
@@ -130,6 +130,11 @@ const ARTIFACT_LAYOUT_ENTRIES = [
       { match: "references/", modes: ["prose"] },
       { match: "schemas/", modes: ["prose"] },
       { match: "scripts/", modes: ["executable"] },
+      // Real Skill packages ship provenance and dependency notes beside `SKILL.md` (`LICENSE.txt`,
+      // `requirements.txt`, `README.md`). Without these the package is only partly addressable, and
+      // a writer that must name every file it installs cannot install it at all.
+      { match: "*.md", modes: ["prose"] },
+      { match: "*.txt", modes: ["prose"] },
     ],
   },
   {
@@ -413,6 +418,26 @@ export function classifySoulPath(path: string): ClassifiedSoulPath | null {
     }
   }
   return null;
+}
+
+/**
+ * Which of an artifact package's own files the layout cannot address.
+ *
+ * A caller installing a package has to know this before it writes: the write gateway rejects the
+ * whole changeset on the first unaddressable path, and the layout registry — not the caller — is
+ * what decides which shapes may live beside a definition. `relativePaths` are POSIX paths relative
+ * to the artifact's own directory.
+ */
+export function unstorableArtifactPaths(
+  kind: ArtifactKind,
+  slug: string,
+  relativePaths: readonly string[]
+): string[] {
+  const layout = BY_KIND.get(kind);
+  if (!layout || layout.scope === "singleton" || !isArtifactSlug(slug)) return [...relativePaths];
+  return relativePaths.filter(
+    (relative) => classifySoulPath(`${layout.directory}/${slug}/${relative}`) === null
+  );
 }
 
 /** Build the canonical definition path for an artifact. */

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -30,6 +30,7 @@ export {
   legacyDefinitionPaths,
   TEMPORAL_CLASSES,
   temporalClassOf,
+  unstorableArtifactPaths,
   withinArtifactTree,
 } from "./artifacts";
 export type { ValidationBoundary } from "./boundaries";
@@ -182,6 +183,7 @@ export type {
   SkillValidationResult,
 } from "./skill-frontmatter";
 export {
+  SKILL_RUNTIME_FRONTMATTER_KEYS,
   SkillFrontmatterSchema,
   serializeSkill,
   validateSkill,

--- a/packages/schema/src/skill-frontmatter.test.ts
+++ b/packages/schema/src/skill-frontmatter.test.ts
@@ -84,6 +84,34 @@ describe("validateSkill", () => {
     });
   });
 
+  // The server writes `_pendingAudit` itself, so re-reading a stored SKILL.md as author input
+  // rejected the exact file the write gateway had just been handed.
+  it("accepts the runtime's own _pendingAudit when the frontmatter came from the Soul", () => {
+    const frontmatter = { ...VALID_FRONTMATTER, _pendingAudit: true };
+    expect(
+      validateSkill({
+        name: "code-review",
+        frontmatter,
+        body: "Follow the review procedure.",
+        content: serializeSkill(frontmatter, "Follow the review procedure."),
+        origin: "stored",
+      })
+    ).toMatchObject({ valid: true });
+  });
+
+  it("still rejects other reserved keys in stored frontmatter", () => {
+    const frontmatter = { ...VALID_FRONTMATTER, _grants: ["tool"] };
+    expect(
+      validateSkill({
+        name: "code-review",
+        frontmatter,
+        body: "Follow the review procedure.",
+        content: serializeSkill(frontmatter, "Follow the review procedure."),
+        origin: "stored",
+      })
+    ).toMatchObject({ valid: false });
+  });
+
   it.each(SKILL_FORBIDDEN_GRANT_KEYS)("rejects grant-shaped key %s", (key) => {
     expect(validate({ ...VALID_FRONTMATTER, [key]: ["tool"] })).toMatchObject({
       valid: false,

--- a/packages/schema/src/skill-frontmatter.ts
+++ b/packages/schema/src/skill-frontmatter.ts
@@ -46,6 +46,15 @@ export interface SkillValidationInput {
   body: string;
   /** Exact raw or would-be-written SKILL.md content used for the character limit. */
   content: string;
+  /**
+   * Where the frontmatter came from.
+   *
+   * `authored` — the default — is the strict form every author-facing surface uses, and is what
+   * stops an Agent granting itself a runtime-owned field. `stored` validates a SKILL.md the server
+   * itself wrote, where {@link SKILL_RUNTIME_FRONTMATTER_KEYS} are expected: re-checking those as
+   * author input rejects the very file the write gateway just accepted.
+   */
+  origin?: "authored" | "stored";
 }
 
 export type SkillValidationResult =
@@ -54,6 +63,15 @@ export type SkillValidationResult =
 
 const checkFrontmatter = ajv.compile(SkillFrontmatterSchema);
 const forbiddenGrantKeys = new Set<string>(SKILL_FORBIDDEN_GRANT_KEYS);
+
+/** Top-level frontmatter keys the runtime writes for itself; an author may never set them. */
+export const SKILL_RUNTIME_FRONTMATTER_KEYS = ["_pendingAudit"] as const;
+
+function withoutRuntimeFields(frontmatter: SkillFrontmatter): Record<string, unknown> {
+  const authored: Record<string, unknown> = { ...frontmatter };
+  for (const key of SKILL_RUNTIME_FRONTMATTER_KEYS) delete authored[key];
+  return authored;
+}
 
 function firstSchemaError(): string {
   const error = checkFrontmatter.errors?.[0];
@@ -106,7 +124,9 @@ export function validateSkill(input: SkillValidationInput): SkillValidationResul
     };
   }
 
-  const keyError = reservedKeyError(frontmatter);
+  const keyError = reservedKeyError(
+    input.origin === "stored" ? withoutRuntimeFields(frontmatter) : frontmatter
+  );
   if (keyError) return { valid: false, error: keyError };
 
   if (input.body.trim().length === 0) {

--- a/packages/soul/src/parse.test.ts
+++ b/packages/soul/src/parse.test.ts
@@ -187,4 +187,34 @@ describe("parseSoulFile still enforces content", () => {
     const result = parseSoulFile({ operation: "delete", path: "../escape.yaml" });
     expect(result.issue?.code).toBe("UNSUPPORTED_SOUL_PATH");
   });
+
+  // The server writes `_pendingAudit` itself so a newly created Skill lands committed but inactive.
+  // Re-checking stored frontmatter as if an author had written it rejected the very file the write
+  // gateway was being asked to commit, which made every Agent-authored Skill uncommittable.
+  it("admits a stored SKILL.md carrying the runtime's own pending-audit marker", () => {
+    const content = `---\n${stringify({ name: "triage", description: "d", _pendingAudit: true })}---\nbody`;
+    const result = parseSoulFile(upsert("skills/triage/SKILL.md", content));
+
+    expect(result.issue).toBeUndefined();
+    expect(result.parsed?.mode).toBe("legacy");
+  });
+
+  it("still refuses other reserved frontmatter keys in a stored SKILL.md", () => {
+    const content = `---\n${stringify({ name: "triage", description: "d", _grants: ["admin"] })}---\nbody`;
+    const result = parseSoulFile(upsert("skills/triage/SKILL.md", content));
+
+    expect(result.issue?.code).toBe("SCHEMA_VALIDATION_FAILED");
+  });
+
+  it("admits the companion files a real Skill package ships beside SKILL.md", () => {
+    for (const path of [
+      "skills/triage/references/playbook.md",
+      "skills/triage/scripts/convert.py",
+      "skills/triage/LICENSE.txt",
+      "skills/triage/requirements.txt",
+      "skills/triage/README.md",
+    ]) {
+      expect(parseSoulFile(upsert(path, "content\n")).issue, path).toBeUndefined();
+    }
+  });
 });

--- a/packages/soul/src/parse.ts
+++ b/packages/soul/src/parse.ts
@@ -113,7 +113,13 @@ function parseLegacy(content: string, location: ClassifiedSoulPath, path: string
         // No frontmatter means this is the prose body a canonical `skill.yaml` points at, not a
         // legacy definition. Only the definition form carries configuration worth validating.
         if (Object.keys(frontmatter).length === 0) return admitted(content, location, "prose");
-        const result = validateSkill({ name: location.slug ?? "", frontmatter, body, content });
+        const result = validateSkill({
+          name: location.slug ?? "",
+          frontmatter,
+          body,
+          content,
+          origin: "stored",
+        });
         return result.valid
           ? admitted(content, location, "legacy")
           : rejected("SCHEMA_VALIDATION_FAILED", path);

--- a/packages/soul/src/writer.test.ts
+++ b/packages/soul/src/writer.test.ts
@@ -481,6 +481,59 @@ describe("SoulWriter — regressions", () => {
     ).rejects.toMatchObject({ code: "INVALID_TARGET" });
   });
 
+  // A real Skill is a package: reference material in subdirectories and provenance files beside
+  // SKILL.md. Every one of them has to be addressable through the gateway, or installing such a
+  // Skill fails as a whole and the only way to land it is the raw-filesystem bypass.
+  it("addresses a Skill's whole package — subdirectory and root companions alike", async () => {
+    const result = await apply([
+      { op: "put", target: { kind: "Skill", slug: "packing" }, content: skillDoc("packing") },
+      {
+        op: "put",
+        target: { kind: "Skill", slug: "packing", companion: "references/bulbs.md" },
+        content: "# Bulb handling\n",
+      },
+      {
+        op: "put",
+        target: { kind: "Skill", slug: "packing", companion: "scripts/pack.py" },
+        content: "print('pack')\n",
+      },
+      {
+        op: "put",
+        target: { kind: "Skill", slug: "packing", companion: "LICENSE.txt" },
+        content: "MIT\n",
+      },
+      {
+        op: "put",
+        target: { kind: "Skill", slug: "packing", companion: "requirements.txt" },
+        content: "pandas\n",
+      },
+    ]);
+
+    expect(result.paths).toEqual([
+      "skills/packing/skill.yaml",
+      "skills/packing/references/bulbs.md",
+      "skills/packing/scripts/pack.py",
+      "skills/packing/LICENSE.txt",
+      "skills/packing/requirements.txt",
+    ]);
+    expect(existsSync(join(soulPath, "skills/packing/references/bulbs.md"))).toBe(true);
+  });
+
+  it("still refuses a companion that escapes the artifact's own directory", async () => {
+    for (const companion of [
+      "../escape/notes.md",
+      "references/../../escape.md",
+      "/etc/passwd",
+      "..\\escape.md",
+    ]) {
+      await expect(
+        apply([
+          { op: "put", target: { kind: "Skill", slug: "packing", companion }, content: "x\n" },
+        ])
+      ).rejects.toMatchObject({ code: "INVALID_TARGET" });
+    }
+  });
+
   it("does not destroy unrelated uncommitted work when materializing a committed changeset", async () => {
     await apply([put("first")]);
     writeFileSync(join(soulPath, "tracked-notes.md"), "committed baseline\n");

--- a/scripts/control-plane-size.test.ts
+++ b/scripts/control-plane-size.test.ts
@@ -159,9 +159,25 @@ import { describe, expect, it } from "vitest";
  * Line count is a crude proxy for ownership, deliberately. A precise measure would need to model
  * what each domain ought to own, which is the argument the refactor itself has to settle; a crude
  * measure that cannot be gamed without noticing is worth more here than a subtle one.
+ *
+ * It moves to 51,117 for the Skill-package install fix, and the +10 is itemised because it is small
+ * enough to be worth showing what stayed:
+ *
+ *   +3  `skillPath` on the scanned and marketplace response shapes, and its OpenAPI property. A
+ *       Skill name is unique only within one directory, so a client had no stable key for a row and
+ *       two same-named Skills collapsed into one selection.
+ *   +6  two `reply.code(400)` guards on install — one naming the package files the Soul cannot
+ *       store, one refusing a same-name selection the scan cannot disambiguate. Both exist so the
+ *       operator is told which file or which package failed instead of receiving the write
+ *       gateway's `invalid soul write target`.
+ *   +1  one import.
+ *
+ * The decision behind the first guard — which files a layout can address — did not stay: it is
+ * `unstorableArtifactPaths` in `packages/schema/src/artifacts.ts`, beside the registry that owns
+ * the answer. Only the HTTP reply for it is here.
  */
 
-const CEILING = 51_107;
+const CEILING = 51_117;
 
 /**
  * Domains inside `apps/api/src` that already have a package of the same name. Everything here that


### PR DESCRIPTION
A Skill ships as a package, but three separate defects made anything richer than a lone SKILL.md unreachable:

- The artifact layout registry had no entry for the root-level `LICENSE.txt`, `requirements.txt` or `README.md` that real Skill packages ship, so the write gateway refused the whole changeset with an opaque `invalid soul write target`.
- `parseSoulFile` re-validated a stored SKILL.md as if an author had written it, so the `_pendingAudit` marker the server itself writes made every Agent-authored Skill uncommittable through `skill_create`.
- The marketplace keyed rows and the selection Set by Skill name, which is not unique within a source, so two same-named Skills merged into one selection and the install request carried a different name set from the screen.

The install route now names the offending file instead of letting the gateway raise a generic error, refuses an ambiguous same-name install rather than installing whichever the scan listed first, and the UI reports an install failure beside the confirm button instead of only in a banner the operator has scrolled past.

Which files a layout can address is decided by `unstorableArtifactPaths` in `packages/schema`, beside the registry that owns the answer; only the HTTP reply for it lives in `apps/api`. The remaining 10 lines of control-plane growth are route-shaped and are itemised against the raised ceiling.

## Summary

<!-- What changed, and why. Link the driving issue if one exists. -->

## Test plan

<!-- Commands you ran, or manual steps / screenshots for UI changes. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (or the scoped `--filter` you actually ran)

## Checklist

- [ ] PR title follows Conventional Commits (`type(scope): subject`) — CI checks this
- [ ] Scoped to one logical change
- [ ] Tests added/updated for the behavior that changed
