### PR TITLE
fix(web): correct Record field display and guard destructive actions

### DIFF
--- a/apps/web/app/components/resource-form.tsx
+++ b/apps/web/app/components/resource-form.tsx
@@ -1,5 +1,5 @@
 import { Link } from "@remix-run/react";
-import { type FormEvent, useState } from "react";
+import { type FormEvent, useRef, useState } from "react";
 import { LinkCombobox } from "~/components/link-combobox";
 import { Button } from "~/components/ui/button";
 import { ApiError } from "~/lib/api";
@@ -80,13 +80,17 @@ export function ResourceForm({
     )
   );
   const [jsonErrors, setJsonErrors] = useState<Record<string, string>>({});
+  // A ref, not state: the `submitting` prop only disables the button one commit after the parent
+  // reacts, so two submit events landing in the same task both pass an is-it-disabled check.
+  const inFlight = useRef(false);
 
   function set(name: string, value: unknown) {
     setValues((prev) => ({ ...prev, [name]: value }));
   }
 
-  function handleSubmit(e: FormEvent) {
+  async function handleSubmit(e: FormEvent) {
     e.preventDefault();
+    if (inFlight.current || submitting) return;
     const payload: Record<string, unknown> = {};
     const nextJsonErrors: Record<string, string> = {};
 
@@ -130,11 +134,16 @@ export function ResourceForm({
       return;
     }
     setJsonErrors({});
-    onSubmit(payload);
+    inFlight.current = true;
+    try {
+      await onSubmit(payload);
+    } finally {
+      inFlight.current = false;
+    }
   }
 
   return (
-    <form onSubmit={handleSubmit} className="flex flex-col gap-4" noValidate>
+    <form onSubmit={(e) => void handleSubmit(e)} className="flex flex-col gap-4" noValidate>
       {formError ? (
         <p className="rounded-sm border border-destructive/40 bg-destructive/5 px-3 py-2 text-destructive">
           error: {formError}

--- a/apps/web/app/components/schema-table.test.tsx
+++ b/apps/web/app/components/schema-table.test.tsx
@@ -123,3 +123,50 @@ test("descending sort reflects aria-sort=descending and the ↓ glyph", () => {
   expect(header).toHaveAttribute("aria-sort", "descending");
   expect(header.textContent).toContain("↓");
 });
+
+// ── Long-value truncation (#439): a wide cell must not dictate the table's column widths ──────────
+
+const LONG_TITLE =
+  "Customer reports the login flow returns a 500 whenever the SSO assertion carries a group claim longer than 256 characters, which cascades into the session store rejecting the write";
+
+const longRecords: ResourceRecord[] = [
+  {
+    id: "TICK-3",
+    title: LONG_TITLE,
+    customerId: "CUST-9",
+    open: true,
+    version: 1,
+    createdAt: "",
+    updatedAt: "2026-06-08T00:00:00Z",
+  },
+];
+
+function renderLongTable() {
+  const Stub = createRemixStub([
+    {
+      path: "/",
+      Component: () => <SchemaTable columns={columns} records={longRecords} type="ticket" />,
+    },
+  ]);
+  render(<Stub initialEntries={["/"]} />);
+}
+
+test("a long cell value is width-capped and truncated rather than widening the column", () => {
+  renderLongTable();
+  const cell = screen.getByText(LONG_TITLE).closest("td");
+  expect(cell).not.toBeNull();
+  const clamp = cell?.querySelector(".truncate");
+  expect(clamp).not.toBeNull();
+  expect(clamp?.className).toMatch(/max-w-/);
+});
+
+test("a truncated cell still offers the full value on hover instead of hiding it", () => {
+  renderLongTable();
+  expect(screen.getByTitle(LONG_TITLE)).toBeInTheDocument();
+});
+
+test("a short cell value carries no title, so hover stays meaningful", () => {
+  renderTable();
+  const cell = screen.getByText("First").closest("td");
+  expect(cell?.querySelector("[title]")).toBeNull();
+});

--- a/apps/web/app/components/schema-table.tsx
+++ b/apps/web/app/components/schema-table.tsx
@@ -1,4 +1,5 @@
 import { Link } from "@remix-run/react";
+import type * as React from "react";
 import type { ResourceRecord } from "~/lib/api";
 import { type FieldDescriptor, type RenderedCell, renderValue, type SortState } from "~/lib/schema";
 
@@ -27,6 +28,30 @@ export function ValueCell({ cell }: { cell: RenderedCell }) {
     default:
       return <span>{cell.text}</span>;
   }
+}
+
+const CELL_MAX_CHARS = 48;
+
+/** The text a cell renders, for the hover title. A boolean glyph has no text worth repeating. */
+function cellFullText(cell: RenderedCell): string {
+  switch (cell.kind) {
+    case "link":
+      return cell.label;
+    case "bool":
+      return "";
+    default:
+      return cell.text;
+  }
+}
+
+/* Long values are clamped so one wide cell cannot dictate every column's width, but the full text
+   stays reachable on hover rather than being silently cropped. */
+function Cell({ text, children }: { text: string; children: React.ReactNode }) {
+  return (
+    <div className="max-w-[24rem] truncate" title={text.length > CELL_MAX_CHARS ? text : undefined}>
+      {children}
+    </div>
+  );
 }
 
 export function SchemaTable({
@@ -84,18 +109,27 @@ export function SchemaTable({
             <tr key={record.id} className="transition-colors hover:bg-accent">
               {columns.map((col) => {
                 const value = record[col.name];
+                if (col.isIdField) {
+                  const label = String(value ?? record.id);
+                  return (
+                    <td key={col.name} className="px-3 py-2 align-top">
+                      <Cell text={label}>
+                        <Link
+                          to={`/resources/${encodeURIComponent(type)}/${encodeURIComponent(record.id)}`}
+                          className="font-medium text-primary hover:underline"
+                        >
+                          {label}
+                        </Link>
+                      </Cell>
+                    </td>
+                  );
+                }
+                const cell = renderValue(col, value);
                 return (
-                  <td key={col.name} className="whitespace-nowrap px-3 py-2 align-top">
-                    {col.isIdField ? (
-                      <Link
-                        to={`/resources/${encodeURIComponent(type)}/${encodeURIComponent(record.id)}`}
-                        className="font-medium text-primary hover:underline"
-                      >
-                        {String(value ?? record.id)}
-                      </Link>
-                    ) : (
-                      <ValueCell cell={renderValue(col, value)} />
-                    )}
+                  <td key={col.name} className="px-3 py-2 align-top">
+                    <Cell text={cellFullText(cell)}>
+                      <ValueCell cell={cell} />
+                    </Cell>
                   </td>
                 );
               })}

--- a/apps/web/app/lib/schema-date.test.ts
+++ b/apps/web/app/lib/schema-date.test.ts
@@ -1,0 +1,70 @@
+import { afterAll, beforeAll, expect, test } from "vitest";
+import {
+  cellText,
+  deriveFields,
+  type FieldDescriptor,
+  parseSchema,
+  renderValue,
+} from "~/lib/schema";
+
+/* Pinned west of Greenwich: a bare YYYY-MM-DD read as UTC midnight lands on the previous day here,
+   which is the half of the date-only defect a locale-agnostic assertion cannot see. */
+const originalTz = process.env.TZ;
+beforeAll(() => {
+  process.env.TZ = "America/Los_Angeles";
+});
+afterAll(() => {
+  process.env.TZ = originalTz;
+});
+
+const DATE_YAML = `
+type: object
+properties:
+  id: { type: string }
+  due: { type: string, format: date }
+  startsAt: { type: string, format: date-time }
+`;
+
+function fields(): Record<string, FieldDescriptor> {
+  const parsed = parseSchema(DATE_YAML);
+  if (!parsed.ok) throw new Error(parsed.error);
+  return Object.fromEntries(deriveFields(parsed.schema).map((f) => [f.name, f]));
+}
+
+function text(field: FieldDescriptor, value: unknown): string {
+  const cell = renderValue(field, value);
+  if (cell.kind !== "text") throw new Error(`expected a text cell, got ${cell.kind}`);
+  return cell.text;
+}
+
+test("a format: date field renders the calendar day it was given, not the UTC-shifted one", () => {
+  expect(text(fields().due, "2026-03-15")).toContain("15");
+  expect(text(fields().due, "2026-03-15")).toContain("2026");
+});
+
+test("a format: date field renders no time of day", () => {
+  expect(text(fields().due, "2026-03-15")).not.toMatch(/\d:\d/);
+});
+
+test("a format: date-time field keeps its time of day", () => {
+  expect(text(fields().startsAt, "2026-03-15T18:30:00Z")).toMatch(/\d:\d/);
+});
+
+test("system date-time columns keep their time of day", () => {
+  const updatedAt: FieldDescriptor = {
+    name: "updatedAt",
+    kind: "date",
+    isSystem: true,
+    isIdField: false,
+  };
+  expect(text(updatedAt, "2026-06-08T14:03:00Z")).toMatch(/\d:\d/);
+});
+
+test("filter text for a format: date field matches the day the user sees", () => {
+  expect(cellText(fields().due, "2026-03-15")).toContain("15");
+  expect(cellText(fields().due, "2026-03-15")).not.toMatch(/\d:\d/);
+});
+
+test("a malformed date-only value passes through unchanged", () => {
+  expect(text(fields().due, "not-a-date")).toBe("not-a-date");
+});

--- a/apps/web/app/lib/schema.ts
+++ b/apps/web/app/lib/schema.ts
@@ -191,6 +191,28 @@ export function formatIso(value: string): string {
   });
 }
 
+const DATE_ONLY = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+/**
+ * Locale-formatted calendar day for a `format: date` field — no time of day.
+ *
+ * A bare `YYYY-MM-DD` must be built from its parts rather than handed to `new Date`, which reads
+ * it as UTC midnight and so renders the previous day everywhere west of Greenwich.
+ */
+export function formatIsoDate(value: string): string {
+  const parts = DATE_ONLY.exec(value.trim());
+  const date = parts
+    ? new Date(Number(parts[1]), Number(parts[2]) - 1, Number(parts[3]))
+    : new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "2-digit" });
+}
+
+// Single entry point for the "date" kind, so the read view and the filter cannot drift apart.
+function formatDateField(field: FieldDescriptor, value: string): string {
+  return field.format === "date" ? formatIsoDate(value) : formatIso(value);
+}
+
 // Best human label for a target record: a hinted field, else the first non-system string, else id.
 // Shared by the x-links combobox (picker) and the detail link (so both show "Acme Corp", not a UUID).
 const LABEL_HINTS = ["name", "title", "label", "summary"];
@@ -228,7 +250,7 @@ export function renderValue(
     case "boolean":
       return { kind: "bool", value: Boolean(value) };
     case "date":
-      return { kind: "text", text: formatIso(String(value)) };
+      return { kind: "text", text: formatDateField(field, String(value)) };
     case "array": {
       const arr = Array.isArray(value) ? value : [value];
       if (arr.length === 0) return { kind: "muted", text: "—" };
@@ -260,7 +282,7 @@ export function cellText(field: FieldDescriptor, value: unknown): string {
     case "boolean":
       return value ? "true" : "false";
     case "date":
-      return formatIso(String(value)).toLowerCase();
+      return formatDateField(field, String(value)).toLowerCase();
     case "array": {
       const arr = Array.isArray(value) ? value : [value];
       return arr.map(String).join(", ").toLowerCase();

--- a/apps/web/app/routes/_app.resources.$type._index.tsx
+++ b/apps/web/app/routes/_app.resources.$type._index.tsx
@@ -11,6 +11,7 @@ import { ResourcePanel } from "~/components/resource-panel";
 import { SchemaTable } from "~/components/schema-table";
 import { ErrorState } from "~/components/states";
 import { Button } from "~/components/ui/button";
+import { ConfirmModal } from "~/components/ui/modal";
 import {
   ApiError,
   deleteResourceType,
@@ -59,20 +60,21 @@ export default function ResourceList() {
   const [loading, setLoading] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [typeError, setTypeError] = useState<string | null>(null);
+  const [confirmingDeleteType, setConfirmingDeleteType] = useState(false);
+  const [deletingType, setDeletingType] = useState(false);
 
   async function onDeleteType() {
-    if (
-      !window.confirm(
-        `Delete the "${type}" resource type? Its records are kept in the database but the type is removed.`
-      )
-    )
-      return;
+    if (deletingType) return;
+    setDeletingType(true);
     setTypeError(null);
     try {
       await deleteResourceType(type);
       navigate("/resources");
     } catch (err) {
       setTypeError(err instanceof ApiError ? err.message : "failed to delete type");
+    } finally {
+      setDeletingType(false);
+      setConfirmingDeleteType(false);
     }
   }
 
@@ -132,10 +134,19 @@ export default function ResourceList() {
         <Button asChild variant="outline" size="sm">
           <Link to={`/resources/${encodeURIComponent(type)}/schema`}>Edit type</Link>
         </Button>
-        <Button variant="destructive" size="sm" onClick={onDeleteType}>
+        <Button variant="destructive" size="sm" onClick={() => setConfirmingDeleteType(true)}>
           Delete type
         </Button>
       </div>
+      <ConfirmModal
+        open={confirmingDeleteType}
+        onClose={() => setConfirmingDeleteType(false)}
+        onConfirm={() => void onDeleteType()}
+        title="Delete resource type"
+        description={`Delete the "${type}" resource type? Its records are kept in the database but the type is removed.`}
+        confirmLabel="Delete type"
+        busy={deletingType}
+      />
       {typeError ? <p className="text-destructive">error: {typeError}</p> : null}
       {schemaError ? (
         <p className="text-destructive">error: schema parse failed — {schemaError}</p>

--- a/apps/web/app/routes/resources.create-guard.test.tsx
+++ b/apps/web/app/routes/resources.create-guard.test.tsx
@@ -1,0 +1,92 @@
+import * as remix from "@remix-run/react";
+import { createRemixStub } from "@remix-run/testing";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { ApiError } from "~/lib/api";
+import { deriveFields, parseSchema } from "~/lib/schema";
+import ResourceCreate from "./_app.resources.$type.new";
+
+/* Render the route directly because real data navigation creates jsdom-undici AbortSignal issues. */
+
+vi.mock("@remix-run/react", async () => {
+  const actual = await vi.importActual<typeof import("@remix-run/react")>("@remix-run/react");
+  return { ...actual, useLoaderData: vi.fn(), useNavigate: vi.fn() };
+});
+
+vi.mock("~/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("~/lib/api")>("~/lib/api");
+  return { ...actual, createRecord: vi.fn() };
+});
+
+const api = await import("~/lib/api");
+
+const parsed = parseSchema(`
+type: object
+properties:
+  title: { type: string }
+`);
+if (!parsed.ok) throw new Error(parsed.error);
+const fields = deriveFields(parsed.schema);
+
+const navigate = vi.fn();
+
+beforeEach(() => {
+  vi.mocked(remix.useNavigate).mockReturnValue(navigate);
+  vi.mocked(remix.useLoaderData).mockReturnValue({
+    type: "ticket",
+    fields,
+    schemaError: undefined,
+  });
+  // Never settles: holds the Create in flight for the whole test, the way a slow POST would.
+  vi.mocked(api.createRecord).mockReturnValue(new Promise(() => {}));
+});
+
+afterEach(() => vi.clearAllMocks());
+
+function renderCreate() {
+  const Stub = createRemixStub([{ path: "/", Component: () => <ResourceCreate /> }]);
+  render(<Stub initialEntries={["/"]} />);
+  return screen.getByRole("button", { name: /create/i });
+}
+
+// Two events inside one task, so React never gets a commit in between — the window in which a
+// `disabled` prop driven by the parent's state does not exist yet.
+function clickTwiceInOneTask(button: HTMLElement) {
+  act(() => {
+    button.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    button.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+  });
+}
+
+test("rapid double-click on Create submits exactly once", () => {
+  clickTwiceInOneTask(renderCreate());
+  expect(api.createRecord).toHaveBeenCalledTimes(1);
+});
+
+test("a second form submit while the first is in flight is ignored", () => {
+  renderCreate();
+  const form = document.querySelector("form");
+  if (!form) throw new Error("no form rendered");
+  act(() => {
+    form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+  });
+  expect(api.createRecord).toHaveBeenCalledTimes(1);
+});
+
+test("Create stays disabled while the request is in flight", () => {
+  const button = renderCreate();
+  fireEvent.click(button);
+  expect(button).toBeDisabled();
+});
+
+test("a failed Create releases the guard so the user can retry", async () => {
+  vi.mocked(api.createRecord).mockRejectedValueOnce(new ApiError(500, "boom"));
+  const button = renderCreate();
+  fireEvent.click(button);
+  await waitFor(() => expect(screen.getByText(/error: boom/i)).toBeInTheDocument());
+
+  vi.mocked(api.createRecord).mockReturnValue(new Promise(() => {}));
+  clickTwiceInOneTask(screen.getByRole("button", { name: /create/i }));
+  expect(api.createRecord).toHaveBeenCalledTimes(2);
+});

--- a/apps/web/app/routes/resources.delete-type.test.tsx
+++ b/apps/web/app/routes/resources.delete-type.test.tsx
@@ -1,0 +1,92 @@
+import * as remix from "@remix-run/react";
+import { createRemixStub } from "@remix-run/testing";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { deriveFields, listColumns, parseSchema } from "~/lib/schema";
+import ResourceList from "./_app.resources.$type._index";
+
+/* Render the route directly because real data navigation creates jsdom-undici AbortSignal issues. */
+
+vi.mock("@remix-run/react", async () => {
+  const actual = await vi.importActual<typeof import("@remix-run/react")>("@remix-run/react");
+  return { ...actual, useLoaderData: vi.fn(), useNavigate: vi.fn() };
+});
+
+vi.mock("~/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("~/lib/api")>("~/lib/api");
+  return { ...actual, deleteResourceType: vi.fn(), listRecords: vi.fn() };
+});
+
+const api = await import("~/lib/api");
+
+const parsed = parseSchema(`
+type: object
+x-id-strategy: { field: id }
+properties:
+  id: { type: string }
+  title: { type: string }
+`);
+if (!parsed.ok) throw new Error(parsed.error);
+const columns = listColumns(deriveFields(parsed.schema), parsed.schema);
+
+const navigate = vi.fn();
+let confirmSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  vi.mocked(remix.useNavigate).mockReturnValue(navigate);
+  vi.mocked(remix.useLoaderData).mockReturnValue({
+    type: "ticket",
+    columns,
+    schemaError: undefined,
+    items: [],
+    nextCursor: null,
+  });
+  vi.mocked(api.deleteResourceType).mockResolvedValue(undefined);
+  confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  confirmSpy.mockRestore();
+});
+
+function renderList() {
+  const Stub = createRemixStub([{ path: "/", Component: () => <ResourceList /> }]);
+  render(<Stub initialEntries={["/"]} />);
+}
+
+// A closed <dialog> is absent from the accessibility tree, and Modal only opens it in an effect —
+// every dialog query here must be async or it races that effect.
+async function openDeleteTypeDialog() {
+  renderList();
+  fireEvent.click(screen.getByRole("button", { name: /delete type/i }));
+  return await screen.findByRole("dialog");
+}
+
+test("Delete type asks for confirmation in an in-app dialog, not window.confirm", async () => {
+  const dialog = await openDeleteTypeDialog();
+  expect(dialog).toBeInTheDocument();
+  expect(confirmSpy).not.toHaveBeenCalled();
+});
+
+test("the Delete type dialog names the type and what survives the delete", async () => {
+  const dialog = await openDeleteTypeDialog();
+  expect(dialog.textContent).toContain("ticket");
+  expect(dialog.textContent).toMatch(/records are kept/i);
+});
+
+test("Delete type does not call the API until the dialog is confirmed", async () => {
+  const dialog = await openDeleteTypeDialog();
+  expect(api.deleteResourceType).not.toHaveBeenCalled();
+
+  fireEvent.click(within(dialog).getByRole("button", { name: /delete type/i }));
+  await waitFor(() => expect(api.deleteResourceType).toHaveBeenCalledWith("ticket"));
+  await waitFor(() => expect(navigate).toHaveBeenCalledWith("/resources"));
+});
+
+test("cancelling the Delete type dialog leaves the type alone", async () => {
+  const dialog = await openDeleteTypeDialog();
+  fireEvent.click(within(dialog).getByRole("button", { name: /cancel/i }));
+  expect(api.deleteResourceType).not.toHaveBeenCalled();
+  expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+});


### PR DESCRIPTION
Four Record UI defects, all confirmed to still reproduce at origin/main and each landed with a test that was red before the fix.

- #440 `renderValue` sent every "date" kind through `formatIso`, which appends hour and minute and parses a bare YYYY-MM-DD as UTC midnight. West of Greenwich that also shifted the displayed day back by one: `2026-03-15` rendered as "14 Mar 2026, 05:00 pm". `format: date` now builds the Date from its parts and formats day-only; `format: date-time` and the system columns are untouched. `cellText` shares the same helper so the filter keeps matching what the user sees.

- #439 List cells were `whitespace-nowrap` with no width bound, so one long value dictated every column's width. Cells now clamp at 24rem and truncate, and expose the full value via `title` when it exceeds the clamp, so nothing is silently cropped.

- #410 "Delete type" called `window.confirm`, a design-system violation and untestable. It now uses the app's `ConfirmModal`, the same primitive the Chat, Secrets and Files screens already use.

- #438 `ResourceForm` had no in-flight guard of its own; it relied entirely on the `submitting` prop, which only disables the button one React commit after the parent reacts. Two submit events landing in the same task both got through and created duplicate Records. A ref now latches synchronously and releases when the submit settles. This narrows the window rather than closing it — a server-side idempotency key is still the real fix.

## Summary

<!-- What changed, and why. Link the driving issue if one exists. -->

## Test plan

<!-- Commands you ran, or manual steps / screenshots for UI changes. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (or the scoped `--filter` you actually ran)

## Checklist

- [ ] PR title follows Conventional Commits (`type(scope): subject`) — CI checks this
- [ ] Scoped to one logical change
- [ ] Tests added/updated for the behavior that changed
