### PR TITLE
fix(llm): report real provider reachability in the llm health check

### DIFF
--- a/apps/api/src/admin/health.test.ts
+++ b/apps/api/src/admin/health.test.ts
@@ -1,6 +1,6 @@
 import { LlmNotConfiguredError, UnknownModelError } from "@tulipfarm/schema";
 import { describe, expect, it, vi } from "vitest";
-import { llmProbe, probeHealth } from "./health";
+import { type HealthResult, llmProbe, probeHealth } from "./health";
 
 /** A configured, resolvable model. Resolution alone cannot tell a live key from a revoked one. */
 const configured = { effortModel: vi.fn(() => ({})) };
@@ -17,7 +17,7 @@ describe("llmProbe", () => {
   it("reports up while a working provider is still answering the live call", async () => {
     // A real model call outlives the probe budget on a cold subscription provider. Awaiting it
     // here timed the probe out, so the page said `down` about a provider that was answering chats.
-    const verify = vi.fn(() => new Promise<void>(() => {}));
+    const verify = vi.fn(() => new Promise<HealthResult>(() => {}));
 
     const [component] = await probeHealth([llmProbe(configured, { reachability: { verify } })], at);
 
@@ -25,11 +25,13 @@ describe("llmProbe", () => {
     expect(verify).toHaveBeenCalledTimes(1);
   });
 
-  it("degrades once the provider refuses the credential", async () => {
+  it("publishes the verdict the reachability check reached, whatever it is", async () => {
     // Resolution succeeds for a revoked key, so without a live check this reported `ok` and the
     // first person to learn the key was dead was a participant mid-chat.
     const probe = llmProbe(configured, {
-      reachability: { verify: async () => Promise.reject(new Error("401 invalid api key")) },
+      reachability: {
+        verify: async () => ({ status: "degraded", detail: "credential refused" }) as HealthResult,
+      },
     });
 
     await probe.check();
@@ -37,23 +39,27 @@ describe("llmProbe", () => {
     await vi.waitFor(async () => {
       const result = await probe.check();
       expect(result.status).toBe("degraded");
-      expect(result.detail).toContain("401 invalid api key");
+      expect(result.detail).toContain("credential refused");
     });
   });
 
-  it("never reports down, so a provider cannot fail this deployment's readiness", async () => {
+  it("reports down when the check itself cannot run, rather than staying green", async () => {
+    // Swallowing this reported a healthy provider on a deployment where nothing had been asked.
     const probe = llmProbe(configured, {
-      reachability: { verify: async () => Promise.reject(new Error("anything")) },
+      reachability: { verify: async () => Promise.reject(new Error("boom")) },
     });
 
     await probe.check();
 
-    await vi.waitFor(async () => expect((await probe.check()).status).toBe("degraded"));
-    expect((await probe.check()).status).not.toBe("down");
+    await vi.waitFor(async () => {
+      const result = await probe.check();
+      expect(result.status).toBe("down");
+      expect(result.detail).toContain("boom");
+    });
   });
 
   it("caches the verdict so scraping the health page cannot spend tokens per hit", async () => {
-    const verify = vi.fn(async () => {});
+    const verify = vi.fn(async (): Promise<HealthResult> => ({ status: "ok" }));
     let clock = 1_000;
     const probe = llmProbe(configured, {
       reachability: { verify },
@@ -81,7 +87,8 @@ describe("llmProbe", () => {
     const [component] = await probeHealth([probe], at);
 
     expect(component.status).toBe("unknown");
-    expect(component.detail).toBe("no LLM provider is configured");
+    expect(component.detail).toContain("no LLM provider is configured");
+    expect(component.detail).toContain("Business → Models");
   });
 
   it("still reports down when a configured model cannot be resolved", async () => {

--- a/apps/api/src/admin/health.ts
+++ b/apps/api/src/admin/health.ts
@@ -128,16 +128,19 @@ export interface ModelProbeTarget {
   effortModel(preset: "balanced"): unknown;
 }
 
-/** Whether the configured credential is still accepted. Absent means "not checked". */
+/** The verdict a live provider call proved. Absent means "not checked". */
 export interface ModelReachability {
-  /** Rejects only when the provider refused the *credential*; transient faults resolve. */
-  verify(): Promise<void>;
+  /**
+   * Resolves with the verdict for every outcome, including failure: a rejection would leave the
+   * probe unable to say anything but that the check itself broke.
+   */
+  verify(): Promise<HealthResult>;
 }
 
 export interface LlmProbeOptions {
   /**
-   * Optional live credential check. Without it the probe reports configuration only, which
-   * cannot distinguish a working key from a revoked one.
+   * Optional live provider call. Without it the probe reports configuration only, which cannot
+   * distinguish a reachable provider from a revoked key or a dead endpoint.
    */
   readonly reachability?: ModelReachability;
   /** Reachability is cached this long so scraping the health page cannot spend tokens per hit. */
@@ -149,17 +152,17 @@ const REACHABILITY_TTL_MS = 60_000;
 
 /**
  * Checks that a model is configured and resolvable, and — when a reachability check is supplied —
- * that the provider still accepts the credential.
+ * what a live call to the configured provider proved.
  *
- * The credential check runs *outside* this call: a real model call takes seconds, `runProbe` gives
- * every probe a two-second budget, and awaiting one here reported a working provider as `down` on
+ * The live call runs *outside* this one: a real model call takes seconds, `runProbe` gives every
+ * probe a two-second budget, and awaiting one here reported a working provider as `down` on
  * exactly the deployments whose first call is slowest. `check()` therefore answers from the last
  * verdict and refreshes in the background, so provider latency can never decide the status.
  *
- * A provider outage is deliberately *not* our failure: only a refused credential downgrades the
- * component, and only to `degraded`. Reporting `down` would hand a third party the power to fail
- * this deployment's readiness. Without that distinction a revoked key reported `ok` and the first
- * person to learn of it was a participant mid-chat.
+ * The verdict itself is the reachability check's to make, and it distinguishes a provider that
+ * answered — a refused credential, a throttle, a request it did not like — from one that never
+ * answered at all. Swallowing the second class reported `ok` straight through an outage, which is
+ * the more dangerous half of an untrustworthy health row: it is wrong silently.
  */
 export function llmProbe(llm: ModelProbeTarget, options: LlmProbeOptions = {}): HealthProbe {
   const now = options.now ?? Date.now;
@@ -173,15 +176,15 @@ export function llmProbe(llm: ModelProbeTarget, options: LlmProbeOptions = {}): 
     void reachability
       .verify()
       .then(
-        () => {
-          cached = { at: now(), result: { status: "ok" } };
+        (result) => {
+          cached = { at: now(), result };
         },
         (error: unknown) => {
           cached = {
             at: now(),
             result: {
-              status: "degraded",
-              detail: `provider rejected the credential: ${message(error)}`,
+              status: "down",
+              detail: `the provider check could not run: ${message(error)}`,
             },
           };
         }
@@ -198,7 +201,10 @@ export function llmProbe(llm: ModelProbeTarget, options: LlmProbeOptions = {}): 
         llm.effortModel("balanced");
       } catch (error) {
         if (error instanceof LlmNotConfiguredError) {
-          return { status: "unknown", detail: "no LLM provider is configured" };
+          return {
+            status: "unknown",
+            detail: "no LLM provider is configured — connect one under Business → Models",
+          };
         }
         throw error;
       }
@@ -209,7 +215,7 @@ export function llmProbe(llm: ModelProbeTarget, options: LlmProbeOptions = {}): 
       if (cached !== undefined && now() - cached.at < ttlMs) return cached.result;
 
       refresh(reachability);
-      return cached?.result ?? { status: "ok", detail: "credential check pending" };
+      return cached?.result ?? { status: "ok", detail: "provider check pending" };
     },
   };
 }

--- a/apps/api/src/admin/model-reachability.test.ts
+++ b/apps/api/src/admin/model-reachability.test.ts
@@ -1,0 +1,134 @@
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { LlmService } from "@tulipfarm/llm";
+import type { SecretsService } from "@tulipfarm/secrets";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { llmProbe, probeHealth } from "./health";
+import { modelReachability } from "./model-reachability";
+
+/**
+ * The `llm` row is the only health check whose verdict comes from a third party, and it was
+ * reported both ways: `down` while chat was answering, then `ok` with the provider unplugged.
+ * These run the real probe, the real service and a real HTTP provider, because every wrong verdict
+ * so far came from the wiring between them rather than from any one of them.
+ */
+
+const secrets = {} as unknown as SecretsService;
+const silent = { info: () => {}, warn: () => {}, error: () => {} };
+
+let server: Server | undefined;
+
+async function listen(respond: (res: import("node:http").ServerResponse) => void): Promise<string> {
+  const created = createServer((_request, response) => respond(response));
+  await new Promise<void>((resolve) => created.listen(0, "127.0.0.1", resolve));
+  server = created;
+  return `http://127.0.0.1:${(created.address() as AddressInfo).port}/v1`;
+}
+
+function json(status: number, body: unknown, delayMs = 0) {
+  return (response: import("node:http").ServerResponse) => {
+    const send = () => {
+      response.writeHead(status, { "content-type": "application/json" });
+      response.end(JSON.stringify(body));
+    };
+    if (delayMs > 0) setTimeout(send, delayMs);
+    else send();
+  };
+}
+
+const ANSWER = {
+  id: "chatcmpl-1",
+  object: "chat.completion",
+  created: 1,
+  model: "test-balanced",
+  choices: [{ index: 0, message: { role: "assistant", content: "OK" }, finish_reason: "stop" }],
+  usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+};
+
+async function serviceFor(baseUrl: string): Promise<LlmService> {
+  process.env.HEALTH_PROBE_TEST_KEY = "not-a-real-key";
+  const entry = (model: string) => ({
+    provider: "openai-compatible",
+    model,
+    api_key_ref: "env://HEALTH_PROBE_TEST_KEY",
+    base_url: baseUrl,
+  });
+  const service = new LlmService();
+  await service.init(
+    {
+      tiers: {
+        quick: { providers: [entry("test-fast")] },
+        standard: { providers: [entry("test-balanced")] },
+        complex: { providers: [entry("test-thorough")] },
+      },
+    },
+    secrets,
+    silent
+  );
+  return service;
+}
+
+async function settledStatus(baseUrl: string) {
+  const service = await serviceFor(baseUrl);
+  const probe = llmProbe(service, { reachability: modelReachability(service) });
+  await probeHealth([probe]);
+  return vi.waitFor(
+    async () => {
+      const [component] = await probeHealth([probe]);
+      expect(component.detail ?? "").not.toContain("pending");
+      return component;
+    },
+    { timeout: 15_000, interval: 100 }
+  );
+}
+
+afterEach(async () => {
+  const running = server;
+  server = undefined;
+  if (running) await new Promise<void>((resolve) => running.close(() => resolve()));
+});
+
+describe("the llm health probe against a real provider", () => {
+  it("reports ok for a provider that answers, however slowly it starts", async () => {
+    const baseUrl = await listen(json(200, ANSWER, 2_500));
+
+    const component = await settledStatus(baseUrl);
+
+    expect(component.status).toBe("ok");
+  }, 30_000);
+
+  it("reports down when the provider cannot be reached at all", async () => {
+    const baseUrl = await listen(json(200, ANSWER));
+    const closing = server;
+    server = undefined;
+    await new Promise<void>((resolve) => closing?.close(() => resolve()));
+
+    const component = await settledStatus(baseUrl);
+
+    expect(component.status).toBe("down");
+    expect(component.detail).toContain("no answer from the provider");
+  }, 30_000);
+
+  it("degrades, and says what to do, when the provider refuses the credential", async () => {
+    const baseUrl = await listen(
+      json(401, { error: { message: "bad key", type: "invalid_request_error" } })
+    );
+
+    const component = await settledStatus(baseUrl);
+
+    expect(component.status).toBe("degraded");
+    expect(component.detail).toContain("Business → Models");
+    expect(component.detail).not.toContain("not-a-real-key");
+  }, 30_000);
+
+  it("blames the check, not the provider, when the provider refuses its request", async () => {
+    const baseUrl = await listen(
+      json(400, { error: { message: "unsupported parameter", type: "invalid_request_error" } })
+    );
+
+    const component = await settledStatus(baseUrl);
+
+    expect(component.status).toBe("degraded");
+    expect(component.detail).toContain("the provider itself is reachable");
+  }, 30_000);
+});

--- a/apps/api/src/admin/model-reachability.ts
+++ b/apps/api/src/admin/model-reachability.ts
@@ -1,48 +1,26 @@
-import { LlmProviderError } from "@tulipfarm/llm";
-import { generateText } from "ai";
-import type { ModelReachability } from "./health";
-
-/** Verifies the deployment's model credential is still accepted, without failing on an outage. */
-
-/**
- * Long enough for a cold subscription-CLI provider to spawn, hand-shake and answer. This call no
- * longer runs inside the probe's response budget, so cutting it short only loses the verdict —
- * an abort is indistinguishable from a healthy provider here, and a revoked key would read `ok`.
- */
-const REACHABILITY_TIMEOUT_MS = 30_000;
-
-/** Provider verdicts that mean *this deployment's credential* is the problem, not the provider. */
-const CREDENTIAL_REASONS = new Set(["model_authentication_failed", "model_billing_inactive"]);
+import { checkModelReachability } from "@tulipfarm/llm";
+import type { HealthResult, ModelReachability } from "./health";
 
 interface ReachabilityTarget {
   effortModel(preset: "balanced"): unknown;
 }
 
 /**
- * The smallest possible real call: enough to make the provider authenticate the credential.
+ * Turns a live provider call into the deployment's `llm` health verdict.
  *
- * Anything that is not a credential verdict resolves successfully. A provider outage, a rate
- * limit or a timeout says nothing about this deployment's health, and letting it downgrade the
- * component would hand a third party control of our readiness page.
+ * The model is resolved per call rather than captured, so a probe started before the operator
+ * connected a provider reports on what is configured now.
  */
 export function modelReachability(llm: ReachabilityTarget): ModelReachability {
   return {
-    async verify() {
-      const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), REACHABILITY_TIMEOUT_MS);
-      try {
-        await generateText({
-          // biome-ignore lint/suspicious/noExplicitAny: the probe target is structural by design.
-          model: llm.effortModel("balanced") as any,
-          prompt: "ping",
-          maxOutputTokens: 1,
-          abortSignal: controller.signal,
-        });
-      } catch (err) {
-        if (err instanceof LlmProviderError && CREDENTIAL_REASONS.has(err.reason)) throw err;
-      } finally {
-        clearTimeout(timer);
-      }
+    async verify(): Promise<HealthResult> {
+      // biome-ignore lint/suspicious/noExplicitAny: the probe target is structural by design.
+      const report = await checkModelReachability(llm.effortModel("balanced") as any);
+      if (report.verdict === "reachable") return { status: "ok" };
+      return {
+        status: report.verdict === "degraded" ? "degraded" : "down",
+        ...(report.detail === undefined ? {} : { detail: report.detail }),
+      };
     },
   };
 }

--- a/packages/llm/AGENTS.md
+++ b/packages/llm/AGENTS.md
@@ -17,6 +17,7 @@ subscription-CLI model adapters.
 | `src/fallback.ts`, `src/provider-error.ts` | Fallback order and hard/transient failures. |
 | `src/embeddings.ts`, `src/embedding-provider.ts` | Embedding providers and execution. |
 | `src/model-spec.ts`, `src/pricing.ts` | Model metadata and cost helpers. |
+| `src/reachability.ts` | One live call's verdict on a configured model, for health reporting. |
 | `src/prompt-cache.ts` | Whether a prompt prefix asks for provider-side caching. |
 | `src/cli/` | Subscription Provider adapters, jail, transcripts, JSON mode, specs. |
 
@@ -51,5 +52,8 @@ subscription-CLI model adapters.
 - Do not pass ambient vendor env credentials through the CLI jail; only saved credentials.
 - Timed-out CLI turns must throw, not finish as a normal `stop`.
 - Subscription Providers are models only: disable shell, file tools, web, and ambient capability.
+- A reachability verdict is `degraded` whenever the provider *answered* — refused credential,
+  throttle, or a request it disliked — and `unreachable` only when no answer arrived. Collapsing
+  the two makes the operator's `llm` health row lie in both directions.
 - New CLI provider: implement `CliLanguageModel`, add a static `ModelSpec`, register provider id in
   `packages/secrets/src/registry.ts`, add `provider.ts` case, dependency, and Docker external.

--- a/packages/llm/src/index.ts
+++ b/packages/llm/src/index.ts
@@ -58,3 +58,8 @@ export {
   type LlmProviderFailureReason,
   ProviderUnavailableError,
 } from "./provider-error";
+export {
+  checkModelReachability,
+  MODEL_REACHABILITY_TIMEOUT_MS,
+  type ModelReachabilityReport,
+} from "./reachability";

--- a/packages/llm/src/reachability.test.ts
+++ b/packages/llm/src/reachability.test.ts
@@ -1,0 +1,128 @@
+import { APICallError } from "ai";
+import { describe, expect, it } from "vitest";
+import { LlmProviderError, ProviderUnavailableError } from "./provider-error";
+import { checkModelReachability } from "./reachability";
+
+/**
+ * A provider that answers is reachable even when it refuses what it was asked. Collapsing the two
+ * is what makes a health row untrustworthy: swallow the difference and an outage reads `ok`;
+ * ignore it and a provider that merely disliked the probe's own request reads `down`.
+ */
+
+function failing(error: unknown) {
+  return {
+    specificationVersion: "v4" as const,
+    provider: "test",
+    modelId: "test-model",
+    supportedUrls: {},
+    doGenerate: () => Promise.reject(error),
+    doStream: () => Promise.reject(error),
+  };
+}
+
+function apiError(statusCode: number | undefined, message: string) {
+  return new APICallError({
+    message,
+    url: "https://provider.example/v1/chat/completions",
+    requestBodyValues: {},
+    statusCode,
+    isRetryable: false,
+  });
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: the AI SDK model type is structural here.
+const asModel = (model: unknown) => model as any;
+
+describe("checkModelReachability", () => {
+  it("reports a provider that answers as reachable", async () => {
+    const model = {
+      specificationVersion: "v4" as const,
+      provider: "test",
+      modelId: "test-model",
+      supportedUrls: {},
+      doGenerate: async () => ({
+        content: [{ type: "text" as const, text: "ok" }],
+        finishReason: "stop" as const,
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        warnings: [],
+      }),
+      doStream: () => Promise.reject(new Error("unused")),
+    };
+
+    expect(await checkModelReachability(asModel(model))).toEqual({ verdict: "reachable" });
+  });
+
+  it("degrades on a refused credential and names the page that fixes it", async () => {
+    const report = await checkModelReachability(
+      asModel(failing(new LlmProviderError("model_authentication_failed", new Error("401"))))
+    );
+
+    expect(report.verdict).toBe("degraded");
+    expect(report.detail).toContain("Business → Models");
+  });
+
+  it("degrades, rather than blaming the provider, when its own request is refused", async () => {
+    const report = await checkModelReachability(asModel(failing(apiError(400, "bad request"))));
+
+    expect(report.verdict).toBe("degraded");
+    expect(report.detail).toContain("the provider itself is reachable");
+  });
+
+  it("degrades on a throttle, which proves the credential and the model are fine", async () => {
+    const report = await checkModelReachability(asModel(failing(apiError(429, "slow down"))));
+
+    expect(report.verdict).toBe("degraded");
+    expect(report.detail).toContain("rate limiting");
+  });
+
+  it("reports unreachable when no response arrives at all", async () => {
+    const report = await checkModelReachability(
+      asModel(failing(apiError(undefined, "Cannot connect to API")))
+    );
+
+    expect(report.verdict).toBe("unreachable");
+    expect(report.detail).toContain("test-model");
+  });
+
+  it("reports unreachable when the provider answers that it is not serving", async () => {
+    const report = await checkModelReachability(asModel(failing(apiError(503, "overloaded"))));
+
+    expect(report.verdict).toBe("unreachable");
+    expect(report.detail).toContain("503");
+  });
+
+  it("reports unreachable when the call is shed before it dials out", async () => {
+    const report = await checkModelReachability(
+      asModel(failing(new ProviderUnavailableError("test", "circuit open")))
+    );
+
+    expect(report.verdict).toBe("unreachable");
+  });
+
+  it("reports unreachable, naming the budget, when the provider never answers", async () => {
+    const hanging = {
+      specificationVersion: "v4" as const,
+      provider: "test",
+      modelId: "test-model",
+      supportedUrls: {},
+      doGenerate: (options: { abortSignal?: AbortSignal }) =>
+        new Promise<never>((_resolve, reject) => {
+          options.abortSignal?.addEventListener("abort", () => reject(new Error("aborted")));
+        }),
+      doStream: () => Promise.reject(new Error("unused")),
+    };
+
+    const report = await checkModelReachability(asModel(hanging), 5);
+
+    expect(report.verdict).toBe("unreachable");
+    expect(report.detail).toContain("did not answer");
+  });
+
+  it("keeps the provider's own words out of the verdict", async () => {
+    const report = await checkModelReachability(
+      asModel(failing(apiError(401, "invalid api key sk-live-do-not-log")))
+    );
+
+    expect(report.detail ?? "").not.toContain("sk-live");
+  });
+});

--- a/packages/llm/src/reachability.ts
+++ b/packages/llm/src/reachability.ts
@@ -1,0 +1,123 @@
+import type { LanguageModel } from "ai";
+import { APICallError, generateText, RetryError } from "ai";
+import { classifyProviderError } from "./provider-error";
+
+/**
+ * What one live call proved about a configured model.
+ *
+ * `degraded` is reserved for a provider that *answered* — a refused credential, a throttle, or a
+ * request it did not like. Only the absence of a usable answer is `unreachable`, because a health
+ * check that cannot tell those apart either cries wolf about a working provider or stays green
+ * through an outage, and both make the verdict worthless.
+ */
+export interface ModelReachabilityReport {
+  readonly verdict: "reachable" | "degraded" | "unreachable";
+  /** Operator-facing, and deliberately built from classified reasons rather than provider text,
+   * so no credential, URL or response body can reach a status page. */
+  readonly detail?: string;
+}
+
+/**
+ * Long enough for a cold subscription-CLI provider to spawn, hand-shake and answer. Callers run
+ * this outside any request budget; cutting it short only loses the verdict.
+ */
+export const MODEL_REACHABILITY_TIMEOUT_MS = 30_000;
+
+/**
+ * Small, but not minimal: a cap of one token is rejected outright by models that reserve an
+ * internal budget before writing, and a request the provider refuses says nothing about whether
+ * the provider is reachable.
+ */
+const PROBE_MAX_OUTPUT_TOKENS = 16;
+
+const RECONNECT = "reconnect the provider under Business → Models";
+
+/** An HTTP status proves the provider answered; its absence proves nothing was reached. */
+function httpStatus(error: unknown): number | undefined {
+  const last = RetryError.isInstance(error) ? httpStatus(error.lastError) : error;
+  if (typeof last === "number") return last;
+  return APICallError.isInstance(last) ? last.statusCode : undefined;
+}
+
+/** The configured model the verdict is about; an operator's first question about a red row. */
+function label(model: LanguageModel): string {
+  return typeof model === "string" ? model : model.modelId;
+}
+
+function report(
+  error: unknown,
+  timedOut: boolean,
+  timeoutMs: number
+): Required<ModelReachabilityReport> {
+  if (timedOut) {
+    return {
+      verdict: "unreachable",
+      detail: `the provider did not answer within ${timeoutMs / 1_000}s`,
+    };
+  }
+  const reason = classifyProviderError(error);
+  if (reason === "model_authentication_failed" || reason === "model_billing_inactive") {
+    return {
+      verdict: "degraded",
+      detail: `the provider refused this deployment's credential (${reason}) — ${RECONNECT}`,
+    };
+  }
+  if (reason === "model_rate_limited") {
+    return {
+      verdict: "degraded",
+      detail: "the provider is rate limiting this deployment; its credential and model are fine",
+    };
+  }
+  if (reason === "model_not_found") {
+    return {
+      verdict: "unreachable",
+      detail:
+        "the provider has no model by the configured id — choose another under Business → Models",
+    };
+  }
+  const status = httpStatus(error);
+  if (reason === "model_provider_unavailable") {
+    return {
+      verdict: "unreachable",
+      detail: `the provider answered ${status === undefined ? "with an error" : `HTTP ${status}`} and is not serving this deployment`,
+    };
+  }
+  if (status !== undefined && status < 500) {
+    return {
+      verdict: "degraded",
+      detail: `the provider answered HTTP ${status}, refusing the reachability check's own request — the provider itself is reachable`,
+    };
+  }
+  return {
+    verdict: "unreachable",
+    detail: "no answer from the provider — the call never completed",
+  };
+}
+
+/**
+ * Makes the smallest real call the provider will authenticate, and reports what it proved.
+ *
+ * Resolves for every outcome: a caller polling this on a status page needs the verdict, and a
+ * rejection would leave it unable to say anything but "the check itself broke".
+ */
+export async function checkModelReachability(
+  model: LanguageModel,
+  timeoutMs: number = MODEL_REACHABILITY_TIMEOUT_MS
+): Promise<ModelReachabilityReport> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    await generateText({
+      model,
+      prompt: "ping",
+      maxOutputTokens: PROBE_MAX_OUTPUT_TOKENS,
+      abortSignal: controller.signal,
+    });
+    return { verdict: "reachable" };
+  } catch (error) {
+    const failure = report(error, controller.signal.aborted, timeoutMs);
+    return { verdict: failure.verdict, detail: `${label(model)} — ${failure.detail}` };
+  } finally {
+    clearTimeout(timer);
+  }
+}


### PR DESCRIPTION
The `llm` row on /operations could not be trusted in either direction. Its live check rejected only for two credential reasons and swallowed everything else, so a provider that could not be reached at all — a refused connection, a timeout, an outage — settled as `ok`, while the one signal it did raise carried no remediation. The naive inverse is worse: a probe that reports `down` on any thrown error calls a working provider dead the moment the provider dislikes the probe's own request.

The verdict now turns on whether the provider answered. A provider that answers — refusing the credential, throttling, or rejecting the check's own request — is `degraded`, and says which of those it was and what the operator should do about it. Only the absence of an answer is `down`. The classification lives in packages/llm beside the provider-error classifier it builds on, and details are composed from classified reasons rather than provider text, so no credential, URL or response body can reach a status page.

## Summary

<!-- What changed, and why. Link the driving issue if one exists. -->

## Test plan

<!-- Commands you ran, or manual steps / screenshots for UI changes. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (or the scoped `--filter` you actually ran)

## Checklist

- [ ] PR title follows Conventional Commits (`type(scope): subject`) — CI checks this
- [ ] Scoped to one logical change
- [ ] Tests added/updated for the behavior that changed
