### PR TITLE
fix(web): keep chat auto-scroll inside the transcript container

### DIFF
--- a/apps/web/app/components/chat/transcript.test.tsx
+++ b/apps/web/app/components/chat/transcript.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Transcript } from "~/components/chat/transcript";
@@ -671,5 +671,69 @@ describe("an attachment the reader can no longer open", () => {
 
     expect(screen.getByRole("button", { name: "Download here.pdf" })).toBeInTheDocument();
     expect(screen.getByText("gone.pdf")).toBeInTheDocument();
+  });
+});
+
+describe("Transcript auto-scroll stays inside its own scroll container", () => {
+  // `scrollIntoView` walks every scrollable ancestor, so the shell's <main> and the document
+  // itself get dragged down with the transcript (#69). Writing `scrollTop` cannot leave the
+  // container, so the guard is that the transcript never reaches for `scrollIntoView` again.
+  function trackScrolling() {
+    const intoView = vi.fn();
+    Element.prototype.scrollIntoView = intoView;
+    const scrolled: number[] = [];
+    const descriptor = Object.getOwnPropertyDescriptor(Element.prototype, "scrollTop");
+    Object.defineProperty(Element.prototype, "scrollTop", {
+      configurable: true,
+      get: () => 0,
+      set: (value: number) => void scrolled.push(value),
+    });
+    return {
+      intoView,
+      scrolled,
+      restore: () => {
+        if (descriptor) Object.defineProperty(Element.prototype, "scrollTop", descriptor);
+      },
+    };
+  }
+
+  function flushFrames() {
+    return act(async () => {
+      await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+    });
+  }
+
+  it("pins to the bottom without scrolling any ancestor while a response is loading", async () => {
+    const tracked = trackScrolling();
+    try {
+      const state = fold([], "hello");
+      expect(state.status).toBe("submitted");
+      render(<Transcript messages={state.messages} status={state.status} onApprove={vi.fn()} />);
+      await flushFrames();
+
+      expect(tracked.intoView).not.toHaveBeenCalled();
+      expect(tracked.scrolled.length).toBeGreaterThan(0);
+    } finally {
+      tracked.restore();
+    }
+  });
+
+  it("pins to the bottom without scrolling any ancestor while text streams in", async () => {
+    const tracked = trackScrolling();
+    try {
+      render(
+        <Transcript
+          messages={fold([{ type: "text", data: { delta: "streaming" } }], "hi").messages}
+          status="streaming"
+          onApprove={vi.fn()}
+        />
+      );
+      await flushFrames();
+
+      expect(tracked.intoView).not.toHaveBeenCalled();
+      expect(tracked.scrolled.length).toBeGreaterThan(0);
+    } finally {
+      tracked.restore();
+    }
   });
 });

--- a/apps/web/app/components/chat/transcript.tsx
+++ b/apps/web/app/components/chat/transcript.tsx
@@ -430,7 +430,6 @@ export function Transcript({
   ) => void | Promise<void>;
 }) {
   const scrollRef = useRef<HTMLDivElement>(null);
-  const endRef = useRef<HTMLDivElement>(null);
   const stick = useRef(true);
 
   function onScroll() {
@@ -439,10 +438,16 @@ export function Transcript({
   }
 
   // Auto-scroll is layout-forcing, so coalesce bursts of stream updates into one write per frame.
+  // Writing scrollTop instead of scrolling a sentinel into view keeps the movement inside this
+  // container: scrollIntoView also scrolls every scrollable ancestor, which dragged the shell's
+  // <main> and the document down whenever a response started loading (#69).
   // biome-ignore lint/correctness/useExhaustiveDependencies: re-pin on any transcript change
   useEffect(() => {
     if (!stick.current) return;
-    const frame = requestAnimationFrame(() => endRef.current?.scrollIntoView({ block: "end" }));
+    const frame = requestAnimationFrame(() => {
+      const el = scrollRef.current;
+      if (el) el.scrollTop = el.scrollHeight;
+    });
     return () => cancelAnimationFrame(frame);
   }, [messages, status]);
 
@@ -464,7 +469,6 @@ export function Transcript({
           />
         ))}
         {status === "submitted" ? <Loader /> : null}
-        <div ref={endRef} />
       </div>
     </div>
   );

--- a/apps/web/app/routes/_app.business.models.test.tsx
+++ b/apps/web/app/routes/_app.business.models.test.tsx
@@ -1,0 +1,95 @@
+import { createRemixStub } from "@remix-run/testing";
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { getLlmConfig, listProviders, listSecrets } from "~/lib/settings";
+import BusinessModels, { clientLoader } from "./_app.business.models";
+
+vi.mock("~/lib/settings", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("~/lib/settings")>()),
+  getLlmConfig: vi.fn(),
+  listProviders: vi.fn(),
+  listSecrets: vi.fn(),
+  putLlmConfig: vi.fn(),
+}));
+
+/**
+ * Raw palette utilities and literal colours are theme-blind: they paint the same value under
+ * `[data-theme="light"]` and `[data-theme="dark"]`, which is how a page ends up stuck in one
+ * theme (#420). Only the `@theme inline` semantic tokens in `app/app.css` follow the attribute.
+ */
+const THEME_BLIND_UTILITY =
+  /^(?:bg|text|border|from|via|to|ring|outline|fill|stroke|decoration|caret|accent|divide|placeholder)-(?:\[[^\]]*(?:#|rgb|hsl|oklch)[^\]]*\]|black(?:\/\d+)?$|white(?:\/\d+)?$|(?:slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-\d{2,3})/;
+
+const LITERAL_COLOUR = /#[0-9a-f]{3,8}\b|\brgba?\(|\bhsla?\(|\boklch\(/i;
+
+function themeBlindStyling(root: HTMLElement): string[] {
+  const found: string[] = [];
+  for (const el of root.querySelectorAll<HTMLElement>("*")) {
+    for (const token of el.className.toString().split(/\s+/).filter(Boolean)) {
+      const utility = token.slice(token.lastIndexOf(":") + 1);
+      if (THEME_BLIND_UTILITY.test(utility)) found.push(token);
+    }
+    const inline = el.getAttribute("style");
+    if (inline && LITERAL_COLOUR.test(inline)) found.push(`style="${inline}"`);
+  }
+  return found;
+}
+
+function classTokens(root: HTMLElement): Set<string> {
+  const tokens = new Set<string>();
+  for (const el of root.querySelectorAll<HTMLElement>("*")) {
+    for (const token of el.className.toString().split(/\s+/).filter(Boolean)) tokens.add(token);
+  }
+  return tokens;
+}
+
+beforeEach(() => {
+  document.documentElement.setAttribute("data-theme", "light");
+  vi.mocked(getLlmConfig).mockResolvedValue({
+    tiers: {
+      quick: { providers: [{ provider: "openai", model: "gpt-5-mini" }] },
+      standard: { providers: [{ provider: "openai", model: "gpt-5" }] },
+      complex: { providers: [{ provider: "anthropic", model: "claude-opus-4" }] },
+    },
+    presets: { default: "balanced", fast: "fast", balanced: "balanced", thorough: "thorough" },
+  });
+  vi.mocked(listSecrets).mockResolvedValue([
+    { key: "OPENAI_API_KEY", type: "user-provided", createdAt: "", updatedAt: "" },
+  ]);
+  vi.mocked(listProviders).mockResolvedValue([
+    {
+      id: "openai",
+      label: "OpenAI",
+      fields: [{ key: "OPENAI_API_KEY", label: "API key", role: "api_key", kind: "secret" }],
+    },
+    {
+      id: "anthropic",
+      label: "Anthropic",
+      fields: [{ key: "ANTHROPIC_API_KEY", label: "API key", role: "api_key", kind: "secret" }],
+    },
+  ]);
+});
+
+afterEach(() => {
+  document.documentElement.removeAttribute("data-theme");
+});
+
+function renderPage() {
+  const Stub = createRemixStub([
+    { path: "/business/models", Component: BusinessModels, loader: clientLoader },
+  ]);
+  return render(<Stub initialEntries={["/business/models"]} />);
+}
+
+test("dresses every surface in theme-aware tokens under the light theme", async () => {
+  const { container } = renderPage();
+  expect(await screen.findByText("gpt-5")).toBeInTheDocument();
+
+  expect(themeBlindStyling(container)).toEqual([]);
+
+  // Absence alone would also pass on an unstyled page, so pin the surfaces that carry the theme:
+  // the Panel's card background and the form controls' page background.
+  const tokens = classTokens(container);
+  expect(tokens).toContain("bg-card");
+  expect(tokens).toContain("bg-background");
+});


### PR DESCRIPTION
scrollIntoView on the transcript's bottom sentinel scrolls every scrollable ancestor, not just the nearest one. The shell's <main> is overflow-auto and the page root drops its overflow-hidden below lg, so the moment a Loader mounted for a submitted Turn the whole page was dragged down and blank space appeared under the chat panel. Writing scrollTop on the transcript's own container pins the same position and cannot leave it.

Also adds a theme guard over /business/models: the route tree already dresses every surface in @theme semantic tokens, so the reported light-theme failure does not reproduce here, and the test fails if a raw palette utility or a literal colour is reintroduced.

Addresses #69. Investigates #420.

## Summary

<!-- What changed, and why. Link the driving issue if one exists. -->

## Test plan

<!-- Commands you ran, or manual steps / screenshots for UI changes. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (or the scoped `--filter` you actually ran)

## Checklist

- [ ] PR title follows Conventional Commits (`type(scope): subject`) — CI checks this
- [ ] Scoped to one logical change
- [ ] Tests added/updated for the behavior that changed
