### PR TITLE
fix(authz): make the Owner access level confer admin rights

### DIFF
--- a/apps/api/src/admin/runtime.test.ts
+++ b/apps/api/src/admin/runtime.test.ts
@@ -156,16 +156,16 @@ describe("runtime operational API", () => {
     expect(await api.getRun(grant, "missing")).toBeNull();
 
     const roles = await api.getRoles(grant);
-    expect(roles.items.map((role) => role.id)).toEqual(["admin", "member"]);
+    expect(roles.items.map((role) => role.id)).toEqual(["owner", "admin", "member"]);
     expect(roles.revision).toMatch(/^[a-f0-9]{64}$/);
     // Per-action, not a blanket `deny any action on secret`. `GET /api/v1/secrets/status` is
     // guarded by `requireAuth` alone (only PUT and DELETE check `role !== "admin"`), so a member
-    // really can list secret metadata. The old blanket deny made this view claim otherwise — the
-    // exact way the Roles page "starts lying about who can do what" that `identity/roles.ts` warns
-    // about.
-    expect(roles.items[1]?.grants).toContain("allow secret.read on secret");
-    expect(roles.items[1]?.grants).toContain("deny secret.write on secret");
-    expect(roles.items[1]?.grants).toContain("deny secret.delete on secret");
+    // really can list secret metadata. Writing is simply absent from the allow-list rather than
+    // spelled as a deny, because a deny would also veto any Role granted on top of member.
+    const member = roles.items.find((role) => role.id === "member");
+    expect(member?.grants).toContain("allow secret.read on secret");
+    expect(member?.grants).not.toContain("allow secret.write on secret");
+    expect(member?.grants).not.toContain("allow secret.delete on secret");
   });
 
   it("reports an absent capability as not implemented rather than as a failure", async () => {

--- a/apps/api/src/auth/owner-access.pg.test.ts
+++ b/apps/api/src/auth/owner-access.pg.test.ts
@@ -1,0 +1,229 @@
+/**
+ * The `Owner` access level, end to end through the composition production runs: migrated rows,
+ * the boot role sync, and `LiveRouteAuthorizer` in enforcing mode.
+ *
+ * Granting `Owner` through the product left the grantee refused by People & access exactly as
+ * before, because the durable `owner` Role was never in the catalog the boot sync owns and so
+ * kept a seed whose resource types no route declares (#408).
+ */
+
+import type { PGlite } from "@electric-sql/pglite";
+import { DEPLOYMENT_BUSINESS_ID } from "@tulipfarm/constants";
+import { PgPrincipalRepo, PgRoleRepo } from "@tulipfarm/storage";
+import type { FastifyInstance } from "fastify";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildApp } from "../app";
+import { LiveRouteAuthorizer } from "../authz/route-gate";
+import { transactionPort } from "../db";
+import { buildApiAuthorityLayerResolver } from "../identity/authority-layers";
+import { syncDeploymentRoles } from "../identity/roles";
+import { makeMigratedPglite } from "../test/pglite";
+import type { TokenDoc, TokenRepo } from "./api-tokens";
+import { CSRF_COOKIE, CSRF_HEADER } from "./csrf";
+import type { UserInviteDoc, UserInviteRepo } from "./invites";
+import { MemorySessionStore } from "./session-store";
+import {
+  createUser,
+  EmailAlreadyExistsError,
+  type PasswordWriteRepo,
+  type UserAdminRepo,
+  type UserDoc,
+  type UserRepo,
+} from "./users";
+
+const PASSWORD = "correct-horse-battery";
+
+class FakeUserRepo implements UserRepo, UserAdminRepo, PasswordWriteRepo {
+  private readonly users: UserDoc[] = [];
+  async findByEmail(email: string): Promise<UserDoc | null> {
+    return this.users.find((u) => u.email === email.trim().toLowerCase()) ?? null;
+  }
+  async findById(id: string): Promise<UserDoc | null> {
+    return this.users.find((u) => u._id === id) ?? null;
+  }
+  async count(): Promise<number> {
+    return this.users.length;
+  }
+  async insert(user: UserDoc): Promise<void> {
+    if (this.users.some((u) => u.email === user.email)) throw new EmailAlreadyExistsError();
+    this.users.push(user);
+  }
+  async listAll(): Promise<UserDoc[]> {
+    return [...this.users];
+  }
+  async setStatus(id: string, status: UserDoc["status"]): Promise<void> {
+    const user = this.users.find((u) => u._id === id);
+    if (user) user.status = status;
+  }
+  async setPassword(id: string, passwordHash: string): Promise<void> {
+    const user = this.users.find((u) => u._id === id);
+    if (user) user.passwordHash = passwordHash;
+  }
+}
+
+class FakeInviteRepo implements UserInviteRepo {
+  private readonly invites: UserInviteDoc[] = [];
+  async create(invite: UserInviteDoc): Promise<void> {
+    this.invites.push(invite);
+  }
+  async deleteUnconsumedForUser(): Promise<void> {}
+  async find(): Promise<UserInviteDoc | null> {
+    return null;
+  }
+  async consume(): Promise<UserInviteDoc | null> {
+    return null;
+  }
+}
+
+class FakeTokenRepo implements TokenRepo {
+  async create(): Promise<void> {}
+  async findByHash(): Promise<TokenDoc | null> {
+    return null;
+  }
+  async findByUserId(): Promise<TokenDoc[]> {
+    return [];
+  }
+  async findAll(): Promise<TokenDoc[]> {
+    return [];
+  }
+  async findById(): Promise<TokenDoc | null> {
+    return null;
+  }
+  async deleteById(): Promise<void> {}
+  async findAllPaginated() {
+    return { items: [], nextCursor: null };
+  }
+  async findByUserIdPaginated() {
+    return { items: [], nextCursor: null };
+  }
+}
+
+describe("the Owner access level under the live route gate", () => {
+  let db: PGlite;
+  let app: FastifyInstance;
+  let repo: FakeUserRepo;
+  let ownerId: string;
+  let memberId: string;
+
+  /** Registers a durable principal for a user the way the users-table trigger does. */
+  async function registerPrincipal(id: string, roleId: "member" | "owner"): Promise<void> {
+    const transactions = transactionPort(db);
+    await new PgPrincipalRepo(transactions).put({
+      businessId: DEPLOYMENT_BUSINESS_ID,
+      id,
+      kind: "user",
+      status: "active",
+    });
+    await new PgRoleRepo(transactions).assign({
+      businessId: DEPLOYMENT_BUSINESS_ID,
+      principalId: id,
+      roleId,
+    });
+  }
+
+  async function login(email: string): Promise<{ sid: string; csrf: string }> {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/auth/login",
+      payload: { email, password: PASSWORD },
+    });
+    expect(res.statusCode).toBe(200);
+    const sid = res.cookies.find((c) => c.name === "tf_sid")?.value;
+    const csrf = res.cookies.find((c) => c.name === CSRF_COOKIE)?.value;
+    if (!sid || !csrf) throw new Error("login issued no session cookie");
+    return { sid, csrf };
+  }
+
+  beforeEach(async () => {
+    db = await makeMigratedPglite();
+    await syncDeploymentRoles(new PgRoleRepo(transactionPort(db)));
+
+    repo = new FakeUserRepo();
+    // Both accounts are invited members — the default "Everyday access". Only one is then given
+    // the Owner level, which is the whole difference the report turns on.
+    const owner = await createUser(repo, "owner@example.com", PASSWORD, "member");
+    const member = await createUser(repo, "member@example.com", PASSWORD, "member");
+    ownerId = owner._id;
+    memberId = member._id;
+    await registerPrincipal(ownerId, "member");
+    await registerPrincipal(memberId, "member");
+    await registerPrincipal(ownerId, "owner");
+
+    app = await buildApp({
+      sessionStore: new MemorySessionStore(),
+      userRepo: repo,
+      tokenRepo: new FakeTokenRepo(),
+      userAdminRepo: repo,
+      userInviteRepo: new FakeInviteRepo(),
+      routeAuthorizer: new LiveRouteAuthorizer(buildApiAuthorityLayerResolver(db)),
+      authorizationGate: { mode: "enforcing" },
+    });
+  });
+
+  afterEach(async () => {
+    await app.close();
+    await db.close();
+  });
+
+  it("lets a granted Owner read People & access", async () => {
+    const { sid } = await login("owner@example.com");
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/users",
+      cookies: { tf_sid: sid },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().items).toHaveLength(2);
+  });
+
+  it("still refuses People & access to everyday access", async () => {
+    const { sid } = await login("member@example.com");
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/users",
+      cookies: { tf_sid: sid },
+    });
+
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("lets a granted Owner change access, not only read it", async () => {
+    const { sid, csrf } = await login("owner@example.com");
+
+    const res = await app.inject({
+      method: "PATCH",
+      url: `/api/v1/users/${memberId}/status`,
+      cookies: { tf_sid: sid, [CSRF_COOKIE]: csrf },
+      headers: { [CSRF_HEADER]: csrf },
+      payload: { status: "disabled" },
+    });
+
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("still refuses everyday access the write half of People & access", async () => {
+    const { sid, csrf } = await login("member@example.com");
+
+    const res = await app.inject({
+      method: "PATCH",
+      url: `/api/v1/users/${ownerId}/status`,
+      cookies: { tf_sid: sid, [CSRF_COOKIE]: csrf },
+      headers: { [CSRF_HEADER]: csrf },
+      payload: { status: "disabled" },
+    });
+
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("does not widen the Owner grant to every principal", async () => {
+    expect(memberId).not.toBe(ownerId);
+    const roles = new PgRoleRepo(transactionPort(db));
+
+    const assignees = await roles.listAssignees(DEPLOYMENT_BUSINESS_ID, "owner", new Date());
+
+    expect(assignees.map((a) => a.principalId)).toEqual([ownerId]);
+  });
+});

--- a/apps/api/src/authz/deployment-role-gate.pg.test.ts
+++ b/apps/api/src/authz/deployment-role-gate.pg.test.ts
@@ -49,6 +49,12 @@ const SECRET_WRITE = {
   fallback: "admin",
 } as const;
 
+/** What People & access requires of its caller. */
+const USER_MANAGE = {
+  action: "user.manage",
+  resourceType: "user",
+  fallback: "admin",
+} as const;
 async function memberGrantCount(db: PGlite): Promise<number> {
   const result = await db.query<{ count: string }>(
     "SELECT count(*)::text AS count FROM role_grants WHERE business_id = $1 AND role_id = 'member'",
@@ -143,5 +149,31 @@ describe("deployment roles under the live route gate", () => {
     }
 
     expect(denied).toEqual([]);
+  });
+
+  /**
+   * The `Owner` level is the only promotion the product offers, and its own copy calls it "can do
+   * anything, including managing access" — so it has to survive the boot sync as authority, not as
+   * the placeholder grants the migration seeded against resource types no route declares (#408).
+   */
+  it("grants a member promoted to Owner the admin-only surfaces", async () => {
+    await new PgRoleRepo(transactionPort(db)).assign({
+      businessId: DEPLOYMENT_BUSINESS_ID,
+      principalId: MEMBER_ID,
+      roleId: "owner",
+    });
+    await syncDeploymentRoles(new PgRoleRepo(transactionPort(db)));
+    const decide = check();
+
+    expect(await decide(member, USER_MANAGE)).toBe(true);
+    expect(await decide(member, SECRET_WRITE)).toBe(true);
+  });
+
+  it("keeps admin-only surfaces refused to everyday access", async () => {
+    await syncDeploymentRoles(new PgRoleRepo(transactionPort(db)));
+    const decide = check();
+
+    expect(await decide(member, USER_MANAGE)).toBe(false);
+    expect(await decide(admin, USER_MANAGE)).toBe(true);
   });
 });

--- a/apps/api/src/identity/roles.test.ts
+++ b/apps/api/src/identity/roles.test.ts
@@ -1,6 +1,11 @@
 import { decideEffectivePermission } from "@tulipfarm/authz";
 import { describe, expect, it } from "vitest";
-import { DEPLOYMENT_ROLES, describeDeploymentRoles } from "./roles";
+import {
+  ADMIN_ONLY_SURFACES,
+  DEPLOYMENT_ROLES,
+  describeDeploymentRoles,
+  MEMBER_UNDOMAINED_RECORD_ACTIONS,
+} from "./roles";
 
 function member() {
   const role = describeDeploymentRoles().find((r) => r.id === "member");
@@ -17,22 +22,54 @@ describe("describeDeploymentRoles", () => {
     ]);
   });
 
-  it("keeps each admin-only surface denied to a member", () => {
+  /**
+   * Asserted as decisions rather than as deny labels: a member is refused an admin-only action by
+   * default deny, and spelling that out as an explicit deny instead is what made every granted
+   * Role — `Owner` included — inert on top of the member baseline (#408).
+   */
+  it("refuses a member every action the admin-only catalog names", () => {
+    const memberRole = DEPLOYMENT_ROLES.find((role) => role.id === "member");
+    if (!memberRole) throw new Error("member role missing from the deployment catalog");
+    const layers = [{ name: "member", grants: memberRole.grants }];
+
+    const allowed = ADMIN_ONLY_SURFACES.flatMap((surface) =>
+      (surface.actions.includes("*")
+        ? [`${surface.type}.probe`, ...MEMBER_UNDOMAINED_RECORD_ACTIONS]
+        : surface.actions
+      )
+        .filter(
+          (action) =>
+            decideEffectivePermission(layers, { action, resourceType: surface.type }).allowed
+        )
+        .map((action) => `${surface.type}: ${action}`)
+    );
+
+    expect(allowed).toEqual([]);
+  });
+
+  /** The residual `resourceType: "*"` allow must not reach a Resource type named after one. */
+  it("keeps the member record wildcard off admin-only resource types", () => {
     const grants = member().grants;
-    expect(grants).toContain("deny secret.write on secret");
-    expect(grants).toContain("deny secret.delete on secret");
-    expect(grants).toContain("deny identity.api_client.create on identity");
-    expect(grants).toContain("deny any action on user");
-    expect(grants).toContain("deny any action on observability");
-    expect(grants).toContain("deny llm_config.resolve on llm_config");
-    expect(grants).toContain("deny llm_config.write on llm_config");
-    expect(grants).toContain("deny any action on knowledge_source");
-    expect(grants).toContain("deny any action on kv_system");
-    expect(grants).toContain("deny any action on setup");
-    expect(grants).toContain("deny any action on operations");
-    expect(grants).toContain("deny any action on audit");
-    expect(grants).toContain("deny any action on soul.business_profile");
-    expect(grants).toContain("deny any action on soul.publication");
+    expect(grants).toContain("deny record.read on user");
+    expect(grants).toContain("deny record.delete on secret");
+  });
+
+  it("lets a Role granted on top of the member baseline actually take effect", () => {
+    const memberRole = DEPLOYMENT_ROLES.find((role) => role.id === "member");
+    const ownerRole = DEPLOYMENT_ROLES.find((role) => role.id === "owner");
+    if (!memberRole || !ownerRole) throw new Error("built-in role missing from the catalog");
+
+    const promoted = decideEffectivePermission(
+      [{ name: "user", grants: [...memberRole.grants, ...ownerRole.grants] }],
+      { action: "user.manage", resourceType: "user" }
+    );
+    const everyday = decideEffectivePermission([{ name: "user", grants: memberRole.grants }], {
+      action: "user.manage",
+      resourceType: "user",
+    });
+
+    expect(promoted.allowed).toBe(true);
+    expect(everyday.allowed).toBe(false);
   });
 
   it("allows only the member surfaces that are actually available today", () => {
@@ -47,7 +84,13 @@ describe("describeDeploymentRoles", () => {
 
   /* Reading the LLM config names every provider, model and api_key_ref, so it is operator-only. */
   it("denies a member the LLM configuration", () => {
-    expect(member().grants).toContain("deny llm_config.read on llm_config");
+    const memberRole = DEPLOYMENT_ROLES.find((role) => role.id === "member");
+    if (!memberRole) throw new Error("member role missing from the deployment catalog");
+    const decision = decideEffectivePermission([{ name: "member", grants: memberRole.grants }], {
+      action: "llm_config.read",
+      resourceType: "llm_config",
+    });
+    expect(decision.allowed).toBe(false);
   });
 
   /* Members manage their own tokens; the Roles view must not deny all api_token actions. */

--- a/apps/api/src/identity/roles.ts
+++ b/apps/api/src/identity/roles.ts
@@ -107,10 +107,14 @@ export const ADMIN_ONLY_SURFACES: readonly {
   },
 ];
 
-/** Member allow-list; new surfaces stay unreachable until added here. */
-// Keeps today's access to legacy Resource types that declare no domain. Once a Resource type
-// declares `domain`, this grant no longer matches; that domain needs its own explicit grant.
-const MEMBER_UNDOMAINED_RECORD_ACTIONS = [
+/**
+ * Keeps today's access to legacy Resource types that declare no domain. Once a Resource type
+ * declares `domain`, this grant no longer matches; that domain needs its own explicit grant.
+ *
+ * Exported because it is the one wildcard `member` still holds, so it is also the only thing the
+ * admin-only carve-out below has to close.
+ */
+export const MEMBER_UNDOMAINED_RECORD_ACTIONS = [
   "record.create",
   "record.list",
   "record.read",
@@ -119,6 +123,7 @@ const MEMBER_UNDOMAINED_RECORD_ACTIONS = [
   "record.search",
 ] as const;
 
+/** Member allow-list; new surfaces stay unreachable until added here. */
 export const MEMBER_ALLOWED_SURFACES: readonly {
   readonly type: string;
   readonly actions: readonly string[];
@@ -224,17 +229,63 @@ function surfaceGrants(
   );
 }
 
+/**
+ * The admin-only carve-out of the allows `member` holds broadly.
+ *
+ * A blanket `deny` on every admin-only action reads safer than it is: a Role's grants all land in
+ * one authority layer and deny beats allow there, so a member carrying those denies could never be
+ * lifted by *any* Role granted on top — `Owner` included, which is the only promotion the product
+ * offers (#408). An admin-only action is already unreachable to a member by default deny, so the
+ * only denies worth keeping are the ones compensating for a member allow that would otherwise
+ * reach the action: the residual `resourceType: "*"` record grant (a business may name a Resource
+ * type after an admin-only one) and any same-type wildcard in `MEMBER_ALLOWED_SURFACES`.
+ */
+function adminOnlyCarveOut(): AccessGrant[] {
+  return ADMIN_ONLY_SURFACES.flatMap((surface) => {
+    const memberActions = MEMBER_ALLOWED_SURFACES.filter(
+      (allowed) => allowed.type === surface.type
+    ).flatMap((allowed) => allowed.actions);
+    const denied = new Set<string>(MEMBER_UNDOMAINED_RECORD_ACTIONS);
+    for (const action of surface.actions) {
+      if (memberActions.includes("*") || memberActions.includes(action)) denied.add(action);
+    }
+    return [...denied].map(
+      (action): AccessGrant => ({ action, resourceType: surface.type, effect: "deny" })
+    );
+  });
+}
+
+/**
+ * Unrestricted authority, spelled for both request shapes: a grant with no domain covers only
+ * domainless requests, so the pair is what "anything" actually means to `grantMatches`.
+ */
+const UNRESTRICTED_GRANTS: readonly AccessGrant[] = [
+  { action: "*", resourceType: "*", effect: "allow" },
+  { action: "*", resourceType: "*", domain: "*", effect: "allow" },
+];
+
 /** Built-in roles in `@tulipfarm/authz` vocabulary; member is an allow-list. */
 export const DEPLOYMENT_ROLES: readonly Role[] = [
+  /**
+   * Owner is the level the access UI describes as "can do anything, including managing access",
+   * and it is the only level a second person can be promoted to from the product. It was missing
+   * from this catalog, so the boot sync never corrected the migration's placeholder grants, which
+   * named resource types (`authz.role`, `authz.assignment`) no route declares — holding it
+   * therefore matched nothing and conferred nothing (#408).
+   */
+  {
+    id: "owner",
+    businessId: DEPLOYMENT_BUSINESS_ID,
+    assignableTo: ["user"],
+    parentRoleIds: [],
+    grants: [...UNRESTRICTED_GRANTS],
+  },
   {
     id: "admin",
     businessId: DEPLOYMENT_BUSINESS_ID,
     assignableTo: ["user"],
     parentRoleIds: [],
-    grants: [
-      { action: "*", resourceType: "*", effect: "allow" },
-      { action: "*", resourceType: "*", domain: "*", effect: "allow" },
-    ],
+    grants: [...UNRESTRICTED_GRANTS],
   },
   {
     id: "member",
@@ -246,7 +297,7 @@ export const DEPLOYMENT_ROLES: readonly Role[] = [
       ...MEMBER_UNDOMAINED_RECORD_ACTIONS.map(
         (action): AccessGrant => ({ action, resourceType: "*", effect: "allow" })
       ),
-      ...surfaceGrants(ADMIN_ONLY_SURFACES, "deny"),
+      ...adminOnlyCarveOut(),
       ...OWNER_SCOPED_SURFACES.map(
         (surface): AccessGrant => ({
           action: "*",
@@ -260,6 +311,7 @@ export const DEPLOYMENT_ROLES: readonly Role[] = [
 ];
 
 const ROLE_NAMES: Readonly<Record<string, string>> = {
+  owner: "Owner",
   admin: "Administrator",
   member: "Member",
 };

--- a/apps/api/src/pg-migrations/index.ts
+++ b/apps/api/src/pg-migrations/index.ts
@@ -769,13 +769,11 @@ async function seedAuthorizationBootstrap(q: Queryable): Promise<void> {
       ON users (setup_bootstrap) WHERE setup_bootstrap AND role = 'admin'`);
   }
 
+  // Kept in step with `DEPLOYMENT_ROLES`: the boot sync rewrites both rows anyway, but a seed that
+  // disagrees with the catalog is how `owner` came to grant nothing at all (#408).
   await seedBootstrapRole(q, "owner", [
-    { action: "*", resourceType: "authz.role", effect: "allow" },
-    { action: "*", resourceType: "authz.role", domain: "*", effect: "allow" },
-    { action: "*", resourceType: "authz.assignment", effect: "allow" },
-    { action: "*", resourceType: "authz.assignment", domain: "*", effect: "allow" },
-    { action: "*", resourceType: "authz.relation", effect: "allow" },
-    { action: "*", resourceType: "authz.relation", domain: "*", effect: "allow" },
+    { action: "*", resourceType: "*", effect: "allow" },
+    { action: "*", resourceType: "*", domain: "*", effect: "allow" },
   ]);
   await seedBootstrapRole(q, "admin", [
     { action: "*", resourceType: "*", effect: "allow" },

--- a/scripts/authz-lockout-safety.test.ts
+++ b/scripts/authz-lockout-safety.test.ts
@@ -172,6 +172,7 @@ describe("a deployment cannot lock itself out of its own authorization", () => {
     expect((await roles.listRoles(BUSINESS)).map((role) => role.id).sort()).toEqual([
       "admin",
       "member",
+      "owner",
     ]);
     expect(await check(principal(ADMIN_ID, "admin"), LEVEL_WRITE)).toBe(true);
   });
@@ -183,7 +184,11 @@ describe("a deployment cannot lock itself out of its own authorization", () => {
     await reconcileSoulRoles(roles, { roles: new Map() }, BUSINESS);
 
     const remaining = (await roles.listRoles(BUSINESS)).map((role) => role.id).sort();
-    expect(remaining, "the reap took a bootstrap Role with it").toEqual(["admin", "member"]);
+    expect(remaining, "the reap took a bootstrap Role with it").toEqual([
+      "admin",
+      "member",
+      "owner",
+    ]);
     expect(remaining).not.toContain("extra");
   });
 

--- a/scripts/control-plane-size.test.ts
+++ b/scripts/control-plane-size.test.ts
@@ -211,9 +211,24 @@ import { describe, expect, it } from "vitest";
  *
  * Both are read off the compiled schema at the point the write is already being validated, so
  * neither is a decision this layer owns rather than borrows.
+ *
+ * It moves to 51,305 for the `Owner` access-level fix, +50 net across the role catalog this app
+ * already owns:
+ *
+ *   +52 `apps/api/src/identity/roles.ts` — `adminOnlyCarveOut()`, which computes `member`'s denies
+ *       from the two existing catalogs instead of hard-coding a blanket deny per admin-only
+ *       surface, plus `UNRESTRICTED_GRANTS` and the `owner` entry. The blanket deny was the bug:
+ *       deny beats allow inside one authority layer, so a member carrying it could never be lifted
+ *       by any Role granted on top. Most of the growth is the TSDoc explaining that, because the
+ *       narrower deny set looks less safe than the broad one it replaces and is not.
+ *   -2  `apps/api/src/pg-migrations/index.ts` — migration v50's seed collapses to the same
+ *       unrestricted pair the catalog states, rather than naming resource types no route declares.
+ *
+ * The catalog is the authority the route gate reads, so it stays here; nothing in it is a decision
+ * a package below could own.
  */
 
-const CEILING = 51_255;
+const CEILING = 51_305;
 
 /**
  * Domains inside `apps/api/src` that already have a package of the same name. Everything here that


### PR DESCRIPTION
The `owner` Role was absent from `DEPLOYMENT_ROLES`, so the boot sync never corrected migration v50's placeholder grants, which named resource types no route declares. Even once corrected, `member` carried a blanket `deny` for every admin-only surface; deny wins inside an authority layer and all of a principal's Roles share one, so no granted Role could ever lift a member. Narrow those denies to the member allows they actually compensate for.

## Summary

<!-- What changed, and why. Link the driving issue if one exists. -->

## Test plan

<!-- Commands you ran, or manual steps / screenshots for UI changes. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (or the scoped `--filter` you actually ran)

## Checklist

- [ ] PR title follows Conventional Commits (`type(scope): subject`) — CI checks this
- [ ] Scoped to one logical change
- [ ] Tests added/updated for the behavior that changed
