### PR TITLE
fix(resources): make Record mutation and history one transaction

### DIFF
--- a/apps/api/AGENTS.md
+++ b/apps/api/AGENTS.md
@@ -66,6 +66,9 @@ PostgreSQL persistence composition, auth, Soul Git writes, and Worker callback p
 - `apps/api/src` is capped by `scripts/control-plane-size.test.ts`: new domain logic belongs in the
   owning package. PGlite repository tests stay here even when the repository does not, because this
   app owns the migrations that build the tables.
+- A Record mutation and its history snapshot are one `ResourceRepo` call, committed on one
+  transaction. There is no separate `appendHistory`: a committed Record with no history entry is an
+  audit gap, and the route emits its domain event only after that call returns.
 - Tools return `ok(data)` or `err(code, message)`, never throw; ToolRegistry validates
   JSON Schema before execution. Read batches run in parallel; mutating batches are serial.
 - Every write to the authored Soul tree goes through `SoulWriter.apply()` (ADR-007) — routes, Tools

--- a/apps/api/src/resources/atomicity.pg.test.ts
+++ b/apps/api/src/resources/atomicity.pg.test.ts
@@ -1,0 +1,239 @@
+import { EventEmitter } from "node:events";
+import type { PGlite } from "@electric-sql/pglite";
+import type { SoulLoader } from "@tulipfarm/soul";
+import { DOMAIN_EVENTS, type PaginatedResult } from "@tulipfarm/storage";
+import type { FastifyInstance } from "fastify";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildApp } from "../app";
+import type { TokenDoc, TokenRepo } from "../auth/api-tokens";
+import { CSRF_COOKIE, CSRF_HEADER } from "../auth/csrf";
+import { SESSION_COOKIE } from "../auth/middleware";
+import { MemorySessionStore } from "../auth/session-store";
+import { createUser, type UserDoc, type UserRepo } from "../auth/users";
+import type { Queryable } from "../db";
+import { makeMigratedPglite } from "../test/pglite";
+import { PgResourceRepo, PgResourceRepoFactory, type ResourceDoc } from "./repo";
+import { createHistoryTableSql, createResourceTableSql } from "./schema";
+
+const TYPE = "ticket";
+const TEST_CSRF = "a".repeat(64);
+
+class FakeUserRepo implements UserRepo {
+  private users: UserDoc[] = [];
+  async findByEmail(e: string): Promise<UserDoc | null> {
+    return this.users.find((u) => u.email === e.trim().toLowerCase()) ?? null;
+  }
+  async findById(id: string): Promise<UserDoc | null> {
+    return this.users.find((u) => u._id === id) ?? null;
+  }
+  async count(): Promise<number> {
+    return this.users.length;
+  }
+  async insert(u: UserDoc): Promise<void> {
+    this.users.push(u);
+  }
+}
+
+class FakeTokenRepo implements TokenRepo {
+  async create(): Promise<void> {}
+  async findByHash(): Promise<TokenDoc | null> {
+    return null;
+  }
+  async findByUserId(): Promise<TokenDoc[]> {
+    return [];
+  }
+  async findAll(): Promise<TokenDoc[]> {
+    return [];
+  }
+  async findById(): Promise<TokenDoc | null> {
+    return null;
+  }
+  async deleteById(): Promise<void> {}
+  async findAllPaginated(): Promise<PaginatedResult<TokenDoc>> {
+    return { items: [], nextCursor: null };
+  }
+  async findByUserIdPaginated(): Promise<PaginatedResult<TokenDoc>> {
+    return { items: [], nextCursor: null };
+  }
+}
+
+/** Lets every Record mutation through and rejects only the history append, as a transient would. */
+function rejectHistoryWrites(db: PGlite): Queryable {
+  const wrap = (q: Queryable): Queryable => ({
+    query: async (text, params) => {
+      if (/INSERT INTO resources\."ticket_history"/.test(text)) {
+        throw new Error("transient: history insert failed");
+      }
+      return q.query(text, params);
+    },
+  });
+  const base = db as unknown as Queryable & {
+    transaction?: (fn: (tx: Queryable) => Promise<unknown>) => Promise<unknown>;
+  };
+  return {
+    ...wrap(base),
+    ...(typeof base.transaction === "function"
+      ? {
+          transaction: (fn: (tx: Queryable) => Promise<unknown>) =>
+            // biome-ignore lint/suspicious/noExplicitAny: PGlite's tx handle is structurally Queryable.
+            (base.transaction as any)((tx: Queryable) => fn(wrap(tx))),
+        }
+      : {}),
+  } as Queryable;
+}
+
+describe("record write atomicity", () => {
+  let db: PGlite;
+  let app: FastifyInstance;
+  let sid: string;
+  let plain: PgResourceRepo;
+  let emitted: string[];
+
+  beforeEach(async () => {
+    emitted = [];
+    const domainEventEmitter = new EventEmitter();
+    for (const name of [DOMAIN_EVENTS.RESOURCE_CREATED, DOMAIN_EVENTS.RESOURCE_UPDATED]) {
+      domainEventEmitter.on(name, () => emitted.push(name));
+    }
+    db = await makeMigratedPglite();
+    await db.query(createResourceTableSql(TYPE));
+    await db.query(createHistoryTableSql(TYPE));
+    plain = new PgResourceRepo(db, TYPE);
+
+    const store = new MemorySessionStore();
+    const userRepo = new FakeUserRepo();
+    const user = await createUser(userRepo, "user@example.com", "pass", "member");
+    sid = await store.create(user._id);
+
+    app = await buildApp({
+      sessionStore: store,
+      userRepo,
+      tokenRepo: new FakeTokenRepo(),
+      soulLoader: {
+        resources: new Map([
+          [
+            TYPE,
+            {
+              name: TYPE,
+              schema: { type: "object", properties: { title: { type: "string" } } },
+              hasHooks: false,
+              hooksEnabled: true,
+            },
+          ],
+        ]),
+      } as unknown as SoulLoader,
+      resourceRepoFactory: new PgResourceRepoFactory(rejectHistoryWrites(db)),
+      counterStore: { makeCounterFn: () => async () => 1 },
+      domainEventEmitter,
+    });
+  });
+
+  afterEach(async () => {
+    await app.close();
+    await db.close();
+  });
+
+  function withSession(extra: Record<string, string> = {}) {
+    return {
+      cookies: { [SESSION_COOKIE]: sid, [CSRF_COOKIE]: TEST_CSRF },
+      headers: { [CSRF_HEADER]: TEST_CSRF, ...extra },
+    };
+  }
+
+  async function historyCount(): Promise<number> {
+    const { rows } = await db.query(`SELECT count(*)::int AS n FROM resources."${TYPE}_history"`);
+    return (rows[0] as { n: number }).n;
+  }
+
+  async function liveRows(): Promise<ResourceDoc[]> {
+    const page = await plain.list({ limit: 50, includeDeleted: true });
+    return page.items;
+  }
+
+  /** Seeds through a repo the fault injector does not wrap, so setup is not the write under test. */
+  async function seed(): Promise<ResourceDoc> {
+    const now = new Date();
+    const doc: ResourceDoc = {
+      _id: "11111111-1111-4111-8111-111111111111",
+      version: 1,
+      createdAt: now,
+      updatedAt: now,
+      title: "seeded",
+    };
+    await plain.insert(doc);
+    return doc;
+  }
+
+  it("does not commit a created Record when its history append fails", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/resources/${TYPE}`,
+      ...withSession(),
+      payload: { title: "Bug" },
+    });
+
+    expect(res.statusCode).toBe(500);
+    expect(await liveRows()).toHaveLength(0);
+    expect(await historyCount()).toBe(0);
+  });
+
+  it("does not commit a replaced Record when its history append fails", async () => {
+    const doc = await seed();
+    const historyBefore = await historyCount();
+    const res = await app.inject({
+      method: "PUT",
+      url: `/api/v1/resources/${TYPE}/${doc._id}`,
+      ...withSession({ "if-match": "1" }),
+      payload: { title: "replaced" },
+    });
+
+    expect(res.statusCode).toBe(500);
+    const rows = await liveRows();
+    expect(rows[0]?.version).toBe(1);
+    expect(rows[0]?.title).toBe("seeded");
+    expect(await historyCount()).toBe(historyBefore);
+  });
+
+  it("does not commit a patched Record when its history append fails", async () => {
+    const doc = await seed();
+    const historyBefore = await historyCount();
+    const res = await app.inject({
+      method: "PATCH",
+      url: `/api/v1/resources/${TYPE}/${doc._id}`,
+      ...withSession({ "if-match": "1" }),
+      payload: { title: "patched" },
+    });
+
+    expect(res.statusCode).toBe(500);
+    const rows = await liveRows();
+    expect(rows[0]?.version).toBe(1);
+    expect(rows[0]?.title).toBe("seeded");
+    expect(await historyCount()).toBe(historyBefore);
+  });
+
+  it("does not commit a soft delete when its history append fails", async () => {
+    const doc = await seed();
+    const historyBefore = await historyCount();
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/api/v1/resources/${TYPE}/${doc._id}`,
+      ...withSession({ "if-match": "1" }),
+    });
+
+    expect(res.statusCode).toBe(500);
+    const rows = await liveRows();
+    expect(rows[0]?.version).toBe(1);
+    expect(rows[0]?.deletedAt).toBeUndefined();
+    expect(await historyCount()).toBe(historyBefore);
+  });
+
+  it("emits no domain event for a write that did not commit", async () => {
+    await app.inject({
+      method: "POST",
+      url: `/api/v1/resources/${TYPE}`,
+      ...withSession(),
+      payload: { title: "Bug" },
+    });
+    expect(emitted).toEqual([]);
+  });
+});

--- a/apps/api/src/resources/repo.pg.test.ts
+++ b/apps/api/src/resources/repo.pg.test.ts
@@ -3,7 +3,7 @@ import type { PGlite } from "@electric-sql/pglite";
 import { decodeCursor } from "@tulipfarm/storage";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { makeMigratedPglite } from "../test/pglite";
-import { PgResourceRepo, type ResourceDoc, type ResourceHistoryDoc } from "./repo";
+import { PgResourceRepo, type ResourceDoc } from "./repo";
 import { createHistoryTableSql, createResourceTableSql } from "./schema";
 
 const TYPE = "ticket";
@@ -81,11 +81,11 @@ describe("PgResourceRepo", () => {
     const d = doc();
     await repo.insert(d);
 
-    const wrong = await repo.replaceOne(d._id, 99, { ...d, version: 100, title: "nope" });
+    const wrong = await repo.replaceOne(d._id, 99, { ...d, version: 100, title: "nope" }, "update");
     expect(wrong).toBe(false);
 
     const next = { ...d, version: 2, title: "updated", updatedAt: new Date() };
-    const ok = await repo.replaceOne(d._id, 1, next);
+    const ok = await repo.replaceOne(d._id, 1, next, "update");
     expect(ok).toBe(true);
 
     const found = await repo.findById(d._id);
@@ -97,28 +97,38 @@ describe("PgResourceRepo", () => {
     const d = doc();
     await repo.insert(d);
 
-    expect(await repo.replaceOne("qa-does-not-exist-id", 1, d)).toBe(false);
+    expect(await repo.replaceOne("qa-does-not-exist-id", 1, d, "update")).toBe(false);
   });
 
-  it("appendHistory writes a snapshot row", async () => {
+  it("writes one history snapshot per committed mutation", async () => {
     const d = doc();
     await repo.insert(d);
-    const entry: ResourceHistoryDoc = {
-      _id: randomUUID(),
-      resourceId: d._id,
-      operation: "create",
-      snapshot: d,
-      at: new Date(),
-    };
-    await repo.appendHistory(entry);
+    await repo.replaceOne(d._id, 1, { ...d, version: 2, title: "updated" }, "update");
+    await repo.replaceOne(d._id, 2, { ...d, version: 3, deletedAt: new Date() }, "delete");
 
     const { rows } = await db.query(
-      `SELECT operation, snapshot FROM resources."${TYPE}_history" WHERE resource_id = $1`,
+      `SELECT operation, snapshot FROM resources."${TYPE}_history"
+       WHERE resource_id = $1 ORDER BY at`,
       [d._id]
     );
-    expect(rows).toHaveLength(1);
-    expect((rows[0] as { operation: string }).operation).toBe("create");
+    expect(rows.map((r) => (r as { operation: string }).operation)).toEqual([
+      "create",
+      "update",
+      "delete",
+    ]);
     expect((rows[0] as { snapshot: { title: string } }).snapshot.title).toBe("Bug");
+  });
+
+  it("writes no history row when the mutation was refused on version", async () => {
+    const d = doc();
+    await repo.insert(d);
+    await repo.replaceOne(d._id, 99, { ...d, version: 100 }, "update");
+
+    const { rows } = await db.query(
+      `SELECT count(*)::int AS n FROM resources."${TYPE}_history" WHERE resource_id = $1`,
+      [d._id]
+    );
+    expect((rows[0] as { n: number }).n).toBe(1);
   });
 
   it("paginates by keyset in created order", async () => {

--- a/apps/api/src/resources/repo.ts
+++ b/apps/api/src/resources/repo.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { CounterFn } from "@tulipfarm/schema";
-import { type PaginatedResult, toPage } from "@tulipfarm/storage";
+import { type PaginatedResult, toPage, withTransaction } from "@tulipfarm/storage";
 import type { Queryable } from "../db";
 import { historyTableName, rowToResourceDoc, tableName } from "./schema";
 
@@ -15,10 +15,12 @@ export interface ResourceDoc {
   [key: string]: unknown;
 }
 
+export type HistoryOp = "create" | "update" | "delete";
+
 export interface ResourceHistoryDoc {
   _id: string;
   resourceId: string;
-  operation: "create" | "update" | "delete";
+  operation: HistoryOp;
   snapshot: ResourceDoc;
   at: Date;
 }
@@ -33,13 +35,16 @@ export interface SearchOpts extends ListOpts {
   filter?: Record<string, unknown>;
 }
 
+/**
+ * Every mutation also writes the Record's history snapshot, and the two must land together: a
+ * committed Record with no history entry is an audit gap no later write can repair.
+ */
 export interface ResourceRepo {
   insert(doc: ResourceDoc): Promise<void>;
   findById(id: string): Promise<ResourceDoc | null>;
   list(opts: ListOpts): Promise<PaginatedResult<ResourceDoc>>;
   search(opts: SearchOpts): Promise<PaginatedResult<ResourceDoc>>;
-  replaceOne(id: string, expectedVersion: number, doc: ResourceDoc): Promise<boolean>;
-  appendHistory(entry: ResourceHistoryDoc): Promise<void>;
+  replaceOne(id: string, expected: number, doc: ResourceDoc, op: HistoryOp): Promise<boolean>;
 }
 
 /** Builds a `ResourceRepo` bound to a resource type's table (per-request, dynamic type). */
@@ -67,11 +72,14 @@ export class PgResourceRepo implements ResourceRepo {
 
   async insert(doc: ResourceDoc): Promise<void> {
     const { _id, version, createdAt, updatedAt, deletedAt, ...data } = doc;
-    await this.q.query(
-      `INSERT INTO ${this.table} (id, version, created_at, updated_at, deleted_at, data)
-       VALUES ($1, $2, $3, $4, $5, $6::jsonb)`,
-      [_id, version, createdAt, updatedAt, deletedAt ?? null, JSON.stringify(data)]
-    );
+    await withTransaction(this.q, async (tx) => {
+      await tx.query(
+        `INSERT INTO ${this.table} (id, version, created_at, updated_at, deleted_at, data)
+         VALUES ($1, $2, $3, $4, $5, $6::jsonb)`,
+        [_id, version, createdAt, updatedAt, deletedAt ?? null, JSON.stringify(data)]
+      );
+      await this.appendHistory(tx, historyEntry(_id, "create", doc));
+    });
   }
 
   async findById(id: string): Promise<ResourceDoc | null> {
@@ -123,21 +131,30 @@ export class PgResourceRepo implements ResourceRepo {
     return toPage(rows.map(rowToResourceDoc), opts.limit);
   }
 
-  async replaceOne(id: string, expectedVersion: number, doc: ResourceDoc): Promise<boolean> {
+  async replaceOne(
+    id: string,
+    expected: number,
+    doc: ResourceDoc,
+    op: HistoryOp
+  ): Promise<boolean> {
     if (!UUID_RE.test(id)) return false;
     const { _id, version, createdAt, updatedAt, deletedAt, ...data } = doc;
-    const { rows } = await this.q.query(
-      `UPDATE ${this.table}
-       SET version = $1, created_at = $2, updated_at = $3, deleted_at = $4, data = $5::jsonb
-       WHERE id = $6 AND version = $7
-       RETURNING id`,
-      [version, createdAt, updatedAt, deletedAt ?? null, JSON.stringify(data), id, expectedVersion]
-    );
-    return rows.length === 1;
+    return withTransaction(this.q, async (tx) => {
+      const { rows } = await tx.query(
+        `UPDATE ${this.table}
+         SET version = $1, created_at = $2, updated_at = $3, deleted_at = $4, data = $5::jsonb
+         WHERE id = $6 AND version = $7
+         RETURNING id`,
+        [version, createdAt, updatedAt, deletedAt ?? null, JSON.stringify(data), id, expected]
+      );
+      if (rows.length !== 1) return false;
+      await this.appendHistory(tx, historyEntry(id, op, doc));
+      return true;
+    });
   }
 
-  async appendHistory(entry: ResourceHistoryDoc): Promise<void> {
-    await this.q.query(
+  private async appendHistory(tx: Queryable, entry: ResourceHistoryDoc): Promise<void> {
+    await tx.query(
       `INSERT INTO ${this.historyTable} (id, resource_id, operation, snapshot, at)
        VALUES ($1, $2, $3, $4::jsonb, $5)`,
       [entry._id, entry.resourceId, entry.operation, JSON.stringify(entry.snapshot), entry.at]
@@ -184,10 +201,6 @@ export function toApiRecord(doc: ResourceDoc): Record<string, unknown> {
   };
 }
 
-export function makeHistoryEntry(
-  resourceId: string,
-  operation: ResourceHistoryDoc["operation"],
-  snapshot: ResourceDoc
-): ResourceHistoryDoc {
+function historyEntry(resourceId: string, operation: HistoryOp, snapshot: ResourceDoc) {
   return { _id: randomUUID(), resourceId, operation, snapshot, at: new Date() };
 }

--- a/apps/api/src/resources/routes.test.ts
+++ b/apps/api/src/resources/routes.test.ts
@@ -15,6 +15,7 @@ import { DEPLOYMENT_ROLES } from "../identity/roles";
 import { LiveRecordAuthorizer } from "./authorize";
 import type {
   CounterStore,
+  HistoryOp,
   ListOpts,
   ResourceDoc,
   ResourceHistoryDoc,
@@ -33,6 +34,11 @@ class FakeResourceRepo implements ResourceRepo {
 
   async insert(doc: ResourceDoc): Promise<void> {
     this.docs.set(doc._id, { ...doc });
+    this.log(doc._id, "create", doc);
+  }
+
+  private log(id: string, operation: HistoryOp, snapshot: ResourceDoc): void {
+    this.history.push({ _id: randomUUID(), resourceId: id, operation, snapshot, at: new Date() });
   }
 
   async findById(id: string): Promise<ResourceDoc | null> {
@@ -57,15 +63,17 @@ class FakeResourceRepo implements ResourceRepo {
     return { items: sliced, nextCursor: items.length > opts.limit ? "next" : null };
   }
 
-  async replaceOne(id: string, expectedVersion: number, doc: ResourceDoc): Promise<boolean> {
+  async replaceOne(
+    id: string,
+    expectedVersion: number,
+    doc: ResourceDoc,
+    op: HistoryOp
+  ): Promise<boolean> {
     const existing = this.docs.get(id);
     if (!existing || existing.version !== expectedVersion) return false;
     this.docs.set(id, { ...doc });
+    this.log(id, op, doc);
     return true;
-  }
-
-  async appendHistory(entry: ResourceHistoryDoc): Promise<void> {
-    this.history.push(entry);
   }
 }
 

--- a/apps/api/src/resources/routes.ts
+++ b/apps/api/src/resources/routes.ts
@@ -7,7 +7,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { ErrorSchema } from "../auth/schemas";
 import type { RecordAction, RecordAuthorizer } from "./authorize";
 import { recordPrincipalOf } from "./authorize";
-import { type CounterStore, makeHistoryEntry, type ResourceRepoFactory, toApiRecord } from "./repo";
+import { type CounterStore, type ResourceRepoFactory, toApiRecord } from "./repo";
 import {
   loadForWrite,
   maybeRunAfterHook,
@@ -142,7 +142,6 @@ export function registerResourceRoutes(
       const doc = { _id: id, version: 1, createdAt: now, updatedAt: now, ...data };
       const repo = repoFactory.forType(type);
       await repo.insert(doc);
-      await repo.appendHistory(makeHistoryEntry(id, "create", doc));
       await maybeRunAfterHook(hookExecutor, resourceDef, type, toApiRecord(doc));
       events?.emit(DOMAIN_EVENTS.RESOURCE_CREATED, {
         resourceType: type,
@@ -317,10 +316,8 @@ export function registerResourceRoutes(
         ...data,
       };
 
-      const replaced = await repo.replaceOne(id, existing.version, newDoc);
+      const replaced = await repo.replaceOne(id, existing.version, newDoc, "update");
       if (!replaced) return reply.code(409).send({ error: "version conflict" });
-
-      await repo.appendHistory(makeHistoryEntry(id, "update", newDoc));
       await maybeRunAfterHook(hookExecutor, resourceDef, type, toApiRecord(newDoc));
       events?.emit(DOMAIN_EVENTS.RESOURCE_UPDATED, {
         resourceType: type,
@@ -414,10 +411,8 @@ export function registerResourceRoutes(
         ...data,
       };
 
-      const replaced = await repo.replaceOne(id, existing.version, newDoc);
+      const replaced = await repo.replaceOne(id, existing.version, newDoc, "update");
       if (!replaced) return reply.code(409).send({ error: "version conflict" });
-
-      await repo.appendHistory(makeHistoryEntry(id, "update", newDoc));
       await maybeRunAfterHook(hookExecutor, resourceDef, type, toApiRecord(newDoc));
       events?.emit(DOMAIN_EVENTS.RESOURCE_UPDATED, {
         resourceType: type,
@@ -487,10 +482,8 @@ export function registerResourceRoutes(
         deletedAt: now,
       };
 
-      const replaced = await repo.replaceOne(id, existing.version, softDeleted);
+      const replaced = await repo.replaceOne(id, existing.version, softDeleted, "delete");
       if (!replaced) return reply.code(409).send({ error: "version conflict" });
-
-      await repo.appendHistory(makeHistoryEntry(id, "delete", softDeleted));
       await maybeRunAfterHook(hookExecutor, resourceDef, type, toApiRecord(softDeleted));
       return reply.code(204).send();
     }

--- a/apps/api/src/resources/tools.test.ts
+++ b/apps/api/src/resources/tools.test.ts
@@ -10,6 +10,7 @@ import {
 import { describe, expect, it, vi } from "vitest";
 import type {
   CounterStore,
+  HistoryOp,
   ListOpts,
   ResourceDoc,
   ResourceHistoryDoc,
@@ -25,6 +26,11 @@ class FakeRepo implements ResourceRepo {
 
   async insert(doc: ResourceDoc): Promise<void> {
     this.docs.set(doc._id, { ...doc });
+    this.log(doc._id, "create", doc);
+  }
+
+  private log(id: string, operation: HistoryOp, snapshot: ResourceDoc): void {
+    this.history.push({ _id: randomUUID(), resourceId: id, operation, snapshot, at: new Date() });
   }
 
   async findById(id: string): Promise<ResourceDoc | null> {
@@ -47,15 +53,17 @@ class FakeRepo implements ResourceRepo {
     return { items: items.slice(0, opts.limit), nextCursor: null };
   }
 
-  async replaceOne(id: string, expectedVersion: number, doc: ResourceDoc): Promise<boolean> {
+  async replaceOne(
+    id: string,
+    expectedVersion: number,
+    doc: ResourceDoc,
+    op: HistoryOp
+  ): Promise<boolean> {
     const ex = this.docs.get(id);
     if (!ex || ex.version !== expectedVersion) return false;
     this.docs.set(id, { ...doc });
+    this.log(id, op, doc);
     return true;
-  }
-
-  async appendHistory(entry: ResourceHistoryDoc): Promise<void> {
-    this.history.push(entry);
   }
 }
 

--- a/apps/api/src/resources/tools.ts
+++ b/apps/api/src/resources/tools.ts
@@ -5,12 +5,7 @@ import { ajv } from "@tulipfarm/schema";
 import type { SoulLoader } from "@tulipfarm/soul";
 import { parsePaginationQuery } from "@tulipfarm/storage";
 import { type ApiToolDefinition, defineApiTool, err, ok } from "@tulipfarm/tool-host";
-import {
-  type CounterStore,
-  makeHistoryEntry,
-  type ResourceRepoFactory,
-  toApiRecord,
-} from "./repo.js";
+import { type CounterStore, type ResourceRepoFactory, toApiRecord } from "./repo.js";
 import {
   loadForWrite,
   maybeRunAfterHook,
@@ -212,7 +207,6 @@ const resourceCreate = defineApiTool<ResourceToolContext>({
     const repo = ctx.repoFactory.forType(type);
     try {
       await repo.insert(doc);
-      await repo.appendHistory(makeHistoryEntry(id, "create", doc));
     } catch (e) {
       return err("internal_error", reason(e));
     }
@@ -357,9 +351,8 @@ const resourceUpdate = defineApiTool<ResourceToolContext>({
     };
 
     try {
-      const replaced = await repo.replaceOne(id, existing.version, newDoc);
+      const replaced = await repo.replaceOne(id, existing.version, newDoc, "update");
       if (!replaced) return err("not_found", "version conflict");
-      await repo.appendHistory(makeHistoryEntry(id, "update", newDoc));
     } catch (e) {
       return err("internal_error", reason(e));
     }
@@ -410,9 +403,8 @@ const resourceDelete = defineApiTool<ResourceToolContext>({
     };
 
     try {
-      const replaced = await repo.replaceOne(id, existing.version, softDeleted);
+      const replaced = await repo.replaceOne(id, existing.version, softDeleted, "delete");
       if (!replaced) return err("not_found", "version conflict");
-      await repo.appendHistory(makeHistoryEntry(id, "delete", softDeleted));
     } catch (e) {
       return err("internal_error", reason(e));
     }


### PR DESCRIPTION
Record create, replace, patch and soft delete committed the Record and then appended its history snapshot as a second, independent query. A history failure therefore returned 500 after the authoritative Record had already changed: the audit invariant broke permanently, after-hooks and domain events were skipped for a committed change, and a caller retrying an ambiguously failed create minted a fresh UUID and a duplicate Record.

The mechanism is the repository, not the routes. `insert` and `replaceOne` now run the row write and its history append on one checked-out client through `withTransaction`, so a failed history insert rolls the mutation back. `appendHistory` leaves the `ResourceRepo` contract and becomes private to that transaction, which is what stops the two-step sequence being reintroduced; `replaceOne` carries the history operation instead. Both write surfaces are covered — the four HTTP routes and the three Agent Tools — and each route now emits its domain event and runs its after-hook only after a committed mutation, because the single repository call is the commit boundary.

No migration and no schema change. `apps/api/src` is two lines smaller.

## Summary

<!-- What changed, and why. Link the driving issue if one exists. -->

## Test plan

<!-- Commands you ran, or manual steps / screenshots for UI changes. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (or the scoped `--filter` you actually ran)

## Checklist

- [ ] PR title follows Conventional Commits (`type(scope): subject`) — CI checks this
- [ ] Scoped to one logical change
- [ ] Tests added/updated for the behavior that changed
