### PR TITLE
chore(release): v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.13.0](https://github.com/TulipFarm/tulipfarm/compare/v0.12.4...v0.13.0) (2026-08-21)
+
+### Features
+
+* **integrations:** add Google Workspace integration — login, chat tools, and token refresh ([#498](https://github.com/TulipFarm/tulipfarm/issues/498)) ([6b3e182](https://github.com/TulipFarm/tulipfarm/commit/6b3e1827cb77258c2733c29262a9307bc0aaec1f))
+
+### Bug Fixes
+
+* **integrations:** add setup_url to GitHub App manifest ([#536](https://github.com/TulipFarm/tulipfarm/issues/536)) ([12957e0](https://github.com/TulipFarm/tulipfarm/commit/12957e03b24ee80f7199c565813557e1ba409c63))
+
 ## [0.12.4](https://github.com/TulipFarm/tulipfarm/compare/v0.12.3...v0.12.4) (2026-08-21)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tulipfarm",
   "private": true,
-  "version": "0.12.4",
+  "version": "0.13.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/TulipFarm/tulipfarm.git"


### PR DESCRIPTION
## Summary

- prepare TulipFarm v0.13.0
- update the package version and generated changelog
- publish the verified GHCR image and GitHub Release automatically after merge

## Test plan

- [ ] Required PR checks pass
- [ ] Version and changelog are approved
