### PR TITLE
fix(chat): never end a Turn without announcing it

### DIFF
--- a/apps/api/src/chat/routes.ts
+++ b/apps/api/src/chat/routes.ts
@@ -15,7 +15,7 @@ import {
 } from "../runs/events";
 import { isConversationEntryError, resolveConversationEntry } from "./conversation-entry";
 import type { ConversationRepo } from "./conversations";
-import { writeSseHeaders } from "./sse";
+import { SSE_KEEPALIVE_MS, writeSseHeaders } from "./sse";
 import { type ChatBody, ChatBodySchema, corsPassthrough } from "./turn-helpers";
 import { durableTurnSubmitter } from "./turn-submit";
 
@@ -189,6 +189,7 @@ export function registerChatRoutes(
           authorize: () => stream.authorize(req, runId),
           sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
           ...(stream.pollIntervalMs === undefined ? {} : { pollIntervalMs: stream.pollIntervalMs }),
+          keepaliveMs: SSE_KEEPALIVE_MS,
           ...(stream.pageSize === undefined ? {} : { pageSize: stream.pageSize }),
         },
         { runId, after: 0 }

--- a/apps/api/src/chat/sse.test.ts
+++ b/apps/api/src/chat/sse.test.ts
@@ -18,8 +18,18 @@ describe("formatSseEvent", () => {
 describe("writeSseHeaders", () => {
   it("sets the event-stream headers plus any extras", () => {
     const setHeader = vi.fn();
-    writeSseHeaders({ setHeader } as unknown as ServerResponse, { "X-Stream-Id": "abc" });
+    writeSseHeaders({ setHeader, flushHeaders: vi.fn() } as unknown as ServerResponse, {
+      "X-Stream-Id": "abc",
+    });
     expect(setHeader).toHaveBeenCalledWith("Content-Type", "text/event-stream");
     expect(setHeader).toHaveBeenCalledWith("X-Stream-Id", "abc");
+  });
+
+  it("flushes the headers so the origin has answered before the first event", () => {
+    // Headers set on the raw reply are not sent until something is written, and the first Run event
+    // can be many seconds away. An edge proxy sees a silent origin and answers the client 524.
+    const flushHeaders = vi.fn();
+    writeSseHeaders({ setHeader: vi.fn(), flushHeaders } as unknown as ServerResponse);
+    expect(flushHeaders).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/api/src/chat/sse.ts
+++ b/apps/api/src/chat/sse.ts
@@ -7,6 +7,12 @@ export interface StreamEvent {
   data: unknown;
 }
 
+/**
+ * How often an idle SSE stream writes a comment. Comfortably inside the 100s an edge proxy waits
+ * for the origin before answering the client 524 on its behalf.
+ */
+export const SSE_KEEPALIVE_MS = 15_000;
+
 /** SSE response headers for a hijacked raw reply. */
 export function writeSseHeaders(raw: ServerResponse, extra?: Record<string, string>): void {
   raw.setHeader("Content-Type", "text/event-stream");
@@ -18,6 +24,9 @@ export function writeSseHeaders(raw: ServerResponse, extra?: Record<string, stri
       raw.setHeader(key, value);
     }
   }
+  // The first Run event can be seconds away; without this the origin has sent nothing at all and
+  // an edge proxy is entitled to call the request timed out.
+  raw.flushHeaders();
 }
 
 /** Serializes SSE with `id:` for resume and one `data:` line per physical payload line. */

--- a/apps/api/src/runs/events.test.ts
+++ b/apps/api/src/runs/events.test.ts
@@ -246,4 +246,83 @@ describe("streamRunEvents", () => {
     expect(sink.chunks).toEqual([]);
     expect(sink.ended).toBe(true);
   });
+
+  it("closes the stream when the Run parks for reconciliation", async () => {
+    // `needs_reconciliation` is where a Chat Run lands when its executor throws. Nothing further
+    // streams for that attempt, so a reader that keeps polling waits forever — the composer stays
+    // busy and the next prompt cannot be sent. Close it and name the status instead.
+    const sink = new RecordingSink();
+    let polls = 0;
+    const guard = async () => {
+      polls += 1;
+      if (polls > 3) throw new Error("stream kept polling a Run nothing will finish");
+    };
+
+    const outcome = await streamRunEvents(
+      sink,
+      { ...deps([record(1)], "needs_reconciliation"), sleep: guard },
+      { runId: RUN_ID, after: 0 }
+    );
+
+    expect(outcome).toBe("completed");
+    expect(types(sink)).toEqual(["state.transitioned", "stream.closed"]);
+    expect(sink.chunks.at(-1)).toContain('"status":"needs_reconciliation"');
+    expect(sink.ended).toBe(true);
+  });
+
+  it("writes a keepalive before the first event so the origin has answered", async () => {
+    // Nothing is written until a Run event exists, and an edge proxy counts silence against the
+    // origin: a turn whose first event is slow returns 524 with no body the client can explain.
+    const sink = new RecordingSink();
+    let polls = 0;
+
+    const outcome = await streamRunEvents(
+      sink,
+      {
+        events: new FakeEventReader([]),
+        runs: {
+          async find() {
+            polls += 1;
+            return { status: polls > 1 ? "succeeded" : "running" };
+          },
+        },
+        authorize: async () => GRANT,
+        sleep: noSleep,
+        keepaliveMs: 15_000,
+      },
+      { runId: RUN_ID, after: 0 }
+    );
+
+    expect(outcome).toBe("completed");
+    expect(sink.chunks[0]).toBe(": keepalive\n\n");
+  });
+
+  it("repeats the keepalive only once the interval has elapsed", async () => {
+    const sink = new RecordingSink();
+    let polls = 0;
+    let clock = 0;
+
+    await streamRunEvents(
+      sink,
+      {
+        events: new FakeEventReader([]),
+        runs: {
+          async find() {
+            polls += 1;
+            return { status: polls > 3 ? "succeeded" : "running" };
+          },
+        },
+        authorize: async () => GRANT,
+        sleep: async () => {
+          clock += 10_000;
+        },
+        keepaliveMs: 15_000,
+        now: () => clock,
+      },
+      { runId: RUN_ID, after: 0 }
+    );
+
+    // Polls at t=0, 10s and 20s: the opening comment, nothing at 10s, a second at 20s.
+    expect(sink.chunks.filter((chunk) => chunk.startsWith(":"))).toHaveLength(2);
+  });
 });

--- a/apps/api/src/runs/events.ts
+++ b/apps/api/src/runs/events.ts
@@ -1,6 +1,6 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { ErrorSchema } from "../auth/schemas";
-import { formatSseEvent, writeSseHeaders } from "../chat/sse";
+import { formatSseEvent, SSE_KEEPALIVE_MS, writeSseHeaders } from "../chat/sse";
 import { makeRateLimitHook, type RateLimiter } from "../rate-limit";
 
 export type RunEventAudience = "participant" | "operator";
@@ -51,6 +51,9 @@ export interface RunEventStreamDeps {
   readonly sleep: (ms: number) => Promise<void>;
   readonly pollIntervalMs?: number;
   readonly pageSize?: number;
+  /** Silence budget: an idle stream writes a comment this often so no proxy calls it a dead origin. */
+  readonly keepaliveMs?: number;
+  now?(): number;
 }
 
 export interface RunEventStreamRequest {
@@ -58,7 +61,17 @@ export interface RunEventStreamRequest {
   readonly after: number;
 }
 
-const TERMINAL_RUN_STATUSES: readonly string[] = ["succeeded", "failed", "cancelled"];
+/**
+ * Statuses this stream closes on. `needs_reconciliation` is not terminal for the Run, but nothing
+ * further streams for the attempt that parked it: a reader left polling never learns the turn is
+ * over, so the chat composer stays busy and the next prompt cannot be sent.
+ */
+const STREAM_CLOSING_RUN_STATUSES: readonly string[] = [
+  "succeeded",
+  "failed",
+  "cancelled",
+  "needs_reconciliation",
+];
 const DEFAULT_POLL_INTERVAL_MS = 500;
 const DEFAULT_PAGE_SIZE = 200;
 
@@ -72,7 +85,9 @@ export async function streamRunEvents(
   request: RunEventStreamRequest
 ): Promise<RunStreamOutcome> {
   const pageSize = deps.pageSize ?? DEFAULT_PAGE_SIZE;
+  const now = deps.now ?? Date.now;
   let cursor = request.after;
+  let lastWriteAt: number | undefined;
 
   for (;;) {
     if (sink.destroyed) return "client_disconnected";
@@ -97,6 +112,7 @@ export async function streamRunEvents(
         eventType: event.eventType,
         data: { ...event.payload, occurredAt: event.occurredAt },
       });
+      lastWriteAt = now();
     }
     // A full page means more backlog is waiting; drain it before polling for Run status.
     if (page.length === pageSize) continue;
@@ -106,7 +122,7 @@ export async function streamRunEvents(
       sink.end();
       return "run_not_found";
     }
-    if (TERMINAL_RUN_STATUSES.includes(run.status)) {
+    if (STREAM_CLOSING_RUN_STATUSES.includes(run.status)) {
       await emit(sink, {
         seq: cursor,
         eventType: "stream.closed",
@@ -114,6 +130,14 @@ export async function streamRunEvents(
       });
       sink.end();
       return "completed";
+    }
+    if (
+      deps.keepaliveMs !== undefined &&
+      (lastWriteAt === undefined || now() - lastWriteAt >= deps.keepaliveMs)
+    ) {
+      // A comment carries no event, so a reader's cursor is untouched by it.
+      sink.write(": keepalive\n\n");
+      lastWriteAt = now();
     }
     await deps.sleep(deps.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS);
   }
@@ -238,6 +262,7 @@ export function registerRunEventRoutes(
           sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
           pollIntervalMs: deps.pollIntervalMs,
           pageSize: deps.pageSize,
+          keepaliveMs: SSE_KEEPALIVE_MS,
         },
         { runId: id, after }
       );

--- a/apps/eval/AGENTS.md
+++ b/apps/eval/AGENTS.md
@@ -64,6 +64,8 @@ before changing how a Case is scored, run or compared.** These are the ones that
 - **Every Case carries a `script`,** so the whole Corpus runs free in ordinary CI.
 - **Two models are a control, not a contest,** and they never run at once.
 - **A Judge failure errors the Trial; it never scores low.**
+- **A `fault` is L3-only and names a dependency, not an outcome.** It breaks what the executor was
+  given, so a Case can measure a Turn abandoned before the loop ever ran.
 - This workspace is CJS-by-default — no `import.meta`.
 
 ## Commands

--- a/apps/eval/corpus/l3-an-abandoned-turn-still-announces-itself.json
+++ b/apps/eval/corpus/l3-an-abandoned-turn-still-announces-itself.json
@@ -1,0 +1,32 @@
+{
+  "id": "l3-an-abandoned-turn-still-announces-itself",
+  "tier": "l3",
+  "agent": "support",
+  "fault": "context",
+  "context": {
+    "memoryDocument": "## Other durable facts\nOpens at 9am on Saturdays.",
+    "governancePages": []
+  },
+  "input": [
+    {
+      "role": "user",
+      "content": "When do you open on Saturdays?"
+    }
+  ],
+  "script": [
+    {
+      "kind": "text",
+      "text": "We open at 9am on Saturdays."
+    }
+  ],
+  "expect": [
+    {
+      "kind": "run_status",
+      "status": "needs_reconciliation"
+    },
+    {
+      "kind": "run_event_emitted",
+      "eventType": "turn.finished"
+    }
+  ]
+}

--- a/apps/eval/src/case.ts
+++ b/apps/eval/src/case.ts
@@ -144,6 +144,16 @@ export interface EvalCase {
    * carried more cheaply by an L2 Case, so keep journeys rare.
    */
   readonly journey?: readonly JourneyTurn[];
+  /**
+   * L3 only. Breaks one of the executor's dependencies, so a Case can measure what the Turn does
+   * when its surroundings fail rather than when the model does.
+   *
+   * Every tier otherwise hands the executor working ports, which means the Corpus can only observe
+   * a Turn that got as far as the loop. A Turn abandoned *before* the loop — Context unreadable,
+   * Soul unreachable — is the one failure a participant can neither see nor retry, so it is worth
+   * the one knob it takes to reach it. `"context"` fails Context resolution.
+   */
+  readonly fault?: "context";
   readonly expect: readonly Expectation[];
   /** Raised above 1 only for Cases used to measure the Noise Floor. */
   readonly trials?: number;

--- a/apps/eval/src/corpus.ts
+++ b/apps/eval/src/corpus.ts
@@ -214,6 +214,13 @@ function validate(raw: unknown, file: string): EvalCase {
         t.input.length > 0, `${file}: every "journey" Turn needs a non-empty "input"`);
     }
   }
+  if (c.fault !== undefined) {
+    require(c.fault === "context", `${file}: unknown fault ${JSON.stringify(c.fault)}`);
+    // Only the L3 tier builds the dependency a fault breaks. On an L2 Case the field would be read
+    // by nothing and the Case would quietly measure an ordinary Turn.
+    require(c.tier ===
+      "l3", `${file}: "fault" needs tier "l3"; this Case is tier ${JSON.stringify(c.tier)}`);
+  }
   if (c.redTeam !== undefined) {
     validateRedTeam(c.redTeam, file);
     const guard = (c.expect as { kind: string }[]).find((e) => e.kind.startsWith("guardrail_"));

--- a/apps/eval/src/l3/context.ts
+++ b/apps/eval/src/l3/context.ts
@@ -53,5 +53,13 @@ export function evalTurnContext(options: EvalTurnContextOptions): EvalTurnContex
     compacted: false,
   };
 
-  return { systemPrompt, resolve: async () => resolved };
+  return {
+    systemPrompt,
+    resolve: async () => {
+      if (evalCase.fault === "context") {
+        throw new Error(`eval fault: Context is unreadable for Case ${evalCase.id}`);
+      }
+      return resolved;
+    },
+  };
 }

--- a/apps/web/app/lib/chat/sse-client.test.ts
+++ b/apps/web/app/lib/chat/sse-client.test.ts
@@ -314,3 +314,27 @@ test("releases the timeline when the Run ends without announcing the turn", () =
   announced({ seq: 1, type: "turn.finished", data: { status: "succeeded", messageId: "m1" } });
   expect(announced({ seq: 2, type: "stream.closed", data: { status: "succeeded" } })).toEqual([]);
 });
+
+test("surfaces an error when the Run ends badly and never said why", () => {
+  // A close is the only frame such a turn produces. Reading it as a plain finish leaves the
+  // composer idle with no answer and no banner — indistinguishable from a turn that succeeded.
+  const failed = createRunEventMapper();
+  expect(failed({ seq: 1, type: "stream.closed", data: { status: "failed" } })).toEqual([
+    { type: "error", data: { message: "The turn stopped before it could answer. Try again." } },
+  ]);
+
+  const parked = createRunEventMapper();
+  expect(
+    parked({ seq: 1, type: "stream.closed", data: { status: "needs_reconciliation" } })
+  ).toEqual([
+    { type: "error", data: { message: "The turn stopped before it could answer. Try again." } },
+  ]);
+});
+
+test("names a turn the runtime abandoned as such, not as a model failure", () => {
+  // `turn_execution_failed` is written when the executor threw outside the model call, so blaming
+  // the model provider would send the reader to the wrong settings page.
+  expect(modelFailureMessage("turn_execution_failed")).toBe(
+    "The turn stopped before it could answer. Try again."
+  );
+});

--- a/apps/web/app/lib/chat/sse-client.ts
+++ b/apps/web/app/lib/chat/sse-client.ts
@@ -88,8 +88,14 @@ type RunEventData = {
   artifactId?: string;
 };
 
+/** A turn that ended without an answer, whichever half of the runtime gave up on it. */
+const TURN_STOPPED_MESSAGE = "The turn stopped before it could answer. Try again.";
+
 export function modelFailureMessage(reason: string | undefined): string {
   switch (reason) {
+    case "turn_execution_failed":
+    case "needs_reconciliation":
+      return TURN_STOPPED_MESSAGE;
     case "model_billing_inactive":
       return "The model provider's API billing is inactive. Activate billing or use another Provider Credential.";
     case "model_authentication_failed":
@@ -235,8 +241,20 @@ export function createRunEventMapper(): (frame: ParsedFrame) => ChatEvent[] {
         return [{ type: "error", data: { message: modelFailureMessage(data.reason) } }];
       }
 
-      case "stream.closed":
-        return finished ? [] : [{ type: "finish", data: { reason: "closed" } }];
+      case "stream.closed": {
+        if (finished) return [];
+        // Only a Run that ended well can close silently. Anything else has no other frame to
+        // explain itself, and a plain finish would leave the composer idle with no answer.
+        if (data.status === "succeeded" || data.status === "cancelled") {
+          return [{ type: "finish", data: { reason: "closed" } }];
+        }
+        return [
+          {
+            type: "error",
+            data: { message: TURN_STOPPED_MESSAGE },
+          },
+        ];
+      }
 
       case "stream.revoked":
         return [{ type: "error", data: { message: "access to this run was revoked" } }];

--- a/packages/turn-executor/src/chat-executor.test.ts
+++ b/packages/turn-executor/src/chat-executor.test.ts
@@ -78,6 +78,7 @@ function harness(
     state?: PersistedState | null;
     answer?: string;
     run?: PersistedRun;
+    contextError?: Error;
   } = {}
 ): { execute: () => Promise<string>; recorded: Recorded } {
   const events: Recorded["events"] = [];
@@ -116,6 +117,7 @@ function harness(
   const context: TurnContextPort = {
     resolve: async () => {
       contexts += 1;
+      if (over.contextError !== undefined) throw over.contextError;
       return CONTEXT;
     },
   };
@@ -231,6 +233,31 @@ describe("createChatExecutor", () => {
 
     expect(recorded.contexts).toBe(0);
     expect(recorded.transitions).toEqual([]);
+    // The participant is still owed an answer, and `needs_reconciliation` is not a status the Run
+    // event stream can close on. Without this the reader waits forever on a Run nothing will
+    // finish.
+    expect(recorded.events).toEqual([
+      {
+        eventType: "turn.finished",
+        payload: { status: "failed", messageId: null, reason: "turn_execution_failed" },
+      },
+    ]);
+  });
+
+  it("announces a failed turn when the executor throws outside the driver", async () => {
+    // Context assembly, State reclaim and guard configuration all run before the driver can emit
+    // anything. A throw there used to reach the dispatcher, which parks the Run at
+    // `needs_reconciliation` — a status the stream never closes on — with no participant event at
+    // all. The turn simply stopped, indistinguishable from success.
+    const { execute, recorded } = harness({ contextError: new Error("soul unreachable") });
+
+    await expect(execute()).resolves.toBe("needs_reconciliation");
+
+    expect(recorded.events.at(-1)).toEqual({
+      eventType: "turn.finished",
+      payload: { status: "failed", messageId: null, reason: "turn_execution_failed" },
+    });
+    expect(recorded.messages).toEqual([]);
   });
 
   it("re-claims the State a resumed Run is still parked on, rather than restarting anything", async () => {

--- a/packages/turn-executor/src/chat-executor.ts
+++ b/packages/turn-executor/src/chat-executor.ts
@@ -69,95 +69,132 @@ export function createChatExecutor(options: ChatExecutorOptions): RunExecutor {
       return "succeeded";
     }
 
-    const state = await options.runs.findState(run.businessId, run.id, INVOKE_STATE_KEY);
-    if (state === null) {
-      // A Chat Run without its `invoke` State cannot have been minted by the invocation gateway.
-      return "needs_reconciliation";
-    }
+    const writer = new TurnEventWriter({
+      events: options.events,
+      businessId: run.businessId,
+      runId: run.id,
+      turnId: identity.turnId,
+      attempt: identity.attempt,
+      ...(options.now === undefined ? {} : { now: options.now }),
+    });
 
-    // Reclaim the same State after approval; no second Run or Turn is minted.
-    if (state.status === "waiting") {
-      await reclaimWaitingState(options.transitions, {
-        businessId: run.businessId,
-        runId: run.id,
-        stateKey: INVOKE_STATE_KEY,
-      });
+    try {
+      return await executeTurn(options, run, identity, writer);
+    } catch (error) {
+      // Everything before the driver — State reclaim, Context assembly, guard configuration — runs
+      // where no `turn.finished` has been written yet, and a throw from here reaches the dispatcher,
+      // which parks the Run at `needs_reconciliation`. That is not a status the Run event stream
+      // closes on, so an unannounced failure leaves the participant waiting on a turn nothing will
+      // ever finish. Announce it, then park.
+      options.log.warn({ runId: run.id, turnId: identity.turnId, error }, "chat turn failed");
+      return announceTurnFailure(writer, options.log);
     }
+  };
+}
 
-    // First dispatch claims the gateway's `pending` invoke State.
-    if (state.status === "pending") {
-      await reclaimPendingState(options.transitions, {
-        businessId: run.businessId,
-        runId: run.id,
-        stateKey: INVOKE_STATE_KEY,
-      });
-    }
+/** Reports a turn no attempt can finish; the Run still parks so reconciliation owns its effects. */
+async function announceTurnFailure(
+  writer: TurnEventWriter,
+  log: ChatExecutorOptions["log"]
+): Promise<RunOutcome> {
+  try {
+    await writer.emit(
+      "turn.finished",
+      { status: "failed", messageId: null, reason: "turn_execution_failed" },
+      "finished"
+    );
+  } catch (error) {
+    log.warn({ error }, "chat turn failure could not be announced");
+  }
+  return "needs_reconciliation";
+}
 
-    const request: TurnRequest = {
+async function executeTurn(
+  options: ChatExecutorOptions,
+  run: PersistedRun,
+  identity: { turnId: string; conversationId: string; attempt: number },
+  writer: TurnEventWriter
+): Promise<RunOutcome> {
+  const state = await options.runs.findState(run.businessId, run.id, INVOKE_STATE_KEY);
+  if (state === null) {
+    // A Chat Run without its `invoke` State cannot have been minted by the invocation gateway.
+    return announceTurnFailure(writer, options.log);
+  }
+
+  // Reclaim the same State after approval; no second Run or Turn is minted.
+  if (state.status === "waiting") {
+    await reclaimWaitingState(options.transitions, {
       businessId: run.businessId,
       runId: run.id,
       stateKey: INVOKE_STATE_KEY,
-      stateStatus:
-        state.status === "waiting" || state.status === "pending" ? "claimed" : state.status,
-      turnId: identity.turnId,
-      conversationId: identity.conversationId,
-      attempt: identity.attempt,
-    };
-
-    const writer = new TurnEventWriter({
-      events: options.events,
-      businessId: request.businessId,
-      runId: request.runId,
-      turnId: request.turnId,
-      attempt: request.attempt,
-      ...(options.now === undefined ? {} : { now: options.now }),
     });
-    const model =
-      typeof options.model === "function"
-        ? options.model({
-            events: writer,
-            budgets: new RunBudgetManager(options.budgets),
-            businessId: run.businessId,
-            runId: run.id,
-            conversationId: identity.conversationId,
-          })
-        : options.model;
+  }
 
-    // Wrap dispatch before the loop exists; unconfigured guards refuse every stage.
-    const guardrails = new TurnGuardrails(options.log);
-
-    const loop = new AgentLoop({
-      model,
-      // Guard before announcing; refused Tool calls never ran.
-      tools: guardrails.guard(announceToolCalls(options.tools ?? options.host, writer), writer),
-      checkpoints: options.checkpoints ?? new InMemoryLoopCheckpointStore(),
-      events: writer,
-      budget: runBudget(options.budgets, run.businessId, run.id),
-      isCancelled: async () => {
-        const current = await options.runs.find(run.businessId, run.id);
-        return current !== null && CANCELLING_STATUSES.has(current.status);
-      },
-      log: options.log,
-      ...(options.now === undefined ? {} : { now: options.now }),
+  // First dispatch claims the gateway's `pending` invoke State.
+  if (state.status === "pending") {
+    await reclaimPendingState(options.transitions, {
+      businessId: run.businessId,
+      runId: run.id,
+      stateKey: INVOKE_STATE_KEY,
     });
+  }
 
-    const driver = new TurnDriver({
-      states: new AgentStateRunner({
-        loop,
-        transitions: options.transitions,
-        waits: options.waits,
-      }),
-      context: options.context,
-      completer: new ConversationTurnCompleter({ store: options.host }),
-      guardrails,
-      buildEvents: () => writer,
-      // Only receipt-capable model ports can name the model actually observed.
-      ...(isReceiptSource(model) ? { modelReceipt: () => model.latestModelCallReceipt() } : {}),
-      ...(options.spend === undefined ? {} : { spend: options.spend }),
-    });
-
-    return driver.run(request);
+  const request: TurnRequest = {
+    businessId: run.businessId,
+    runId: run.id,
+    stateKey: INVOKE_STATE_KEY,
+    stateStatus:
+      state.status === "waiting" || state.status === "pending" ? "claimed" : state.status,
+    turnId: identity.turnId,
+    conversationId: identity.conversationId,
+    attempt: identity.attempt,
   };
+
+  const model =
+    typeof options.model === "function"
+      ? options.model({
+          events: writer,
+          budgets: new RunBudgetManager(options.budgets),
+          businessId: run.businessId,
+          runId: run.id,
+          conversationId: identity.conversationId,
+        })
+      : options.model;
+
+  // Wrap dispatch before the loop exists; unconfigured guards refuse every stage.
+  const guardrails = new TurnGuardrails(options.log);
+
+  const loop = new AgentLoop({
+    model,
+    // Guard before announcing; refused Tool calls never ran.
+    tools: guardrails.guard(announceToolCalls(options.tools ?? options.host, writer), writer),
+    checkpoints: options.checkpoints ?? new InMemoryLoopCheckpointStore(),
+    events: writer,
+    budget: runBudget(options.budgets, run.businessId, run.id),
+    isCancelled: async () => {
+      const current = await options.runs.find(run.businessId, run.id);
+      return current !== null && CANCELLING_STATUSES.has(current.status);
+    },
+    log: options.log,
+    ...(options.now === undefined ? {} : { now: options.now }),
+  });
+
+  const driver = new TurnDriver({
+    states: new AgentStateRunner({
+      loop,
+      transitions: options.transitions,
+      waits: options.waits,
+    }),
+    context: options.context,
+    completer: new ConversationTurnCompleter({ store: options.host }),
+    guardrails,
+    buildEvents: () => writer,
+    // Only receipt-capable model ports can name the model actually observed.
+    ...(isReceiptSource(model) ? { modelReceipt: () => model.latestModelCallReceipt() } : {}),
+    ...(options.spend === undefined ? {} : { spend: options.spend }),
+  });
+
+  return driver.run(request);
 }
 
 /** The Run kernel budget, narrowed to the one Run being charged. */

--- a/scripts/control-plane-size.test.ts
+++ b/scripts/control-plane-size.test.ts
@@ -251,9 +251,29 @@ import { describe, expect, it } from "vitest";
  * The knowledge that did not stay here: which stage each guard is valid in is
  * `GUARDRAIL_STAGE_BY_GUARD` in `packages/schema/src/guardrails.ts`, beside the stage unions that
  * decide it, so the Tool derives the stage rather than restating the mapping.
+ *
+ * It moves to 51,508 for the silent-chat-turn fix, +35 net across the two files that own the SSE
+ * transport for a Chat Turn:
+ *
+ *   +25 `apps/api/src/runs/events.ts` — `needs_reconciliation` joins the statuses that close the
+ *       stream, and `streamRunEvents` writes a `: keepalive` comment on an idle poll. A Run parked
+ *       for reconciliation is not Run-terminal, so the poll loop had no reason to stop and the
+ *       response never ended; and because nothing was written until the first Run event existed,
+ *       the origin sent zero bytes and the edge answered 524 rather than the backend answering at
+ *       all. Most of the growth is the TSDoc separating "stream-terminal" from "Run-terminal",
+ *       because the two sets look like they should be one and must not be.
+ *   +9  `apps/api/src/chat/sse.ts` — `SSE_KEEPALIVE_MS`, and `writeSseHeaders` now flushing. Node
+ *       holds headers until the first body write, so setting them was not answering.
+ *   +1  one import in `apps/api/src/chat/routes.ts`.
+ *
+ * The guarantee this fix exists for did *not* stay here. That a Chat Turn always announces its own
+ * failure is enforced in `packages/turn-executor/src/chat-executor.ts`, beside the driver that owns
+ * a Turn's lifecycle, so a Turn dispatched by the Worker rather than streamed over HTTP is covered
+ * by the same code. Only the transport consequence — when to stop polling, and when to put a byte
+ * on the wire — is Fastify-adjacent and therefore here.
  */
 
-const CEILING = 51_473;
+const CEILING = 51_508;
 
 /**
  * Domains inside `apps/api/src` that already have a package of the same name. Everything here that


### PR DESCRIPTION
createChatExecutor built its TurnEventWriter only after the State reclaim, Context resolve and guardrail configure had already run. Anything that threw in that prologue propagated to RunDispatcher, which parked the Run at needs_reconciliation -- an operator fact on the Run row. No participant Run event was ever written, so the transcript simply stopped mid-turn and the composer went idle, indistinguishable from success.

The hypothesis that proved correct: the silent stop, the 524 and the dead retry are one path, not three bugs. Because the executor emitted nothing, the SSE loop had no terminal event to stop on and needs_reconciliation was absent from the statuses that close the stream, so the response was held open; and because writeSseHeaders only set headers -- Node holds them until the first body write, and the first write is the first Run event -- the origin sent zero bytes and the edge answered 524 at ~100s, past the 60s chat-response-complete budget. The web mapper then read a close with no turn.finished as a plain finish, and while the stream stayed open the reducer held status at streaming, so the composer refused the next prompt as busy.

The writer is now built as soon as the Turn is found, and every path out of the executor -- including a missing invoke State -- announces turn.finished{failed}. The stream flushes its headers immediately, keepalives every 15s and closes on needs_reconciliation. A close without turn.finished is an error in the client, not a finish.

No hard request deadline was added. The edge times out on bytes, so the right origin-side budget for a stream is a write deadline; a 60s request cut-off would kill legitimately long turns without cancelling the Run.

Closes #427

## Summary

<!-- What changed, and why. Link the driving issue if one exists. -->

## Test plan

<!-- Commands you ran, or manual steps / screenshots for UI changes. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (or the scoped `--filter` you actually ran)

## Checklist

- [ ] PR title follows Conventional Commits (`type(scope): subject`) — CI checks this
- [ ] Scoped to one logical change
- [ ] Tests added/updated for the behavior that changed
