### PR TITLE
fix(web): surface soul git sync status and give section pages an h1

### DIFF
--- a/apps/docs/content/docs/administration/the-soul-repository.mdx
+++ b/apps/docs/content/docs/administration/the-soul-repository.mdx
@@ -35,6 +35,10 @@ single highest-value thing on this page.
 You can also seed this at boot with `SOUL_GIT_REMOTE_URL` and `SOUL_GIT_CREDENTIAL`, which is what
 a scripted deployment should do.
 
+The panel above the file tree always reports where the soul stands: **Not connected** until a
+remote is set, then **Up to date**, **N ahead, M behind**, or **Sync failed** with the reason git
+gave. Below it sit the short commit the soul is on and when it last synced.
+
 <Callout type="warn">
   A backed-up soul is **not** a backup of your instance. Records, knowledge, chats, runs,
   approvals, memory, secrets, audit, and identity are all in PostgreSQL. Losing the database loses

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -43,6 +43,9 @@ client data loading, schema-driven resource UI, and browser rendering of Surface
 - All API calls go through `app/lib/api.ts`; never call `fetch` ad hoc from routes.
 - Gate admin UI on `isBusinessAdmin` / `useIsAdmin`, never on `user.role`: an access level granted
   from People & access confers admin authority without rewriting the account role.
+- A section page's one `h1` comes from `SectionShell` and is `sr-only`, because the top bar already
+  names the page. A route drilled into from a section names itself instead; `_app.business.access`
+  covers its own tab children.
 - `apiWrite` must send cookies, `x-csrf-token` from the non-httpOnly `csrf_token` cookie, and
   optional `Authorization: Bearer` from `VITE_API_TOKEN`.
 - Render API validation errors from `ApiError.path` as field errors; map `409` to a concurrency

--- a/apps/web/app/components/section-shell.test.tsx
+++ b/apps/web/app/components/section-shell.test.tsx
@@ -1,0 +1,37 @@
+import { createRemixStub } from "@remix-run/testing";
+import { render, screen } from "@testing-library/react";
+import { expect, test } from "vitest";
+import { SectionShell } from "./section-shell";
+
+function renderAt(pathname: string) {
+  const Stub = createRemixStub([{ path: "*", Component: SectionShell }]);
+  return render(<Stub initialEntries={[pathname]} />);
+}
+
+test.each([
+  ["/business/soul", "Soul"],
+  ["/business/guardrails", "Guardrails"],
+  ["/business/profile", "Business profile"],
+  ["/business/models", "Models"],
+  ["/business/access", "People & access"],
+  ["/business/activities", "Activities"],
+  ["/settings/appearance", "Appearance"],
+  ["/integrations", "Integrations"],
+])("%s names itself with exactly one h1", (pathname, label) => {
+  renderAt(pathname);
+  const headings = screen.getAllByRole("heading", { level: 1 });
+  expect(headings).toHaveLength(1);
+  expect(headings[0].textContent).toBe(label);
+});
+
+test("leaves the h1 to a detail route that names itself", () => {
+  renderAt("/integrations/slack");
+  expect(screen.queryByRole("heading", { level: 1 })).toBeNull();
+});
+
+test("still renders the section description on the section's own page", () => {
+  renderAt("/business/soul");
+  expect(
+    screen.getByText("Browse the version-controlled repository your workspace is defined in.")
+  ).toBeTruthy();
+});

--- a/apps/web/app/components/section-shell.tsx
+++ b/apps/web/app/components/section-shell.tsx
@@ -9,11 +9,16 @@ import { cn } from "~/lib/utils";
 export function SectionShell() {
   const { pathname } = useLocation();
   const section = sectionForPath(pathname);
-  const description = section && pathname === section.to ? section.description : undefined;
+  const ownPage = section !== undefined && pathname === section.to;
+  const description = ownPage ? section?.description : undefined;
 
   return (
     <div className="h-full min-h-0 overflow-y-auto">
       <div className={cn("w-full px-6 py-8 md:px-8", !section?.wide && "max-w-3xl")}>
+        {/* The top bar owns page identity visually, so this heading is for assistive technology
+            only: without it a section page starts at h2 and screen-reader heading navigation has
+            no "page starts here". A page drilled into from here names itself. */}
+        {ownPage && section ? <h1 className="sr-only">{section.label}</h1> : null}
         {description ? (
           <p className="mb-6 max-w-prose text-sm text-muted-foreground">{description}</p>
         ) : null}

--- a/apps/web/app/components/soul/soul-git-config.test.tsx
+++ b/apps/web/app/components/soul/soul-git-config.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, expect, test, vi } from "vitest";
+import type { SoulGitConfig, SoulGitStatus } from "~/lib/soul";
+import * as useSessionUser from "~/lib/use-session-user";
+import { SoulGitConfigPanel } from "./soul-git-config";
+
+vi.mock("~/lib/use-session-user", async () => {
+  const actual =
+    await vi.importActual<typeof import("~/lib/use-session-user")>("~/lib/use-session-user");
+  return { ...actual, useIsAdmin: vi.fn(() => true) };
+});
+const useIsAdmin = vi.mocked(useSessionUser.useIsAdmin);
+
+function status(overrides: Partial<SoulGitStatus> = {}): SoulGitStatus {
+  return {
+    remoteConfigured: true,
+    ahead: 0,
+    behind: 0,
+    headSha: "0123456789abcdef0123456789abcdef01234567",
+    lastSyncError: null,
+    lastSyncAt: "2026-08-19T01:02:00.000Z",
+    ...overrides,
+  };
+}
+
+function renderPanel(config: SoulGitConfig) {
+  return render(<SoulGitConfigPanel config={config} onSaved={() => {}} />);
+}
+
+beforeEach(() => {
+  useIsAdmin.mockReturnValue(true);
+});
+
+test("shows Not connected while an admin sees the connect form", () => {
+  renderPanel({
+    credentialSet: false,
+    status: status({ remoteConfigured: false, headSha: null, lastSyncAt: null }),
+  });
+
+  expect(screen.getByText("Connect a git remote")).toBeTruthy();
+  expect(screen.getByText("Not connected")).toBeTruthy();
+});
+
+test("shows Not connected to a non-admin who cannot open the form", () => {
+  useIsAdmin.mockReturnValue(false);
+  renderPanel({
+    credentialSet: false,
+    status: status({ remoteConfigured: false, headSha: null, lastSyncAt: null }),
+  });
+
+  expect(screen.getByText("Not connected")).toBeTruthy();
+});
+
+test("shows Up to date with the last sync time and head commit", () => {
+  renderPanel({
+    remoteUrl: "https://github.com/northgate/soul.git",
+    credentialSet: true,
+    status: status(),
+  });
+
+  expect(screen.getByText("Up to date")).toBeTruthy();
+  expect(screen.getByText(/last synced/)).toBeTruthy();
+  expect(screen.getByText("0123456")).toBeTruthy();
+});
+
+test("shows the ahead/behind counts when the remote has diverged", () => {
+  renderPanel({
+    remoteUrl: "https://github.com/northgate/soul.git",
+    credentialSet: true,
+    status: status({ ahead: 2, behind: 3 }),
+  });
+
+  expect(screen.getByText("2 ahead, 3 behind")).toBeTruthy();
+});
+
+test("shows Sync failed with the failure reason", () => {
+  renderPanel({
+    remoteUrl: "https://github.com/northgate/soul.git",
+    credentialSet: true,
+    status: status({ lastSyncError: "could not read Username for 'https://github.com'" }),
+  });
+
+  expect(screen.getByText("Sync failed")).toBeTruthy();
+  expect(screen.getByText(/personal access token/)).toBeTruthy();
+});
+
+test("says never synced when a configured remote has never been reached", () => {
+  renderPanel({
+    remoteUrl: "https://github.com/northgate/soul.git",
+    credentialSet: true,
+    status: status({ lastSyncAt: null, headSha: null }),
+  });
+
+  expect(screen.getByText("never synced")).toBeTruthy();
+});
+
+test("keeps the status visible while an admin edits a configured remote", async () => {
+  const user = (await import("@testing-library/user-event")).default;
+  renderPanel({
+    remoteUrl: "https://github.com/northgate/soul.git",
+    credentialSet: true,
+    status: status({ ahead: 1, behind: 0 }),
+  });
+
+  await user.click(screen.getByRole("button", { name: "Edit" }));
+
+  expect(screen.getByText("Edit git remote")).toBeTruthy();
+  expect(screen.getByText("1 ahead")).toBeTruthy();
+});

--- a/apps/web/app/components/soul/soul-git-config.tsx
+++ b/apps/web/app/components/soul/soul-git-config.tsx
@@ -1,6 +1,6 @@
 import { GitBranch } from "lucide-react";
 import { type FormEvent, useState } from "react";
-import { Badge } from "~/components/ui/badge";
+import { StatusBadge, type StatusTone } from "~/components/status-badge";
 import { Button } from "~/components/ui/button";
 import { Field } from "~/components/ui/field";
 import { Input } from "~/components/ui/input";
@@ -16,23 +16,28 @@ function errorMessage(err: unknown): string {
   return err instanceof Error ? friendlyGitError(err.message) : "request failed";
 }
 
+/**
+ * Every state below is one `GET /api/v1/soul/git-config` can actually report: `remoteConfigured`,
+ * `lastSyncError`, and the `ahead`/`behind` counts `GitSync.getStatus()` derives from
+ * `rev-list --left-right`. Nothing here is inferred.
+ */
 function statusLabel(status: SoulGitConfig["status"]): {
   text: string;
-  variant: "neutral" | "danger" | "primary";
+  tone: StatusTone;
 } {
   if (!status.remoteConfigured) {
-    return { text: "Not connected", variant: "neutral" };
+    return { text: "Not connected", tone: "neutral" };
   }
   if (status.lastSyncError) {
-    return { text: "Sync failed", variant: "danger" };
+    return { text: "Sync failed", tone: "danger" };
   }
   if (status.ahead === 0 && status.behind === 0) {
-    return { text: "Up to date", variant: "neutral" };
+    return { text: "Up to date", tone: "success" };
   }
   const parts: string[] = [];
   if (status.ahead > 0) parts.push(`${status.ahead} ahead`);
   if (status.behind > 0) parts.push(`${status.behind} behind`);
-  return { text: parts.join(", "), variant: "primary" };
+  return { text: parts.join(", "), tone: "warning" };
 }
 
 function formatLastSync(iso: string | null): string {
@@ -100,38 +105,44 @@ export function SoulGitConfigPanel({
         </p>
       ) : null}
 
+      {/* The status header is outside the editing branch: an admin with no remote lands straight in
+          the connect form, and that is exactly the operator who needs to be told the soul is not
+          connected. */}
+      <div className="flex items-center gap-2 px-3 py-2">
+        <GitBranch aria-hidden className="size-4 text-muted-foreground" />
+        <span className="font-medium text-foreground">Git remote</span>
+        <StatusBadge label={status.text} tone={status.tone} />
+        {!editing ? (
+          <div className="ml-auto flex items-center gap-1">
+            {config.remoteUrl ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="cursor-pointer rounded-sm"
+                disabled={syncing}
+                onClick={onSync}
+              >
+                {syncing ? "Syncing…" : "Sync now"}
+              </Button>
+            ) : null}
+            {isAdmin ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="cursor-pointer rounded-sm"
+                onClick={() => setEditing(true)}
+              >
+                Edit
+              </Button>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+
       {!editing ? (
         <>
-          <div className="flex items-center gap-2 px-3 py-2">
-            <GitBranch aria-hidden className="size-4 text-muted-foreground" />
-            <span className="font-medium text-foreground">Git remote</span>
-            <Badge variant={status.variant}>{status.text}</Badge>
-            <div className="ml-auto flex items-center gap-1">
-              {config.remoteUrl ? (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  className="cursor-pointer rounded-sm"
-                  disabled={syncing}
-                  onClick={onSync}
-                >
-                  {syncing ? "Syncing…" : "Sync now"}
-                </Button>
-              ) : null}
-              {isAdmin ? (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  className="cursor-pointer rounded-sm"
-                  onClick={() => setEditing(true)}
-                >
-                  Edit
-                </Button>
-              ) : null}
-            </div>
-          </div>
           {config.remoteUrl ? (
             <p className="truncate border-t border-border px-3 py-2 font-mono text-xs text-muted-foreground">
               {config.remoteUrl}
@@ -143,6 +154,12 @@ export function SoulGitConfigPanel({
           )}
           {config.remoteUrl ? (
             <p className="truncate border-t border-border px-3 py-2 text-xs text-muted-foreground">
+              {config.status.headSha ? (
+                <>
+                  <span className="font-mono">{config.status.headSha.slice(0, 7)}</span>
+                  {" · "}
+                </>
+              ) : null}
               {formatLastSync(config.status.lastSyncAt)}
             </p>
           ) : null}
@@ -156,7 +173,7 @@ export function SoulGitConfigPanel({
           ) : null}
         </>
       ) : (
-        <form onSubmit={onSubmit} className="flex flex-col gap-3 p-3">
+        <form onSubmit={onSubmit} className="flex flex-col gap-3 border-t border-border p-3">
           <p className="text-sm font-medium text-foreground">
             {config.remoteUrl ? "Edit git remote" : "Connect a git remote"}
           </p>

--- a/apps/web/app/routes/_app.business.access.tsx
+++ b/apps/web/app/routes/_app.business.access.tsx
@@ -1,8 +1,20 @@
-import { type MetaFunction, Outlet } from "@remix-run/react";
+import { type MetaFunction, Outlet, useLocation } from "@remix-run/react";
+import { sectionForPath } from "~/lib/nav";
 
 export const meta: MetaFunction = () => [{ title: "Access · Business · tulipfarm" }];
 
 // Thin layout for the Access subtree (groups / grants / check). Each child owns its data.
 export default function AccessLayout() {
-  return <Outlet />;
+  const { pathname } = useLocation();
+  const section = sectionForPath(pathname);
+  // The section shell names only a section's own page, and these tabs are deeper paths of the same
+  // page — so without this the tab routes would start their heading order at h2.
+  const tabPage = section !== undefined && pathname !== section.to;
+
+  return (
+    <>
+      {tabPage && section ? <h1 className="sr-only">{section.label}</h1> : null}
+      <Outlet />
+    </>
+  );
 }

--- a/apps/web/app/routes/business-access-layout.test.tsx
+++ b/apps/web/app/routes/business-access-layout.test.tsx
@@ -1,0 +1,24 @@
+import { createRemixStub } from "@remix-run/testing";
+import { render, screen } from "@testing-library/react";
+import { expect, test } from "vitest";
+import AccessLayout from "./_app.business.access";
+
+function renderAt(pathname: string) {
+  const Stub = createRemixStub([{ path: "*", Component: AccessLayout }]);
+  return render(<Stub initialEntries={[pathname]} />);
+}
+
+test.each(["/business/access/agents", "/business/access/teams", "/business/access/check"])(
+  "%s names the page it is a tab of",
+  (pathname) => {
+    renderAt(pathname);
+    const headings = screen.getAllByRole("heading", { level: 1 });
+    expect(headings).toHaveLength(1);
+    expect(headings[0].textContent).toBe("People & access");
+  }
+);
+
+test("leaves the h1 to the section shell on the tabs' own page", () => {
+  renderAt("/business/access");
+  expect(screen.queryByRole("heading", { level: 1 })).toBeNull();
+});


### PR DESCRIPTION
The Soul page hid its git status badge whenever the connect/edit form was open, which is the default for an admin on an instance with no remote — the one operator who most needs to be told the soul is not connected. The status header now renders in both branches, reuses the shared StatusBadge so the tone is semantic rather than coral primary, and shows the head commit the API already returns alongside the last sync time.

Section pages under /business, /settings and /integrations also started their heading order at h2, so screen-reader heading navigation had no "page starts here". SectionShell now emits one sr-only h1 from the nav label — sr-only because the top bar owns page identity — and the Access layout covers its own tab children. A route drilled into from a section still names itself.

Fixes #414
Fixes #413

## Summary

<!-- What changed, and why. Link the driving issue if one exists. -->

## Test plan

<!-- Commands you ran, or manual steps / screenshots for UI changes. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (or the scoped `--filter` you actually ran)

## Checklist

- [ ] PR title follows Conventional Commits (`type(scope): subject`) — CI checks this
- [ ] Scoped to one logical change
- [ ] Tests added/updated for the behavior that changed
