### PR TITLE
fix(integrations): thread Slack replies and drop invalid GitHub App events

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -684,6 +684,7 @@ async function boot() {
 
     const slackTooling = buildSlackTooling({
       secrets: async () => secretsService,
+      channelRunDelivery: channelRunDeliveries,
     });
     const slackEffects = new PgEffectStore(runTransactions);
     const slackTools = buildSlackTools(DEPLOYMENT_BUSINESS_ID, {

--- a/apps/api/src/tools/slack/compose.ts
+++ b/apps/api/src/tools/slack/compose.ts
@@ -2,6 +2,7 @@ import {
   type IntegrationHttpPort,
   SLACK_ADAPTER_REF,
   SlackToolAdapter,
+  type SlackToolAdapterDeps,
 } from "@tulipfarm/integrations";
 import {
   type SecretAuthorizer,
@@ -25,6 +26,7 @@ import {
 export interface BuildSlackToolingOptions {
   readonly secrets: () => Promise<SecretsService>;
   readonly http?: IntegrationHttpPort;
+  readonly channelRunDelivery?: SlackToolAdapterDeps["channelRunDelivery"];
 }
 
 export interface SlackTooling {
@@ -43,7 +45,7 @@ const slackOnlyAuthorizer: SecretAuthorizer = {
 
 export function buildSlackTooling(options: BuildSlackToolingOptions): SlackTooling {
   const http = options.http ?? new SlackWebApiHttp();
-  const adapter = new SlackToolAdapter({ http });
+  const adapter = new SlackToolAdapter({ http, channelRunDelivery: options.channelRunDelivery });
 
   const tokenProvider = new SlackBotTokenProvider({ secrets: options.secrets });
   const provider = slackCompositeSecretProvider(

--- a/docs/architecture/github-app-manifest.md
+++ b/docs/architecture/github-app-manifest.md
@@ -37,8 +37,9 @@ the locked contract-scope decision.
 - `push`
 - `check_run`
 - `check_suite`
-- `installation`
-- `installation_repositories`
+
+`installation` and `installation_repositories` are account-level events GitHub sends
+automatically once the App is installed — not valid in `default_events`, so they are omitted.
 
 ## Auth model
 

--- a/integrations/github/manifest.yml
+++ b/integrations/github/manifest.yml
@@ -68,8 +68,6 @@ auth:
         - push
         - check_run
         - check_suite
-        - installation
-        - installation_repositories
     exchange:
       url: https://api.github.com/app-manifests/{code}/conversions
       map:

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@tulipfarm/authz": "workspace:*",
     "@tulipfarm/schema": "workspace:*",
+    "@tulipfarm/storage": "workspace:*",
     "@tulipfarm/tool-broker": "workspace:*"
   },
   "devDependencies": {

--- a/packages/integrations/src/slack/tool-adapter.test.ts
+++ b/packages/integrations/src/slack/tool-adapter.test.ts
@@ -121,3 +121,87 @@ describe("SlackToolAdapter mention encoding", () => {
     );
   });
 });
+
+function threadTs(calls: readonly IntegrationHttpRequest[]): string | undefined {
+  const call = calls.find((c) => c.path === "/chat.postMessage");
+  const body = call?.body as { thread_ts?: string } | undefined;
+  return body?.thread_ts;
+}
+
+describe("SlackToolAdapter thread replies", () => {
+  it("threads a reply when the Run started from a Slack thread in the same channel", async () => {
+    const http = fakeHttp([]);
+    const adapter = new SlackToolAdapter({
+      http,
+      channelRunDelivery: {
+        async find() {
+          return {
+            businessId: "biz-1",
+            runId: "run-1",
+            integrationId: "int-1",
+            routeId: "route-1",
+            provider: "slack",
+            destination: "C0123456789",
+            threadId: "1700000000.000001",
+            agentId: "agent-1",
+            principalId: "principal-1",
+            idempotencyKey: "idem-1",
+            status: "pending",
+            createdAt: "2026-01-01T00:00:00.000Z",
+            updatedAt: "2026-01-01T00:00:00.000Z",
+          };
+        },
+      },
+    });
+
+    await adapter.dispatch(sendRequest("C0123456789", "here you go"), CREDENTIAL);
+
+    expect(threadTs(http.calls)).toBe("1700000000.000001");
+  });
+
+  it("does not thread when the Run's origin channel differs from the target channel", async () => {
+    const http = fakeHttp([]);
+    const adapter = new SlackToolAdapter({
+      http,
+      channelRunDelivery: {
+        async find() {
+          return {
+            businessId: "biz-1",
+            runId: "run-1",
+            integrationId: "int-1",
+            routeId: "route-1",
+            provider: "slack",
+            destination: "C0999999999",
+            threadId: "1700000000.000001",
+            agentId: "agent-1",
+            principalId: "principal-1",
+            idempotencyKey: "idem-1",
+            status: "pending",
+            createdAt: "2026-01-01T00:00:00.000Z",
+            updatedAt: "2026-01-01T00:00:00.000Z",
+          };
+        },
+      },
+    });
+
+    await adapter.dispatch(sendRequest("C0123456789", "here you go"), CREDENTIAL);
+
+    expect(threadTs(http.calls)).toBeUndefined();
+  });
+
+  it("does not thread when the Run has no recorded delivery", async () => {
+    const http = fakeHttp([]);
+    const adapter = new SlackToolAdapter({
+      http,
+      channelRunDelivery: {
+        async find() {
+          return null;
+        },
+      },
+    });
+
+    await adapter.dispatch(sendRequest("C0123456789", "here you go"), CREDENTIAL);
+
+    expect(threadTs(http.calls)).toBeUndefined();
+  });
+});

--- a/packages/integrations/src/slack/tool-adapter.ts
+++ b/packages/integrations/src/slack/tool-adapter.ts
@@ -1,3 +1,4 @@
+import type { ChannelRunDeliveryStore } from "@tulipfarm/storage";
 import type { ToolAdapter, ToolAdapterRequest } from "@tulipfarm/tool-broker";
 import { AdapterDispatchError } from "@tulipfarm/tool-broker";
 import { classifyHttpFailure, type IntegrationHttpPort } from "../http";
@@ -10,6 +11,11 @@ import { encodeMentionsInText, type SlackUserLookupPort } from "./mentions";
  */
 export interface SlackToolAdapterDeps {
   readonly http: IntegrationHttpPort;
+  /**
+   * When the Run that's calling this Tool was itself started from a Slack thread, replies to the
+   * same channel default to that thread instead of posting a new root message.
+   */
+  readonly channelRunDelivery?: Pick<ChannelRunDeliveryStore, "find">;
 }
 
 interface SlackApiChannel {
@@ -77,12 +83,18 @@ export class SlackToolAdapter implements ToolAdapter {
       ? channel
       : await this.resolveChannelId(normalizeChannelName(channel), credential);
     const encodedText = await encodeMentionsInText(text, this.userLookup(credential));
+    const threadTs = await this.originatingThreadTs(request, channelId, credential);
 
     const response = await this.deps.http.send(
       {
         method: "POST",
         path: "/chat.postMessage",
-        body: { channel: channelId, text: encodedText, client_msg_id: request.idempotencyKey },
+        body: {
+          channel: channelId,
+          text: encodedText,
+          ...(threadTs === undefined ? {} : { thread_ts: threadTs }),
+          client_msg_id: request.idempotencyKey,
+        },
       },
       credential
     );
@@ -101,6 +113,31 @@ export class SlackToolAdapter implements ToolAdapter {
       throw new AdapterDispatchError("after_dispatch", "invalid_response", false);
     }
     return { channelId, ts, threadId: ts };
+  }
+
+  /**
+   * Best-effort: only threads a reply when this Run started from a Slack thread in the same
+   * channel the Tool is posting to. A lookup failure or channel mismatch falls back to a fresh
+   * root message rather than blocking the send.
+   */
+  private async originatingThreadTs(
+    request: ToolAdapterRequest,
+    channelId: string,
+    credential: string
+  ): Promise<string | undefined> {
+    if (this.deps.channelRunDelivery === undefined) return undefined;
+    const delivery = await this.deps.channelRunDelivery
+      .find(request.intent.businessId, request.intent.runId)
+      .catch(() => null);
+    if (delivery === null || delivery.provider !== "slack" || delivery.threadId === undefined) {
+      return undefined;
+    }
+    const destinationId = isChannelId(delivery.destination)
+      ? delivery.destination
+      : await this.resolveChannelId(normalizeChannelName(delivery.destination), credential).catch(
+          () => undefined
+        );
+    return destinationId === channelId ? delivery.threadId : undefined;
   }
 
   /** Memoized best-effort user lookup; first-name fallback only when exactly one match exists. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1002,6 +1002,9 @@ importers:
       '@tulipfarm/schema':
         specifier: workspace:*
         version: link:../schema
+      '@tulipfarm/storage':
+        specifier: workspace:*
+        version: link:../storage
       '@tulipfarm/tool-broker':
         specifier: workspace:*
         version: link:../tool-broker


### PR DESCRIPTION
## Summary
- `send_slack_message` always posted a new root channel message; it never read/forwarded Slack `thread_ts`, so an agent replying inside a Slack thread landed the reply in the channel instead. `SlackToolAdapter` now looks up the calling Run's `ChannelRunDeliveryStore` record and defaults `thread_ts` to the originating thread when the Run started from a Slack thread in the same channel it's posting to. Falls back to a fresh root message on any lookup failure or channel mismatch.
- GitHub App manifest listed `installation` and `installation_repositories` in `default_events`, which GitHub rejects — they're account-level events delivered automatically once the App is installed, not subscribable event types. Removed from `integrations/github/manifest.yml` and documented the reason in `docs/architecture/github-app-manifest.md`.

## Test plan
- [x] `pnpm --filter @tulipfarm/integrations test src/slack` — new threading cases pass
- [x] `pnpm --filter @tulipfarm/api test src/tools/slack` — compose wiring unaffected
- [x] `pnpm lint`
- [x] `pnpm typecheck`

https://claude.ai/code/session_01D2pPQp9Udb6bCeKWKvsiRz