### PR TITLE
fix(knowledge): place and grant a Page authored by create_knowledge_page

### DIFF
--- a/apps/api/src/knowledge/created-page-usable.pg.test.ts
+++ b/apps/api/src/knowledge/created-page-usable.pg.test.ts
@@ -1,0 +1,145 @@
+/**
+ * A Page authored by `create_knowledge_page` must be usable by everything that reads Pages.
+ *
+ * The Tool reported success for a Page that had no Space, no path and no ACL entry: absent from
+ * every Space listing, denied by the Page gate that `GET /knowledge/pages/:id` consults, and
+ * invisible to the lexical arm of `hybridSearchPages`, which only considers placed Pages. The
+ * authoring Agent saw none of that, because it read the Page back through `getPage` alone.
+ *
+ * These assertions walk the reader's own paths, in the order the QA journey did.
+ */
+
+import { randomUUID } from "node:crypto";
+import type { PGlite } from "@electric-sql/pglite";
+import type { EmbeddingPort } from "@tulipfarm/knowledge";
+import {
+  KNOWLEDGE_TOOLS,
+  KnowledgeService,
+  type KnowledgeToolContext,
+  PageReadGate,
+  PageRetrievalService,
+  PgKnowledgeAclRepo,
+  PgKnowledgeChunkRepo,
+  PgKnowledgeLinksRepo,
+  PgKnowledgePageRepo,
+  PgKnowledgeRevisionRepo,
+  PgKnowledgeSpaceOverrideRepo,
+  PgKnowledgeSpaceRepo,
+} from "@tulipfarm/knowledge";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { makeMigratedPglite } from "../test/pglite";
+
+const BUSINESS = "tulipfarm-local";
+
+const FAQ = "Go to Settings > Auth > Reset password. The reset link expires in 15 min.";
+
+function lexicalOnly(): EmbeddingPort {
+  return {
+    isAvailable: () => false,
+    embedMany: async (values) => ({ embeddings: values.map(() => [0, 0, 0]), dimension: 3 }),
+    getActive: () => null,
+    getDimension: () => null,
+    pendingReindex: () => false,
+    clearPendingReindex: () => {},
+  };
+}
+
+const byName = Object.fromEntries(KNOWLEDGE_TOOLS.map((t) => [t.name, t]));
+
+type Result = { success: boolean; data?: unknown; error?: unknown };
+
+describe("a Page created by create_knowledge_page is reachable by every reader", () => {
+  let db: PGlite;
+  let service: KnowledgeService;
+  let gate: PageReadGate;
+  let author: string;
+  let reader: string;
+  let pageId: string;
+
+  const ctx = (userId: string): KnowledgeToolContext => ({ userId, service, pageGate: gate });
+
+  const call = (name: string, args: object, userId: string): Promise<Result> =>
+    byName[name].handler(args, ctx(userId)) as Promise<Result>;
+
+  async function addMember(): Promise<string> {
+    const id = randomUUID();
+    await db.query(
+      `INSERT INTO users (id, email, password_hash, role, created_at)
+       VALUES ($1, $2, 'x', 'member', now())`,
+      [id, `${id}@example.test`]
+    );
+    return id;
+  }
+
+  beforeEach(async () => {
+    db = await makeMigratedPglite();
+    service = new KnowledgeService({
+      pages: new PgKnowledgePageRepo(db),
+      chunks: new PgKnowledgeChunkRepo(db),
+      revisions: new PgKnowledgeRevisionRepo(db),
+      spaces: new PgKnowledgeSpaceRepo(db),
+      links: new PgKnowledgeLinksRepo(db),
+      overrides: new PgKnowledgeSpaceOverrideRepo(db),
+      embeddings: lexicalOnly(),
+      retrieval: new PageRetrievalService(db),
+      acl: new PgKnowledgeAclRepo(db),
+    });
+    gate = new PageReadGate(db, BUSINESS);
+
+    author = await addMember();
+    reader = await addMember();
+
+    const created = await call(
+      "create_knowledge_page",
+      { title: "Password Reset FAQ", content: FAQ },
+      author
+    );
+    if (!created.success) throw new Error(`create failed: ${JSON.stringify(created)}`);
+    pageId = (created.data as { id: string }).id;
+  });
+
+  afterEach(async () => {
+    await db.close();
+  });
+
+  it("belongs to a Space and appears in that Space's page list", async () => {
+    const page = await service.getPage(pageId);
+    expect(page?.spaceId ?? null).not.toBeNull();
+
+    const listed = await service.listSpacePages(page?.spaceId ?? "");
+    expect(listed.map((p) => p._id)).toContain(pageId);
+  });
+
+  it("passes the Page gate the detail route reads through", async () => {
+    expect(await gate.canRead(author, pageId)).toBe(true);
+    expect(await gate.canRead(reader, pageId)).toBe(true);
+  });
+
+  it("is returned by query_knowledge so an Agent can ground on it", async () => {
+    const res = await call("query_knowledge", { query: "reset my password" }, reader);
+
+    expect(res.success).toBe(true);
+    const hits = (res.data as { results: { pageId: string }[] }).results;
+    expect(hits.map((h) => h.pageId)).toContain(pageId);
+  });
+
+  it("is readable by get_page from another Agent's turn", async () => {
+    const res = await call("get_page", { pageId }, reader);
+    expect(res.success).toBe(true);
+  });
+
+  it("places a second Page of the same title beside the first, not over it", async () => {
+    const again = await call(
+      "create_knowledge_page",
+      { title: "Password Reset FAQ", content: "A later revision of the FAQ." },
+      author
+    );
+
+    expect(again.success).toBe(true);
+    const second = (again.data as { id: string }).id;
+    expect(second).not.toBe(pageId);
+    const page = await service.getPage(pageId);
+    const listed = await service.listSpacePages(page?.spaceId ?? "");
+    expect(listed.map((p) => p._id).sort()).toEqual([pageId, second].sort());
+  });
+});

--- a/packages/knowledge/AGENTS.md
+++ b/packages/knowledge/AGENTS.md
@@ -15,6 +15,7 @@ propagation. This is the sole accountable owner for source ACL enforcement.
 | `src/indexing.ts`, `src/retrieve.ts` | Authorized indexing and authorize -> rank -> re-check. |
 | `src/graph-expand.ts` | Bounded hop walk over `knowledge_links` and the banded hop-decay score. |
 | `src/graphrag/` | GraphRAG: LLM extraction, deterministic clustering, community summaries, local/global search, graph repo and invalidation. |
+| `src/authored-page.ts` | Standalone Page authoring: the `Notes` Space, path derivation, blanket grant. |
 | `src/{invalidate,delete,staleness}.ts` | Invalidation, deletion, stale-ACL sweeps. |
 | `src/provenance.ts` | `authorizeSynthesis` citation reauthorization. |
 | `src/types.ts`, `src/chunk.ts` | Shared page/chunk/space/search shapes and text chunking. |
@@ -36,6 +37,13 @@ propagation. This is the sole accountable owner for source ACL enforcement.
   both onto one `decideKnowledgeAccess`; a second ACL evaluator is a defect. Authored ACLs are
   read live from our own tables, so they project as a fresh `snapshot` with a finite max age —
   never an infinite one, which would fail open on a malformed timestamp.
+- Every authored Page is **placed and granted in the same write that inserts it**. `createPage`
+  lands a standalone Page in the unrestricted `Notes` Space with a derived path and records the
+  blanket read grant, exactly as `writePage` does for a Space page. Neither half is optional: an
+  unplaced Page is invisible to retrieval's lexical arm and to every Space listing, and an ungranted
+  Page is denied by `PageReadGate` to everyone including its author — so the write reports success
+  for a Page nothing can open, list or cite. `create_knowledge_page` re-reads both facts through the
+  reader's own paths and fails the call rather than report that success.
 - A **File** is `source: "file"` — an authored Page carrying explicit reader grants, never a
   connected source with a captured ACL snapshot. The grants are the File's own owner and sharees,
   so a share change is felt on the very next question with nothing to refresh. `ingestSource`

--- a/packages/knowledge/src/authored-page.ts
+++ b/packages/knowledge/src/authored-page.ts
@@ -1,0 +1,113 @@
+/**
+ * Authoring a standalone Page — the write behind `create_knowledge_page` and
+ * `POST /knowledge/pages`, as distinct from `writePage`, which authors into a Space the caller
+ * names.
+ *
+ * A standalone Page still has to be *placed* and *granted*, which is the whole reason this is not
+ * a bare insert: the lexical arm of retrieval only considers Pages carrying a Space and a path, no
+ * Space listing can show a Page that is in no Space, the Page detail route has no live Page to
+ * render without a path, and the read gate denies a Page carrying no ACL entry — to its author
+ * included.
+ */
+
+import { randomUUID } from "node:crypto";
+import type { KnowledgeServiceDeps } from "./service";
+import { afterWrite } from "./service-indexing";
+import { createSpace, grantBlanketRead } from "./service-spaces";
+import type { KnowledgePage } from "./types";
+
+/** The Space a Page authored without one of its own lands in. Made on first use; never restricted. */
+export const NOTES_SPACE_NAME = "Notes";
+
+/** What {@link createAuthoredPage} needs; the service's own `CreatePageInput`. */
+interface AuthoredPageInput {
+  title: string;
+  content: string;
+  domain?: string | null;
+  tags?: string[];
+  alwaysLoadForAgents?: boolean;
+}
+
+/**
+ * The Space for Pages authored outside any Space, made if it is not there yet.
+ *
+ * Left unrestricted on purpose: grants intersect down the Space-to-Page chain, so an unrestricted
+ * Space imposes no ceiling and each Page's own grants stay the whole of its authorization.
+ *
+ * @returns `null` when OKF is unwired, which leaves the Page flat rather than failing the write.
+ */
+async function notesSpaceId(deps: KnowledgeServiceDeps): Promise<string | null> {
+  const spaces = deps.spaces;
+  if (!spaces) return null;
+  const existing = await spaces.getByName(NOTES_SPACE_NAME);
+  if (existing) return existing._id;
+  const created = await createSpace(deps, {
+    name: NOTES_SPACE_NAME,
+    description: "Pages authored on their own, outside any other space.",
+  });
+  if (created.ok) return created.space._id;
+  // Lost the race with a concurrent create: whoever won already made it.
+  return created.reason === "name_taken"
+    ? ((await spaces.getByName(NOTES_SPACE_NAME))?._id ?? null)
+    : null;
+}
+
+/** `Password Reset FAQ` -> `password-reset-faq`. A title with no slug characters falls back. */
+function slugifyTitle(title: string): string {
+  const slug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80)
+    .replace(/-+$/g, "");
+  return slug.length > 0 ? slug : "page";
+}
+
+/**
+ * A path no Page in `spaceId` already holds. Paths are unique per Space, so a second "Password
+ * Reset FAQ" has to land beside the first rather than overwrite it.
+ */
+async function freePath(
+  deps: KnowledgeServiceDeps,
+  spaceId: string,
+  title: string
+): Promise<string> {
+  const base = slugifyTitle(title);
+  for (let attempt = 1; attempt <= 50; attempt += 1) {
+    const candidate = attempt === 1 ? base : `${base}-${attempt}`;
+    if (!(await deps.pages.getBySpacePath(spaceId, candidate))) return candidate;
+  }
+  return `${base}-${randomUUID().slice(0, 8)}`;
+}
+
+/** Author a standalone Page, placed in {@link NOTES_SPACE_NAME} and readable Business-wide. */
+export async function createAuthoredPage(
+  deps: KnowledgeServiceDeps,
+  input: AuthoredPageInput
+): Promise<KnowledgePage> {
+  const now = new Date();
+  const id = randomUUID();
+  const spaceId = await notesSpaceId(deps);
+  const page: KnowledgePage = {
+    _id: id,
+    title: input.title,
+    content: input.content,
+    plainText: input.content.trim(),
+    source: "authored",
+    sourceId: id,
+    domain: input.domain ?? null,
+    tags: input.tags ?? [],
+    active: true,
+    alwaysLoadForAgents: input.alwaysLoadForAgents ?? false,
+    version: 1,
+    ...(spaceId === null ? {} : { spaceId, path: await freePath(deps, spaceId, input.title) }),
+    createdAt: now,
+    updatedAt: now,
+  };
+  await deps.pages.insert(page);
+  // Before the index, never after: a Page indexed while it still carries no grant is a Page the
+  // gate denies to everyone, its author included.
+  await grantBlanketRead(deps, id);
+  await afterWrite(deps, page);
+  return page;
+}

--- a/packages/knowledge/src/index.ts
+++ b/packages/knowledge/src/index.ts
@@ -18,6 +18,7 @@ export {
   PgKnowledgeSubjectStore,
   PgPrincipalResolver,
 } from "./acl-repo";
+export { NOTES_SPACE_NAME } from "./authored-page";
 export { type ChunkOptions, chunkText, type TextChunk } from "./chunk";
 export { type KnowledgeChunkRepo, PgKnowledgeChunkRepo, pageFilterConditions } from "./chunks-repo";
 export { buildDefaultRegistry } from "./connectors/registry";

--- a/packages/knowledge/src/service-spaces.ts
+++ b/packages/knowledge/src/service-spaces.ts
@@ -247,7 +247,7 @@ export function listSpacePages(
  * Every Page is readable by everyone in the Business by default. The grant names the blanket Role
  * rather than expanding to members, so it never drifts as people join or leave.
  */
-async function grantBlanketRead(deps: KnowledgeServiceDeps, pageId: string): Promise<void> {
+export async function grantBlanketRead(deps: KnowledgeServiceDeps, pageId: string): Promise<void> {
   if (!deps.acl) return;
   await deps.acl.put({
     businessId: DEPLOYMENT_BUSINESS_ID,

--- a/packages/knowledge/src/service.ts
+++ b/packages/knowledge/src/service.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { DEPLOYMENT_BUSINESS_ID } from "@tulipfarm/constants";
 import type { PaginatedResult } from "@tulipfarm/storage";
 import type { KnowledgeAclRepo, PageVisibilityScope, PageVisibilitySource } from "./acl-repo";
+import { createAuthoredPage } from "./authored-page";
 import type { KnowledgeChunkRepo } from "./chunks-repo";
 import type { KnowledgeLinksRepo } from "./links-repo";
 import {
@@ -151,27 +152,8 @@ export class KnowledgeService {
 
   // ── pages ────────────────────────────────────────────────────────────────────
 
-  async createPage(input: CreatePageInput): Promise<KnowledgePage> {
-    const now = new Date();
-    const id = randomUUID();
-    const page: KnowledgePage = {
-      _id: id,
-      title: input.title,
-      content: input.content,
-      plainText: input.content.trim(),
-      source: "authored",
-      sourceId: id,
-      domain: input.domain ?? null,
-      tags: input.tags ?? [],
-      active: true,
-      alwaysLoadForAgents: input.alwaysLoadForAgents ?? false,
-      version: 1,
-      createdAt: now,
-      updatedAt: now,
-    };
-    await this.deps.pages.insert(page);
-    await afterWrite(this.deps, page);
-    return page;
+  createPage(input: CreatePageInput): Promise<KnowledgePage> {
+    return createAuthoredPage(this.deps, input);
   }
 
   getPage(id: string): Promise<KnowledgePage | null> {

--- a/packages/knowledge/src/tools.test.ts
+++ b/packages/knowledge/src/tools.test.ts
@@ -328,11 +328,39 @@ describe("knowledge tools", () => {
   });
 
   it("create_knowledge_page validates and returns the id", async () => {
-    const createPage = vi.fn(async () => ({ _id: "doc-1", title: "T" }));
+    const stored = { _id: "doc-1", title: "T", spaceId: "space-1", path: "t" };
+    const createPage = vi.fn(async () => stored);
+    const getActivePage = vi.fn(async () => stored);
     const t = getTool("create_knowledge_page");
     expect(await t.handler({ title: "T" }, ctx({}))).toMatchObject({ success: false });
-    const res = await t.handler({ title: "T", content: "body" }, ctx({ createPage } as never));
-    expect(res).toMatchObject({ success: true, data: { id: "doc-1" } });
+    const res = await t.handler(
+      { title: "T", content: "body" },
+      ctx({ createPage, getActivePage } as never)
+    );
+    expect(res).toMatchObject({ success: true, data: { id: "doc-1", spaceId: "space-1" } });
+  });
+
+  /**
+   * A Page the reader's own paths cannot reach is not a created Page. Reporting success for one is
+   * how an Agent comes to believe it wrote content that nothing can later cite.
+   */
+  it("create_knowledge_page fails rather than reporting a Page no reader can reach", async () => {
+    const t = getTool("create_knowledge_page");
+    const unplaced = { _id: "doc-1", title: "T", spaceId: null, path: null };
+    const placed = { _id: "doc-1", title: "T", spaceId: "space-1", path: "t" };
+
+    const noPlace = await t.handler(
+      { title: "T", content: "body" },
+      ctx({ createPage: async () => unplaced, getActivePage: async () => unplaced } as never)
+    );
+    const noRead = await getTool("create_knowledge_page").handler({ title: "T", content: "body" }, {
+      userId: "u1",
+      service: { createPage: async () => placed, getActivePage: async () => placed },
+      pageGate: { ...allowAll, canRead: async () => false },
+    } as never);
+
+    expect(noPlace).toMatchObject({ success: false, error: { message: "page_not_placed" } });
+    expect(noRead).toMatchObject({ success: false, error: { message: "page_not_readable" } });
   });
 
   it("returns internal_error (never throws) when the service fails", async () => {

--- a/packages/knowledge/src/tools.ts
+++ b/packages/knowledge/src/tools.ts
@@ -212,7 +212,7 @@ const citeSources = defineApiTool<KnowledgeToolContext>({
 const createKnowledgePage = defineApiTool<KnowledgeToolContext>({
   name: "create_knowledge_page",
   description:
-    "Author a new knowledge page (markdown). Use for durable, page-sized content that exceeds Memory. Returns the new page id.",
+    "Author a new knowledge page (markdown). Use for durable, page-sized content that exceeds Memory. The page lands in the shared 'Notes' space, readable by everyone in the business. Returns the new page id, its space and its path.",
   tier: "platform",
   mutating: true,
   inputSchema: CREATE_PAGE_SCHEMA,
@@ -226,7 +226,13 @@ const createKnowledgePage = defineApiTool<KnowledgeToolContext>({
     const a = args as { title: string; content: string; domain?: string; tags?: string[] };
     try {
       const page = await ctx.service.createPage(a);
-      return ok({ id: page._id, title: page.title });
+      // The writer verifies through the reader's own paths before reporting success. A Page that
+      // is unplaced or ungranted is one an Agent will later cite and be refused, so an unusable
+      // Page is a failed write here rather than a success the next turn discovers.
+      const stored = await ctx.service.getActivePage(page._id);
+      if (!stored?.spaceId || !stored.path) return err("internal_error", "page_not_placed");
+      if (!(await mayReadPage(ctx, page._id))) return err("internal_error", "page_not_readable");
+      return ok({ id: page._id, title: page.title, spaceId: stored.spaceId, path: stored.path });
     } catch (e) {
       return err("internal_error", reason(e));
     }


### PR DESCRIPTION
`KnowledgeService.createPage` inserted a Page with no Space, no path and no ACL entry, then reported success. `writePage` does all three; this path did only the insert, and nothing downstream can work without the other two.

An unplaced Page is absent from every Space listing, has no detail route to render (the loader requires `spaceId` and `path`), and is invisible to the lexical arm of `hybridSearchPages`, which only considers placed Pages — so on any deployment with no embedding provider it is unreachable by retrieval entirely. An ungranted Page is denied by `PageReadGate` to everyone, its own author included, because an authored subject with no entries resolves to no permitted principals. Together that is a Page an Agent believes it wrote and can then neither open, list nor cite; the Agent answers from generic model knowledge instead.

Authoring now lands the Page in an unrestricted `Notes` Space with a path derived from its title, and records the blanket read grant between the insert and the index, so the Page is never indexed while the gate would still refuse it. The Tool re-reads both facts through the reader's own paths and fails the call rather than report success for a Page nothing can find.

## Summary

<!-- What changed, and why. Link the driving issue if one exists. -->

## Test plan

<!-- Commands you ran, or manual steps / screenshots for UI changes. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (or the scoped `--filter` you actually ran)

## Checklist

- [ ] PR title follows Conventional Commits (`type(scope): subject`) — CI checks this
- [ ] Scoped to one logical change
- [ ] Tests added/updated for the behavior that changed
