### PR TITLE
fix(integrations): add setup_url to GitHub App manifest

### DIFF
--- a/integrations/github/manifest.yml
+++ b/integrations/github/manifest.yml
@@ -50,6 +50,10 @@ auth:
       url: "{web_url}"
       # GitHub redirects here after creation with `?code=`, which the exchange below redeems.
       redirect_url: "{callback_url}"
+      # Without this, GitHub never redirects back after "Install on GitHub" — the install step's
+      # `installation_id` capture (below) would never fire and the integration would stay
+      # "Not connected" no matter how many times the operator installs the App.
+      setup_url: "{callback_url}"
       hook_attributes:
         url: "{api_url}/api/v1/integrations/github/webhook"
         active: true


### PR DESCRIPTION
## Summary
- GitHub App manifest was missing `setup_url`, so GitHub never redirected the browser back to TulipFarm after "Install on GitHub".
- `installation_id` was therefore never captured, and the integration stayed "Not connected" no matter how many times the App was installed.
- Adds `setup_url: "{callback_url}"`, reusing the same callback route already used for the App-creation redirect.

## Test plan
- [x] `pnpm --filter @tulipfarm/api exec vitest run src/tools/declarative/bundled-manifests.test.ts src/integrations/routes.test.ts` — 29 passed
- [ ] Manual: recreate the GitHub App (existing Apps predate this fix and have no `setup_url` set), then Install on GitHub and confirm the integration flips to "Connected"