### PR TITLE
fix(tools): cancel timed-out Tool calls instead of racing them

### DIFF
--- a/apps/api/src/tools/registry.test.ts
+++ b/apps/api/src/tools/registry.test.ts
@@ -6,6 +6,7 @@ import type {
   ToolCallResult,
   ToolDef,
 } from "@tulipfarm/tool-host";
+import { isIndeterminateFault, isInfrastructureFault } from "@tulipfarm/tool-host";
 import { describe, expect, it, vi } from "vitest";
 import {
   MAX_PRESENTATION_CORRECTIVE_ATTEMPTS,
@@ -28,6 +29,21 @@ function makeTool(overrides: Partial<ToolDef> = {}): ToolDef {
 }
 
 const ctx: RequestContext = { userId: "u1", agentId: "a1" };
+
+/** Drives fake timers until `promise` settles, so a deadline plus grace window cannot deadlock. */
+async function advanceUntilSettled(promise: Promise<unknown> | undefined): Promise<void> {
+  if (promise === undefined) return;
+  let finished = false;
+  void promise.then(
+    () => {
+      finished = true;
+    },
+    () => {
+      finished = true;
+    }
+  );
+  for (let i = 0; i < 200 && !finished; i += 1) await vi.advanceTimersByTimeAsync(1_000);
+}
 
 describe("ToolRegistry", () => {
   it("register + getAll returns all tools in insertion order", () => {
@@ -431,13 +447,85 @@ describe("ToolRegistry", () => {
           {},
           { messages: [], context: undefined, toolCallId: "tc" }
         );
-        vi.advanceTimersByTime(TOOL_TIMEOUT_MS);
+        await advanceUntilSettled(resultPromise);
         const result = await resultPromise;
         expect(result).toEqual({
           success: false,
           error: { code: "internal_error", message: "tool execution timed out" },
         });
         expect(abortSignal?.aborted).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("never lets a timed-out mutating Tool's late write reach the model", async () => {
+      vi.useFakeTimers();
+      try {
+        let committed = 0;
+        const reg = new ToolRegistry();
+        reg.register(
+          makeTool({
+            name: "write_x",
+            mutating: true,
+            execute: (_args, context) =>
+              new Promise<ToolCallResult>((resolve) => {
+                setTimeout(() => {
+                  // A cooperating Tool checks the signal before it commits anything.
+                  if (context.abortSignal?.aborted === true) {
+                    resolve({ success: false, error: { code: "unavailable", message: "aborted" } });
+                    return;
+                  }
+                  committed += 1;
+                  resolve({ success: true, data: "written" });
+                }, TOOL_TIMEOUT_MS * 2);
+              }),
+          })
+        );
+        const ts = reg.buildToolSet(ctx);
+        const resultPromise = ts.write_x.execute?.(
+          {},
+          { messages: [], context: undefined, toolCallId: "tc" }
+        );
+        await advanceUntilSettled(resultPromise);
+
+        expect(await resultPromise).toEqual({
+          success: false,
+          error: {
+            code: "indeterminate",
+            message: expect.stringContaining("may already have been applied"),
+          },
+        });
+        await vi.advanceTimersByTimeAsync(TOOL_TIMEOUT_MS * 2);
+        expect(committed).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("keeps a mutating Tool that ignores its abort out of the model's retry path", async () => {
+      vi.useFakeTimers();
+      try {
+        const reg = new ToolRegistry();
+        reg.register(
+          makeTool({
+            name: "write_y",
+            mutating: true,
+            execute: () => new Promise<ToolCallResult>(() => {}),
+          })
+        );
+        const ts = reg.buildToolSet(ctx);
+        const resultPromise = ts.write_y.execute?.(
+          {},
+          { messages: [], context: undefined, toolCallId: "tc" }
+        );
+        await advanceUntilSettled(resultPromise);
+
+        const result = (await resultPromise) as ToolCallResult;
+        expect(result.success).toBe(false);
+        expect(!result.success && result.error.code).toBe("indeterminate");
+        expect(isIndeterminateFault("indeterminate")).toBe(true);
+        expect(isInfrastructureFault("indeterminate")).toBe(false);
       } finally {
         vi.useRealTimers();
       }

--- a/packages/tool-host/AGENTS.md
+++ b/packages/tool-host/AGENTS.md
@@ -21,6 +21,7 @@ Individual Tool families (`packages/kv`, `apps/api/src/tools/**`), the model-fac
 | `src/types.ts` | `ToolDef`, `RequestContext`, `ToolCallResult`, `ToolErrorCode`, fault classes |
 | `src/define.ts` | `defineApiTool` / `toToolDef` — declaration plus bound per-request context |
 | `src/dispatcher.ts` | `RegistryToolDispatcher`: authorize → credential → entitlement → approve → execute |
+| `src/timeout.ts`, `src/execution.ts` | Deadline and abort delivery; the attempt loop and effect settlement |
 | `src/gate.ts` | `LiveToolGate`, autonomy mapping, agent authority layer, DLP rules |
 | `src/eligibility.ts` | `localDispatchRefusal` — which Tools a non-control-plane process may run |
 | `src/capability-restrictions.ts` | An Agent's authored restrictions, decided at offer and at dispatch |
@@ -37,6 +38,10 @@ Individual Tool families (`packages/kv`, `apps/api/src/tools/**`), the model-fac
   the catalog for UX; `agentCapabilityDenial` runs inside `dispatch` before authority, approval and
   `execute`. A Soul-less host such as `apps/worker` composes no `agents` resolver and reads the
   Agent off `TurnAuthority.agent` instead, so dropping that field unenforces both it and autonomy.
+- **A deadline must cancel, and an uncancelled deadline is not a plain failure.** Never race a
+  Tool against a bare timer; the loser keeps mutating and its result is lost. `timeout.ts` aborts,
+  waits `CANCELLATION_GRACE_MS` for an acknowledgement, and reports unacknowledged mutating work as
+  `indeterminate`, which nothing may retry and `dispatcher.ts` settles `ambiguous`.
 - **`eligibility.ts` fails closed.** A process without a live Soul, a renderer registry or
   provider credential leases must not authorize a Tool that needs them. Widening the rule needs a
   reason why the weaker check is still the same check.

--- a/packages/tool-host/src/dispatcher.test.ts
+++ b/packages/tool-host/src/dispatcher.test.ts
@@ -83,6 +83,21 @@ function makeDispatcher(
   };
 }
 
+/** Drives fake timers until `promise` settles, so a deadline plus grace window cannot deadlock. */
+async function drain<T>(promise: Promise<T>): Promise<T> {
+  let finished = false;
+  void promise.then(
+    () => {
+      finished = true;
+    },
+    () => {
+      finished = true;
+    }
+  );
+  for (let i = 0; i < 200 && !finished; i += 1) await vi.advanceTimersByTimeAsync(100);
+  return promise;
+}
+
 /** An `AgentResolver` that answers with one authored Agent, ceiling included. */
 function agentWithAutonomy(autonomy: ChatAutonomy | undefined): AgentResolver {
   return { resolve: () => ({ name: "mutator", ...(autonomy === undefined ? {} : { autonomy }) }) };
@@ -136,6 +151,8 @@ describe("RegistryToolDispatcher", () => {
         surfaceCatalog: expect.any(Array),
         surfaceCatalogRevision: expect.any(String),
         surfaceRendererManifest: expect.anything(),
+        // Every dispatch now carries its own deadline, so the Tool can fail closed on abort.
+        abortSignal: expect.any(AbortSignal),
       },
     ]);
     expect(artifacts.read).toHaveBeenCalledWith(
@@ -1191,7 +1208,7 @@ describe("effect ledger", () => {
     ) as ToolDef;
   }
 
-  function ledgerDispatcher(tool: ToolDef) {
+  function ledgerDispatcher(tool: ToolDef, executeTimeoutMs?: number) {
     const registry = new InMemoryToolCatalog();
     registry.register(tool);
     const effects = new MemoryEffectStore();
@@ -1201,6 +1218,7 @@ describe("effect ledger", () => {
         registry,
         artifacts: fakeArtifacts() as unknown as ArtifactService,
         effects,
+        ...(executeTimeoutMs === undefined ? {} : { executeTimeoutMs }),
       }),
     };
   }
@@ -1245,6 +1263,56 @@ describe("effect ledger", () => {
     expect(conflicting).toMatchObject({ status: "failed" });
     expect(conflicting.status === "failed" && conflicting.reason).toContain("different arguments");
     expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("settles a mutating tool that ignored its abort as ambiguous, not failed", async () => {
+    vi.useFakeTimers();
+    try {
+      let committed = 0;
+      const { dispatcher, effects } = ledgerDispatcher(
+        ledgeredTool(
+          () =>
+            new Promise((resolve) => {
+              setTimeout(() => {
+                committed += 1;
+                resolve(ok({ done: true }));
+              }, 60_000);
+            })
+        ),
+        1_000
+      );
+
+      const result = await drain(dispatcher.dispatch(AUTHORITY, CALL));
+
+      expect(result).toMatchObject({ status: "failed" });
+      expect(result.status === "failed" && result.reason).toContain(
+        "may already have been applied"
+      );
+      const records = await effects.list(BUSINESS_ID);
+      expect(records[0]?.state).toBe("ambiguous");
+      // The abandoned call keeps running; its write must never reach the caller's answer.
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(committed).toBe(1);
+      expect((await effects.list(BUSINESS_ID))[0]?.state).toBe("ambiguous");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("replays an abandoned call as unresolved instead of running it a second time", async () => {
+    vi.useFakeTimers();
+    try {
+      const execute = vi.fn(() => new Promise<ReturnType<typeof ok>>(() => {}));
+      const { dispatcher } = ledgerDispatcher(ledgeredTool(execute), 1_000);
+
+      await drain(dispatcher.dispatch(AUTHORITY, CALL));
+      const second = await drain(dispatcher.dispatch(AUTHORITY, CALL));
+
+      expect(execute).toHaveBeenCalledTimes(1);
+      expect(second).toMatchObject({ status: "failed" });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("settles a thrown mutating tool as ambiguous, not failed", async () => {

--- a/packages/tool-host/src/dispatcher.ts
+++ b/packages/tool-host/src/dispatcher.ts
@@ -6,7 +6,6 @@ import {
   type CompositeToolEntitlement,
   type EffectStore,
   NOT_APPLICABLE,
-  retryDelayMs,
   type ToolAuthorizationDenialReason,
   type ToolTargetRef,
 } from "@tulipfarm/tool-broker";
@@ -27,6 +26,7 @@ import { availableToolsFor, type ToolCatalog } from "./catalog";
 import type { CredentialResolution, CredentialResolver } from "./credential-mode";
 import { ChatEffectLedger, ledgerOwnsCall } from "./effect-ledger";
 import { localDispatchRefusal } from "./eligibility";
+import { runToolAttempts } from "./execution";
 import { gateAutonomyOf, type ToolGate } from "./gate";
 import type {
   AgentResolver,
@@ -40,11 +40,7 @@ import type {
 import { type AuthorityPrincipal, principalKindOf } from "./principal";
 import { presentationContextForAuthority, readChatRequest } from "./request";
 import type { SurfaceActionStore, SurfaceArtifactStore } from "./surface-ports";
-import type { RequestContext, ToolDef, ToolErrorCode } from "./types";
-import { isInfrastructureFault } from "./types";
-
-/** Default infra-fault retries without a ledger: one retry, then stop to avoid duplicate writes. */
-const DEFAULT_TRANSIENT_ATTEMPTS = 2;
+import type { RequestContext, ToolDef } from "./types";
 
 /**
  * Used when no `AgentResolver` was composed. It carries no `toolAllowlist`, which means the whole
@@ -85,6 +81,14 @@ export interface RegistryToolDispatcherOptions {
    * that slipped into the local catalog is refused rather than authorized on thinner evidence.
    */
   readonly localDispatchOnly?: boolean;
+  /**
+   * Wall-clock ceiling on one `execute`. Without it a Tool that never settles pins the Run's lease
+   * forever; with it the call is aborted, and a mutating Tool that ignored the abort settles
+   * `ambiguous` for reconciliation instead of being answered as a plain failure.
+   */
+  readonly executeTimeoutMs?: number;
+  /** Host cancellation — Run cancellation or drain — delivered to the Tool as `abortSignal`. */
+  readonly abortSignal?: AbortSignal;
   now?(): Date;
 }
 
@@ -196,22 +200,6 @@ export class RegistryToolDispatcher implements TurnToolDispatcher {
       decision: "denied",
       result: { status: "denied", reason: denialReason(call.name, outcome.reason) },
     };
-  }
-
-  /** Retry only infrastructure faults with budget; mutating Tools need explicit `safeToRetry`. */
-  private mayRetryFault(tool: ToolDef, code: ToolErrorCode, attempt: number): boolean {
-    if (!isInfrastructureFault(code)) return false;
-    // Provider Tools already spent their ledger retry budget; do not start a second effect.
-    if (tool.definition?.provider !== undefined) return false;
-    const policy = tool.definition?.retry;
-    if (attempt >= Math.max(1, policy?.maxAttempts ?? DEFAULT_TRANSIENT_ATTEMPTS)) return false;
-    // Without a phase, landed-then-failed is indistinguishable from never-landed.
-    return !tool.mutating || policy?.safeToRetry === true;
-  }
-
-  private async wait(delayMs: number): Promise<void> {
-    if (delayMs <= 0) return;
-    await new Promise((resolve) => setTimeout(resolve, delayMs));
   }
 
   /** Provider entitlement checks run for human calls, even with personal credentials. */
@@ -455,6 +443,7 @@ export class RegistryToolDispatcher implements TurnToolDispatcher {
       surfaceActionStore: this.options.surfaceActionStore,
       surfaceComponents,
       ...surfaceFields,
+      ...(this.options.abortSignal === undefined ? {} : { abortSignal: this.options.abortSignal }),
       ...(credential.use === "principal" ? { credentialPrincipal: credential.principal } : {}),
     };
     // Reserve only after refusals and approval; denied calls leave no effect row.
@@ -490,54 +479,17 @@ export class RegistryToolDispatcher implements TurnToolDispatcher {
       };
     }
 
-    let result: Awaited<ReturnType<ToolDef["execute"]>>;
-    for (let attempt = 1; ; attempt += 1) {
-      try {
-        result = await definition.execute(call.arguments, context);
-      } catch {
-        // Throws are unknown phase: never retry, and settle ledgered writes as `ambiguous`.
-        if (ledger && reservation) {
-          await ledger.finishAttempt(
-            authority.businessId,
-            reservation.effectId,
-            reservation.attempt,
-            {
-              state: "ambiguous",
-              errorCode: "tool_raised",
-            }
-          );
-        }
-        return { status: "failed", reason: `tool "${call.name}" raised an internal error` };
-      }
-      if (result.success) {
-        if (ledger && reservation) {
-          await ledger.finishAttempt(
-            authority.businessId,
-            reservation.effectId,
-            reservation.attempt,
-            { state: "confirmed" }
-          );
-        }
-        return { status: "succeeded", output: result.data };
-      }
-      if (!this.mayRetryFault(definition, result.error.code, attempt)) break;
-      await this.wait(retryDelayMs(attempt));
-    }
-    // Structured errors have a known phase; there is nothing to reconcile.
-    if (ledger && reservation) {
-      await ledger.finishAttempt(authority.businessId, reservation.effectId, reservation.attempt, {
-        state: "failed",
-        errorCode: result.error.code,
-      });
-    }
-    // Schema-shaped rejections count against the model repair budget.
-    if (result.error.code === "validation_error") {
-      return { status: "invalid_arguments", reason: result.error.message };
-    }
-    // Exhausted infra faults are machinery failures, not repairable argument failures.
-    return isInfrastructureFault(result.error.code)
-      ? { status: "failed", reason: `tool "${call.name}" is temporarily unavailable; try again` }
-      : { status: "failed", reason: result.error.message };
+    return runToolAttempts({
+      businessId: authority.businessId,
+      tool: definition,
+      call,
+      context,
+      ...(this.options.executeTimeoutMs === undefined
+        ? {}
+        : { timeoutMs: this.options.executeTimeoutMs }),
+      ...(ledger === undefined ? {} : { ledger }),
+      ...(reservation === undefined ? {} : { reservation }),
+    });
   }
 }
 

--- a/packages/tool-host/src/execution.ts
+++ b/packages/tool-host/src/execution.ts
@@ -1,0 +1,100 @@
+import { retryDelayMs } from "@tulipfarm/tool-broker";
+import type { HostedToolCall, HostedToolResult } from "./authority";
+import type { ChatEffectLedger } from "./effect-ledger";
+import { executeToolWithTimeout } from "./timeout";
+import type { RequestContext, ToolDef, ToolErrorCode } from "./types";
+import { isIndeterminateFault, isInfrastructureFault } from "./types";
+
+/** Default infra-fault retries without a ledger: one retry, then stop to avoid duplicate writes. */
+const DEFAULT_TRANSIENT_ATTEMPTS = 2;
+
+/** Matches the chat host's ceiling, so the same Tool is abandoned at the same point either way. */
+const DEFAULT_EXECUTE_TIMEOUT_MS = 30_000;
+
+/** The reserved effect this call must settle, if the Tool is one the ledger owns. */
+export interface EffectReservation {
+  readonly effectId: string;
+  readonly attempt: number;
+}
+
+export interface ToolAttemptInput {
+  readonly businessId: string;
+  readonly tool: ToolDef;
+  readonly call: HostedToolCall;
+  readonly context: RequestContext;
+  readonly timeoutMs?: number;
+  readonly ledger?: ChatEffectLedger;
+  readonly reservation?: EffectReservation;
+}
+
+/** Retry only infrastructure faults with budget; mutating Tools need explicit `safeToRetry`. */
+function mayRetryFault(tool: ToolDef, code: ToolErrorCode, attempt: number): boolean {
+  if (!isInfrastructureFault(code)) return false;
+  // Provider Tools already spent their ledger retry budget; do not start a second effect.
+  if (tool.definition?.provider !== undefined) return false;
+  const policy = tool.definition?.retry;
+  if (attempt >= Math.max(1, policy?.maxAttempts ?? DEFAULT_TRANSIENT_ATTEMPTS)) return false;
+  // Without a phase, landed-then-failed is indistinguishable from never-landed.
+  return !tool.mutating || policy?.safeToRetry === true;
+}
+
+async function wait(delayMs: number): Promise<void> {
+  if (delayMs <= 0) return;
+  await new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+/**
+ * Runs one authorized Tool call to a terminal answer: bounded execution, the transient-fault retry
+ * budget, and the effect settlement each outcome earns.
+ *
+ * Execution is never unbounded — a Tool that does not settle would otherwise hold the Run forever,
+ * and one that does not honour its abort returns `indeterminate`, whose write may have landed after
+ * the caller stopped waiting. That settles `ambiguous` for reconciliation, because `failed` reads
+ * as never-landed and invites the retry that duplicates it.
+ */
+export async function runToolAttempts(input: ToolAttemptInput): Promise<HostedToolResult> {
+  const { businessId, tool, call, ledger, reservation } = input;
+  const settle = async (state: "confirmed" | "failed" | "ambiguous", errorCode?: string) => {
+    if (!ledger || !reservation) return;
+    await ledger.finishAttempt(businessId, reservation.effectId, reservation.attempt, {
+      state,
+      ...(errorCode === undefined ? {} : { errorCode }),
+    });
+  };
+
+  let result: Awaited<ReturnType<ToolDef["execute"]>>;
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      result = await executeToolWithTimeout(
+        tool,
+        call.arguments,
+        input.context,
+        input.timeoutMs ?? DEFAULT_EXECUTE_TIMEOUT_MS
+      );
+    } catch {
+      // Throws are unknown phase: never retry, and settle ledgered writes as `ambiguous`.
+      await settle("ambiguous", "tool_raised");
+      return { status: "failed", reason: `tool "${call.name}" raised an internal error` };
+    }
+    if (result.success) {
+      await settle("confirmed");
+      return { status: "succeeded", output: result.data };
+    }
+    if (!mayRetryFault(tool, result.error.code, attempt)) break;
+    await wait(retryDelayMs(attempt));
+  }
+  if (isIndeterminateFault(result.error.code)) {
+    await settle("ambiguous", "tool_timeout");
+    return { status: "failed", reason: `tool "${call.name}" ${result.error.message}` };
+  }
+  // Structured errors have a known phase; there is nothing to reconcile.
+  await settle("failed", result.error.code);
+  // Schema-shaped rejections count against the model repair budget.
+  if (result.error.code === "validation_error") {
+    return { status: "invalid_arguments", reason: result.error.message };
+  }
+  // Exhausted infra faults are machinery failures, not repairable argument failures.
+  return isInfrastructureFault(result.error.code)
+    ? { status: "failed", reason: `tool "${call.name}" is temporarily unavailable; try again` }
+    : { status: "failed", reason: result.error.message };
+}

--- a/packages/tool-host/src/fault-taxonomy.test.ts
+++ b/packages/tool-host/src/fault-taxonomy.test.ts
@@ -1,7 +1,12 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { isInfrastructureFault, TOOL_FAULT_CLASS, type ToolErrorCode } from "./types";
+import {
+  isIndeterminateFault,
+  isInfrastructureFault,
+  TOOL_FAULT_CLASS,
+  type ToolErrorCode,
+} from "./types";
 
 describe("tool fault taxonomy", () => {
   it("classifies exactly the codes the union declares, no more and no fewer", () => {
@@ -28,16 +33,24 @@ describe("tool fault taxonomy", () => {
     expect(isInfrastructureFault("unavailable")).toBe(true);
   });
 
-  it("keeps both classes populated, so neither reading collapses", () => {
+  it("keeps an abandoned call out of both retryable readings", () => {
+    expect(isInfrastructureFault("indeterminate")).toBe(false);
+    expect(isIndeterminateFault("indeterminate")).toBe(true);
+    expect(isIndeterminateFault("unavailable")).toBe(false);
+  });
+
+  it("keeps every class populated, so no reading collapses", () => {
     const values = Object.values(TOOL_FAULT_CLASS);
     expect(values).toContain("business");
     expect(values).toContain("infrastructure");
+    expect(values).toContain("indeterminate");
   });
 
   it("gives every code exactly one class", () => {
     for (const [code, klass] of Object.entries(TOOL_FAULT_CLASS)) {
-      expect(["business", "infrastructure"]).toContain(klass);
+      expect(["business", "infrastructure", "indeterminate"]).toContain(klass);
       expect(isInfrastructureFault(code as ToolErrorCode)).toBe(klass === "infrastructure");
+      expect(isIndeterminateFault(code as ToolErrorCode)).toBe(klass === "indeterminate");
     }
   });
 });

--- a/packages/tool-host/src/index.ts
+++ b/packages/tool-host/src/index.ts
@@ -106,7 +106,16 @@ export type {
   SurfaceActionStore,
   SurfaceArtifactStore,
 } from "./surface-ports";
-export { executeToolWithTimeout, withAbortTimeout } from "./timeout";
+export {
+  CANCELLATION_GRACE_MS,
+  type CancellationOptions,
+  type CancellationOutcome,
+  executeToolWithTimeout,
+  INDETERMINATE_TIMEOUT_MESSAGE,
+  type LateSettlement,
+  runWithCancellation,
+  type ToolTimeoutOptions,
+} from "./timeout";
 export {
   type ApprovalDecision,
   type ApprovalGate,
@@ -114,6 +123,7 @@ export {
   type ChatAutonomy,
   type ClientContext,
   err,
+  isIndeterminateFault,
   isInfrastructureFault,
   ok,
   type RequestContext,

--- a/packages/tool-host/src/timeout.test.ts
+++ b/packages/tool-host/src/timeout.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it, vi } from "vitest";
+import { executeToolWithTimeout, runWithCancellation } from "./timeout";
+import type { RequestContext, ToolCallResult, ToolDef } from "./types";
+
+const ctx: RequestContext = { userId: "u1" };
+
+function tool(overrides: Partial<ToolDef> = {}): ToolDef {
+  return {
+    name: "t",
+    tier: "platform",
+    mutating: false,
+    description: "",
+    inputSchema: { type: "object" },
+    execute: async () => ({ success: true, data: "ok" }),
+    ...overrides,
+  };
+}
+
+/** Advances fake timers until `promise` settles, so a grace window cannot deadlock the test. */
+async function settle<T>(promise: Promise<T>): Promise<T> {
+  const done = promise.then(
+    (value) => ({ value }),
+    (error: unknown) => ({ error })
+  );
+  let finished = false;
+  void done.then(() => {
+    finished = true;
+  });
+  for (let i = 0; i < 200 && !finished; i += 1) {
+    await vi.advanceTimersByTimeAsync(100);
+  }
+  return promise;
+}
+
+describe("runWithCancellation", () => {
+  it("returns the value when the operation beats its deadline", async () => {
+    const outcome = await runWithCancellation(async () => "fast", 1_000);
+    expect(outcome).toEqual({ kind: "settled", value: "fast" });
+  });
+
+  it("reports cancelled when the operation acknowledges its abort", async () => {
+    vi.useFakeTimers();
+    try {
+      const outcome = settle(
+        runWithCancellation(
+          (signal) =>
+            new Promise<string>((_resolve, reject) => {
+              signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+            }),
+          1_000
+        )
+      );
+      expect(await outcome).toEqual({ kind: "cancelled" });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("reports indeterminate when the operation ignores its abort", async () => {
+    vi.useFakeTimers();
+    try {
+      const outcome = settle(runWithCancellation(() => new Promise<string>(() => {}), 1_000));
+      expect(await outcome).toEqual({ kind: "indeterminate" });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("reports a late success to the host instead of dropping it", async () => {
+    vi.useFakeTimers();
+    try {
+      const late = vi.fn();
+      const outcome = settle(
+        runWithCancellation(
+          () => new Promise<string>((resolve) => setTimeout(() => resolve("landed"), 30_000)),
+          1_000,
+          { onLateSettlement: late }
+        )
+      );
+      expect(await outcome).toEqual({ kind: "indeterminate" });
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(late).toHaveBeenCalledWith({ kind: "resolved", value: "landed" });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("aborts as soon as the caller's own signal aborts", async () => {
+    const outer = new AbortController();
+    let inner: AbortSignal | undefined;
+    const promise = runWithCancellation(
+      (signal) => {
+        inner = signal;
+        return new Promise<string>((_resolve, reject) => {
+          signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+        });
+      },
+      60_000,
+      { outerSignal: outer.signal }
+    );
+    outer.abort();
+    expect(await promise).toEqual({ kind: "cancelled" });
+    expect(inner?.aborted).toBe(true);
+  });
+});
+
+describe("executeToolWithTimeout", () => {
+  it("delivers an aborted signal to the Tool when the deadline expires", async () => {
+    vi.useFakeTimers();
+    try {
+      let signal: AbortSignal | undefined;
+      const result = settle(
+        executeToolWithTimeout(
+          tool({
+            execute: (_args, context) => {
+              signal = context.abortSignal;
+              return new Promise<ToolCallResult>(() => {});
+            },
+          }),
+          {},
+          ctx,
+          1_000
+        )
+      );
+      await result;
+      expect(signal?.aborted).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("marks an uncancellable mutating Tool indeterminate rather than a plain failure", async () => {
+    vi.useFakeTimers();
+    try {
+      const result = settle(
+        executeToolWithTimeout(
+          tool({ mutating: true, execute: () => new Promise<ToolCallResult>(() => {}) }),
+          {},
+          ctx,
+          1_000
+        )
+      );
+      expect(await result).toEqual({
+        success: false,
+        error: {
+          code: "indeterminate",
+          message: expect.stringContaining("could not be cancelled"),
+        },
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps a cancelled mutating Tool a definitive timeout, because nothing was committed", async () => {
+    vi.useFakeTimers();
+    try {
+      const result = settle(
+        executeToolWithTimeout(
+          tool({
+            mutating: true,
+            execute: (_args, context) =>
+              new Promise<ToolCallResult>((_resolve, reject) => {
+                context.abortSignal?.addEventListener("abort", () => reject(new Error("aborted")), {
+                  once: true,
+                });
+              }),
+          }),
+          {},
+          ctx,
+          1_000
+        )
+      );
+      expect(await result).toEqual({
+        success: false,
+        error: { code: "internal_error", message: "tool execution timed out" },
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not commit a mutating Tool's post-deadline write into the caller's result", async () => {
+    vi.useFakeTimers();
+    try {
+      let committed = 0;
+      const late: unknown[] = [];
+      const result = settle(
+        executeToolWithTimeout(
+          tool({
+            mutating: true,
+            execute: (_args, context) =>
+              new Promise<ToolCallResult>((resolve) => {
+                setTimeout(() => {
+                  if (context.abortSignal?.aborted === true) {
+                    resolve({ success: false, error: { code: "internal_error", message: "x" } });
+                    return;
+                  }
+                  committed += 1;
+                  resolve({ success: true, data: "written" });
+                }, 30_000);
+              }),
+          }),
+          {},
+          ctx,
+          1_000,
+          { onLateSettlement: (settlement) => late.push(settlement) }
+        )
+      );
+      expect(await result).toEqual({
+        success: false,
+        error: { code: "indeterminate", message: expect.any(String) },
+      });
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(committed).toBe(0);
+      expect(late).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/tool-host/src/timeout.ts
+++ b/packages/tool-host/src/timeout.ts
@@ -1,33 +1,133 @@
 import { err, type RequestContext, type ToolCallResult, type ToolDef } from "./types";
 
-/** Runs an operation until its deadline, aborting work that has not completed. */
-export async function withAbortTimeout<T>(
-  execute: (abortSignal: AbortSignal) => Promise<T>,
-  timeoutMs: number,
-  timeoutResult: () => T
-): Promise<T> {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
-  const timedOut = new Promise<T>((resolve) => {
-    controller.signal.addEventListener("abort", () => resolve(timeoutResult()), { once: true });
-  });
-  try {
-    return await Promise.race([execute(controller.signal), timedOut]);
-  } finally {
-    clearTimeout(timer);
-  }
+/**
+ * How long an aborted operation is given to acknowledge its cancellation before its outcome is
+ * treated as indeterminate. A cooperating operation rejects on the signal in the same tick, so the
+ * window only costs latency for work that ignored the abort — exactly the work we cannot trust.
+ */
+export const CANCELLATION_GRACE_MS = 2_000;
+
+/** What the caller never saw: the operation settled after its deadline had already been answered. */
+export type LateSettlement<T> =
+  | { readonly kind: "resolved"; readonly value: T }
+  | { readonly kind: "rejected"; readonly error: unknown };
+
+/**
+ * `cancelled` means the operation acknowledged its abort, so nothing it had not already committed
+ * can land. `indeterminate` means it did not, so the side effect may or may not have happened and
+ * only reconciliation can decide — never an automatic retry.
+ */
+export type CancellationOutcome<T> =
+  | { readonly kind: "settled"; readonly value: T }
+  | { readonly kind: "cancelled" }
+  | { readonly kind: "indeterminate" };
+
+export interface CancellationOptions<T> {
+  readonly graceMs?: number;
+  /** The host's own cancellation, e.g. Run cancellation or shutdown; aborts before the deadline. */
+  readonly outerSignal?: AbortSignal;
+  readonly onLateSettlement?: (settlement: LateSettlement<T>) => void;
 }
 
-/** Executes a Tool with a deadline while preserving a per-invocation cancellation signal. */
-export function executeToolWithTimeout(
+const EXPIRED = Symbol("expired");
+
+function delay(ms: number): Promise<typeof EXPIRED> {
+  return new Promise((resolve) => setTimeout(() => resolve(EXPIRED), ms));
+}
+
+/**
+ * Runs an operation under a deadline, aborts it when the deadline expires, and then reports
+ * whether the abort was actually honoured.
+ *
+ * A plain `Promise.race` against a timer cannot tell a cancelled operation from one that is still
+ * mutating state, and it drops whatever the loser eventually produced. Both matter: the first
+ * decides whether a retry is safe, the second is the only evidence that a write landed after the
+ * caller was told it had failed.
+ */
+export async function runWithCancellation<T>(
+  execute: (abortSignal: AbortSignal) => Promise<T>,
+  timeoutMs: number,
+  options: CancellationOptions<T> = {}
+): Promise<CancellationOutcome<T>> {
+  const controller = new AbortController();
+  const abort = () => controller.abort();
+  const { outerSignal, onLateSettlement } = options;
+  if (outerSignal?.aborted === true) abort();
+  else outerSignal?.addEventListener("abort", abort, { once: true });
+  const timer = timeoutMs > 0 ? setTimeout(abort, timeoutMs) : undefined;
+  const release = () => {
+    if (timer !== undefined) clearTimeout(timer);
+    outerSignal?.removeEventListener("abort", abort);
+  };
+
+  // Settlement is observed rather than raced away, so a result arriving after the deadline is
+  // still reportable instead of vanishing into an unobserved promise.
+  const observed: Promise<LateSettlement<T>> = (async () => {
+    try {
+      return { kind: "resolved", value: await execute(controller.signal) };
+    } catch (error) {
+      return { kind: "rejected", error };
+    }
+  })();
+  const aborted = new Promise<typeof EXPIRED>((resolve) => {
+    controller.signal.addEventListener("abort", () => resolve(EXPIRED), { once: true });
+  });
+
+  const first = await Promise.race([observed, aborted]);
+  if (first !== EXPIRED) {
+    release();
+    if (first.kind === "rejected") throw first.error;
+    return { kind: "settled", value: first.value };
+  }
+
+  const grace = delay(options.graceMs ?? CANCELLATION_GRACE_MS);
+  const acknowledged = await Promise.race([observed, grace]);
+  release();
+  if (acknowledged === EXPIRED) {
+    if (onLateSettlement !== undefined) void observed.then(onLateSettlement);
+    return { kind: "indeterminate" };
+  }
+  if (acknowledged.kind === "rejected") return { kind: "cancelled" };
+  onLateSettlement?.(acknowledged);
+  return { kind: "indeterminate" };
+}
+
+export interface ToolTimeoutOptions {
+  readonly graceMs?: number;
+  readonly onLateSettlement?: (settlement: LateSettlement<ToolCallResult>) => void;
+}
+
+/** Written for the model, so it says what to do rather than inviting the retry that duplicates. */
+export const INDETERMINATE_TIMEOUT_MESSAGE =
+  "tool execution timed out and could not be cancelled; the change may already have been " +
+  "applied — verify the current state before attempting it again";
+
+/**
+ * Executes a Tool under a deadline with a per-invocation cancellation signal, and reports a
+ * mutating Tool that ignored its abort as `indeterminate` rather than a failure a caller may retry.
+ */
+export async function executeToolWithTimeout(
   tool: ToolDef,
   args: unknown,
   context: RequestContext,
-  timeoutMs: number
+  timeoutMs: number,
+  options: ToolTimeoutOptions = {}
 ): Promise<ToolCallResult> {
-  return withAbortTimeout(
+  const outcome = await runWithCancellation(
     (abortSignal) => tool.execute(args, { ...context, abortSignal }),
     timeoutMs,
-    () => err("internal_error", "tool execution timed out")
+    {
+      ...(context.abortSignal === undefined ? {} : { outerSignal: context.abortSignal }),
+      ...(options.graceMs === undefined ? {} : { graceMs: options.graceMs }),
+      ...(options.onLateSettlement === undefined
+        ? {}
+        : { onLateSettlement: options.onLateSettlement }),
+    }
   );
+  if (outcome.kind === "settled") return outcome.value;
+  // A read that timed out committed nothing, so there is nothing to reconcile either way.
+  if (outcome.kind === "cancelled" || !tool.mutating) {
+    return err("internal_error", "tool execution timed out");
+  }
+  return err("indeterminate", INDETERMINATE_TIMEOUT_MESSAGE);
 }

--- a/packages/tool-host/src/types.ts
+++ b/packages/tool-host/src/types.ts
@@ -18,7 +18,15 @@ export type ToolErrorCode =
    * failure it cannot repair, spends repair budget rewording arguments that were never wrong, and
    * the person reading the turn is told the platform is broken when it was merely busy.
    */
-  | "unavailable";
+  | "unavailable"
+  /**
+   * The call was abandoned — a deadline expired — without the work acknowledging its cancellation,
+   * so whether the side effect landed is unknown. Neither `internal_error` nor `unavailable` can
+   * carry this: one invites a repair the arguments do not need, the other invites the retry that
+   * duplicates a payment, a notification, or a record write. Nothing may retry an indeterminate
+   * call automatically; the effect is settled `ambiguous` and reconciliation decides.
+   */
+  | "indeterminate";
 
 /**
  * What kind of fault a code represents, and therefore who may act on it. The request itself is the
@@ -26,7 +34,9 @@ export type ToolErrorCode =
  * can only reproduce it. Retrying is the correct response and the model must *not* be asked to
  * repair it, because there is nothing in the arguments to fix.
  */
-export const TOOL_FAULT_CLASS: Readonly<Record<ToolErrorCode, "business" | "infrastructure">> = {
+export const TOOL_FAULT_CLASS: Readonly<
+  Record<ToolErrorCode, "business" | "infrastructure" | "indeterminate">
+> = {
   validation_error: "business",
   surface_invalid: "business",
   presentation_unavailable: "business",
@@ -36,10 +46,16 @@ export const TOOL_FAULT_CLASS: Readonly<Record<ToolErrorCode, "business" | "infr
   audit_required: "business",
   internal_error: "business",
   unavailable: "infrastructure",
+  indeterminate: "indeterminate",
 };
 
 export function isInfrastructureFault(code: ToolErrorCode): boolean {
   return TOOL_FAULT_CLASS[code] === "infrastructure";
+}
+
+/** True when the call's side effect may have landed, so only reconciliation may retry it. */
+export function isIndeterminateFault(code: ToolErrorCode): boolean {
+  return TOOL_FAULT_CLASS[code] === "indeterminate";
 }
 
 export type ToolCallResult =


### PR DESCRIPTION
A deadline enforced with a bare Promise.race answers the caller while the losing operation keeps running. Nothing could tell a Tool that honoured its abort from one still mutating state, and whatever the loser eventually produced was dropped, so a write that landed after we reported failure left no trace. The registry dispatcher was worse: it called execute with no deadline and no signal at all, so a Tool that never settled held the Run forever and a caller-side cancellation never reached the work.

The timeout now aborts, then waits a bounded grace window for the work to acknowledge it. An acknowledged abort is a definitive timeout and stays retryable. Unacknowledged mutating work becomes the new `indeterminate` fault: its own class, outside both retryable readings, whose effect settles `ambiguous` so reconciliation decides rather than an automatic retry repeating a payment, a notification or a record write. Late settlements are reported instead of vanishing.

## Summary

<!-- What changed, and why. Link the driving issue if one exists. -->

## Test plan

<!-- Commands you ran, or manual steps / screenshots for UI changes. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (or the scoped `--filter` you actually ran)

## Checklist

- [ ] PR title follows Conventional Commits (`type(scope): subject`) — CI checks this
- [ ] Scoped to one logical change
- [ ] Tests added/updated for the behavior that changed
