### PR TITLE
fix(integration-worker): gate Slack self-posts and metadata subtypes

### DIFF
--- a/apps/docs/content/docs/administration/connect-slack.mdx
+++ b/apps/docs/content/docs/administration/connect-slack.mdx
@@ -65,6 +65,9 @@ signed, one-use OAuth state identifies Slack when the provider returns.
 
 - DM the bot for private chat with TulipFarm.
 - @mention the bot in a channel to start or continue a channel thread.
+- Replies inside a thread the bot already answered continue that chat without another @mention.
+- Everything else is ignored silently: unaddressed channel chatter, threads the bot never joined,
+  and message edits or deletions. Nothing is posted and no agent turn runs.
 - If the sender is not linked, TulipFarm offers a single-use channel-link flow.
 
 ## Link a Slack account

--- a/apps/integration-worker/AGENTS.md
+++ b/apps/integration-worker/AGENTS.md
@@ -31,6 +31,8 @@ reconciliation, and rate limits for channel workers.
 - This app never migrates; wait for the schema floor and fail closed like `apps/worker`.
 - Serve `/livez` and `/readyz`; drain cleanly on `SIGTERM`/`SIGINT`.
 - Slack Socket Mode ingress and delivery polling register loops through `src/channels/`.
+- Every Slack `events_api` envelope passes `channels/mention-gate.ts` before the adapter; the gate
+  is a required dispatch dependency, never an option.
 - Telegram long-poll and delivery retry should join the same loop array pattern.
 - `src/db.ts` is a deliberate local `pg` copy; apps must not import other apps.
 - Keep `src/index.ts` as the public barrel for transport scaffolds, separate from `main.ts`.

--- a/apps/integration-worker/src/channels/mention-gate.test.ts
+++ b/apps/integration-worker/src/channels/mention-gate.test.ts
@@ -15,7 +15,7 @@ function deps(overrides: Partial<MentionGateDeps> = {}): MentionGateDeps {
   };
 }
 
-function envelope(event: Record<string, unknown>): SlackEventEnvelope {
+function envelope(event: Record<string, unknown>, botUserId = "UBOT"): SlackEventEnvelope {
   return {
     token: "t",
     team_id: "T1",
@@ -23,6 +23,7 @@ function envelope(event: Record<string, unknown>): SlackEventEnvelope {
     event_id: "Ev1",
     event_time: 1720000000,
     type: "event_callback",
+    ...(botUserId === "" ? {} : { authorizations: [{ user_id: botUserId, is_bot: true }] }),
     // biome-ignore lint/suspicious/noExplicitAny: test builds a raw Slack payload shape
     event: event as any,
   };
@@ -107,6 +108,55 @@ describe("applyMentionGate", () => {
       gateDeps
     );
     expect(result).toEqual({ outcome: "drop", reason: "bot_message" });
+  });
+
+  it("drops a message sent by the bot's own user id even when Slack stamps no bot_id", async () => {
+    const result = await applyMentionGate(
+      envelope({ type: "message", channel: "D1", channel_type: "im", ts: "1.1", user: "UBOT" }),
+      deps()
+    );
+    expect(result).toEqual({ outcome: "drop", reason: "self_message" });
+  });
+
+  it("still passes a DM when the envelope carries no authorizations to identify the bot", async () => {
+    const result = await applyMentionGate(
+      envelope({ type: "message", channel: "D1", channel_type: "im", ts: "1.1", user: "U1" }, ""),
+      deps()
+    );
+    expect(result.outcome).toBe("pass");
+  });
+
+  it("drops a metadata subtype whose author lives under event.message, not event.user", async () => {
+    for (const subtype of ["message_changed", "message_deleted", "channel_join"]) {
+      const result = await applyMentionGate(
+        envelope({ type: "message", subtype, channel: "D1", channel_type: "im", ts: "1.1" }),
+        deps()
+      );
+      expect(result).toEqual({ outcome: "drop", reason: "non_chat_subtype" });
+    }
+  });
+
+  it("passes the message subtypes that still carry a human's chat text", async () => {
+    const gateDeps = deps({
+      mentionedThreads: {
+        mark: vi.fn(),
+        isMentioned: vi.fn().mockResolvedValue(true),
+      } as unknown as ChannelMentionedThreadStore,
+    });
+    for (const subtype of ["file_share", "me_message", "thread_broadcast"]) {
+      const result = await applyMentionGate(
+        envelope({
+          type: "message",
+          subtype,
+          channel: "C1",
+          ts: "1.2",
+          thread_ts: "1.1",
+          user: "U1",
+        }),
+        gateDeps
+      );
+      expect(result.outcome).toBe("pass");
+    }
   });
 
   it("drops the duplicate plain-message delivery paired with a fresh top-level app_mention", async () => {

--- a/apps/integration-worker/src/channels/mention-gate.ts
+++ b/apps/integration-worker/src/channels/mention-gate.ts
@@ -23,8 +23,38 @@ export type MentionGateResult =
   | { outcome: "pass"; envelope: SlackEventEnvelope }
   | { outcome: "drop"; reason: string };
 
+/**
+ * Slack `message` subtypes that still carry a human's chat text. Every other subtype
+ * (`message_changed`, `message_deleted`, `channel_join`, …) describes metadata about a message
+ * rather than one being sent, and reports the author under `event.message`, not `event.user` —
+ * so gating such an event on the outer fields decides on data Slack never populated.
+ */
+const CHAT_MESSAGE_SUBTYPES: ReadonlySet<string> = new Set([
+  "file_share",
+  "me_message",
+  "thread_broadcast",
+]);
+
 function requiredString(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+/**
+ * The installed bot's own Slack user id, from the envelope's `authorizations`. Absent on older
+ * or unusual deliveries; the caller then falls back to the `bot_id` check alone.
+ */
+function botUserId(envelope: SlackEventEnvelope): string | undefined {
+  const authorizations = (envelope as { authorizations?: unknown }).authorizations;
+  if (!Array.isArray(authorizations)) return undefined;
+  for (const entry of authorizations) {
+    if (entry === null || typeof entry !== "object") continue;
+    const record = entry as { user_id?: unknown; is_bot?: unknown };
+    if (record.is_bot === true) {
+      const userId = requiredString(record.user_id);
+      if (userId !== undefined) return userId;
+    }
+  }
+  return undefined;
 }
 
 /** DMs and app mentions pass; channel replies pass only in already-mentioned threads. */
@@ -40,6 +70,19 @@ export async function applyMentionGate(
 
   if (event.bot_id !== undefined || event.subtype === "bot_message") {
     return { outcome: "drop", reason: "bot_message" };
+  }
+
+  const self = botUserId(envelope);
+  if (self !== undefined && event.user === self) {
+    return { outcome: "drop", reason: "self_message" };
+  }
+
+  if (
+    event.type === "message" &&
+    typeof event.subtype === "string" &&
+    !CHAT_MESSAGE_SUBTYPES.has(event.subtype)
+  ) {
+    return { outcome: "drop", reason: "non_chat_subtype" };
   }
 
   const channelId = requiredString(event.channel);

--- a/apps/integration-worker/src/slack/dispatch.test.ts
+++ b/apps/integration-worker/src/slack/dispatch.test.ts
@@ -11,18 +11,35 @@ function adapter(result: SlackReceiveResult): SlackChannelAdapter {
   return { receive: vi.fn().mockResolvedValue(result) } as unknown as SlackChannelAdapter;
 }
 
+/** The gate is mandatory, so every events_api case needs one; `mentioned` opens the thread path. */
+function gate(mentioned = true) {
+  return {
+    businessId: "business-1",
+    provider: "slack",
+    mentionedThreads: {
+      mark: vi.fn().mockResolvedValue(undefined),
+      isMentioned: vi.fn().mockResolvedValue(mentioned),
+    } as unknown as ChannelMentionedThreadStore,
+  };
+}
+
+const DM_EVENT = {
+  type: "event_callback",
+  event: { type: "message", channel_type: "im", channel: "D1", ts: "1.1", user: "U1" },
+};
+
 describe("dispatchSlackEnvelope", () => {
   it("routes an events_api envelope to the channel adapter with an already-acked no-op ack", async () => {
     const channelAdapter = adapter({ outcome: "started", runId: "run-1" });
 
     await dispatchSlackEnvelope(
-      { envelope_id: "env-1", type: "events_api", payload: { event: {} } },
-      { businessId: "business-1", channelAdapter, log: log() }
+      { envelope_id: "env-1", type: "events_api", payload: DM_EVENT },
+      { businessId: "business-1", channelAdapter, mentionGate: gate(), log: log() }
     );
 
     expect(channelAdapter.receive).toHaveBeenCalledWith(
       "business-1",
-      { event: {} },
+      DM_EVENT,
       expect.any(Function)
     );
   });
@@ -32,8 +49,8 @@ describe("dispatchSlackEnvelope", () => {
     const logger = log();
 
     await dispatchSlackEnvelope(
-      { envelope_id: "env-1", type: "events_api", payload: {} },
-      { businessId: "business-1", channelAdapter, log: logger }
+      { envelope_id: "env-1", type: "events_api", payload: DM_EVENT },
+      { businessId: "business-1", channelAdapter, mentionGate: gate(), log: logger }
     );
 
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("external_identity_unmapped"));
@@ -47,9 +64,18 @@ describe("dispatchSlackEnvelope", () => {
       {
         envelope_id: "env-1",
         type: "events_api",
-        payload: { event: { user: "U1", channel: "C1", thread_ts: "1.1" } },
+        payload: {
+          type: "event_callback",
+          event: { type: "message", user: "U1", channel: "C1", ts: "1.2", thread_ts: "1.1" },
+        },
       },
-      { businessId: "business-1", channelAdapter, identityBindOffer, log: log() }
+      {
+        businessId: "business-1",
+        channelAdapter,
+        mentionGate: gate(),
+        identityBindOffer,
+        log: log(),
+      }
     );
 
     expect(identityBindOffer.offer).toHaveBeenCalledWith({
@@ -68,9 +94,18 @@ describe("dispatchSlackEnvelope", () => {
       {
         envelope_id: "env-1",
         type: "events_api",
-        payload: { event: { user: "U1", channel: "C1" } },
+        payload: {
+          type: "event_callback",
+          event: { type: "message", channel_type: "im", user: "U1", channel: "D1", ts: "1.1" },
+        },
       },
-      { businessId: "business-1", channelAdapter, identityBindOffer, log: log() }
+      {
+        businessId: "business-1",
+        channelAdapter,
+        mentionGate: gate(),
+        identityBindOffer,
+        log: log(),
+      }
     );
 
     expect(identityBindOffer.offer).not.toHaveBeenCalled();
@@ -84,8 +119,8 @@ describe("dispatchSlackEnvelope", () => {
 
     await expect(
       dispatchSlackEnvelope(
-        { envelope_id: "env-1", type: "events_api", payload: {} },
-        { businessId: "business-1", channelAdapter, log: logger }
+        { envelope_id: "env-1", type: "events_api", payload: DM_EVENT },
+        { businessId: "business-1", channelAdapter, mentionGate: gate(), log: logger }
       )
     ).resolves.toBeUndefined();
     expect(logger.warn).toHaveBeenCalled();
@@ -97,7 +132,7 @@ describe("dispatchSlackEnvelope", () => {
 
     await dispatchSlackEnvelope(
       { envelope_id: "env-2", type: "interactive", payload: { action: "approve" } },
-      { businessId: "business-1", channelAdapter, onInteractive, log: log() }
+      { businessId: "business-1", channelAdapter, mentionGate: gate(), onInteractive, log: log() }
     );
 
     expect(onInteractive).toHaveBeenCalledWith({ action: "approve" });
@@ -109,7 +144,7 @@ describe("dispatchSlackEnvelope", () => {
     await expect(
       dispatchSlackEnvelope(
         { envelope_id: "env-2", type: "interactive", payload: {} },
-        { businessId: "business-1", channelAdapter, log: log() }
+        { businessId: "business-1", channelAdapter, mentionGate: gate(), log: log() }
       )
     ).resolves.toBeUndefined();
   });
@@ -129,14 +164,7 @@ describe("dispatchSlackEnvelope", () => {
       {
         businessId: "business-1",
         channelAdapter,
-        mentionGate: {
-          businessId: "business-1",
-          provider: "slack",
-          mentionedThreads: {
-            mark: vi.fn(),
-            isMentioned: vi.fn().mockResolvedValue(false),
-          } as unknown as ChannelMentionedThreadStore,
-        },
+        mentionGate: gate(false),
         log: log(),
       }
     );
@@ -159,14 +187,7 @@ describe("dispatchSlackEnvelope", () => {
       {
         businessId: "business-1",
         channelAdapter,
-        mentionGate: {
-          businessId: "business-1",
-          provider: "slack",
-          mentionedThreads: {
-            mark: vi.fn().mockResolvedValue(undefined),
-            isMentioned: vi.fn(),
-          } as unknown as ChannelMentionedThreadStore,
-        },
+        mentionGate: gate(),
         log: log(),
       }
     );
@@ -183,7 +204,7 @@ describe("dispatchSlackEnvelope", () => {
 
     await dispatchSlackEnvelope(
       { envelope_id: "env-3", type: "slash_commands", payload: {} },
-      { businessId: "business-1", channelAdapter, log: log() }
+      { businessId: "business-1", channelAdapter, mentionGate: gate(), log: log() }
     );
 
     expect(channelAdapter.receive).not.toHaveBeenCalled();

--- a/apps/integration-worker/src/slack/dispatch.ts
+++ b/apps/integration-worker/src/slack/dispatch.ts
@@ -11,8 +11,8 @@ function optionalString(value: unknown): string | undefined {
 export interface SlackDispatchDeps {
   businessId: string;
   channelAdapter: SlackChannelAdapter;
-  /** Optional events_api gate; without it every subscribed DM/channel message reaches the adapter. */
-  mentionGate?: MentionGateDeps;
+  /** Required: without it every subscribed DM/channel message would reach the adapter (#508). */
+  mentionGate: MentionGateDeps;
   /** Optional bind-link offer for `external_identity_unmapped` denials. */
   identityBindOffer?: ChannelIdentityBindOfferPort;
   /** Optional Approve/Deny block-action handler; Slack interactive envelopes are already acked. */
@@ -28,12 +28,9 @@ export async function dispatchSlackEnvelope(
   if (envelope.type === "events_api") {
     try {
       const rawEvent = envelope.payload as SlackEventEnvelope;
-      let gated = rawEvent;
-      if (deps.mentionGate !== undefined) {
-        const gate = await applyMentionGate(rawEvent, deps.mentionGate);
-        if (gate.outcome === "drop") return;
-        gated = gate.envelope;
-      }
+      const gate = await applyMentionGate(rawEvent, deps.mentionGate);
+      if (gate.outcome === "drop") return;
+      const gated = gate.envelope;
       const result = await deps.channelAdapter.receive(deps.businessId, gated, async () => {
         // Already acked at the transport layer before dispatch ran.
       });

--- a/apps/integration-worker/src/slack/ingress-gating.test.ts
+++ b/apps/integration-worker/src/slack/ingress-gating.test.ts
@@ -1,0 +1,390 @@
+import {
+  type ChannelIdentityPort,
+  type ChannelInboundEvent,
+  type ChannelInboundStore,
+  type ChannelRoutingSnapshot,
+  type ChannelRoutingSource,
+  type IntegrationHttpPort,
+  type IntegrationHttpRequest,
+  SlackChannelAdapter,
+} from "@tulipfarm/integrations";
+import type { AccessGrantDefinition } from "@tulipfarm/schema";
+import type { ChannelMentionedThreadStore } from "@tulipfarm/storage";
+import { beforeEach, describe, expect, it } from "vitest";
+import { httpChannelRunStarter } from "../channels/run-starter";
+import type { InternalApiClient } from "../internal/client";
+import { dispatchSlackEnvelope } from "./dispatch";
+import { SlackSocketTransport } from "./socket-transport";
+
+const BUSINESS_ID = "business-1";
+const APP_ID = "00000000-0000-4000-8000-000000000001";
+const INTEGRATION_ID = "00000000-0000-4000-8000-000000000002";
+const AGENT_ID = "00000000-0000-4000-8000-000000000003";
+const PRINCIPAL_ID = "00000000-0000-4000-8000-000000000005";
+const BOT_USER_ID = "UBOT";
+const CHANNEL = "C-OPS";
+const DM = "D-OPS";
+
+function grant(): AccessGrantDefinition {
+  return {
+    apiVersion: "tulipfarm.ai/v1",
+    kind: "AccessGrant",
+    metadata: {
+      id: "00000000-0000-4000-8000-000000000006",
+      slug: "slack-channel-access",
+      schemaVersion: 1,
+      authoredVersion: 1,
+      lifecycle: "active",
+    },
+    spec: {
+      integrationId: INTEGRATION_ID,
+      principals: [{ kind: "user", id: PRINCIPAL_ID }],
+      actions: ["channels.message.receive"],
+      externalTargets: [{ type: "slack.channel", ids: [CHANNEL, DM] }],
+      delegable: false,
+    },
+  };
+}
+
+function snapshot(): ChannelRoutingSnapshot {
+  return {
+    apps: [
+      {
+        id: APP_ID,
+        businessId: BUSINESS_ID,
+        provider: "slack",
+        externalAppId: "A-PRIMARY",
+        credentialRefs: ["secret://slack/bot"],
+        status: "active",
+      },
+    ],
+    integrations: [
+      {
+        id: INTEGRATION_ID,
+        businessId: BUSINESS_ID,
+        appId: APP_ID,
+        externalTenantId: "T-ACME",
+        credentialRef: "secret://slack/bot",
+        status: "active",
+      },
+    ],
+    accessGrants: [grant()],
+    routes: [
+      {
+        id: "route-default",
+        businessId: BUSINESS_ID,
+        integrationId: INTEGRATION_ID,
+        agentId: AGENT_ID,
+        channelId: CHANNEL,
+        eventTypes: ["message"],
+        priority: 10,
+        status: "active",
+      },
+      {
+        id: "route-dm",
+        businessId: BUSINESS_ID,
+        integrationId: INTEGRATION_ID,
+        agentId: AGENT_ID,
+        channelId: DM,
+        eventTypes: ["message"],
+        priority: 10,
+        status: "active",
+      },
+    ],
+  };
+}
+
+/** In-memory stand-in for the `channel_mentioned_threads` table. */
+function mentionedThreadStore(seed: readonly string[] = []) {
+  const marked = new Set(seed);
+  const key = (i: { channelId: string; threadId: string }) => `${i.channelId}:${i.threadId}`;
+  return {
+    marked,
+    store: {
+      async mark(input: { channelId: string; threadId: string }) {
+        marked.add(key(input));
+      },
+      async isMentioned(input: { channelId: string; threadId: string }) {
+        return marked.has(key(input));
+      },
+    } as unknown as ChannelMentionedThreadStore,
+  };
+}
+
+interface Harness {
+  /** Every Run the API was asked to mint — one per Turn the bot decided to take. */
+  runs: { channelId: string; threadId?: string; text: string }[];
+  /** Every Slack Web API call the ingress path made, i.e. everything a human would see. */
+  slackCalls: IntegrationHttpRequest[];
+  accepted: ChannelInboundEvent[];
+  marked: Set<string>;
+  warnings: unknown[];
+  deliver(event: Record<string, unknown>): Promise<void>;
+}
+
+function harness(options: { mentionedThreads?: readonly string[] } = {}): Harness {
+  const runs: Harness["runs"] = [];
+  const slackCalls: IntegrationHttpRequest[] = [];
+  const accepted: ChannelInboundEvent[] = [];
+  const mentioned = mentionedThreadStore(options.mentionedThreads);
+
+  const inbound: ChannelInboundStore = {
+    async accept(event) {
+      accepted.push(event);
+      return { outcome: "accepted" };
+    },
+  };
+  const identities: ChannelIdentityPort = {
+    async resolve() {
+      return { kind: "user", id: PRINCIPAL_ID };
+    },
+  };
+  const routing: ChannelRoutingSource = {
+    async load() {
+      return snapshot();
+    },
+  };
+  const http: IntegrationHttpPort = {
+    async send(request) {
+      slackCalls.push(request);
+      if (request.path === "/apps.connections.open") {
+        return { status: 200, headers: {}, body: { ok: true, url: "wss://slack.test/ws" } };
+      }
+      return { status: 200, headers: {}, body: { ok: true, ts: "9.9" } };
+    },
+  };
+  const internalApi = {
+    async require(_method: string, path: string, body?: unknown) {
+      if (path === "/api/v1/internal/channels/runs") {
+        const message = (
+          body as { message: { channelId: string; threadId?: string; text: string } }
+        ).message;
+        runs.push(message);
+        return { runId: `run-${runs.length}`, outcome: "started" };
+      }
+      throw new Error(`unexpected internal call ${path}`);
+    },
+  } as unknown as InternalApiClient;
+
+  const warnings: unknown[] = [];
+  const log = {
+    info: () => {},
+    warn: (message: string, error?: unknown) => {
+      warnings.push([message, error instanceof Error ? error.message : error]);
+    },
+  };
+  const channelAdapter = new SlackChannelAdapter({
+    inbound,
+    identities,
+    routing,
+    runs: httpChannelRunStarter(internalApi, "slack", {
+      assistantStatus: { http, credential: "xoxb-test", log },
+    }),
+    now: () => "2026-01-01T00:00:00.000Z",
+  });
+
+  let onMessage: ((event: { data?: unknown }) => void) | undefined;
+  const socket = {
+    addEventListener(type: string, listener: (event: { data?: unknown }) => void) {
+      if (type === "message") onMessage = listener;
+    },
+    send() {},
+    close() {},
+  };
+
+  const transport = new SlackSocketTransport({
+    http,
+    appToken: "xapp-test",
+    openWebSocket: () => socket,
+    log,
+    onEnvelope: (envelope) =>
+      dispatchSlackEnvelope(envelope, {
+        businessId: BUSINESS_ID,
+        channelAdapter,
+        mentionGate: {
+          businessId: BUSINESS_ID,
+          provider: "slack",
+          mentionedThreads: mentioned.store,
+        },
+        log,
+      }),
+  });
+
+  let sequence = 0;
+  return {
+    runs,
+    slackCalls,
+    accepted,
+    marked: mentioned.marked,
+    warnings,
+    async deliver(event) {
+      sequence += 1;
+      await transport.connect(new AbortController().signal);
+      slackCalls.length = 0;
+      const payload = {
+        token: "t",
+        team_id: "T-ACME",
+        api_app_id: "A-PRIMARY",
+        event_id: `Ev${sequence}`,
+        event_time: 1_720_000_000 + sequence,
+        type: "event_callback",
+        authorizations: [{ user_id: BOT_USER_ID, is_bot: true }],
+        event,
+      };
+      warnings.length = 0;
+      onMessage?.({
+        data: JSON.stringify({ envelope_id: `env-${sequence}`, type: "events_api", payload }),
+      });
+      // `SlackSocketTransport` acks first and dispatches without awaiting; drain the queue.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    },
+  };
+}
+
+describe("slack ingress gating (issue #508)", () => {
+  let h: Harness;
+  beforeEach(() => {
+    h = harness();
+  });
+
+  it("1. plain channel chatter starts no Turn and posts nothing", async () => {
+    await h.deliver({
+      type: "message",
+      channel_type: "channel",
+      user: "U1",
+      channel: CHANNEL,
+      ts: "1.1",
+      text: "anyone got lunch plans",
+    });
+    expect(h.runs).toEqual([]);
+    expect(h.slackCalls).toEqual([]);
+  });
+
+  it("2a. an app_mention starts a Turn", async () => {
+    await h.deliver({
+      type: "app_mention",
+      user: "U1",
+      channel: CHANNEL,
+      ts: "2.1",
+      text: `<@${BOT_USER_ID}> summarize this`,
+    });
+    expect(h.warnings).toEqual([]);
+    expect(h.runs).toHaveLength(1);
+    expect(h.slackCalls.map((c) => c.path)).toContain("/assistant.threads.setStatus");
+  });
+
+  it("2b. the app_mention/message pair Slack sends for one @mention starts exactly one Turn", async () => {
+    // Slack delivers both events for the same @mention; the `message` copy must not double-answer.
+    const mention = {
+      user: "U1",
+      channel: CHANNEL,
+      ts: "2.2",
+      text: `hey <@${BOT_USER_ID}> can you help`,
+    };
+    await h.deliver({ ...mention, type: "app_mention" });
+    await h.deliver({ ...mention, type: "message", channel_type: "channel" });
+    expect(h.warnings).toEqual([]);
+    expect(h.runs).toHaveLength(1);
+  });
+
+  it("3. a reply in a thread the bot already answered starts a Turn", async () => {
+    const seeded = harness({ mentionedThreads: [`${CHANNEL}:3.0`] });
+    await seeded.deliver({
+      type: "message",
+      channel_type: "channel",
+      user: "U1",
+      channel: CHANNEL,
+      ts: "3.1",
+      thread_ts: "3.0",
+      text: "and the second one?",
+    });
+    expect(seeded.warnings).toEqual([]);
+    expect(seeded.runs).toHaveLength(1);
+  });
+
+  it("4. a reply in a thread the bot never joined starts no Turn", async () => {
+    await h.deliver({
+      type: "message",
+      channel_type: "channel",
+      user: "U1",
+      channel: CHANNEL,
+      ts: "4.1",
+      thread_ts: "4.0",
+      text: "unrelated thread chatter",
+    });
+    expect(h.runs).toEqual([]);
+    expect(h.slackCalls).toEqual([]);
+  });
+
+  it("5. a direct message starts a Turn", async () => {
+    await h.deliver({
+      type: "message",
+      channel_type: "im",
+      user: "U1",
+      channel: DM,
+      ts: "5.1",
+      text: "hello there",
+    });
+    expect(h.warnings).toEqual([]);
+    expect(h.runs).toHaveLength(1);
+  });
+
+  it("6a. the bot's own posted message starts no Turn", async () => {
+    await h.deliver({
+      type: "message",
+      channel_type: "im",
+      bot_id: "B123",
+      user: BOT_USER_ID,
+      channel: DM,
+      ts: "6.1",
+      text: "here is your answer",
+    });
+    expect(h.runs).toEqual([]);
+    expect(h.slackCalls).toEqual([]);
+  });
+
+  it("6b. a message from the bot's own user id without bot_id starts no Turn", async () => {
+    await h.deliver({
+      type: "message",
+      channel_type: "im",
+      user: BOT_USER_ID,
+      channel: DM,
+      ts: "6.2",
+      text: "here is your answer",
+    });
+    expect(h.runs).toEqual([]);
+    expect(h.slackCalls).toEqual([]);
+  });
+
+  it("7a. a message_changed edit starts no Turn", async () => {
+    await h.deliver({
+      type: "message",
+      subtype: "message_changed",
+      channel_type: "im",
+      channel: DM,
+      ts: "7.1",
+      message: { type: "message", user: "U1", ts: "7.0", text: "edited" },
+      previous_message: { type: "message", user: "U1", ts: "7.0", text: "original" },
+    });
+    expect(h.warnings).toEqual([]);
+    expect(h.accepted).toEqual([]);
+    expect(h.runs).toEqual([]);
+    expect(h.slackCalls).toEqual([]);
+  });
+
+  it("7b. a message_deleted tombstone starts no Turn", async () => {
+    await h.deliver({
+      type: "message",
+      subtype: "message_deleted",
+      channel_type: "im",
+      channel: DM,
+      ts: "7.2",
+      deleted_ts: "7.0",
+      previous_message: { type: "message", user: "U1", ts: "7.0", text: "original" },
+    });
+    expect(h.warnings).toEqual([]);
+    expect(h.accepted).toEqual([]);
+    expect(h.runs).toEqual([]);
+    expect(h.slackCalls).toEqual([]);
+  });
+});


### PR DESCRIPTION
Issue #508 reports the Slack bot replying to every channel message. That symptom does not reproduce: an end-to-end harness over the live Socket Mode ingress shows unaddressed channel chatter and replies in threads the bot never joined are already dropped by `mention-gate.ts`, which is wired on the only Slack ingress path (the manifest webhook route 404s for Slack, which declares no `ingress` block).

The harness did expose the same class of defect one layer down. The gate decides on outer-envelope fields only, so two shapes slip through:

- A message whose `user` is the bot's own user id but which carries no `bot_id`. `bot_id` was the single guard standing between the runtime and an infinite self-reply loop in DMs and in already-mentioned threads, where the gate passes unconditionally. The bot's own id is present in the envelope's `authorizations` and was never read.
- Subtyped `message` events (`message_changed`, `message_deleted`, `channel_join`). Slack reports their author under `event.message`, so the outer `user` and `bot_id` the gate reads are never populated. These passed the gate and were stopped only by a `malformed_payload` exception thrown inside the adapter and swallowed as a log line — a routing decision made on data that does not exist.

The gate now resolves the bot's user id from `authorizations`, drops anything it sent, and admits only the `message` subtypes that still carry human chat (`file_share`, `me_message`, `thread_broadcast`). The gate also becomes a required dispatch dependency rather than an option, so the configuration whose own comment described issue #508's symptom is no longer representable.

Behaviour stays silent rather than reactive: there is no first-class acknowledge-without-replying primitive, and a reaction would need a new Slack scope that every existing installation would have to re-consent to.

## Summary

<!-- What changed, and why. Link the driving issue if one exists. -->

## Test plan

<!-- Commands you ran, or manual steps / screenshots for UI changes. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (or the scoped `--filter` you actually ran)

## Checklist

- [ ] PR title follows Conventional Commits (`type(scope): subject`) — CI checks this
- [ ] Scoped to one logical change
- [ ] Tests added/updated for the behavior that changed
