### PR TITLE
test(resources): pin the blank and barrier cases two bugs reported

### DIFF
--- a/apps/api/src/resources/routes.test.ts
+++ b/apps/api/src/resources/routes.test.ts
@@ -273,6 +273,37 @@ describe("resource routes", () => {
       expect(fakeRepo.docs.size).toBe(0);
     });
 
+    // `""` is omitted by the create form, so whitespace is the shape a browser actually sends for
+    // a required field the user left blank. Pinned apart from the `""` case because an equality
+    // test against the empty string passes that one and reopens this (#434).
+    it("returns 422 when a required field holds only whitespace", async () => {
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/v1/resources/ticket",
+        cookies: { [SESSION_COOKIE]: sid, [CSRF_COOKIE]: TEST_CSRF },
+        headers: { [CSRF_HEADER]: TEST_CSRF },
+        payload: { title: "   " },
+      });
+      expect(res.statusCode).toBe(422);
+      expect(res.json<{ path: string; boundary: string }>()).toMatchObject({
+        path: "/title",
+        boundary: "resource",
+      });
+      expect(fakeRepo.docs.size).toBe(0);
+    });
+
+    it("keeps meaningful surrounding whitespace on a required field", async () => {
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/v1/resources/ticket",
+        cookies: { [SESSION_COOKIE]: sid, [CSRF_COOKIE]: TEST_CSRF },
+        headers: { [CSRF_HEADER]: TEST_CSRF },
+        payload: { title: " Bug " },
+      });
+      expect(res.statusCode).toBe(201);
+      expect(res.json<{ title: string }>().title).toBe(" Bug ");
+    });
+
     it("still accepts a filled required field", async () => {
       const res = await app.inject({
         method: "POST",
@@ -621,6 +652,29 @@ describe("resource routes", () => {
       expect(res.statusCode).toBe(422);
       expect(res.json<{ path: string }>().path).toBe("/title");
       expect(fakeRepo.docs.get(id)?.title).toBe("Bug");
+    });
+
+    it("returns 422 when an update blanks a required field with whitespace", async () => {
+      const id = randomUUID();
+      fakeRepo.docs.set(id, {
+        _id: id,
+        version: 1,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        title: "Bug",
+      });
+
+      const res = await app.inject({
+        method: "PUT",
+        url: `/api/v1/resources/ticket/${id}`,
+        cookies: { [SESSION_COOKIE]: sid, [CSRF_COOKIE]: TEST_CSRF },
+        headers: { [CSRF_HEADER]: TEST_CSRF, "if-match": "1" },
+        payload: { title: "   " },
+      });
+      expect(res.statusCode).toBe(422);
+      expect(res.json<{ path: string }>().path).toBe("/title");
+      expect(fakeRepo.docs.get(id)?.title).toBe("Bug");
+      expect(fakeRepo.docs.get(id)?.version).toBe(1);
     });
   });
 

--- a/apps/api/src/resources/tools.test.ts
+++ b/apps/api/src/resources/tools.test.ts
@@ -412,6 +412,16 @@ describe("record_create", () => {
     expect(result).toMatchObject({ success: false, error: { code: "validation_error" } });
   });
 
+  // The Agent path has to refuse the same blank the HTTP route refuses, or a Record an operator
+  // could not create by hand is one `record_create` call away (#434).
+  it("returns validation_error and writes nothing when a required field is only whitespace", async () => {
+    const factory = new FakeRepoFactory();
+    const tool = getTool("record_create");
+    const result = await tool.handler({ type: "ticket", data: { title: "   " } }, makeCtx(factory));
+    expect(result).toMatchObject({ success: false, error: { code: "validation_error" } });
+    expect((factory.forType("ticket") as FakeRepo).docs.size).toBe(0);
+  });
+
   it("returns validation_error for bad args (no type)", async () => {
     const tool = getTool("record_create");
     const result = await tool.handler({ data: {} }, makeCtx());

--- a/apps/api/src/surfaces/request-input-barrier.test.ts
+++ b/apps/api/src/surfaces/request-input-barrier.test.ts
@@ -91,7 +91,7 @@ function choicesCall(props: Record<string, unknown>) {
   };
 }
 
-async function runTurn(props: Record<string, unknown>) {
+async function runTurn(props: Record<string, unknown>, alsoInSameBatch: readonly string[] = []) {
   const created: string[] = [];
   const registry = new InMemoryToolCatalog();
   registry.register(requestInputTool);
@@ -128,7 +128,14 @@ async function runTurn(props: Record<string, unknown>) {
 
   const loop = new AgentLoop({
     model: scriptedModel(
-      toolCalls([choicesCall(props)]),
+      toolCalls([
+        choicesCall(props),
+        ...alsoInSameBatch.map((id) => ({
+          callId: id,
+          name: "agent_create",
+          arguments: { name: id },
+        })),
+      ]),
       toolCalls([{ callId: "create-1", name: "agent_create", arguments: { name: "Sam" } }]),
       {
         requestId: "req",
@@ -188,5 +195,20 @@ describe("request_input stops a Chat Turn", () => {
     expect(created).toEqual([]);
     expect(dispatched).toEqual(["request_input"]);
     expect(outcome).toMatchObject({ status: "failed", reason: "input_request_failed" });
+  });
+
+  // A model that asks and acts in one output is the shape #458 reported: the confirmation card and
+  // the bulk writes it was meant to gate arrive together, so the operator's Cancel lands on work
+  // that already ran. The barrier has to hold within the batch, not only across iterations.
+  it("dispatches nothing else from the batch that carried the question", async () => {
+    const { outcome, dispatched, created } = await runTurn(VALID_CHOICES, [
+      "bulk-1",
+      "bulk-2",
+      "bulk-3",
+    ]);
+
+    expect(created).toEqual([]);
+    expect(dispatched).toEqual(["request_input"]);
+    expect(outcome).toMatchObject({ status: "input_required", callId: "input-1" });
   });
 });


### PR DESCRIPTION
Both #458 and #434 stopped reproducing before this branch was cut, and neither issue was closed. Rather than land a redundant fix, this pins the exact reported inputs so the next refactor cannot quietly reopen them.

#458 — Cancel on a bulk-create confirmation did not stop `record_create`. The mechanism was the Tool loop reading its `request_input` barrier off the call's *result*: a card that reached a Surface but whose action handles were never wired came back as an ordinary Tool failure, so the Turn never parked, the operator's click had no server-side handle to resolve, and the model went on to write. #500 made the barrier the call's *identity*. What no test covered is the shape #458 actually reported — the question and the writes arriving in one model output — so the new case asserts that the batch carrying the question dispatches nothing else. It fails if the park is deferred to the end of the batch, and the two existing cases do not.

#434 — a required text field accepted `"   "`. #472 added a blank guard, but its
tests only assert `""`, which the create form omits entirely; whitespace is what
a browser actually sends for a field the user left blank. An equality test
against the empty string passes every existing case and reopens the bug, so the
whitespace input is now pinned on all three write doors and on `record_create`,
the Agent path an operator cannot inspect. A companion case pins that " Bug " is
still stored verbatim: the guard rejects blanks, it does not trim stored values.

Refs #458
Refs #434

## Summary

<!-- What changed, and why. Link the driving issue if one exists. -->

## Test plan

<!-- Commands you ran, or manual steps / screenshots for UI changes. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (or the scoped `--filter` you actually ran)

## Checklist

- [ ] PR title follows Conventional Commits (`type(scope): subject`) — CI checks this
- [ ] Scoped to one logical change
- [ ] Tests added/updated for the behavior that changed
