### PR TITLE
fix(integrations): cage caller-supplied Git clone sources

### DIFF
--- a/apps/api/AGENTS.md
+++ b/apps/api/AGENTS.md
@@ -113,6 +113,7 @@ PostgreSQL persistence composition, auth, Soul Git writes, and Worker callback p
   secret env values to `secret://` refs, commit, and reload Soul.
 - Third-party integration installs copy only regular `manifest.yml` and `setup-guide.md`; manifests
   must stay declarative, https-only for provider URLs, and non-executable.
-- Keep the shared Git source allowlist in `@tulipfarm/soul` (`src/git-source.ts`); do not fork SSRF policy.
+- Clone every caller-supplied Git source through `withGitSourceClone` from `@tulipfarm/integrations`
+  (`src/git-source/`); do not fork SSRF policy and never return git's stderr to a caller.
 
 See [Integration authoring](../../docs/architecture/building-an-integration.md).

--- a/apps/api/src/integrations/install.ts
+++ b/apps/api/src/integrations/install.ts
@@ -1,11 +1,11 @@
 import { createHash } from "node:crypto";
 import type { Dirent } from "node:fs";
-import { readdir, readFile, rm } from "node:fs/promises";
+import { readdir, readFile } from "node:fs/promises";
 import { basename, join, relative } from "node:path";
 import { DEPLOYMENT_BUSINESS_ID } from "@tulipfarm/constants";
+import { gitSourceHttpError, withGitSourceClone } from "@tulipfarm/integrations";
 import {
   type CommitActor,
-  cloneToTemp,
   type IntegrationManifest,
   type SoulLoader,
   type SoulWrite,
@@ -41,7 +41,7 @@ export interface DiscoveredIntegration {
 export class IntegrationInstallError extends Error {
   constructor(
     message: string,
-    readonly status: 400 | 404 | 409
+    readonly status: 400 | 404 | 409 | 429
   ) {
     super(message);
     this.name = "IntegrationInstallError";
@@ -191,27 +191,29 @@ export interface InstallResult {
  * Clone `source` and report what it offers, without writing anything. The install route uses the
  * same discovery, so a preview can never disagree with what installing would do.
  */
-export async function inspectIntegrationSource(source: string): Promise<{
+export async function inspectIntegrationSource(
+  source: string,
+  actorId: string
+): Promise<{
   ref: string;
   integrations: DiscoveredIntegration[];
 }> {
-  let dir: string | undefined;
   try {
-    const clone = await cloneToTemp(source, "integration-scan-");
-    dir = clone.dir;
-    const integrations = await discoverIntegrations(dir);
-    if (integrations.length === 0) {
-      throw new IntegrationInstallError("no manifest.yml found in repo", 400);
-    }
-    return { ref: clone.ref, integrations };
-  } catch (error) {
-    if (error instanceof IntegrationInstallError) throw error;
-    throw new IntegrationInstallError(
-      `clone failed: ${error instanceof Error ? error.message : String(error)}`,
-      400
+    return await withGitSourceClone(
+      source,
+      { prefix: "integration-scan-", actorId },
+      async ({ dir, ref }) => {
+        const integrations = await discoverIntegrations(dir);
+        if (integrations.length === 0) {
+          throw new IntegrationInstallError("no manifest.yml found in repo", 400);
+        }
+        return { ref, integrations };
+      }
     );
-  } finally {
-    if (dir) await rm(dir, { recursive: true, force: true });
+  } catch (error) {
+    const denial = gitSourceHttpError(error);
+    if (!denial) throw error;
+    throw new IntegrationInstallError(denial.body.error, denial.status);
   }
 }
 
@@ -228,9 +230,11 @@ export async function installIntegrationFromSource(
     soulWriter: SoulWriter;
     bundledSlugs: ReadonlySet<string>;
     actor?: CommitActor;
+    /** Whoever asked; the clone gate bounds concurrent scans per actor. */
+    actorId: string;
   }
 ): Promise<InstallResult> {
-  const { ref, integrations } = await inspectIntegrationSource(options.source);
+  const { ref, integrations } = await inspectIntegrationSource(options.source, deps.actorId);
 
   let chosen: DiscoveredIntegration | undefined;
   if (options.name) {

--- a/apps/api/src/integrations/marketplace-routes.test.ts
+++ b/apps/api/src/integrations/marketplace-routes.test.ts
@@ -145,6 +145,9 @@ describe("integration marketplace routes", () => {
   const temps: string[] = [];
 
   beforeEach(async () => {
+    // Browse and install are exercised against local git repos, which the clone policy denies
+    // unless the deployment opted in.
+    process.env.GIT_SOURCE_ALLOW_LOCAL_PATHS = "1";
     const store = new MemorySessionStore();
     const userRepo = new FakeUserRepo();
     const tokenRepo = new FakeTokenRepo();
@@ -225,6 +228,7 @@ describe("integration marketplace routes", () => {
   afterEach(async () => {
     // Avoid leaking literal `undefined` into later path resolution.
     delete process.env.BUNDLED_INTEGRATIONS_DIR;
+    delete process.env.GIT_SOURCE_ALLOW_LOCAL_PATHS;
     await app.close();
     for (const dir of temps.splice(0)) await rm(dir, { recursive: true, force: true });
   });
@@ -310,7 +314,41 @@ describe("integration marketplace routes", () => {
         payload: { source: "git@internal.example.com:secrets/repo.git" },
       });
       expect(res.statusCode).toBe(400);
-      expect(res.json().error).toContain("owner/repo slug");
+      expect(res.json().error).toContain('"owner/repo" slug');
+    });
+
+    // Issue #183: the same cage guards this route, and it is applied before git is started.
+    it.each([
+      ["a local filesystem repository", "file:///srv/secrets/repo"],
+      ["plain HTTP", "http://github.com/owner/repo.git"],
+      ["embedded credentials", "https://user:pass@github.com/owner/repo.git"],
+      ["IPv4 loopback", "https://127.0.0.1/owner/repo.git"],
+      ["the cloud metadata address", "https://169.254.169.254/owner/repo.git"],
+      ["an unapproved host", "https://git.internal.example/owner/repo.git"],
+    ])("rejects %s", async (_label, source) => {
+      delete process.env.GIT_SOURCE_ALLOW_LOCAL_PATHS;
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/v1/integrations/inspect",
+        cookies: auth(),
+        headers,
+        payload: { source },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).not.toContain("git clone");
+    });
+
+    // Issue #437: a failing clone reports a verdict, not git's stderr or a server path.
+    it("reports a clone failure without leaking the command or temp paths", async () => {
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/v1/integrations/inspect",
+        cookies: auth(),
+        headers,
+        payload: { source: `file://${join(tmpdir(), "no-such-integration-repo-xyz")}` },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toBe("Repository not found or not accessible.");
     });
 
     it("reports what a repo offers without writing anything", async () => {
@@ -671,7 +709,7 @@ describe("integration marketplace routes", () => {
         payload: { source: `file://${join(tmpdir(), "does-not-exist-repo")}` },
       });
       expect(res.statusCode).toBe(400);
-      expect(res.json().error).toContain("clone failed");
+      expect(res.json().error).toBe("Repository not found or not accessible.");
     });
   });
 

--- a/apps/api/src/integrations/marketplace-routes.ts
+++ b/apps/api/src/integrations/marketplace-routes.ts
@@ -1,10 +1,5 @@
 import type { BundledIntegration, SoulLoader, SoulWriter } from "@tulipfarm/soul";
-import {
-  ALLOWED_SOURCE_HINT,
-  isAllowedSource,
-  isSoulWriteError,
-  soulWriteHttpError,
-} from "@tulipfarm/soul";
+import { isSoulWriteError, soulWriteHttpError } from "@tulipfarm/soul";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { ErrorSchema } from "../auth/schemas";
 import { commitActorFromRequest } from "../soul/commit-actor";
@@ -70,16 +65,15 @@ export function registerIntegrationMarketplaceRoutes(
           },
           400: ErrorSchema,
           401: ErrorSchema,
+          429: ErrorSchema,
         },
       },
     },
     async (req, reply) => {
       const { source } = req.body as { source: string };
-      if (!isAllowedSource(source)) {
-        return reply.code(400).send({ error: ALLOWED_SOURCE_HINT });
-      }
       try {
-        const { ref, integrations } = await inspectIntegrationSource(source);
+        const actorId = commitActorFromRequest(req).principalId;
+        const { ref, integrations } = await inspectIntegrationSource(source, actorId);
         const bundledNames = bundledSlugs();
         return {
           source,
@@ -138,15 +132,14 @@ export function registerIntegrationMarketplaceRoutes(
           404: ErrorSchema,
           409: ErrorSchema,
           422: ErrorSchema,
+          429: ErrorSchema,
           500: ErrorSchema,
         },
       },
     },
     async (req, reply) => {
       const { source, name } = req.body as { source: string; name?: string };
-      if (!isAllowedSource(source)) {
-        return reply.code(400).send({ error: ALLOWED_SOURCE_HINT });
-      }
+      const actor = commitActorFromRequest(req);
       try {
         return await installIntegrationFromSource(
           { source, name },
@@ -154,7 +147,8 @@ export function registerIntegrationMarketplaceRoutes(
             soulLoader,
             soulWriter,
             bundledSlugs: bundledSlugs(),
-            actor: commitActorFromRequest(req),
+            actor,
+            actorId: actor.principalId,
           }
         );
       } catch (error) {

--- a/apps/api/src/soul/skills/routes.test.ts
+++ b/apps/api/src/soul/skills/routes.test.ts
@@ -136,6 +136,9 @@ describe("skills routes", () => {
   const temps: string[] = [];
 
   beforeEach(async () => {
+    // These tests serve their fixtures from local git repos, which the clone policy denies unless
+    // the deployment opted in. The policy itself is exercised in "clone source policy" below.
+    process.env.GIT_SOURCE_ALLOW_LOCAL_PATHS = "1";
     store = new MemorySessionStore();
     const userRepo = new FakeUserRepo();
     const tokenRepo = new FakeTokenRepo();
@@ -227,6 +230,7 @@ describe("skills routes", () => {
   });
 
   afterEach(async () => {
+    delete process.env.GIT_SOURCE_ALLOW_LOCAL_PATHS;
     await app.close();
     for (const dir of temps.splice(0)) await rm(dir, { recursive: true, force: true });
   });
@@ -426,30 +430,6 @@ spec:
       expect(res.statusCode).toBe(400);
     });
 
-    it("rejects a disallowed source scheme (ssh) before cloning", async () => {
-      const res = await app.inject({
-        method: "POST",
-        url: "/api/v1/skills/scan",
-        cookies: auth(),
-        headers,
-        payload: { source: "ssh://internal-host/repo.git" },
-      });
-      expect(res.statusCode).toBe(400);
-      expect(res.json().error).toMatch(/owner\/repo|http/);
-    });
-
-    it("rejects a source with an unsafe #ref suffix before cloning", async () => {
-      const res = await app.inject({
-        method: "POST",
-        url: "/api/v1/skills/scan",
-        cookies: auth(),
-        headers,
-        payload: { source: "owner/repo#--upload-pack=evil" },
-      });
-      expect(res.statusCode).toBe(400);
-      expect(res.json().error).toMatch(/owner\/repo|http/);
-    });
-
     it("scans a non-default branch when the source carries a #ref suffix", async () => {
       const remote = await makeRemoteRepo();
       temps.push(remote);
@@ -531,6 +511,66 @@ spec:
       );
       const stale = await scan(fileUrl);
       expect(stale.json().skills[0]).toMatchObject({ installed: true, updateAvailable: true });
+    });
+  });
+
+  describe("POST /api/v1/skills/scan — clone source policy", () => {
+    beforeEach(() => {
+      delete process.env.GIT_SOURCE_ALLOW_LOCAL_PATHS;
+    });
+
+    const scan = (source: string) =>
+      app.inject({
+        method: "POST",
+        url: "/api/v1/skills/scan",
+        cookies: auth(),
+        headers,
+        payload: { source },
+      });
+
+    // Every row must be refused by the URL/address policy, before any git process is started.
+    const forbidden: ReadonlyArray<readonly [string, string]> = [
+      ["a local filesystem repository", "file:///srv/secrets/repo"],
+      ["plain HTTP", "http://github.com/owner/repo.git"],
+      ["embedded credentials", "https://user:pass@github.com/owner/repo.git"],
+      ["IPv4 loopback", "https://127.0.0.1/owner/repo.git"],
+      ["IPv6 loopback", "https://[::1]/owner/repo.git"],
+      ["the unspecified address", "https://0.0.0.0/owner/repo.git"],
+      ["the cloud metadata address", "https://169.254.169.254/latest/repo.git"],
+      ["RFC 1918 10/8", "https://10.1.2.3/owner/repo.git"],
+      ["RFC 1918 192.168/16", "https://192.168.1.1/owner/repo.git"],
+      ["RFC 1918 172.16/12", "https://172.20.0.1/owner/repo.git"],
+      ["unique local IPv6", "https://[fd00::1]/owner/repo.git"],
+      ["link-local IPv6", "https://[fe80::1]/owner/repo.git"],
+      ["decimal-encoded IPv4", "https://2130706433/owner/repo.git"],
+      ["hex-encoded IPv4", "https://0x7f000001/owner/repo.git"],
+      ["octal-encoded IPv4", "https://0177.0.0.1/owner/repo.git"],
+      ["IPv4-mapped IPv6", "https://[::ffff:127.0.0.1]/owner/repo.git"],
+      ["an unapproved host", "https://git.internal.example/owner/repo.git"],
+      ["a trailing-dot unapproved host", "https://git.internal.example./owner/repo.git"],
+      ["an scp-style source", "git@internal.example.com:secrets/repo.git"],
+      ["a git:// source", "git://internal.example.com/repo.git"],
+      ["an ssh source", "ssh://internal-host/repo.git"],
+      ["an unsafe #ref suffix", "owner/repo#--upload-pack=evil"],
+    ];
+
+    it.each(forbidden)("rejects %s without cloning", async (_label, source) => {
+      const res = await scan(source);
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).not.toContain("git clone");
+    });
+
+    // Issue #437: the operator sees a verdict, never the command, its stderr or a server path.
+    it("reports a clone failure without leaking the command, stderr or temp paths", async () => {
+      process.env.GIT_SOURCE_ALLOW_LOCAL_PATHS = "1";
+      const res = await scan(`file://${join(tmpdir(), "does-not-exist-qa-stress-xyz")}`);
+      expect(res.statusCode).toBe(400);
+      const { error } = res.json() as { error: string };
+      expect(error).toBe("Repository not found or not accessible.");
+      expect(error).not.toContain("git clone");
+      expect(error).not.toContain("Command failed");
+      expect(error).not.toContain("fatal:");
+      expect(error).not.toContain(tmpdir());
     });
   });
 

--- a/apps/api/src/soul/skills/routes.ts
+++ b/apps/api/src/soul/skills/routes.ts
@@ -1,8 +1,9 @@
 // biome-ignore-all format: keep business logic local while meeting the control-plane size cap
 import { createHash, randomUUID } from "node:crypto";
-import { readdir, readFile, readlink, realpath, rm } from "node:fs/promises";
+import { readdir, readFile, readlink, realpath } from "node:fs/promises";
 import { basename, dirname, isAbsolute, join, relative } from "node:path";
 import { DEPLOYMENT_BUSINESS_ID } from "@tulipfarm/constants";
+import { gitSourceHttpError, withGitSourceClone } from "@tulipfarm/integrations";
 import type { LlmService } from "@tulipfarm/llm";
 import { SandboxRuntimeProfileRegistry, shellTsPythonV1 } from "@tulipfarm/sandbox";
 import {
@@ -14,14 +15,11 @@ import {
   validateSkill,
 } from "@tulipfarm/schema";
 import {
-  ALLOWED_SOURCE_HINT,
   artifactWriteTarget,
   type BundledSkill,
-  cloneToTemp as cloneSourceToTemp,
   convertLegacySkill,
   DISABLED_BUNDLED_SKILLS_FILE,
   type GitSyncService,
-  isAllowedSource,
   isSoulWriteError,
   mergedSkills,
   parseFrontmatter,
@@ -335,21 +333,18 @@ async function loadMarketplace(gitSync: GitSyncService, soulLoader: SoulLoader, 
       }),
     };
   }
-  let dir: string | undefined;
-  try {
-    const clone = await cloneSourceToTemp(source, "skill-scan-");
-    dir = clone.dir;
+  await withGitSourceClone(source, { prefix: "skill-scan-", actorId: "system:marketplace" }, async ({ dir, ref }) => {
     const scanId = randomUUID();
     pruneScans(now);
-    scans.set(scanId, { source, ref: clone.ref, skills: await discoverSkills(dir), audited: new Set(), expires: now + SCAN_TTL_MS });
+    scans.set(scanId, { source, ref, skills: await discoverSkills(dir), audited: new Set(), expires: now + SCAN_TTL_MS });
     marketplaceCache.set(source, { scanId, expires: now + SCAN_TTL_MS, manifest: await readManifest(dir) });
-    return loadMarketplace(gitSync, soulLoader, bundledSkills, disabledBundledSkills);
-  } finally {
-    if (dir) await rm(dir, { recursive: true, force: true });
-  }
+  });
+  return loadMarketplace(gitSync, soulLoader, bundledSkills, disabledBundledSkills);
 }
+// The operator sees that the catalog is unreachable, never git's stderr or a server temp path.
 function sendMarketplaceUnavailable(reply: FastifyReply, error: unknown) {
-  return reply.code(502).send({ error: `marketplace unavailable: ${error instanceof Error ? error.message : String(error)}` });
+  const denial = gitSourceHttpError(error);
+  return reply.code(502).send({ error: `marketplace unavailable: ${denial?.body.error ?? "the catalog repository could not be read"}` });
 }
 function rethrowSoulWriteError(reply: FastifyReply, error: unknown): never | FastifyReply {
   if (isSoulWriteError(error)) {
@@ -456,26 +451,24 @@ export function registerSkillRoutes(app: FastifyInstance, soulLoader: SoulLoader
       description: "Clone a git repo (source accepts an optional #branch suffix) and discover installable SKILL.md files.",
       tags: ["skills"], security: [{ sessionCookie: [] }, { bearerToken: [] }],
       body: SkillScanBodySchema,
-      response: { 200: SkillScanResponseSchema, 400: ErrorSchema, 401: ErrorSchema },
+      response: { 200: SkillScanResponseSchema, 400: ErrorSchema, 401: ErrorSchema, 429: ErrorSchema },
     },
   }, async (req, reply) => {
     const { source } = req.body as { source: string };
-    if (!isAllowedSource(source)) return reply.code(400).send({ error: ALLOWED_SOURCE_HINT });
-    let dir: string | undefined;
     try {
-      const clone = await cloneSourceToTemp(source, "skill-scan-");
-      dir = clone.dir;
-      const discovered = await discoverSkills(dir);
-      if (discovered.length === 0) return reply.code(400).send({ error: "no SKILL.md files found in repo" });
-      const lock = await readLock(gitSync.path);
-      const scanId = randomUUID();
-      pruneScans(Date.now());
-      scans.set(scanId, { source, ref: clone.ref, skills: discovered, audited: new Set(), expires: Date.now() + SCAN_TTL_MS });
-      return { scanId, skills: discovered.map((skill) => ({ name: skill.name, skillPath: skill.skillPath, description: skill.description, ...installStatus(skill, lock, soulLoader, bundledSkills, disabledBundledSkills) })) };
+      return await withGitSourceClone(source, { prefix: "skill-scan-", actorId: commitActorFromRequest(req).principalId }, async ({ dir, ref }) => {
+        const discovered = await discoverSkills(dir);
+        if (discovered.length === 0) return reply.code(400).send({ error: "no SKILL.md files found in repo" });
+        const lock = await readLock(gitSync.path);
+        const scanId = randomUUID();
+        pruneScans(Date.now());
+        scans.set(scanId, { source, ref, skills: discovered, audited: new Set(), expires: Date.now() + SCAN_TTL_MS });
+        return { scanId, skills: discovered.map((skill) => ({ name: skill.name, skillPath: skill.skillPath, description: skill.description, ...installStatus(skill, lock, soulLoader, bundledSkills, disabledBundledSkills) })) };
+      });
     } catch (error) {
-      return reply.code(400).send({ error: `scan failed: ${error instanceof Error ? error.message : String(error)}` });
-    } finally {
-      if (dir) await rm(dir, { recursive: true, force: true });
+      const denial = gitSourceHttpError(error);
+      if (!denial) throw error;
+      return reply.code(denial.status).send(denial.body);
     }
   });
   app.post("/api/v1/skills/audit", {

--- a/packages/integrations/AGENTS.md
+++ b/packages/integrations/AGENTS.md
@@ -16,6 +16,7 @@ Owns adapter contracts, event normalization, source ACLs, sync checkpoints, and 
 | `src/http.ts` | Provider-neutral HTTP port, failure classification, bounded pagination. |
 | `src/grants.ts` | Default-deny grants for concrete external targets. |
 | `src/egress/` | Manifest-to-ToolContract compiler, adapter, fetch transport, destination cage. |
+| `src/git-source/` | Pre-clone Git source cage and the bounded, sanitised clone helper. |
 | `src/import/`, `src/ingress/`, `src/external-protocol/` | Import and ingress protocols. |
 | `src/github/`, `src/jira/` | Tool adapters and provider contracts. |
 | `src/slack/`, `src/telegram/` | Messaging Tool adapters and provider contracts. |
@@ -31,6 +32,9 @@ Owns adapter contracts, event normalization, source ACLs, sync checkpoints, and 
 - Manifest hosts are chat-authored: compile through `assertPublicEgressUrl`, send through
   `GuardedEgressHttp`. Neither subsumes the other — a public name can hold an inward A record.
 - `openapi-compile.ts` must resolve every `$ref`; survivors can break unrelated Tool registration.
+- Every caller-supplied Git source clones through `withGitSourceClone`; never spawn `git` directly
+  and never surface its stderr. `GIT_SOURCE_ALLOWED_HOSTS` widens the host allowlist;
+  `GIT_SOURCE_ALLOW_LOCAL_PATHS=1` (fixtures only) re-enables `file://`.
 - `collectPages` must throw `PaginationBoundError` rather than silently truncate a paged read.
 - Jira creates use `tulipfarm-effect-<hash>` labels and must read provider state before writing.
 - Integration events must resolve external principals; never borrow Conversation owner identity.

--- a/packages/integrations/src/egress/destination.test.ts
+++ b/packages/integrations/src/egress/destination.test.ts
@@ -49,6 +49,14 @@ describe("isPrivateNetworkAddress", () => {
     expect(isPrivateNetworkAddress("::ffff:8.8.8.8")).toBe(false);
   });
 
+  // `new URL()` rewrites the dotted mapped form to hextets, so both spellings reach a guard.
+  it("denies an IPv4-mapped address written as hextets", () => {
+    for (const address of ["::ffff:7f00:1", "::ffff:a00:5", "::ffff:c0a8:1", "::ffff:a9fe:a9fe"]) {
+      expect(isPrivateNetworkAddress(address), address).toBe(true);
+    }
+    expect(isPrivateNetworkAddress("::ffff:808:808")).toBe(false);
+  });
+
   it("denies anything that is not an address, because a guard that cannot tell must not allow", () => {
     for (const value of ["", "not-an-ip", "10.1.2", "10.1.2.3.4", "999.1.1.1"]) {
       expect(isPrivateNetworkAddress(value), value).toBe(true);

--- a/packages/integrations/src/egress/destination.ts
+++ b/packages/integrations/src/egress/destination.ts
@@ -54,7 +54,13 @@ function isPrivateIpv6(address: string): boolean {
   if (normalized.startsWith("fc") || normalized.startsWith("fd")) return true;
   if (/^fe[89ab]/.test(normalized)) return true;
   const mappedIpv4 = normalized.match(/::ffff:(\d+\.\d+\.\d+\.\d+)$/)?.[1];
-  return mappedIpv4 !== undefined && isPrivateIpv4(mappedIpv4);
+  if (mappedIpv4 !== undefined) return isPrivateIpv4(mappedIpv4);
+  // `new URL()` rewrites `::ffff:127.0.0.1` to `::ffff:7f00:1`, so the dotted form is not the
+  // only spelling that reaches here.
+  const hextets = normalized.match(/^::ffff:([\da-f]{1,4}):([\da-f]{1,4})$/);
+  if (hextets === null) return false;
+  const [high, low] = [Number.parseInt(hextets[1], 16), Number.parseInt(hextets[2], 16)];
+  return isPrivateIpv4(`${high >> 8}.${high & 255}.${low >> 8}.${low & 255}`);
 }
 
 /** Loopback, link-local, RFC 1918, CGNAT, multicast and IPv4-mapped IPv6 all count as private. */

--- a/packages/integrations/src/git-source/clone.test.ts
+++ b/packages/integrations/src/git-source/clone.test.ts
@@ -1,0 +1,177 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { withGitSourceClone } from "./clone";
+import { GitSourceError } from "./policy";
+
+const publicResolver = async () => ["93.184.216.34"];
+
+afterEach(() => {
+  delete process.env.GIT_SOURCE_ALLOW_LOCAL_PATHS;
+});
+
+/** Stands in for the real `git`, so the assertion is about whether a process would start at all. */
+function fakeGit(onClone?: (dir: string) => Promise<void>) {
+  return vi.fn(async (args: readonly string[]) => {
+    if (args[0] === "clone") {
+      const dir = args.at(-1) ?? "";
+      await mkdir(dir, { recursive: true });
+      await onClone?.(dir);
+      return "";
+    }
+    return "cafebabe\n";
+  });
+}
+
+describe("withGitSourceClone", () => {
+  const forbidden = [
+    ["a local repository", "file:///srv/secrets/repo"],
+    ["IPv4 loopback", "https://127.0.0.1/o/r.git"],
+    ["IPv6 loopback", "https://[::1]/o/r.git"],
+    ["the cloud metadata address", "https://169.254.169.254/o/r.git"],
+    ["plain HTTP", "http://github.com/o/r.git"],
+    ["credentials in the URL", "https://user:pass@github.com/o/r.git"],
+    ["an unapproved host", "https://git.internal.example/o/r.git"],
+  ] as const;
+
+  it.each(forbidden)("starts no git process for %s", async (_label, source) => {
+    const runGit = fakeGit();
+    const use = vi.fn();
+    await expect(
+      withGitSourceClone(
+        source,
+        { prefix: "t-", actorId: "u1", runGit, resolve: publicResolver },
+        use
+      )
+    ).rejects.toBeInstanceOf(GitSourceError);
+    expect(runGit).not.toHaveBeenCalled();
+    expect(use).not.toHaveBeenCalled();
+  });
+
+  it("clones an allowed source and removes the directory afterwards", async () => {
+    const runGit = fakeGit();
+    let cloned = "";
+    const ref = await withGitSourceClone(
+      "TulipFarm/skills",
+      { prefix: "clone-ok-", actorId: "u1", runGit, resolve: publicResolver },
+      async (clone) => {
+        cloned = clone.dir;
+        return clone.ref;
+      }
+    );
+    expect(ref).toBe("cafebabe");
+    expect(runGit.mock.calls[0][0]).toContain("--depth");
+    await expect(import("node:fs/promises").then((fs) => fs.stat(cloned))).rejects.toThrow();
+  });
+
+  it("removes the directory when the caller's own work throws", async () => {
+    const runGit = fakeGit();
+    let cloned = "";
+    await expect(
+      withGitSourceClone(
+        "TulipFarm/skills",
+        { prefix: "clone-boom-", actorId: "u1", runGit, resolve: publicResolver },
+        async (clone) => {
+          cloned = clone.dir;
+          throw new Error("scan blew up");
+        }
+      )
+    ).rejects.toThrow("scan blew up");
+    await expect(import("node:fs/promises").then((fs) => fs.stat(cloned))).rejects.toThrow();
+  });
+
+  it("reports a clone failure without any of git's output", async () => {
+    const runGit = vi.fn(async () => {
+      throw new Error("Command failed: git clone --depth 1 https://… /tmp/skill-scan-1gEQgo");
+    });
+    await expect(
+      withGitSourceClone(
+        "TulipFarm/skills",
+        { prefix: "t-", actorId: "u1", runGit, resolve: publicResolver },
+        async () => "unreachable"
+      )
+    ).rejects.toMatchObject({ denial: "clone_failed" });
+  });
+
+  it("refuses a second concurrent clone from the same actor", async () => {
+    let releaseFirst: () => void = () => undefined;
+    const held = new Promise<void>((resolve) => {
+      releaseFirst = () => resolve();
+    });
+    const runGit = fakeGit();
+    const options = { prefix: "t-", actorId: "u1", runGit, resolve: publicResolver };
+    const first = withGitSourceClone("TulipFarm/skills", options, async () => {
+      await held;
+      return "first";
+    });
+    await expect(
+      withGitSourceClone("TulipFarm/skills", options, async () => "second")
+    ).rejects.toMatchObject({ denial: "too_many_clones" });
+    releaseFirst();
+    expect(await first).toBe("first");
+  });
+
+  it("refuses once the global ceiling is reached, even across actors", async () => {
+    let releaseFirst: () => void = () => undefined;
+    const held = new Promise<void>((resolve) => {
+      releaseFirst = () => resolve();
+    });
+    const runGit = fakeGit();
+    const limits = { maxConcurrent: 1 };
+    const first = withGitSourceClone(
+      "TulipFarm/skills",
+      { prefix: "t-", actorId: "u1", runGit, resolve: publicResolver, limits },
+      async () => {
+        await held;
+        return "first";
+      }
+    );
+    await expect(
+      withGitSourceClone(
+        "TulipFarm/skills",
+        { prefix: "t-", actorId: "u2", runGit, resolve: publicResolver, limits },
+        async () => "second"
+      )
+    ).rejects.toMatchObject({ denial: "too_many_clones" });
+    releaseFirst();
+    expect(await first).toBe("first");
+  });
+
+  it("aborts a repository that grows past the byte limit", async () => {
+    const runGit = vi.fn(async (args: readonly string[], options: { signal: AbortSignal }) => {
+      if (args[0] !== "clone") return "cafebabe\n";
+      const dir = args.at(-1) ?? "";
+      await mkdir(dir, { recursive: true });
+      await writeFile(join(dir, "pack"), Buffer.alloc(4096));
+      await new Promise<void>((resolve, reject) => {
+        options.signal.addEventListener("abort", () => reject(new Error("aborted")), {
+          once: true,
+        });
+        setTimeout(resolve, 5_000);
+      });
+      return "";
+    });
+    await expect(
+      withGitSourceClone(
+        "TulipFarm/skills",
+        {
+          prefix: "t-big-",
+          actorId: "u1",
+          runGit,
+          resolve: publicResolver,
+          limits: { maxBytes: 1024 },
+        },
+        async () => "unreachable"
+      )
+    ).rejects.toMatchObject({ denial: "repository_too_large" });
+  });
+
+  it("releases the slot after a refusal so the actor is not locked out", async () => {
+    const runGit = fakeGit();
+    const options = { prefix: "t-", actorId: "u3", runGit, resolve: publicResolver };
+    await expect(
+      withGitSourceClone("https://127.0.0.1/o/r.git", options, async () => "x")
+    ).rejects.toBeInstanceOf(GitSourceError);
+    expect(await withGitSourceClone("TulipFarm/skills", options, async () => "ok")).toBe("ok");
+  });
+});

--- a/packages/integrations/src/git-source/clone.ts
+++ b/packages/integrations/src/git-source/clone.ts
@@ -1,0 +1,202 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, readdir, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import {
+  assertClonableGitSource,
+  type ClonableGitSource,
+  type GitHostResolver,
+  GitSourceError,
+} from "./policy";
+
+const execFileP = promisify(execFile);
+
+export interface GitCloneLimits {
+  readonly timeoutMs: number;
+  readonly maxBytes: number;
+  /** Ceiling across the whole process, so one caller cannot starve every other. */
+  readonly maxConcurrent: number;
+  readonly maxPerActor: number;
+}
+
+export const DEFAULT_GIT_CLONE_LIMITS: GitCloneLimits = {
+  timeoutMs: 60_000,
+  maxBytes: 256 * 1024 * 1024,
+  maxConcurrent: 4,
+  maxPerActor: 1,
+};
+
+const SIZE_POLL_MS = 500;
+
+/**
+ * A deliberately small environment. `process.env` carries `GIT_CONFIG_*`, `GIT_SSH_COMMAND`,
+ * `GIT_PROXY_COMMAND` and askpass hooks that turn a clone into arbitrary execution or a redirect
+ * to another repository, and it carries the deployment's own secrets. Proxy variables survive
+ * because an operator behind an egress proxy has no other way to reach the allowed host.
+ */
+const PASSED_THROUGH = ["PATH", "HTTPS_PROXY", "HTTP_PROXY", "NO_PROXY"];
+
+function cloneEnv(): Record<string, string> {
+  const env: Record<string, string> = {
+    GIT_TERMINAL_PROMPT: "0",
+    GIT_ASKPASS: "",
+    SSH_ASKPASS: "",
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_CONFIG_SYSTEM: "/dev/null",
+    GIT_ALLOW_PROTOCOL: "https:file",
+    LC_ALL: "C",
+  };
+  for (const key of PASSED_THROUGH) {
+    const value = process.env[key] ?? process.env[key.toLowerCase()];
+    if (value !== undefined) env[key] = value;
+  }
+  env.PATH ??= "/usr/bin:/bin";
+  return env;
+}
+
+export type GitRunner = (
+  args: readonly string[],
+  options: { cwd?: string; timeoutMs: number; signal: AbortSignal }
+) => Promise<string>;
+
+const spawnGit: GitRunner = async (args, options) => {
+  const { stdout } = await execFileP("git", [...args], {
+    cwd: options.cwd,
+    timeout: options.timeoutMs,
+    signal: options.signal,
+    env: cloneEnv(),
+  });
+  return stdout;
+};
+
+async function directoryBytes(directory: string): Promise<number> {
+  const entries = await readdir(directory, { withFileTypes: true, recursive: true }).catch(
+    () => []
+  );
+  let total = 0;
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    const info = await stat(join(entry.parentPath, entry.name)).catch(() => undefined);
+    total += info?.size ?? 0;
+  }
+  return total;
+}
+
+/**
+ * Bounds how many clones can be in flight at once, globally and per caller. Without it every
+ * authenticated request is a free process, socket and disk allocation.
+ */
+class CloneGate {
+  private inFlight = 0;
+  private readonly perActor = new Map<string, number>();
+
+  acquire(actorId: string, limits: GitCloneLimits): () => void {
+    const held = this.perActor.get(actorId) ?? 0;
+    if (this.inFlight >= limits.maxConcurrent || held >= limits.maxPerActor) {
+      throw new GitSourceError("too_many_clones");
+    }
+    this.inFlight += 1;
+    this.perActor.set(actorId, held + 1);
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      this.inFlight -= 1;
+      const remaining = (this.perActor.get(actorId) ?? 1) - 1;
+      if (remaining <= 0) this.perActor.delete(actorId);
+      else this.perActor.set(actorId, remaining);
+    };
+  }
+}
+
+const gate = new CloneGate();
+
+function timedOut(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "killed" in error &&
+    (error as { killed?: boolean }).killed === true
+  );
+}
+
+async function cloneInto(
+  directory: string,
+  target: ClonableGitSource,
+  limits: GitCloneLimits,
+  run: GitRunner
+): Promise<string> {
+  const controller = new AbortController();
+  let overSize = false;
+  const watch = setInterval(() => {
+    void directoryBytes(directory).then((bytes) => {
+      if (bytes <= limits.maxBytes || overSize) return;
+      overSize = true;
+      controller.abort();
+    });
+  }, SIZE_POLL_MS);
+  try {
+    const branch = target.ref ? ["--branch", target.ref] : [];
+    await run(["clone", "--depth", "1", ...branch, "--", target.url, directory], {
+      timeoutMs: limits.timeoutMs,
+      signal: controller.signal,
+    });
+  } catch (error) {
+    if (overSize) throw new GitSourceError("repository_too_large");
+    throw new GitSourceError(timedOut(error) ? "clone_timeout" : "clone_failed");
+  } finally {
+    clearInterval(watch);
+  }
+  try {
+    const head = await run(["rev-parse", "HEAD"], {
+      cwd: directory,
+      timeoutMs: limits.timeoutMs,
+      signal: controller.signal,
+    });
+    return head.trim();
+  } catch {
+    throw new GitSourceError("clone_failed");
+  }
+}
+
+export interface GitClone {
+  readonly dir: string;
+  readonly ref: string;
+}
+
+export interface GitCloneOptions {
+  readonly prefix: string;
+  /** Whoever asked for the clone; the per-actor bound is meaningless without it. */
+  readonly actorId: string;
+  readonly limits?: Partial<GitCloneLimits>;
+  /** Injected so tests never touch DNS or spawn git. */
+  readonly resolve?: GitHostResolver;
+  readonly runGit?: GitRunner;
+}
+
+/**
+ * Clone an allowed source into a temp directory, hand it to `use`, and remove it however `use`
+ * ends. Nothing reaches git until the source has passed `assertClonableGitSource`.
+ *
+ * @throws GitSourceError for any refusal or clone failure, with no git output attached.
+ */
+export async function withGitSourceClone<T>(
+  source: string,
+  options: GitCloneOptions,
+  use: (clone: GitClone) => Promise<T>
+): Promise<T> {
+  const limits = { ...DEFAULT_GIT_CLONE_LIMITS, ...options.limits };
+  const target = await assertClonableGitSource(source, { resolve: options.resolve });
+  const release = gate.acquire(options.actorId, limits);
+  let directory: string | undefined;
+  try {
+    directory = await mkdtemp(join(tmpdir(), options.prefix));
+    const ref = await cloneInto(directory, target, limits, options.runGit ?? spawnGit);
+    return await use({ dir: directory, ref });
+  } finally {
+    release();
+    if (directory) await rm(directory, { recursive: true, force: true });
+  }
+}

--- a/packages/integrations/src/git-source/index.ts
+++ b/packages/integrations/src/git-source/index.ts
@@ -1,0 +1,17 @@
+export {
+  DEFAULT_GIT_CLONE_LIMITS,
+  type GitClone,
+  type GitCloneLimits,
+  type GitCloneOptions,
+  type GitRunner,
+  withGitSourceClone,
+} from "./clone";
+export {
+  assertClonableGitSource,
+  type ClonableGitSource,
+  type GitHostResolver,
+  type GitSourceDenial,
+  GitSourceError,
+  gitSourceHttpError,
+  splitGitSourceRef,
+} from "./policy";

--- a/packages/integrations/src/git-source/policy.test.ts
+++ b/packages/integrations/src/git-source/policy.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { assertClonableGitSource, GitSourceError, gitSourceHttpError } from "./policy";
+
+/** Every resolver answer is public, so a denial can only come from the URL itself. */
+const publicResolver = async () => ["93.184.216.34"];
+
+afterEach(() => {
+  delete process.env.GIT_SOURCE_ALLOWED_HOSTS;
+  delete process.env.GIT_SOURCE_ALLOW_LOCAL_PATHS;
+});
+
+async function denialFor(source: string): Promise<string> {
+  try {
+    await assertClonableGitSource(source, { resolve: publicResolver });
+  } catch (error) {
+    if (error instanceof GitSourceError) return error.denial;
+    throw error;
+  }
+  return "allowed";
+}
+
+describe("assertClonableGitSource", () => {
+  const forbidden: ReadonlyArray<readonly [string, string, string]> = [
+    ["a local filesystem repository", "file:///srv/secrets/repo", "unsupported_scheme"],
+    ["a bare local path", "/srv/secrets/repo", "malformed_source"],
+    ["plain HTTP", "http://github.com/owner/repo.git", "unsupported_scheme"],
+    ["an ssh URL", "ssh://internal-host/repo.git", "unsupported_scheme"],
+    ["a git protocol URL", "git://internal-host/repo.git", "unsupported_scheme"],
+    ["an scp-style source", "git@internal.example.com:secrets/repo.git", "malformed_source"],
+    ["embedded credentials", "https://user:pass@github.com/o/r.git", "embedded_credentials"],
+    ["a bare username", "https://token@github.com/o/r.git", "embedded_credentials"],
+    ["IPv4 loopback", "https://127.0.0.1/o/r.git", "private_destination"],
+    ["IPv4 loopback in another octet", "https://127.9.9.9/o/r.git", "private_destination"],
+    ["IPv6 loopback", "https://[::1]/o/r.git", "private_destination"],
+    ["the unspecified IPv4 address", "https://0.0.0.0/o/r.git", "private_destination"],
+    ["the unspecified IPv6 address", "https://[::]/o/r.git", "private_destination"],
+    ["the cloud metadata address", "https://169.254.169.254/o/r.git", "private_destination"],
+    ["RFC 1918 10/8", "https://10.1.2.3/o/r.git", "private_destination"],
+    ["RFC 1918 172.16/12 low", "https://172.16.0.1/o/r.git", "private_destination"],
+    ["RFC 1918 172.16/12 high", "https://172.31.255.254/o/r.git", "private_destination"],
+    ["RFC 1918 192.168/16", "https://192.168.1.1/o/r.git", "private_destination"],
+    ["CGNAT 100.64/10", "https://100.100.0.1/o/r.git", "private_destination"],
+    ["unique local IPv6 fc00::/7", "https://[fc00::1]/o/r.git", "private_destination"],
+    ["unique local IPv6 fd00::/8", "https://[fd12:3456::1]/o/r.git", "private_destination"],
+    ["link-local IPv6 fe80::/10", "https://[fe80::1]/o/r.git", "private_destination"],
+    ["IPv4-mapped IPv6", "https://[::ffff:127.0.0.1]/o/r.git", "private_destination"],
+    ["a public IP literal off the allowlist", "https://93.184.216.34/o/r.git", "host_not_allowed"],
+    ["decimal-encoded IPv4", "https://2130706433/o/r.git", "private_destination"],
+    ["hex-encoded IPv4", "https://0x7f000001/o/r.git", "private_destination"],
+    ["octal-encoded IPv4", "https://0177.0.0.1/o/r.git", "private_destination"],
+    ["an unapproved host", "https://git.internal.example/o/r.git", "host_not_allowed"],
+    ["a trailing-dot unapproved host", "https://git.internal.example./o/r.git", "host_not_allowed"],
+    [
+      "an allowlisted host as a subdomain suffix",
+      "https://github.com.evil.tld/o/r.git",
+      "host_not_allowed",
+    ],
+    ["a ref that looks like a git flag", "owner/repo#--upload-pack=evil", "invalid_ref"],
+    ["a ref with a shell metacharacter", "owner/repo#main;rm -rf /", "invalid_ref"],
+    ["a source that is not a URL at all", "not a url", "malformed_source"],
+  ];
+
+  it.each(forbidden)("rejects %s", async (_label, source, denial) => {
+    expect(await denialFor(source)).toBe(denial);
+  });
+
+  const allowed: ReadonlyArray<readonly [string, string, string]> = [
+    ["an owner/repo slug", "TulipFarm/skills", "https://github.com/TulipFarm/skills.git"],
+    ["a slug with a branch", "TulipFarm/skills#next", "https://github.com/TulipFarm/skills.git"],
+    ["an https GitHub URL", "https://github.com/o/r.git", "https://github.com/o/r.git"],
+    ["a mixed-case host", "https://GitHub.com/o/r.git", "https://github.com/o/r.git"],
+    [
+      "a trailing-dot allowlisted host",
+      "https://github.com./o/r.git",
+      "https://github.com/o/r.git",
+    ],
+  ];
+
+  it.each(allowed)("allows %s", async (_label, source, url) => {
+    const target = await assertClonableGitSource(source, { resolve: publicResolver });
+    expect(target.url).toBe(url);
+  });
+
+  it("carries the branch through", async () => {
+    const target = await assertClonableGitSource("TulipFarm/skills#next", {
+      resolve: publicResolver,
+    });
+    expect(target.ref).toBe("next");
+  });
+
+  // DNS rebinding: the name passes the allowlist, the answer does not.
+  it("rejects an allowlisted host whose DNS answer is private", async () => {
+    process.env.GIT_SOURCE_ALLOWED_HOSTS = "git.example.com";
+    const target = assertClonableGitSource("https://git.example.com/o/r.git", {
+      resolve: async () => ["93.184.216.34", "10.0.0.5"],
+    });
+    await expect(target).rejects.toMatchObject({ denial: "private_destination" });
+  });
+
+  it("rejects an allowlisted host that resolves to nothing", async () => {
+    process.env.GIT_SOURCE_ALLOWED_HOSTS = "git.example.com";
+    const target = assertClonableGitSource("https://git.example.com/o/r.git", {
+      resolve: async () => [],
+    });
+    await expect(target).rejects.toMatchObject({ denial: "unresolved_destination" });
+  });
+
+  it("allows a host an operator explicitly approved", async () => {
+    process.env.GIT_SOURCE_ALLOWED_HOSTS = " git.example.com , gitlab.com ";
+    const target = await assertClonableGitSource("https://gitlab.com/o/r.git", {
+      resolve: publicResolver,
+    });
+    expect(target.url).toBe("https://gitlab.com/o/r.git");
+  });
+
+  it("allows a local repository only when the operator opted in", async () => {
+    expect(await denialFor("file:///srv/repo")).toBe("unsupported_scheme");
+    process.env.GIT_SOURCE_ALLOW_LOCAL_PATHS = "1";
+    expect(await denialFor("file:///srv/repo")).toBe("allowed");
+  });
+
+  // The opt-in is for local paths only; it must not reopen the network.
+  it("keeps the network policy in force when local paths are allowed", async () => {
+    process.env.GIT_SOURCE_ALLOW_LOCAL_PATHS = "1";
+    expect(await denialFor("https://127.0.0.1/o/r.git")).toBe("private_destination");
+    expect(await denialFor("http://github.com/o/r.git")).toBe("unsupported_scheme");
+  });
+});
+
+describe("gitSourceHttpError", () => {
+  it("answers 429 for a concurrency refusal and 400 for a policy refusal", () => {
+    expect(gitSourceHttpError(new GitSourceError("too_many_clones"))?.status).toBe(429);
+    expect(gitSourceHttpError(new GitSourceError("host_not_allowed"))?.status).toBe(400);
+  });
+
+  it("reports a clone failure without quoting git", () => {
+    const mapped = gitSourceHttpError(new GitSourceError("clone_failed"));
+    expect(mapped?.body).toEqual({ error: "Repository not found or not accessible." });
+  });
+
+  it("does not claim errors it did not raise", () => {
+    expect(gitSourceHttpError(new Error("Command failed: git clone …"))).toBeUndefined();
+  });
+});

--- a/packages/integrations/src/git-source/policy.ts
+++ b/packages/integrations/src/git-source/policy.ts
@@ -1,0 +1,158 @@
+import { lookup } from "node:dns/promises";
+import { isIP } from "node:net";
+import { isPrivateNetworkAddress } from "../egress/destination";
+
+/**
+ * Clone-source cage. A scan source is pasted by an authenticated caller and handed to `git`
+ * running inside the deployment's own network and filesystem, so an unguarded one is an SSRF and
+ * local-read primitive: `file:///srv`, `http://10.0.0.5/`, `https://169.254.169.254/`. The gate is
+ * an allowlist of hosts rather than a denylist of addresses, because every encoded form of a
+ * private address — decimal, octal, hex, IPv4-mapped IPv6 — fails an exact host match without
+ * having to be enumerated.
+ */
+
+export type GitSourceDenial =
+  | "malformed_source"
+  | "invalid_ref"
+  | "unsupported_scheme"
+  | "embedded_credentials"
+  | "host_not_allowed"
+  | "private_destination"
+  | "unresolved_destination"
+  | "too_many_clones"
+  | "clone_timeout"
+  | "repository_too_large"
+  | "clone_failed";
+
+/**
+ * Operator-facing text for every denial. `clone_failed` deliberately says nothing about what git
+ * reported: the raw stderr carries the assembled command line and the server temp path.
+ */
+const DENIAL_MESSAGES: Readonly<Record<GitSourceDenial, string>> = {
+  malformed_source:
+    'Source must be an "owner/repo" slug or an https URL, with an optional #branch suffix.',
+  invalid_ref: "The #branch suffix may only contain letters, digits, dots, dashes and slashes.",
+  unsupported_scheme: "Only https git sources can be cloned.",
+  embedded_credentials: "The source URL must not carry a username or password.",
+  host_not_allowed: "That host is not an approved git source.",
+  private_destination: "That host is not publicly routable.",
+  unresolved_destination: "That host could not be resolved.",
+  too_many_clones: "Too many repository scans are already running. Try again in a moment.",
+  clone_timeout: "The repository took too long to clone.",
+  repository_too_large: "The repository is larger than the scan limit.",
+  clone_failed: "Repository not found or not accessible.",
+};
+
+export class GitSourceError extends Error {
+  readonly name = "GitSourceError";
+
+  constructor(readonly denial: GitSourceDenial) {
+    super(DENIAL_MESSAGES[denial]);
+  }
+}
+
+/** HTTP shape for a denial; anything else is not this module's to answer. */
+export function gitSourceHttpError(
+  error: unknown
+): { status: 400 | 429; body: { error: string } } | undefined {
+  if (!(error instanceof GitSourceError)) return undefined;
+  return { status: error.denial === "too_many_clones" ? 429 : 400, body: { error: error.message } };
+}
+
+const SLUG_RE = /^[\w.-]+\/[\w.-]+$/;
+/** Leading dash forbidden so a ref can never be mistaken for a git flag. */
+const REF_RE = /^[\w][\w./-]*$/;
+const DEFAULT_ALLOWED_HOSTS = ["github.com"];
+
+function allowedHosts(): ReadonlySet<string> {
+  const configured = (process.env.GIT_SOURCE_ALLOWED_HOSTS ?? "")
+    .split(",")
+    .map((host) => host.trim().toLowerCase())
+    .filter((host) => host !== "");
+  return new Set([...DEFAULT_ALLOWED_HOSTS, ...configured]);
+}
+
+/**
+ * Local repositories are a local-read primitive, so they are off unless an operator turns them on
+ * for an offline deployment that serves its catalog from disk.
+ */
+function localPathsAllowed(): boolean {
+  return process.env.GIT_SOURCE_ALLOW_LOCAL_PATHS === "1";
+}
+
+/** Pre-merge branches can be scanned: "owner/repo#my-branch". No "#" means the default branch. */
+export function splitGitSourceRef(source: string): { base: string; ref?: string } {
+  const index = source.indexOf("#");
+  return index === -1
+    ? { base: source }
+    : { base: source.slice(0, index), ref: source.slice(index + 1) };
+}
+
+export type GitHostResolver = (hostname: string) => Promise<readonly string[]>;
+
+async function resolveHost(hostname: string): Promise<readonly string[]> {
+  const answers = await lookup(hostname, { all: true, verbatim: true });
+  return answers.map((answer) => answer.address);
+}
+
+function hostnameOf(url: URL): string {
+  const literal = url.hostname.startsWith("[") ? url.hostname.slice(1, -1) : url.hostname;
+  // A trailing dot is the same name to a resolver but a different string to an allowlist.
+  return (literal.endsWith(".") ? literal.slice(0, -1) : literal).toLowerCase();
+}
+
+export interface ClonableGitSource {
+  /** The exact URL to hand to git, rebuilt from the host that was actually checked. */
+  readonly url: string;
+  readonly ref?: string;
+}
+
+/**
+ * Decide whether a caller-supplied source may be cloned, before any process is started.
+ *
+ * The resolved-address check narrows the DNS-rebinding window rather than closing it: the answers
+ * are not pinned to the socket git then opens, so a record that changes between this call and the
+ * connection is not caught. Closing it needs a connector git does not expose.
+ *
+ * @throws GitSourceError with the denial that stopped it.
+ */
+export async function assertClonableGitSource(
+  source: string,
+  options: { resolve?: GitHostResolver } = {}
+): Promise<ClonableGitSource> {
+  const { base, ref } = splitGitSourceRef(source);
+  if (ref !== undefined && !REF_RE.test(ref)) throw new GitSourceError("invalid_ref");
+  const normalized = SLUG_RE.test(base) ? `https://github.com/${base}.git` : base;
+
+  let url: URL;
+  try {
+    url = new URL(normalized);
+  } catch {
+    throw new GitSourceError("malformed_source");
+  }
+
+  if (url.protocol === "file:") {
+    if (!localPathsAllowed()) throw new GitSourceError("unsupported_scheme");
+    return { url: normalized, ref };
+  }
+  if (url.protocol !== "https:") throw new GitSourceError("unsupported_scheme");
+  if (url.username !== "" || url.password !== "") {
+    throw new GitSourceError("embedded_credentials");
+  }
+
+  const host = hostnameOf(url);
+  if (host === "") throw new GitSourceError("malformed_source");
+  if (isIP(host) !== 0) {
+    if (isPrivateNetworkAddress(host)) throw new GitSourceError("private_destination");
+    if (!allowedHosts().has(host)) throw new GitSourceError("host_not_allowed");
+    return { url: url.toString(), ref };
+  }
+  if (!allowedHosts().has(host)) throw new GitSourceError("host_not_allowed");
+
+  const addresses = await (options.resolve ?? resolveHost)(host).catch(() => []);
+  if (addresses.length === 0) throw new GitSourceError("unresolved_destination");
+  if (addresses.some(isPrivateNetworkAddress)) throw new GitSourceError("private_destination");
+
+  url.hostname = host;
+  return { url: url.toString(), ref };
+}

--- a/packages/integrations/src/index.ts
+++ b/packages/integrations/src/index.ts
@@ -128,6 +128,23 @@ export {
   GenericWebhookError,
 } from "./generic";
 export type {
+  ClonableGitSource,
+  GitClone,
+  GitCloneLimits,
+  GitCloneOptions,
+  GitHostResolver,
+  GitRunner,
+  GitSourceDenial,
+} from "./git-source";
+export {
+  assertClonableGitSource,
+  DEFAULT_GIT_CLONE_LIMITS,
+  GitSourceError,
+  gitSourceHttpError,
+  splitGitSourceRef,
+  withGitSourceClone,
+} from "./git-source";
+export type {
   CachingInstallationTokenMinterDeps,
   GitHubAdapterDeps,
   GitHubCheckRunAction,

--- a/packages/soul/AGENTS.md
+++ b/packages/soul/AGENTS.md
@@ -19,7 +19,7 @@ Loader, compiler, publisher, and git-sync engine for Soul artifacts. Root `soul/
 | `src/migrations/`, `src/soul-migrations.ts` | Migrations. |
 | `src/writer.ts` | `SoulWriter` — the one authored-tree write gateway. |
 | `src/skills/`, `src/integrations/`, `src/agents/` | Skill threat scan, bundled discovery, registries, platform agents. |
-| `src/{catalogue,tree,git-source,write-errors}.ts` | Catalogue, safe tree walk, Git source allowlist, write-error mapping. |
+| `src/{catalogue,tree,git-source,write-errors}.ts` | Catalogue, safe tree walk, Git source parsing, write-error mapping. |
 | `src/soul-writer-double.ts` | In-memory `SoulWriter` for tests. |
 
 ## Rules

--- a/packages/soul/src/git-source.ts
+++ b/packages/soul/src/git-source.ts
@@ -1,66 +1,10 @@
-import { execFile } from "node:child_process";
-import { mkdtemp } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { promisify } from "node:util";
-
-const execFileP = promisify(execFile);
-
-const CLONE_TIMEOUT_MS = 60_000;
-
 // pre-merge branches can be scanned and tested: "owner/repo#my-branch". No "#" ⇒ default branch.
 export function splitSourceRef(source: string): { base: string; ref?: string } {
   const idx = source.indexOf("#");
   return idx === -1 ? { base: source } : { base: source.slice(0, idx), ref: source.slice(idx + 1) };
 }
 
-// Leading dash forbidden so a ref can never be mistaken for a git flag.
-const REF_RE = /^[\w][\w./-]*$/;
-
-/**
- * Only allow sources we are willing to hand to `git clone`: a bare "owner/repo" slug, or an
- * http(s)/file URL, each with an optional "#<ref>" suffix. ssh:// and scp-style (git@host:path)
- * sources are rejected to avoid the operator's clone reaching internal hosts (SSRF). Single-trust
- * V1; a tighter allowlist is a post-V1 hardening.
- */
-export function isAllowedSource(source: string): boolean {
-  const { base, ref } = splitSourceRef(source);
-  if (ref !== undefined && !REF_RE.test(ref)) return false;
-  return /^[\w.-]+\/[\w.-]+$/.test(base) || /^(https?|file):\/\//.test(base);
-}
-
-export const ALLOWED_SOURCE_HINT =
-  "source must be a github owner/repo slug or an http(s)/file URL, with an optional #branch suffix";
-
-// "owner/repo" becomes a GitHub https URL; an http(s)/file URL is used as-is.
-export function normalizeGitUrl(base: string): string {
-  if (/^[\w.-]+\/[\w.-]+$/.test(base)) return `https://github.com/${base}.git`;
-  return base;
-}
-
 export function sourceType(source: string): "github" | "git" {
   const { base } = splitSourceRef(source);
   return /github\.com|^[\w.-]+\/[\w.-]+$/.test(base) ? "github" : "git";
-}
-
-/**
- * Shallow-clone an allowed source into a temp dir and report the exact commit fetched. Callers own
- * the returned directory and must remove it.
- */
-export async function cloneToTemp(
-  source: string,
-  prefix: string
-): Promise<{ dir: string; ref: string }> {
-  const { base, ref } = splitSourceRef(source);
-  const dir = await mkdtemp(join(tmpdir(), prefix));
-  await execFileP(
-    "git",
-    ["clone", "--depth", "1", ...(ref ? ["--branch", ref] : []), normalizeGitUrl(base), dir],
-    {
-      timeout: CLONE_TIMEOUT_MS,
-      env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
-    }
-  );
-  const { stdout } = await execFileP("git", ["rev-parse", "HEAD"], { cwd: dir });
-  return { dir, ref: stdout.trim() };
 }

--- a/packages/soul/src/index.ts
+++ b/packages/soul/src/index.ts
@@ -95,14 +95,7 @@ export {
   convertLegacySkill,
 } from "./converters/legacy-definitions";
 export { hermeticGitEnv } from "./git-env";
-export {
-  ALLOWED_SOURCE_HINT,
-  cloneToTemp,
-  isAllowedSource,
-  normalizeGitUrl,
-  sourceType,
-  splitSourceRef,
-} from "./git-source";
+export { sourceType, splitSourceRef } from "./git-source";
 export type { SoulCommitRequest, SoulCommitResult, SoulGitStoreErrorCode } from "./git-store";
 export { SoulGitStore, SoulGitStoreError } from "./git-store";
 export type {


### PR DESCRIPTION
The integration inspect/install routes and the skill marketplace scan all handed a caller-controlled source straight to `git clone`, and handed git's stderr straight back. Any authenticated user could aim the server at `file:///`, at loopback, or at a private-range host and read the resulting failure text, which also carried the assembled command line and the server temp path. That is an SSRF and local-read primitive with a built-in oracle, unbounded in size, time and concurrency.

The fix is one gate in `@tulipfarm/integrations`, applied before any process starts: parse with WHATWG URL (which normalises decimal/octal/hex and IPv4-mapped forms for free), require https, reject embedded credentials, match the host against an exact allowlist, then resolve and reject private, loopback, link-local and reserved answers. Clones run under a global and per-actor concurrency gate with a timeout, a byte cap, guaranteed temp cleanup and an environment built from scratch rather than inherited. Failures carry a fixed verdict string, so git output cannot reach a caller.

The DNS answers are not pinned to the socket git opens, so the check-to- connect window stays open; the exact-host allowlist is the primary gate for that reason.

## Summary

<!-- What changed, and why. Link the driving issue if one exists. -->

## Test plan

<!-- Commands you ran, or manual steps / screenshots for UI changes. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (or the scoped `--filter` you actually ran)

## Checklist

- [ ] PR title follows Conventional Commits (`type(scope): subject`) — CI checks this
- [ ] Scoped to one logical change
- [ ] Tests added/updated for the behavior that changed
