### PR TITLE
fix(eval): expose file_read/file_list as shipped platform Tools

### DIFF
--- a/apps/eval/corpus/support-rereads-a-file-from-an-earlier-turn.json
+++ b/apps/eval/corpus/support-rereads-a-file-from-an-earlier-turn.json
@@ -4,13 +4,7 @@
   "agent": "support",
   "context": {
     "customInstructions": "Answer from the documents the person has given you.",
-    "governancePages": [],
-    "availableTools": [
-      {
-        "name": "file_read",
-        "description": "Read one File by id."
-      }
-    ]
+    "governancePages": []
   },
   "input": [
     {
@@ -36,18 +30,27 @@
       "content": "Warranty policy. Claims must be filed within 90 days of delivery."
     }
   ],
-  "tools": [
-    {
-      "name": "file_read",
-      "description": "Read one File by id.",
-      "inputSchema": {
-        "type": "object",
-        "properties": { "fileId": { "type": "string" } },
-        "required": ["fileId"]
-      }
-    }
-  ],
+  "platformTools": ["file_read", "file_list"],
   "toolResults": [
+    {
+      "name": "file_list",
+      "output": {
+        "scope": "all",
+        "files": [
+          {
+            "fileId": "file-warranty",
+            "filename": "warranty-policy.pdf",
+            "mediaType": "application/pdf",
+            "sizeBytes": 64,
+            "origin": "uploaded",
+            "source": "mine",
+            "createdAt": "2026-08-01T00:00:00.000Z"
+          }
+        ],
+        "count": 1,
+        "limit": 20
+      }
+    },
     {
       "name": "file_read",
       "output": {


### PR DESCRIPTION
## Summary
- `support-rereads-a-file-from-an-earlier-turn` hand-declared a stub `file_read` tool instead of referencing `platformTools`, so it measured the model against a description no deployment sends and dropped `file_list` + the shared GUIDANCE text.
- Both real-model Sweep legs (sonnet, terra) failed this Case in CI run [32362255017](https://github.com/TulipFarm/tulipfarm/actions/runs/32362255017/job/96404143737) for that reason — the real model had no way to discover the earlier Turn's fileId to re-fetch it.
- Fix: use `platformTools: ["file_read", "file_list"]` (the shipped declarations) and add a scripted `file_list` result so discovery works on the scripted tier too.

Note: editing `corpus/` moves `corpusHash` (was `038551ea12770561`), retiring the existing Baseline — a maintainer needs to re-promote against the new Corpus before the real-model gate compares anything again.

## Test plan
- [x] `pnpm eval` — 28 passed, 0 failed, 0 errored
- [x] `pnpm exec biome check --write apps/eval/corpus/support-rereads-a-file-from-an-earlier-turn.json` — clean

https://claude.ai/code/session_01DMim83gR8mz419Jq2XUTd6