### PR TITLE
fix(soul): tolerate a bundled integration's manifest-less Soul dir

### DIFF
--- a/apps/api/src/ingress/routes.test.ts
+++ b/apps/api/src/ingress/routes.test.ts
@@ -160,7 +160,7 @@ describe("POST /api/v1/hooks/integrations/:name", () => {
   it("dedups on a declared header and forwards context headers into the job", async () => {
     await app.close();
     const integration = makeIntegration();
-    const ingress = integration.manifest.ingress;
+    const ingress = integration.manifest?.ingress;
     if (ingress) {
       ingress.webhook.dedup_key = undefined;
       ingress.webhook.dedup_header = "X-Provider-Delivery";
@@ -184,7 +184,7 @@ describe("POST /api/v1/hooks/integrations/:name", () => {
   it("enqueues without dedup when the manifest declares no dedup_key", async () => {
     await app.close();
     const integration = makeIntegration();
-    const ingress = integration.manifest.ingress;
+    const ingress = integration.manifest?.ingress;
     if (ingress) ingress.webhook.dedup_key = undefined;
     await build([integration]);
     await inject(EVENT);
@@ -283,7 +283,7 @@ describe("POST /api/v1/hooks/integrations/:name", () => {
   it("enqueues everything when no accept filter is declared", async () => {
     await app.close();
     const integration = makeIntegration();
-    const ingress = integration.manifest.ingress;
+    const ingress = integration.manifest?.ingress;
     if (ingress) ingress.webhook.accept = undefined;
     await build([integration]);
     const res = await inject({ kind: "system_notice" });

--- a/apps/api/src/ingress/routes.ts
+++ b/apps/api/src/ingress/routes.ts
@@ -68,7 +68,7 @@ export async function registerIngressRoutes(
         const integration = deps.soulLoader.integrations.get(name);
         if (!integration) return reply.code(404).send(NOT_FOUND);
 
-        const ingress = integration.manifest.ingress;
+        const ingress = integration.manifest?.ingress;
         if (!ingress?.webhook || !ingress.handler || !integration.ingressHandler) {
           return reply.code(404).send(NOT_FOUND);
         }

--- a/apps/api/src/integrations/routes.ts
+++ b/apps/api/src/integrations/routes.ts
@@ -64,9 +64,13 @@ export function mergeIntegrations(
   }
   for (const [slug, soulEntry] of soulLoader.integrations) {
     const bundledEntry = bundled.get(slug);
+    const manifest = bundledEntry?.manifest ?? soulEntry.manifest;
+    // Soul entry has no manifest of its own (bundled, code-owned) and no bundled entry either —
+    // nothing to catalog.
+    if (manifest === undefined) continue;
     merged.set(slug, {
       slug,
-      manifest: bundledEntry?.manifest ?? soulEntry.manifest,
+      manifest,
       connected: soulEntry.connection?.enabled === true,
       connectionEnv: soulEntry.connection?.env,
       setupGuide: bundledEntry?.setupGuide ?? soulEntry.setupGuide,

--- a/apps/api/src/internal/delivery-host.ts
+++ b/apps/api/src/internal/delivery-host.ts
@@ -448,7 +448,7 @@ export class IngressDeliveryHost {
     };
 
     const integration = this.options.soulLoader.integrations.get(envelope.slug);
-    const ingress = integration?.manifest.ingress;
+    const ingress = integration?.manifest?.ingress;
     const handler = integration?.ingressHandler;
     if (!integration?.connection?.enabled || ingress === undefined || handler === undefined) {
       throw new DeliveryDeniedError("integration_unavailable");

--- a/apps/api/src/tools/declarative/tools.ts
+++ b/apps/api/src/tools/declarative/tools.ts
@@ -143,6 +143,7 @@ function integrationResource(slug: string): string {
 
 /** Resolve auth steps before credential mode so legacy `oauth` keeps personal credentials. */
 function credentialModeFor(integration: SoulIntegration): ToolCredentialMode {
+  if (integration.manifest === undefined) return "service";
   const personal = resolveAuthSteps(integration.manifest).some(isPersonalCredentialStep);
   return personal ? "user_preferred" : "service";
 }
@@ -304,7 +305,10 @@ interface CompiledIntegration {
 function compileIntegration(integration: SoulIntegration): CompiledIntegration {
   const { manifest, slug } = integration;
   const credentialMode = credentialModeFor(integration);
-  if (manifest.egress?.type !== "openapi") return { slug, tools: [], credentialMode };
+  // Callers filter out manifest-less (bundled) integrations before reaching here.
+  if (manifest === undefined || manifest.egress?.type !== "openapi") {
+    return { slug, tools: [], credentialMode };
+  }
 
   // Connection env fills `{VAR}` placeholders in `base_url` — a per-install path segment such as
   // an Atlassian cloud id. Secret references are excluded: the credential has its own placement,
@@ -518,6 +522,9 @@ export function buildDeclarativeTools(
   const toolOwners = new Map<string, string>();
 
   for (const integration of integrations) {
+    // No manifest means a bundled, code-owned integration (Soul holds only connection state);
+    // its Tools are handwritten, not declarative.
+    if (integration.manifest === undefined) continue;
     try {
       const compiled = compileIntegration(integration);
       if (compiled.tools.length === 0) continue;

--- a/packages/soul/src/catalogue.ts
+++ b/packages/soul/src/catalogue.ts
@@ -56,9 +56,10 @@ export function buildSoulCatalogue(soulLoader: SoulLoader | undefined): SoulCata
     .sort(byName);
 
   const integrations = values(soulLoader?.integrations)
+    .filter((i) => i.manifest !== undefined)
     .map((i) => ({
       name: i.slug,
-      description: asDesc(i.manifest.description),
+      description: asDesc(i.manifest?.description),
     }))
     .sort(byName);
 

--- a/packages/soul/src/published-loader.ts
+++ b/packages/soul/src/published-loader.ts
@@ -363,6 +363,15 @@ export class SoulLoader {
       // manifest.yml is the V2 format; manifest.json is no longer supported
       const manifestPath = join(dir, "manifest.yml");
       try {
+        // Bundled integrations are code-owned: Soul holds connection.yaml only, no manifest.yml
+        // (install.ts refuses to write one). Such a dir just carries connection state.
+        if (!(await fileExists(this.soulPath, manifestPath))) {
+          const connRaw = (parseYaml(
+            await readContainedFile(this.soulPath, join(dir, "connection.yaml"))
+          ) ?? {}) as IntegrationConnection;
+          map.set(slug, { slug, sourceIntegration: slug, connection: connRaw });
+          continue;
+        }
         const parsedManifest =
           parseYaml(await readContainedFile(this.soulPath, manifestPath)) ?? {};
         const manifestRaw = validateLegacyIntegrationManifest(

--- a/packages/soul/src/soul-loader.test.ts
+++ b/packages/soul/src/soul-loader.test.ts
@@ -68,6 +68,24 @@ describe("SoulLoader", () => {
         reason: expect.stringContaining("/egress"),
       });
     });
+
+    it("loads a bundled integration's connection.yaml with no manifest.yml", async () => {
+      // Bundled integrations are code-owned: Soul holds only connection state, never manifest.yml
+      // (install.ts refuses to write one for a bundled slug). Reload must not throw on that dir.
+      await write(
+        join(TMP, "integrations", "github", "connection.yaml"),
+        "enabled: true\nenv:\n  GITHUB_INSTALLATION_ID: '123'\n"
+      );
+      const loader = new SoulLoader(TMP, makeLogger());
+
+      await expect(loader.load()).resolves.toBeUndefined();
+
+      const github = loader.integrations.get("github");
+      expect(github?.manifest).toBeUndefined();
+      expect(github?.connection?.enabled).toBe(true);
+      expect(github?.connection?.env?.GITHUB_INSTALLATION_ID).toBe("123");
+      expect(loader.quarantined).toEqual([]);
+    });
   });
 
   describe("agents", () => {

--- a/packages/soul/src/types.ts
+++ b/packages/soul/src/types.ts
@@ -282,7 +282,8 @@ export interface IntegrationConnection {
 export interface SoulIntegration {
   slug: string;
   sourceIntegration: string;
-  manifest: IntegrationManifest;
+  /** Absent for a bundled integration: Soul holds only `connection.yaml`, manifest is code-owned. */
+  manifest?: IntegrationManifest;
   connection?: IntegrationConnection;
   setupGuide?: string;
   ingressHandler?: { source: string; hash: string };

--- a/packages/tool-host/src/credential-mode.ts
+++ b/packages/tool-host/src/credential-mode.ts
@@ -35,6 +35,7 @@ export interface CredentialResolverDeps {
 
 /** Personal support is explicit `personal: true`, never inferred from OAuth grant type. */
 export function providerSupportsPersonalCredential(integration: SoulIntegration): boolean {
+  if (integration.manifest === undefined) return false;
   return resolveAuthSteps(integration.manifest).some(isPersonalCredentialStep);
 }
 


### PR DESCRIPTION
## Summary
- GitHub App auth callback wrote `soul/integrations/github/connection.yaml`, then `soulLoader.reload()` scanned the dir and required `manifest.yml` unconditionally, throwing ENOENT → 500 (`Soul: failed to load published integration "github"`) — bundled integrations are code-owned and never get a `manifest.yml` in Soul.
- `SoulIntegration.manifest` is now optional; `loadIntegrations()` accepts a connection-only dir as a valid bundled entry instead of throwing.
- Updated the small set of consumers that dereferenced `.manifest` to optional-chain or skip manifest-less entries.

## Test plan
- [x] `pnpm --filter @tulipfarm/soul test src/soul-loader.test.ts` — new regression test reproduces the exact stg dir shape (connection.yaml, no manifest.yml) and asserts `load()` doesn't throw
- [x] `pnpm --filter @tulipfarm/soul test`, `pnpm --filter @tulipfarm/api test src/integrations src/ingress src/internal src/tools/declarative` — all pass
- [x] `pnpm typecheck` (root) — clean
- [ ] Manual: connect a GitHub App through the web UI locally and confirm the callback redirects with `status=ok`, no 500
