### PR TITLE
fix(skills): identify scanned Skills by path through install

### DIFF
--- a/apps/api/src/soul/skills/routes.test.ts
+++ b/apps/api/src/soul/skills/routes.test.ts
@@ -1125,6 +1125,117 @@ spec:
       expect(installRes.json().error).toContain("more than one skill with the same name");
       expect(commits).toEqual([]);
     });
+
+    // Selecting by name loses which of two same-named rows the operator reviewed, so the whole
+    // pair became uninstallable. `paths` carries that identity from the scan to the write.
+    it("installs the one same-named row the operator selected when identified by path", async () => {
+      const remote = await makeRemoteRepo();
+      temps.push(remote);
+      const second = join(remote, "extra", "demo-skill");
+      await mkdir(second, { recursive: true });
+      await writeFile(
+        join(second, "SKILL.md"),
+        "---\nname: demo-skill\ndescription: A rival demo skill.\n---\nDo it differently.",
+        "utf8"
+      );
+      await execFileP("git", ["add", "-A"], { cwd: remote });
+      await execFileP("git", ["commit", "-q", "-m", "add duplicate name"], { cwd: remote });
+
+      const scanRes = await app.inject({
+        method: "POST",
+        url: "/api/v1/skills/scan",
+        cookies: auth(),
+        headers,
+        payload: { source: `file://${remote}` },
+      });
+      const { scanId, skills } = scanRes.json();
+      const rival = (skills as { skillPath: string }[]).find((skill) =>
+        skill.skillPath.startsWith("extra/")
+      )?.skillPath;
+      expect(rival).toBeDefined();
+
+      buildAudit.mockResolvedValue({
+        riskRating: "low",
+        summary: "No issue found.",
+        toolsReach: [],
+        findings: [],
+        deterministicScan: CLEAN_DETERMINISTIC_SCAN,
+      });
+      await app.inject({
+        method: "POST",
+        url: "/api/v1/skills/audit",
+        cookies: auth(),
+        headers,
+        payload: { scanId, name: "demo-skill", skillPath: rival },
+      });
+      // The audit resolved the selected row, not whichever the scan listed first.
+      expect(buildAudit.mock.calls[0][1]).toMatchObject({ description: "A rival demo skill." });
+
+      const installRes = await app.inject({
+        method: "POST",
+        url: "/api/v1/skills/install",
+        cookies: auth(),
+        headers,
+        payload: { scanId, paths: [rival] },
+      });
+
+      expect(installRes.statusCode).toBe(200);
+      const written = await readFile(join(soulPath, "skills", "demo-skill", "SKILL.md"), "utf8");
+      expect(written).toContain("Do it differently.");
+    });
+
+    it("refuses to install two selected rows that share a name, naming both paths", async () => {
+      const remote = await makeRemoteRepo();
+      temps.push(remote);
+      const second = join(remote, "extra", "demo-skill");
+      await mkdir(second, { recursive: true });
+      await writeFile(
+        join(second, "SKILL.md"),
+        "---\nname: demo-skill\ndescription: A rival demo skill.\n---\nDo it differently.",
+        "utf8"
+      );
+      await execFileP("git", ["add", "-A"], { cwd: remote });
+      await execFileP("git", ["commit", "-q", "-m", "add duplicate name"], { cwd: remote });
+
+      const scanRes = await app.inject({
+        method: "POST",
+        url: "/api/v1/skills/scan",
+        cookies: auth(),
+        headers,
+        payload: { source: `file://${remote}` },
+      });
+      const { scanId, skills } = scanRes.json();
+      const paths = (skills as { skillPath: string }[]).map((skill) => skill.skillPath);
+
+      buildAudit.mockResolvedValue({
+        riskRating: "low",
+        summary: "No issue found.",
+        toolsReach: [],
+        findings: [],
+        deterministicScan: CLEAN_DETERMINISTIC_SCAN,
+      });
+      for (const skillPath of paths) {
+        await app.inject({
+          method: "POST",
+          url: "/api/v1/skills/audit",
+          cookies: auth(),
+          headers,
+          payload: { scanId, name: "demo-skill", skillPath },
+        });
+      }
+
+      const installRes = await app.inject({
+        method: "POST",
+        url: "/api/v1/skills/install",
+        cookies: auth(),
+        headers,
+        payload: { scanId, paths },
+      });
+
+      expect(installRes.statusCode).toBe(400);
+      for (const skillPath of paths) expect(installRes.json().error).toContain(skillPath);
+      expect(commits).toEqual([]);
+    });
   });
 
   describe("DELETE /api/v1/skills/:name", () => {

--- a/apps/api/src/soul/skills/routes.ts
+++ b/apps/api/src/soul/skills/routes.ts
@@ -487,15 +487,15 @@ export function registerSkillRoutes(app: FastifyInstance, soulLoader: SoulLoader
       response: { 200: SkillAuditResponseSchema, 401: ErrorSchema, 404: ErrorSchema, 422: ErrorSchema, 502: ErrorSchema },
     },
   }, async (req, reply) => {
-    const { scanId, name } = req.body as { scanId: string; name: string };
+    const { scanId, name, skillPath } = req.body as { scanId: string; name: string; skillPath?: string };
     const entry = scans.get(scanId);
-    const skill = entry?.skills.find((scannedSkill) => scannedSkill.name === name);
+    const skill = entry?.skills.find((scannedSkill) => (skillPath === undefined ? scannedSkill.name === name : scannedSkill.skillPath === skillPath));
     if (!entry || !skill) return reply.code(404).send({ error: "scanned skill not found (scan may have expired)" });
     const { body } = parseFrontmatter(skill.content);
     const deterministicScan = { ...scanSkill(skill.files), trustLevel: skillTrustLevel(entry.source) };
     try {
       const report = await buildAudit(llmService.effortModel("balanced"), { name: skill.name, description: skill.description, body }, deterministicScan);
-      entry.audited.add(name);
+      entry.audited.add(skill.skillPath);
       return { report };
     } catch (error) {
       if (error instanceof LlmNotConfiguredError) {
@@ -513,19 +513,24 @@ export function registerSkillRoutes(app: FastifyInstance, soulLoader: SoulLoader
       response: { 200: SkillInstallResponseSchema, 400: ErrorSchema, 401: ErrorSchema, 404: ErrorSchema, 409: ErrorSchema, 422: ErrorSchema, 500: ErrorSchema },
     },
   }, async (req, reply) => {
-    const { scanId, names } = req.body as { scanId: string; names: string[] };
+    const { scanId, names, paths } = req.body as { scanId: string; names?: string[]; paths?: string[] };
     const entry = scans.get(scanId);
     if (!entry) return reply.code(404).send({ error: "scan not found (it may have expired)" });
-    const unique = [...new Set(names)];
-    const chosen = unique.map((name) => entry.skills.find((skill) => skill.name === name));
-    const missing = unique.filter((_, index) => !chosen[index]);
+    // `paths` names a scanned row exactly; `names` is the legacy selection and cannot tell two same-named packages apart, so it stays ambiguous by construction.
+    const wanted = paths !== undefined
+      ? [...new Set(paths)].map((path) => ({ key: path, matches: entry.skills.filter((skill) => skill.skillPath === path) }))
+      : [...new Set(names ?? [])].map((name) => ({ key: name, matches: entry.skills.filter((skill) => skill.name === name) }));
+    if (wanted.length === 0) return reply.code(400).send({ error: "select at least one skill to install" });
+    const missing = wanted.filter((want) => want.matches.length === 0).map((want) => want.key);
     if (missing.length > 0) return reply.code(400).send({ error: `not in scan: ${missing.join(", ")}` });
-    const unaudited = unique.filter((name) => !entry.audited.has(name));
-    if (unaudited.length > 0) return reply.code(409).send({ error: `audit required before install: ${unaudited.join(", ")}` });
-    // A Skill name is its soul directory, so two discovered Skills sharing one name cannot both be installed. Refuse rather than install whichever the scan listed first: the operator reviewed two packages and would be given one.
-    const ambiguous = unique.map((name) => entry.skills.filter((skill) => skill.name === name)).filter((matches) => matches.length > 1);
+    const chosen = wanted.flatMap((want) => (want.matches.length === 1 ? want.matches : []));
+    // A Skill name is its soul directory, so two chosen Skills sharing one name cannot both be installed. Refuse rather than install whichever the scan listed first: the operator reviewed two packages and would be given one.
+    const collisions = [...new Set(chosen.map((skill) => skill.name))].map((name) => chosen.filter((skill) => skill.name === name)).filter((group) => group.length > 1);
+    const ambiguous = [...wanted.filter((want) => want.matches.length > 1).map((want) => want.matches), ...collisions];
     if (ambiguous.length > 0) return reply.code(400).send({ error: `this source defines more than one skill with the same name, so the selection is ambiguous: ${ambiguous.map((matches) => `${matches[0].name} (${matches.map((skill) => skill.skillPath).join(", ")})`).join("; ")}` });
-    for (const skill of chosen as DiscoveredSkill[]) {
+    const unaudited = chosen.filter((skill) => !entry.audited.has(skill.skillPath));
+    if (unaudited.length > 0) return reply.code(409).send({ error: `audit required before install: ${unaudited.map((skill) => skill.name).join(", ")}` });
+    for (const skill of chosen) {
       const { frontmatter, body } = parseFrontmatter(skill.content);
       const validation = validateSkill({ name: skill.name, frontmatter, body, content: skill.content });
       if (!validation.valid) return reply.code(400).send({ error: `invalid Skill "${skill.name}": ${validation.error}` });
@@ -540,12 +545,12 @@ export function registerSkillRoutes(app: FastifyInstance, soulLoader: SoulLoader
     }
     const installed: string[] = [];
     const changes: SoulWrite[] = [];
-    for (const skill of chosen as DiscoveredSkill[]) {
+    for (const skill of chosen) {
       changes.push(...(await skillInstallChanges(gitSync.path, skill)));
       installed.push(skill.name);
     }
     const lock = await readLock(gitSync.path);
-    for (const skill of chosen as DiscoveredSkill[]) {
+    for (const skill of chosen) {
       lock.skills[skill.name] = { sourceUrl: stripUrlCredentials(entry.source), sourceType: sourceType(entry.source), skillPath: skill.skillPath, ref: entry.ref, hash: skillDirectoryHash(skill.files) };
     }
     changes.push({ op: "put", target: { kind: "SkillsLock" }, content: `${JSON.stringify(lock, null, 2)}\n` });

--- a/apps/api/src/soul/skills/schemas.ts
+++ b/apps/api/src/soul/skills/schemas.ts
@@ -144,7 +144,12 @@ export const SkillAuditBodySchema = {
   type: "object",
   required: ["scanId", "name"],
   additionalProperties: false,
-  properties: { scanId: { type: "string" }, name: { type: "string" } },
+  properties: {
+    scanId: { type: "string" },
+    name: { type: "string" },
+    /** Resolves the row exactly; `name` alone picks whichever row the scan listed first. */
+    skillPath: { type: "string" },
+  },
 } as const;
 
 export const SkillAuditResponseSchema = {
@@ -155,11 +160,14 @@ export const SkillAuditResponseSchema = {
 
 export const SkillInstallBodySchema = {
   type: "object",
-  required: ["scanId", "names"],
+  required: ["scanId"],
   additionalProperties: false,
   properties: {
     scanId: { type: "string" },
+    /** Legacy selection; cannot distinguish two scanned skills that share a name. */
     names: { type: "array", items: { type: "string" }, minItems: 1 },
+    /** `skillPath` values from the scan — unique per row, so this is the preferred selection. */
+    paths: { type: "array", items: { type: "string" }, minItems: 1 },
   },
 } as const;
 

--- a/apps/docs/content/docs/using-tulipfarm/install-a-skill.mdx
+++ b/apps/docs/content/docs/using-tulipfarm/install-a-skill.mdx
@@ -58,6 +58,9 @@ After every selected skill has an audit report, choose **Confirm install**. Tuli
 skills into the soul, records the change, and pins exactly which version came from where — so what
 runs later is what you reviewed now.
 
+If the install fails, the reason appears next to **Confirm install** and takes focus, so nothing is
+written and you can correct the selection and try again.
+
 ## Verify
 
 Open **Skills**. The installed skills should appear with their descriptions and

--- a/apps/web/app/lib/skills.ts
+++ b/apps/web/app/lib/skills.ts
@@ -112,20 +112,36 @@ export async function scanSkills(source: string): Promise<ScanResult> {
   return apiWrite<ScanResult>("POST", "/api/v1/skills/scan", { source });
 }
 
-export async function auditSkill(scanId: string, name: string): Promise<SkillAuditReport> {
+export async function auditSkill(
+  scanId: string,
+  name: string,
+  skillPath?: string
+): Promise<SkillAuditReport> {
   const body = await apiWrite<{ report: SkillAuditReport }>("POST", "/api/v1/skills/audit", {
     scanId,
     name,
+    skillPath,
   });
   return body.report;
 }
 
-// Operator confirm step: actually install the named scanned skills into the soul repo.
+/**
+ * Operator confirm step: install the selected scanned rows into the soul repo.
+ *
+ * Rows are sent as `paths` so the server installs exactly what the operator reviewed; `names`
+ * is the fallback for a source whose scan predates `skillPath` and cannot tell two same-named
+ * packages apart.
+ */
 export async function installSkills(
   scanId: string,
-  names: string[]
+  skills: readonly { name: string; skillPath?: string }[]
 ): Promise<{ installed: string[] }> {
-  return apiWrite<{ installed: string[] }>("POST", "/api/v1/skills/install", { scanId, names });
+  const paths = skills.flatMap((skill) => (skill.skillPath ? [skill.skillPath] : []));
+  const body =
+    paths.length === skills.length
+      ? { scanId, paths }
+      : { scanId, names: skills.map((skill) => skill.name) };
+  return apiWrite<{ installed: string[] }>("POST", "/api/v1/skills/install", body);
 }
 
 export async function marketplaceSkills(): Promise<MarketplaceCatalog> {

--- a/apps/web/app/routes/_app.skills.marketplace.tsx
+++ b/apps/web/app/routes/_app.skills.marketplace.tsx
@@ -1,5 +1,5 @@
 import { Link, type MetaFunction, useLoaderData } from "@remix-run/react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { ResourcePanel } from "~/components/resource-panel";
 import { SkillsTabs } from "~/components/skills-tabs";
 import { Button } from "~/components/ui/button";
@@ -183,11 +183,14 @@ export default function SkillsMarketplace() {
   const [error, setError] = useState<string | null>(null);
   const [installError, setInstallError] = useState<string | null>(null);
   const [installed, setInstalled] = useState<string[] | null>(null);
+  const installErrorRef = useRef<HTMLParagraphElement>(null);
 
-  // Selection is keyed by row, not by name: a source may define two skills with the same name.
+  // Selection, reports and the install payload are all keyed by row, never by name: a source may
+  // define two different skills with the same name, and merging them silently swaps one package
+  // for another between what the operator reviewed and what is written to the soul.
   const selectedSkills = (scan?.skills ?? []).filter((s) => selected.has(skillRowKey(s)));
-  const selectedNames = selectedSkills.map((s) => s.name);
-  const allAudited = selectedSkills.length > 0 && selectedSkills.every((s) => reports[s.name]);
+  const allAudited =
+    selectedSkills.length > 0 && selectedSkills.every((s) => reports[skillRowKey(s)]);
   const catalogGroups = new Map<string, MarketplaceCatalog["skills"]>();
   for (const skill of catalog?.skills ?? []) {
     const category = skill.category ?? "other";
@@ -196,6 +199,12 @@ export default function SkillsMarketplace() {
     else catalogGroups.set(category, [skill]);
   }
   const updateCount = catalog?.skills.filter((skill) => skill.updateAvailable).length ?? 0;
+
+  // The report list is long, so an error rendered beside the confirm button can still be off
+  // screen. Focus scrolls it into view and announces it at the point of failure (#444).
+  useEffect(() => {
+    if (installError) installErrorRef.current?.focus();
+  }, [installError]);
 
   // Load one or more catalog skills into the select → audit → confirm pipeline (the audit gate runs
   // unchanged). Used by the per-row Install/Update buttons and the "Review all" button.
@@ -240,19 +249,19 @@ export default function SkillsMarketplace() {
   }
 
   async function onAudit() {
-    if (!scan || selectedNames.length === 0) return;
+    if (!scan || selectedSkills.length === 0) return;
     setBusy("audit");
     setError(null);
     setInstallError(null);
     // Audit each selected skill independently so one failure does not discard the others' reports.
     const settled = await Promise.allSettled(
-      selectedNames.map((name) => auditSkill(scan.scanId, name))
+      selectedSkills.map((s) => auditSkill(scan.scanId, s.name, s.skillPath))
     );
     const next: Record<string, SkillAuditReport> = {};
     const failures: string[] = [];
     settled.forEach((result, i) => {
-      if (result.status === "fulfilled") next[selectedNames[i]] = result.value;
-      else failures.push(`${selectedNames[i]}: ${errMessage(result.reason)}`);
+      if (result.status === "fulfilled") next[skillRowKey(selectedSkills[i])] = result.value;
+      else failures.push(`${selectedSkills[i].name}: ${errMessage(result.reason)}`);
     });
     setReports(next);
     setError(failures.length > 0 ? failures.join("; ") : null);
@@ -265,7 +274,10 @@ export default function SkillsMarketplace() {
     setError(null);
     setInstallError(null);
     try {
-      const res = await installSkills(scan.scanId, selectedNames);
+      const res = await installSkills(
+        scan.scanId,
+        selectedSkills.map((s) => ({ name: s.name, skillPath: s.skillPath }))
+      );
       setInstalled(res.installed);
     } catch (e) {
       // Kept beside the confirm button as well as in the page banner: the banner sits above a long
@@ -445,11 +457,11 @@ export default function SkillsMarketplace() {
                       )}
                       <span className="ml-auto flex shrink-0 items-baseline gap-2">
                         <InstallBadge installed={s.installed} updateAvailable={s.updateAvailable} />
-                        {reports[s.name] ? (
+                        {reports[skillRowKey(s)] ? (
                           <span
-                            className={`rounded-sm border px-1.5 py-0.5 text-xs uppercase tracking-[0.15em] ${RISK_CLASS[reports[s.name].riskRating]}`}
+                            className={`rounded-sm border px-1.5 py-0.5 text-xs uppercase tracking-[0.15em] ${RISK_CLASS[reports[skillRowKey(s)].riskRating]}`}
                           >
-                            {reports[s.name].riskRating}
+                            {reports[skillRowKey(s)].riskRating}
                           </span>
                         ) : null}
                       </span>
@@ -457,15 +469,19 @@ export default function SkillsMarketplace() {
                   </li>
                 ))}
               </ul>
-              <Button
-                size="sm"
-                variant="outline"
-                className="self-start"
-                onClick={() => void onAudit()}
-                disabled={busy !== null || selectedNames.length === 0}
-              >
-                {busy === "audit" ? "Auditing…" : `Run SkillAudit (${selectedNames.length})`}
-              </Button>
+              {/* Once the selection is audited the only action left is confirm; offering both at
+                  once left the operator unable to tell which one advanced the flow (#444). */}
+              {allAudited ? null : (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="self-start"
+                  onClick={() => void onAudit()}
+                  disabled={busy !== null || selectedSkills.length === 0}
+                >
+                  {busy === "audit" ? "Auditing…" : `Run SkillAudit (${selectedSkills.length})`}
+                </Button>
+              )}
             </div>
           ) : null}
 
@@ -473,7 +489,11 @@ export default function SkillsMarketplace() {
           {allAudited ? (
             <div className="flex flex-col gap-3 border-t border-border pt-4">
               {selectedSkills.map((s) => (
-                <AuditReportCard key={skillRowKey(s)} name={s.name} report={reports[s.name]} />
+                <AuditReportCard
+                  key={skillRowKey(s)}
+                  name={s.name}
+                  report={reports[skillRowKey(s)]}
+                />
               ))}
               <p className="rounded-sm border border-border bg-muted px-3 py-2 text-xs text-muted-foreground">
                 SkillAudit is <span className="text-foreground">advisory, not a guarantee</span>. A
@@ -484,8 +504,10 @@ export default function SkillsMarketplace() {
               </p>
               {installError ? (
                 <p
+                  ref={installErrorRef}
+                  tabIndex={-1}
                   role="alert"
-                  className="rounded-sm border border-destructive bg-destructive/10 px-3 py-2 text-destructive"
+                  className="rounded-sm border border-destructive bg-destructive/10 px-3 py-2 text-destructive outline-none"
                 >
                   install failed: {installError}
                 </p>
@@ -496,7 +518,7 @@ export default function SkillsMarketplace() {
                 onClick={() => void onInstall()}
                 disabled={busy !== null}
               >
-                {busy === "install" ? "Installing…" : `Confirm install (${selectedNames.length})`}
+                {busy === "install" ? "Installing…" : `Confirm install (${selectedSkills.length})`}
               </Button>
             </div>
           ) : null}

--- a/apps/web/app/routes/skills.marketplace.test.tsx
+++ b/apps/web/app/routes/skills.marketplace.test.tsx
@@ -1,7 +1,7 @@
 import { createRemixStub } from "@remix-run/testing";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { expect, test, vi } from "vitest";
+import { beforeEach, expect, test, vi } from "vitest";
 
 // Mock the skills client so no real fetch/audit runs; drive the flow through the UI.
 vi.mock("~/lib/skills", () => ({
@@ -15,6 +15,11 @@ vi.mock("~/lib/skills", () => ({
 import { auditSkill, installSkills, type MarketplaceCatalog, scanSkills } from "~/lib/skills";
 import SkillsMarketplace from "./_app.skills.marketplace";
 
+// Call arguments are asserted per test, so recorded calls must not leak between them.
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
 function renderInstall(catalog: MarketplaceCatalog | null = null) {
   const Stub = createRemixStub([
     { path: "/", Component: () => <SkillsMarketplace />, loader: () => ({ catalog }) },
@@ -27,7 +32,13 @@ test("scan → audit → advisory + operator confirm → install", async () => {
   vi.mocked(scanSkills).mockResolvedValue({
     scanId: "s1",
     skills: [
-      { name: "demo-skill", description: "A demo.", installed: false, updateAvailable: false },
+      {
+        name: "demo-skill",
+        skillPath: "skills/demo-skill/SKILL.md",
+        description: "A demo.",
+        installed: false,
+        updateAvailable: false,
+      },
     ],
   });
   vi.mocked(auditSkill).mockResolvedValue({
@@ -76,7 +87,9 @@ test("scan → audit → advisory + operator confirm → install", async () => {
   await user.click(screen.getByRole("button", { name: /confirm install/i }));
 
   expect(await screen.findByText(/Installed demo-skill/i)).toBeInTheDocument();
-  expect(installSkills).toHaveBeenCalledWith("s1", ["demo-skill"]);
+  expect(installSkills).toHaveBeenCalledWith("s1", [
+    { name: "demo-skill", skillPath: "skills/demo-skill/SKILL.md" },
+  ]);
 });
 
 test("marketplace catalog feeds the same audit → operator-confirm flow", async () => {
@@ -121,7 +134,10 @@ test("marketplace catalog feeds the same audit → operator-confirm flow", async
 
   await user.click(screen.getByRole("button", { name: /confirm install/i }));
   expect(await screen.findByText(/Installed demo-skill/i)).toBeInTheDocument();
-  expect(installSkills).toHaveBeenCalledWith("mkt-1", ["demo-skill"]);
+  // A catalog row without a path falls back to identifying the skill by name.
+  expect(installSkills).toHaveBeenCalledWith("mkt-1", [
+    { name: "demo-skill", skillPath: undefined },
+  ]);
 });
 
 test("a missing marketplace catalog still renders the manual git-url scan form", async () => {
@@ -273,4 +289,207 @@ test("an install failure is reported beside the confirm button, not only in the 
   // The confirm button is still there to retry, and nothing claims a successful install.
   expect(screen.getByRole("button", { name: /confirm install/i })).toBeInTheDocument();
   expect(screen.queryByText(/^Installed /)).not.toBeInTheDocument();
+});
+
+// The two rows are distinct packages, so each must get its own report. Auditing by name alone
+// makes the server resolve whichever row it listed first and shows that one report twice.
+test("two scanned skills sharing a name are audited and reported separately", async () => {
+  const user = userEvent.setup();
+  vi.mocked(scanSkills).mockResolvedValue({
+    scanId: "s4",
+    skills: [
+      {
+        name: "review-contract",
+        skillPath: "legal/review-contract/SKILL.md",
+        description: "Negotiation playbook review.",
+        installed: false,
+        updateAvailable: false,
+      },
+      {
+        name: "review-contract",
+        skillPath: "small-business/review-contract/SKILL.md",
+        description: "Plain-English review.",
+        installed: false,
+        updateAvailable: false,
+      },
+    ],
+  });
+  vi.mocked(auditSkill).mockImplementation(async (_scanId, _name, skillPath) => ({
+    riskRating: "low",
+    summary:
+      skillPath === "legal/review-contract/SKILL.md" ? "Legal summary." : "Small-biz summary.",
+    toolsReach: [],
+    findings: [],
+    deterministicScan: { verdict: "safe", trustLevel: "community", findings: [] },
+  }));
+
+  renderInstall();
+  await user.type(await screen.findByLabelText(/git url/i), "owner/repo");
+  await user.click(screen.getByRole("button", { name: /^Scan$/ }));
+  await user.click(await screen.findByRole("button", { name: /Run SkillAudit \(2\)/ }));
+
+  expect(await screen.findByText("Legal summary.")).toBeInTheDocument();
+  expect(screen.getByText("Small-biz summary.")).toBeInTheDocument();
+});
+
+// What the operator selected must reach the install request intact. Sending bare names collapses
+// the two rows into one string and silently drops a package the operator saw and confirmed.
+test("the install payload identifies each selected row by its path", async () => {
+  const user = userEvent.setup();
+  vi.mocked(scanSkills).mockResolvedValue({
+    scanId: "s5",
+    skills: [
+      {
+        name: "review-contract",
+        skillPath: "legal/review-contract/SKILL.md",
+        description: "Negotiation playbook review.",
+        installed: false,
+        updateAvailable: false,
+      },
+      {
+        name: "review-contract",
+        skillPath: "small-business/review-contract/SKILL.md",
+        description: "Plain-English review.",
+        installed: false,
+        updateAvailable: false,
+      },
+    ],
+  });
+  vi.mocked(auditSkill).mockResolvedValue({
+    riskRating: "low",
+    summary: "Benign.",
+    toolsReach: [],
+    findings: [],
+    deterministicScan: { verdict: "safe", trustLevel: "community", findings: [] },
+  });
+  vi.mocked(installSkills).mockResolvedValue({ installed: ["review-contract"] });
+
+  renderInstall();
+  await user.type(await screen.findByLabelText(/git url/i), "owner/repo");
+  await user.click(screen.getByRole("button", { name: /^Scan$/ }));
+  await user.click(await screen.findByRole("button", { name: /Run SkillAudit \(2\)/ }));
+  await user.click(await screen.findByRole("button", { name: /confirm install/i }));
+
+  expect(installSkills).toHaveBeenCalledWith("s5", [
+    { name: "review-contract", skillPath: "legal/review-contract/SKILL.md" },
+    { name: "review-contract", skillPath: "small-business/review-contract/SKILL.md" },
+  ]);
+});
+
+test("selecting one of two same-named rows installs exactly that row", async () => {
+  const user = userEvent.setup();
+  vi.mocked(scanSkills).mockResolvedValue({
+    scanId: "s6",
+    skills: [
+      {
+        name: "review-contract",
+        skillPath: "legal/review-contract/SKILL.md",
+        description: "Negotiation playbook review.",
+        installed: false,
+        updateAvailable: false,
+      },
+      {
+        name: "review-contract",
+        skillPath: "small-business/review-contract/SKILL.md",
+        description: "Plain-English review.",
+        installed: false,
+        updateAvailable: false,
+      },
+    ],
+  });
+  vi.mocked(auditSkill).mockResolvedValue({
+    riskRating: "low",
+    summary: "Benign.",
+    toolsReach: [],
+    findings: [],
+    deterministicScan: { verdict: "safe", trustLevel: "community", findings: [] },
+  });
+  vi.mocked(installSkills).mockResolvedValue({ installed: ["review-contract"] });
+
+  renderInstall();
+  await user.type(await screen.findByLabelText(/git url/i), "owner/repo");
+  await user.click(screen.getByRole("button", { name: /^Scan$/ }));
+
+  const boxes = await screen.findAllByRole("checkbox");
+  await user.click(boxes[1]);
+  await user.click(await screen.findByRole("button", { name: /Run SkillAudit \(1\)/ }));
+  await user.click(await screen.findByRole("button", { name: /confirm install/i }));
+
+  expect(installSkills).toHaveBeenCalledWith("s6", [
+    { name: "review-contract", skillPath: "legal/review-contract/SKILL.md" },
+  ]);
+});
+
+// #444: after the audit resolves the operator was offered two competing primary actions with no
+// indication which one advanced the flow.
+test("the audit action gives way to confirm once the selection is audited", async () => {
+  const user = userEvent.setup();
+  vi.mocked(scanSkills).mockResolvedValue({
+    scanId: "s7",
+    skills: [
+      {
+        name: "demo-skill",
+        skillPath: "skills/demo-skill/SKILL.md",
+        description: "A demo.",
+        installed: false,
+        updateAvailable: false,
+      },
+    ],
+  });
+  vi.mocked(auditSkill).mockResolvedValue({
+    riskRating: "low",
+    summary: "Benign.",
+    toolsReach: [],
+    findings: [],
+    deterministicScan: { verdict: "safe", trustLevel: "trusted", findings: [] },
+  });
+
+  renderInstall();
+  await user.type(await screen.findByLabelText(/git url/i), "owner/repo");
+  await user.click(screen.getByRole("button", { name: /^Scan$/ }));
+  await user.click(await screen.findByRole("button", { name: /Run SkillAudit/ }));
+
+  expect(await screen.findByRole("button", { name: /confirm install/i })).toBeInTheDocument();
+  expect(screen.queryByRole("button", { name: /Run SkillAudit/ })).not.toBeInTheDocument();
+
+  // Changing the selection invalidates the audit, so the audit action comes back.
+  await user.click(screen.getByRole("checkbox"));
+  expect(await screen.findByRole("button", { name: /Run SkillAudit \(0\)/ })).toBeInTheDocument();
+  expect(screen.queryByRole("button", { name: /confirm install/i })).not.toBeInTheDocument();
+});
+
+// #444: the report list is long, so an error rendered in place is still off-screen. Move focus to
+// it so the failure is announced and scrolled to at the point of failure.
+test("an install failure takes focus so it is seen at the point of failure", async () => {
+  const user = userEvent.setup();
+  vi.mocked(scanSkills).mockResolvedValue({
+    scanId: "s8",
+    skills: [
+      {
+        name: "demo-skill",
+        skillPath: "skills/demo-skill/SKILL.md",
+        description: "A demo.",
+        installed: false,
+        updateAvailable: false,
+      },
+    ],
+  });
+  vi.mocked(auditSkill).mockResolvedValue({
+    riskRating: "low",
+    summary: "Benign.",
+    toolsReach: [],
+    findings: [],
+    deterministicScan: { verdict: "safe", trustLevel: "trusted", findings: [] },
+  });
+  vi.mocked(installSkills).mockRejectedValue(new Error("invalid soul write target"));
+
+  renderInstall();
+  await user.type(await screen.findByLabelText(/git url/i), "owner/repo");
+  await user.click(screen.getByRole("button", { name: /^Scan$/ }));
+  await user.click(await screen.findByRole("button", { name: /Run SkillAudit/ }));
+  await user.click(await screen.findByRole("button", { name: /confirm install/i }));
+
+  const alert = await screen.findByRole("alert");
+  expect(alert).toHaveTextContent(/install failed: invalid soul write target/i);
+  expect(alert).toHaveFocus();
 });

--- a/docs/qa/playbooks/skills.md
+++ b/docs/qa/playbooks/skills.md
@@ -102,7 +102,7 @@ keep this to exactly one skill this run can identify unambiguously.
 | 1 | On `/skills/marketplace`, `click` `Install` on the chosen row | Loads just that one skill into the pipeline: `Run SkillAudit (1)` appears |
 | 2 | `note` the exact skill name shown — this is the artifact identity for the rest of this scenario and for S5–S7's cleanup in S7 | Recorded |
 | 3 | `click` `Run SkillAudit (1)` | Button reads "Auditing…" |
-| 4 | `wait-until` settled (max 10s) | An audit report card renders: skill name, a risk pill (`low risk` / `medium risk` / `high risk`), a summary sentence, and — if present — a "tool reach:" line listing the abilities the audit attributes to the skill | Rendered |
+| 4 | `wait-until` settled (max 10s) | An audit report card renders: skill name, a risk pill (`low risk` / `medium risk` / `high risk`), a summary sentence, and — if present — a "tool reach:" line listing the abilities the audit attributes to the skill. `Run SkillAudit` gives way to `Confirm install`, so exactly one action is offered | Rendered |
 | 5 | `expect` a findings list (or "No specific findings.") — each finding shows a category and a detail sentence | Present |
 | 6 | `expect` a "Deterministic pre-scan" block: a verdict pill (`safe`/`caution`/`dangerous`), a trust-level tag (`builtin`/`trusted`/`community` source), and the text "Advisory scanner evidence is shown verbatim and never blocks the operator's choice." | Present |
 | 7 | If the deterministic scan has structural findings, `expect` each is grouped by category (`exfiltration`, `injection`, `destructive`, `obfuscation`, `network`, or `persistence`) and shows severity, a `patternId`, `file:line`, a description, and the matched text verbatim | Present |

--- a/scripts/control-plane-size.test.ts
+++ b/scripts/control-plane-size.test.ts
@@ -480,9 +480,21 @@ import { describe, expect, it } from "vitest";
  * +130, the Agent capability restrictions itemised above. Four rebases now, four raises, and the
  * difference over main has been exactly 1_216 at every one of them — the branch has added no line
  * to `apps/api/src` since its own entries above were reviewed.
+ *
+ * 52_854 -> 52_867 is thirteen lines across `soul/skills/routes.ts` and `soul/skills/schemas.ts`,
+ * paying for skill identity at the install boundary (#445). A scanned source can define two
+ * distinct Skills under the same directory name, so `names: string[]` could not say which of them
+ * the operator reviewed and confirmed — selecting either one was refused as ambiguous and the pair
+ * was uninstallable. `POST /skills/install` now also accepts `paths`, the `skillPath` values the
+ * scan already returns, and `POST /skills/audit` an optional `skillPath`; resolution, the audited
+ * set and the same-name refusal are rekeyed onto that path. Ten of the thirteen lines are the
+ * install handler's resolve-then-refuse block, which grew because it must now distinguish "this
+ * name matches two rows" from "these two selected rows collide"; the rest is the two body schemas.
+ * None of it belongs in `packages/soul`: the ambiguity only exists because an HTTP client sent a
+ * selection, and the scan cache it resolves against lives in this route module.
  */
 
-const CEILING = 52_854;
+const CEILING = 52_867;
 
 /**
  * Domains inside `apps/api/src` that already have a package of the same name. Everything here that


### PR DESCRIPTION
A scanned source can define two distinct Skills under the same directory name, so `name` was never a usable identity. The rows were already keyed apart in the DOM, but the audit and install contracts still spoke in names: auditing either duplicate returned whichever row the scan listed first, both rows rendered that one report, and install refused the pair as ambiguous even when the operator had selected exactly one of them. The operator therefore confirmed a report that did not describe the package they picked, and could not install either.

Audit and install now carry the `skillPath` the scan already returns, and the web keys its reports and payload by the same row key. The refusal is narrowed to what it is actually about: two *selected* Skills whose shared name would claim one soul directory.

Also closes the remaining UI half of #444 — the install error takes focus so it is seen at the point of failure, and the audit action gives way to confirm so only one action is ever offered.

## Summary

<!-- What changed, and why. Link the driving issue if one exists. -->

## Test plan

<!-- Commands you ran, or manual steps / screenshots for UI changes. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (or the scoped `--filter` you actually ran)

## Checklist

- [ ] PR title follows Conventional Commits (`type(scope): subject`) — CI checks this
- [ ] Scoped to one logical change
- [ ] Tests added/updated for the behavior that changed
