### PR TITLE
fix(authz): let a granted Owner reach every admin-only action

### DIFF
--- a/apps/api/src/auth/owner-page-access.pg.test.ts
+++ b/apps/api/src/auth/owner-page-access.pg.test.ts
@@ -1,0 +1,213 @@
+/**
+ * The literal #408 repro, through product surfaces only: an admin invites someone, they accept,
+ * the admin gives them the `Owner` access level from "Give more access", and they sign in fresh
+ * and load People & access.
+ *
+ * The page's loader fans out over the whole authz read surface and fails as a unit, so an Owner
+ * refused by any one of those routes sees the same "You are not an admin of this business." as
+ * before the grant. Asserting only `/api/v1/users` cannot see that.
+ */
+
+import type { PGlite } from "@electric-sql/pglite";
+import { DEPLOYMENT_BUSINESS_ID } from "@tulipfarm/constants";
+import { PgGroupRepo, PgPrincipalRepo, PgRoleRepo } from "@tulipfarm/storage";
+import type { FastifyInstance } from "fastify";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildApp } from "../app";
+import { LiveRouteAuthorizer, makeAuthorizationCheck } from "../authz/route-gate";
+import { AuthzAdminService } from "../authz/service";
+import { transactionPort } from "../db";
+import { buildApiAuthorityLayerResolver } from "../identity/authority-layers";
+import { ADMIN_ONLY_SURFACES, syncDeploymentRoles } from "../identity/roles";
+import { makeMigratedPglite } from "../test/pglite";
+import { PgTokenRepo } from "./api-tokens";
+import { CSRF_COOKIE, CSRF_HEADER } from "./csrf";
+import { PgUserInviteRepo } from "./invites";
+import { MemorySessionStore } from "./session-store";
+import { createUser, PgUserRepo } from "./users";
+
+const PASSWORD = "correct-horse-battery";
+
+interface Session {
+  readonly sid: string;
+  readonly csrf: string;
+}
+
+/** Every request `_app.business.access._index` issues before it renders anything. */
+function pageReads(principalId: string): string[] {
+  return [
+    "/api/v1/users",
+    "/api/v1/authz/roles",
+    "/api/v1/authz/groups",
+    "/api/v1/authz/roles/owner/assignees",
+    "/api/v1/authz/roles/member/assignees",
+    `/api/v1/authz/principals/${principalId}/grants`,
+  ];
+}
+
+/** Every admin-only action a route declares by name. `*` is a catalog entry, not a request. */
+const ADMIN_ONLY_ACTIONS = ADMIN_ONLY_SURFACES.flatMap((surface) =>
+  surface.actions
+    .filter((action) => action !== "*")
+    .map((action) => ({ action, resourceType: surface.type, fallback: "admin" }) as const)
+);
+
+describe("promoting an invited member to Owner, exactly as the product does it", () => {
+  let db: PGlite;
+  let app: FastifyInstance;
+  let decide: ReturnType<typeof makeAuthorizationCheck>;
+  let inviteeId: string;
+  let bystanderId: string;
+
+  async function login(email: string): Promise<Session> {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/auth/login",
+      payload: { email, password: PASSWORD },
+    });
+    expect(res.statusCode).toBe(200);
+    const sid = res.cookies.find((cookie) => cookie.name === "tf_sid")?.value;
+    const csrf = res.cookies.find((cookie) => cookie.name === CSRF_COOKIE)?.value;
+    if (!sid || !csrf) throw new Error("login issued no session cookie");
+    return { sid, csrf };
+  }
+
+  function get(as: Session, url: string) {
+    return app.inject({ method: "GET", url, cookies: { tf_sid: as.sid } });
+  }
+
+  /** "Invite someone" on People & access, then the invitee redeeming the link. */
+  async function inviteAndAccept(as: Session, email: string): Promise<string> {
+    const created = await app.inject({
+      method: "POST",
+      url: "/api/v1/users",
+      cookies: { tf_sid: as.sid, [CSRF_COOKIE]: as.csrf },
+      headers: { [CSRF_HEADER]: as.csrf },
+      payload: { email },
+    });
+    expect(created.statusCode).toBe(201);
+
+    const accepted = await app.inject({
+      method: "POST",
+      url: "/api/v1/auth/invites/accept",
+      payload: { token: created.json().invite.token, password: PASSWORD },
+    });
+    expect(accepted.statusCode).toBe(200);
+    return created.json().user.id;
+  }
+
+  /** The request the "Give more access" form makes. */
+  function giveOwner(as: Session, principalId: string) {
+    return app.inject({
+      method: "POST",
+      url: "/api/v1/authz/roles/owner/assignments",
+      cookies: { tf_sid: as.sid, [CSRF_COOKIE]: as.csrf },
+      headers: { [CSRF_HEADER]: as.csrf },
+      payload: { principalId },
+    });
+  }
+
+  beforeEach(async () => {
+    db = await makeMigratedPglite();
+    const transactions = transactionPort(db);
+    await syncDeploymentRoles(new PgRoleRepo(transactions));
+
+    const users = new PgUserRepo(db);
+    await createUser(users, "admin@example.com", PASSWORD, "admin");
+
+    const resolver = buildApiAuthorityLayerResolver(db);
+    decide = makeAuthorizationCheck(new LiveRouteAuthorizer(resolver), { mode: "enforcing" });
+    app = await buildApp({
+      sessionStore: new MemorySessionStore(),
+      userRepo: users,
+      userAdminRepo: users,
+      passwordWriteRepo: users,
+      tokenRepo: new PgTokenRepo(db),
+      userInviteRepo: new PgUserInviteRepo(db),
+      routeAuthorizer: new LiveRouteAuthorizer(resolver),
+      authorizationGate: { mode: "enforcing" },
+      authzAdmin: new AuthzAdminService({
+        roles: new PgRoleRepo(transactions),
+        groups: new PgGroupRepo(transactions),
+        principals: new PgPrincipalRepo(transactions),
+        resolver,
+        businessId: DEPLOYMENT_BUSINESS_ID,
+      }),
+    });
+
+    const admin = await login("admin@example.com");
+    inviteeId = await inviteAndAccept(admin, "invitee@example.com");
+    bystanderId = await inviteAndAccept(admin, "bystander@example.com");
+    expect((await giveOwner(admin, inviteeId)).statusCode).toBe(200);
+  });
+
+  afterEach(async () => {
+    await app.close();
+    await db.close();
+  });
+
+  it("serves every read the page's loader fans out over", async () => {
+    const owner = await login("invitee@example.com");
+
+    const results = await Promise.all(
+      pageReads(bystanderId).map(async (url) => `${url} -> ${(await get(owner, url)).statusCode}`)
+    );
+
+    expect(results).toEqual(pageReads(bystanderId).map((url) => `${url} -> 200`));
+  });
+
+  it("tells the grantee's own session that they are an admin of the business", async () => {
+    const res = await get(await login("invitee@example.com"), "/api/v1/auth/session");
+
+    expect(res.json().user).toMatchObject({ role: "member", isAdmin: true });
+  });
+
+  it("admits the grantee on the session they already held when it was given", async () => {
+    const before = await login("bystander@example.com");
+    expect((await get(before, "/api/v1/auth/session")).json().user.isAdmin).toBe(false);
+
+    expect((await giveOwner(await login("admin@example.com"), bystanderId)).statusCode).toBe(200);
+
+    const after = await get(before, "/api/v1/auth/session");
+    expect(after.json().user).toMatchObject({ isAdmin: true });
+    expect((await get(before, `/api/v1/authz/principals/${inviteeId}/grants`)).statusCode).toBe(
+      200
+    );
+  });
+
+  it("lets an Owner pass the access on, which is the level's own definition", async () => {
+    const res = await giveOwner(await login("invitee@example.com"), bystanderId);
+
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("confers every admin-only action, which is what the level's own copy promises", async () => {
+    const owner = {
+      id: inviteeId,
+      kind: "user",
+      businessId: DEPLOYMENT_BUSINESS_ID,
+      credential: "session",
+      authMethods: ["password"],
+      authenticatedAt: new Date(),
+      role: "member",
+    } as const;
+
+    const refused: string[] = [];
+    for (const request of ADMIN_ONLY_ACTIONS) {
+      if (!(await decide(owner, request)))
+        refused.push(`${request.resourceType}:${request.action}`);
+    }
+
+    expect(refused).toEqual([]);
+  });
+
+  it("leaves everyday access refused across the same reads", async () => {
+    const bystander = await login("bystander@example.com");
+
+    const results = await Promise.all(
+      pageReads(inviteeId).map(async (url) => `${url} -> ${(await get(bystander, url)).statusCode}`)
+    );
+
+    expect(results).toEqual(pageReads(inviteeId).map((url) => `${url} -> 403`));
+  });
+});

--- a/apps/api/src/identity/role-catalog-fitness.test.ts
+++ b/apps/api/src/identity/role-catalog-fitness.test.ts
@@ -220,6 +220,41 @@ describe("role catalog fitness", () => {
     ).toEqual([]);
   });
 
+  it("catalogs every action a narrowed member surface could reach", () => {
+    const adminByType = new Map(ADMIN_ONLY_SURFACES.map((s) => [s.type, s.actions]));
+    const allTypes = [
+      ...new Set([...adminByType.keys(), ...MEMBER_ALLOWED_SURFACES.map((s) => s.type)]),
+    ];
+    const narrowed = MEMBER_ALLOWED_SURFACES.filter(
+      (surface) => adminByType.has(surface.type) && !surface.actions.includes("*")
+    );
+    const declared = sourceFiles()
+      .flatMap((path) => [
+        ...readFileSync(resolveCitation(path), "utf8").matchAll(/action: "([a-z0-9_.]+)"/g),
+      ])
+      .map((match) => match[1])
+      .filter((action): action is string => action !== undefined);
+
+    // A dotted action belongs to the longest type that prefixes it, so `integration.github.*`
+    // is never mistaken for an uncatalogued action of the shorter `integration` surface.
+    const ownerType = (action: string): string | undefined =>
+      allTypes
+        .filter((type) => action.startsWith(`${type}.`))
+        .sort((a, b) => b.length - a.length)[0];
+
+    const uncatalogued = narrowed.flatMap((surface) => {
+      const known = new Set([...surface.actions, ...(adminByType.get(surface.type) ?? [])]);
+      return declared.filter((action) => ownerType(action) === surface.type && !known.has(action));
+    });
+
+    expect(
+      [...new Set(uncatalogued)].sort(),
+      "A member surface named action by action stops being an allow-list the moment a new action " +
+        "on that type ships uncatalogued: the member silently loses it. Add it to " +
+        "MEMBER_ALLOWED_SURFACES, or to ADMIN_ONLY_SURFACES if it is operator-only."
+    ).toEqual([]);
+  });
+
   it("grants a member every action the member catalog names", () => {
     const member = DEPLOYMENT_ROLES.find((role) => role.id === "member");
     if (!member) throw new Error("member role missing from the deployment catalog");

--- a/apps/api/src/identity/roles.ts
+++ b/apps/api/src/identity/roles.ts
@@ -3,8 +3,11 @@ import {
   assertRoleGraphAcyclic,
   collectRoleGrants,
   type Role,
+  restrictedSurfaceCarveOut,
+  surfaceGrants,
 } from "@tulipfarm/authz";
 import { DEPLOYMENT_BUSINESS_ID } from "@tulipfarm/constants";
+import { GITHUB_TOOL_IDS } from "@tulipfarm/integrations";
 import type { GrantRecord, RoleRecord, RoleRepo } from "@tulipfarm/storage";
 
 /** Mirrors live role gates; update this catalog whenever route or Tool gates change. */
@@ -170,9 +173,21 @@ export const MEMBER_ALLOWED_SURFACES: readonly {
   { type: "soul.agent", actions: ["*"], enforcedIn: "soul/agents/routes.ts; soul/agents/tools.ts" },
   { type: "soul.guardrails", actions: ["*"], enforcedIn: "platform/guardrail-tool.ts" },
   { type: "soul.repo", actions: ["*"], enforcedIn: "platform/tools.ts" },
+  /**
+   * Named action by action rather than `*` for the same reason as `integration.github`: a same-type
+   * wildcard forces a deny for each admin-only action, which no granted Role can then lift (#408).
+   */
   {
     type: "soul.resource_type",
-    actions: ["*"],
+    actions: [
+      "soul.resource_type.create",
+      "soul.resource_type.list",
+      "soul.resource_type.read",
+      "soul.resource_type.update",
+      "soul.resource_type.hooks.read",
+      "soul.resource_type.hooks.update",
+      "soul.resource_type.hooks.delete",
+    ],
     enforcedIn: "soul/resource-types/routes.ts; soul/resource-types/tools.ts",
   },
   { type: "soul.routine", actions: ["*"], enforcedIn: "platform/tools.ts" },
@@ -190,8 +205,20 @@ export const MEMBER_ALLOWED_SURFACES: readonly {
   { type: "platform.state", actions: ["*"], enforcedIn: "platform/tools.ts" },
   { type: "platform.task", actions: ["*"], enforcedIn: "platform/tools.ts" },
   { type: "platform.time", actions: ["*"], enforcedIn: "platform/tools.ts" },
-  /** Provider grants expose the surface only; provider ACLs still decide account access. */
-  { type: "integration.github", actions: ["*"], enforcedIn: "tools/github/tools.ts" },
+  /**
+   * Provider grants expose the surface only; provider ACLs still decide account access. Named
+   * action by action rather than `*`: a same-type wildcard forces a compensating deny for each
+   * admin-only action, and that deny then outranks any Role granted on top of `member` (#408).
+   */
+  {
+    type: "integration.github",
+    actions: [
+      ...Object.values(GITHUB_TOOL_IDS),
+      "github.repository.list",
+      "integration.github.read",
+    ],
+    enforcedIn: "tools/github/tools.ts",
+  },
   { type: "integration.slack", actions: ["*"], enforcedIn: "tools/slack/tools.ts" },
   /** Explicit vocabulary counterpart; authority already comes from the wildcard grant. */
   {
@@ -220,41 +247,6 @@ export const OWNER_SCOPED_SURFACES: readonly {
     enforcedIn: "integrations/auth-routes.ts",
   },
 ];
-
-function surfaceGrants(
-  surfaces: readonly { readonly type: string; readonly actions: readonly string[] }[],
-  effect: AccessGrant["effect"]
-): AccessGrant[] {
-  return surfaces.flatMap((surface) =>
-    surface.actions.map((action): AccessGrant => ({ action, resourceType: surface.type, effect }))
-  );
-}
-
-/**
- * The admin-only carve-out of the allows `member` holds broadly.
- *
- * A blanket `deny` on every admin-only action reads safer than it is: a Role's grants all land in
- * one authority layer and deny beats allow there, so a member carrying those denies could never be
- * lifted by *any* Role granted on top — `Owner` included, which is the only promotion the product
- * offers (#408). An admin-only action is already unreachable to a member by default deny, so the
- * only denies worth keeping are the ones compensating for a member allow that would otherwise
- * reach the action: the residual `resourceType: "*"` record grant (a business may name a Resource
- * type after an admin-only one) and any same-type wildcard in `MEMBER_ALLOWED_SURFACES`.
- */
-function adminOnlyCarveOut(): AccessGrant[] {
-  return ADMIN_ONLY_SURFACES.flatMap((surface) => {
-    const memberActions = MEMBER_ALLOWED_SURFACES.filter(
-      (allowed) => allowed.type === surface.type
-    ).flatMap((allowed) => allowed.actions);
-    const denied = new Set<string>(MEMBER_UNDOMAINED_RECORD_ACTIONS);
-    for (const action of surface.actions) {
-      if (memberActions.includes("*") || memberActions.includes(action)) denied.add(action);
-    }
-    return [...denied].map(
-      (action): AccessGrant => ({ action, resourceType: surface.type, effect: "deny" })
-    );
-  });
-}
 
 /**
  * Unrestricted authority, spelled for both request shapes: a grant with no domain covers only
@@ -298,7 +290,11 @@ export const DEPLOYMENT_ROLES: readonly Role[] = [
       ...MEMBER_UNDOMAINED_RECORD_ACTIONS.map(
         (action): AccessGrant => ({ action, resourceType: "*", effect: "allow" })
       ),
-      ...adminOnlyCarveOut(),
+      ...restrictedSurfaceCarveOut(
+        ADMIN_ONLY_SURFACES,
+        MEMBER_ALLOWED_SURFACES,
+        MEMBER_UNDOMAINED_RECORD_ACTIONS
+      ),
       ...OWNER_SCOPED_SURFACES.map(
         (surface): AccessGrant => ({
           action: "*",

--- a/packages/authz/src/index.ts
+++ b/packages/authz/src/index.ts
@@ -103,3 +103,5 @@ export {
   RoleResolutionError,
 } from "./roles";
 export { compileRoutineAuthority } from "./routine-authority";
+export type { RoleSurface } from "./surface-catalog";
+export { restrictedSurfaceCarveOut, surfaceGrants } from "./surface-catalog";

--- a/packages/authz/src/surface-catalog.test.ts
+++ b/packages/authz/src/surface-catalog.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { restrictedSurfaceCarveOut, surfaceGrants } from "./surface-catalog";
+
+describe("surfaceGrants", () => {
+  it("emits one grant per named action", () => {
+    expect(surfaceGrants([{ type: "secret", actions: ["secret.read", "*"] }], "allow")).toEqual([
+      { action: "secret.read", resourceType: "secret", effect: "allow" },
+      { action: "*", resourceType: "secret", effect: "allow" },
+    ]);
+  });
+});
+
+describe("restrictedSurfaceCarveOut", () => {
+  const restricted = [{ type: "secret", actions: ["secret.write"] }];
+
+  it("denies a restricted action a same-type wildcard would otherwise reach", () => {
+    expect(restrictedSurfaceCarveOut(restricted, [{ type: "secret", actions: ["*"] }])).toEqual([
+      { action: "secret.write", resourceType: "secret", effect: "deny" },
+    ]);
+  });
+
+  it("denies a restricted action named outright by the allow-list", () => {
+    const allowed = [{ type: "secret", actions: ["secret.read", "secret.write"] }];
+    expect(restrictedSurfaceCarveOut(restricted, allowed)).toEqual([
+      { action: "secret.write", resourceType: "secret", effect: "deny" },
+    ]);
+  });
+
+  it("emits nothing when the allow-list cannot reach the restricted action", () => {
+    expect(
+      restrictedSurfaceCarveOut(restricted, [{ type: "secret", actions: ["secret.read"] }])
+    ).toEqual([]);
+  });
+
+  it("always denies the caller's residual actions, whatever the allow-list names", () => {
+    expect(restrictedSurfaceCarveOut(restricted, [], ["record.read"])).toEqual([
+      { action: "record.read", resourceType: "secret", effect: "deny" },
+    ]);
+  });
+});

--- a/packages/authz/src/surface-catalog.ts
+++ b/packages/authz/src/surface-catalog.ts
@@ -1,0 +1,46 @@
+import type { AccessGrant } from "./grants";
+
+/** One resource type and the actions on it a catalog entry speaks for. */
+export interface RoleSurface {
+  readonly type: string;
+  readonly actions: readonly string[];
+}
+
+/** Compiles a surface catalog into grants of one effect, one grant per named action. */
+export function surfaceGrants(
+  surfaces: readonly RoleSurface[],
+  effect: AccessGrant["effect"]
+): AccessGrant[] {
+  return surfaces.flatMap((surface) =>
+    surface.actions.map((action): AccessGrant => ({ action, resourceType: surface.type, effect }))
+  );
+}
+
+/**
+ * The denies an allow-listed role needs so its own broad allows cannot reach a restricted action.
+ *
+ * A blanket `deny` on every restricted action reads safer than it is: a Role's grants all land in
+ * one authority layer and deny beats allow there, so a role carrying those denies could never be
+ * lifted by *any* Role granted on top of it (#408). A restricted action is already unreachable by
+ * default deny, so the only denies worth keeping are the ones compensating for an allow that would
+ * otherwise reach it — a same-type wildcard, an exact same-action allow, or `alwaysDenied`, which
+ * covers a residual `resourceType: "*"` allow the caller holds outside this catalog.
+ */
+export function restrictedSurfaceCarveOut(
+  restricted: readonly RoleSurface[],
+  allowed: readonly RoleSurface[],
+  alwaysDenied: readonly string[] = []
+): AccessGrant[] {
+  return restricted.flatMap((surface) => {
+    const allowedActions = allowed
+      .filter((entry) => entry.type === surface.type)
+      .flatMap((entry) => entry.actions);
+    const denied = new Set<string>(alwaysDenied);
+    for (const action of surface.actions) {
+      if (allowedActions.includes("*") || allowedActions.includes(action)) denied.add(action);
+    }
+    return [...denied].map(
+      (action): AccessGrant => ({ action, resourceType: surface.type, effect: "deny" })
+    );
+  });
+}


### PR DESCRIPTION
The `member` role held `["*"]` on `integration.github` and `soul.resource_type`, the only two resource types it shares with `ADMIN_ONLY_SURFACES`. A same-type wildcard forces a compensating deny for each admin-only action on that type, and every Role a principal holds lands in one authority layer where deny beats allow. So the deny a promoted member still carried outranked the unrestricted allow of the `Owner` granted on top, and five admin-only actions stayed refused: the three `integration.github` install actions and the two `soul.resource_type` domain actions. The grant wrote, read back and rendered its badge while conferring nothing on those surfaces (#408).

Name those two member surfaces action by action instead. With no same-type wildcard there is nothing to compensate for, the denies are never generated, and a granted Role is free to confer the authority it promises. This is data, not engine: deny still overrides allow, "everything except X" is still authorable, and the outcome cannot depend on the order roles resolve in.

The GitHub list is spread from `GITHUB_TOOL_IDS` so a new Tool cannot silently drop out of member reach, and a new catalog fitness test fails on any action declared on a narrowed surface that neither catalog names.

`surfaceGrants` and the carve-out compiler move to `@tulipfarm/authz`, which owns authority vocabulary and keeps the api line budget negative.

The reported "sign out and back in" step is not a factor: `SessionRecord` carries no role or claim and `sessionUser` recomputes `isAdmin` through the gate per request, so a session held across the grant sees it too. The web has no second admin predicate; it renders whatever the API decided. Both are pinned by tests here.

## Summary

<!-- What changed, and why. Link the driving issue if one exists. -->

## Test plan

<!-- Commands you ran, or manual steps / screenshots for UI changes. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (or the scoped `--filter` you actually ran)

## Checklist

- [ ] PR title follows Conventional Commits (`type(scope): subject`) — CI checks this
- [ ] Scoped to one logical change
- [ ] Tests added/updated for the behavior that changed
