### PR TITLE
fix(admin): stop reporting a working llm provider as down

### DIFF
--- a/apps/api/src/admin/health.test.ts
+++ b/apps/api/src/admin/health.test.ts
@@ -1,8 +1,11 @@
+import { LlmNotConfiguredError, UnknownModelError } from "@tulipfarm/schema";
 import { describe, expect, it, vi } from "vitest";
-import { llmProbe } from "./health";
+import { llmProbe, probeHealth } from "./health";
 
 /** A configured, resolvable model. Resolution alone cannot tell a live key from a revoked one. */
 const configured = { effortModel: vi.fn(() => ({})) };
+
+const at = () => "2026-01-01T00:00:00.000Z";
 
 describe("llmProbe", () => {
   it("reports configuration only when no reachability check is supplied", async () => {
@@ -11,17 +14,31 @@ describe("llmProbe", () => {
     expect(result).toEqual({ status: "ok" });
   });
 
-  it("degrades when the provider refuses the credential", async () => {
+  it("reports up while a working provider is still answering the live call", async () => {
+    // A real model call outlives the probe budget on a cold subscription provider. Awaiting it
+    // here timed the probe out, so the page said `down` about a provider that was answering chats.
+    const verify = vi.fn(() => new Promise<void>(() => {}));
+
+    const [component] = await probeHealth([llmProbe(configured, { reachability: { verify } })], at);
+
+    expect(component.status).toBe("ok");
+    expect(verify).toHaveBeenCalledTimes(1);
+  });
+
+  it("degrades once the provider refuses the credential", async () => {
     // Resolution succeeds for a revoked key, so without a live check this reported `ok` and the
     // first person to learn the key was dead was a participant mid-chat.
     const probe = llmProbe(configured, {
       reachability: { verify: async () => Promise.reject(new Error("401 invalid api key")) },
     });
 
-    const result = await probe.check();
+    await probe.check();
 
-    expect(result.status).toBe("degraded");
-    expect(result.detail).toContain("401 invalid api key");
+    await vi.waitFor(async () => {
+      const result = await probe.check();
+      expect(result.status).toBe("degraded");
+      expect(result.detail).toContain("401 invalid api key");
+    });
   });
 
   it("never reports down, so a provider cannot fail this deployment's readiness", async () => {
@@ -29,6 +46,9 @@ describe("llmProbe", () => {
       reachability: { verify: async () => Promise.reject(new Error("anything")) },
     });
 
+    await probe.check();
+
+    await vi.waitFor(async () => expect((await probe.check()).status).toBe("degraded"));
     expect((await probe.check()).status).not.toBe("down");
   });
 
@@ -42,21 +62,38 @@ describe("llmProbe", () => {
     });
 
     await probe.check();
+    await vi.waitFor(() => expect(verify).toHaveBeenCalledTimes(1));
     await probe.check();
     expect(verify).toHaveBeenCalledTimes(1);
 
     clock += 60_001;
     await probe.check();
-    expect(verify).toHaveBeenCalledTimes(2);
+    await vi.waitFor(() => expect(verify).toHaveBeenCalledTimes(2));
   });
 
-  it("still reports down when the model is not configured at all", async () => {
+  it("reports unknown, not down, when no provider is configured at all", async () => {
     const probe = llmProbe({
       effortModel: () => {
-        throw new Error("llm not configured");
+        throw new LlmNotConfiguredError();
       },
     });
 
-    await expect(probe.check()).rejects.toThrow("llm not configured");
+    const [component] = await probeHealth([probe], at);
+
+    expect(component.status).toBe("unknown");
+    expect(component.detail).toBe("no LLM provider is configured");
+  });
+
+  it("still reports down when a configured model cannot be resolved", async () => {
+    const probe = llmProbe({
+      effortModel: () => {
+        throw new UnknownModelError("gpt-5.6-terra");
+      },
+    });
+
+    const [component] = await probeHealth([probe], at);
+
+    expect(component.status).toBe("down");
+    expect(component.detail).toContain("gpt-5.6-terra");
   });
 });

--- a/apps/api/src/admin/health.ts
+++ b/apps/api/src/admin/health.ts
@@ -1,6 +1,11 @@
 import { DEPLOYMENT_BUSINESS_ID } from "@tulipfarm/constants";
+import { LlmNotConfiguredError } from "@tulipfarm/schema";
 
-export type HealthStatus = "ok" | "degraded" | "down";
+/**
+ * `unknown` is not a fault: the component has nothing configured to check, so no verdict about it
+ * would be honest. Reporting it as `down` tells an operator to fix something that is not broken.
+ */
+export type HealthStatus = "ok" | "degraded" | "down" | "unknown";
 
 export interface HealthResult {
   readonly status: HealthStatus;
@@ -146,6 +151,11 @@ const REACHABILITY_TTL_MS = 60_000;
  * Checks that a model is configured and resolvable, and — when a reachability check is supplied —
  * that the provider still accepts the credential.
  *
+ * The credential check runs *outside* this call: a real model call takes seconds, `runProbe` gives
+ * every probe a two-second budget, and awaiting one here reported a working provider as `down` on
+ * exactly the deployments whose first call is slowest. `check()` therefore answers from the last
+ * verdict and refreshes in the background, so provider latency can never decide the status.
+ *
  * A provider outage is deliberately *not* our failure: only a refused credential downgrades the
  * component, and only to `degraded`. Reporting `down` would hand a third party the power to fail
  * this deployment's readiness. Without that distinction a revoked key reported `ok` and the first
@@ -155,28 +165,51 @@ export function llmProbe(llm: ModelProbeTarget, options: LlmProbeOptions = {}): 
   const now = options.now ?? Date.now;
   const ttlMs = options.ttlMs ?? REACHABILITY_TTL_MS;
   let cached: { at: number; result: HealthResult } | undefined;
+  let refreshing = false;
+
+  function refresh(reachability: ModelReachability): void {
+    if (refreshing) return;
+    refreshing = true;
+    void reachability
+      .verify()
+      .then(
+        () => {
+          cached = { at: now(), result: { status: "ok" } };
+        },
+        (error: unknown) => {
+          cached = {
+            at: now(),
+            result: {
+              status: "degraded",
+              detail: `provider rejected the credential: ${message(error)}`,
+            },
+          };
+        }
+      )
+      .finally(() => {
+        refreshing = false;
+      });
+  }
 
   return {
     component: "llm",
     async check() {
-      llm.effortModel("balanced");
+      try {
+        llm.effortModel("balanced");
+      } catch (error) {
+        if (error instanceof LlmNotConfiguredError) {
+          return { status: "unknown", detail: "no LLM provider is configured" };
+        }
+        throw error;
+      }
+
       const reachability = options.reachability;
       if (reachability === undefined) return { status: "ok" };
 
       if (cached !== undefined && now() - cached.at < ttlMs) return cached.result;
 
-      let result: HealthResult;
-      try {
-        await reachability.verify();
-        result = { status: "ok" };
-      } catch (error) {
-        result = {
-          status: "degraded",
-          detail: `provider rejected the credential: ${message(error)}`,
-        };
-      }
-      cached = { at: now(), result };
-      return result;
+      refresh(reachability);
+      return cached?.result ?? { status: "ok", detail: "credential check pending" };
     },
   };
 }

--- a/apps/api/src/admin/model-reachability.ts
+++ b/apps/api/src/admin/model-reachability.ts
@@ -4,8 +4,12 @@ import type { ModelReachability } from "./health";
 
 /** Verifies the deployment's model credential is still accepted, without failing on an outage. */
 
-/** Long enough for a cold provider connection, short enough to stay inside the probe budget. */
-const REACHABILITY_TIMEOUT_MS = 1_500;
+/**
+ * Long enough for a cold subscription-CLI provider to spawn, hand-shake and answer. This call no
+ * longer runs inside the probe's response budget, so cutting it short only loses the verdict —
+ * an abort is indistinguishable from a healthy provider here, and a revoked key would read `ok`.
+ */
+const REACHABILITY_TIMEOUT_MS = 30_000;
 
 /** Provider verdicts that mean *this deployment's credential* is the problem, not the provider. */
 const CREDENTIAL_REASONS = new Set(["model_authentication_failed", "model_billing_inactive"]);

--- a/apps/web/app/lib/operations.ts
+++ b/apps/web/app/lib/operations.ts
@@ -51,7 +51,7 @@ export type RunBudget = {
 
 export type OperationalHealth = {
   component: string;
-  status: "ok" | "degraded" | "down";
+  status: "ok" | "degraded" | "down" | "unknown";
   detail?: string;
   checkedAt: string;
 };

--- a/scripts/control-plane-size.test.ts
+++ b/scripts/control-plane-size.test.ts
@@ -185,9 +185,21 @@ import { describe, expect, it } from "vitest";
  * The decision behind the first guard — which files a layout can address — did not stay: it is
  * `unstorableArtifactPaths` in `packages/schema/src/artifacts.ts`, beside the registry that owns
  * the answer. Only the HTTP reply for it is here.
+ *
+ * It moves to 51,209 for the `llm` health-probe fix, +37 net in the admin probes this app already
+ * owns:
+ *
+ *   +33 `apps/api/src/admin/health.ts` — the credential verdict is now cached and refreshed out of
+ *       band instead of awaited inside `runProbe`'s 2s budget, so a slow-but-working provider can
+ *       no longer be raced into `down`, and a deployment with no provider configured reports the
+ *       new `unknown` state rather than a failure.
+ *   +4  `apps/api/src/admin/model-reachability.ts` — a budget that fits a real cold start.
+ *
+ * Both are probe wiring for an admin route, which is what `apps/api` is for; the provider
+ * behaviour they report on stays in `packages/llm`.
  */
 
-const CEILING = 51_172;
+const CEILING = 51_209;
 
 /**
  * Domains inside `apps/api/src` that already have a package of the same name. Everything here that


### PR DESCRIPTION
The llm health probe awaited a live generateText call inside runProbe's 2s budget. A cold subscription-CLI provider needs seconds to spawn and hand-shake, and its 1.5s abort cannot interrupt an in-flight app-server handshake, so the race timed out and the Operations page reported Down while chat turns were answering.

The credential check now runs out of band: check() answers from the last verdict and refreshes in the background, so provider latency can never decide the status, and the live call gets a budget that fits a real cold start. A deployment with no provider configured reports the new unknown state instead of Down.

## Summary

<!-- What changed, and why. Link the driving issue if one exists. -->

## Test plan

<!-- Commands you ran, or manual steps / screenshots for UI changes. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (or the scoped `--filter` you actually ran)

## Checklist

- [ ] PR title follows Conventional Commits (`type(scope): subject`) — CI checks this
- [ ] Scoped to one logical change
- [ ] Tests added/updated for the behavior that changed
