### PR TITLE
fix(auth): issue an invite link in one statement

### DIFF
--- a/apps/api/src/auth/invites.pg.test.ts
+++ b/apps/api/src/auth/invites.pg.test.ts
@@ -104,4 +104,24 @@ describe("user invites (Postgres)", () => {
     );
     expect(rows[0].consumed_at).not.toBeNull();
   });
+
+  it("keeps exactly one live link when two issues for the same user overlap", async () => {
+    const user = await inviteUser(users, "overlap@example.com");
+    const [first, second] = await Promise.all([
+      issueInvite(invites, { userId: user._id, createdBy: adminId }),
+      issueInvite(invites, { userId: user._id, createdBy: adminId }),
+    ]);
+
+    const { rows } = await db.query<{ token_hash: string }>(
+      "SELECT token_hash FROM user_invites WHERE user_id = $1 AND consumed_at IS NULL",
+      [user._id]
+    );
+    const live = rows.map((r) => r.token_hash);
+    const issued = [first, second].map((i) => hashInviteToken(i.token));
+
+    expect({
+      liveCount: live.length,
+      stranded: issued.filter((h) => !live.includes(h)).length,
+    }).toEqual({ liveCount: 1, stranded: 1 });
+  });
 });

--- a/apps/api/src/auth/invites.ts
+++ b/apps/api/src/auth/invites.ts
@@ -16,9 +16,8 @@ export interface UserInviteDoc {
 }
 
 export interface UserInviteRepo {
+  /** Issues the one live link for a user, superseding any link still outstanding. */
   create(invite: UserInviteDoc): Promise<void>;
-  /** Revokes every outstanding link for a user, so at most one is ever live. */
-  deleteUnconsumedForUser(userId: string): Promise<void>;
   /** Unspent state of an invite, for previewing it without spending it. */
   find(tokenHash: string): Promise<UserInviteDoc | null>;
   /** Atomically spends the invite; null when unknown, expired, or already redeemed. */
@@ -44,8 +43,12 @@ export class PgUserInviteRepo implements UserInviteRepo {
   constructor(private readonly q: Queryable) {}
 
   async create(invite: UserInviteDoc): Promise<void> {
+    // Revoking the outstanding link and inserting its replacement must be one statement. As two,
+    // a concurrent issue for the same user lands in between and deletes the token already handed
+    // to the admin, so a link they were shown seconds ago previews as dead on its first use.
     await this.q.query(
-      `INSERT INTO user_invites (token_hash, user_id, created_by, created_at, expires_at, consumed_at)
+      `WITH revoked AS (DELETE FROM user_invites WHERE user_id = $2 AND consumed_at IS NULL)
+       INSERT INTO user_invites (token_hash, user_id, created_by, created_at, expires_at, consumed_at)
        VALUES ($1, $2, $3, $4, $5, $6)`,
       [
         invite.tokenHash,
@@ -56,12 +59,6 @@ export class PgUserInviteRepo implements UserInviteRepo {
         invite.consumedAt,
       ]
     );
-  }
-
-  async deleteUnconsumedForUser(userId: string): Promise<void> {
-    await this.q.query("DELETE FROM user_invites WHERE user_id = $1 AND consumed_at IS NULL", [
-      userId,
-    ]);
   }
 
   async find(tokenHash: string): Promise<UserInviteDoc | null> {
@@ -83,11 +80,17 @@ export class PgUserInviteRepo implements UserInviteRepo {
   }
 }
 
+/** Why an invite was refused. Server-side only — the wire message stays coarse. */
+export type InviteDenialReason = "no-invite" | "redeemed" | "no-user" | "disabled";
+
 /** Coarse rejection reason; never reveal guessed vs expired vs redeemed. */
 export class InviteDeniedError extends Error {
-  constructor(message = "this invite link is no longer valid") {
+  readonly reason: InviteDenialReason;
+
+  constructor(reason: InviteDenialReason, message = "this invite link is no longer valid") {
     super(message);
     this.name = "InviteDeniedError";
+    this.reason = reason;
   }
 }
 
@@ -96,7 +99,7 @@ export interface IssuedInvite {
   expiresAt: Date;
 }
 
-/** Issue the one live link for a user; revoke older links first. */
+/** Issue the one live link for a user, superseding any link still outstanding. */
 export async function issueInvite(
   repo: UserInviteRepo,
   input: { userId: string; createdBy: string; ttlSeconds?: number }
@@ -107,7 +110,6 @@ export async function issueInvite(
     now.getTime() + (input.ttlSeconds ?? DEFAULT_INVITE_TTL_SECONDS) * 1000
   );
 
-  await repo.deleteUnconsumedForUser(input.userId);
   await repo.create({
     tokenHash: hashInviteToken(raw),
     userId: input.userId,
@@ -134,10 +136,11 @@ export interface InviteOffer {
 /** Preview resolves the account without spending the token. */
 export async function previewInvite(stores: InviteStores, raw: string): Promise<InviteOffer> {
   const invite = await stores.invites.find(hashInviteToken(raw));
-  if (!invite) throw new InviteDeniedError();
+  if (!invite) throw new InviteDeniedError("no-invite");
   const user = await stores.users.findById(invite.userId);
   // Disabled-account invites are dead even if the invite row remains.
-  if (!user || user.status === "disabled") throw new InviteDeniedError();
+  if (!user || user.status === "disabled")
+    throw new InviteDeniedError(user ? "disabled" : "no-user");
   return { email: user.email, expiresAt: invite.expiresAt };
 }
 
@@ -147,9 +150,10 @@ export async function redeemInvite(
   input: { raw: string; passwordHash: string }
 ): Promise<UserDoc> {
   const invite = await stores.invites.consume(hashInviteToken(input.raw));
-  if (!invite) throw new InviteDeniedError();
+  if (!invite) throw new InviteDeniedError("redeemed");
   const user = await stores.users.findById(invite.userId);
-  if (!user || user.status === "disabled") throw new InviteDeniedError();
+  if (!user || user.status === "disabled")
+    throw new InviteDeniedError(user ? "disabled" : "no-user");
 
   await stores.passwords.setPassword(user._id, input.passwordHash);
   return { ...user, passwordHash: input.passwordHash, status: "active" };

--- a/apps/api/src/auth/owner-access.pg.test.ts
+++ b/apps/api/src/auth/owner-access.pg.test.ts
@@ -66,7 +66,6 @@ class FakeInviteRepo implements UserInviteRepo {
   async create(invite: UserInviteDoc): Promise<void> {
     this.invites.push(invite);
   }
-  async deleteUnconsumedForUser(): Promise<void> {}
   async find(): Promise<UserInviteDoc | null> {
     return null;
   }

--- a/apps/api/src/auth/routes.test.ts
+++ b/apps/api/src/auth/routes.test.ts
@@ -74,13 +74,9 @@ class FakeInviteRepo implements UserInviteRepo {
   readonly invites: UserInviteDoc[] = [];
 
   async create(invite: UserInviteDoc): Promise<void> {
+    const live = this.invites.findIndex((i) => i.userId === invite.userId && i.consumedAt === null);
+    if (live >= 0) this.invites.splice(live, 1);
     this.invites.push(invite);
-  }
-  async deleteUnconsumedForUser(userId: string): Promise<void> {
-    for (let i = this.invites.length - 1; i >= 0; i--) {
-      const invite = this.invites[i];
-      if (invite.userId === userId && invite.consumedAt === null) this.invites.splice(i, 1);
-    }
   }
   private live(tokenHash: string): UserInviteDoc | undefined {
     return this.invites.find(

--- a/apps/api/src/auth/routes/session.ts
+++ b/apps/api/src/auth/routes/session.ts
@@ -5,6 +5,7 @@ import { userPrincipal } from "../../identity/principal";
 import { sessionCookieOptions } from "../cookie-security";
 import { CSRF_COOKIE, setCsrfCookie } from "../csrf";
 import {
+  hashInviteToken,
   InviteDeniedError,
   type InviteStores,
   previewInvite,
@@ -43,6 +44,12 @@ function getDummyHash(): Promise<string> {
 }
 
 type PreHandler = (req: FastifyRequest, reply: FastifyReply) => Promise<void>;
+
+/** A denial is opaque on the wire; log which cause it was, keyed by a hash prefix, not the token. */
+function logInviteDenial(req: FastifyRequest, at: string, err: InviteDeniedError, token: string) {
+  const hash = hashInviteToken(token).slice(0, 12);
+  req.log.warn({ at, reason: err.reason, hash }, "invite denied");
+}
 
 export interface SessionRouteDeps {
   store: SessionStore;
@@ -363,6 +370,7 @@ export function registerSessionRoutes(app: FastifyInstance, deps: SessionRouteDe
           return reply.send({ email: offer.email, expiresAt: offer.expiresAt.toISOString() });
         } catch (err) {
           if (err instanceof InviteDeniedError) {
+            logInviteDenial(req, "preview", err, token);
             return reply.code(404).send({ error: err.message });
           }
           throw err;
@@ -422,6 +430,7 @@ export function registerSessionRoutes(app: FastifyInstance, deps: SessionRouteDe
           });
         } catch (err) {
           if (err instanceof InviteDeniedError) {
+            logInviteDenial(req, "accept", err, token);
             return reply.code(404).send({ error: err.message });
           }
           throw err;


### PR DESCRIPTION
Revoking a user's outstanding invite and inserting its replacement were two autocommitted statements with no transaction between them. A second issue for the same user that lands in that window deletes the row backing the token the first call already returned, so the admin is shown a link that has no row behind it and previews 404 on its very first load — the reported symptom of a "fresh, never-used" link being refused. The delete now runs as a CTE of the insert, so nothing can land between them.

Higher-ranked hypotheses were falsified against a full staging-shape reproduction — real Postgres with runtime-role privilege separation, the real index.ts boot, the production SPA served from WEB_DIST, and a fresh Chromium context opening the link: the fragment survives, the route is registered, and preview returns 200. The report's own replication theory does not hold either; there are no replicas and one pool.

A denial is deliberately opaque on the wire, which left an operator no way to tell "no row" from "expired" from "disabled account" when this was reported. InviteDeniedError now carries that reason and both invite routes log it against a prefix of the stored hash, never the token.

## Summary

<!-- What changed, and why. Link the driving issue if one exists. -->

## Test plan

<!-- Commands you ran, or manual steps / screenshots for UI changes. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (or the scoped `--filter` you actually ran)

## Checklist

- [ ] PR title follows Conventional Commits (`type(scope): subject`) — CI checks this
- [ ] Scoped to one logical change
- [ ] Tests added/updated for the behavior that changed
