### PR TITLE
fix(web): filter navigation by session capabilities

### DIFF
--- a/apps/api/src/auth/routes.test.ts
+++ b/apps/api/src/auth/routes.test.ts
@@ -167,22 +167,12 @@ function cookieValue(res: { cookies: Array<{ name: string; value: string }> }): 
 describe("auth routes", () => {
   let app: FastifyInstance;
   let store: MemorySessionStore;
-  let deniedNavigationActions = new Set<string>();
 
   beforeEach(async () => {
-    deniedNavigationActions = new Set();
     store = new MemorySessionStore();
     const repo = new FakeUserRepo();
     await createUser(repo, "user@example.com", "correct-horse", "admin");
-    app = await buildApp({
-      sessionStore: store,
-      userRepo: repo,
-      tokenRepo: new MemoryTokenRepo(),
-      routeAuthorizer: {
-        authorize: async (_principal, authorization) =>
-          !deniedNavigationActions.has(authorization.action),
-      },
-    });
+    app = await buildApp({ sessionStore: store, userRepo: repo, tokenRepo: new MemoryTokenRepo() });
   });
 
   afterEach(async () => {
@@ -256,39 +246,6 @@ describe("auth routes", () => {
     expect(res.statusCode).toBe(200);
     expect(res.json().user.email).toBe("user@example.com");
     expect(res.json().user.navigation.visiblePaths).toContain("/inbox");
-  });
-
-  it("GET /session omits every destination the same gate denies", async () => {
-    deniedNavigationActions = new Set([
-      "operations.read",
-      "soul.git_config.read",
-      "llm_config.read",
-    ]);
-    const login = await app.inject({
-      method: "POST",
-      url: "/api/v1/auth/login",
-      payload: { email: "user@example.com", password: "correct-horse" },
-    });
-    const sid = cookieValue(login);
-    const res = await app.inject({
-      method: "GET",
-      url: "/api/v1/auth/session",
-      cookies: { [SESSION_COOKIE]: sid as string },
-    });
-
-    expect(res.statusCode).toBe(200);
-    expect(res.json().user.navigation.visiblePaths).toEqual(
-      expect.not.arrayContaining([
-        "/inbox",
-        "/runs",
-        "/operations",
-        "/business/guardrails",
-        "/business/soul",
-        "/business/models",
-        "/business/secrets",
-      ])
-    );
-    expect(res.json().user.navigation.visiblePaths).toContain("/business/activities");
   });
 
   it("GET /session returns 401 without a cookie", async () => {

--- a/apps/api/src/auth/routes.test.ts
+++ b/apps/api/src/auth/routes.test.ts
@@ -167,12 +167,22 @@ function cookieValue(res: { cookies: Array<{ name: string; value: string }> }): 
 describe("auth routes", () => {
   let app: FastifyInstance;
   let store: MemorySessionStore;
+  let deniedNavigationActions = new Set<string>();
 
   beforeEach(async () => {
+    deniedNavigationActions = new Set();
     store = new MemorySessionStore();
     const repo = new FakeUserRepo();
     await createUser(repo, "user@example.com", "correct-horse", "admin");
-    app = await buildApp({ sessionStore: store, userRepo: repo, tokenRepo: new MemoryTokenRepo() });
+    app = await buildApp({
+      sessionStore: store,
+      userRepo: repo,
+      tokenRepo: new MemoryTokenRepo(),
+      routeAuthorizer: {
+        authorize: async (_principal, authorization) =>
+          !deniedNavigationActions.has(authorization.action),
+      },
+    });
   });
 
   afterEach(async () => {
@@ -245,6 +255,40 @@ describe("auth routes", () => {
     });
     expect(res.statusCode).toBe(200);
     expect(res.json().user.email).toBe("user@example.com");
+    expect(res.json().user.navigation.visiblePaths).toContain("/inbox");
+  });
+
+  it("GET /session omits every destination the same gate denies", async () => {
+    deniedNavigationActions = new Set([
+      "operations.read",
+      "soul.git_config.read",
+      "llm_config.read",
+    ]);
+    const login = await app.inject({
+      method: "POST",
+      url: "/api/v1/auth/login",
+      payload: { email: "user@example.com", password: "correct-horse" },
+    });
+    const sid = cookieValue(login);
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/auth/session",
+      cookies: { [SESSION_COOKIE]: sid as string },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().user.navigation.visiblePaths).toEqual(
+      expect.not.arrayContaining([
+        "/inbox",
+        "/runs",
+        "/operations",
+        "/business/guardrails",
+        "/business/soul",
+        "/business/models",
+        "/business/secrets",
+      ])
+    );
+    expect(res.json().user.navigation.visiblePaths).toContain("/business/activities");
   });
 
   it("GET /session returns 401 without a cookie", async () => {

--- a/apps/api/src/auth/routes/session.ts
+++ b/apps/api/src/auth/routes/session.ts
@@ -1,5 +1,6 @@
+import { withSessionNav } from "@tulipfarm/authz";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
-import type { AuthorizationCheck, RouteAuthorization } from "../../authz/route-gate";
+import type { AuthorizationCheck } from "../../authz/route-gate";
 import { makeAuthorizationCheck } from "../../authz/route-gate";
 import { userPrincipal } from "../../identity/principal";
 import { sessionCookieOptions } from "../cookie-security";
@@ -31,7 +32,6 @@ import {
   type UserDoc,
   type UserRepo,
 } from "../users";
-import { USER_MANAGE } from "./users";
 
 // Precomputed lazily and reused: verifying against a dummy hash on unknown-user
 // login keeps response timing similar to the known-user path (no user enumeration).
@@ -44,79 +44,6 @@ function getDummyHash(): Promise<string> {
 }
 
 type PreHandler = (req: FastifyRequest, reply: FastifyReply) => Promise<void>;
-
-type NavigationRequirement = {
-  path: string;
-  authorizations: readonly RouteAuthorization[];
-};
-
-const AUTHENTICATED_NAVIGATION: RouteAuthorization = {
-  action: "auth_session.read",
-  resourceType: "auth_session",
-  fallback: "authenticated",
-};
-
-const OPERATIONS_READ: RouteAuthorization = {
-  action: "operations.read",
-  resourceType: "operations",
-  fallback: "admin",
-};
-
-/** Server-owned visibility requirements for every static destination in the product shell. */
-const NAVIGATION_REQUIREMENTS: readonly NavigationRequirement[] = [
-  { path: "/farm", authorizations: [AUTHENTICATED_NAVIGATION] },
-  { path: "/resources", authorizations: [AUTHENTICATED_NAVIGATION] },
-  { path: "/agents", authorizations: [AUTHENTICATED_NAVIGATION] },
-  { path: "/skills", authorizations: [AUTHENTICATED_NAVIGATION] },
-  { path: "/routines", authorizations: [AUTHENTICATED_NAVIGATION] },
-  { path: "/knowledge", authorizations: [AUTHENTICATED_NAVIGATION] },
-  { path: "/knowledge/files", authorizations: [AUTHENTICATED_NAVIGATION] },
-  { path: "/inbox", authorizations: [OPERATIONS_READ] },
-  { path: "/runs", authorizations: [OPERATIONS_READ] },
-  { path: "/business/activities", authorizations: [AUTHENTICATED_NAVIGATION] },
-  { path: "/operations", authorizations: [OPERATIONS_READ] },
-  {
-    path: "/business/observability",
-    authorizations: [
-      { action: "observability.read", resourceType: "observability", fallback: "admin" },
-    ],
-  },
-  { path: "/business/profile", authorizations: [AUTHENTICATED_NAVIGATION] },
-  {
-    path: "/business/models",
-    authorizations: [
-      { action: "llm_config.read", resourceType: "llm_config", fallback: "admin" },
-      { action: "secret.read", resourceType: "secret", fallback: "authenticated" },
-    ],
-  },
-  {
-    path: "/business/secrets",
-    authorizations: [
-      { action: "secret.read", resourceType: "secret", fallback: "authenticated" },
-      { action: "llm_config.read", resourceType: "llm_config", fallback: "admin" },
-    ],
-  },
-  { path: "/integrations", authorizations: [AUTHENTICATED_NAVIGATION] },
-  {
-    path: "/business/soul",
-    authorizations: [
-      { action: "soul.git_config.read", resourceType: "soul.git_config", fallback: "admin" },
-    ],
-  },
-  { path: "/business/guardrails", authorizations: [OPERATIONS_READ] },
-  { path: "/business/access", authorizations: [OPERATIONS_READ] },
-  { path: "/business/about", authorizations: [AUTHENTICATED_NAVIGATION] },
-  { path: "/settings/profile", authorizations: [AUTHENTICATED_NAVIGATION] },
-  { path: "/settings/appearance", authorizations: [AUTHENTICATED_NAVIGATION] },
-  {
-    path: "/settings/auth",
-    authorizations: [
-      { action: "api_token.read", resourceType: "api_token", fallback: "authenticated" },
-    ],
-  },
-  { path: "/settings/instructions", authorizations: [AUTHENTICATED_NAVIGATION] },
-  { path: "/design-guide", authorizations: [AUTHENTICATED_NAVIGATION] },
-];
 
 /** A denial is opaque on the wire; log which cause it was, keyed by a hash prefix, not the token. */
 function logInviteDenial(req: FastifyRequest, at: string, err: InviteDeniedError, token: string) {
@@ -158,27 +85,7 @@ export function registerSessionRoutes(app: FastifyInstance, deps: SessionRouteDe
    * own session is how the app boots, and every admin surface is gated again on its own request.
    */
   async function sessionUser(user: UserDoc) {
-    const principal = userPrincipal(user, "session");
-    const [isAdmin, visiblePaths] = await Promise.all([
-      authorizationCheck(principal, USER_MANAGE).catch(() => false),
-      Promise.all(
-        NAVIGATION_REQUIREMENTS.map(async ({ path, authorizations }) => {
-          const allowed = await Promise.all(
-            authorizations.map((authorization) => authorizationCheck(principal, authorization))
-          ).catch(() => []);
-          return allowed.length === authorizations.length && allowed.every(Boolean)
-            ? path
-            : undefined;
-        })
-      ),
-    ]);
-    return {
-      ...toPublicUser(user),
-      isAdmin,
-      navigation: {
-        visiblePaths: visiblePaths.filter((path): path is string => path !== undefined),
-      },
-    };
+    return withSessionNav(toPublicUser(user), userPrincipal(user, "session"), authorizationCheck);
   }
   const loginPreHandlers = [rateLimitHook, loginRateLimitHook].filter(
     (hook): hook is PreHandler => hook !== undefined

--- a/apps/api/src/auth/routes/session.ts
+++ b/apps/api/src/auth/routes/session.ts
@@ -1,5 +1,5 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
-import type { AuthorizationCheck } from "../../authz/route-gate";
+import type { AuthorizationCheck, RouteAuthorization } from "../../authz/route-gate";
 import { makeAuthorizationCheck } from "../../authz/route-gate";
 import { userPrincipal } from "../../identity/principal";
 import { sessionCookieOptions } from "../cookie-security";
@@ -45,6 +45,79 @@ function getDummyHash(): Promise<string> {
 
 type PreHandler = (req: FastifyRequest, reply: FastifyReply) => Promise<void>;
 
+type NavigationRequirement = {
+  path: string;
+  authorizations: readonly RouteAuthorization[];
+};
+
+const AUTHENTICATED_NAVIGATION: RouteAuthorization = {
+  action: "auth_session.read",
+  resourceType: "auth_session",
+  fallback: "authenticated",
+};
+
+const OPERATIONS_READ: RouteAuthorization = {
+  action: "operations.read",
+  resourceType: "operations",
+  fallback: "admin",
+};
+
+/** Server-owned visibility requirements for every static destination in the product shell. */
+const NAVIGATION_REQUIREMENTS: readonly NavigationRequirement[] = [
+  { path: "/farm", authorizations: [AUTHENTICATED_NAVIGATION] },
+  { path: "/resources", authorizations: [AUTHENTICATED_NAVIGATION] },
+  { path: "/agents", authorizations: [AUTHENTICATED_NAVIGATION] },
+  { path: "/skills", authorizations: [AUTHENTICATED_NAVIGATION] },
+  { path: "/routines", authorizations: [AUTHENTICATED_NAVIGATION] },
+  { path: "/knowledge", authorizations: [AUTHENTICATED_NAVIGATION] },
+  { path: "/knowledge/files", authorizations: [AUTHENTICATED_NAVIGATION] },
+  { path: "/inbox", authorizations: [OPERATIONS_READ] },
+  { path: "/runs", authorizations: [OPERATIONS_READ] },
+  { path: "/business/activities", authorizations: [AUTHENTICATED_NAVIGATION] },
+  { path: "/operations", authorizations: [OPERATIONS_READ] },
+  {
+    path: "/business/observability",
+    authorizations: [
+      { action: "observability.read", resourceType: "observability", fallback: "admin" },
+    ],
+  },
+  { path: "/business/profile", authorizations: [AUTHENTICATED_NAVIGATION] },
+  {
+    path: "/business/models",
+    authorizations: [
+      { action: "llm_config.read", resourceType: "llm_config", fallback: "admin" },
+      { action: "secret.read", resourceType: "secret", fallback: "authenticated" },
+    ],
+  },
+  {
+    path: "/business/secrets",
+    authorizations: [
+      { action: "secret.read", resourceType: "secret", fallback: "authenticated" },
+      { action: "llm_config.read", resourceType: "llm_config", fallback: "admin" },
+    ],
+  },
+  { path: "/integrations", authorizations: [AUTHENTICATED_NAVIGATION] },
+  {
+    path: "/business/soul",
+    authorizations: [
+      { action: "soul.git_config.read", resourceType: "soul.git_config", fallback: "admin" },
+    ],
+  },
+  { path: "/business/guardrails", authorizations: [OPERATIONS_READ] },
+  { path: "/business/access", authorizations: [OPERATIONS_READ] },
+  { path: "/business/about", authorizations: [AUTHENTICATED_NAVIGATION] },
+  { path: "/settings/profile", authorizations: [AUTHENTICATED_NAVIGATION] },
+  { path: "/settings/appearance", authorizations: [AUTHENTICATED_NAVIGATION] },
+  {
+    path: "/settings/auth",
+    authorizations: [
+      { action: "api_token.read", resourceType: "api_token", fallback: "authenticated" },
+    ],
+  },
+  { path: "/settings/instructions", authorizations: [AUTHENTICATED_NAVIGATION] },
+  { path: "/design-guide", authorizations: [AUTHENTICATED_NAVIGATION] },
+];
+
 /** A denial is opaque on the wire; log which cause it was, keyed by a hash prefix, not the token. */
 function logInviteDenial(req: FastifyRequest, at: string, err: InviteDeniedError, token: string) {
   const hash = hashInviteToken(token).slice(0, 12);
@@ -61,7 +134,7 @@ export interface SessionRouteDeps {
   passwordWriteRepo?: PasswordWriteRepo;
   profileWriteRepo?: ProfileWriteRepo;
   inviteRepo?: UserInviteRepo;
-  /** Decides `isAdmin`. Defaults to the no-authorizer gate, which answers from the account role. */
+  /** Decides session authority. Defaults to the no-authorizer gate, which answers from the account role. */
   authorizationCheck?: AuthorizationCheck;
 }
 
@@ -85,10 +158,27 @@ export function registerSessionRoutes(app: FastifyInstance, deps: SessionRouteDe
    * own session is how the app boots, and every admin surface is gated again on its own request.
    */
   async function sessionUser(user: UserDoc) {
-    const isAdmin = await authorizationCheck(userPrincipal(user, "session"), USER_MANAGE).catch(
-      () => false
-    );
-    return { ...toPublicUser(user), isAdmin };
+    const principal = userPrincipal(user, "session");
+    const [isAdmin, visiblePaths] = await Promise.all([
+      authorizationCheck(principal, USER_MANAGE).catch(() => false),
+      Promise.all(
+        NAVIGATION_REQUIREMENTS.map(async ({ path, authorizations }) => {
+          const allowed = await Promise.all(
+            authorizations.map((authorization) => authorizationCheck(principal, authorization))
+          ).catch(() => []);
+          return allowed.length === authorizations.length && allowed.every(Boolean)
+            ? path
+            : undefined;
+        })
+      ),
+    ]);
+    return {
+      ...toPublicUser(user),
+      isAdmin,
+      navigation: {
+        visiblePaths: visiblePaths.filter((path): path is string => path !== undefined),
+      },
+    };
   }
   const loginPreHandlers = [rateLimitHook, loginRateLimitHook].filter(
     (hook): hook is PreHandler => hook !== undefined

--- a/apps/api/src/auth/schemas.ts
+++ b/apps/api/src/auth/schemas.ts
@@ -18,16 +18,6 @@ export const PublicUserSchema = {
   required: ["id", "email", "name", "role", "status"],
 } as const;
 
-/** The single capability payload the shell reads instead of probing every page's API. */
-export const SessionNavigationSchema = {
-  type: "object",
-  additionalProperties: false,
-  properties: {
-    visiblePaths: { type: "array", items: { type: "string" } },
-  },
-  required: ["visiblePaths"],
-} as const;
-
 /**
  * The caller's own account, admin authority, and allowed navigation paths. `role` is the account's
  * own level and a Role grant never rewrites it, so a client deriving "is an admin" from `role`
@@ -38,7 +28,12 @@ export const SessionUserSchema = {
   properties: {
     ...PublicUserSchema.properties,
     isAdmin: { type: "boolean" },
-    navigation: SessionNavigationSchema,
+    navigation: {
+      type: "object",
+      additionalProperties: false,
+      properties: { visiblePaths: { type: "array", items: { type: "string" } } },
+      required: ["visiblePaths"],
+    },
   },
   required: [...PublicUserSchema.required, "isAdmin", "navigation"],
 } as const;

--- a/apps/api/src/auth/schemas.ts
+++ b/apps/api/src/auth/schemas.ts
@@ -18,15 +18,29 @@ export const PublicUserSchema = {
   required: ["id", "email", "name", "role", "status"],
 } as const;
 
+/** The single capability payload the shell reads instead of probing every page's API. */
+export const SessionNavigationSchema = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    visiblePaths: { type: "array", items: { type: "string" } },
+  },
+  required: ["visiblePaths"],
+} as const;
+
 /**
- * The caller's own account plus whether it holds admin authority right now. `role` is the account's
+ * The caller's own account, admin authority, and allowed navigation paths. `role` is the account's
  * own level and a Role grant never rewrites it, so a client deriving "is an admin" from `role`
  * hides every admin surface from a granted `Owner` (#408).
  */
 export const SessionUserSchema = {
   type: "object",
-  properties: { ...PublicUserSchema.properties, isAdmin: { type: "boolean" } },
-  required: [...PublicUserSchema.required, "isAdmin"],
+  properties: {
+    ...PublicUserSchema.properties,
+    isAdmin: { type: "boolean" },
+    navigation: SessionNavigationSchema,
+  },
+  required: [...PublicUserSchema.required, "isAdmin", "navigation"],
 } as const;
 
 /**

--- a/apps/web/app/components/app-sidebar.test.tsx
+++ b/apps/web/app/components/app-sidebar.test.tsx
@@ -20,6 +20,14 @@ vi.mock("~/lib/conversations-context", () => ({ useConversations: vi.fn() }));
 const useConversations = vi.mocked(conversationsContext.useConversations);
 
 const SidebarStub = createRemixStub([{ path: "*", Component: AppSidebar }]);
+const RestrictedSidebarStub = createRemixStub([
+  {
+    path: "*",
+    Component: () => (
+      <AppSidebar navigation={{ visiblePaths: ["/resources", "/business/activities"] }} />
+    ),
+  },
+]);
 const ShellStub = createRemixStub([
   {
     path: "*",
@@ -35,13 +43,13 @@ const AccountShellStub = createRemixStub([
     path: "*",
     Component: () => (
       <AppShell
-        isAdmin
         user={{
           id: "u1",
           email: "priya.nair@northgate.dev",
           name: null,
           role: "admin",
           status: "active",
+          navigation: { visiblePaths: [] },
         }}
       >
         <p>Page content</p>
@@ -174,6 +182,21 @@ test("renders Operate destinations and the live Inbox badge", () => {
   for (const label of ["Inbox", "Runs", "Integrations", "Operations"]) {
     expect(screen.getByRole("link", { name: new RegExp(label, "i") })).toBeInTheDocument();
   }
+});
+
+test("hides denied destinations and sends Operate to the first allowed page", () => {
+  render(<RestrictedSidebarStub initialEntries={["/business/activities"]} />);
+
+  const rail = screen.getByRole("navigation", { name: "Product modes" });
+  expect(within(rail).getByRole("link", { name: "Operate" })).toHaveAttribute(
+    "href",
+    "/business/activities"
+  );
+  expect(screen.getByRole("link", { name: "Activities" })).toBeInTheDocument();
+  for (const label of ["Inbox", "Runs", "Operations", "Soul", "Models"]) {
+    expect(screen.queryByRole("link", { name: new RegExp(label, "i") })).not.toBeInTheDocument();
+  }
+  expect(within(rail).queryByRole("link", { name: "Knowledge" })).not.toBeInTheDocument();
 });
 
 test("renders only personal destinations under Settings", () => {

--- a/apps/web/app/components/app-sidebar.tsx
+++ b/apps/web/app/components/app-sidebar.tsx
@@ -20,13 +20,16 @@ import { logout, type SessionUser } from "~/lib/api";
 import { useApprovals } from "~/lib/approvals-context";
 import { useConversations } from "~/lib/conversations-context";
 import {
+  destinationForMode,
   hasContextPanel,
   iconForPath,
   MODE_META,
+  type NavigationVisibility,
   type ProductMode as NavProductMode,
   modeForPath as navModeForPath,
   PRIMARY_MODES,
   titleForPath,
+  visibleModes,
   visibleSections,
 } from "~/lib/nav";
 import { isBusinessAdmin } from "~/lib/use-session-user";
@@ -78,8 +81,8 @@ function SignOutButton({ compact = false }: { compact?: boolean }) {
  * depends on color alone, and the shared Tooltip replaces the native `title` delay for these
  * icon-only targets.
  */
-function RailLink({ mode, active }: { mode: ProductMode; active: boolean }) {
-  const { label, to, icon: Icon } = MODE_META[mode];
+function RailLink({ mode, active, to }: { mode: ProductMode; active: boolean; to: string }) {
+  const { label, icon: Icon } = MODE_META[mode];
   return (
     <Tooltip content={label}>
       <Link
@@ -101,7 +104,15 @@ function RailLink({ mode, active }: { mode: ProductMode; active: boolean }) {
   );
 }
 
-function Rail({ mode }: { mode: ProductMode }) {
+function Rail({
+  mode,
+  modes,
+  visibility,
+}: {
+  mode: ProductMode;
+  modes: readonly ProductMode[];
+  visibility: NavigationVisibility;
+}) {
   return (
     <div className="flex w-14 shrink-0 flex-col items-center border-r border-sidebar-border bg-background">
       <div className={cn(HEADER_ROW, "w-full justify-center border-b border-sidebar-border")}>
@@ -110,14 +121,31 @@ function Rail({ mode }: { mode: ProductMode }) {
         </Link>
       </div>
       <nav aria-label="Product modes" className="flex flex-1 flex-col items-center gap-1 py-3">
-        {PRIMARY_MODES.map((item) => (
-          <RailLink key={item} mode={item} active={mode === item} />
+        {PRIMARY_MODES.filter((item) => modes.includes(item)).map((item) => (
+          <RailLink
+            key={item}
+            mode={item}
+            to={destinationForMode(item, visibility)}
+            active={mode === item}
+          />
         ))}
       </nav>
       <div className="flex flex-col items-center gap-1 pb-3">
         <Separator className="mb-2 w-6" />
-        <RailLink mode="farm" active={mode === "farm"} />
-        <RailLink mode="settings" active={mode === "settings"} />
+        {modes.includes("farm") ? (
+          <RailLink
+            mode="farm"
+            to={destinationForMode("farm", visibility)}
+            active={mode === "farm"}
+          />
+        ) : null}
+        {modes.includes("settings") ? (
+          <RailLink
+            mode="settings"
+            to={destinationForMode("settings", visibility)}
+            active={mode === "settings"}
+          />
+        ) : null}
         <span className="flex size-10 items-center justify-center">
           <ThemeToggle iconOnly />
         </span>
@@ -215,14 +243,14 @@ function ChatContext({ onNavigate }: { onNavigate: () => void }) {
 function LinkList({
   mode,
   onNavigate,
-  isAdmin,
+  visibility,
 }: {
   mode: "build" | "operate" | "settings";
   onNavigate: () => void;
-  isAdmin: boolean;
+  visibility: NavigationVisibility;
 }) {
   const { count } = useApprovals();
-  const sections = visibleSections(mode, { isAdmin, isDev: import.meta.env.DEV });
+  const sections = visibleSections(mode, visibility);
   return (
     <nav aria-label={`${mode} navigation`} className="flex flex-col gap-5 px-2">
       {sections.map((section, index) => (
@@ -251,11 +279,11 @@ function LinkList({
 function ContextPanel({
   mode,
   onNavigate,
-  isAdmin,
+  visibility,
 }: {
   mode: ProductMode;
   onNavigate: () => void;
-  isAdmin: boolean;
+  visibility: NavigationVisibility;
 }) {
   const { label, icon: Icon } = MODE_META[mode];
   return (
@@ -263,7 +291,9 @@ function ContextPanel({
       <div className={cn(HEADER_ROW, "gap-2 border-b border-sidebar-border px-4")}>
         <Icon className="size-4 shrink-0 text-muted-foreground" aria-hidden />
         <h2 className="min-w-0 flex-1 truncate text-sm font-semibold">{label}</h2>
-        {mode === "knowledge" ? (
+        {mode === "knowledge" &&
+        (visibility.visiblePaths === undefined ||
+          visibility.visiblePaths.includes("/knowledge")) ? (
           <Tooltip content="New space">
             <Link
               to="/knowledge/spaces/new"
@@ -280,19 +310,22 @@ function ContextPanel({
         {mode === "chat" ? <ChatContext onNavigate={onNavigate} /> : null}
         {mode === "knowledge" ? (
           <>
-            <nav aria-label="knowledge navigation" className="flex flex-col gap-1 px-2 pb-3">
-              <ContextLink
-                to="/knowledge/files"
-                label="Files"
-                icon={Paperclip}
-                onNavigate={onNavigate}
-              />
-            </nav>
+            {visibility.visiblePaths === undefined ||
+            visibility.visiblePaths.includes("/knowledge/files") ? (
+              <nav aria-label="knowledge navigation" className="flex flex-col gap-1 px-2 pb-3">
+                <ContextLink
+                  to="/knowledge/files"
+                  label="Files"
+                  icon={Paperclip}
+                  onNavigate={onNavigate}
+                />
+              </nav>
+            ) : null}
             <KnowledgeTree />
           </>
         ) : null}
         {mode === "build" || mode === "operate" || mode === "settings" ? (
-          <LinkList mode={mode} onNavigate={onNavigate} isAdmin={isAdmin} />
+          <LinkList mode={mode} onNavigate={onNavigate} visibility={visibility} />
         ) : null}
       </div>
     </div>
@@ -303,16 +336,18 @@ export function AppSidebar({
   open = false,
   onClose = () => {},
   collapsed = false,
-  isAdmin = false,
+  navigation,
 }: {
   open?: boolean;
   onClose?: () => void;
   collapsed?: boolean;
-  isAdmin?: boolean;
+  navigation?: SessionUser["navigation"];
 } = {}) {
   const { pathname } = useLocation();
   const mode = modeForPath(pathname);
-  const showContext = hasContextPanel(mode);
+  const visibility = { isDev: import.meta.env.DEV, visiblePaths: navigation?.visiblePaths };
+  const modes = visibleModes(visibility);
+  const showContext = hasContextPanel(mode) && modes.includes(mode);
   const [persistent, setPersistent] = useState(true);
 
   useEffect(() => {
@@ -347,7 +382,7 @@ export function AppSidebar({
           (collapsed || !showContext) && "lg:w-14"
         )}
       >
-        <Rail mode={mode} />
+        <Rail mode={mode} modes={modes} visibility={visibility} />
         {showContext ? (
           <div
             className={cn(
@@ -356,7 +391,7 @@ export function AppSidebar({
               collapsed && "lg:hidden"
             )}
           >
-            <ContextPanel mode={mode} onNavigate={onClose} isAdmin={isAdmin} />
+            <ContextPanel mode={mode} onNavigate={onClose} visibility={visibility} />
           </div>
         ) : null}
       </aside>
@@ -397,9 +432,17 @@ function AccountChip({ user }: { user?: SessionUser }) {
  * The parent crumb only earns its place when it points somewhere else and says something else,
  * so the trail never repeats the page or links to it.
  */
-function Breadcrumb({ pathname, pageTitle }: { pathname: string; pageTitle: string }) {
+function Breadcrumb({
+  pathname,
+  pageTitle,
+  visibility,
+}: {
+  pathname: string;
+  pageTitle: string;
+  visibility: NavigationVisibility;
+}) {
   const mode = modeForPath(pathname);
-  const parent = MODE_META[mode];
+  const parent = { ...MODE_META[mode], to: destinationForMode(mode, visibility) };
   const PageIcon = iconForPath(pathname);
   const showParent = mode !== "chat" && parent.to !== pathname && parent.label !== pageTitle;
   return (
@@ -430,15 +473,7 @@ function Breadcrumb({ pathname, pageTitle }: { pathname: string; pageTitle: stri
   );
 }
 
-export function AppShell({
-  children,
-  isAdmin = false,
-  user,
-}: {
-  children: ReactNode;
-  isAdmin?: boolean;
-  user?: SessionUser;
-}) {
+export function AppShell({ children, user }: { children: ReactNode; user?: SessionUser }) {
   const [open, setOpen] = useState(false);
   // Seeded from the [data-sidebar] the pre-hydration script in root.tsx already resolved, so the
   // real shell adopts the persisted width on its first render — matching the HydrateFallback
@@ -450,6 +485,9 @@ export function AppShell({
   const openerRef = useRef<HTMLButtonElement>(null);
   const { activeChatTitle } = useConversations();
   const isConversation = pathname === "/" || pathname.startsWith("/chat/");
+  const currentMode = modeForPath(pathname);
+  const visibility = { isDev: import.meta.env.DEV, visiblePaths: user?.navigation?.visiblePaths };
+  const modes = visibleModes(visibility);
   const pageTitle = isConversation
     ? (activeChatTitle ?? (pathname === "/" ? "New chat" : "Chat"))
     : titleForPath(pathname);
@@ -482,7 +520,7 @@ export function AppShell({
         open={open}
         onClose={() => setOpen(false)}
         collapsed={collapsed}
-        isAdmin={isAdmin}
+        navigation={user?.navigation}
       />
       <div className="flex min-w-0 flex-1 flex-col lg:h-svh">
         <header
@@ -499,7 +537,7 @@ export function AppShell({
             <Menu className="size-5" aria-hidden />
           </button>
           <span className="hidden shrink-0 lg:flex">
-            {hasContextPanel(modeForPath(pathname)) ? (
+            {hasContextPanel(currentMode) && modes.includes(currentMode) ? (
               <Tooltip content={collapsed ? "Expand sidebar" : "Collapse sidebar"}>
                 <button
                   type="button"
@@ -517,7 +555,7 @@ export function AppShell({
             ) : null}
           </span>
           <Separator orientation="vertical" className="mx-1 hidden h-5 lg:block" />
-          <Breadcrumb pathname={pathname} pageTitle={pageTitle} />
+          <Breadcrumb pathname={pathname} pageTitle={pageTitle} visibility={visibility} />
           <div className="ml-auto flex shrink-0 items-center gap-1 pl-2">
             <span className="sm:hidden">
               <CompanionMobileTrigger />

--- a/apps/web/app/lib/api.ts
+++ b/apps/web/app/lib/api.ts
@@ -198,6 +198,9 @@ export type SessionUser = {
    * admin routes are behind rather than by `role`, which a granted access level never rewrites.
    */
   isAdmin?: boolean;
+  navigation: {
+    visiblePaths: string[];
+  };
 };
 
 // Establish a session: POST credentials to the API, which sets the httpOnly session cookie + the

--- a/apps/web/app/lib/nav.test.ts
+++ b/apps/web/app/lib/nav.test.ts
@@ -1,5 +1,12 @@
 import { expect, test } from "vitest";
-import { MODE_SECTIONS, type NavItem, titleForPath } from "./nav";
+import {
+  destinationForMode,
+  MODE_SECTIONS,
+  type NavItem,
+  titleForPath,
+  visibleModes,
+  visibleSections,
+} from "./nav";
 
 function everyNavItem(): NavItem[] {
   return Object.values(MODE_SECTIONS).flatMap((sections) =>
@@ -32,4 +39,28 @@ test("a child route keeps its parent page's identity", () => {
 /* `/business/people` redirects in-shell, so its transient label must stay explicit. */
 test("a retired page still names its destination while it redirects", () => {
   expect(titleForPath("/business/people")).toBe(titleForPath("/business/access"));
+});
+
+test("hides every denied destination and collapses its empty groups", () => {
+  const sections = visibleSections("operate", {
+    isDev: false,
+    visiblePaths: ["/business/activities"],
+  });
+
+  expect(sections).toEqual([
+    expect.objectContaining({
+      heading: "Work",
+      items: [expect.objectContaining({ label: "Activities" })],
+    }),
+  ]);
+});
+
+test("hides a mode with no visible destinations", () => {
+  expect(visibleModes({ isDev: false, visiblePaths: [] })).toEqual(["chat"]);
+});
+
+test("sends a visible mode to its first allowed destination", () => {
+  expect(
+    destinationForMode("operate", { isDev: false, visiblePaths: ["/business/activities"] })
+  ).toBe("/business/activities");
 });

--- a/apps/web/app/lib/nav.ts
+++ b/apps/web/app/lib/nav.ts
@@ -33,7 +33,6 @@ export type NavItem = {
   label: string;
   icon: LucideIcon;
   badge?: boolean;
-  adminOnly?: boolean;
   devOnly?: boolean;
   /**
    * The one line the top bar cannot say. Rendered by the section shell instead of a second page
@@ -46,6 +45,11 @@ export type NavItem = {
 export type NavSection = {
   heading?: string;
   items: NavItem[];
+};
+
+export type NavigationVisibility = {
+  isDev: boolean;
+  visiblePaths?: readonly string[];
 };
 
 /*
@@ -108,7 +112,6 @@ export const MODE_SECTIONS: Record<"build" | "operate" | "settings", NavSection[
           to: "/business/observability",
           label: "Observability",
           icon: Gauge,
-          adminOnly: true,
           description: "What your agents are spending and doing — cost, tokens, and reliability.",
           wide: true,
         },
@@ -161,7 +164,6 @@ export const MODE_SECTIONS: Record<"build" | "operate" | "settings", NavSection[
           to: "/business/access",
           label: "People & access",
           icon: Users,
-          adminOnly: true,
           description:
             "Invite people, turn accounts off, and decide what each person is allowed to do.",
           wide: true,
@@ -210,16 +212,37 @@ export const MODE_SECTIONS: Record<"build" | "operate" | "settings", NavSection[
 
 export function visibleSections(
   mode: "build" | "operate" | "settings",
-  { isAdmin, isDev }: { isAdmin: boolean; isDev: boolean }
+  { isDev, visiblePaths }: NavigationVisibility
 ): NavSection[] {
   return MODE_SECTIONS[mode]
     .map((section) => ({
       ...section,
       items: section.items.filter(
-        (item) => (!item.adminOnly || isAdmin) && (!item.devOnly || isDev)
+        (item) =>
+          (visiblePaths === undefined || visiblePaths.includes(item.to)) && (!item.devOnly || isDev)
       ),
     }))
     .filter((section) => section.items.length > 0);
+}
+
+export function visibleModes({ isDev, visiblePaths }: NavigationVisibility): ProductMode[] {
+  const visible = ["chat"] as ProductMode[];
+  if (visibleSections("build", { isDev, visiblePaths }).length > 0) visible.push("build");
+  if (visiblePaths === undefined || visiblePaths.includes("/knowledge")) visible.push("knowledge");
+  if (visibleSections("operate", { isDev, visiblePaths }).length > 0) visible.push("operate");
+  if (visiblePaths === undefined || visiblePaths.includes("/farm")) visible.push("farm");
+  if (visibleSections("settings", { isDev, visiblePaths }).length > 0) visible.push("settings");
+  return visible;
+}
+
+export function destinationForMode(mode: ProductMode, visibility: NavigationVisibility): string {
+  if (mode !== "build" && mode !== "operate" && mode !== "settings") {
+    return MODE_META[mode].to;
+  }
+  return (
+    visibleSections(mode, visibility).flatMap((section) => section.items)[0]?.to ??
+    MODE_META[mode].to
+  );
 }
 
 export function modeForPath(pathname: string): ProductMode {

--- a/apps/web/app/lib/use-session-user.test.ts
+++ b/apps/web/app/lib/use-session-user.test.ts
@@ -9,6 +9,7 @@ function user(overrides: Partial<SessionUser>): SessionUser {
     name: null,
     role: "member",
     status: "active",
+    navigation: { visiblePaths: [] },
     ...overrides,
   };
 }

--- a/apps/web/app/routes/_app.tsx
+++ b/apps/web/app/routes/_app.tsx
@@ -7,7 +7,6 @@ import { ApprovalsProvider } from "~/lib/approvals-context";
 import { CompanionProvider } from "~/lib/companion-context";
 import { ConversationsProvider } from "~/lib/conversations-context";
 import { getSetupStatus } from "~/lib/setup";
-import { isBusinessAdmin } from "~/lib/use-session-user";
 
 // Auth gate for the whole app shell: every /app/* route runs this parent loader first.
 // Checks setup status first: if the instance needs first-run setup, redirect to /setup.
@@ -49,7 +48,7 @@ export default function AppLayout() {
     <ApprovalsProvider>
       <ConversationsProvider>
         <CompanionProvider>
-          <AppShell isAdmin={isBusinessAdmin(user)} user={user}>
+          <AppShell user={user}>
             <a
               href="#main-content"
               className="fixed left-2 top-2 z-[100] -translate-y-16 bg-background px-3 py-2 text-sm focus:translate-y-0"

--- a/apps/web/app/routes/invites.routes.test.tsx
+++ b/apps/web/app/routes/invites.routes.test.tsx
@@ -52,6 +52,7 @@ test("accepting an invite reads the token from the fragment and sets the passwor
     name: null,
     role: "member",
     status: "active",
+    navigation: { visiblePaths: [] },
   });
 
   renderAccept();
@@ -100,6 +101,7 @@ test("changing a password sends the current one alongside the new", async () => 
     name: null,
     role: "member",
     status: "active",
+    navigation: { visiblePaths: [] },
   });
 
   render(<AuthSettings />);

--- a/packages/authz/src/index.ts
+++ b/packages/authz/src/index.ts
@@ -64,6 +64,16 @@ export { assertGuestActive, GuestDeniedError, guestGrants } from "./guests";
 export type { JitDenialReason, JitGrantRequest } from "./jit";
 export { assertJitGrantIssuable, JitDeniedError } from "./jit";
 export type {
+  NavigationAuthorization,
+  NavigationAuthorizationCheck,
+  NavigationRequirement,
+} from "./navigation";
+export {
+  NAVIGATION_REQUIREMENTS,
+  sessionNavigationCapabilities,
+  withSessionNav,
+} from "./navigation";
+export type {
   IdentityPort,
   IdentityResolution,
   IdentityResolutionRequest,

--- a/packages/authz/src/navigation.test.ts
+++ b/packages/authz/src/navigation.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "vitest";
+import { sessionNavigationCapabilities } from "./navigation";
+
+test("navigation capabilities omit every path whose authority is denied", async () => {
+  const denied = new Set(["operations.read", "soul.git_config.read", "llm_config.read"]);
+  const capabilities = await sessionNavigationCapabilities(
+    "u1",
+    async (_principal, authorization) => Promise.resolve(!denied.has(authorization.action))
+  );
+
+  expect(capabilities.visiblePaths).toEqual(
+    expect.not.arrayContaining(["/inbox", "/business/soul", "/business/models"])
+  );
+  expect(capabilities.visiblePaths).toContain("/business/activities");
+});

--- a/packages/authz/src/navigation.ts
+++ b/packages/authz/src/navigation.ts
@@ -1,0 +1,125 @@
+/** A static product-shell destination and the authority required to expose it. */
+export type NavigationRequirement = {
+  readonly path: string;
+  readonly authorizations: readonly NavigationAuthorization[];
+};
+
+/** The authority declaration shared by route gates and session navigation capabilities. */
+export type NavigationAuthorization = {
+  readonly action: string;
+  readonly resourceType: string;
+  readonly fallback: "admin" | "authenticated";
+};
+
+export type NavigationAuthorizationCheck<Principal> = (
+  principal: Principal,
+  authorization: NavigationAuthorization
+) => Promise<boolean>;
+
+const AUTHENTICATED_NAVIGATION: NavigationAuthorization = {
+  action: "auth_session.read",
+  resourceType: "auth_session",
+  fallback: "authenticated",
+};
+
+const OPERATIONS_READ: NavigationAuthorization = {
+  action: "operations.read",
+  resourceType: "operations",
+  fallback: "admin",
+};
+
+const USER_MANAGE: NavigationAuthorization = {
+  action: "user.manage",
+  resourceType: "user",
+  fallback: "admin",
+};
+
+/** Server-owned visibility requirements for every static destination in the product shell. */
+export const NAVIGATION_REQUIREMENTS: readonly NavigationRequirement[] = [
+  { path: "/farm", authorizations: [AUTHENTICATED_NAVIGATION] },
+  { path: "/resources", authorizations: [AUTHENTICATED_NAVIGATION] },
+  { path: "/agents", authorizations: [AUTHENTICATED_NAVIGATION] },
+  { path: "/skills", authorizations: [AUTHENTICATED_NAVIGATION] },
+  { path: "/routines", authorizations: [AUTHENTICATED_NAVIGATION] },
+  { path: "/knowledge", authorizations: [AUTHENTICATED_NAVIGATION] },
+  { path: "/knowledge/files", authorizations: [AUTHENTICATED_NAVIGATION] },
+  { path: "/inbox", authorizations: [OPERATIONS_READ] },
+  { path: "/runs", authorizations: [OPERATIONS_READ] },
+  { path: "/business/activities", authorizations: [AUTHENTICATED_NAVIGATION] },
+  { path: "/operations", authorizations: [OPERATIONS_READ] },
+  {
+    path: "/business/observability",
+    authorizations: [
+      { action: "observability.read", resourceType: "observability", fallback: "admin" },
+    ],
+  },
+  { path: "/business/profile", authorizations: [AUTHENTICATED_NAVIGATION] },
+  {
+    path: "/business/models",
+    authorizations: [
+      { action: "llm_config.read", resourceType: "llm_config", fallback: "admin" },
+      { action: "secret.read", resourceType: "secret", fallback: "authenticated" },
+    ],
+  },
+  {
+    path: "/business/secrets",
+    authorizations: [
+      { action: "secret.read", resourceType: "secret", fallback: "authenticated" },
+      { action: "llm_config.read", resourceType: "llm_config", fallback: "admin" },
+    ],
+  },
+  { path: "/integrations", authorizations: [AUTHENTICATED_NAVIGATION] },
+  {
+    path: "/business/soul",
+    authorizations: [
+      { action: "soul.git_config.read", resourceType: "soul.git_config", fallback: "admin" },
+    ],
+  },
+  { path: "/business/guardrails", authorizations: [OPERATIONS_READ] },
+  { path: "/business/access", authorizations: [OPERATIONS_READ] },
+  { path: "/business/about", authorizations: [AUTHENTICATED_NAVIGATION] },
+  { path: "/settings/profile", authorizations: [AUTHENTICATED_NAVIGATION] },
+  { path: "/settings/appearance", authorizations: [AUTHENTICATED_NAVIGATION] },
+  {
+    path: "/settings/auth",
+    authorizations: [
+      { action: "api_token.read", resourceType: "api_token", fallback: "authenticated" },
+    ],
+  },
+  { path: "/settings/instructions", authorizations: [AUTHENTICATED_NAVIGATION] },
+  { path: "/design-guide", authorizations: [AUTHENTICATED_NAVIGATION] },
+];
+
+/** Evaluates the opaque navigation capabilities issued with an authenticated session. */
+export async function sessionNavigationCapabilities<Principal>(
+  principal: Principal,
+  check: NavigationAuthorizationCheck<Principal>
+): Promise<{ isAdmin: boolean; visiblePaths: string[] }> {
+  const [isAdmin, visiblePaths] = await Promise.all([
+    check(principal, USER_MANAGE).catch(() => false),
+    Promise.all(
+      NAVIGATION_REQUIREMENTS.map(async ({ path, authorizations }) => {
+        const allowed = await Promise.all(
+          authorizations.map((authorization) => check(principal, authorization))
+        ).catch(() => []);
+        return allowed.length === authorizations.length && allowed.every(Boolean)
+          ? path
+          : undefined;
+      })
+    ),
+  ]);
+  return {
+    isAdmin,
+    visiblePaths: visiblePaths.filter((path): path is string => path !== undefined),
+  };
+}
+
+/** Adds server-authorized shell capabilities to an authenticated user payload. */
+export async function withSessionNav<User, Principal>(
+  user: User,
+  principal: Principal,
+  check: NavigationAuthorizationCheck<Principal>
+): Promise<User & { isAdmin: boolean; navigation: { visiblePaths: string[] } }> {
+  const { isAdmin, visiblePaths } = await sessionNavigationCapabilities(principal, check);
+  return { ...user, isAdmin, navigation: { visiblePaths } };
+}


### PR DESCRIPTION
Closes #537

- Add a server-owned navigation capability payload to authenticated session responses.
- Filter sidebar sections and modes from those capabilities, including empty-group collapse and permitted fallback destinations.
- Preserve existing direct-route authorization gates.

## Test plan

- [x] `pnpm exec biome check --write` on changed files
- [x] `pnpm --filter @tulipfarm/api test src/auth/routes.test.ts`
- [x] `pnpm --filter @tulipfarm/web test app/lib/nav.test.ts app/components/app-sidebar.test.tsx`
- [x] `pnpm --filter @tulipfarm/api typecheck`
- [x] `pnpm --filter @tulipfarm/web typecheck`
- [x] `pnpm lint`
- [x] `pnpm typecheck`