### PR TITLE
fix(chat): show an empty state for every mention trigger

### DIFF
--- a/apps/web/app/components/chat/editor/mention-config.ts
+++ b/apps/web/app/components/chat/editor/mention-config.ts
@@ -8,16 +8,41 @@ export interface MentionKindConfig {
   char: string;
   /** ProseMirror node name for this mention's inline chip. */
   nodeName: string;
+  /** Shown when the menu has nothing to offer. Required so no trigger can render an invisible menu. */
+  emptyLabel: string;
+  /**
+   * Shown while a server-side search is in flight. Present only for search-powered triggers: the
+   * suggestion plugin reports `loading` for every trigger, but a statically filtered list is never
+   * genuinely pending.
+   */
+  loadingLabel?: string;
 }
 
 export const MENTION_KINDS: readonly MentionKindConfig[] = [
-  { kind: "agent", char: "@", nodeName: "mentionAgent" },
-  { kind: "skill", char: "/", nodeName: "mentionSkill" },
-  { kind: "resource", char: "#", nodeName: "mentionResource" },
-  { kind: "knowledge", char: "~", nodeName: "mentionKnowledge" },
+  { kind: "agent", char: "@", nodeName: "mentionAgent", emptyLabel: "No matching Agents." },
+  { kind: "skill", char: "/", nodeName: "mentionSkill", emptyLabel: "No matching Skills." },
+  {
+    kind: "resource",
+    char: "#",
+    nodeName: "mentionResource",
+    emptyLabel: "No matching Resource types.",
+  },
+  {
+    kind: "knowledge",
+    char: "~",
+    nodeName: "mentionKnowledge",
+    emptyLabel: "No matching Knowledge.",
+    loadingLabel: "Searching Knowledge…",
+  },
 ];
 
 /** Reverse lookup: ProseMirror node name → its mention config. Used by the serializer. */
 export const NODE_TO_KIND: Record<string, MentionKindConfig> = Object.fromEntries(
   MENTION_KINDS.map((c) => [c.nodeName, c])
 );
+
+/** Reverse lookup: trigger kind → its config. Used by the menu to label its empty/loading states. */
+export const KIND_TO_CONFIG = Object.fromEntries(MENTION_KINDS.map((c) => [c.kind, c])) as Record<
+  MentionKind,
+  MentionKindConfig
+>;

--- a/apps/web/app/components/chat/editor/mention-list.test.tsx
+++ b/apps/web/app/components/chat/editor/mention-list.test.tsx
@@ -16,6 +16,16 @@ describe("MentionList", () => {
     expect(screen.getByText("No matching Knowledge.")).toBeInTheDocument();
   });
 
+  // The suggestion plugin awaits `items` even when it resolves synchronously, so it reports
+  // `loading` for every trigger. Only Knowledge actually queries a server; the rest must not
+  // borrow its wording for the microtask before their static list arrives.
+  it("never shows a search state for a trigger that cannot search", () => {
+    render(<MentionList command={vi.fn()} items={[]} kind="skill" loading />);
+
+    expect(screen.getByText("No matching Skills.")).toBeInTheDocument();
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
   it("keeps selecting returned Knowledge items with keyboard navigation", () => {
     const command = vi.fn();
     const ref = createRef<MentionListRef>();

--- a/apps/web/app/components/chat/editor/mention-list.tsx
+++ b/apps/web/app/components/chat/editor/mention-list.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, useEffect, useImperativeHandle, useState } from "react";
 import { AgentGlyph } from "~/components/agent-glyph";
-import type { MentionKind } from "./mention-config";
+import { KIND_TO_CONFIG, type MentionKind } from "./mention-config";
 import type { MentionItem } from "./serialize";
 
 /** Imperative key handling keeps suggestion navigation from blurring the editor. */
@@ -14,9 +14,9 @@ export const MentionList = forwardRef<
   {
     items: MentionItem[];
     command: (item: { id: string; label: string }) => void;
-    /** Trigger kind — agent rows render a glyph avatar; skill/resource rows don't. */
-    kind?: MentionKind;
-    /** Async Knowledge search is pending; render feedback instead of hiding the menu. */
+    /** Trigger kind — picks the empty/loading wording, and agent rows render a glyph avatar. */
+    kind: MentionKind;
+    /** A search is pending; rendered only for a trigger that declares a `loadingLabel`. */
     loading?: boolean;
   }
 >(({ items, command, kind, loading = false }, ref) => {
@@ -49,12 +49,15 @@ export const MentionList = forwardRef<
     [items, selected, command]
   );
 
+  // A menu that renders nothing is indistinguishable from a broken one, so an empty list still
+  // draws a labelled panel for every trigger (docs/qa/playbooks/chat.md S4 step 6).
   if (items.length === 0) {
-    if (!loading && kind !== "knowledge") return null;
+    const { emptyLabel, loadingLabel } = KIND_TO_CONFIG[kind];
+    const pending = loading ? loadingLabel : undefined;
     return (
       <div className="w-64 rounded-sm border border-border bg-card p-2 text-sm shadow-md">
-        <p className="text-muted-foreground" role={loading ? "status" : undefined}>
-          {loading ? "Searching Knowledge…" : "No matching Knowledge."}
+        <p className="text-muted-foreground" role={pending ? "status" : undefined}>
+          {pending ?? emptyLabel}
         </p>
       </div>
     );

--- a/apps/web/app/components/chat/editor/mention-menu.test.tsx
+++ b/apps/web/app/components/chat/editor/mention-menu.test.tsx
@@ -1,0 +1,110 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { type Editor, EditorContent, useEditor } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import { useEffect } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SearchResponse } from "~/lib/knowledge-api";
+import { buildMentionExtensions } from "./mentions";
+import type { MentionItem } from "./serialize";
+import type { GetItems } from "./use-mention-data";
+
+const searchKnowledge = vi.hoisted(() => vi.fn());
+vi.mock("~/lib/knowledge-api", () => ({ searchKnowledge }));
+
+const AGENTS: MentionItem[] = [{ id: "atlas", label: "Atlas", description: "Ops agent" }];
+const withAgents: GetItems = (kind) => (kind === "agent" ? AGENTS : []);
+const withNothing: GetItems = () => [];
+
+function Harness({ getItems, onReady }: { getItems: GetItems; onReady: (e: Editor) => void }) {
+  const editor = useEditor({
+    immediatelyRender: false,
+    extensions: [StarterKit.configure({ heading: false }), ...buildMentionExtensions(getItems)],
+  });
+  useEffect(() => {
+    if (editor) onReady(editor);
+  }, [editor, onReady]);
+  return <EditorContent editor={editor} />;
+}
+
+async function mountEditor(getItems: GetItems = withAgents): Promise<Editor> {
+  let editor: Editor | null = null;
+  render(<Harness getItems={getItems} onReady={(e) => (editor = e)} />);
+  await waitFor(() => expect(editor).not.toBeNull());
+  return editor as unknown as Editor;
+}
+
+async function type(editor: Editor, text: string) {
+  await act(async () => {
+    editor.commands.insertContent(text);
+    await Promise.resolve();
+  });
+}
+
+function hit(pageId: string, title: string, content: string): SearchResponse["results"][number] {
+  return { pageId, chunkId: `${pageId}-c1`, title, content, source: "authored", score: 0.9 };
+}
+
+beforeEach(() => {
+  searchKnowledge.mockReset();
+  searchKnowledge.mockResolvedValue({ results: [], warnings: [] } satisfies SearchResponse);
+});
+
+describe("Knowledge (~) mention menu", () => {
+  it("renders a loading state, then the matching Knowledge pages", async () => {
+    let resolveSearch: (r: SearchResponse) => void = () => {};
+    searchKnowledge.mockReturnValue(
+      new Promise<SearchResponse>((resolve) => {
+        resolveSearch = resolve;
+      })
+    );
+
+    const editor = await mountEditor();
+    await type(editor, "~");
+    await type(editor, "a");
+
+    expect(await screen.findByRole("status")).toHaveTextContent("Searching Knowledge…");
+
+    await act(async () => {
+      resolveSearch({
+        results: [hit("page-1", "Autonomy policy", "How much rope an agent gets")],
+        warnings: [],
+      });
+      await Promise.resolve();
+    });
+
+    expect(await screen.findByRole("button", { name: /Autonomy policy/i })).toBeInTheDocument();
+  });
+
+  it("renders an empty state when the Knowledge search returns no hits", async () => {
+    const editor = await mountEditor();
+    await type(editor, "~");
+    await type(editor, "zzz");
+
+    expect(await screen.findByText("No matching Knowledge.")).toBeInTheDocument();
+  });
+
+  it("still opens the agent (@) menu", async () => {
+    const editor = await mountEditor();
+    await type(editor, "@");
+    await type(editor, "a");
+
+    expect(await screen.findByRole("button", { name: /Atlas/i })).toBeInTheDocument();
+  });
+});
+
+// chat.md S4 step 6: every trigger shows an empty state when there are no matches. A fresh instance
+// has no Skills and no Resource types, so `/` and `#` hit this on the operator's first session.
+describe("every mention trigger shows an empty state", () => {
+  it.each([
+    ["@", "No matching Agents."],
+    ["/", "No matching Skills."],
+    ["#", "No matching Resource types."],
+    ["~", "No matching Knowledge."],
+  ])("%s renders its own empty state over an empty catalog", async (char, label) => {
+    const editor = await mountEditor(withNothing);
+    await type(editor, char);
+    await type(editor, "zzz");
+
+    expect(await screen.findByText(label)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
#421 (the Knowledge `~` menu never rendering) was already fixed on main by #450, which replaced `MentionList`'s bare `return null` on an empty list with a labelled panel. That fix was gated on `kind === "knowledge"`, so it closed one quarter of the defect: `@`, `/` and `#` still rendered nothing at all when their list was empty. `docs/qa/playbooks/chat.md` S4 step 6 requires an empty state for all four triggers, and calls a menu that draws nothing a broken dropdown rather than a legitimate empty state.

This is not hypothetical: a fresh instance has no Skills and no custom Resource types, so `/` and `#` reproduced #421's exact symptom during the operator's first session.

The empty and loading labels now live in `MENTION_KINDS`, the table that already drives trigger detection and node names, and `kind` is required on `MentionList`. A fifth trigger therefore cannot be added without an empty label, which is what let this regress silently the first time.

Also stops the three synchronous triggers borrowing Knowledge's wording. The suggestion plugin awaits `items` even when it resolves synchronously, so it reports `loading: true` for every trigger; an empty agent menu briefly read "Searching Knowledge…". Only a trigger that declares a `loadingLabel` — just Knowledge, the one search-powered trigger — can render a pending state.

Adds an integration test that drives a real Tiptap editor, which #450's props-level unit test could not: it proves each trigger character actually reaches `MentionList` with the props its states depend on.

## Summary

<!-- What changed, and why. Link the driving issue if one exists. -->

## Test plan

<!-- Commands you ran, or manual steps / screenshots for UI changes. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (or the scoped `--filter` you actually ran)

## Checklist

- [ ] PR title follows Conventional Commits (`type(scope): subject`) — CI checks this
- [ ] Scoped to one logical change
- [ ] Tests added/updated for the behavior that changed
