### PR TITLE
feat(integrations): support targeting a GitHub org for App creation

### DIFF
--- a/apps/api/src/integrations/auth-broker.test.ts
+++ b/apps/api/src/integrations/auth-broker.test.ts
@@ -221,6 +221,80 @@ describe("startAuthStep", () => {
     expect(action.url).toContain(`state=${repo.requests[0].state}`);
   });
 
+  it("targets an org's create_url when the caller names one and the step supports it", async () => {
+    const repo = new MemoryAuthRequestRepo();
+    const action = await startAuthStep({
+      slug: "github",
+      manifest: manifestWith([
+        {
+          kind: "app_manifest",
+          create_url: "https://github.com/settings/apps/new?state={state}",
+          create_url_for_org:
+            "https://github.com/organizations/{org}/settings/apps/new?state={state}",
+          manifest_param: "manifest",
+          delivery: "form_post",
+          manifest: { name: "Tulip" },
+        },
+      ]),
+      stepIndex: 0,
+      env: {},
+      endpoints,
+      repo,
+      org: "acme-corp",
+    });
+    if (action.action !== "form_post") throw new Error("expected form_post");
+    expect(action.url).toBe(
+      `https://github.com/organizations/acme-corp/settings/apps/new?state=${repo.requests[0].state}`
+    );
+  });
+
+  it("falls back to the personal create_url when no org is given", async () => {
+    const repo = new MemoryAuthRequestRepo();
+    const action = await startAuthStep({
+      slug: "github",
+      manifest: manifestWith([
+        {
+          kind: "app_manifest",
+          create_url: "https://github.com/settings/apps/new?state={state}",
+          create_url_for_org:
+            "https://github.com/organizations/{org}/settings/apps/new?state={state}",
+          manifest_param: "manifest",
+          delivery: "form_post",
+          manifest: { name: "Tulip" },
+        },
+      ]),
+      stepIndex: 0,
+      env: {},
+      endpoints,
+      repo,
+    });
+    if (action.action !== "form_post") throw new Error("expected form_post");
+    expect(action.url).toBe(`https://github.com/settings/apps/new?state=${repo.requests[0].state}`);
+  });
+
+  it("ignores an org when the step declares no create_url_for_org", async () => {
+    const repo = new MemoryAuthRequestRepo();
+    const action = await startAuthStep({
+      slug: "github",
+      manifest: manifestWith([
+        {
+          kind: "app_manifest",
+          create_url: "https://github.com/settings/apps/new?state={state}",
+          manifest_param: "manifest",
+          delivery: "form_post",
+          manifest: { name: "Tulip" },
+        },
+      ]),
+      stepIndex: 0,
+      env: {},
+      endpoints,
+      repo,
+      org: "acme-corp",
+    });
+    if (action.action !== "form_post") throw new Error("expected form_post");
+    expect(action.url).toBe(`https://github.com/settings/apps/new?state=${repo.requests[0].state}`);
+  });
+
   it("sends the app manifest as a query param when the provider wants one", async () => {
     const repo = new MemoryAuthRequestRepo();
     const action = await startAuthStep({

--- a/apps/api/src/integrations/auth-broker.ts
+++ b/apps/api/src/integrations/auth-broker.ts
@@ -58,6 +58,8 @@ export interface StartAuthStepInput {
   /** User-scoped connect is allowed only for personal OAuth2 steps; never downgrade to shared. */
   fetchImpl?: typeof globalThis.fetch;
   principal?: { readonly kind: string; readonly id: string };
+  /** Target org login for an `app_manifest` step; ignored by steps with no `create_url_for_org`. */
+  org?: string;
 }
 
 function stepAt(manifest: IntegrationManifest, index: number): AuthStep {
@@ -195,8 +197,12 @@ export async function startAuthStep(input: StartAuthStepInput): Promise<AuthStar
 
     case "app_manifest": {
       const state = await issueState(input, null);
+      const org = input.org?.trim();
       const vars = integrationAuthEndpointVars(input.endpoints, input.env);
-      const url = renderTemplate(step.create_url, { ...vars, state });
+      // An org can only be targeted through a template the step opts into; a step with no
+      // create_url_for_org silently falls back to its personal-account create_url.
+      const createUrl = org && step.create_url_for_org ? step.create_url_for_org : step.create_url;
+      const url = renderTemplate(createUrl, { ...vars, state, ...(org ? { org } : {}) });
       const value = JSON.stringify(renderDeep(step.manifest, vars));
       if (step.delivery === "query_param") {
         const withParam = new URL(url);

--- a/apps/api/src/integrations/auth-routes.ts
+++ b/apps/api/src/integrations/auth-routes.ts
@@ -101,6 +101,14 @@ export function registerIntegrationAuthRoutes(
               description:
                 "`business` (default) connects the deployment's shared credential and requires an administrator. `user` connects the caller's own credential and requires only authentication; only an oauth2 authorization_code step declaring `personal: true` can issue one.",
             },
+            org: {
+              type: "string",
+              minLength: 1,
+              maxLength: 39,
+              pattern: "^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$",
+              description:
+                "Optional target org login for an app_manifest step, so the provider app is created under that org instead of the caller's personal account. Ignored by steps that do not support org targeting.",
+            },
           },
           additionalProperties: false,
         },
@@ -123,7 +131,9 @@ export function registerIntegrationAuthRoutes(
       const manifest = resolveManifest(name);
       if (!manifest) return reply.code(404).send({ error: `integration not found: ${name}` });
 
-      const scope = (req.body as { scope?: string } | undefined)?.scope ?? "business";
+      const body = req.body as { scope?: string; org?: string } | undefined;
+      const scope = body?.scope ?? "business";
+      const org = body?.org?.trim();
       // Credential owner comes from authenticated request, never the body.
       const caller = req.principal;
       if (caller === undefined) {
@@ -155,6 +165,7 @@ export function registerIntegrationAuthRoutes(
           endpoints,
           repo: deps.repo,
           fetchImpl: deps.fetchImpl,
+          ...(org ? { org } : {}),
           ...(scope === "user" && caller !== undefined
             ? { principal: { kind: caller.kind, id: caller.id } }
             : {}),

--- a/apps/api/src/integrations/github-auth-flow.test.ts
+++ b/apps/api/src/integrations/github-auth-flow.test.ts
@@ -278,6 +278,20 @@ describe("github declarative auth flow", () => {
     expect(res.statusCode).toBe(302);
   }
 
+  it("targets the org's manifest-creation URL when the operator names one", async () => {
+    const started = await app.inject({
+      method: "POST",
+      url: "/api/v1/integrations/github/auth/start/0",
+      cookies: auth(),
+      headers,
+      payload: { org: "acme-corp" },
+    });
+    expect(started.statusCode).toBe(200);
+    expect(String(started.json().url)).toContain(
+      "github.com/organizations/acme-corp/settings/apps/new"
+    );
+  });
+
   it("posts the App definition to GitHub instead of asking the operator to fill a form", async () => {
     const started = await startStep(0);
     const body = started.json();

--- a/apps/api/src/integrations/routes.ts
+++ b/apps/api/src/integrations/routes.ts
@@ -166,6 +166,8 @@ async function toDetail(entry: MergedIntegration, listing?: RegistryEntry) {
       // walkthrough: a step that writes nothing is satisfied before it is started.
       producesEnv: authStepProducesEnv(step),
       fields: step.kind === "fields" ? step.fields : undefined,
+      // Only an app_manifest step that declares an org-scoped create_url can honor an org input.
+      supportsOrgTarget: step.kind === "app_manifest" && step.create_url_for_org !== undefined,
     })),
     connected: entry.connected,
     setupGuide: entry.setupGuide,

--- a/apps/web/app/components/integrations/auth-flow.test.tsx
+++ b/apps/web/app/components/integrations/auth-flow.test.tsx
@@ -250,6 +250,46 @@ test("a form_post step POSTs the manifest, which a redirect cannot express", asy
   expect(input.value).toBe('{"name":"TulipFarm"}');
 });
 
+test("an org typed into the optional field is sent with the handoff", async () => {
+  const user = userEvent.setup();
+  const submit = vi.fn();
+  vi.spyOn(HTMLFormElement.prototype, "submit").mockImplementation(submit);
+  startAuthStep.mockResolvedValue({
+    action: "form_post",
+    url: "https://github.com/organizations/acme-corp/settings/apps/new?state=xyz",
+    field: "manifest",
+    value: '{"name":"TulipFarm"}',
+  });
+  flow([
+    {
+      index: 0,
+      kind: "app_manifest",
+      title: "Create the GitHub App",
+      satisfied: false,
+      producesEnv: true,
+      supportsOrgTarget: true,
+    },
+  ]);
+
+  await user.type(screen.getByLabelText("Organization (optional)"), "acme-corp");
+  await user.click(screen.getByRole("button", { name: /Create app on Slack/ }));
+
+  await waitFor(() => expect(startAuthStep).toHaveBeenCalledWith("slack", 0, "acme-corp"));
+});
+
+test("the org field is absent when the step does not support org targeting", () => {
+  flow([
+    {
+      index: 0,
+      kind: "app_manifest",
+      title: "Create the Slack app",
+      satisfied: false,
+      producesEnv: true,
+    },
+  ]);
+  expect(screen.queryByLabelText("Organization (optional)")).not.toBeInTheDocument();
+});
+
 test("a handoff failure is reported and the button becomes usable again", async () => {
   const user = userEvent.setup();
   startAuthStep.mockRejectedValue(new Error("SLACK_CLIENT_ID is not set"));

--- a/apps/web/app/components/integrations/auth-flow.tsx
+++ b/apps/web/app/components/integrations/auth-flow.tsx
@@ -66,9 +66,13 @@ function postForm(url: string, field: string, value: string, newTab: boolean): v
 export async function startHandoff(
   slug: string,
   stepIndex: number,
-  newTab = false
+  newTab = false,
+  org?: string
 ): Promise<"handed_off" | "completed"> {
-  const action = await startAuthStep(slug, stepIndex);
+  // Passed only when set, so a call with no org keeps matching call sites that never knew of it.
+  const action = org
+    ? await startAuthStep(slug, stepIndex, org)
+    : await startAuthStep(slug, stepIndex);
   if (action.action === "redirect") {
     if (newTab) window.open(action.url, "_blank", "noopener,noreferrer");
     else window.location.assign(action.url);
@@ -247,6 +251,7 @@ function ActiveStep({
   const [blank, setBlank] = useState<string[]>([]);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string>();
+  const [org, setOrg] = useState("");
 
   async function submitFields(e: React.FormEvent) {
     e.preventDefault();
@@ -276,7 +281,12 @@ function ActiveStep({
     setBusy(true);
     setError(undefined);
     try {
-      const outcome = await startHandoff(slug, step.index, !step.producesEnv);
+      const outcome = await startHandoff(
+        slug,
+        step.index,
+        !step.producesEnv,
+        org.trim() || undefined
+      );
       if (outcome === "completed") {
         onAdvance();
         setBusy(false);
@@ -327,16 +337,40 @@ function ActiveStep({
           </div>
         </form>
       ) : (
-        <div>
-          <Button type="button" disabled={busy} onClick={handoff}>
-            {busy
-              ? step.kind === "webhook"
-                ? "Registering…"
-                : "Opening…"
-              : `${HANDOFF_VERB[step.kind]} ${providerLabel}`}
-            {/* No external-link affordance for a step that never leaves the app. */}
-            {step.kind !== "webhook" && <ExternalLink aria-hidden />}
-          </Button>
+        <div className="flex flex-col gap-4">
+          {step.kind === "app_manifest" && step.supportsOrgTarget && (
+            <div className="flex flex-col gap-1.5">
+              <label className="text-sm font-medium text-foreground" htmlFor="auth-org-target">
+                Organization (optional)
+              </label>
+              <p className="text-xs text-muted-foreground">
+                Leave blank to create the app under your personal account, or enter an organization
+                login to create it there instead.
+              </p>
+              <Input
+                id="auth-org-target"
+                name="org"
+                type="text"
+                value={org}
+                autoComplete="off"
+                spellCheck={false}
+                placeholder="e.g. acme-corp"
+                className="max-w-xs font-mono text-sm"
+                onChange={(e) => setOrg(e.target.value)}
+              />
+            </div>
+          )}
+          <div>
+            <Button type="button" disabled={busy} onClick={handoff}>
+              {busy
+                ? step.kind === "webhook"
+                  ? "Registering…"
+                  : "Opening…"
+                : `${HANDOFF_VERB[step.kind]} ${providerLabel}`}
+              {/* No external-link affordance for a step that never leaves the app. */}
+              {step.kind !== "webhook" && <ExternalLink aria-hidden />}
+            </Button>
+          </div>
         </div>
       )}
     </>

--- a/apps/web/app/lib/integrations.ts
+++ b/apps/web/app/lib/integrations.ts
@@ -85,6 +85,8 @@ export type AuthStepSummary = {
   producesEnv: boolean;
   /** Present only for `fields` steps. */
   fields?: RequiredEnvVar[];
+  /** Whether an `app_manifest` step can create the app under a caller-named org. */
+  supportsOrgTarget?: boolean;
 };
 
 /** UI switches on broker `action`, not provider name, to avoid per-provider branches. */
@@ -95,11 +97,15 @@ export type AuthStartAction =
   /** The server already did the work — there is no handoff, only a refresh. */
   | { action: "completed" };
 
-export async function startAuthStep(name: string, step: number): Promise<AuthStartAction> {
+export async function startAuthStep(
+  name: string,
+  step: number,
+  org?: string
+): Promise<AuthStartAction> {
   return apiWrite<AuthStartAction>(
     "POST",
     `/api/v1/integrations/${encodeURIComponent(name)}/auth/start/${step}`,
-    {}
+    org ? { org } : {}
   );
 }
 

--- a/integrations/github/manifest.yml
+++ b/integrations/github/manifest.yml
@@ -40,6 +40,9 @@ auth:
     description: GitHub builds the App from a definition we send, so there is nothing to fill in
       by hand. The App belongs to this deployment, not to TulipFarm.
     create_url: https://github.com/settings/apps/new?state={state}
+    # Used instead of create_url when the operator names a target org, so the App is created
+    # under that org rather than their personal account.
+    create_url_for_org: https://github.com/organizations/{org}/settings/apps/new?state={state}
     manifest_param: manifest
     delivery: form_post
     manifest:

--- a/packages/soul/src/integration-auth.ts
+++ b/packages/soul/src/integration-auth.ts
@@ -167,6 +167,9 @@ export function validateAuthSteps(manifest: IntegrationManifest): string[] {
         break;
       case "app_manifest":
         if (!step.create_url) issues.push(`${at}: create_url missing`);
+        if (step.create_url_for_org && !step.create_url_for_org.includes("{org}")) {
+          issues.push(`${at}: create_url_for_org must contain {org}`);
+        }
         if (!step.manifest_param) issues.push(`${at}: manifest_param missing`);
         for (const env of Object.values(step.exchange?.map ?? {})) available.add(env);
         for (const env of step.exchange?.secret_envs ?? []) {

--- a/packages/soul/src/integration-trust.ts
+++ b/packages/soul/src/integration-trust.ts
@@ -39,6 +39,9 @@ function authUrls(step: AuthStep): { label: string; url: string }[] {
     case "app_manifest":
       return [
         { label: "auth.app_manifest.create_url", url: step.create_url },
+        ...(step.create_url_for_org
+          ? [{ label: "auth.app_manifest.create_url_for_org", url: step.create_url_for_org }]
+          : []),
         ...(step.exchange
           ? [{ label: "auth.app_manifest.exchange.url", url: step.exchange.url }]
           : []),

--- a/packages/soul/src/types.ts
+++ b/packages/soul/src/types.ts
@@ -182,6 +182,8 @@ export interface AuthAppManifestStep {
   title?: string;
   description?: string;
   create_url: string;
+  /** Alternate `create_url` template used when the caller names a target org; must contain `{org}`. */
+  create_url_for_org?: string;
   delivery: "form_post" | "query_param";
   manifest_param: string;
   manifest: Record<string, unknown>;


### PR DESCRIPTION
## Summary
- GitHub App manifest flow always created the App under the user's personal GitHub account; no way to target an org.
- The generic `app_manifest` auth step already supported an optional `create_url_for_org` template end-to-end (types, validation, broker), just unused — GitHub's manifest never declared it.
- Wires it up: `integrations/github/manifest.yml` now declares `create_url_for_org`, and the Connect UI shows an optional "Organization" input that routes to it.

## Test plan
- [x] `pnpm --filter @tulipfarm/soul test src/integration-auth.test.ts src/integration-trust.test.ts`
- [x] `pnpm --filter @tulipfarm/api test src/integrations/auth-broker.test.ts src/integrations/auth-routes.test.ts src/integrations/github-auth-flow.test.ts`
- [x] `pnpm --filter @tulipfarm/web test app/components/integrations/auth-flow.test.tsx`
- [x] `pnpm --filter @tulipfarm/soul typecheck && pnpm --filter @tulipfarm/api typecheck && pnpm --filter @tulipfarm/web typecheck`