### PR TITLE
fix(web): target the login bounce at the route being loaded

### DIFF
--- a/apps/web/app/routes/_app.design-guide.test.tsx
+++ b/apps/web/app/routes/_app.design-guide.test.tsx
@@ -1,11 +1,38 @@
 import { createRemixStub } from "@remix-run/testing";
 import { render, screen } from "@testing-library/react";
-import { beforeAll, expect, test, vi } from "vitest";
-import DesignGuideRoute from "./_app.design-guide";
+import { afterEach, beforeAll, expect, test, vi } from "vitest";
+import DesignGuideRoute, { clientLoader } from "./_app.design-guide";
 
 // jsdom has no layout engine; the transcript's auto-scroll calls scrollIntoView.
 beforeAll(() => {
   Element.prototype.scrollIntoView = vi.fn();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+// The guide is a development-only internal reference: it ships demo-only specimens and an
+// unreleased component vocabulary, so a built instance must not serve it. Staging and production
+// 404 by design — see docs/qa/playbooks/design-system.md.
+test("serves the guide only while running the dev server", () => {
+  vi.stubEnv("DEV", true);
+
+  expect(clientLoader()).toBeNull();
+});
+
+test("404s the guide on a built instance rather than exposing it", () => {
+  vi.stubEnv("DEV", false);
+
+  let thrown: unknown;
+  try {
+    clientLoader();
+  } catch (err) {
+    thrown = err;
+  }
+
+  expect(thrown).toBeInstanceOf(Response);
+  expect((thrown as Response).status).toBe(404);
 });
 
 test("showcases the live token, status, action, form, and composition vocabulary", () => {

--- a/apps/web/app/routes/_app.design-guide.tsx
+++ b/apps/web/app/routes/_app.design-guide.tsx
@@ -15,6 +15,12 @@ import { Separator } from "~/components/ui/separator";
 
 export const meta: MetaFunction = () => [{ title: "Design guide · tulipfarm" }];
 
+/**
+ * Development-only surface. The guide ships demo-only specimens and component vocabulary that has
+ * not been released yet, so a built instance must never serve it — the sidebar entry is `devOnly`
+ * and this gate makes the route itself unreachable. The 404 on staging and production is
+ * deliberate; see `docs/qa/playbooks/design-system.md`.
+ */
 export function clientLoader() {
   if (!import.meta.env.DEV) throw new Response("Not found", { status: 404 });
   return null;

--- a/apps/web/app/routes/_app.gate.test.tsx
+++ b/apps/web/app/routes/_app.gate.test.tsx
@@ -1,0 +1,73 @@
+import type { ClientLoaderFunctionArgs } from "@remix-run/react";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import * as api from "~/lib/api";
+import { ApiError } from "~/lib/api";
+import * as setup from "~/lib/setup";
+import { clientLoader } from "./_app";
+
+vi.mock("~/lib/setup", () => ({ getSetupStatus: vi.fn() }));
+vi.mock("~/lib/api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("~/lib/api")>()),
+  getSession: vi.fn(),
+}));
+
+const getSetupStatus = vi.mocked(setup.getSetupStatus);
+const getSession = vi.mocked(api.getSession);
+
+beforeEach(() => {
+  getSetupStatus.mockResolvedValue({ needsSetup: false });
+  getSession.mockRejectedValue(new ApiError(401, "unauthenticated"));
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  window.history.replaceState({}, "", "/");
+});
+
+/**
+ * `browserPath` is what the address bar still reads while the gate runs; `requestPath` is the
+ * destination Remix is actually loading. They differ during a redirect hop, which is the whole
+ * point of these cases.
+ */
+async function runGate(browserPath: string, requestPath: string): Promise<Response> {
+  window.history.replaceState({}, "", browserPath);
+  const args = {
+    request: new Request(new URL(requestPath, "http://localhost")),
+    params: {},
+  } as unknown as ClientLoaderFunctionArgs;
+  try {
+    await clientLoader(args);
+  } catch (thrown) {
+    if (thrown instanceof Response) return thrown;
+    throw thrown;
+  }
+  throw new Error("expected the gate to redirect");
+}
+
+test("sends an unauthenticated visitor to login carrying the path they asked for", async () => {
+  const response = await runGate("/chats", "/chats");
+
+  expect(response.headers.get("Location")).toBe("/login?redirectTo=%2Fchats");
+});
+
+test("captures the destination being loaded, not the URL the browser is still showing", async () => {
+  // The /setup gate has already thrown redirect("/"), so Remix is loading "/" while the address
+  // bar still reads "/setup" — history only commits after the loaders resolve.
+  const response = await runGate("/setup", "/");
+
+  expect(response.headers.get("Location")).toBe("/login?redirectTo=%2F");
+});
+
+test("sends a never-provisioned instance to the wizard before it considers auth", async () => {
+  getSetupStatus.mockResolvedValue({ needsSetup: true });
+
+  const response = await runGate("/chats", "/chats");
+
+  expect(response.headers.get("Location")).toBe("/setup");
+});
+
+test("rethrows a non-401 session failure instead of masking it as a login bounce", async () => {
+  getSession.mockRejectedValue(new ApiError(503, "api unreachable"));
+
+  await expect(runGate("/chats", "/chats")).rejects.toThrow("api unreachable");
+});

--- a/apps/web/app/routes/_app.tsx
+++ b/apps/web/app/routes/_app.tsx
@@ -1,4 +1,4 @@
-import { Outlet, redirect, useLoaderData } from "@remix-run/react";
+import { type ClientLoaderFunctionArgs, Outlet, redirect, useLoaderData } from "@remix-run/react";
 import { AppShell } from "~/components/app-sidebar";
 import { OnboardingCompanion } from "~/components/onboarding/companion";
 import { GlobalConnectionStatus } from "~/components/shell/states";
@@ -12,7 +12,7 @@ import { isBusinessAdmin } from "~/lib/use-session-user";
 // Auth gate for the whole app shell: every /app/* route runs this parent loader first.
 // Checks setup status first: if the instance needs first-run setup, redirect to /setup.
 // Then checks auth: unauthenticated session (401) redirects to /login.
-export async function clientLoader() {
+export async function clientLoader({ request }: ClientLoaderFunctionArgs) {
   // Both requests go out together: this loader gates the first paint, so a second serial round trip
   // is pure blank-screen time on a slow host. Precedence is unchanged — setup still wins over auth.
   // On an un-set-up instance this does spend one wasted (401) session call, which is the cheaper
@@ -29,7 +29,10 @@ export async function clientLoader() {
 
   if (!session.ok) {
     if (session.err instanceof ApiError && session.err.status === 401) {
-      const here = typeof window !== "undefined" ? window.location.pathname : "/";
+      // The destination Remix is loading, not `window.location`: history only commits after the
+      // loaders resolve, so on a redirect hop (`/setup` -> `/`) the address bar still reads the
+      // route we are leaving and would send the user back to it after login.
+      const here = new URL(request.url).pathname;
       throw redirect(`/login?redirectTo=${encodeURIComponent(here)}`);
     }
     throw session.err;

--- a/docs/qa/playbooks/a11y-console-hygiene.md
+++ b/docs/qa/playbooks/a11y-console-hygiene.md
@@ -30,7 +30,7 @@ Every scenario stands alone — a failure in one does not block the next.
 
 ## S2 — Screen reader ARIA and semantic HTML audit
 
-Sweep across top-level routes (`/`, `/chats`, `/resources`, `/agents`, `/skills`, `/routines`, `/knowledge`, `/integrations`, `/inbox`, `/settings`, `/business/profile`, `/design-guide`).
+Sweep across top-level routes (`/`, `/chats`, `/resources`, `/agents`, `/skills`, `/routines`, `/knowledge`, `/integrations`, `/inbox`, `/settings`, `/business/profile`, and — on a dev server only — `/design-guide`).
 
 | # | Action | Expected |
 | --- | --- | --- |
@@ -45,7 +45,7 @@ Sweep across top-level routes (`/`, `/chats`, `/resources`, `/agents`, `/skills`
 
 | # | Action | Expected |
 | --- | --- | --- |
-| 1 | On `/design-guide` and `/settings`, set theme to **Light** | Light theme active |
+| 1 | On `/design-guide` (dev server only) and `/settings`, set theme to **Light** | Light theme active |
 | 2 | `expect` all primary text, secondary text, mute text, badges, and button labels meet contrast guidelines against background | High legibility, no light grey on white |
 | 3 | Set theme to **Dark** | Dark theme active |
 | 4 | `expect` dark mode contrast meets guidelines; no dark text on dark background, no un-themed white component boxes | Legible dark theme |
@@ -68,7 +68,7 @@ Sweep across top-level routes (`/`, `/chats`, `/resources`, `/agents`, `/skills`
 
 | # | Action | Expected |
 | --- | --- | --- |
-| 1 | Sequentially visit all top-level routes: `/`, `/chats`, `/resources`, `/agents`, `/skills`, `/routines`, `/knowledge`, `/integrations`, `/inbox`, `/runs`, `/operations`, `/settings`, `/business/profile`, `/business/people`, `/business/guardrails`, `/design-guide` | All routes loaded |
+| 1 | Sequentially visit all top-level routes: `/`, `/chats`, `/resources`, `/agents`, `/skills`, `/routines`, `/knowledge`, `/integrations`, `/inbox`, `/runs`, `/operations`, `/settings`, `/business/profile`, `/business/people`, `/business/guardrails`, and `/design-guide` (dev server only; it 404s on a built instance by design) | All routes loaded |
 | 2 | Compare all console messages against `evidence/console-baseline.txt` recorded in Preflight | Zero new uncaught exceptions or error logs |
 | 3 | `expect` no React hydration mismatch warnings (`Hydration failed because...`) | Clean React hydration |
 | 4 | `expect` no unhandled promise rejections | Clean console |

--- a/docs/qa/playbooks/design-system.md
+++ b/docs/qa/playbooks/design-system.md
@@ -3,7 +3,7 @@ id: design-system
 area: Design System
 suites: [smoke, full]
 routes: ["/design-guide"]
-preconditions: [signed-in session]
+preconditions: [signed-in session, run against the dev server — the route is development-only]
 blast_radius: none — read-only design token and component showcase
 est_minutes: 8
 smoke_scenarios: [S1]
@@ -13,13 +13,20 @@ smoke_scenarios: [S1]
 
 The Design System showcase at `/design-guide` acts as the single source of truth for TulipFarm's visual identity, component primitives, HSL color tokens, typography scale, effort selection widgets, status badges, empty states, and theme compliance.
 
+**This playbook only runs against a dev server (`pnpm dev`).** `/design-guide` is development-only
+by design: its `clientLoader` throws `404 Not found` whenever `import.meta.env.DEV` is false, and
+its sidebar entry is `devOnly` (`apps/web/app/lib/nav.ts`). The page ships demo-only specimens and
+an unreleased component vocabulary, so a built instance must not serve it. **A `404` on staging or
+production is expected behaviour, not a finding** — do not file it. If the route ever *does* render
+on a built instance, that is the finding (P2, internal surface exposed).
+
 Every scenario stands alone — a failure in one does not block the next.
 
 ## S1 — Design system token gallery and typography scale
 
 | # | Action | Expected |
 | --- | --- | --- |
-| 1 | `navigate /design-guide` | Page loads within 5s; heading `Design System` or `Design Guide` |
+| 1 | `navigate /design-guide` | Page loads within 5s; heading `TulipFarm design guide`. On a built instance (staging/production) this is `404 Not found` instead — expected, skip the rest of this playbook |
 | 2 | `expect` color palette tokens render (Primary, Secondary, Accent, Muted, Destructive, Card, Background) with hex/HSL values | Palette grid visible |
 | 3 | `expect` typography scale section renders headings (`h1` through `h4`), body text, caption, and code typography samples | Typography scale rendered |
 | 4 | `capture` screenshot, console delta, failed requests | — |

--- a/docs/qa/playbooks/index.md
+++ b/docs/qa/playbooks/index.md
@@ -35,7 +35,7 @@ Preflight always runs. It is the only playbook that aborts the run on failure.
 | 14 | Channel Linking | [`channel-linking.md`](channel-linking.md) | `/link-channel` | smoke, full | S1 | integration-worker running | 8m |
 | 15 | Operations & Dispatch | [`operations-monitoring.md`](operations-monitoring.md) | `/operations` | smoke, full | S1 | worker running | 8m |
 | 16 | Audit & Compliance | [`audit-compliance.md`](audit-compliance.md) | `/business/activities` | smoke, full | S1 | — | 10m |
-| 17 | Design System | [`design-system.md`](design-system.md) | `/design-guide` | smoke, full | S1 | — | 8m |
+| 17 | Design System | [`design-system.md`](design-system.md) | `/design-guide` | smoke, full | S1 | **dev server only** — the route 404s on a built instance | 8m |
 | 18 | Setup & Onboarding | [`onboarding-setup.md`](onboarding-setup.md) | `/setup`, `/onboarding` | smoke, full | S1 | fresh incognito context available | 8m |
 | 19 | Guardrails & Governance | [`guardrails-governance.md`](guardrails-governance.md) | `/business/guardrails` | smoke, full | S1 | signed-in session; admin for writes | 10m |
 | 20 | Soul Git Operations | [`soul-git-operations.md`](soul-git-operations.md) | `/business/soul` | smoke, full | S1 | — | 10m |


### PR DESCRIPTION
The app-shell auth gate read `window.location.pathname` to decide where to send a user back after signing in. History only commits after loaders resolve, so on a redirect hop the address bar still shows the route being left. Visiting `/setup` on a provisioned instance therefore produced `/login?redirectTo=%2Fsetup` — bouncing the user back to a wizard that only redirects again — instead of the documented `%2F`. Reading the pathname from the `request` the loader was handed names the destination, not the origin.

`/design-guide` returning 404 on staging is deliberate, not a regression: the route has been gated on `import.meta.env.DEV` since it was introduced, and its sidebar entry is `devOnly`. It ships demo-only specimens and unreleased component vocabulary, so a built instance must not serve it. The gate is now stated in the route and in the QA playbooks that kept filing the 404 as a finding, plus locked by a test for both values of the env.

Closes #403
Closes #409

## Summary

<!-- What changed, and why. Link the driving issue if one exists. -->

## Test plan

<!-- Commands you ran, or manual steps / screenshots for UI changes. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (or the scoped `--filter` you actually ran)

## Checklist

- [ ] PR title follows Conventional Commits (`type(scope): subject`) — CI checks this
- [ ] Scoped to one logical change
- [ ] Tests added/updated for the behavior that changed
