### PR TITLE
chore(deps): upgrade biome, turbo, lefthook and lint-staged

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,7 +256,7 @@ never assume it ran. See [`apps/eval/README.md`](apps/eval/README.md).
 
 ## Lint / format — Biome
 
-`biome.json` (Biome 2.4.16) is the single source of truth. **No ESLint, no Prettier.**
+`biome.json` (Biome 2.5.9) is the single source of truth. **No ESLint, no Prettier.**
 
 ```bash
 pnpm exec biome check --write .   # lint + format + organize imports

--- a/apps/api/src/approvals/routine-approvals.pg.test.ts
+++ b/apps/api/src/approvals/routine-approvals.pg.test.ts
@@ -154,7 +154,7 @@ describe("routine approvals as durable waits", () => {
     const row = await repo.findById(opened.approvalId);
     expect(row).toMatchObject({ kind: "routine_state", status: "pending" });
     // The token lives beside the approval, in the process that redeems it — never in the answer.
-    expect((row?.payload as { resumeToken?: string }).resumeToken).toEqual(expect.any(String));
+    expect((row?.payload as { resumeToken?: string })?.resumeToken).toEqual(expect.any(String));
   });
 
   it("returns the approval already open for this State occurrence rather than asking twice", async () => {

--- a/apps/api/src/identity/knowledge-identity-map.test.ts
+++ b/apps/api/src/identity/knowledge-identity-map.test.ts
@@ -100,12 +100,12 @@ describe("ExternalLinkKnowledgeIdentityMap", () => {
       });
     };
 
-    it.each([
-      "link_token",
-      "bind_link",
-    ] as const)("grants Knowledge access for %s, which proves control of both accounts", async (method) => {
-      expect(await resolveVia(method)).toEqual([{ kind: "user", id: "u1" }]);
-    });
+    it.each(["link_token", "bind_link"] as const)(
+      "grants Knowledge access for %s, which proves control of both accounts",
+      async (method) => {
+        expect(await resolveVia(method)).toEqual([{ kind: "user", id: "u1" }]);
+      }
+    );
 
     // A Slack Connect counterparty controls their own users' email addresses. If a
     // provider-asserted email were enough, they could set one to our CEO's and inherit every
@@ -114,12 +114,12 @@ describe("ExternalLinkKnowledgeIdentityMap", () => {
       expect(await resolveVia("manifest_email")).toBeUndefined();
     });
 
-    it.each([
-      null,
-      undefined,
-    ])("grants no Knowledge access when provenance is %s, because unknown is not trusted", async (method) => {
-      expect(await resolveVia(method)).toBeUndefined();
-    });
+    it.each([null, undefined])(
+      "grants no Knowledge access when provenance is %s, because unknown is not trusted",
+      async (method) => {
+        expect(await resolveVia(method)).toBeUndefined();
+      }
+    );
 
     it("keeps every knowledge-grade method out of the chat-only set", () => {
       expect(PROVEN_LINK_VERIFICATION).not.toContain("manifest_email");

--- a/apps/api/src/ingress/identity.test.ts
+++ b/apps/api/src/ingress/identity.test.ts
@@ -252,16 +252,16 @@ describe("IngressIdentityResolver sender authority", () => {
     return result;
   }
 
-  it.each([
-    "link_token",
-    "bind_link",
-  ] as const)("lets a %s sender wield the user's own authority", async (verifiedVia) => {
-    const result = await linkedAs(verifiedVia);
+  it.each(["link_token", "bind_link"] as const)(
+    "lets a %s sender wield the user's own authority",
+    async (verifiedVia) => {
+      const result = await linkedAs(verifiedVia);
 
-    expect(result.user).toBe(alice);
-    expect(result.principalId).toBe(alice._id);
-    expect(result.principalRef).toBe(`user:${alice._id}`);
-  });
+      expect(result.user).toBe(alice);
+      expect(result.principalId).toBe(alice._id);
+      expect(result.principalRef).toBe(`user:${alice._id}`);
+    }
+  );
 
   it.each([
     ["manifest_email", "manifest_email" as const],

--- a/apps/api/src/knowledge-sources/live-authorization.test.ts
+++ b/apps/api/src/knowledge-sources/live-authorization.test.ts
@@ -171,12 +171,12 @@ describe("SlackLiveSourceAuthorization", () => {
       return auth.check(baseInput([{ kind: "user", id: "user-1" }]));
     };
 
-    it.each([
-      "link_token",
-      "bind_link",
-    ] as const)("allows a current member mapped via %s", async (method) => {
-      expect(await checkVia(method)).toEqual({ allowed: true });
-    });
+    it.each(["link_token", "bind_link"] as const)(
+      "allows a current member mapped via %s",
+      async (method) => {
+        expect(await checkVia(method)).toEqual({ allowed: true });
+      }
+    );
 
     it("denies a current member whose mapping came from a provider-asserted email", async () => {
       expect(await checkVia("manifest_email")).toEqual({ allowed: false });

--- a/apps/api/src/resources/repo.pg.test.ts
+++ b/apps/api/src/resources/repo.pg.test.ts
@@ -50,7 +50,7 @@ describe("PgResourceRepo", () => {
     expect(found).not.toBeNull();
     expect(found?._id).toBe(d._id);
     expect(found?.version).toBe(1);
-    expect((found?.createdAt as Date).getTime()).toBe(created.getTime());
+    expect((found?.createdAt as Date)?.getTime()).toBe(created.getTime());
     expect(found?.title).toBe("Bug");
     expect(found?.priority).toBe("high");
     expect(found?.meta).toEqual({ tags: ["a", "b"], n: 3 });

--- a/apps/api/src/schedule/register.test.ts
+++ b/apps/api/src/schedule/register.test.ts
@@ -59,7 +59,7 @@ describe("registerScheduleDispatch", () => {
       fakeDispatcher(async () => {})
     );
 
-    expect((created[0]?.options as { policy: string }).policy).toBe("exclusive");
+    expect((created[0]?.options as { policy: string })?.policy).toBe("exclusive");
   });
 
   it("registers no process-local timer, so replicas cannot each fire the same Routine", async () => {

--- a/apps/api/src/soul/llm-config/routes.test.ts
+++ b/apps/api/src/soul/llm-config/routes.test.ts
@@ -520,7 +520,7 @@ describe("llm-config routes", () => {
         "fetch",
         vi.fn(async (url: string, init?: RequestInit) => {
           if (url === "http://localhost:11434/v1/models") {
-            expect((init?.headers as Record<string, string>).Authorization).toBe("Bearer sk-test");
+            expect((init?.headers as Record<string, string>)?.Authorization).toBe("Bearer sk-test");
             return {
               ok: true,
               json: async () => ({ data: [{ id: "llama3" }, { id: "mixtral" }] }),

--- a/apps/api/src/soul/roles/authoring.test.ts
+++ b/apps/api/src/soul/roles/authoring.test.ts
@@ -502,26 +502,22 @@ describe("deleteLevel refuses to leave the roles directory", () => {
     await rm(soulPath, { recursive: true, force: true });
   });
 
-  it.each([
-    "../..",
-    "../../etc",
-    "..",
-    "a/../../b",
-    "/etc",
-    "sub/dir",
-  ])("refuses %s without touching the filesystem", async (slug) => {
-    const outside = join(soulPath, "keep-me.txt");
-    await writeFile(outside, "important", "utf8");
+  it.each(["../..", "../../etc", "..", "a/../../b", "/etc", "sub/dir"])(
+    "refuses %s without touching the filesystem",
+    async (slug) => {
+      const outside = join(soulPath, "keep-me.txt");
+      await writeFile(outside, "important", "utf8");
 
-    await expect(
-      deleteLevel(slug, {
-        soulWriter,
-        catalog: () => CATALOG,
-        reconcile: async () => undefined,
-      })
-    ).rejects.toThrowError(expect.objectContaining({ code: "not_found" }));
+      await expect(
+        deleteLevel(slug, {
+          soulWriter,
+          catalog: () => CATALOG,
+          reconcile: async () => undefined,
+        })
+      ).rejects.toThrowError(expect.objectContaining({ code: "not_found" }));
 
-    await expect(readFile(outside, "utf8")).resolves.toBe("important");
-    expect(committed).not.toHaveBeenCalled();
-  });
+      await expect(readFile(outside, "utf8")).resolves.toBe("important");
+      expect(committed).not.toHaveBeenCalled();
+    }
+  );
 });

--- a/apps/api/src/surfaces/tools.test.ts
+++ b/apps/api/src/surfaces/tools.test.ts
@@ -43,7 +43,7 @@ describe("Surface presentation Tool schema", () => {
       },
       surfaceCatalog: [recordTable],
     });
-    const component = (schema?.properties as Record<string, unknown>).component as {
+    const component = (schema?.properties as Record<string, unknown>)?.component as {
       description: string;
       oneOf: Array<{
         examples: unknown[];
@@ -111,10 +111,10 @@ describe("Surface presentation Tool schema", () => {
     };
     const presentSchema = presentTool.inputSchemaFor?.(ctx);
     const requestSchema = requestInputTool.inputSchemaFor?.(ctx);
-    const presentComponent = (presentSchema?.properties as Record<string, unknown>).component as {
+    const presentComponent = (presentSchema?.properties as Record<string, unknown>)?.component as {
       oneOf: Array<{ properties: { name: { const: string } } }>;
     };
-    const requestComponent = (requestSchema?.properties as Record<string, unknown>).component as {
+    const requestComponent = (requestSchema?.properties as Record<string, unknown>)?.component as {
       oneOf: Array<{ properties: { name: { const: string } } }>;
     };
 

--- a/apps/web/app/components/status-badge.test.tsx
+++ b/apps/web/app/components/status-badge.test.tsx
@@ -8,12 +8,10 @@ test("renders status text with a non-color icon cue", () => {
   expect(container.querySelector("svg")).toHaveAttribute("aria-hidden", "true");
 });
 
-test.each([
-  "low",
-  "medium",
-  "high",
-  "critical",
-] as const)("renders the closed %s priority", (priority) => {
-  render(<PriorityBadge priority={priority} />);
-  expect(screen.getByText(priority)).toBeInTheDocument();
-});
+test.each(["low", "medium", "high", "critical"] as const)(
+  "renders the closed %s priority",
+  (priority) => {
+    render(<PriorityBadge priority={priority} />);
+    expect(screen.getByText(priority)).toBeInTheDocument();
+  }
+);

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.9/schema.json",
   "files": {
     "includes": [
       "**",
@@ -28,7 +28,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "complexity": {
         "noImportantStyles": "off"
       },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "*.{ts,tsx,js,jsx,json,css}": "biome check --write --no-errors-on-unmatched"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.1",
+    "@biomejs/biome": "^2.5.9",
     "@commitlint/cli": "^21.1.0",
     "@commitlint/config-conventional": "^21.1.0",
     "@playwright/test": "^1.62.1",
@@ -51,11 +51,11 @@
     "@types/semver": "^7.7.1",
     "conventional-changelog": "^7.2.0",
     "conventional-changelog-conventionalcommits": "^9.3.1",
-    "lefthook": "^2.1.9",
-    "lint-staged": "^17.0.8",
+    "lefthook": "^2.1.10",
+    "lint-staged": "^17.3.0",
     "playwright": "^1.62.1",
     "semver": "^7.7.4",
-    "turbo": "^2.10.0",
+    "turbo": "^2.10.10",
     "typescript": "^6.0.3",
     "vitest": "^4.1.9"
   },

--- a/packages/agent-runtime/src/models/effort-router.test.ts
+++ b/packages/agent-runtime/src/models/effort-router.test.ts
@@ -72,18 +72,17 @@ describe("classifyWithQuickModel", () => {
     expect(await classifyWithQuickModel("p", answering(label))).toBe(label);
   });
 
-  it.each([
-    " Thorough.\n",
-    "FAST",
-    '"balanced"',
-  ])("tolerates casing and punctuation in %j", async (answer) => {
-    expect(await classifyWithQuickModel("p", answering(answer))).toBe(
-      answer
-        .trim()
-        .toLowerCase()
-        .replace(/[.!,'"`]/g, "")
-    );
-  });
+  it.each([" Thorough.\n", "FAST", '"balanced"'])(
+    "tolerates casing and punctuation in %j",
+    async (answer) => {
+      expect(await classifyWithQuickModel("p", answering(answer))).toBe(
+        answer
+          .trim()
+          .toLowerCase()
+          .replace(/[.!,'"`]/g, "")
+      );
+    }
+  );
 
   it.each([
     ["an unknown label", "complicated"],

--- a/packages/authz/test/security-matrix/authorization-isolation.test.ts
+++ b/packages/authz/test/security-matrix/authorization-isolation.test.ts
@@ -26,30 +26,31 @@ describe("authorization isolation matrix", () => {
     );
   });
 
-  it.each(
-    SESSION_SUBSTITUTION_MATRIX
-  )("$dimension: denies $description without identity substitution", ({ principal, session }) => {
-    try {
-      assertSessionMatchesPrincipal(session, principal, NOW);
-      throw new Error("expected session substitution denial");
-    } catch (error) {
-      expect(error).toBeInstanceOf(PrincipalDeniedError);
-      expect((error as PrincipalDeniedError).reason).toBe("substitution");
+  it.each(SESSION_SUBSTITUTION_MATRIX)(
+    "$dimension: denies $description without identity substitution",
+    ({ principal, session }) => {
+      try {
+        assertSessionMatchesPrincipal(session, principal, NOW);
+        throw new Error("expected session substitution denial");
+      } catch (error) {
+        expect(error).toBeInstanceOf(PrincipalDeniedError);
+        expect((error as PrincipalDeniedError).reason).toBe("substitution");
+      }
     }
-  });
+  );
 
-  it.each(EXTERNAL_IDENTITY_MATRIX)("external identity: denies $description with safe evidence", ({
-    mapping,
-    expectedReason,
-  }) => {
-    try {
-      assertConversationSenderAuthorized(mapping, "user-owner", "business-a", NOW);
-      throw new Error("expected external identity denial");
-    } catch (error) {
-      expect(error).toBeInstanceOf(ExternalIdentityDeniedError);
-      expect((error as ExternalIdentityDeniedError).reason).toBe(expectedReason);
+  it.each(EXTERNAL_IDENTITY_MATRIX)(
+    "external identity: denies $description with safe evidence",
+    ({ mapping, expectedReason }) => {
+      try {
+        assertConversationSenderAuthorized(mapping, "user-owner", "business-a", NOW);
+        throw new Error("expected external identity denial");
+      } catch (error) {
+        expect(error).toBeInstanceOf(ExternalIdentityDeniedError);
+        expect((error as ExternalIdentityDeniedError).reason).toBe(expectedReason);
+      }
     }
-  });
+  );
 
   it("revocation removes delegated guest authority immediately", () => {
     const grants = guestGrants(REVOCATION_CASE.guest, REVOCATION_CASE.sponsor, NOW);

--- a/packages/curator/src/review.test.ts
+++ b/packages/curator/src/review.test.ts
@@ -64,17 +64,16 @@ describe("shadow review disclosure", () => {
     expect(JSON.stringify(shape)).not.toContain("triaging");
   });
 
-  it.each([
-    "knowledge_promotion",
-    "knowledge_page",
-    "proposal_seed",
-  ])("shows %s in full — it is business-bound content, not one person's", (kind) => {
-    const effect = { kind, payload: { statement: "The team ships on Fridays" } };
-    expect(redactShadowEffect(effect, false)).toEqual({
-      disclosure: "full",
-      payload: effect.payload,
-    });
-  });
+  it.each(["knowledge_promotion", "knowledge_page", "proposal_seed"])(
+    "shows %s in full — it is business-bound content, not one person's",
+    (kind) => {
+      const effect = { kind, payload: { statement: "The team ships on Fridays" } };
+      expect(redactShadowEffect(effect, false)).toEqual({
+        disclosure: "full",
+        payload: effect.payload,
+      });
+    }
+  );
 
   it("classifies exactly the two person-scoped kinds as private", () => {
     expect(["memory_patch", "proposal"].every(isPrivateEffectKind)).toBe(true);

--- a/packages/integrations/src/egress/openapi-compile.test.ts
+++ b/packages/integrations/src/egress/openapi-compile.test.ts
@@ -97,7 +97,7 @@ describe("compileOpenApiEgress", () => {
     expect(JSON.stringify(tool?.contract.spec.inputSchema)).not.toContain("$ref");
     const body = (
       tool?.contract.spec.inputSchema.properties as Record<string, { required?: string[] }>
-    ).body;
+    )?.body;
     expect(body?.required).toEqual(["query"]);
   });
 

--- a/packages/integrations/src/github/adapter.test.ts
+++ b/packages/integrations/src/github/adapter.test.ts
@@ -432,8 +432,8 @@ describe("GitHubAdapter effects", () => {
     });
     const output = await dispatch(commentIntent);
     const posted = http.calls.find((call) => call.method === "POST");
-    expect(String((posted?.body as { body: string }).body)).toContain(marker);
-    expect(String((posted?.body as { body: string }).body)).toContain("duplicate of #12");
+    expect(String((posted?.body as { body: string })?.body)).toContain(marker);
+    expect(String((posted?.body as { body: string })?.body)).toContain("duplicate of #12");
     expect(output).toEqual({
       commentId: "900",
       htmlUrl: "https://github.com/tulip/farm/issues/41#issuecomment-900",
@@ -712,7 +712,9 @@ describe("GitHubAdapter pull requests", () => {
       })
     );
     const posted = http.calls.find((call) => call.method === "POST");
-    expect(String((posted?.body as { body: string }).body)).toContain(githubEffectMarker("idem-1"));
+    expect(String((posted?.body as { body: string })?.body)).toContain(
+      githubEffectMarker("idem-1")
+    );
     expect(output).toMatchObject({ number: 12, headRef: "fix-crash", baseRef: "main" });
   });
 
@@ -782,7 +784,9 @@ describe("GitHubAdapter pull requests", () => {
       })
     );
     const posted = http.calls.find((call) => call.method === "POST");
-    expect(String((posted?.body as { body: string }).body)).toContain(githubEffectMarker("idem-1"));
+    expect(String((posted?.body as { body: string })?.body)).toContain(
+      githubEffectMarker("idem-1")
+    );
     expect(output).toEqual({
       reviewId: "55",
       state: "APPROVED",
@@ -1002,7 +1006,7 @@ describe("GitHubAdapter repo push", () => {
     const commitCall = http.calls.find(
       (call) => call.method === "POST" && call.path === "/repos/tulip/farm/git/commits"
     );
-    expect(String((commitCall?.body as { message: string }).message)).toContain(marker);
+    expect(String((commitCall?.body as { message: string })?.message)).toContain(marker);
     const refCall = http.calls.find((call) => call.method === "PATCH");
     expect(refCall?.body).toEqual({ sha: "new-commit-sha", force: false });
     expect(output).toEqual({
@@ -1194,8 +1198,8 @@ describe("GitHubAdapter issue create", () => {
     http.route("POST", "/repos/tulip/farm/issues", { status: 201, headers: {}, body: ISSUE_BODY });
     const output = await dispatch(createIntent);
     const posted = http.calls.find((call) => call.method === "POST");
-    expect(String((posted?.body as { body: string }).body)).toContain(marker);
-    expect(String((posted?.body as { body: string }).body)).toContain("steps to repro");
+    expect(String((posted?.body as { body: string })?.body)).toContain(marker);
+    expect(String((posted?.body as { body: string })?.body)).toContain("steps to repro");
     expect(output).toMatchObject({ number: 41, title: "Crash on save" });
   });
 

--- a/packages/integrations/src/jira/adapter.test.ts
+++ b/packages/integrations/src/jira/adapter.test.ts
@@ -326,7 +326,7 @@ describe("JiraAdapter effects", () => {
 
     const output = await dispatch(createIntent);
     const posted = http.calls.find((call) => call.method === "POST");
-    expect((posted?.body as { fields: { labels: string[] } }).fields.labels).toContain(label);
+    expect((posted?.body as { fields: { labels: string[] } })?.fields.labels).toContain(label);
     expect(output).toEqual({
       issueKey: "FARM-13",
       issueId: "10001",

--- a/packages/knowledge/test/security/authored-acl.test.ts
+++ b/packages/knowledge/test/security/authored-acl.test.ts
@@ -229,16 +229,16 @@ describe("authored Page authorization through retrieve()", () => {
     expectNoDisclosure(result, audit.events);
   });
 
-  it.each([
-    "revoked",
-    "deleted",
-  ] as const)("withholds a %s Page even where the ACL would allow it", async (status) => {
-    const { deps } = await harness([
-      openPage([entry("space", SPACE_OPEN, everyone, "grant")]),
-      boardPage([entry("space", SPACE_BOARD, everyone, "grant")], status),
-    ]);
-    expect(ids(await ask(deps, [alice, everyone]))).toEqual([PAGE_OPEN]);
-  });
+  it.each(["revoked", "deleted"] as const)(
+    "withholds a %s Page even where the ACL would allow it",
+    async (status) => {
+      const { deps } = await harness([
+        openPage([entry("space", SPACE_OPEN, everyone, "grant")]),
+        boardPage([entry("space", SPACE_BOARD, everyone, "grant")], status),
+      ]);
+      expect(ids(await ask(deps, [alice, everyone]))).toEqual([PAGE_OPEN]);
+    }
+  );
 });
 
 describe("group membership resolved at query time", () => {

--- a/packages/llm/src/cli/claude-code.test.ts
+++ b/packages/llm/src/cli/claude-code.test.ts
@@ -400,8 +400,8 @@ describe("ClaudeCodeModel — failure classification", () => {
     } catch (err) {
       error = err as LlmProviderError;
     }
-    expect((error?.cause as Error).message).toContain("claude setup-token");
-    expect((error?.cause as Error).message).toContain("Please run /login");
+    expect((error?.cause as Error)?.message).toContain("claude setup-token");
+    expect((error?.cause as Error)?.message).toContain("Please run /login");
   });
 
   it("raises a plain error for a non-auth failure so the fallback chain may retry", async () => {

--- a/packages/llm/src/cli/codex.test.ts
+++ b/packages/llm/src/cli/codex.test.ts
@@ -508,14 +508,12 @@ describe("isCodexAuthFailure", () => {
     expect(isCodexAuthFailure(text)).toBe(true);
   });
 
-  it.each([
-    "rate limit exceeded",
-    "upstream 503",
-    "context length exceeded",
-    "socket hang up",
-  ])("does not match %s", (text) => {
-    expect(isCodexAuthFailure(text)).toBe(false);
-  });
+  it.each(["rate limit exceeded", "upstream 503", "context length exceeded", "socket hang up"])(
+    "does not match %s",
+    (text) => {
+      expect(isCodexAuthFailure(text)).toBe(false);
+    }
+  );
 });
 
 describe("isCodexAuthError", () => {

--- a/packages/llm/src/cli/specs.test.ts
+++ b/packages/llm/src/cli/specs.test.ts
@@ -72,14 +72,12 @@ describe("isSubscriptionProvider", () => {
     expect(isSubscriptionProvider("codex")).toBe(true);
   });
 
-  it.each([
-    "anthropic",
-    "openai",
-    "azure",
-    "openai-compatible",
-  ])("does not treat %s as one", (provider) => {
-    expect(isSubscriptionProvider(provider)).toBe(false);
-  });
+  it.each(["anthropic", "openai", "azure", "openai-compatible"])(
+    "does not treat %s as one",
+    (provider) => {
+      expect(isSubscriptionProvider(provider)).toBe(false);
+    }
+  );
 
   it("stays in step with the spec table, so a new provider is unpriced by construction", () => {
     for (const provider of SUBSCRIPTION_PROVIDERS) {

--- a/packages/sandbox/src/backend.test.ts
+++ b/packages/sandbox/src/backend.test.ts
@@ -276,19 +276,19 @@ describe("SandboxProtocolExecutor", () => {
     expect(backend.execute).not.toHaveBeenCalled();
   });
 
-  it.each([
-    "local",
-    "ssh",
-  ] as const)("rejects signed %s backend attestations before dispatch", async (isolation) => {
-    const { backend, executor } = setup({
-      attestation: attestation({ isolation }),
-    });
+  it.each(["local", "ssh"] as const)(
+    "rejects signed %s backend attestations before dispatch",
+    async (isolation) => {
+      const { backend, executor } = setup({
+        attestation: attestation({ isolation }),
+      });
 
-    await expect(executor.execute(request())).rejects.toMatchObject({
-      code: "weak_backend_isolation",
-    });
-    expect(backend.execute).not.toHaveBeenCalled();
-  });
+      await expect(executor.execute(request())).rejects.toMatchObject({
+        code: "weak_backend_isolation",
+      });
+      expect(backend.execute).not.toHaveBeenCalled();
+    }
+  );
 
   it("rejects forged backend attestations and results", async () => {
     const forgedAttestation = setup({ attestationSignature: "forged" });

--- a/packages/sandbox/src/skill-execution.test.ts
+++ b/packages/sandbox/src/skill-execution.test.ts
@@ -179,20 +179,19 @@ describe("SkillExecutionCoordinator", () => {
     expect(outputPublisher.publish).toHaveBeenCalledOnce();
   });
 
-  it.each([
-    "../secret",
-    "/host/secret",
-    "assets/../../secret",
-  ])("rejects traversal path %s before resolving an Artifact", async (path) => {
-    const { assets, coordinator, sandbox } = setup();
+  it.each(["../secret", "/host/secret", "assets/../../secret"])(
+    "rejects traversal path %s before resolving an Artifact",
+    async (path) => {
+      const { assets, coordinator, sandbox } = setup();
 
-    await expectCode(
-      coordinator.execute(input({ requestedAssetPaths: [path] })),
-      "unsafe_asset_path"
-    );
-    expect(assets.resolve).not.toHaveBeenCalled();
-    expect(sandbox.execute).not.toHaveBeenCalled();
-  });
+      await expectCode(
+        coordinator.execute(input({ requestedAssetPaths: [path] })),
+        "unsafe_asset_path"
+      );
+      expect(assets.resolve).not.toHaveBeenCalled();
+      expect(sandbox.execute).not.toHaveBeenCalled();
+    }
+  );
 
   it("rejects undeclared assets and unmediated web destinations", async () => {
     const undeclared = setup();

--- a/packages/sandbox/test/security/skill-boundary.security.test.ts
+++ b/packages/sandbox/test/security/skill-boundary.security.test.ts
@@ -106,18 +106,17 @@ function setup(
 }
 
 describe("Skill sandbox threat boundary", () => {
-  it.each([
-    "file:///etc/passwd",
-    "/host/root",
-    "https://attacker.invalid/payload",
-  ])("rejects resolver escape Artifact reference %s", async (artifactRef) => {
-    const { coordinator, sandbox } = setup({ artifactRef });
+  it.each(["file:///etc/passwd", "/host/root", "https://attacker.invalid/payload"])(
+    "rejects resolver escape Artifact reference %s",
+    async (artifactRef) => {
+      const { coordinator, sandbox } = setup({ artifactRef });
 
-    await expect(coordinator.execute(execution())).rejects.toEqual(
-      new SkillExecutionError("unsafe_artifact_ref")
-    );
-    expect(sandbox.execute).not.toHaveBeenCalled();
-  });
+      await expect(coordinator.execute(execution())).rejects.toEqual(
+        new SkillExecutionError("unsafe_artifact_ref")
+      );
+      expect(sandbox.execute).not.toHaveBeenCalled();
+    }
+  );
 
   it("denies SSRF destinations before dispatch", async () => {
     const { coordinator, sandbox } = setup();

--- a/packages/schema/src/definitions/schema-snapshot.test.ts
+++ b/packages/schema/src/definitions/schema-snapshot.test.ts
@@ -26,10 +26,11 @@ describe("definition schema wire contract", () => {
     );
   });
 
-  it.each(
-    registrations.map((entry) => [entry.kind, entry] as const)
-  )("%s matches its locked schema", async (kind, registration) => {
-    const schema = `${JSON.stringify(sortDeep(registration.schema), null, 2)}\n`;
-    await expect(schema).toMatchFileSnapshot(`./__schemas__/${kind}.json`);
-  });
+  it.each(registrations.map((entry) => [entry.kind, entry] as const))(
+    "%s matches its locked schema",
+    async (kind, registration) => {
+      const schema = `${JSON.stringify(sortDeep(registration.schema), null, 2)}\n`;
+      await expect(schema).toMatchFileSnapshot(`./__schemas__/${kind}.json`);
+    }
+  );
 });

--- a/packages/soul/src/bundle.test.ts
+++ b/packages/soul/src/bundle.test.ts
@@ -92,9 +92,9 @@ describe("InMemoryBundleStore", () => {
 
     (document.spec as Record<string, unknown>).nested = { value: 2 };
 
-    expect((stored.bundle.definitions[0]?.document.spec as Record<string, unknown>).nested).toEqual(
-      { value: 1 }
-    );
+    expect(
+      (stored.bundle.definitions[0]?.document.spec as Record<string, unknown>)?.nested
+    ).toEqual({ value: 1 });
     expect(Object.isFrozen(stored.bundle.definitions[0]?.document.spec)).toBe(true);
   });
 

--- a/packages/soul/src/changeset.test.ts
+++ b/packages/soul/src/changeset.test.ts
@@ -52,38 +52,34 @@ function changeset(overrides: Partial<SoulChangeset> = {}): SoulChangeset {
 }
 
 describe("validateSoulChangeset", () => {
-  it.each<SoulChangesetSource>([
-    "ui",
-    "api",
-    "import",
-    "migration",
-    "agent",
-    "discovery",
-  ])("accepts a valid %s changeset through the same public validator", (source) => {
-    const result = validateSoulChangeset(changeset({ source }), baseCommit);
+  it.each<SoulChangesetSource>(["ui", "api", "import", "migration", "agent", "discovery"])(
+    "accepts a valid %s changeset through the same public validator",
+    (source) => {
+      const result = validateSoulChangeset(changeset({ source }), baseCommit);
 
-    expect(result).toMatchObject({
-      id: "changeset_01",
-      businessId: "business_01",
-      principalId: "user_01",
-      source,
-      expectedBaseCommit: baseCommit,
-      evidence: { outcome: "validated", fileCount: 2 },
-    });
-    expect(result.files).toEqual([
-      expect.objectContaining({
-        operation: "upsert",
-        path: "agents/general-assistant/agent.yaml",
-        kind: "Agent",
-      }),
-      expect.objectContaining({
-        operation: "upsert",
-        path: "agents/general-assistant/instructions.md",
-      }),
-    ]);
-    expect(result.files.every((file) => /^[a-f0-9]{64}$/.test(file.hash))).toBe(true);
-    expect(JSON.stringify(result)).not.toContain("Be helpful and precise");
-  });
+      expect(result).toMatchObject({
+        id: "changeset_01",
+        businessId: "business_01",
+        principalId: "user_01",
+        source,
+        expectedBaseCommit: baseCommit,
+        evidence: { outcome: "validated", fileCount: 2 },
+      });
+      expect(result.files).toEqual([
+        expect.objectContaining({
+          operation: "upsert",
+          path: "agents/general-assistant/agent.yaml",
+          kind: "Agent",
+        }),
+        expect.objectContaining({
+          operation: "upsert",
+          path: "agents/general-assistant/instructions.md",
+        }),
+      ]);
+      expect(result.files.every((file) => /^[a-f0-9]{64}$/.test(file.hash))).toBe(true);
+      expect(JSON.stringify(result)).not.toContain("Be helpful and precise");
+    }
+  );
 
   it("rejects the whole set when one file fails strict schema validation", () => {
     const invalid = { ...agent, spec: { ...agent.spec, authority: "superuser" } };

--- a/packages/soul/src/signatures.test.ts
+++ b/packages/soul/src/signatures.test.ts
@@ -80,7 +80,7 @@ describe("signExecutionBundle / verifyExecutionBundle", () => {
     (record.bundle.definitions[0].document.spec as Record<string, unknown>).instructions = "exfil";
 
     expect(
-      (runtime.get("Agent", "triage")?.document.spec as Record<string, unknown>).instructions
+      (runtime.get("Agent", "triage")?.document.spec as Record<string, unknown>)?.instructions
     ).toBe("be helpful");
   });
 

--- a/packages/surface/src/catalog.test.ts
+++ b/packages/surface/src/catalog.test.ts
@@ -40,7 +40,7 @@ describe("SHIPPED_SURFACE_COMPONENTS", () => {
           fields: { items: { properties: { input: { anyOf: { const: string }[] } } } };
         };
       }
-    ).properties.fields.items.properties.input.anyOf.map((literal) => literal.const);
+    )?.properties.fields.items.properties.input.anyOf.map((literal) => literal.const);
     expect(inputEnum).toEqual(expect.arrayContaining(["multiselect", "radio"]));
   });
 

--- a/packages/testkit/src/failure.test.ts
+++ b/packages/testkit/src/failure.test.ts
@@ -2,29 +2,29 @@ import { describe, expect, it } from "vitest";
 import { FailureInjector, InjectedFailure } from "./failure";
 
 describe("FailureInjector", () => {
-  it.each([
-    "before",
-    "after",
-  ] as const)("crashes %s a declared durable boundary without exposing payloads", async (phase) => {
-    const injector = new FailureInjector(["effect.persist"] as const);
-    injector.failAt("effect.persist", phase);
-    let operationCalls = 0;
+  it.each(["before", "after"] as const)(
+    "crashes %s a declared durable boundary without exposing payloads",
+    async (phase) => {
+      const injector = new FailureInjector(["effect.persist"] as const);
+      injector.failAt("effect.persist", phase);
+      let operationCalls = 0;
 
-    const operation = injector.runAround("effect.persist", async () => {
-      operationCalls += 1;
-      return { secret: "do-not-copy-to-error" };
-    });
+      const operation = injector.runAround("effect.persist", async () => {
+        operationCalls += 1;
+        return { secret: "do-not-copy-to-error" };
+      });
 
-    await expect(operation).rejects.toMatchObject({
-      name: "InjectedFailure",
-      code: "TESTKIT_INJECTED_FAILURE",
-      boundary: "effect.persist",
-      phase,
-      occurrence: 1,
-    });
-    await expect(operation).rejects.not.toThrow("do-not-copy-to-error");
-    expect(operationCalls).toBe(phase === "before" ? 0 : 1);
-  });
+      await expect(operation).rejects.toMatchObject({
+        name: "InjectedFailure",
+        code: "TESTKIT_INJECTED_FAILURE",
+        boundary: "effect.persist",
+        phase,
+        occurrence: 1,
+      });
+      await expect(operation).rejects.not.toThrow("do-not-copy-to-error");
+      expect(operationCalls).toBe(phase === "before" ? 0 : 1);
+    }
+  );
 
   it("can target a later occurrence for crash/retry tests", async () => {
     const injector = new FailureInjector(["outbox.commit"] as const);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ importers:
   .:
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.5.1
-        version: 2.5.1
+        specifier: ^2.5.9
+        version: 2.5.9
       '@commitlint/cli':
         specifier: ^21.1.0
         version: 21.1.0(@types/node@26.1.1)(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)(typescript@6.0.3)
@@ -84,11 +84,11 @@ importers:
         specifier: ^9.3.1
         version: 9.3.1
       lefthook:
-        specifier: ^2.1.9
-        version: 2.1.9
+        specifier: ^2.1.10
+        version: 2.1.10
       lint-staged:
-        specifier: ^17.0.8
-        version: 17.0.8
+        specifier: ^17.3.0
+        version: 17.3.0
       playwright:
         specifier: ^1.62.1
         version: 1.62.1
@@ -96,8 +96,8 @@ importers:
         specifier: ^7.7.4
         version: 7.8.5
       turbo:
-        specifier: ^2.10.0
-        version: 2.10.0
+        specifier: ^2.10.10
+        version: 2.10.10
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -1844,59 +1844,59 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@biomejs/biome@2.5.1':
-    resolution: {integrity: sha512-IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q==}
+  '@biomejs/biome@2.5.9':
+    resolution: {integrity: sha512-KkgCvdHB4IhtpHpF564plA9jo6fDOwWGQ/3jvreLzgOtRLEDoPqr7QO9qejNA8jKwDsSkAKr77hqBHnyUbIw4g==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.5.1':
-    resolution: {integrity: sha512-npqDzvqv7vFaWRiNN1Te71siRgPaqS9MpqgYCdP/CrUbkJ7ApezaeaKjueKHRN/JH/6lRjJQAHi8acQDCAz22w==}
+  '@biomejs/cli-darwin-arm64@2.5.9':
+    resolution: {integrity: sha512-am22pX2aBqznqq1eMyIj/bZ++riF3Lk6ct7cbv+gQK0csFhr+d8O0RkOi2FF2qSgFgANbqNkIZ0/PxlnW2pLFg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.5.1':
-    resolution: {integrity: sha512-RgwTqPAM8g2tn1j+b5oRjF/DbSBX8a4gwojtuG9XuhfK7GgomvZ9+T+tqjXiVbjLEeGJOoL6VEk8mvRTVeSybw==}
+  '@biomejs/cli-darwin-x64@2.5.9':
+    resolution: {integrity: sha512-l44KWDHLDvEnD0N/XcrVs7VXb3A18xL7QS3WB0eL93wbmk529ffIG55vleGCqaunpRUjLrdnjK05Qki1dsjylg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.5.1':
-    resolution: {integrity: sha512-WMcvMLgByyTqVxGlq918NBBYliq9FRR9GAQVETHb+VjGVqXCZFfHlZHC1FX4ibuYY/Hg6TJE3rHU0xVrdJXNRw==}
+  '@biomejs/cli-linux-arm64-musl@2.5.9':
+    resolution: {integrity: sha512-7ImVPwBLCtkmpR5esd8RHhTqW94f0JLJQum6AneYcy94jRm18TaPPm7slaigGzFhfgt3QiD1Vj52LKmBAnKizA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.5.1':
-    resolution: {integrity: sha512-yhV35CzZh38VyMvTEXi3JTjxZBs++oCKK9KG8vB6VI5+uvQvZNR3BFWEKKzuOmx9DJJj7sQpZ4LQJcmbGTs3+Q==}
+  '@biomejs/cli-linux-arm64@2.5.9':
+    resolution: {integrity: sha512-ICaK+IYaVZvKbBxX2rwrPT0DdUDMnE9Vm3nQGe+mltQPmUg19pONzkPWGdY4FCsoreDETWDynvdt4ysCbF5gNQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.5.1':
-    resolution: {integrity: sha512-ANTowtlLmPYm5yeMckWY8Xzb9Ix+JJP3tgHR/n6xRj1VWyIzzWtfRfih9hv9VmClwadpBvZduISZIbBsIlYG3A==}
+  '@biomejs/cli-linux-x64-musl@2.5.9':
+    resolution: {integrity: sha512-RXGaD0o1/pTTguYw1aeDJh9ad6Lfrui0fI7mBderTyGr7WuUJkBIttgLkR3XJyoxOkkgfBDspaUT8wXArTqLZw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.5.1':
-    resolution: {integrity: sha512-J/7uHSX7NfoYDI7HijAkd8lnQIOrRb2W7j3X+tw4R+N5ExvXGsyXFiGdQcfcxfOmNQmZVSQOCDk757fwpzqQcg==}
+  '@biomejs/cli-linux-x64@2.5.9':
+    resolution: {integrity: sha512-z22Q/zFYSvbIJfW1CbfZPu4X8PddS6Qd2ORbc6h+aT6EcwAxUF3m6fA4HjNvA3TU4X0dTJRwNPB165ES3PJXzg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.5.1':
-    resolution: {integrity: sha512-zgXnKNgWPC4iPF7Y1lR3STUeCUuZRpD6IiOrC7TZTlh0Lx6FiVUT05myuMQHQ9D+1cc7uyMldi4forE6lp0ivQ==}
+  '@biomejs/cli-win32-arm64@2.5.9':
+    resolution: {integrity: sha512-nHK+/HHC+D0ogAHUxomgoSTdjImb6fmNNVTKmf0tyu4eDL1DqPKIHc+i+UL8+b0RnAu8224qo8F2tCVnaT0A3w==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.5.1':
-    resolution: {integrity: sha512-6uxpR9hvaglANkZemeSiN/FhYgkGasrEGn267eXIWvjrjJ2LhDlk251IhjVJq6MXzkV2/bcXwLwSroLyPtqRZg==}
+  '@biomejs/cli-win32-x64@2.5.9':
+    resolution: {integrity: sha512-Yiq0H56LjXSSw/hd9YkXgSLQfzyDJzbzU2TezozxyNw+uKWAqOtqGVvBfzKRRDiaFF5avGAhHdWKx7LtDOShUw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -4235,33 +4235,33 @@ packages:
       '@tiptap/core': 3.27.1
       '@tiptap/pm': 3.27.1
 
-  '@turbo/darwin-64@2.10.0':
-    resolution: {integrity: sha512-EwvHThXzpY0KGd1/NAmuewI5D+aVa3Rl/OlxE36yfjUKb/+ySrfJrSlEFt8aD1OXwnnaHnQnPKHFndor0Zxlsg==}
+  '@turbo/darwin-64@2.10.10':
+    resolution: {integrity: sha512-gFDD+wRP5hWxBRghGyEbjpbLOY7aIU/wvsnKdMM7odQcp/wHMrnI83p0FyxxMRZnFH9ZD+S59MvcpOC5b+nrCA==}
     cpu: [x64]
     os: [darwin]
 
-  '@turbo/darwin-arm64@2.10.0':
-    resolution: {integrity: sha512-9d2fTyyG0lf5Wq1bwJA9qUaeecViMkLcdctWaMMmCkxZ/JqypmqOwK3W6vmejeKVgkr06gSoiX8bD+xN5Jpxcg==}
+  '@turbo/darwin-arm64@2.10.10':
+    resolution: {integrity: sha512-VZYsxZ6yjyDosUqtiroAVSXPLmx/qBxdHJgIxdMH9RyNmLdOLOWtJnYMnI4qckwCgQMK85G3fu94/xk5+iBCgw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@turbo/linux-64@2.10.0':
-    resolution: {integrity: sha512-sZBtjMuufitanjzi6UssoUpJMnnPlLMcdcJj3m3ptNsSq31Xh7MnjhwA5nWvLDTfEFg8GPcbYFXMo8vSdKRfqQ==}
+  '@turbo/linux-64@2.10.10':
+    resolution: {integrity: sha512-lAvW+yEnmsCKMEIwNugjozawvYytHKPhU0kfLBizu83MIs8OUb9KobYvkZ56L5akSM6K7+gBFLEIfQkaceh90g==}
     cpu: [x64]
-    os: [linux]
+    os: [android, linux]
 
-  '@turbo/linux-arm64@2.10.0':
-    resolution: {integrity: sha512-vkq/Z8R+1DQ+kifWFa810IjRy2NNBVvha3cg9sWA3nFh6nnGrHSMnnJKrzH7c/No9kq4Jb55Ru44YKsCSBgrKg==}
+  '@turbo/linux-arm64@2.10.10':
+    resolution: {integrity: sha512-MSJ+NkRTd79Z9+YEZpUV9VOWVOOigFhE+v/ETNYJEuTJp3r00y9YgFvDXrmM+DP8Kal6tk3U6xSugD2/Ojh+Jg==}
     cpu: [arm64]
-    os: [linux]
+    os: [android, linux]
 
-  '@turbo/windows-64@2.10.0':
-    resolution: {integrity: sha512-CRUEguLWxFQHptYZS7HjPhNhAFawfea07iR+xAQ5e4klgLrPCMdexBkXwSCwOxqTFknJ7RZFN3gOaADsw+Gttg==}
+  '@turbo/windows-64@2.10.10':
+    resolution: {integrity: sha512-ycWpXDkUfnDFDY9d+4Qna/UZotDB0wj+s9agrlmNt0Q7a3XHORhK8GPKJdzgzeutXu9EW5P/jyabTEHlohuDXw==}
     cpu: [x64]
     os: [win32]
 
-  '@turbo/windows-arm64@2.10.0':
-    resolution: {integrity: sha512-dVHGaf9F8twzgibcBqKoADT/LLqf9++jDb+hq/LPWWaOmRpp4M+/pVOm7vy4z9D++xg8eaxWLT0+wQxFwhYu9A==}
+  '@turbo/windows-arm64@2.10.10':
+    resolution: {integrity: sha512-PMk6zQN0csUFklLe+1hz/5G9uU1YmV0cEIey2R/bSeA6o69qcBTlN4A3jOqkgenOO5dOpMHmq2sEUZo8r1+Ssg==}
     cpu: [arm64]
     os: [win32]
 
@@ -4524,10 +4524,6 @@ packages:
   ansi-align@3.0.1:
     resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
 
-  ansi-escapes@7.3.0:
-    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
-    engines: {node: '>=18'}
-
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -4782,17 +4778,9 @@ packages:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
     engines: {node: '>=8'}
 
-  cli-cursor@5.0.0:
-    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
-    engines: {node: '>=18'}
-
   cli-spinners@2.9.2:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
-
-  cli-truncate@5.2.0:
-    resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
-    engines: {node: '>=20'}
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
@@ -5180,10 +5168,6 @@ packages:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
 
-  environment@1.1.0:
-    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
-    engines: {node: '>=18'}
-
   err-code@2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
 
@@ -5302,9 +5286,6 @@ packages:
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
-
-  eventemitter3@5.0.4:
-    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
@@ -5873,10 +5854,6 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
-  is-fullwidth-code-point@5.1.0:
-    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
-    engines: {node: '>=18'}
-
   is-generator-function@1.1.2:
     resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
     engines: {node: '>= 0.4'}
@@ -6051,58 +6028,58 @@ packages:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
 
-  lefthook-darwin-arm64@2.1.9:
-    resolution: {integrity: sha512-119HryNcvr4nqn0wUIrNPgpMEPn9yMQzEcW/lezRsnb56PCJriJB92+MCySPVcWDxJnZef7o0T3jdnPNiSH7Qg==}
+  lefthook-darwin-arm64@2.1.10:
+    resolution: {integrity: sha512-nw+X8wRNDoUUV6WSteyKBbcLySq+fsmZt5WV/s50ZJpysmsDKJOUMln6SllNfP+60dzUahAO7REco/2633BsLg==}
     cpu: [arm64]
     os: [darwin]
 
-  lefthook-darwin-x64@2.1.9:
-    resolution: {integrity: sha512-dwo5Tke2XcQCM56DGHgFKBfRbJIL6xs2wZ0zG1TUVZgl4t4mQUt6LiZ4V/ZQfYHTZF9qywvXoIlR5N35qOaiVQ==}
+  lefthook-darwin-x64@2.1.10:
+    resolution: {integrity: sha512-KQ/bHmvpkFdHMn4pZnUdTf+GuSC+aBBgBTxZT4GW+6cSf+qbErKZBhK7cH6BmILsvx43+VzEArvHYY7YOfRFOQ==}
     cpu: [x64]
     os: [darwin]
 
-  lefthook-freebsd-arm64@2.1.9:
-    resolution: {integrity: sha512-+09PVap6nl6xsaHch5JLtq7WvIR++U1Q2MzA2ai0M4uB/VP3AqrvKqHw6+9hjyKnIH+HHL83uqi77EAY+LaxLA==}
+  lefthook-freebsd-arm64@2.1.10:
+    resolution: {integrity: sha512-8su6DwydP7+pv7kG0zCtjphqsw4ouOnfexRUErapy5GTxYBoUOhYz3RSHTSWNRsK6W4jva7FPUh2Lp5/PSn30w==}
     cpu: [arm64]
     os: [freebsd]
 
-  lefthook-freebsd-x64@2.1.9:
-    resolution: {integrity: sha512-8XresjKIYpkE9ARgCtBEZgJZxAU3T4MIqzj4zNy15XRT59I1Us+QdqXTNm+pkZ41Yd2X/nxs2Pkvbq3NWWlIGw==}
+  lefthook-freebsd-x64@2.1.10:
+    resolution: {integrity: sha512-GeAJEFxko3Lk+AsnS3NleAFrpyMLFUKOlgJvPKuU0xHwVEI/z+ZoCcmuO0BX+4CS0NLbZhC/YQAvBASqDvvVdQ==}
     cpu: [x64]
     os: [freebsd]
 
-  lefthook-linux-arm64@2.1.9:
-    resolution: {integrity: sha512-1oNIQfwrPe6rgU2KcDM3aF6+hpZDCKx1TmawQKpXUY5gVsbZ7MqX0Sk/1lnnWxqPm+kQQ5f6J2dpFWd+4xH8jg==}
+  lefthook-linux-arm64@2.1.10:
+    resolution: {integrity: sha512-1sHTCmpTWjVMs+yKPBLRNT1kuuIr1yjietlk7rCB6wFPVOS6Ph3o2zPFH2AvW1UymHlqwyHXzBr9EtDpQ7j1mQ==}
     cpu: [arm64]
     os: [linux]
 
-  lefthook-linux-x64@2.1.9:
-    resolution: {integrity: sha512-fT+7Q+BJyGp+CslFQkNXmdFRgyVXsPHPi9NAsDX0a6QOyNnoORByAsvx6zeAKuF5rL3BBgNfho1/v2RuGxGy9w==}
+  lefthook-linux-x64@2.1.10:
+    resolution: {integrity: sha512-z/VlRB3bh6mBvW3r1rwnJ5vP8z+Krx5gJzkZ4veDXh+6FlRTx8wtd3g3fllOv/yZMxkgmL3fQoFXv05Esa7vBQ==}
     cpu: [x64]
     os: [linux]
 
-  lefthook-openbsd-arm64@2.1.9:
-    resolution: {integrity: sha512-4bVuafBk3dddVNo0+3hMbjcJs4mqYAstxpPMmX2ufkudSTYFNIhWoqwuGVQV/SS/xdcOKJAldW4qayAzed2ysw==}
+  lefthook-openbsd-arm64@2.1.10:
+    resolution: {integrity: sha512-430zL8sSIKw5P0YXGG6PB+eAhHa06n0PXuaERaAQE4Ss3odfqwnl5Mq9hQmkEnOS1EGiQEKkd0UHv/i4PtMNIQ==}
     cpu: [arm64]
     os: [openbsd]
 
-  lefthook-openbsd-x64@2.1.9:
-    resolution: {integrity: sha512-PmPoMmLP/wQQWcQ9u2YH86bTZ3UCfBsxuEmVTEyPU2U8R1qSTp5r/Gs3G8cN5Mxo91XB9oBERtF1n+xD3W6aVA==}
+  lefthook-openbsd-x64@2.1.10:
+    resolution: {integrity: sha512-bgkO8PphGZVDhQgCJ524aYYPI5491pVmCiLPGjBIo1AvOSlIyw4N1Y+1C3QfqwEmechzw+Aq16SNc8pqv6UuXg==}
     cpu: [x64]
     os: [openbsd]
 
-  lefthook-windows-arm64@2.1.9:
-    resolution: {integrity: sha512-KphfkBKmwBnmolyrdhIl3lrBaOyTcCgXBT2AB/9OHnEXhOLvv5uTCUkrD4YRAxXPtFKq6UvnapIeoL3GZq0bdA==}
+  lefthook-windows-arm64@2.1.10:
+    resolution: {integrity: sha512-5Q6etF0Fla2DDA4ilDySrdNgiR5+W7cJZwnZ69Je3kvWCaWm4wnkuc8FEdjp3kiL2x3ZXipdI00f5vpO8aWmog==}
     cpu: [arm64]
     os: [win32]
 
-  lefthook-windows-x64@2.1.9:
-    resolution: {integrity: sha512-2qlUtkJHZ3MyUxgV5XTEmcrIoNZA07iwaquoswAcqv/1MeBFXlD+O+koFRfrzWng2O5WYEbpJnd8tvaYnV8fTA==}
+  lefthook-windows-x64@2.1.10:
+    resolution: {integrity: sha512-c/XH8YZtylG4XaxzqFfXluvq2LXq2W/p54Bnzn3+Z7E5X2Fk3JlFJAibulMbIt2+w8T7UI/r97ok5GqE4kGaeA==}
     cpu: [x64]
     os: [win32]
 
-  lefthook@2.1.9:
-    resolution: {integrity: sha512-bwDaIOViTktE8kJLf9jP0p+H2/RDTlFFlc43Am2YgUsX22hI6Sq4RbzsrecwzY5y+MHTipOH7WsmWSEniePHWQ==}
+  lefthook@2.1.10:
+    resolution: {integrity: sha512-K7mM4WoqMwqfXYK11EHy+lSH1uW8XHni3Yn/bSqyerPkUPygGdf3xn18JoV5HyA06xuQL3ofGAOjG01QX9oJ4w==}
     hasBin: true
 
   leven@4.1.0:
@@ -6196,14 +6173,10 @@ packages:
   linkifyjs@4.3.3:
     resolution: {integrity: sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==}
 
-  lint-staged@17.0.8:
-    resolution: {integrity: sha512-B2P/d+jVW0UXOQ0MVMLrB/9ydA1P+zz6jYfdrbbEd9ur3S2rcbduFWKiUCC02Sm5hbC8nrm7y24WuYMG54HfxA==}
+  lint-staged@17.3.0:
+    resolution: {integrity: sha512-woZS3vNe3UKqBaLPvbLOtKRY4tLANpWQhom12MGWqC8Mh1lCOO+WgSwmX2amjJAqTY9BkXYW87fCUH5H9Ph6xw==}
     engines: {node: '>=22.22.1'}
     hasBin: true
-
-  listr2@10.2.1:
-    resolution: {integrity: sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q==}
-    engines: {node: '>=22.13.0'}
 
   loader-utils@3.3.1:
     resolution: {integrity: sha512-FMJTLMXfCLMLfJxcX9PFqX5qD88Z5MRGaZCVzfuqeZSPsyiBzs+pahDQjbIWz2QIzPZz0NX9Zy4FX3lmK6YHIg==}
@@ -6229,10 +6202,6 @@ packages:
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
-
-  log-update@6.1.0:
-    resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
-    engines: {node: '>=18'}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -6637,10 +6606,6 @@ packages:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
 
-  mimic-function@5.0.1:
-    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
-    engines: {node: '>=18'}
-
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -6878,10 +6843,6 @@ packages:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
 
-  onetime@7.0.0:
-    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
-    engines: {node: '>=18'}
-
   oniguruma-parser@0.12.2:
     resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
 
@@ -7032,6 +6993,10 @@ packages:
 
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
   pidtree@0.6.1:
@@ -7491,10 +7456,6 @@ packages:
     resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
     engines: {node: '>=8'}
 
-  restore-cursor@5.1.0:
-    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
-    engines: {node: '>=18'}
-
   ret@0.5.0:
     resolution: {integrity: sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==}
     engines: {node: '>=10'}
@@ -7666,14 +7627,6 @@ packages:
     resolution: {integrity: sha512-sQPR5AtK/ijRjou7zw7mlLp08oB6FH7i0lOy5XJ2zp9mJs/yejgiOn7KvQoe2q4YJIx6VmgUSW5AOefebPt5kg==}
     engines: {node: '>=0.12.18'}
 
-  slice-ansi@7.1.2:
-    resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
-    engines: {node: '>=18'}
-
-  slice-ansi@8.0.0:
-    resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
-    engines: {node: '>=20'}
-
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
 
@@ -7752,10 +7705,6 @@ packages:
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
-
-  string-width@8.2.1:
-    resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
-    engines: {node: '>=20'}
 
   string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
@@ -7920,8 +7869,8 @@ packages:
   turbo-stream@3.2.0:
     resolution: {integrity: sha512-EK+bZ9UVrVh7JLslVFOV0GEMsociOqVOvEMTAd4ixMyffN5YNIEdLZWXUx5PJqDbTxSIBWw04HS9gCY4frYQDQ==}
 
-  turbo@2.10.0:
-    resolution: {integrity: sha512-o016H9PPtuH2deb3mh3Vci3Avfi9UYgM/RONQisY7HnloupP0IFSbFS3gFYJgFJP8nwBrByHWFQIDa8T2zIXPw==}
+  turbo@2.10.10:
+    resolution: {integrity: sha512-/90KTW+USzvYOPmafRZHVKLBsHXQ5810Ao/HdtJYAqguIhZ+XruS6eIUjqJUDtrSxaZYynNFht68qckGKAOWTA==}
     hasBin: true
 
   tw-animate-css@1.4.0:
@@ -8312,10 +8261,6 @@ packages:
 
   wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
-
-  wrap-ansi@10.0.0:
-    resolution: {integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==}
-    engines: {node: '>=20'}
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -8730,39 +8675,39 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@biomejs/biome@2.5.1':
+  '@biomejs/biome@2.5.9':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.5.1
-      '@biomejs/cli-darwin-x64': 2.5.1
-      '@biomejs/cli-linux-arm64': 2.5.1
-      '@biomejs/cli-linux-arm64-musl': 2.5.1
-      '@biomejs/cli-linux-x64': 2.5.1
-      '@biomejs/cli-linux-x64-musl': 2.5.1
-      '@biomejs/cli-win32-arm64': 2.5.1
-      '@biomejs/cli-win32-x64': 2.5.1
+      '@biomejs/cli-darwin-arm64': 2.5.9
+      '@biomejs/cli-darwin-x64': 2.5.9
+      '@biomejs/cli-linux-arm64': 2.5.9
+      '@biomejs/cli-linux-arm64-musl': 2.5.9
+      '@biomejs/cli-linux-x64': 2.5.9
+      '@biomejs/cli-linux-x64-musl': 2.5.9
+      '@biomejs/cli-win32-arm64': 2.5.9
+      '@biomejs/cli-win32-x64': 2.5.9
 
-  '@biomejs/cli-darwin-arm64@2.5.1':
+  '@biomejs/cli-darwin-arm64@2.5.9':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.5.1':
+  '@biomejs/cli-darwin-x64@2.5.9':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.5.1':
+  '@biomejs/cli-linux-arm64-musl@2.5.9':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.5.1':
+  '@biomejs/cli-linux-arm64@2.5.9':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.5.1':
+  '@biomejs/cli-linux-x64-musl@2.5.9':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.5.1':
+  '@biomejs/cli-linux-x64@2.5.9':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.5.1':
+  '@biomejs/cli-win32-arm64@2.5.9':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.5.1':
+  '@biomejs/cli-win32-x64@2.5.9':
     optional: true
 
   '@bramus/specificity@2.4.2':
@@ -10847,22 +10792,22 @@ snapshots:
       '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
       '@tiptap/pm': 3.27.1
 
-  '@turbo/darwin-64@2.10.0':
+  '@turbo/darwin-64@2.10.10':
     optional: true
 
-  '@turbo/darwin-arm64@2.10.0':
+  '@turbo/darwin-arm64@2.10.10':
     optional: true
 
-  '@turbo/linux-64@2.10.0':
+  '@turbo/linux-64@2.10.10':
     optional: true
 
-  '@turbo/linux-arm64@2.10.0':
+  '@turbo/linux-arm64@2.10.10':
     optional: true
 
-  '@turbo/windows-64@2.10.0':
+  '@turbo/windows-64@2.10.10':
     optional: true
 
-  '@turbo/windows-arm64@2.10.0':
+  '@turbo/windows-arm64@2.10.10':
     optional: true
 
   '@tybys/wasm-util@0.10.2':
@@ -11191,10 +11136,6 @@ snapshots:
     dependencies:
       string-width: 4.2.3
 
-  ansi-escapes@7.3.0:
-    dependencies:
-      environment: 1.1.0
-
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.2.2: {}
@@ -11467,16 +11408,7 @@ snapshots:
     dependencies:
       restore-cursor: 3.1.0
 
-  cli-cursor@5.0.0:
-    dependencies:
-      restore-cursor: 5.1.0
-
   cli-spinners@2.9.2: {}
-
-  cli-truncate@5.2.0:
-    dependencies:
-      slice-ansi: 8.0.0
-      string-width: 8.2.1
 
   client-only@0.0.1: {}
 
@@ -11818,8 +11750,6 @@ snapshots:
 
   env-paths@2.2.1: {}
 
-  environment@1.1.0: {}
-
   err-code@2.0.3: {}
 
   error-ex@1.3.4:
@@ -12021,8 +11951,6 @@ snapshots:
       require-like: 0.1.2
 
   event-target-shim@5.0.1: {}
-
-  eventemitter3@5.0.4: {}
 
   events@3.3.0: {}
 
@@ -12725,10 +12653,6 @@ snapshots:
 
   is-fullwidth-code-point@3.0.0: {}
 
-  is-fullwidth-code-point@5.1.0:
-    dependencies:
-      get-east-asian-width: 1.6.0
-
   is-generator-function@1.1.2:
     dependencies:
       call-bound: 1.0.4
@@ -12894,48 +12818,48 @@ snapshots:
 
   kleur@4.1.5: {}
 
-  lefthook-darwin-arm64@2.1.9:
+  lefthook-darwin-arm64@2.1.10:
     optional: true
 
-  lefthook-darwin-x64@2.1.9:
+  lefthook-darwin-x64@2.1.10:
     optional: true
 
-  lefthook-freebsd-arm64@2.1.9:
+  lefthook-freebsd-arm64@2.1.10:
     optional: true
 
-  lefthook-freebsd-x64@2.1.9:
+  lefthook-freebsd-x64@2.1.10:
     optional: true
 
-  lefthook-linux-arm64@2.1.9:
+  lefthook-linux-arm64@2.1.10:
     optional: true
 
-  lefthook-linux-x64@2.1.9:
+  lefthook-linux-x64@2.1.10:
     optional: true
 
-  lefthook-openbsd-arm64@2.1.9:
+  lefthook-openbsd-arm64@2.1.10:
     optional: true
 
-  lefthook-openbsd-x64@2.1.9:
+  lefthook-openbsd-x64@2.1.10:
     optional: true
 
-  lefthook-windows-arm64@2.1.9:
+  lefthook-windows-arm64@2.1.10:
     optional: true
 
-  lefthook-windows-x64@2.1.9:
+  lefthook-windows-x64@2.1.10:
     optional: true
 
-  lefthook@2.1.9:
+  lefthook@2.1.10:
     optionalDependencies:
-      lefthook-darwin-arm64: 2.1.9
-      lefthook-darwin-x64: 2.1.9
-      lefthook-freebsd-arm64: 2.1.9
-      lefthook-freebsd-x64: 2.1.9
-      lefthook-linux-arm64: 2.1.9
-      lefthook-linux-x64: 2.1.9
-      lefthook-openbsd-arm64: 2.1.9
-      lefthook-openbsd-x64: 2.1.9
-      lefthook-windows-arm64: 2.1.9
-      lefthook-windows-x64: 2.1.9
+      lefthook-darwin-arm64: 2.1.10
+      lefthook-darwin-x64: 2.1.10
+      lefthook-freebsd-arm64: 2.1.10
+      lefthook-freebsd-x64: 2.1.10
+      lefthook-linux-arm64: 2.1.10
+      lefthook-linux-x64: 2.1.10
+      lefthook-openbsd-arm64: 2.1.10
+      lefthook-openbsd-x64: 2.1.10
+      lefthook-windows-arm64: 2.1.10
+      lefthook-windows-x64: 2.1.10
 
   leven@4.1.0: {}
 
@@ -13000,22 +12924,13 @@ snapshots:
 
   linkifyjs@4.3.3: {}
 
-  lint-staged@17.0.8:
+  lint-staged@17.3.0:
     dependencies:
-      listr2: 10.2.1
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       string-argv: 0.3.2
       tinyexec: 1.2.4
     optionalDependencies:
       yaml: 2.9.0
-
-  listr2@10.2.1:
-    dependencies:
-      cli-truncate: 5.2.0
-      eventemitter3: 5.0.4
-      log-update: 6.1.0
-      rfdc: 1.4.1
-      wrap-ansi: 10.0.0
 
   loader-utils@3.3.1: {}
 
@@ -13039,14 +12954,6 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
-
-  log-update@6.1.0:
-    dependencies:
-      ansi-escapes: 7.3.0
-      cli-cursor: 5.0.0
-      slice-ansi: 7.1.2
-      strip-ansi: 7.2.0
-      wrap-ansi: 9.0.2
 
   longest-streak@3.1.0: {}
 
@@ -13883,8 +13790,6 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
-  mimic-function@5.0.1: {}
-
   min-indent@1.0.1: {}
 
   minimatch@10.2.5:
@@ -14087,10 +13992,6 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
-  onetime@7.0.0:
-    dependencies:
-      mimic-function: 5.0.1
-
   oniguruma-parser@0.12.2: {}
 
   oniguruma-to-es@4.3.6:
@@ -14252,6 +14153,8 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  picomatch@4.0.5: {}
 
   pidtree@0.6.1: {}
 
@@ -14820,11 +14723,6 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
 
-  restore-cursor@5.1.0:
-    dependencies:
-      onetime: 7.0.0
-      signal-exit: 4.1.0
-
   ret@0.5.0: {}
 
   retry@0.12.0: {}
@@ -15128,16 +15026,6 @@ snapshots:
 
   simple-icons@16.28.0: {}
 
-  slice-ansi@7.1.2:
-    dependencies:
-      ansi-styles: 6.2.3
-      is-fullwidth-code-point: 5.1.0
-
-  slice-ansi@8.0.0:
-    dependencies:
-      ansi-styles: 6.2.3
-      is-fullwidth-code-point: 5.1.0
-
   sonic-boom@4.2.1:
     dependencies:
       atomic-sleep: 1.0.0
@@ -15209,11 +15097,6 @@ snapshots:
   string-width@7.2.0:
     dependencies:
       emoji-regex: 10.6.0
-      get-east-asian-width: 1.6.0
-      strip-ansi: 7.2.0
-
-  string-width@8.2.1:
-    dependencies:
       get-east-asian-width: 1.6.0
       strip-ansi: 7.2.0
 
@@ -15370,14 +15253,14 @@ snapshots:
 
   turbo-stream@3.2.0: {}
 
-  turbo@2.10.0:
+  turbo@2.10.10:
     optionalDependencies:
-      '@turbo/darwin-64': 2.10.0
-      '@turbo/darwin-arm64': 2.10.0
-      '@turbo/linux-64': 2.10.0
-      '@turbo/linux-arm64': 2.10.0
-      '@turbo/windows-64': 2.10.0
-      '@turbo/windows-arm64': 2.10.0
+      '@turbo/darwin-64': 2.10.10
+      '@turbo/darwin-arm64': 2.10.10
+      '@turbo/linux-64': 2.10.10
+      '@turbo/linux-arm64': 2.10.10
+      '@turbo/windows-64': 2.10.10
+      '@turbo/windows-arm64': 2.10.10
 
   tw-animate-css@1.4.0: {}
 
@@ -15808,12 +15691,6 @@ snapshots:
       string-width: 5.1.2
 
   wordwrap@1.0.0: {}
-
-  wrap-ansi@10.0.0:
-    dependencies:
-      ansi-styles: 6.2.3
-      string-width: 8.2.1
-      strip-ansi: 7.2.0
 
   wrap-ansi@7.0.0:
     dependencies:

--- a/scripts/request-release.test.ts
+++ b/scripts/request-release.test.ts
@@ -2,28 +2,20 @@ import { describe, expect, it } from "vitest";
 import { formatDispatchError, isReleaseVersion, parseReleaseVersion } from "./request-release";
 
 describe("release request", () => {
-  it.each([
-    "0.5.0",
-    "1.0.0",
-    "0.5.0-alpha.0",
-    "12.34.56-rc.1",
-  ])("accepts a release version: %s", (version) => {
-    expect(isReleaseVersion(version)).toBe(true);
-    expect(parseReleaseVersion([version])).toBe(version);
-  });
+  it.each(["0.5.0", "1.0.0", "0.5.0-alpha.0", "12.34.56-rc.1"])(
+    "accepts a release version: %s",
+    (version) => {
+      expect(isReleaseVersion(version)).toBe(true);
+      expect(parseReleaseVersion([version])).toBe(version);
+    }
+  );
 
-  it.each([
-    "",
-    "v0.5.0",
-    "0.5",
-    "01.5.0",
-    "0.5.0-",
-    "0.5.0-01",
-    "0.5.0+build.1",
-    "minor",
-  ])("rejects an invalid or ambiguous version: %s", (version) => {
-    expect(isReleaseVersion(version)).toBe(false);
-  });
+  it.each(["", "v0.5.0", "0.5", "01.5.0", "0.5.0-", "0.5.0-01", "0.5.0+build.1", "minor"])(
+    "rejects an invalid or ambiguous version: %s",
+    (version) => {
+      expect(isReleaseVersion(version)).toBe(false);
+    }
+  );
 
   it("requires exactly one version argument", () => {
     expect(() => parseReleaseVersion([])).toThrow("Usage: pnpm release <version>");


### PR DESCRIPTION
Keeps the lint and repo-tooling group on the latest patch line. Biome 2.5.9 changes two things a reviewer must look at:

- Its formatter now collapses short array arguments onto the call line, so 20 test files are reformatted. That churn is mechanical and behaviour-neutral; typecheck and the affected suites are green.
- correctness/noUnsafeOptionalChaining now flags `(a?.b as T).c`, which throws a TypeError when `a` is undefined instead of short-circuiting. 21 such sites across 11 test files now short-circuit through the assertion with `(a?.b as T)?.c`. No suppressions were added.

`biome migrate` renamed `linter.rules.recommended` to `linter.rules.preset`; the enabled rule set is unchanged. The pinned `$schema` URL and the stale version in AGENTS.md follow the bump.

turbo lands on 2.10.10 rather than 2.10.11: 2.10.11 was published inside the repo's minimumReleaseAge window and fails the lockfile supply-chain check.

## Summary

<!-- What changed, and why. Link the driving issue if one exists. -->

## Test plan

<!-- Commands you ran, or manual steps / screenshots for UI changes. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (or the scoped `--filter` you actually ran)

## Checklist

- [ ] PR title follows Conventional Commits (`type(scope): subject`) — CI checks this
- [ ] Scoped to one logical change
- [ ] Tests added/updated for the behavior that changed
