### PR TITLE
fix(forge): enforce name and resource checks in forge Tools

### DIFF
--- a/apps/api/src/platform/forge-tool.test.ts
+++ b/apps/api/src/platform/forge-tool.test.ts
@@ -45,6 +45,34 @@ function trigger(slug = "daily-report-manual") {
   };
 }
 
+function routineOverRecords(resourceType: string) {
+  return {
+    ...VALID_ROUTINE,
+    spec: {
+      owner: "operations",
+      start: "Search",
+      states: [
+        {
+          name: "Search",
+          type: "tool",
+          toolRef: { name: "record_search", version: "1" },
+          action: "record_search",
+          input: { type: resourceType },
+          transition: "Update",
+        },
+        {
+          name: "Update",
+          type: "tool",
+          toolRef: { name: "record_update", version: "1" },
+          action: "record_update",
+          input: { type: resourceType, id: "${states.Search.output.id}" },
+          end: true,
+        },
+      ],
+    },
+  };
+}
+
 function makeSoulWriter(): SoulWriter & { apply: ReturnType<typeof vi.fn> } {
   return {
     apply: vi.fn().mockResolvedValue({
@@ -162,6 +190,40 @@ describe("routine_forge", () => {
     expect(result).toMatchObject({ success: false, error: { code: "internal_error" } });
     expect(JSON.stringify(result)).toContain("bundle storage unavailable");
     expect(onRoutinesChanged).not.toHaveBeenCalled();
+  });
+
+  // #436: a Routine whose Record States name a Resource type that was never created is doomed at
+  // every future Run, so the reference has to be checked against the Soul before it is committed.
+  it("refuses a Routine that references a Resource type the Soul does not have", async () => {
+    const result = await routineForgeTool.handler(
+      {
+        name: "daily-report",
+        definition: routineOverRecords("totally-nonexistent-resource-xyz"),
+        triggers: [trigger()],
+      },
+      { ...ctx(), soulLoader: { skills: new Map(), agents: new Map(), resources: new Map() } }
+    );
+
+    expect(result).toMatchObject({ success: false, error: { code: "validation_error" } });
+    expect(JSON.stringify(result)).toContain("totally-nonexistent-resource-xyz");
+    expect(soulWriter.apply).not.toHaveBeenCalled();
+  });
+
+  it("commits a Routine whose referenced Resource type exists", async () => {
+    const result = await routineForgeTool.handler(
+      { name: "daily-report", definition: routineOverRecords("ticket"), triggers: [trigger()] },
+      {
+        ...ctx(),
+        soulLoader: {
+          skills: new Map(),
+          agents: new Map(),
+          resources: new Map([["ticket", {}]]),
+        },
+      }
+    );
+
+    expect(result).toMatchObject({ success: true, data: { name: "daily-report" } });
+    expect(soulWriter.apply).toHaveBeenCalledOnce();
   });
 
   it("describes canonical Routine and Trigger requirements", () => {

--- a/apps/api/src/platform/tools.ts
+++ b/apps/api/src/platform/tools.ts
@@ -16,6 +16,7 @@ import {
   type SoulSkill,
   SoulWriteError,
   type SoulWriter,
+  unresolvedRoutineResourceTypes,
 } from "@tulipfarm/soul";
 import type { RequestContext } from "@tulipfarm/tool-host";
 import { type ApiToolDefinition, defineApiTool } from "@tulipfarm/tool-host";
@@ -32,6 +33,8 @@ export interface PlatformToolContext {
     skills: Map<string, SoulSkill>;
     agents: Map<string, SoulAgent>;
     routines?: Map<string, SoulRoutine>;
+    /** Read by `routine_forge` so a Routine cannot name a Resource type the Soul does not have. */
+    resources?: ReadonlyMap<string, unknown>;
   };
   soulPath?: string;
   gitSync?: GitSyncService;
@@ -297,6 +300,8 @@ export const routineForgeTool = defineApiTool<PlatformToolContext>({
       return err("validation_error", "definition.metadata.slug must match name");
     if (routine.metadata.lifecycle !== "published")
       return err("validation_error", "definition.metadata.lifecycle must be published");
+    const unresolved = unresolvedRoutineResourceTypes(routine.spec, ctx.soulLoader?.resources);
+    if (unresolved !== undefined) return err(unresolved.code, unresolved.message);
     if (
       new Set(triggerDefinitions.map((trigger) => trigger.metadata.slug)).size !==
       triggerDefinitions.length

--- a/apps/api/src/soul/agents/name-conflict.test.ts
+++ b/apps/api/src/soul/agents/name-conflict.test.ts
@@ -1,0 +1,165 @@
+import type { GitSyncService, SoulAgent, SoulLoader, SoulWriter } from "@tulipfarm/soul";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AGENT_TOOLS, type AgentToolContext } from "./tools";
+
+function makeSoulLoader(agents: SoulAgent[]): SoulLoader {
+  return {
+    agents: new Map(agents.map((agent) => [agent.name, agent])),
+    reload: vi.fn().mockResolvedValue(undefined),
+  } as unknown as SoulLoader;
+}
+
+function makeSoulWriter(): SoulWriter & { apply: ReturnType<typeof vi.fn> } {
+  return {
+    apply: vi.fn().mockResolvedValue({
+      commitSha: "abc1234",
+      filesChanged: 1,
+      paths: [],
+      pushed: false,
+      published: true,
+    }),
+  } as unknown as SoulWriter & { apply: ReturnType<typeof vi.fn> };
+}
+
+const createTool = AGENT_TOOLS.find(
+  (tool) => tool.name === "agent_create"
+) as (typeof AGENT_TOOLS)[number];
+
+const EXISTING_LABEL = "FAQ Support Agent";
+
+describe("agent_create refuses a duplicate Agent name in the Tool execution path", () => {
+  let soulWriter: ReturnType<typeof makeSoulWriter>;
+
+  function ctx(agents: SoulAgent[]): AgentToolContext {
+    return {
+      gitSync: {} as GitSyncService,
+      soulLoader: makeSoulLoader(agents),
+      soulWriter,
+    };
+  }
+
+  beforeEach(() => {
+    soulWriter = makeSoulWriter();
+  });
+
+  // #435: the collision is on the *display* name. The slugs differ, so the Soul writer's
+  // absent-slug precondition never fires and the duplicate lands silently.
+  it("refuses a frontmatter label that duplicates an existing Agent, even when the slug is free", async () => {
+    const existing: SoulAgent = {
+      name: "qa-20260819-0102-fullstaging-authtest",
+      frontmatter: { label: EXISTING_LABEL },
+      body: "original",
+    };
+
+    const result = await createTool.handler(
+      {
+        name: "faq-support-agent",
+        body: "answers pricing questions",
+        frontmatter: { label: EXISTING_LABEL, domain: "qa-stress-dup" },
+      },
+      ctx([existing])
+    );
+
+    expect(result).toMatchObject({ success: false, error: { code: "validation_error" } });
+    expect(JSON.stringify(result)).toContain(existing.name);
+    expect(soulWriter.apply).not.toHaveBeenCalled();
+  });
+
+  // #463: the refusal must carry the resolution vocabulary, or the caller has nothing to do with
+  // the user's answer except ask the question again.
+  it("names the resolving argument in the refusal", async () => {
+    const result = await createTool.handler(
+      {
+        name: "support-triage",
+        body: "triage",
+        frontmatter: { label: "Support Triage" },
+      },
+      ctx([{ name: "support-triage", frontmatter: { label: "Support Triage" }, body: "old" }])
+    );
+
+    expect(result).toMatchObject({ success: false, error: { code: "validation_error" } });
+    expect(JSON.stringify(result)).toContain("onExisting");
+  });
+
+  // #463: "leave unchanged" must be expressible as a Tool call that SUCCEEDS and writes nothing.
+  // Without one the answer has nowhere to land, so every later Turn re-derives the same card.
+  it("terminates on 'leave the existing Agent unchanged' without writing", async () => {
+    const existing: SoulAgent = {
+      name: "support-triage",
+      frontmatter: { label: "Support Triage" },
+      body: "old",
+    };
+
+    const result = await createTool.handler(
+      {
+        name: "support-triage",
+        body: "new body",
+        frontmatter: { label: "Support Triage" },
+        onExisting: "keep",
+      },
+      ctx([existing])
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      data: { name: "support-triage", created: false, changed: false },
+    });
+    expect(soulWriter.apply).not.toHaveBeenCalled();
+  });
+
+  // #463: and so must "update the existing one", in one call, with no second question.
+  it("terminates on 'update the existing Agent' with a single write", async () => {
+    const existing: SoulAgent = {
+      name: "support-triage",
+      frontmatter: { label: "Support Triage" },
+      body: "old",
+    };
+
+    const result = await createTool.handler(
+      {
+        name: "support-triage",
+        body: "new body",
+        frontmatter: { label: "Support Triage" },
+        onExisting: "update",
+      },
+      ctx([existing])
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      data: { name: "support-triage", created: false, changed: true },
+    });
+    expect(soulWriter.apply).toHaveBeenCalledOnce();
+    const request = soulWriter.apply.mock.calls[0]?.[0] as { preconditions?: unknown[] };
+    expect(request.preconditions).toBeUndefined();
+  });
+
+  // A decided call must never re-enter the undecided branch: answering the question once ends it.
+  it("never re-refuses a call that already carries a decision", async () => {
+    const agents: SoulAgent[] = [
+      { name: "support-triage", frontmatter: { label: "Support Triage" }, body: "old" },
+      { name: "other", frontmatter: { label: "Support Triage" }, body: "other" },
+    ];
+    for (const onExisting of ["keep", "update"] as const) {
+      const first = await createTool.handler(
+        { name: "support-triage", body: "b", frontmatter: { label: "Support Triage" }, onExisting },
+        ctx(agents)
+      );
+      const second = await createTool.handler(
+        { name: "support-triage", body: "b", frontmatter: { label: "Support Triage" }, onExisting },
+        ctx(agents)
+      );
+      expect(first, onExisting).toMatchObject({ success: true });
+      expect(second, onExisting).toMatchObject({ success: true });
+    }
+  });
+
+  it("still creates when nothing collides", async () => {
+    const result = await createTool.handler(
+      { name: "brand-new", body: "b", frontmatter: { label: "Brand New" } },
+      ctx([{ name: "support-triage", frontmatter: { label: "Support Triage" }, body: "old" }])
+    );
+    expect(result).toMatchObject({ success: true, data: { name: "brand-new", created: true } });
+    expect(soulWriter.apply).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/api/src/soul/agents/tools.test.ts
+++ b/apps/api/src/soul/agents/tools.test.ts
@@ -98,7 +98,13 @@ describe("agent_create", () => {
 
     expect(res).toEqual({
       success: true,
-      data: { name: "task-planner", frontmatter: {}, body: "You plan tasks." },
+      data: {
+        name: "task-planner",
+        created: true,
+        changed: true,
+        frontmatter: {},
+        body: "You plan tasks.",
+      },
     });
     expect(ctx.soulWriter.apply).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/api/src/soul/agents/tools.ts
+++ b/apps/api/src/soul/agents/tools.ts
@@ -1,7 +1,11 @@
 import { DEPLOYMENT_BUSINESS_ID } from "@tulipfarm/constants";
 import { ajv, TulipFarmValidationError, validateAgentFrontmatter } from "@tulipfarm/schema";
 import {
+  AGENT_EXISTING_DECISIONS,
+  type AgentExistingDecision,
+  agentWriteRequest,
   type GitSyncService,
+  resolveAgentName,
   type SoulLoader,
   SoulWriteError,
   type SoulWriter,
@@ -14,7 +18,6 @@ import {
   type RequestContext,
   type ToolCallResult,
 } from "@tulipfarm/tool-host";
-import { stringify } from "yaml";
 import { SYSTEM_SOUL_COMMIT_ACTOR } from "../../runtime/soul-writer";
 import { soulCommitError } from "../../tools/soul-faults";
 
@@ -77,11 +80,6 @@ function firstError(validate: ReturnType<typeof ajv.compile>): string {
   return `${e.instancePath || "(root)"} ${e.message ?? "is invalid"}`.trim();
 }
 
-function serializeAgent(frontmatter: Record<string, unknown>, body: string): string {
-  if (Object.keys(frontmatter).length === 0) return body;
-  return `---\n${stringify(frontmatter)}---\n${body}`;
-}
-
 // Write-time meta-schema gate (VAL-V1-010). Returns a validation_error
 // result on invalid frontmatter, or null when it passes.
 function frontmatterError(frontmatter: Record<string, unknown>): ToolCallResult | null {
@@ -93,6 +91,25 @@ function frontmatterError(frontmatter: Record<string, unknown>): ToolCallResult 
       return err("validation_error", `${e.path} ${e.message}`.trim());
     }
     throw e;
+  }
+}
+
+/** The one `AGENT.md` write both agent Tools take: the failing result, or `null` once committed. */
+async function putAgent(
+  ctx: AgentToolContext,
+  verb: "add" | "update",
+  name: string,
+  frontmatter: Record<string, unknown>,
+  body: string,
+  onPrecondition: () => ToolCallResult
+): Promise<ToolCallResult | null> {
+  const actor = ctx.requestContext?.actor ?? SYSTEM_SOUL_COMMIT_ACTOR;
+  try {
+    await ctx.soulWriter.apply(agentWriteRequest(verb, name, frontmatter, body, actor));
+    return null;
+  } catch (e) {
+    if (e instanceof SoulWriteError) return mapSoulWriteError(e, onPrecondition);
+    return err("internal_error", reason(e));
   }
 }
 
@@ -113,6 +130,12 @@ const CREATE_SCHEMA = {
       type: "object",
       description:
         "Optional frontmatter. Allowed keys: label, domain, description, model, autonomy (full|supervised|approval-required|manual), modelPolicy, capabilityRestrictions, placeholder (string[]), suggestions (string[]). Use capabilityRestrictions to set server-enforced Tool, Record, and Resource type limits such as read-only access.",
+    },
+    onExisting: {
+      type: "string",
+      enum: [...AGENT_EXISTING_DECISIONS],
+      description:
+        "The user's decision when an Agent already holds this name or label. Omit on the first attempt; the Tool then reports the collision. Ask the user once, then re-call with 'keep' to leave the existing Agent untouched or 'update' to replace its body and frontmatter. Never ask the same question twice.",
     },
   },
 } as const;
@@ -139,10 +162,12 @@ const agentCreate = defineApiTool<AgentToolContext>({
       name,
       body,
       frontmatter = {},
+      onExisting,
     } = args as {
       name: string;
       body: string;
       frontmatter?: Record<string, unknown>;
+      onExisting?: AgentExistingDecision;
     };
 
     if (!NAME_RE.test(name)) return err("validation_error", "invalid agent name");
@@ -150,29 +175,16 @@ const agentCreate = defineApiTool<AgentToolContext>({
     const fmError = frontmatterError(frontmatter);
     if (fmError) return fmError;
 
-    try {
-      await ctx.soulWriter.apply({
-        subject: `soul: add agent ${name}`,
-        source: "agent",
-        actor: ctx.requestContext?.actor ?? SYSTEM_SOUL_COMMIT_ACTOR,
-        businessId: DEPLOYMENT_BUSINESS_ID,
-        changes: [
-          {
-            op: "put",
-            target: { kind: "Agent", slug: name, definitionMode: "legacy" },
-            content: serializeAgent(frontmatter, body),
-          },
-        ],
-        preconditions: [{ kind: "Agent", slug: name, state: "absent" }],
-      });
-    } catch (e) {
-      if (e instanceof SoulWriteError) {
-        return mapSoulWriteError(e, () => err("validation_error", "agent already exists"));
-      }
-      return err("internal_error", reason(e));
-    }
+    const plan = resolveAgentName(ctx.soulLoader.agents, name, frontmatter, onExisting);
+    if (plan.outcome === "refuse") return err("validation_error", plan.message);
+    if (plan.outcome === "keep") return ok({ created: false, changed: false, ...plan.agent });
 
-    return ok({ name, frontmatter, body });
+    const created = plan.outcome === "create";
+    const target = created ? name : plan.agent.name;
+    const failure = await putAgent(ctx, created ? "add" : "update", target, frontmatter, body, () =>
+      err("validation_error", "agent already exists")
+    );
+    return failure ?? ok({ name: target, created, changed: true, frontmatter, body });
   },
 });
 
@@ -232,28 +244,10 @@ const agentUpdate = defineApiTool<AgentToolContext>({
     const newBody = body ?? existing.body;
     const newFm = frontmatter ?? existing.frontmatter;
 
-    try {
-      await ctx.soulWriter.apply({
-        subject: `soul: update agent ${name}`,
-        source: "agent",
-        actor: ctx.requestContext?.actor ?? SYSTEM_SOUL_COMMIT_ACTOR,
-        businessId: DEPLOYMENT_BUSINESS_ID,
-        changes: [
-          {
-            op: "put",
-            target: { kind: "Agent", slug: name, definitionMode: "legacy" },
-            content: serializeAgent(newFm, newBody),
-          },
-        ],
-      });
-    } catch (e) {
-      if (e instanceof SoulWriteError) {
-        return mapSoulWriteError(e, () => err("not_found", `agent not found: ${name}`));
-      }
-      return err("internal_error", reason(e));
-    }
-
-    return ok({ name, frontmatter: newFm, body: newBody });
+    const failure = await putAgent(ctx, "update", name, newFm, newBody, () =>
+      err("not_found", `agent not found: ${name}`)
+    );
+    return failure ?? ok({ name, frontmatter: newFm, body: newBody });
   },
 });
 

--- a/apps/docs/content/docs/using-tulipfarm/build-a-routine.mdx
+++ b/apps/docs/content/docs/using-tulipfarm/build-a-routine.mdx
@@ -27,6 +27,11 @@ want to trigger it manually.
 The assistant loads `routine-forge`, asks for missing inputs, writes the routine into the
 soul, commits it, and reconciles live.
 
+A routine that reads or writes records can only refer to a resource type that already exists.
+If it names one you have not defined yet, the forge refuses to publish and tells you which type
+is missing, so [define the resource type](/docs/using-tulipfarm/define-a-resource-type) first
+and then ask again.
+
 ## Review it on the canvas
 
 <Steps>

--- a/apps/docs/content/docs/using-tulipfarm/create-an-agent.mdx
+++ b/apps/docs/content/docs/using-tulipfarm/create-an-agent.mdx
@@ -49,6 +49,18 @@ cannot hand the work to a less restricted agent instead. Ask the forge to read t
 to you before it commits, so you can correct it. See
 [Agents](/docs/using-tulipfarm/agents#tools-and-current-limits).
 
+## Reuse or replace an existing name
+
+If an agent with that name already exists, the forge stops before it writes and asks you once
+which one you mean. Answer in chat:
+
+```prompt
+Leave the existing agent unchanged.
+```
+
+Say "update the existing agent" instead and the forge rewrites that agent rather than adding a
+second one with the same name. Either answer ends the question — the forge does not ask again.
+
 ## Verify and use it
 
 <Steps>

--- a/packages/soul/AGENTS.md
+++ b/packages/soul/AGENTS.md
@@ -13,7 +13,7 @@ Loader, compiler, publisher, and git-sync engine for Soul artifacts. Root `soul/
 | `src/soul-loader.ts`, `src/tree-reader.ts`, `src/soul-path.ts` | Disk and tree reads. |
 | `src/compiler.ts`, `src/bundle.ts`, `src/bundle-retention.ts`, `src/published-loader.ts` | Runtime bundles. |
 | `src/signatures.ts`, `src/publication.ts`, `src/publisher.ts` | Publish flow. |
-| `src/routine-catalog.ts` | Routines browse model over the active publication. |
+| `src/routine-catalog.ts`, `src/routines/` | Routines browse model; Routine reference validation. |
 | `src/git-*`, `src/pinned-definition.ts`, `src/definition-reader.ts` | Git and pinned reads. |
 | `src/integration-*`, `src/types.ts` | Integration manifest trust/auth contracts. |
 | `src/migrations/`, `src/soul-migrations.ts` | Migrations. |

--- a/packages/soul/src/agents/agent-write.ts
+++ b/packages/soul/src/agents/agent-write.ts
@@ -1,0 +1,39 @@
+import { DEPLOYMENT_BUSINESS_ID } from "@tulipfarm/constants";
+import { stringify } from "yaml";
+import type { CommitActor } from "../commit-signing";
+import type { SoulWriteRequest } from "../writer";
+
+/** An Agent's `AGENT.md` text: a frontmatter block when there is any, then the markdown body. */
+export function serializeAgent(frontmatter: Record<string, unknown>, body: string): string {
+  if (Object.keys(frontmatter).length === 0) return body;
+  return `---\n${stringify(frontmatter)}---\n${body}`;
+}
+
+/**
+ * The `AGENT.md` changeset for a create or an update. Only `add` asserts the slug is free — an
+ * update carrying that precondition could never apply to the Agent it is meant to replace.
+ */
+export function agentWriteRequest(
+  verb: "add" | "update",
+  name: string,
+  frontmatter: Record<string, unknown>,
+  body: string,
+  actor: CommitActor
+): SoulWriteRequest {
+  return {
+    subject: `soul: ${verb} agent ${name}`,
+    source: "agent",
+    actor,
+    businessId: DEPLOYMENT_BUSINESS_ID,
+    changes: [
+      {
+        op: "put",
+        target: { kind: "Agent", slug: name, definitionMode: "legacy" },
+        content: serializeAgent(frontmatter, body),
+      },
+    ],
+    ...(verb === "add"
+      ? { preconditions: [{ kind: "Agent" as const, slug: name, state: "absent" as const }] }
+      : {}),
+  };
+}

--- a/packages/soul/src/agents/name-conflict.ts
+++ b/packages/soul/src/agents/name-conflict.ts
@@ -1,0 +1,71 @@
+import type { SoulAgent } from "../types";
+
+/** What the caller decided about an Agent that already occupies the requested name. */
+export const AGENT_EXISTING_DECISIONS = ["keep", "update"] as const;
+export type AgentExistingDecision = (typeof AGENT_EXISTING_DECISIONS)[number];
+
+/** What `agent_create` should do, once the Soul has been consulted. */
+export type AgentNamePlan =
+  | { readonly outcome: "create" }
+  | { readonly outcome: "keep"; readonly agent: SoulAgent }
+  | { readonly outcome: "replace"; readonly agent: SoulAgent }
+  | { readonly outcome: "refuse"; readonly message: string };
+
+function labelKey(frontmatter: Record<string, unknown> | undefined): string | undefined {
+  const label = frontmatter?.label;
+  if (typeof label !== "string") return undefined;
+  const key = label.trim().toLowerCase();
+  return key.length === 0 ? undefined : key;
+}
+
+/**
+ * The Agent already answering to this name, by Soul slug or by display label.
+ *
+ * The write gateway guards only the slug, so two Agents sharing a `label` — the name @-mention,
+ * delegation and every list render on — are indistinguishable to a human while being perfectly
+ * legal on disk. Both have to be checked, and before the write, or the Tool has nothing to offer.
+ */
+function occupant(
+  agents: ReadonlyMap<string, SoulAgent>,
+  name: string,
+  frontmatter: Record<string, unknown> | undefined
+): { agent: SoulAgent; kind: "slug" | "label" } | undefined {
+  const bySlug = agents.get(name);
+  if (bySlug) return { agent: bySlug, kind: "slug" };
+  const wanted = labelKey(frontmatter);
+  if (wanted === undefined) return undefined;
+  for (const agent of agents.values())
+    if (labelKey(agent.frontmatter) === wanted) return { agent, kind: "label" };
+  return undefined;
+}
+
+/**
+ * Decide the name collision before anything is written.
+ *
+ * `decision` is where the user's answer lands. Without somewhere to put it the Tool can only refuse
+ * again, so the answer gets narrated back and the next Turn re-derives the same clarification from
+ * the same Tool result — reworded each time, because it is regenerated rather than replayed.
+ */
+export function resolveAgentName(
+  agents: ReadonlyMap<string, SoulAgent>,
+  name: string,
+  frontmatter: Record<string, unknown> | undefined,
+  decision: AgentExistingDecision | undefined
+): AgentNamePlan {
+  const taken = occupant(agents, name, frontmatter);
+  if (taken === undefined) return { outcome: "create" };
+  if (decision === "keep") return { outcome: "keep", agent: taken.agent };
+  if (decision === "update") return { outcome: "replace", agent: taken.agent };
+  const collision =
+    taken.kind === "slug"
+      ? `Agent "${taken.agent.name}" already exists`
+      : `Agent "${taken.agent.name}" already uses that label`;
+  return {
+    outcome: "refuse",
+    message:
+      `${collision}, so creating "${name}" would leave two Agents users cannot tell apart. Ask ` +
+      `the user once, then re-call agent_create with onExisting="keep" to leave ` +
+      `"${taken.agent.name}" exactly as it is, or onExisting="update" to replace its body and ` +
+      "frontmatter. Choose a different name and label to have both.",
+  };
+}

--- a/packages/soul/src/index.ts
+++ b/packages/soul/src/index.ts
@@ -7,6 +7,9 @@ export type {
   PublishedAgentVersion,
 } from "./agent-publication";
 export { AgentPublicationError, publishAgentVersion } from "./agent-publication";
+export { agentWriteRequest, serializeAgent } from "./agents/agent-write";
+export type { AgentExistingDecision, AgentNamePlan } from "./agents/name-conflict";
+export { AGENT_EXISTING_DECISIONS, resolveAgentName } from "./agents/name-conflict";
 export type { PlatformAgent } from "./agents/platform-agents";
 export {
   DEFAULT_ASSISTANT,
@@ -198,6 +201,11 @@ export type {
   RoutineCatalogTrigger,
 } from "./routine-catalog";
 export { ActiveRoutineCatalog } from "./routine-catalog";
+export type { RoutineResourceRefusal } from "./routines/resource-references";
+export {
+  routineResourceTypeReferences,
+  unresolvedRoutineResourceTypes,
+} from "./routines/resource-references";
 export { scaffoldSoul } from "./scaffold-soul";
 export { validateSoulSemantics } from "./semantic";
 export type { BundleSigner, BundleVerifier, TrustedBundlePublicKey } from "./signatures";

--- a/packages/soul/src/routines/resource-references.ts
+++ b/packages/soul/src/routines/resource-references.ts
@@ -1,0 +1,64 @@
+/**
+ * Resource types a canonical Routine's Record States name, and whether the Soul actually has them.
+ *
+ * A Routine is validated document-by-document — shape, slug, lifecycle, Trigger back-references —
+ * and every one of those checks is internal to the paperwork. A `record_*` State naming a Resource
+ * type nobody created passes all of them and then fails, or silently no-ops, on every Run it ever
+ * has. The reference is only meaningful against the Soul, so it has to be checked against the Soul.
+ */
+
+const RECORD_TOOL_PREFIX = "record_";
+
+function literalResourceType(state: unknown): string | undefined {
+  if (state === null || typeof state !== "object") return undefined;
+  const { type, toolRef, action, input } = state as Record<string, unknown>;
+  if (type !== "tool") return undefined;
+  const tool = (toolRef as { name?: unknown } | undefined)?.name ?? action;
+  if (typeof tool !== "string" || !tool.startsWith(RECORD_TOOL_PREFIX)) return undefined;
+  const referenced = (input as { type?: unknown } | undefined)?.type;
+  if (typeof referenced !== "string" || referenced.length === 0) return undefined;
+  // Only a literal is a claim about the Soul; an expression resolves per Run and cannot be checked.
+  return referenced.includes("$") || referenced.includes("{") ? undefined : referenced;
+}
+
+/** Every distinct Resource type the Routine's Record States name literally. */
+export function routineResourceTypeReferences(spec: unknown): string[] {
+  const states = (spec as { states?: unknown } | undefined)?.states;
+  if (!Array.isArray(states)) return [];
+  const referenced = new Set<string>();
+  for (const state of states) {
+    const type = literalResourceType(state);
+    if (type !== undefined) referenced.add(type);
+  }
+  return [...referenced];
+}
+
+export interface RoutineResourceRefusal {
+  readonly code: "validation_error" | "unavailable";
+  readonly message: string;
+}
+
+/**
+ * Why the Routine must not be committed, or `undefined` when every reference resolves.
+ *
+ * An absent `known` map is refused rather than waved through: a Routine whose references were never
+ * checked is indistinguishable from one whose references are wrong, and only one of those is safe.
+ */
+export function unresolvedRoutineResourceTypes(
+  spec: unknown,
+  known: ReadonlyMap<string, unknown> | undefined
+): RoutineResourceRefusal | undefined {
+  const referenced = routineResourceTypeReferences(spec);
+  if (referenced.length === 0) return undefined;
+  if (known === undefined)
+    return {
+      code: "unavailable",
+      message: `Resource types are not loaded, so the references to ${referenced.join(", ")} cannot be verified and the Routine was not committed.`,
+    };
+  const missing = referenced.filter((type) => !known.has(type));
+  if (missing.length === 0) return undefined;
+  return {
+    code: "validation_error",
+    message: `No Resource type named ${missing.join(", ")} exists, so every Run of this Routine would fail. Create the Resource type first with create_resource_type, or point the Routine at an existing type.`,
+  };
+}


### PR DESCRIPTION
agent_create had no name decision of its own. Its only uniqueness guard was the `absent` precondition handed to SoulWriter, keyed on the Soul slug alone, so two Agents could share a `frontmatter.label` — the name people @-mention and delegate by — while being perfectly legal on disk (#435). When the slug did collide the gateway threw PRECONDITION_FAILED, which mapped to a bare `validation_error`; that code has fault class "business", so the Tool loop handed it back as a repairable-argument fault. Nothing was repairable, and no argument existed in which the user's answer could be recorded, so the answer was narrated and dropped and the next Turn re-derived the identical question from the identical Tool result — regenerated, not replayed, which is why the options came back reworded every time (#463). One defect, two faces.

resolveAgentName now consults the Soul by slug and by normalised label before anything is written, and `onExisting` gives the user's decision somewhere to land: "keep" returns the existing Agent and writes nothing, "update" rewrites that Agent with no `absent` precondition. Both terminate, so the clarification is asked at most once.

routine_forge validated only intra-document facts — shape, slug match, lifecycle, Trigger back-references — and never cross-checked a reference against the Soul, so a `record_*` State naming a Resource type nobody created published cleanly and failed on every Run (#436). The literal Resource types a Routine names are now resolved against `soulLoader.resources`, the same map `record_create` reads, and an unloadable map refuses rather than waves through.

Every check runs in the Tool handler, not in prompt text. The decision logic lives in @tulipfarm/soul to keep the apps/api/src line delta at -1.

Closes #463
Closes #435
Closes #436

## Summary

<!-- What changed, and why. Link the driving issue if one exists. -->

## Test plan

<!-- Commands you ran, or manual steps / screenshots for UI changes. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (or the scoped `--filter` you actually ran)

## Checklist

- [ ] PR title follows Conventional Commits (`type(scope): subject`) — CI checks this
- [ ] Scoped to one logical change
- [ ] Tests added/updated for the behavior that changed
