### PR TITLE
fix(web): buffer model sheet edits so a cleared Model ID cannot land

### DIFF
--- a/apps/web/app/components/model-chains.test.tsx
+++ b/apps/web/app/components/model-chains.test.tsx
@@ -313,6 +313,78 @@ test("a fallback with no provider selected stays in the sheet with a field error
   expect(within(fast as HTMLElement).getAllByRole("listitem")).toHaveLength(1);
 });
 
+test("a whitespace-only fallback Model ID is refused like an empty one", async () => {
+  const onSubmit = renderChains();
+
+  const fast = screen.getByRole("heading", { name: "Fast" }).closest("section");
+  await userEvent.click(within(fast as HTMLElement).getByRole("button", { name: /add fallback/i }));
+  await userEvent.type(await screen.findByLabelText("Model ID"), "   ");
+  await userEvent.click(screen.getByRole("button", { name: /^done$/i }));
+
+  expect(screen.getByText("Enter a Model ID.")).toBeInTheDocument();
+  expect(within(fast as HTMLElement).getAllByRole("listitem")).toHaveLength(1);
+
+  await userEvent.click(screen.getByRole("button", { name: /^close$/i }));
+  await userEvent.click(screen.getByRole("button", { name: /save changes/i }));
+  expect((onSubmit.mock.calls[0][0] as LlmConfig).tiers?.quick.providers).toHaveLength(1);
+});
+
+test("abandoning an edit that emptied the Model ID leaves the chain entry intact", async () => {
+  const onSubmit = renderChains();
+
+  await userEvent.click(screen.getByRole("button", { name: "Edit claude-haiku-4-5" }));
+  await userEvent.clear(await screen.findByLabelText("Model ID"));
+  await userEvent.click(screen.getByRole("button", { name: /^done$/i }));
+  expect(screen.getByText("Enter a Model ID.")).toBeInTheDocument();
+
+  await userEvent.click(screen.getByRole("button", { name: /^close$/i }));
+
+  const fast = screen.getByRole("heading", { name: "Fast" }).closest("section");
+  expect(within(fast as HTMLElement).queryByText(/no model set/i)).not.toBeInTheDocument();
+  expect(within(fast as HTMLElement).getAllByRole("listitem")[0]).toHaveTextContent(
+    "claude-haiku-4-5"
+  );
+
+  // Re-opening the row must not carry the refusal that the discarded edit raised.
+  await userEvent.click(screen.getByRole("button", { name: "Edit claude-haiku-4-5" }));
+  expect(await screen.findByLabelText("Model ID")).toHaveValue("claude-haiku-4-5");
+  expect(screen.queryByText("Enter a Model ID.")).not.toBeInTheDocument();
+  await userEvent.click(screen.getByRole("button", { name: /^close$/i }));
+
+  await userEvent.click(screen.getByRole("button", { name: /save changes/i }));
+  expect((onSubmit.mock.calls[0][0] as LlmConfig).tiers?.quick.providers[0]?.model).toBe(
+    "claude-haiku-4-5"
+  );
+});
+
+test("a chain already holding a blank entry never offers it as a preset target", async () => {
+  renderChains({
+    initial: {
+      ...initial,
+      tiers: {
+        quick: {
+          providers: [
+            { provider: "anthropic", model: "claude-haiku-4-5" },
+            { provider: "openai", model: "" },
+            { provider: "openai", model: "gpt-4o-mini" },
+          ],
+        },
+        standard: initial.tiers?.standard ?? { providers: [] },
+        complex: initial.tiers?.complex ?? { providers: [] },
+      },
+    },
+  });
+
+  const options = within(screen.getByLabelText("Fast"))
+    .getAllByRole("option")
+    .map((o) => o.textContent ?? "")
+    .join("|");
+  expect(options).not.toMatch(/unset/);
+  expect(options).not.toMatch(/fast-fallback-1\b/);
+  // The usable third entry keeps its real position, so a preset targeting it still resolves.
+  expect(options).toMatch(/fast-fallback-2/);
+});
+
 test("Auto is shown as the profile it resolves to", async () => {
   const onSubmit = renderChains();
 

--- a/apps/web/app/components/model-chains.tsx
+++ b/apps/web/app/components/model-chains.tsx
@@ -100,10 +100,12 @@ export function ModelChains({
 }) {
   const [chains, setChains] = useState<Chains>(() => cloneChains(initial));
   const [presets, setPresets] = useState<Presets>(() => clonePresets(initial));
-  const [editing, setEditing] = useState<{ tier: WireTier; uid: number } | null>(null);
-  // An "Add fallback" row lives here until the sheet is completed. Inserting it into the chain up
-  // front is what let a dismissed sheet leave a "no model set" entry behind, ready to be saved.
-  const [draft, setDraft] = useState<{ tier: WireTier; row: Row } | null>(null);
+  // Both adding and editing buffer the row here until the sheet is completed. Letting a sheet write
+  // into the chain as it is typed is what left a dismissed sheet with a "no model set" entry
+  // behind, ready to be saved.
+  const [sheet, setSheet] = useState<{ tier: WireTier; row: Row; mode: "add" | "edit" } | null>(
+    null
+  );
   const [localError, setLocalError] = useState<string | null>(null);
 
   const configured = useMemo(
@@ -134,42 +136,33 @@ export function ModelChains({
     return ids;
   }, [chains, presets, providers]);
 
-  const editingRow = draft
-    ? draft.row
-    : editing
-      ? chains[editing.tier].find((r) => r.uid === editing.uid)
-      : undefined;
+  const editingRow = sheet?.row;
 
   function mutate(tier: WireTier, fn: (rows: Row[]) => Row[]) {
     setChains((prev) => ({ ...prev, [tier]: fn(prev[tier]) }));
     setLocalError(null);
   }
 
-  function updateRow(tier: WireTier, uid: number, patch: Partial<Row>) {
-    mutate(tier, (rows) => rows.map((r) => (r.uid === uid ? { ...r, ...patch } : r)));
-  }
-
   function addRow(tier: WireTier) {
     setLocalError(null);
-    setDraft({
+    setSheet({
       tier,
+      mode: "add",
       row: { uid: nextUid++, provider: configured[0]?.id ?? providers[0]?.id ?? "", model: "" },
     });
   }
 
   function commitSheet() {
-    if (draft) {
-      const { tier, row } = draft;
-      mutate(tier, (rows) => [...rows, row]);
-      setDraft(null);
-      return;
-    }
-    setEditing(null);
+    if (!sheet) return;
+    const { tier, row, mode } = sheet;
+    mutate(tier, (rows) =>
+      mode === "add" ? [...rows, row] : rows.map((r) => (r.uid === row.uid ? row : r))
+    );
+    setSheet(null);
   }
 
   function cancelSheet() {
-    setDraft(null);
-    setEditing(null);
+    setSheet(null);
   }
 
   function move(tier: WireTier, index: number, delta: number) {
@@ -280,7 +273,7 @@ export function ModelChains({
                     providers={providers}
                     secretKeys={secretKeys}
                     profileId={profileIdFor(tier.preset, index)}
-                    onEdit={() => setEditing({ tier: tier.wire, uid: row.uid })}
+                    onEdit={() => setSheet({ tier: tier.wire, row, mode: "edit" })}
                     onMove={(delta) => move(tier.wire, index, delta)}
                     onRemove={() =>
                       mutate(tier.wire, (rows) => rows.filter((r) => r.uid !== row.uid))
@@ -361,13 +354,9 @@ export function ModelChains({
         secretKeys={secretKeys}
         onCancel={cancelSheet}
         onDone={commitSheet}
-        onChange={(patch) => {
-          if (draft) {
-            setDraft({ tier: draft.tier, row: { ...draft.row, ...patch } });
-            return;
-          }
-          if (editing) updateRow(editing.tier, editing.uid, patch);
-        }}
+        onChange={(patch) =>
+          setSheet((prev) => (prev ? { ...prev, row: { ...prev.row, ...patch } } : prev))
+        }
       />
     </div>
   );

--- a/apps/web/app/components/model-chains/model-sheet.tsx
+++ b/apps/web/app/components/model-chains/model-sheet.tsx
@@ -37,12 +37,15 @@ export function ModelSheet({
   const [resolving, setResolving] = useState(false);
   const [candidates, setCandidates] = useState<string[]>([]);
   const [unmatched, setUnmatched] = useState(false);
-  // Scoped to the row it was raised for, so a newly opened row never inherits it.
-  const [errors, setErrors] = useState<{ uid: number; provider?: string; model?: string } | null>(
-    null
-  );
+  // Cleared when the sheet closes, so re-opening a row never shows the refusal from a previous
+  // visit to a value that has since been discarded.
+  const [errors, setErrors] = useState<{ provider?: string; model?: string } | null>(null);
   const provider = row?.provider;
   const model = row?.model;
+
+  useEffect(() => {
+    if (!open) setErrors(null);
+  }, [open]);
 
   useEffect(() => {
     if (!open || !provider) {
@@ -107,18 +110,16 @@ export function ModelSheet({
   function finish() {
     if (!row) return;
     if (!row.provider.trim()) {
-      setErrors({ uid: row.uid, provider: "Select a provider." });
+      setErrors({ provider: "Select a provider." });
       return;
     }
     if (!row.model.trim()) {
-      setErrors({ uid: row.uid, model: "Enter a Model ID." });
+      setErrors({ model: "Enter a Model ID." });
       return;
     }
     setErrors(null);
     onDone();
   }
-
-  const shownErrors = errors?.uid === row?.uid ? errors : undefined;
 
   return (
     <Sheet open={open} onClose={onCancel} title="Model">
@@ -126,7 +127,7 @@ export function ModelSheet({
         <div className="space-y-4 p-4">
           <Field
             label="Provider"
-            error={shownErrors?.provider}
+            error={errors?.provider}
             help={ready ? undefined : "This provider has no credential yet."}
           >
             <Select
@@ -149,7 +150,7 @@ export function ModelSheet({
           <Field
             label="Model ID"
             htmlFor={modelFieldId}
-            error={shownErrors?.model}
+            error={errors?.model}
             help={
               options?.source === "live"
                 ? "Listed from your configured endpoint."


### PR DESCRIPTION
Adding a fallback with a blank Model ID was already refused (#430, #475), but editing an existing chain entry was not: the sheet wrote every keystroke straight into the chain via `updateRow`, so clearing the Model ID and then dismissing the sheet with Close, Escape or a backdrop click left a "no model set" row behind. That is issue #415's symptom reached by the other door — an entry that cannot serve a request sitting in the chain the operator is about to save.

The sheet now holds a single buffered row for both add and edit, and only `commitSheet` writes it into the chain, so an in-progress entry never exists in the chain at all and the existing Done guard is the sole way in. The error state loses its uid scoping and is cleared when the sheet closes, so re-opening a row no longer shows a refusal raised against a value that was discarded.

The invariant that stops such a row reaching persisted config already lives in `ChainIdentifierSchema` (`minLength: 1`, `^\S+$`), which every write path goes through via `validateLlmConfig`; this change is the UI half only. The preset dropdowns keep skipping blank-model rows because a config saved before that constraint existed still reaches the page through GET.

## Summary

<!-- What changed, and why. Link the driving issue if one exists. -->

## Test plan

<!-- Commands you ran, or manual steps / screenshots for UI changes. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (or the scoped `--filter` you actually ran)

## Checklist

- [ ] PR title follows Conventional Commits (`type(scope): subject`) — CI checks this
- [ ] Scoped to one logical change
- [ ] Tests added/updated for the behavior that changed
