### PR TITLE
fix(tools): surface all validation errors, fix routine-forge doc gap

### DIFF
--- a/apps/api/src/platform/frontend-tools.ts
+++ b/apps/api/src/platform/frontend-tools.ts
@@ -8,13 +8,7 @@ import {
   type ToolDef,
   toToolDef,
 } from "@tulipfarm/tool-host";
-
-function firstError(errors: ReturnType<typeof ajv.compile>["errors"]): string {
-  const e = errors?.[0];
-  return e
-    ? `${e.instancePath || "(root)"} ${e.message ?? "is invalid"}`.trim()
-    : "invalid arguments";
-}
+import { firstError } from "./tool-args";
 
 function requireContextRead(ctx: RequestContext): ToolCallResult | null {
   if (ctx.contextRead && !ctx.contextRead.value) {

--- a/apps/api/src/platform/tool-args.ts
+++ b/apps/api/src/platform/tool-args.ts
@@ -24,19 +24,38 @@ export function soulTarget(
   return id === undefined ? [] : [{ type, id }];
 }
 
-// Prefer deepest non-oneOf AJV errors so users see the real schema defect.
-function bestError(errors: AjvErrors): NonNullable<AjvErrors>[number] | undefined {
-  if (!errors || errors.length === 0) return undefined;
+// AJV's own `oneOf` errors just say "must match exactly one schema"; the branch errors nested
+// under them name the real defect. Drop the `oneOf` noise, but only once something more specific
+// survives to replace it.
+function meaningfulErrors(errors: AjvErrors): NonNullable<AjvErrors> {
+  if (!errors || errors.length === 0) return [];
   const specific = errors.filter((e) => e.keyword !== "oneOf");
-  const pool = specific.length > 0 ? specific : errors;
-  return pool.reduce((deepest, e) =>
-    e.instancePath.length > deepest.instancePath.length ? e : deepest
-  );
+  return specific.length > 0 ? specific : errors;
 }
 
+/**
+ * Renders every AJV violation from one failed call, not just one — AJV is configured with
+ * `allErrors: true` (`packages/schema/src/ajv.ts`) so it already finds them all. Reporting a
+ * single error forced a model correcting a bad Tool call to discover the rest one repair attempt
+ * at a time, burning the Turn's repair budget on defects it was never told about.
+ */
 export function firstError(errors: AjvErrors): string {
-  const e = bestError(errors);
-  return e
-    ? `${e.instancePath || "(root)"} ${e.message ?? "is invalid"}`.trim()
-    : "invalid arguments";
+  const list = meaningfulErrors(errors);
+  if (list.length === 0) return "invalid arguments";
+
+  const seen = new Set<string>();
+  const lines: string[] = [];
+  for (const e of list) {
+    const path = e.instancePath || "(root)";
+    const message = e.message ?? "is invalid";
+    const key = `${path}|${message}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    lines.push(`- \`${path}\`: ${message}`);
+  }
+
+  return (
+    `<validation_errors count="${lines.length}">\n${lines.join("\n")}\n</validation_errors>\n` +
+    "Fix every error listed above before retrying the call."
+  );
 }

--- a/apps/api/src/resources/tools.ts
+++ b/apps/api/src/resources/tools.ts
@@ -5,6 +5,7 @@ import { ajv } from "@tulipfarm/schema";
 import type { SoulLoader } from "@tulipfarm/soul";
 import { parsePaginationQuery } from "@tulipfarm/storage";
 import { type ApiToolDefinition, defineApiTool, err, ok } from "@tulipfarm/tool-host";
+import { firstError } from "../platform/tool-args";
 import { type CounterStore, type ResourceRepoFactory, toApiRecord } from "./repo.js";
 import {
   loadForWrite,
@@ -33,12 +34,6 @@ export interface ResourceServices {
   soulLoader: SoulLoader;
   hookExecutor?: HookExecutor;
   events?: EventEmitter;
-}
-
-function firstError(validate: ReturnType<typeof ajv.compile>): string {
-  const e = validate.errors?.[0];
-  if (!e) return "invalid arguments";
-  return `${e.instancePath || "(root)"} ${e.message ?? "is invalid"}`.trim();
 }
 
 function reason(e: unknown): string {
@@ -171,7 +166,7 @@ const resourceCreate = defineApiTool<ResourceToolContext>({
     dataClasses: ["business_record"],
   },
   handler: async (args, ctx) => {
-    if (!validateCreate(args)) return err("validation_error", firstError(validateCreate));
+    if (!validateCreate(args)) return err("validation_error", firstError(validateCreate.errors));
     const { type, data: rawData } = args as { type: string; data: Record<string, unknown> };
 
     const resourceDef = ctx.soulLoader.resources.get(type);
@@ -229,7 +224,7 @@ const resourceList = defineApiTool<ResourceToolContext>({
     dataClasses: ["business_record"],
   },
   handler: async (args, ctx) => {
-    if (!validateList(args)) return err("validation_error", firstError(validateList));
+    if (!validateList(args)) return err("validation_error", firstError(validateList.errors));
     const a = args as { type: string; cursor?: string; limit?: number; includeDeleted?: boolean };
 
     if (!ctx.soulLoader.resources.has(a.type))
@@ -261,7 +256,7 @@ const resourceGet = defineApiTool<ResourceToolContext>({
     dataClasses: ["business_record"],
   },
   handler: async (args, ctx) => {
-    if (!validateGet(args)) return err("validation_error", firstError(validateGet));
+    if (!validateGet(args)) return err("validation_error", firstError(validateGet.errors));
     const { type, id } = args as { type: string; id: string };
 
     if (!ctx.soulLoader.resources.has(type))
@@ -292,7 +287,7 @@ const resourceUpdate = defineApiTool<ResourceToolContext>({
     dataClasses: ["business_record"],
   },
   handler: async (args, ctx) => {
-    if (!validateUpdate(args)) return err("validation_error", firstError(validateUpdate));
+    if (!validateUpdate(args)) return err("validation_error", firstError(validateUpdate.errors));
     const {
       type,
       id,
@@ -375,7 +370,7 @@ const resourceDelete = defineApiTool<ResourceToolContext>({
     dataClasses: ["business_record"],
   },
   handler: async (args, ctx) => {
-    if (!validateDelete(args)) return err("validation_error", firstError(validateDelete));
+    if (!validateDelete(args)) return err("validation_error", firstError(validateDelete.errors));
     const { type, id, version } = args as { type: string; id: string; version: number };
 
     const resourceDef = ctx.soulLoader.resources.get(type);
@@ -428,7 +423,7 @@ const resourceSearch = defineApiTool<ResourceToolContext>({
     dataClasses: ["business_record"],
   },
   handler: async (args, ctx) => {
-    if (!validateSearch(args)) return err("validation_error", firstError(validateSearch));
+    if (!validateSearch(args)) return err("validation_error", firstError(validateSearch.errors));
     const a = args as {
       type: string;
       filters?: Record<string, unknown>;

--- a/apps/api/src/soul/agents/tools.ts
+++ b/apps/api/src/soul/agents/tools.ts
@@ -18,6 +18,7 @@ import {
   type RequestContext,
   type ToolCallResult,
 } from "@tulipfarm/tool-host";
+import { firstError } from "../../platform/tool-args";
 import { SYSTEM_SOUL_COMMIT_ACTOR } from "../../runtime/soul-writer";
 import { soulCommitError } from "../../tools/soul-faults";
 
@@ -72,12 +73,6 @@ function agentTargets(args: unknown) {
   const id = stringArg(args, "name");
   // Soul targets use the same two-level name as their static resource (`soul.<thing>`).
   return id === undefined ? [] : [{ type: SOUL_AGENT_TARGET, id }];
-}
-
-function firstError(validate: ReturnType<typeof ajv.compile>): string {
-  const e = validate.errors?.[0];
-  if (!e) return "invalid arguments";
-  return `${e.instancePath || "(root)"} ${e.message ?? "is invalid"}`.trim();
 }
 
 // Write-time meta-schema gate (VAL-V1-010). Returns a validation_error
@@ -157,7 +152,7 @@ const agentCreate = defineApiTool<AgentToolContext>({
   },
   requiresApproval: false,
   handler: async (args, ctx) => {
-    if (!validateCreate(args)) return err("validation_error", firstError(validateCreate));
+    if (!validateCreate(args)) return err("validation_error", firstError(validateCreate.errors));
     const {
       name,
       body,
@@ -224,7 +219,7 @@ const agentUpdate = defineApiTool<AgentToolContext>({
   },
   requiresApproval: false,
   handler: async (args, ctx) => {
-    if (!validateUpdate(args)) return err("validation_error", firstError(validateUpdate));
+    if (!validateUpdate(args)) return err("validation_error", firstError(validateUpdate.errors));
     const { name, body, frontmatter } = args as {
       name: string;
       body?: string;
@@ -278,7 +273,7 @@ const agentGet = defineApiTool<AgentToolContext>({
   },
   requiresApproval: false,
   handler: async (args, ctx) => {
-    if (!validateGet(args)) return err("validation_error", firstError(validateGet));
+    if (!validateGet(args)) return err("validation_error", firstError(validateGet.errors));
     const { name } = args as { name: string };
     const agent = ctx.soulLoader.agents.get(name);
     if (!agent) return err("not_found", `agent not found: ${name}`);
@@ -309,7 +304,7 @@ const agentList = defineApiTool<AgentToolContext>({
   },
   requiresApproval: false,
   handler: async (args, ctx) => {
-    if (!validateList(args)) return err("validation_error", firstError(validateList));
+    if (!validateList(args)) return err("validation_error", firstError(validateList.errors));
     const agents = Array.from(ctx.soulLoader.agents.values()).map(({ name, frontmatter }) => ({
       name,
       frontmatter,
@@ -346,7 +341,7 @@ const agentDelete = defineApiTool<AgentToolContext>({
   },
   requiresApproval: false,
   handler: async (args, ctx) => {
-    if (!validateDelete(args)) return err("validation_error", firstError(validateDelete));
+    if (!validateDelete(args)) return err("validation_error", firstError(validateDelete.errors));
     const { name } = args as { name: string };
 
     if (!ctx.soulLoader.agents.has(name)) return err("not_found", `agent not found: ${name}`);

--- a/apps/api/src/soul/resource-types/tools.ts
+++ b/apps/api/src/soul/resource-types/tools.ts
@@ -19,6 +19,7 @@ import {
   type ToolCallResult,
 } from "@tulipfarm/tool-host";
 import { parse as parseYaml } from "yaml";
+import { firstError } from "../../platform/tool-args";
 import { SYSTEM_SOUL_COMMIT_ACTOR } from "../../runtime/soul-writer";
 import { soulCommitError } from "../../tools/soul-faults";
 
@@ -158,12 +159,6 @@ const validateList = ajv.compile(LIST_SCHEMA);
 const validateSchemaGet = ajv.compile(SCHEMA_GET_SCHEMA);
 const validateUpdate = ajv.compile(UPDATE_SCHEMA);
 
-function firstError(validate: ReturnType<typeof ajv.compile>): string {
-  const e = validate.errors?.[0];
-  if (!e) return "invalid arguments";
-  return `${e.instancePath || "(root)"} ${e.message ?? "is invalid"}`.trim();
-}
-
 const createResourceType = defineApiTool<ResourceTypeToolContext>({
   name: "create_resource_type",
   description:
@@ -179,7 +174,7 @@ const createResourceType = defineApiTool<ResourceTypeToolContext>({
     dataClasses: ["soul_definition"],
   },
   handler: async (args, ctx) => {
-    if (!validateCreate(args)) return err("validation_error", firstError(validateCreate));
+    if (!validateCreate(args)) return err("validation_error", firstError(validateCreate.errors));
     const { name, schema: schemaYaml } = args as { name: string; schema: string };
 
     if (!NAME_RE.test(name)) return err("validation_error", "invalid resource type name");
@@ -235,7 +230,7 @@ const listResourceTypes = defineApiTool<ResourceTypeToolContext>({
     dataClasses: ["soul_definition"],
   },
   handler: async (args, ctx) => {
-    if (!validateList(args)) return err("validation_error", firstError(validateList));
+    if (!validateList(args)) return err("validation_error", firstError(validateList.errors));
     const types = Array.from(ctx.soulLoader.resources.values()).map(resourceTypePayload);
     return ok({ types });
   },
@@ -255,7 +250,8 @@ const resourceTypeSchema = defineApiTool<ResourceTypeToolContext>({
     dataClasses: ["soul_definition"],
   },
   handler: async (args, ctx) => {
-    if (!validateSchemaGet(args)) return err("validation_error", firstError(validateSchemaGet));
+    if (!validateSchemaGet(args))
+      return err("validation_error", firstError(validateSchemaGet.errors));
     const { name } = args as { name: string };
 
     const rt = ctx.soulLoader.resources.get(name);
@@ -280,7 +276,7 @@ const resourceTypeUpdate = defineApiTool<ResourceTypeToolContext>({
     dataClasses: ["soul_definition"],
   },
   handler: async (args, ctx) => {
-    if (!validateUpdate(args)) return err("validation_error", firstError(validateUpdate));
+    if (!validateUpdate(args)) return err("validation_error", firstError(validateUpdate.errors));
     const { name, schema: schemaYaml } = args as { name: string; schema: string };
 
     if (!ctx.soulLoader.resources.has(name))
@@ -429,7 +425,8 @@ const createResourceHooks = defineApiTool<ResourceTypeToolContext>({
     dataClasses: ["soul_definition"],
   },
   handler: async (args, ctx) => {
-    if (!validateHooksWrite(args)) return err("validation_error", firstError(validateHooksWrite));
+    if (!validateHooksWrite(args))
+      return err("validation_error", firstError(validateHooksWrite.errors));
     const { name, source } = args as { name: string; source: string };
 
     if (!ctx.soulLoader.resources.has(name)) {
@@ -482,7 +479,8 @@ const getResourceHooks = defineApiTool<ResourceTypeToolContext>({
     dataClasses: ["soul_definition"],
   },
   handler: async (args, ctx) => {
-    if (!validateHooksGet(args)) return err("validation_error", firstError(validateHooksGet));
+    if (!validateHooksGet(args))
+      return err("validation_error", firstError(validateHooksGet.errors));
     const { name } = args as { name: string };
 
     const rt = ctx.soulLoader.resources.get(name);
@@ -507,7 +505,8 @@ const deleteResourceHooks = defineApiTool<ResourceTypeToolContext>({
     dataClasses: ["soul_definition"],
   },
   handler: async (args, ctx) => {
-    if (!validateHooksDelete(args)) return err("validation_error", firstError(validateHooksDelete));
+    if (!validateHooksDelete(args))
+      return err("validation_error", firstError(validateHooksDelete.errors));
     const { name } = args as { name: string };
 
     if (!ctx.soulLoader.resources.has(name)) {

--- a/apps/api/src/soul/skills/tools.ts
+++ b/apps/api/src/soul/skills/tools.ts
@@ -35,6 +35,7 @@ import {
   type RequestContext,
   type ToolCallResult,
 } from "@tulipfarm/tool-host";
+import { firstError } from "../../platform/tool-args";
 import { SYSTEM_SOUL_COMMIT_ACTOR } from "../../runtime/soul-writer";
 import { soulCommitError } from "../../tools/soul-faults";
 import { buildAudit } from "./audit.js";
@@ -94,12 +95,6 @@ function skillTargets(args: unknown) {
   return id === undefined ? [] : [{ type: SOUL_SKILL_TARGET, id }];
 }
 
-function firstError(validate: ReturnType<typeof ajv.compile>): string {
-  const e = validate.errors?.[0];
-  if (!e) return "invalid arguments";
-  return `${e.instancePath || "(root)"} ${e.message ?? "is invalid"}`.trim();
-}
-
 function publicFrontmatter(frontmatter: Record<string, unknown>): {
   frontmatter: Record<string, unknown>;
   pendingAudit: boolean;
@@ -127,7 +122,7 @@ const skillCreate = defineApiTool<SkillToolContext>({
   },
   requiresApproval: false,
   handler: async (args, ctx) => {
-    if (!validateCreate(args)) return err("validation_error", firstError(validateCreate));
+    if (!validateCreate(args)) return err("validation_error", firstError(validateCreate.errors));
     const { name, body, frontmatter } = args as {
       name: string;
       body: string;
@@ -231,7 +226,7 @@ const skillUpdate = defineApiTool<SkillToolContext>({
   },
   requiresApproval: false,
   handler: async (args, ctx) => {
-    if (!validateUpdate(args)) return err("validation_error", firstError(validateUpdate));
+    if (!validateUpdate(args)) return err("validation_error", firstError(validateUpdate.errors));
     const { name, body, frontmatter, old_string, new_string, replace_all } = args as {
       name: string;
       body?: string;
@@ -377,7 +372,7 @@ const skillGet = defineApiTool<SkillToolContext>({
   },
   requiresApproval: false,
   handler: async (args, ctx) => {
-    if (!validateGet(args)) return err("validation_error", firstError(validateGet));
+    if (!validateGet(args)) return err("validation_error", firstError(validateGet.errors));
     const { name } = args as { name: string };
     const soulSkill = ctx.soulLoader.skills.get(name);
     const skill = resolveSkill(name, ctx.soulLoader, ctx.bundledSkills, ctx.disabledBundledSkills);
@@ -408,7 +403,7 @@ const skillList = defineApiTool<SkillToolContext>({
   },
   requiresApproval: false,
   handler: async (args, ctx) => {
-    if (!validateList(args)) return err("validation_error", firstError(validateList));
+    if (!validateList(args)) return err("validation_error", firstError(validateList.errors));
     const skills = Array.from(
       mergedSkills(ctx.soulLoader, ctx.bundledSkills, ctx.disabledBundledSkills).values()
     ).map(({ name, frontmatter }) => ({
@@ -439,7 +434,7 @@ const skillDelete = defineApiTool<SkillToolContext>({
   },
   requiresApproval: false,
   handler: async (args, ctx) => {
-    if (!validateDelete(args)) return err("validation_error", firstError(validateDelete));
+    if (!validateDelete(args)) return err("validation_error", firstError(validateDelete.errors));
     const { name } = args as { name: string };
 
     const soulSkill = ctx.soulLoader.skills.get(name);
@@ -521,7 +516,8 @@ const skillActivate = defineApiTool<SkillToolContext>({
   },
   requiresApproval: false,
   handler: async (args, ctx) => {
-    if (!validateActivate(args)) return err("validation_error", firstError(validateActivate));
+    if (!validateActivate(args))
+      return err("validation_error", firstError(validateActivate.errors));
     const { name } = args as { name: string };
 
     const skill = ctx.soulLoader.skills.get(name);

--- a/apps/api/src/tasks/tools.ts
+++ b/apps/api/src/tasks/tools.ts
@@ -8,6 +8,7 @@ import {
   type TaskSubjectRef,
 } from "@tulipfarm/storage";
 import { type ApiToolDefinition, defineApiTool, err, ok } from "@tulipfarm/tool-host";
+import { firstError } from "../platform/tool-args";
 
 /** Per-request context a task tool handler runs against — closes over the calling Agent. */
 export interface TaskToolContext {
@@ -83,12 +84,6 @@ const CLOSE_SCHEMA: Record<string, unknown> = {
 
 const validateCreate = ajv.compile(CREATE_SCHEMA);
 const validateClose = ajv.compile(CLOSE_SCHEMA);
-
-function firstError(errors: typeof validateCreate.errors): string {
-  const e = errors?.[0];
-  if (!e) return "invalid arguments";
-  return `${e.instancePath || "(root)"} ${e.message ?? "is invalid"}`.trim();
-}
 
 interface CreateTaskArgs {
   assignee: { kind: TaskAssigneeKind; id: string };

--- a/apps/web/app/lib/chat/sse-client.ts
+++ b/apps/web/app/lib/chat/sse-client.ts
@@ -96,6 +96,8 @@ export function modelFailureMessage(reason: string | undefined): string {
     case "turn_execution_failed":
     case "needs_reconciliation":
       return TURN_STOPPED_MESSAGE;
+    case "repair_budget_exhausted":
+      return "The Agent kept producing an invalid result and gave up retrying. Try rephrasing your request.";
     case "model_billing_inactive":
       return "The model provider's API billing is inactive. Activate billing or use another Provider Credential.";
     case "model_authentication_failed":

--- a/skills/forge/routine-forge/SKILL.md
+++ b/skills/forge/routine-forge/SKILL.md
@@ -14,13 +14,21 @@ canonical published Soul definitions, not the retired Serverless Workflow format
 1. Ask only for missing business choices: the owner, the Trigger type and schedule, and any Tool
    or Agent reference. Do not invent a destination, principal, or credential.
 2. Build a canonical `Routine` document with `apiVersion: tulipfarm.ai/v1`, `kind: Routine`, and
-   metadata `id`, `slug`, `schemaVersion: 1`, `authoredVersion`, and `lifecycle: published`.
-   Its `spec` needs `owner`, `start`, and one or more canonical States.
-3. Build one or more canonical `Trigger` documents. Each uses the same metadata fields and
-   `lifecycle: published`; its `spec.routineRef` must use the Routine slug and authored version.
-   Every Trigger needs `backgroundIdentity`, `deduplication`, `eventType`, and `eventVersion`.
-   Add a `manual` Trigger when the user needs a Routines UI entry point. `cron`, `interval`, and
-   `datetime` Triggers run automatically after publication.
+   `metadata` with exactly these keys — no others, the schema rejects additional properties:
+   - `id`: a fresh UUID or ULID (`8f14e...` / `01ARZ3...`), never the routine slug or a made-up
+     string.
+   - `slug`: lowercase kebab-case, matching the tool's `name` argument.
+   - `schemaVersion: 1`, `authoredVersion` (integer, starts at `1`), `lifecycle: published`.
+   Its `spec` needs `owner` and one or more canonical States. Every State key — `start`, each
+   State's own `name`, and every `transition`/`branches`/`body`/`forState` reference to another
+   State — must match `^[A-Za-z][A-Za-z0-9_]*$`: letters, digits, underscore only, **no hyphens**.
+   Use PascalCase or snake_case (e.g. `ReadIssue`, `send_reply`), never the hyphenated style used
+   for the Routine's own `slug`/`name`.
+3. Build one or more canonical `Trigger` documents. Each uses the same `metadata` rules as step 2
+   (fresh `id`, matching `slug`, `lifecycle: published`); its `spec.routineRef` must use the
+   Routine slug and authored version. Every Trigger needs `backgroundIdentity`, `deduplication`,
+   `eventType`, and `eventVersion`. Add a `manual` Trigger when the user needs a Routines UI entry
+   point. `cron`, `interval`, and `datetime` Triggers run automatically after publication.
 4. Preview purpose, Triggers, and State flow. Get the user's approval.
 5. Call `routine_forge` with `name`, the canonical Routine as `definition`, and all canonical
    Trigger documents as `triggers`. It writes them in one atomic Soul changeset.


### PR DESCRIPTION
## Summary
- Return every AJV validation error (not just the first) from Tool calls, in an XML-tagged/markdown format an agent can parse and fix in one repair attempt. Consolidated 7 copy-pasted `firstError` helpers onto one shared implementation in `apps/api/src/platform/tool-args.ts`.
- Document the exact Routine `metadata` field list and no-hyphen State-key naming pattern in `routine-forge`'s SKILL.md, so the model stops generating documents AJV rejects.
- Add a specific client-side message for `repair_budget_exhausted` so a live chat session shows something other than a generic failure.

## Test plan
- [x] `pnpm exec biome check --write` on touched files — clean
- [x] `pnpm --filter @tulipfarm/api typecheck` — clean
- [x] `pnpm --filter @tulipfarm/api test src/tasks src/resources src/platform src/soul/resource-types src/soul/agents src/soul/skills` — 452 passed
- [ ] No manual/browser retest performed (requested skipped)