### PR TITLE
fix(skills): name the marketplace install action for its skill

### DIFF
--- a/apps/api/src/soul/skills/routes.test.ts
+++ b/apps/api/src/soul/skills/routes.test.ts
@@ -12,7 +12,7 @@ import {
   type GitSyncService,
   type Logger,
   SoulGitStore,
-  type SoulLoader,
+  SoulLoader,
   type SoulSkill,
   SoulWriter,
 } from "@tulipfarm/soul";
@@ -1006,6 +1006,72 @@ spec:
       );
       await expect(readFile(join(installed, "LICENSE.txt"), "utf8")).resolves.toBe("MIT\n");
       await expect(readFile(join(installed, "requirements.txt"), "utf8")).resolves.toBe("pandas\n");
+    });
+
+    // A 200 from install is not the claim that matters; the claim is that the package is usable.
+    // `load_skill_reference` reaches a companion only once `SoulLoader` has resolved the Skill it
+    // sits under, so a tree that committed but quarantines — or whose companions never landed —
+    // is an install that reported success and delivered nothing a Turn can read. The fixture is
+    // the shape of the packages #446 reported: `LICENSE.txt` and `requirements.txt` beside the
+    // definition, which is what the layout could not address, not the directories it named.
+    it("resolves an installed package's companions through the reader's own path", async () => {
+      const remote = await makeRemoteRepo();
+      temps.push(remote);
+      const skillDir = join(remote, "skills", "demo-skill");
+      await mkdir(join(skillDir, "references"), { recursive: true });
+      await mkdir(join(skillDir, "scripts"), { recursive: true });
+      await writeFile(join(skillDir, "references", "01-playbook.md"), "# Playbook\n", "utf8");
+      await writeFile(join(skillDir, "scripts", "convert_to_asm.py"), "print('convert')\n", "utf8");
+      await writeFile(join(skillDir, "LICENSE.txt"), "MIT\n", "utf8");
+      await writeFile(join(skillDir, "requirements.txt"), "pandas\n", "utf8");
+      await execFileP("git", ["add", "-A"], { cwd: remote });
+      await execFileP("git", ["commit", "-q", "-m", "add package files"], { cwd: remote });
+
+      const scanRes = await app.inject({
+        method: "POST",
+        url: "/api/v1/skills/scan",
+        cookies: auth(),
+        headers,
+        payload: { source: `file://${remote}` },
+      });
+      const { scanId } = scanRes.json();
+      buildAudit.mockResolvedValue({
+        riskRating: "low",
+        summary: "No issue found.",
+        toolsReach: [],
+        findings: [],
+        deterministicScan: CLEAN_DETERMINISTIC_SCAN,
+      });
+      await app.inject({
+        method: "POST",
+        url: "/api/v1/skills/audit",
+        cookies: auth(),
+        headers,
+        payload: { scanId, name: "demo-skill" },
+      });
+
+      const installRes = await app.inject({
+        method: "POST",
+        url: "/api/v1/skills/install",
+        cookies: auth(),
+        headers,
+        payload: { scanId, names: ["demo-skill"] },
+      });
+      expect(installRes.statusCode).toBe(200);
+
+      const reader = new SoulLoader(soulPath, { info() {}, warn() {}, error() {} });
+      await reader.load();
+      expect(reader.quarantined.filter((entry) => entry.name === "demo-skill")).toEqual([]);
+      expect(reader.skills.get("demo-skill")).toBeDefined();
+      // The exact resolution `load_skill_reference` performs beside the loaded Skill.
+      const base = join(soulPath, "skills", "demo-skill");
+      await expect(readFile(join(base, "references", "01-playbook.md"), "utf8")).resolves.toBe(
+        "# Playbook\n"
+      );
+      await expect(readFile(join(base, "scripts", "convert_to_asm.py"), "utf8")).resolves.toBe(
+        "print('convert')\n"
+      );
+      await expect(readFile(join(base, "LICENSE.txt"), "utf8")).resolves.toBe("MIT\n");
     });
 
     // A canonical-format package ships its own `skill.yaml`. That file is the Skill's definition,

--- a/apps/web/app/routes/_app.skills.marketplace.tsx
+++ b/apps/web/app/routes/_app.skills.marketplace.tsx
@@ -369,6 +369,10 @@ export default function SkillsMarketplace() {
                               variant={s.updateAvailable ? "default" : "outline"}
                               className="shrink-0"
                               disabled={busy !== null}
+                              // The catalog is ~88 identical actions deep, so the visible text is
+                              // the only thing distinguishing them and it is the same on every row.
+                              // Name the Skill in the label so navigating by role stays usable.
+                              aria-label={`${s.updateAvailable ? "Update" : "Install"} ${s.name}`}
                               onClick={() => loadIntoPipeline(catalog.scanId, [s])}
                             >
                               {s.updateAvailable ? "Update" : "Install"}

--- a/apps/web/app/routes/skills.marketplace.test.tsx
+++ b/apps/web/app/routes/skills.marketplace.test.tsx
@@ -178,8 +178,8 @@ test("catalog rows badge installed and update-available skills", async () => {
   expect(await screen.findByText(/official marketplace/i)).toBeInTheDocument();
   // Current install reads as a badge; not-installed and stale get per-row actions.
   expect(screen.getByText(/installed ✓/i)).toBeInTheDocument();
-  expect(screen.getByRole("button", { name: /^Install$/ })).toBeInTheDocument();
-  expect(screen.getByRole("button", { name: /^Update$/ })).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "Install fresh-skill" })).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "Update stale-skill" })).toBeInTheDocument();
   expect(screen.getByRole("heading", { name: "productivity" })).toBeInTheDocument();
   expect(screen.getByRole("heading", { name: "engineering" })).toBeInTheDocument();
   expect(screen.getByText("1 update available")).toBeInTheDocument();
@@ -196,7 +196,7 @@ test("per-row Install loads only that skill into the audit pipeline", async () =
     ],
   });
 
-  const installButtons = await screen.findAllByRole("button", { name: /^Install$/ });
+  const installButtons = await screen.findAllByRole("button", { name: /^Install /i });
   await user.click(installButtons[0]);
   // Only the chosen skill is queued for audit (1 selected), not the whole catalog.
   expect(await screen.findByRole("button", { name: /Run SkillAudit \(1\)/ })).toBeInTheDocument();
@@ -492,4 +492,26 @@ test("an install failure takes focus so it is seen at the point of failure", asy
   const alert = await screen.findByRole("alert");
   expect(alert).toHaveTextContent(/install failed: invalid soul write target/i);
   expect(alert).toHaveFocus();
+});
+
+// #447: the catalog is ~88 rows deep and every row ships the same action, so the accessible name
+// is the only thing a reader navigating by role has to tell them apart. "Install" repeated is a
+// list of identical controls: it names the verb and never the Skill the verb applies to.
+test("each catalog row's action is named for the skill it acts on", async () => {
+  renderInstall({
+    scanId: "mkt-4",
+    source: "tulipfarm/skills",
+    skills: [
+      { name: "kb-article", description: "One.", installed: false, updateAvailable: false },
+      { name: "sql-queries", description: "Two.", installed: false, updateAvailable: false },
+      { name: "ticket-triage", description: "Three.", installed: true, updateAvailable: true },
+    ],
+  });
+
+  const actions = await screen.findAllByRole("button", { name: /^(install|update) /i });
+  expect(actions).toHaveLength(3);
+  // Pairwise distinct: each name resolves to exactly one control.
+  for (const name of ["Install kb-article", "Install sql-queries", "Update ticket-triage"]) {
+    expect(screen.getAllByRole("button", { name }), name).toHaveLength(1);
+  }
 });


### PR DESCRIPTION
The marketplace catalog renders one action per row and every one of them was called exactly "Install" (or "Update"). Across ~88 rows that is a list of identical controls: navigating by role announces the verb and never the Skill the verb applies to, so the only way to tell them apart is to linearly read the row first. The visible text is unchanged; the accessible name now carries the Skill name, which also keeps the visible label contained in the accessible one.

Closes #447.

#446 and #445 were re-checked against this tree and neither reproduces; both were closed by earlier merges that left the issues open. Each is now pinned by a test that is red against the tree that carried the defect:

- #446 ("invalid soul write target" on any package with references/ or scripts/) was never about those directories — the layout registry has always addressed them. Every package that failed also shipped a root LICENSE.txt, and every package that installed shipped nothing but SKILL.md; the root provenance file was the unaddressable path, and the gateway rejects a changeset whole on its first bad target. Fixed by #464 and #494. The new test additionally reads the installed companions back through the reader's own path — SoulLoader resolving the Skill, then the resolution load_skill_reference performs beside it — because a 200 from install is not the claim that matters.

- #445 (duplicate skill name corrupts checkbox selection) was reported as a React key collision. It was not: restoring the colliding keys alone leaves the behaviour correct and produces only React's duplicate-key warning. The defect was the selection Set keyed by skill name, so two rows sharing a name read and wrote one entry — ticking one ticked both and the count desynced from the DOM. Fixed by #464 and #496.

## Summary

<!-- What changed, and why. Link the driving issue if one exists. -->

## Test plan

<!-- Commands you ran, or manual steps / screenshots for UI changes. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (or the scoped `--filter` you actually ran)

## Checklist

- [ ] PR title follows Conventional Commits (`type(scope): subject`) — CI checks this
- [ ] Scoped to one logical change
- [ ] Tests added/updated for the behavior that changed
