### PR TITLE
fix(curator): retire a job whose Run was parked for reconciliation

### DIFF
--- a/packages/curator-host/AGENTS.md
+++ b/packages/curator-host/AGENTS.md
@@ -34,5 +34,6 @@ Prompts, output schemas and citation rules (`packages/curator`), SQL and table s
   moved, the job is retired (`context_drifted`); output validated against inputs it never saw
   proves nothing. Drift is judged **per section** at submit, so one moved section does not discard
   the rest of the answer.
-- Age alone never kills a job. Only a job with no Run, or one whose Run the kernel calls terminal,
-  is touched.
+- Age alone never kills a job. Only a job with no Run, or one whose Run can no longer make
+  progress — terminal, or parked in `needs_reconciliation`, which nothing requeues — is touched.
+  Retiring one closes its Run too, so no Run outlives the work it describes.

--- a/packages/curator-host/src/mint.pg.test.ts
+++ b/packages/curator-host/src/mint.pg.test.ts
@@ -8,6 +8,7 @@ import {
   CuratorMintStore,
   CuratorRepo,
   type Queryable,
+  RUN_STORAGE_STATEMENTS,
   recordCuratorWork,
   TASK_STORAGE_STATEMENTS,
 } from "@tulipfarm/storage";
@@ -85,6 +86,7 @@ describe("CuratorMinter", () => {
     pool = database as unknown as Queryable;
     for (const statement of [
       ...TASK_STORAGE_STATEMENTS,
+      ...RUN_STORAGE_STATEMENTS,
       ...CURATOR_WORK_STORAGE_STATEMENTS,
       ...CURATOR_STORAGE_STATEMENTS,
       ...CURATOR_ADMISSION_STATEMENTS,

--- a/packages/curator-host/src/recovery.ts
+++ b/packages/curator-host/src/recovery.ts
@@ -29,7 +29,7 @@ export interface CuratorRecoveryDeps {
  * between committing its job and starting its Run leaves a job holding the target forever, so that
  * user is silently retired from the loop and the work they already produced is stranded `claimed`
  * behind it. Nothing here decides a job is dead from age alone — a Run that is merely slow is still
- * a Run — so only a job with *no* Run, or one whose Run the kernel says is terminal, is touched.
+ * a Run — so only a job with *no* Run, or one whose Run can no longer make progress, is touched.
  */
 export class CuratorRecovery {
   constructor(private readonly deps: CuratorRecoveryDeps) {}

--- a/packages/curator-host/src/stuck-run.pg.test.ts
+++ b/packages/curator-host/src/stuck-run.pg.test.ts
@@ -1,0 +1,196 @@
+import { PGlite } from "@electric-sql/pglite";
+import {
+  ArtifactService,
+  DurableInvocationGateway,
+  INVOCATION_STORAGE_STATEMENTS,
+  PgDurableInvocationStore,
+  RunLeaseManager,
+  TypedOutputValidator,
+} from "@tulipfarm/run-kernel";
+import { INVOCATION_REQUEST_SCHEMAS } from "@tulipfarm/schema";
+import {
+  ARTIFACT_STORAGE_STATEMENTS,
+  ArtifactStore,
+  ambientTransactionPort,
+  CURATOR_ADMISSION_STATEMENTS,
+  CURATOR_STORAGE_STATEMENTS,
+  CURATOR_WORK_STORAGE_STATEMENTS,
+  CuratorAdmissionLedger,
+  CuratorMintStore,
+  CuratorRepo,
+  type Queryable,
+  RUN_STORAGE_STATEMENTS,
+  RunStore,
+  recordCuratorWork,
+  TASK_STORAGE_STATEMENTS,
+  transactionPort,
+} from "@tulipfarm/storage";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CuratorMinter } from "./mint";
+import { CuratorRecovery } from "./recovery";
+
+const BUSINESS = "business-1";
+const USER = "user-1";
+const OWNER = "worker-1";
+const MINTED_AT = new Date("2026-08-19T01:00:48.000Z");
+const SWEPT_AT = new Date("2026-08-19T01:10:48.000Z");
+const LIMITS = {
+  workLimit: 50,
+  candidateLimit: 50,
+  runCostMicros: 50_000,
+  dailyCapMicros: 5_000_000,
+};
+
+const validator = new TypedOutputValidator(INVOCATION_REQUEST_SCHEMAS);
+
+describe("a Curator Run parked for reconciliation", () => {
+  let database: PGlite;
+  let pool: Queryable;
+  let repo: CuratorRepo;
+  let minter: CuratorMinter;
+  let recovery: CuratorRecovery;
+  let runs: RunStore;
+
+  beforeEach(async () => {
+    database = new PGlite();
+    pool = database as unknown as Queryable;
+    for (const statement of [
+      ...TASK_STORAGE_STATEMENTS,
+      ...RUN_STORAGE_STATEMENTS,
+      ...ARTIFACT_STORAGE_STATEMENTS,
+      ...INVOCATION_STORAGE_STATEMENTS,
+      ...CURATOR_STORAGE_STATEMENTS,
+      ...CURATOR_WORK_STORAGE_STATEMENTS,
+      ...CURATOR_ADMISSION_STATEMENTS,
+    ])
+      await database.exec(statement);
+
+    repo = new CuratorRepo(pool);
+    runs = new RunStore(transactionPort(pool));
+    const invocations = new DurableInvocationGateway({
+      store: new PgDurableInvocationStore(
+        transactionPort(pool),
+        (transaction) =>
+          new ArtifactService(new ArtifactStore(ambientTransactionPort(transaction)), validator)
+      ),
+      validator,
+    });
+    minter = new CuratorMinter({
+      store: new CuratorMintStore(pool, repo, new CuratorAdmissionLedger(pool), LIMITS),
+      repo,
+      pool,
+      invocations,
+      providerAvailable: async () => true,
+      soulDigest: () => "a".repeat(64),
+      now: () => MINTED_AT,
+    });
+    recovery = new CuratorRecovery({ repo, minter, now: () => SWEPT_AT });
+  });
+
+  afterEach(async () => await database.close());
+
+  const mint = async (): Promise<{ jobId: string; runId: string }> => {
+    await recordCuratorWork(
+      pool,
+      { businessId: BUSINESS, userId: USER, reason: "turn_completed", sourceKey: "turn-1" },
+      MINTED_AT
+    );
+    const minted = await minter.mintForUser(BUSINESS, USER);
+    if (minted.outcome !== "minted") throw new Error(`mint refused: ${minted.reason}`);
+    return { jobId: minted.jobId, runId: minted.runId };
+  };
+
+  /**
+   * Exactly what `RunDispatcher` does when an executor throws: claim, start, then release the Run
+   * to `needs_reconciliation`. The Curator executor never touches its own State, so the State the
+   * gateway created stays `pending` with no attempts — which is what the Run inspector renders.
+   */
+  const parkForReconciliation = async (runId: string): Promise<void> => {
+    const leases = new RunLeaseManager(runs);
+    const claimed = await leases.claimBatch({
+      businessId: BUSINESS,
+      owner: OWNER,
+      now: MINTED_AT,
+      leaseDurationMs: 60_000,
+      limit: 10,
+    });
+    const run = claimed.find((candidate) => candidate.id === runId);
+    if (!run) throw new Error("dispatcher claimed nothing");
+    const started = await leases.claim({
+      businessId: BUSINESS,
+      runId,
+      owner: OWNER,
+      now: MINTED_AT,
+      leaseDurationMs: 60_000,
+      expectedVersion: run.version,
+      expectedStatus: "claimed",
+      status: "running",
+    });
+    if (!started.run) throw new Error("dispatcher could not start the Run");
+    await leases.release({
+      businessId: BUSINESS,
+      runId,
+      expectedVersion: started.run.version,
+      expectedStatus: "running",
+      status: "needs_reconciliation",
+    });
+  };
+
+  const workStatuses = async (): Promise<string[]> =>
+    (
+      await pool.query<{ status: string }>(
+        "SELECT status FROM curator_user_work ORDER BY source_key"
+      )
+    ).rows.map((row) => row.status);
+
+  it("reproduces the reported shape: parked Run, pending State, zero attempts", async () => {
+    const { runId } = await mint();
+    await parkForReconciliation(runId);
+
+    expect((await runs.find(BUSINESS, runId))?.status).toBe("needs_reconciliation");
+    const states = await runs.listStates(BUSINESS, runId);
+    expect(states.map((state) => [state.key, state.status])).toEqual([["invoke", "pending"]]);
+    const attempts = await pool.query<{ count: number }>(
+      "SELECT count(*)::int AS count FROM state_attempts WHERE run_id = $1",
+      [runId]
+    );
+    expect(attempts.rows[0]?.count).toBe(0);
+  });
+
+  it("frees the target of a job whose Run was parked, so the loop can mint again", async () => {
+    const { runId } = await mint();
+    await parkForReconciliation(runId);
+
+    expect(await recovery.run(BUSINESS)).toEqual({ recovered: 0, abandoned: 1 });
+    expect(await workStatuses()).toEqual(["due"]);
+    await expect(minter.mintForUser(BUSINESS, USER)).resolves.toMatchObject({ outcome: "minted" });
+  });
+
+  it("terminalizes the parked Run it gave up on, so no Run is left unresolvable", async () => {
+    const { runId } = await mint();
+    await parkForReconciliation(runId);
+
+    await recovery.run(BUSINESS);
+
+    expect((await runs.find(BUSINESS, runId))?.status).toBe("failed");
+  });
+
+  it("leaves a Run that is merely slow alone", async () => {
+    const { jobId, runId } = await mint();
+    expect(await recovery.run(BUSINESS)).toEqual({ recovered: 0, abandoned: 0 });
+    expect((await runs.find(BUSINESS, runId))?.status).toBe("queued");
+    expect((await repo.getJob(BUSINESS, jobId))?.state).toBe("minted");
+  });
+
+  it("never claws back a job that already answered", async () => {
+    const { jobId, runId } = await mint();
+    await parkForReconciliation(runId);
+    await pool.query("UPDATE curator_job SET output_digest = 'settled' WHERE id = $1", [jobId]);
+
+    expect(await recovery.run(BUSINESS)).toEqual({ recovered: 0, abandoned: 1 });
+    expect((await repo.getJob(BUSINESS, jobId))?.state).toBe("minted");
+    expect(await workStatuses()).toEqual(["claimed"]);
+    // An answer may have landed, so the Run stays parked rather than being called failed.
+    expect((await runs.find(BUSINESS, runId))?.status).toBe("needs_reconciliation");
+  });
+});

--- a/packages/storage/src/curator/reconcile.pg.test.ts
+++ b/packages/storage/src/curator/reconcile.pg.test.ts
@@ -48,6 +48,10 @@ describe("Curator reconciliation (PostgreSQL)", () => {
     return rows[0]?.id ?? "";
   };
 
+  const runStatus = async (runId: string): Promise<string | undefined> =>
+    (await database.query<{ status: string }>(`SELECT status FROM runs WHERE id = $1`, [runId]))
+      .rows[0]?.status;
+
   beforeAll(async () => {
     database = new PGlite();
     for (const sql of [
@@ -98,6 +102,14 @@ describe("Curator reconciliation (PostgreSQL)", () => {
     it("reports a job whose Run reached a terminal state as abandoned", async () => {
       const jobId = await mint();
       await repo.attachRun(jobId, await run("failed"));
+      const stale = await repo.listStale(BUSINESS, NOW, 10);
+      expect(stale.map((entry) => entry.disposition)).toEqual(["abandoned"]);
+      expect(stale[0]?.job.id).toBe(jobId);
+    });
+
+    it("reports a job whose Run was parked for reconciliation as abandoned", async () => {
+      const jobId = await mint();
+      await repo.attachRun(jobId, await run("needs_reconciliation"));
       const stale = await repo.listStale(BUSINESS, NOW, 10);
       expect(stale.map((entry) => entry.disposition)).toEqual(["abandoned"]);
       expect(stale[0]?.job.id).toBe(jobId);
@@ -160,6 +172,26 @@ describe("Curator reconciliation (PostgreSQL)", () => {
       const jobId = await mint();
       expect(await abandonCuratorJob(db, jobId)).toBe(true);
       expect(await abandonCuratorJob(db, jobId)).toBe(false);
+    });
+
+    it("closes the parked Run it gave up on", async () => {
+      const jobId = await mint();
+      const runId = await run("needs_reconciliation");
+      await repo.attachRun(jobId, runId);
+
+      expect(await abandonCuratorJob(db, jobId)).toBe(true);
+
+      expect(await runStatus(runId)).toBe("failed");
+    });
+
+    it("leaves a Run the kernel already settled exactly as it found it", async () => {
+      const jobId = await mint();
+      const runId = await run("succeeded");
+      await repo.attachRun(jobId, runId);
+
+      expect(await abandonCuratorJob(db, jobId)).toBe(true);
+
+      expect(await runStatus(runId)).toBe("succeeded");
     });
   });
 });

--- a/packages/storage/src/curator/reconcile.ts
+++ b/packages/storage/src/curator/reconcile.ts
@@ -5,9 +5,9 @@ import { releaseCuratorWork } from "./work";
 
 /**
  * Retires a job that will never reason, in one transaction: terminal state, work back to `due`,
- * reservation released.
+ * reservation released, and the Run that was doing it terminalized.
  *
- * All three or none. Releasing the work without terminalizing the job leaves the live-target unique
+ * All four or none. Releasing the work without terminalizing the job leaves the live-target unique
  * index holding the target forever, so the next mint is refused and the work it just freed can
  * never be claimed by anyone — the exact deadlock the index exists to prevent.
  */
@@ -19,15 +19,37 @@ export async function abandonCuratorJob(
   return withTransaction(db, async (tx) => {
     // Only a job that never settled: one that already recorded effects has answered, and replaying
     // its work would ask the model the same question twice.
-    const { rows } = await tx.query<{ id: string }>(
+    const { rows } = await tx.query<{ id: string; run_id: string | null }>(
       `UPDATE curator_job SET state = $2, updated_at = now()
         WHERE id = $1 AND state IN ('minted', 'running') AND output_digest IS NULL
-        RETURNING id`,
+        RETURNING id, run_id`,
       [jobId, state]
     );
-    if (rows.length === 0) return false;
+    const abandoned = rows[0];
+    if (!abandoned) return false;
     await releaseCuratorWork(tx, jobId);
     await settleCuratorReservation(tx, jobId, 0);
+    if (abandoned.run_id) await failParkedRun(tx, abandoned.run_id);
     return true;
   });
+}
+
+/**
+ * Closes the Run of a job the reconciler just gave up on.
+ *
+ * Guarded to the single `needs_reconciliation -> failed` move the kernel already allows, so this
+ * can neither race a live Run nor invent a transition. Without it the operator is left a Run that
+ * no sweep will ever drive again, describing work nobody is still doing.
+ */
+async function failParkedRun(tx: Queryable, runId: string): Promise<void> {
+  await tx.query(
+    `UPDATE runs
+        SET status = 'failed',
+            version = version + 1,
+            finished_at = COALESCE(finished_at, now()),
+            lease_owner = NULL,
+            lease_expires_at = NULL
+      WHERE id::text = $1 AND status = 'needs_reconciliation'`,
+    [runId]
+  );
 }

--- a/packages/storage/src/curator/repo.ts
+++ b/packages/storage/src/curator/repo.ts
@@ -194,8 +194,13 @@ export class CuratorRepo {
    * This exists because the live-target unique index is otherwise a trap: a job stuck in `minted`
    * holds its target forever, so one crash silently retires that user from the loop. Age alone
    * never decides — a Run that is merely slow is still a Run — so `unstartedBefore` must be
-   * comfortably longer than a mint's own gateway call, and a bound Run is judged only by the
-   * kernel's own terminal statuses.
+   * comfortably longer than a mint's own gateway call.
+   *
+   * `needs_reconciliation` counts as dead here even though the kernel allows a Run to leave it:
+   * dispatch parks a Run there when its executor throws, nothing requeues a parked Run, and a
+   * Curator Run's State never enters reconciliation, so `StateReconciler` cannot settle it either.
+   * Treating it as live is what strands the target. Freeing it costs nothing, because
+   * `abandonCuratorJob` still refuses any job that already recorded an answer.
    */
   async listStale(
     businessId: string,
@@ -214,7 +219,9 @@ export class CuratorRepo {
             (run_id IS NULL AND created_at < $2)
             OR EXISTS (SELECT 1 FROM runs
                         WHERE runs.id::text = curator_job.run_id
-                          AND runs.status IN ('succeeded', 'failed', 'cancelled'))
+                          AND runs.status IN (
+                                'succeeded', 'failed', 'cancelled', 'needs_reconciliation'
+                              ))
           )
         ORDER BY created_at
         LIMIT $3`,


### PR DESCRIPTION
A Curator Run reaches `needs_reconciliation` when `RunDispatcher` catches a throw from the Curator executor — a 4xx from the internal context route, an unresolvable model selector, a provider timeout. Nothing ever leaves that status again: `claimNextQueuedRunRows` only claims `queued`, and `StateReconciler` needs the *State* parked, while a Curator Run's `invoke` State is still `pending` because the executor deliberately drives no State machine.

`CuratorRepo.listStale` judged a bound Run dead only on `succeeded|failed|cancelled`, so it read the parked Run as live and left the job in `minted`. That job holds the target's partial unique index, so every later mint for that user was refused `target_busy` and the work it had already claimed stayed `claimed` — the user was silently and permanently retired from the loop, which is the exact trap `CuratorRecovery` exists to prevent.

The sweep now counts a parked Run as unable to make progress, and `abandonCuratorJob` closes that Run in the same transaction that frees the target, the work and the reservation, so no Run outlives the work it describes. A job that already recorded an answer is still refused, and its Run stays parked: an effect that may have landed is never guessed resolved.

The reported "0 attempts" is not evidence the Run was never dispatched — `needs_reconciliation` is only reachable from `running`. Every Curator Run shows a `pending` `invoke` State with no attempts, success or failure.

## Summary

<!-- What changed, and why. Link the driving issue if one exists. -->

## Test plan

<!-- Commands you ran, or manual steps / screenshots for UI changes. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (or the scoped `--filter` you actually ran)

## Checklist

- [ ] PR title follows Conventional Commits (`type(scope): subject`) — CI checks this
- [ ] Scoped to one logical change
- [ ] Tests added/updated for the behavior that changed
