### PR TITLE
fix(storage): re-assert bundled bucket secret perms every boot

### DIFF
--- a/packages/storage/src/ports/bundled-bucket.ts
+++ b/packages/storage/src/ports/bundled-bucket.ts
@@ -45,16 +45,18 @@ export function writeBucketSecrets(dataDir: string): BucketSecretsResult {
   const dir = join(dataDir, BUCKET_SECRETS_DIR);
   const rpcSecretFile = join(dir, RPC_SECRET_FILE);
   const adminTokenFile = join(dir, ADMIN_TOKEN_FILE);
-  if (existsSync(rpcSecretFile) && existsSync(adminTokenFile)) {
-    return { generated: false, rpcSecretFile, adminTokenFile };
-  }
+  const alreadyGenerated = existsSync(rpcSecretFile) && existsSync(adminTokenFile);
 
   try {
     mkdirSync(dir, { recursive: true });
     for (const file of [rpcSecretFile, adminTokenFile]) {
-      if (existsSync(file)) continue;
-      // No trailing newline: Garage reads the whole file as the secret.
-      writeFileSync(file, randomBytes(32).toString("hex"), { mode: 0o600 });
+      if (!existsSync(file)) {
+        // No trailing newline: Garage reads the whole file as the secret.
+        writeFileSync(file, randomBytes(32).toString("hex"), { mode: 0o600 });
+      }
+      // Garage refuses to boot against a world-readable secret; re-assert the mode on every
+      // boot, not just the one that wrote the file, since a prior version of this code (or a
+      // volume populated some other way) may have left it looser than 0600.
       chmodSync(file, 0o600);
     }
   } catch (err) {
@@ -65,7 +67,7 @@ export function writeBucketSecrets(dataDir: string): BucketSecretsResult {
         "S3_ENDPOINT at an external S3 provider and supply its credentials instead."
     );
   }
-  return { generated: true, rpcSecretFile, adminTokenFile };
+  return { generated: !alreadyGenerated, rpcSecretFile, adminTokenFile };
 }
 
 /** How the S3 credentials on `env` were arrived at. */


### PR DESCRIPTION
## Summary
- `writeBucketSecrets` early-returned once both secret files existed, skipping the `chmod 0600` — a file left world-readable (older build, manual copy, etc.) never got fixed on later boots.
- Garage refuses to start against a world-readable `rpc-secret`, breaking the bundled bucket container on every restart until manually chmod'd.
- Mode is now reasserted on every call, whether the file was just written or already existed.

## Test plan
- [x] `pnpm exec biome check packages/storage/src/ports/bundled-bucket.ts`
- [x] `pnpm --filter @tulipfarm/storage exec vitest run src/ports/bundled-bucket.test.ts` (17 passed)