### PR TITLE
fix(deps): restore the undici 7.29.0 lockfile entry

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7905,6 +7905,10 @@ packages:
     resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
     engines: {node: '>=18.17'}
 
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
+    engines: {node: '>=20.18.1'}
+
   undici@8.10.0:
     resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
     engines: {node: '>=22.19.0'}
@@ -15284,6 +15288,8 @@ snapshots:
   undici-types@8.3.0: {}
 
   undici@6.28.0: {}
+
+  undici@7.29.0: {}
 
   undici@8.10.0: {}
 


### PR DESCRIPTION
The ai sdk upgrade (#479) brought in @ai-sdk/provider-utils@5.0.27, which depends on undici 7.29.0, and the vitest upgrade (#477) regenerated the lockfile without that resolution. Each was green on its own branch; merged together they left a snapshot referencing undici@7.29.0 with no matching entry in the packages section, so `pnpm install --frozen-lockfile` failed and every job on main went red, including the Docker builds that gate the container checks.

Regenerated with a full `pnpm install` rather than `--fix-lockfile`, which cannot see registry metadata under `--lockfile-only` and would have stripped unrelated hasBin markers and peer resolutions.

## Summary

<!-- What changed, and why. Link the driving issue if one exists. -->

## Test plan

<!-- Commands you ran, or manual steps / screenshots for UI changes. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (or the scoped `--filter` you actually ran)

## Checklist

- [ ] PR title follows Conventional Commits (`type(scope): subject`) — CI checks this
- [ ] Scoped to one logical change
- [ ] Tests added/updated for the behavior that changed
