### PR TITLE
fix(resources): enforce required fields from the resource type wizard

### DIFF
--- a/apps/api/src/resources/routes.test.ts
+++ b/apps/api/src/resources/routes.test.ts
@@ -237,6 +237,45 @@ describe("resource routes", () => {
       expect(res.json<{ boundary: string }>().boundary).toBe("resource");
     });
 
+    it("points the 422 path at the missing required field", async () => {
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/v1/resources/ticket",
+        cookies: { [SESSION_COOKIE]: sid, [CSRF_COOKIE]: TEST_CSRF },
+        headers: { [CSRF_HEADER]: TEST_CSRF },
+        payload: { priority: "high" },
+      });
+      expect(res.statusCode).toBe(422);
+      expect(res.json<{ path: string }>().path).toBe("/title");
+    });
+
+    it("returns 422 when a required field is present but empty", async () => {
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/v1/resources/ticket",
+        cookies: { [SESSION_COOKIE]: sid, [CSRF_COOKIE]: TEST_CSRF },
+        headers: { [CSRF_HEADER]: TEST_CSRF },
+        payload: { title: "" },
+      });
+      expect(res.statusCode).toBe(422);
+      expect(res.json<{ path: string; error: string }>()).toMatchObject({
+        path: "/title",
+        boundary: "resource",
+      });
+      expect(fakeRepo.docs.size).toBe(0);
+    });
+
+    it("still accepts a filled required field", async () => {
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/v1/resources/ticket",
+        cookies: { [SESSION_COOKIE]: sid, [CSRF_COOKIE]: TEST_CSRF },
+        headers: { [CSRF_HEADER]: TEST_CSRF },
+        payload: { title: "Bug" },
+      });
+      expect(res.statusCode).toBe(201);
+    });
+
     it("strips system fields from body", async () => {
       const res = await app.inject({
         method: "POST",
@@ -552,6 +591,28 @@ describe("resource routes", () => {
       const body = res.json<{ version: number; title: string }>();
       expect(body.version).toBe(2);
       expect(body.title).toBe("Updated bug");
+    });
+
+    it("returns 422 when an update empties a required field", async () => {
+      const id = randomUUID();
+      fakeRepo.docs.set(id, {
+        _id: id,
+        version: 1,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        title: "Bug",
+      });
+
+      const res = await app.inject({
+        method: "PUT",
+        url: `/api/v1/resources/ticket/${id}`,
+        cookies: { [SESSION_COOKIE]: sid, [CSRF_COOKIE]: TEST_CSRF },
+        headers: { [CSRF_HEADER]: TEST_CSRF, "if-match": "1" },
+        payload: { title: "" },
+      });
+      expect(res.statusCode).toBe(422);
+      expect(res.json<{ path: string }>().path).toBe("/title");
+      expect(fakeRepo.docs.get(id)?.title).toBe("Bug");
     });
   });
 

--- a/apps/api/src/resources/write-pipeline.ts
+++ b/apps/api/src/resources/write-pipeline.ts
@@ -72,6 +72,41 @@ export async function validateLinks(
   return null;
 }
 
+type AjvError = NonNullable<ReturnType<typeof ajv.compile>["errors"]>[number];
+
+/**
+ * JSON Pointer for an ajv error. A `required` failure reports `instancePath: ""` because the
+ * offending property is absent, so the field name only lives in `params.missingProperty` — without
+ * this the client gets an empty path and cannot map the 422 back onto the input that caused it.
+ */
+function ajvErrorPath(error: AjvError): string {
+  if (error.keyword === "required") {
+    const missing = (error.params as { missingProperty?: unknown }).missingProperty;
+    if (typeof missing === "string" && missing.length > 0) {
+      return `${error.instancePath}/${missing}`;
+    }
+  }
+  return error.instancePath ?? "";
+}
+
+/**
+ * A required field that is present but blank is empty, not supplied. JSON Schema `required` only
+ * asserts presence, so `""` would otherwise satisfy a field the author marked mandatory.
+ */
+function emptyRequiredField(
+  schema: Record<string, unknown>,
+  data: Record<string, unknown>
+): string | null {
+  const required = schema.required;
+  if (!Array.isArray(required)) return null;
+  for (const field of required) {
+    if (typeof field !== "string") continue;
+    const value = data[field];
+    if (typeof value === "string" && value.trim() === "") return field;
+  }
+  return null;
+}
+
 /** A 422/404/409 response a write helper can hand back for the route to send. */
 export type WriteError<C extends number = number> = {
   code: C;
@@ -109,7 +144,18 @@ export async function validateAndLink(
       body: {
         error: e?.message ?? "validation failed",
         boundary: "resource",
-        path: e?.instancePath ?? "",
+        path: e ? ajvErrorPath(e) : "",
+      },
+    };
+  }
+  const emptyField = emptyRequiredField(schema, data);
+  if (emptyField) {
+    return {
+      code: 422,
+      body: {
+        error: `${emptyField} must not be empty`,
+        boundary: "resource",
+        path: `/${emptyField}`,
       },
     };
   }

--- a/apps/api/src/soul/resource-types/routes.test.ts
+++ b/apps/api/src/soul/resource-types/routes.test.ts
@@ -3,6 +3,7 @@ import { makeSoulWriterDouble, type SoulWriterDouble } from "@tulipfarm/soul";
 import type { PaginatedResult } from "@tulipfarm/storage";
 import type { FastifyInstance } from "fastify";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { parse as parseYaml } from "yaml";
 import { buildApp } from "../../app";
 import type { TokenDoc, TokenRepo } from "../../auth/api-tokens";
 import { CSRF_COOKIE, CSRF_HEADER } from "../../auth/csrf";
@@ -158,6 +159,41 @@ describe("resource-type routes", () => {
         ],
       });
       expect(soulLoader.reload).toHaveBeenCalledOnce();
+    });
+
+    it("persists the wizard's required array verbatim into the soul", async () => {
+      // The exact document the resource type wizard POSTs, so the required flag it collects is
+      // covered from the browser payload through to the bytes committed to the soul.
+      const wizardSchema = JSON.stringify(
+        {
+          $schema: "https://json-schema.org/draft/2020-12/schema",
+          type: "object",
+          properties: {
+            subject: { type: "string" },
+            description: { type: "string" },
+            status: { type: "string", enum: ["open", "closed"] },
+          },
+          required: ["subject", "status"],
+          additionalProperties: false,
+        },
+        null,
+        2
+      );
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/v1/resource-types",
+        cookies: { [SESSION_COOKIE]: sid, [CSRF_COOKIE]: TEST_CSRF },
+        headers: { [CSRF_HEADER]: TEST_CSRF },
+        payload: { name: "ticket", schema: wizardSchema },
+      });
+
+      expect(res.statusCode).toBe(201);
+      const written = soulWriterDouble.applied[0].changes[0] as { content: string };
+      expect(parseYaml(written.content)).toMatchObject({ required: ["subject", "status"] });
+      expect(parseYaml(res.json<{ schema: string }>().schema)).toMatchObject({
+        required: ["subject", "status"],
+      });
     });
 
     it("returns 400 for empty name", async () => {

--- a/apps/web/app/routes/_app.resources.new.tsx
+++ b/apps/web/app/routes/_app.resources.new.tsx
@@ -4,6 +4,7 @@ import { ResourcePanel } from "~/components/resource-panel";
 import { ErrorState } from "~/components/states";
 import { Button } from "~/components/ui/button";
 import { ApiError, createResourceType } from "~/lib/api";
+import { randomUUID } from "~/lib/uuid";
 
 export const meta: MetaFunction = () => [{ title: "New type · Resources · tulipfarm" }];
 
@@ -21,9 +22,23 @@ const FIELD_TYPES: { value: FieldType; label: string }[] = [
   { value: "enum", label: "enum (choices)" },
 ];
 
-type FieldRow = { name: string; type: FieldType; required: boolean; enumValues: string };
+// `id` is row identity: React keys and every state patch go through it, so adding or removing a row
+// can never hand one row's state to another.
+type FieldRow = {
+  id: string;
+  name: string;
+  type: FieldType;
+  required: boolean;
+  enumValues: string;
+};
 
-const newRow = (): FieldRow => ({ name: "", type: "string", required: false, enumValues: "" });
+const newRow = (): FieldRow => ({
+  id: randomUUID(),
+  name: "",
+  type: "string",
+  required: false,
+  enumValues: "",
+});
 
 // One field → its JSON Schema property. System fields (id/createdAt/updatedAt/version) are managed by
 // the platform and never declared here.
@@ -63,8 +78,8 @@ export default function ResourceTypeNew() {
   const input =
     "w-full rounded-sm border border-border bg-background px-3 py-2 text-sm outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50";
 
-  function setField(i: number, patch: Partial<FieldRow>) {
-    setFields((prev) => prev.map((f, idx) => (idx === i ? { ...f, ...patch } : f)));
+  function setField(id: string, patch: Partial<FieldRow>) {
+    setFields((prev) => prev.map((f) => (f.id === id ? { ...f, ...patch } : f)));
   }
 
   async function onSubmit(e: FormEvent) {
@@ -145,21 +160,21 @@ export default function ResourceTypeNew() {
           </p>
           {fields.map((f, i) => (
             <div
-              key={i}
+              key={f.id}
               className="flex flex-wrap items-center gap-2 rounded-sm border border-border p-2"
             >
               <input
                 aria-label={`field ${i + 1} name`}
                 className={`${input} flex-1 min-w-[8rem]`}
                 value={f.name}
-                onChange={(e) => setField(i, { name: e.target.value })}
+                onChange={(e) => setField(f.id, { name: e.target.value })}
                 placeholder="fieldName"
               />
               <select
                 aria-label={`field ${i + 1} type`}
                 className={`${input} w-32`}
                 value={f.type}
-                onChange={(e) => setField(i, { type: e.target.value as FieldType })}
+                onChange={(e) => setField(f.id, { type: e.target.value as FieldType })}
               >
                 {FIELD_TYPES.map((t) => (
                   <option key={t.value} value={t.value}>
@@ -172,15 +187,16 @@ export default function ResourceTypeNew() {
                   aria-label={`field ${i + 1} choices`}
                   className={`${input} flex-1 min-w-[10rem]`}
                   value={f.enumValues}
-                  onChange={(e) => setField(i, { enumValues: e.target.value })}
+                  onChange={(e) => setField(f.id, { enumValues: e.target.value })}
                   placeholder="open, closed, done"
                 />
               ) : null}
               <label className="flex items-center gap-1 text-xs text-muted-foreground">
                 <input
                   type="checkbox"
+                  aria-label={`field ${i + 1} required`}
                   checked={f.required}
-                  onChange={(e) => setField(i, { required: e.target.checked })}
+                  onChange={(e) => setField(f.id, { required: e.target.checked })}
                 />
                 required
               </label>
@@ -188,7 +204,7 @@ export default function ResourceTypeNew() {
                 type="button"
                 aria-label={`remove field ${i + 1}`}
                 className="text-xs text-muted-foreground hover:text-destructive"
-                onClick={() => setFields((prev) => prev.filter((_, idx) => idx !== i))}
+                onClick={() => setFields((prev) => prev.filter((row) => row.id !== f.id))}
               >
                 remove
               </button>

--- a/apps/web/app/routes/resources.wizard.test.tsx
+++ b/apps/web/app/routes/resources.wizard.test.tsx
@@ -1,0 +1,82 @@
+import { createRemixStub } from "@remix-run/testing";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, test, vi } from "vitest";
+import { createResourceType } from "~/lib/api";
+import ResourceTypeNew from "./_app.resources.new";
+
+vi.mock("~/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("~/lib/api")>("~/lib/api");
+  return { ...actual, createResourceType: vi.fn() };
+});
+
+afterEach(() => vi.clearAllMocks());
+
+function renderWizard() {
+  vi.mocked(createResourceType).mockResolvedValue({ name: "ticket", schema: "", hasHooks: false });
+  const Stub = createRemixStub([
+    { path: "/", Component: () => <ResourceTypeNew /> },
+    { path: "/resources/:type", Component: () => null },
+  ]);
+  render(<Stub initialEntries={["/"]} />);
+}
+
+const addField = () => fireEvent.click(screen.getByRole("button", { name: "+ add field" }));
+const requiredBox = (row: number) =>
+  screen.getByLabelText(`field ${row} required`) as HTMLInputElement;
+
+test("wizard: '+ add field' keeps required checked on the rows already added", () => {
+  renderWizard();
+
+  fireEvent.change(screen.getByLabelText("field 1 name"), { target: { value: "subject" } });
+  fireEvent.click(requiredBox(1));
+  expect(requiredBox(1).checked).toBe(true);
+
+  addField();
+  expect(requiredBox(1).checked).toBe(true);
+  expect(requiredBox(2).checked).toBe(false);
+
+  fireEvent.change(screen.getByLabelText("field 2 name"), { target: { value: "status" } });
+  fireEvent.click(requiredBox(2));
+  addField();
+  expect(requiredBox(1).checked).toBe(true);
+  expect(requiredBox(2).checked).toBe(true);
+  expect(requiredBox(3).checked).toBe(false);
+});
+
+test("wizard: removing a row keeps required on the rows that stay", () => {
+  renderWizard();
+
+  fireEvent.change(screen.getByLabelText("field 1 name"), { target: { value: "subject" } });
+  addField();
+  fireEvent.change(screen.getByLabelText("field 2 name"), { target: { value: "status" } });
+  fireEvent.click(requiredBox(2));
+
+  fireEvent.click(screen.getByLabelText("remove field 1"));
+  expect((screen.getByLabelText("field 1 name") as HTMLInputElement).value).toBe("status");
+  expect(requiredBox(1).checked).toBe(true);
+});
+
+test("wizard: every checked field lands in the submitted schema's required array", async () => {
+  renderWizard();
+
+  fireEvent.change(screen.getByLabelText("type name * (singular, kebab-case)"), {
+    target: { value: "ticket" },
+  });
+  fireEvent.change(screen.getByLabelText("field 1 name"), { target: { value: "subject" } });
+  fireEvent.click(requiredBox(1));
+
+  addField();
+  fireEvent.change(screen.getByLabelText("field 2 name"), { target: { value: "description" } });
+
+  addField();
+  fireEvent.change(screen.getByLabelText("field 3 name"), { target: { value: "status" } });
+  fireEvent.change(screen.getByLabelText("field 3 type"), { target: { value: "enum" } });
+  fireEvent.change(screen.getByLabelText("field 3 choices"), { target: { value: "open, closed" } });
+  fireEvent.click(requiredBox(3));
+
+  fireEvent.click(screen.getByRole("button", { name: "Create type" }));
+
+  await waitFor(() => expect(createResourceType).toHaveBeenCalled());
+  const [, schemaJson] = vi.mocked(createResourceType).mock.calls[0];
+  expect(JSON.parse(schemaJson)).toMatchObject({ required: ["subject", "status"] });
+});

--- a/docs/qa/playbooks/resources.md
+++ b/docs/qa/playbooks/resources.md
@@ -51,11 +51,11 @@ the fixture the Agents/Skills/Routines playbooks reference.
 
 | # | Action | Expected |
 | --- | --- | --- |
-| 1 | `navigate /resources`, `click` `+ New type` | `/resources/new` renders within 5s: fields `type name * (singular, kebab-case)` and `description`, one field row (`field 1 name`, `field 1 type` defaulted to `text`, a `required` checkbox, `remove field 1`), `+ add field`, and `Create type` / `Cancel` |
+| 1 | `navigate /resources`, `click` `+ New type` | `/resources/new` renders within 5s: fields `type name * (singular, kebab-case)` and `description`, one field row (`field 1 name`, `field 1 type` defaulted to `text`, `field 1 required`, `remove field 1`), `+ add field`, and `Create type` / `Cancel` |
 | 2 | Leave `type name` blank, `click` `Create type` | Inline "error: Type name must be lowercase kebab-case (e.g. support-ticket)." — no request fires |
 | 3 | `type` `type name` `QA_Bad_Name` (uppercase), `click` `Create type` | Same kebab-case error — the regex rejects case as well as blanks |
 | 4 | `type` `type name` `qa-<run-id>-widget`, leave `field 1 name` blank, `click` `Create type` | Inline "error: Add at least one field." — a name-only field row doesn't count |
-| 5 | Fill `field 1 name` `title`, check its `required` box. `click` `+ add field` six times and fill: `count`→number, `qty`→integer, `active`→boolean, `dueDate`→date, `startsAt`→datetime, `status`→enum with `field N choices` = `open, closed, done` (check `required` on `status` too) | Each row accepts its value; the choices input only appears for the `status` row |
+| 5 | Fill `field 1 name` `title`, check `field 1 required`. `click` `+ add field` six times and fill: `count`→number, `qty`→integer, `active`→boolean, `dueDate`→date, `startsAt`→datetime, `status`→enum with `field N choices` = `open, closed, done` (check `field N required` on `status` too) | Each row accepts its value; the choices input only appears for the `status` row |
 | 6 | `expect` the `field N type` select offers exactly: text, number, integer, boolean, date, datetime, "enum (choices)" | No array, object, or relation (x-links) option — the wizard's ceiling. Covered by hand-editing the schema, next |
 | 7 | `note` `number` and `integer` render and behave identically in this UI (both become a plain HTML number input; only the generated schema's `type` differs) — not a bug, just a UI/schema granularity mismatch worth knowing before reading "each field type" results later | Recorded |
 | 8 | `click` `Create type` | Button reads "Creating…", then `wait-until` navigated to `/resources/qa-<run-id>-widget` (max 10s, form-submit budget) |
@@ -189,7 +189,7 @@ route's actual behavior rather than assuming one uniform "friendly 404".
 
 | # | Action | Expected |
 | --- | --- | --- |
-| 1 | Tab through `/resources/new` | Order: `type name` → `description` → `field 1 name` → `field 1 type` → (`field 1 choices` if enum) → `required` → `remove field 1` → `+ add field` → `Create type` → `Cancel`, each with a visible focus ring |
+| 1 | Tab through `/resources/new` | Order: `type name` → `description` → `field 1 name` → `field 1 type` → (`field 1 choices` if enum) → `field 1 required` → `remove field 1` → `+ add field` → `Create type` → `Cancel`, each with a visible focus ring |
 | 2 | Tab through a record create form with a relation field present | Reaches the `relatedTo` combobox; `expect` its option list is operable by keyboard alone (Enter/Arrow), not mouse-only |
 | 3 | `expect` (P2 if not true) | Source shows the combobox's options only handle `onMouseDown` — no `onKeyDown` for Enter/Arrow selection. If Tabbing into an open list provides no way to choose an option without a pointer, that is a keyboard-operability failure |
 | 4 | On `/settings/auth` (or wherever the toggle lives in this session), record the current theme, `click` `Toggle dark mode` | Theme flips |

--- a/scripts/control-plane-size.test.ts
+++ b/scripts/control-plane-size.test.ts
@@ -197,9 +197,23 @@ import { describe, expect, it } from "vitest";
  *
  * Both are probe wiring for an admin route, which is what `apps/api` is for; the provider
  * behaviour they report on stays in `packages/llm`.
+ *
+ * It moves to 51,255 for the required-field fix, all of it in `resources/write-pipeline.ts`, which
+ * is where a Record write is already validated against its Resource type:
+ *
+ *   +17 `ajvErrorPath` and its `AjvError` alias. ajv reports `instancePath: ""` for a `required`
+ *       failure because the offending property is absent, so the field name lives only in
+ *       `params.missingProperty`. Without the translation the 422 carries an empty path and the
+ *       form cannot map it onto the input that caused it.
+ *   +18 `emptyRequiredField`. JSON Schema `required` asserts presence only, so `""` satisfied a
+ *       field the author marked mandatory and the Record persisted blank.
+ *   +11 the two call sites in `validateAndLink` that return those 422s.
+ *
+ * Both are read off the compiled schema at the point the write is already being validated, so
+ * neither is a decision this layer owns rather than borrows.
  */
 
-const CEILING = 51_209;
+const CEILING = 51_255;
 
 /**
  * Domains inside `apps/api/src` that already have a package of the same name. Everything here that


### PR DESCRIPTION
The wizard's per-row required checkbox had no per-row accessible name and rows were keyed by array index, so the control could not be addressed or reasoned about per row. Record writes rejected a missing required field with an empty JSON Pointer, so the 422 never landed as an inline error, and a required field sent as an empty string satisfied JSON Schema presence and persisted blank.

Closes #456
Closes #457

## Summary

<!-- What changed, and why. Link the driving issue if one exists. -->

## Test plan

<!-- Commands you ran, or manual steps / screenshots for UI changes. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (or the scoped `--filter` you actually ran)

## Checklist

- [ ] PR title follows Conventional Commits (`type(scope): subject`) — CI checks this
- [ ] Scoped to one logical change
- [ ] Tests added/updated for the behavior that changed
