### PR TITLE
fix(chat): restore live turns after navigation

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -473,6 +473,7 @@ export async function buildApp(opts: AppOptions = {}) {
         {
           repo: opts.conversationRepo,
           messageRepo: opts.messageRepo,
+          ...(opts.conversationStore === undefined ? {} : { turnStore: opts.conversationStore }),
           knowledge: opts.knowledgeService,
           soulLoader: opts.soulLoader,
           toolRegistry,

--- a/apps/api/src/chat/conversation-routes.test.ts
+++ b/apps/api/src/chat/conversation-routes.test.ts
@@ -1,9 +1,66 @@
 import Fastify, { type FastifyInstance } from "fastify";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { UserDoc } from "../auth/users";
+import type { PersistedTurn } from "../conversations/service";
 import { registerConversationRoutes } from "./conversation-routes";
 import type { ConversationDeleteOutcome, ConversationRepo } from "./conversations";
 import type { MessageRepo } from "./messages";
+
+describe("restoring the latest Turn", () => {
+  let app: FastifyInstance;
+  const findLatestTurn = vi.fn(
+    async (): Promise<PersistedTurn | undefined> => ({
+      id: "turn-1",
+      businessId: "default",
+      conversationId: "chat-1",
+      idempotencyKey: "key-1",
+      requestMessageId: "message-1",
+      status: "running",
+      attempt: 1,
+      runId: "run-1",
+      cursor: 3,
+      supersededRunIds: [],
+      createdAt: new Date("2026-08-21T00:00:00.000Z"),
+      updatedAt: new Date("2026-08-21T00:00:01.000Z"),
+    })
+  );
+
+  beforeEach(async () => {
+    app = Fastify();
+    const repo = {
+      findById: async () => ({
+        _id: "chat-1",
+        userId: "user-1",
+        createdAt: new Date("2026-08-21T00:00:00.000Z"),
+        updatedAt: new Date("2026-08-21T00:00:01.000Z"),
+      }),
+    } as unknown as ConversationRepo;
+    registerConversationRoutes(
+      app,
+      { repo, messageRepo: {} as MessageRepo, turnStore: { findLatestTurn } },
+      async (request) => {
+        request.user = { _id: "user-1" } as UserDoc;
+      }
+    );
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+    await app.close();
+  });
+
+  it("returns the Run needed to rebuild live state", async () => {
+    const response = await app.inject({ method: "GET", url: "/api/v1/chats/chat-1" });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().latestTurn).toEqual({
+      id: "turn-1",
+      runId: "run-1",
+      status: "running",
+    });
+  });
+});
 
 describe("conversation deletion route", () => {
   let app: FastifyInstance;

--- a/apps/api/src/chat/conversation-routes.ts
+++ b/apps/api/src/chat/conversation-routes.ts
@@ -2,6 +2,7 @@ import { DEPLOYMENT_BUSINESS_ID } from "@tulipfarm/constants";
 import type { FileService } from "@tulipfarm/files";
 import type { KnowledgeService } from "@tulipfarm/knowledge";
 import type { MemoryDocumentRepo } from "@tulipfarm/memory";
+import { ConversationDetailSchema } from "@tulipfarm/schema";
 import type { BundledSkill, SoulLoader } from "@tulipfarm/soul";
 import {
   buildSoulCatalogue,
@@ -16,6 +17,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { ErrorSchema } from "../auth/schemas";
 import type { UserDoc } from "../auth/users";
 import type { ToolRegistry } from "../broker/tool-adapter";
+import type { ConversationStore } from "../conversations/service";
 import { presentationContextFor, surfaceCatalogPromptFor } from "../surfaces/renderer-registry";
 import { githubDisabledSkillNames, githubExcludedToolNames } from "../tools/github/visibility";
 import type { ConversationDoc, ConversationRepo } from "./conversations";
@@ -43,6 +45,7 @@ async function findOwnedConversation(
 /** Read/update routes over conversation metadata + messages (no streaming). */
 export interface ConversationRoutesDeps {
   repo: ConversationRepo;
+  turnStore?: Pick<ConversationStore, "findLatestTurn">;
   /** The conversation owner's Memory Document, so the reconstructed prompt matches the live one. */
   memoryDocuments?: MemoryDocumentRepo;
   messageRepo: MessageRepo;
@@ -79,6 +82,7 @@ export function registerConversationRoutes(
     disabledBundledSkills,
     githubStatus,
     files,
+    turnStore,
   } = deps;
 
   app.get(
@@ -260,7 +264,7 @@ export function registerConversationRoutes(
     {
       preHandler: requireAuth,
       schema: {
-        description: "Fetch a conversation's metadata. Owner-only.",
+        description: "Fetch a conversation's metadata and latest Turn for Chat restoration.",
         tags: ["chat"],
         security: [{ sessionCookie: [] }, { bearerToken: [] }],
         params: {
@@ -269,20 +273,7 @@ export function registerConversationRoutes(
           properties: { id: { type: "string" } },
         },
         response: {
-          200: {
-            type: "object",
-            properties: {
-              id: { type: "string" },
-              userId: { type: ["string", "null"] },
-              agentId: { type: ["string", "null"] },
-              model: { type: ["string", "null"] },
-              title: { type: ["string", "null"] },
-              starred: { type: "boolean" },
-              createdAt: { type: "string" },
-              updatedAt: { type: "string" },
-            },
-            required: ["id", "createdAt", "updatedAt"],
-          },
+          200: ConversationDetailSchema,
           401: ErrorSchema,
           404: ErrorSchema,
         },
@@ -295,6 +286,7 @@ export function registerConversationRoutes(
       if (!convo) {
         return reply.code(404).send({ error: "conversation not found" });
       }
+      const latestTurn = await turnStore?.findLatestTurn(DEPLOYMENT_BUSINESS_ID, id);
       return reply.send({
         id: convo._id,
         userId: convo.userId ?? null,
@@ -304,6 +296,9 @@ export function registerConversationRoutes(
         starred: convo.starred ?? false,
         createdAt: convo.createdAt,
         updatedAt: convo.updatedAt,
+        latestTurn: latestTurn
+          ? { id: latestTurn.id, runId: latestTurn.runId, status: latestTurn.status }
+          : null,
       });
     }
   );

--- a/apps/api/src/conversations/service.test.ts
+++ b/apps/api/src/conversations/service.test.ts
@@ -35,6 +35,13 @@ class FakeStore implements ConversationStore {
     return this.turns.find((turn) => turn.id === turnId);
   }
 
+  async findLatestTurn(
+    _businessId: string,
+    conversationId: string
+  ): Promise<PersistedTurn | undefined> {
+    return [...this.turns].reverse().find((turn) => turn.conversationId === conversationId);
+  }
+
   async findTurnByRunId(_businessId: string, runId: string): Promise<PersistedTurn | undefined> {
     return this.turns.find((turn) => turn.runId === runId);
   }

--- a/apps/api/src/conversations/service.ts
+++ b/apps/api/src/conversations/service.ts
@@ -1,6 +1,7 @@
 /** SPEC §10/§18: persist the Turn before dispatch; stream resumes from its durable cursor. */
 
 import {
+  type ConversationTurn,
   contentText,
   type MessageContent,
   type MessageFilePart,
@@ -8,7 +9,7 @@ import {
 } from "@tulipfarm/schema";
 import type { CuratorWorkRef } from "@tulipfarm/storage";
 
-export type TurnStatus = "pending" | "running" | "start_failed" | "succeeded" | "failed";
+export type TurnStatus = ConversationTurn["status"];
 
 export interface PersistedMessage {
   readonly id: string;
@@ -56,6 +57,7 @@ export interface PersistedTurn {
 export interface ConversationStore {
   findTurnByIdempotencyKey(businessId: string, key: string): Promise<PersistedTurn | undefined>;
   findTurn(businessId: string, turnId: string): Promise<PersistedTurn | undefined>;
+  findLatestTurn(businessId: string, conversationId: string): Promise<ConversationTurn | undefined>;
   /** Live Run→Turn mapping; `same_turn` retries supersede stale executors. */
   findTurnByRunId(businessId: string, runId: string): Promise<PersistedTurn | undefined>;
   appendMessage(message: PersistedMessage): Promise<void>;

--- a/apps/api/src/conversations/store.pg.test.ts
+++ b/apps/api/src/conversations/store.pg.test.ts
@@ -127,6 +127,26 @@ describe("PgConversationStore", () => {
     ).resolves.toBeUndefined();
   });
 
+  it("finds the newest Turn for a Conversation", async () => {
+    await store.saveTurn(turn({ status: "failed", runId: RUN_ID }));
+    const latest = turn({
+      id: "00000000-0000-4000-8000-000000000010",
+      idempotencyKey: "client-key-2",
+      requestMessageId: "00000000-0000-4000-8000-000000000011",
+      status: "running",
+      runId: "00000000-0000-4000-8000-000000000012",
+      createdAt: new Date("2026-07-26T00:01:00.000Z"),
+      updatedAt: new Date("2026-07-26T00:01:00.000Z"),
+    });
+    await store.saveTurn(latest);
+
+    await expect(store.findLatestTurn(DEPLOYMENT_BUSINESS_ID, CONVERSATION_ID)).resolves.toEqual({
+      id: latest.id,
+      runId: latest.runId,
+      status: latest.status,
+    });
+  });
+
   it("keeps the first outcome an attempt recorded", async () => {
     await store.saveTurn(turn());
     const completion = {

--- a/apps/api/src/conversations/store.pg.ts
+++ b/apps/api/src/conversations/store.pg.ts
@@ -1,6 +1,6 @@
 import { DEPLOYMENT_BUSINESS_ID } from "@tulipfarm/constants";
 import { normalizeMessageContent } from "@tulipfarm/schema";
-import { recordCuratorWork } from "@tulipfarm/storage";
+import { findLatestConversationTurn, recordCuratorWork } from "@tulipfarm/storage";
 import type { Queryable } from "../db";
 import { withTransaction } from "../db";
 import type {
@@ -163,6 +163,11 @@ export class PgConversationStore implements ConversationStore {
     );
     const row = rows[0] as unknown as TurnRow | undefined;
     return row ? toTurn(row) : undefined;
+  }
+
+  async findLatestTurn(businessId: string, conversationId: string) {
+    assertDeploymentBusiness(businessId);
+    return findLatestConversationTurn(this.q, conversationId);
   }
 
   async findTurnByRunId(businessId: string, runId: string): Promise<PersistedTurn | undefined> {

--- a/apps/api/src/platform/delegation.test.ts
+++ b/apps/api/src/platform/delegation.test.ts
@@ -84,6 +84,9 @@ class FakeConversationStore implements ConversationStore {
   async findTurn(_b: string, turnId: string) {
     return this.turns.find((turn) => turn.id === turnId);
   }
+  async findLatestTurn(_b: string, conversationId: string) {
+    return [...this.turns].reverse().find((turn) => turn.conversationId === conversationId);
+  }
   async findTurnByRunId(_b: string, runId: string) {
     return this.turns.find((turn) => turn.runId === runId);
   }

--- a/apps/api/src/test/turn-host-fixtures.ts
+++ b/apps/api/src/test/turn-host-fixtures.ts
@@ -50,6 +50,12 @@ export class FakeConversationStore implements ConversationStore {
     return this.turns.find((candidate) => candidate.id === turnId);
   }
 
+  async findLatestTurn(_businessId: string, conversationId: string) {
+    return [...this.turns]
+      .reverse()
+      .find((candidate) => candidate.conversationId === conversationId);
+  }
+
   async findTurnByRunId(_businessId: string, runId: string) {
     return this.turns.find((candidate) => candidate.runId === runId);
   }

--- a/apps/web/app/components/chat/chat-panel.tsx
+++ b/apps/web/app/components/chat/chat-panel.tsx
@@ -3,6 +3,7 @@ import { AgentGlyph } from "~/components/agent-glyph";
 import { ConnectionStatus } from "~/components/shell/states";
 import type { ChatMessage, ChatModelSelector } from "~/lib/chat/types";
 import { useChatStream } from "~/lib/chat/use-chat-stream";
+import type { ConversationTurn } from "~/lib/conversations";
 import { errorAction } from "~/lib/error-actions";
 import type { Suggestion } from "~/lib/onboarding";
 import type { Task } from "~/lib/tasks";
@@ -76,6 +77,7 @@ export function ChatPanel({
   businessName,
   initialConversationId,
   initialMessages,
+  initialTurn,
   onConversationChange,
   initialDraft,
   attachFileId,
@@ -87,6 +89,7 @@ export function ChatPanel({
   businessName?: string;
   initialConversationId?: string;
   initialMessages?: ChatMessage[];
+  initialTurn?: ConversationTurn | null;
   onConversationChange?: (conversationId: string | undefined) => void;
   /** A prompt to draft into the composer once, seeded by the onboarding Companion. */
   initialDraft?: string;
@@ -110,6 +113,7 @@ export function ChatPanel({
   } = useChatStream({
     initialConversationId,
     initialMessages,
+    initialTurn,
     onConversationChange,
   });
   const busy = status === "submitted" || status === "streaming";

--- a/apps/web/app/lib/chat/sse-client.test.ts
+++ b/apps/web/app/lib/chat/sse-client.test.ts
@@ -4,6 +4,7 @@ import {
   modelFailureMessage,
   parseSseFrames,
   postChat,
+  resumeRun,
 } from "~/lib/chat/sse-client";
 
 afterEach(() => {
@@ -124,6 +125,29 @@ test("recovers a dropped stream from the Run's own events without duplicating th
   expect(fetchMock.mock.calls[1]?.[1]).toMatchObject({
     headers: expect.objectContaining({ "Last-Event-ID": "1" }),
   });
+});
+
+test("replays a persisted Run from the beginning when a Chat mounts again", async () => {
+  const fetchMock = vi
+    .fn()
+    .mockResolvedValueOnce(
+      streamResponse(
+        'id: 1\nevent: text.delta\ndata: {"text":"Checking"}\n\n' +
+          'id: 2\nevent: tool.call\ndata: {"callId":"c1","name":"record_list","argsDigest":"d1"}\n\n' +
+          'id: 3\nevent: tool.result\ndata: {"callId":"c1","status":"error","errorCode":"timeout"}\n\n' +
+          'id: 4\nevent: turn.finished\ndata: {"status":"failed","reason":"model_timeout"}\n\n'
+      )
+    );
+  vi.stubGlobal("fetch", fetchMock);
+  const events: string[] = [];
+
+  await resumeRun("run-1", { onEvent: (event) => events.push(event.type) });
+
+  expect(fetchMock).toHaveBeenCalledWith(
+    expect.stringContaining("/api/v1/runs/run-1/events?after=0"),
+    expect.objectContaining({ method: "GET", credentials: "include" })
+  );
+  expect(events).toEqual(["text", "tool-call", "tool-result", "error"]);
 });
 
 test("submits the effort preset id in the chat model field", async () => {

--- a/apps/web/app/lib/chat/sse-client.ts
+++ b/apps/web/app/lib/chat/sse-client.ts
@@ -354,32 +354,62 @@ async function postTurnStream(
   });
 
   const map = createRunEventMapper();
-  let outcome = await consumeSse(res, handlers, 0, map);
-  if (outcome.terminal || !runId) return;
+  if (!runId) {
+    await consumeSse(res, handlers, 0, map);
+    return;
+  }
+  await consumeRunStream(runId, res, handlers, 0, map);
+}
 
-  for (let attempt = 1; attempt <= 3; attempt++) {
-    handlers.onConnectionState?.("reconnecting");
-    const headers = mutationHeaders();
-    delete headers["Content-Type"];
-    headers.Accept = "text/event-stream";
-    headers["Last-Event-ID"] = String(outcome.lastSequence);
-    const resumed = await fetch(
-      `${API_BASE}/api/v1/runs/${encodeURIComponent(runId)}/events?after=${outcome.lastSequence}`,
-      {
-        method: "GET",
-        credentials: "include",
-        headers,
-        signal,
-      }
-    );
-    if (!resumed.ok) throw await readChatError(resumed);
-    outcome = await consumeSse(resumed, handlers, outcome.lastSequence, map);
+async function fetchRunEvents(
+  runId: string,
+  after: number,
+  signal?: AbortSignal
+): Promise<Response> {
+  const headers = mutationHeaders();
+  delete headers["Content-Type"];
+  headers.Accept = "text/event-stream";
+  headers["Last-Event-ID"] = String(after);
+  const response = await fetch(
+    `${API_BASE}/api/v1/runs/${encodeURIComponent(runId)}/events?after=${after}`,
+    {
+      method: "GET",
+      credentials: "include",
+      headers,
+      signal,
+    }
+  );
+  if (!response.ok) throw await readChatError(response);
+  return response;
+}
+
+async function consumeRunStream(
+  runId: string,
+  response: Response,
+  handlers: PostChatHandlers,
+  after: number,
+  map: (frame: ParsedFrame) => ChatEvent[]
+): Promise<void> {
+  let currentResponse = response;
+  let cursor = after;
+
+  for (let attempt = 0; attempt <= 3; attempt++) {
+    const outcome = await consumeSse(currentResponse, handlers, cursor, map);
+    cursor = outcome.lastSequence;
     if (outcome.terminal) {
-      handlers.onConnectionState?.("online");
+      if (attempt > 0) handlers.onConnectionState?.("online");
       return;
     }
+    if (attempt === 3) break;
+    handlers.onConnectionState?.("reconnecting");
+    currentResponse = await fetchRunEvents(runId, cursor, handlers.signal);
   }
   throw new ApiError(503, "The stream could not be recovered from its persisted cursor.");
+}
+
+export async function resumeRun(runId: string, handlers: PostChatHandlers): Promise<void> {
+  const response = await fetchRunEvents(runId, 0, handlers.signal);
+  await consumeRunStream(runId, response, handlers, 0, createRunEventMapper());
 }
 
 async function consumeSse(

--- a/apps/web/app/lib/chat/use-chat-stream.restore.test.tsx
+++ b/apps/web/app/lib/chat/use-chat-stream.restore.test.tsx
@@ -1,0 +1,124 @@
+import { createRemixStub } from "@remix-run/testing";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, expect, test, vi } from "vitest";
+import type { ChatMessage } from "./types";
+import { useChatStream } from "./use-chat-stream";
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+function streamResponse(frames: string) {
+  const body = new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(frames));
+      controller.close();
+    },
+  });
+  return new Response(body, { status: 200 });
+}
+
+const initialMessages: ChatMessage[] = [
+  {
+    id: "message-1",
+    role: "user",
+    parts: [{ kind: "text", text: "Check the records" }],
+    sealed: true,
+  },
+];
+
+const initialTurn = { id: "turn-1", runId: "run-1", status: "running" } as const;
+const initialPendingTurn = { id: "turn-1", runId: null, status: "pending" } as const;
+
+const frames =
+  'id: 1\nevent: text.delta\ndata: {"text":"Checking"}\n\n' +
+  'id: 2\nevent: tool.call\ndata: {"callId":"c1","name":"record_list","argsDigest":"d1"}\n\n' +
+  'id: 3\nevent: tool.result\ndata: {"callId":"c1","status":"error","errorCode":"timeout"}\n\n' +
+  'id: 4\nevent: turn.finished\ndata: {"status":"failed","reason":"model_timeout"}\n\n';
+
+function Harness() {
+  const chat = useChatStream({
+    initialConversationId: "conversation-1",
+    initialMessages,
+    initialTurn,
+  });
+  const assistant = chat.messages.find((message) => message.role === "assistant");
+  const tool = assistant?.parts.find((part) => part.kind === "tool");
+  return (
+    <div>
+      <p>{chat.status}</p>
+      <p>{assistant?.parts.find((part) => part.kind === "text")?.text}</p>
+      <p>{tool?.kind === "tool" ? `${tool.toolName}:${tool.outcome}` : ""}</p>
+      <p>{chat.error}</p>
+    </div>
+  );
+}
+
+function PendingHarness() {
+  const chat = useChatStream({
+    initialConversationId: "conversation-1",
+    initialMessages,
+    initialTurn: initialPendingTurn,
+  });
+  const assistant = chat.messages.find((message) => message.role === "assistant");
+  return (
+    <div>
+      <p>{chat.status}</p>
+      <p>{assistant?.parts.find((part) => part.kind === "text")?.text}</p>
+    </div>
+  );
+}
+
+test("rebuilds streamed text, Tool failure, and model error every time the Chat mounts", async () => {
+  const fetchMock = vi
+    .fn()
+    .mockResolvedValueOnce(streamResponse(frames))
+    .mockResolvedValueOnce(streamResponse(frames));
+  vi.stubGlobal("fetch", fetchMock);
+  const App = createRemixStub([{ path: "/", Component: Harness }]);
+
+  const first = render(<App />);
+  expect(await screen.findByText("Checking")).toBeInTheDocument();
+  expect(screen.getByText("record_list:error")).toBeInTheDocument();
+  expect(screen.getByText("The model request failed. Try again.")).toBeInTheDocument();
+  first.unmount();
+
+  render(<App />);
+  expect(await screen.findByText("Checking")).toBeInTheDocument();
+  expect(screen.getByText("record_list:error")).toBeInTheDocument();
+  expect(screen.getByText("The model request failed. Try again.")).toBeInTheDocument();
+  expect(fetchMock).toHaveBeenCalledTimes(2);
+});
+
+test("keeps the loading state while a pending Turn receives its Run", async () => {
+  const fetchMock = vi
+    .fn()
+    .mockResolvedValueOnce(
+      Response.json({
+        id: "conversation-1",
+        userId: "user-1",
+        agentId: null,
+        model: null,
+        title: null,
+        starred: false,
+        createdAt: "2026-08-21T00:00:00.000Z",
+        updatedAt: "2026-08-21T00:00:01.000Z",
+        latestTurn: { id: "turn-1", runId: "run-1", status: "running" },
+      })
+    )
+    .mockResolvedValueOnce(
+      streamResponse(
+        'id: 1\nevent: text.delta\ndata: {"text":"Started"}\n\n' +
+          'id: 2\nevent: turn.finished\ndata: {"status":"succeeded","messageId":"message-2"}\n\n'
+      )
+    );
+  vi.stubGlobal("fetch", fetchMock);
+  const App = createRemixStub([{ path: "/", Component: PendingHarness }]);
+
+  render(<App />);
+  expect(screen.getByText("submitted")).toBeInTheDocument();
+  expect(await screen.findByText("Started", {}, { timeout: 1_000 })).toBeInTheDocument();
+  expect(fetchMock.mock.calls[0]?.[0]).toContain("/api/v1/chats/conversation-1");
+  expect(fetchMock.mock.calls[1]?.[0]).toContain("/api/v1/runs/run-1/events?after=0");
+});

--- a/apps/web/app/lib/chat/use-chat-stream.test.ts
+++ b/apps/web/app/lib/chat/use-chat-stream.test.ts
@@ -25,4 +25,33 @@ describe("seedState", () => {
       "conversation"
     );
   });
+
+  it("restores an active Turn as submitted with its Run", () => {
+    expect(
+      seedState({
+        initialConversationId: "conversation",
+        initialTurn: { id: "turn-1", runId: "run-1", status: "running" },
+      })
+    ).toMatchObject({ status: "submitted", runId: "run-1" });
+  });
+
+  it("surfaces a Turn that failed before a Run was created", () => {
+    expect(
+      seedState({
+        initialConversationId: "conversation",
+        initialTurn: { id: "turn-1", runId: null, status: "start_failed" },
+      })
+    ).toMatchObject({ status: "error", error: "The response could not be started. Try again." });
+  });
+
+  it("does not replay stale active metadata over a persisted assistant reply", () => {
+    const state = seedState({
+      initialConversationId: "conversation",
+      initialMessages: [{ id: "reply", role: "assistant", parts: [], sealed: true }],
+      initialTurn: { id: "turn-1", runId: "run-1", status: "running" },
+    });
+
+    expect(state.status).toBe("idle");
+    expect(state).not.toHaveProperty("runId");
+  });
 });

--- a/apps/web/app/lib/chat/use-chat-stream.ts
+++ b/apps/web/app/lib/chat/use-chat-stream.ts
@@ -5,7 +5,7 @@
  */
 
 import { type NavigateFunction, useNavigate } from "@remix-run/react";
-import { useCallback, useReducer, useRef, useState } from "react";
+import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import { invokeClientAction, prefillForm } from "~/lib/chat/action-registry";
 import {
   appendUserMessage,
@@ -17,6 +17,7 @@ import type { ChatStreamMeta } from "~/lib/chat/sse-client";
 import {
   postChat,
   postSurfaceInteraction,
+  resumeRun,
   sendApprovalDecision,
   stopChatRun,
 } from "~/lib/chat/sse-client";
@@ -29,6 +30,7 @@ import type {
   ChatTurnOptions,
   ChatTurnSource,
 } from "~/lib/chat/types";
+import { type ConversationTurn, getConversation } from "~/lib/conversations";
 import { clearFeedback, sendFeedback as postFeedback } from "~/lib/feedback";
 import { randomUUID } from "~/lib/uuid";
 
@@ -37,21 +39,41 @@ export type SendOptions = ChatTurnOptions;
 export type UseChatStreamOptions = {
   initialConversationId?: string;
   initialMessages?: ChatMessage[];
+  initialTurn?: ConversationTurn | null;
   onConversationChange?: (conversationId: string | undefined) => void;
 };
 
+function needsRunReplay(opts?: UseChatStreamOptions): boolean {
+  const turn = opts?.initialTurn;
+  if (!turn) return false;
+  return opts?.initialMessages?.at(-1)?.role !== "assistant";
+}
+
 export function seedState(opts?: UseChatStreamOptions): ChatState {
-  if (opts?.initialMessages && opts.initialMessages.length > 0) {
+  const messages = opts?.initialMessages ?? [];
+  const base: ChatState = {
+    messages,
+    pendingApprovals: {},
+    status: "idle",
+    ...(opts?.initialConversationId === undefined
+      ? {}
+      : { conversationId: opts.initialConversationId }),
+  };
+  if (!needsRunReplay(opts)) return base;
+  const turn = opts?.initialTurn;
+  if (!turn) return base;
+  if (turn.status === "start_failed" || (turn.status === "failed" && turn.runId === null)) {
     return {
-      messages: opts.initialMessages,
-      pendingApprovals: {},
-      status: "idle",
-      conversationId: opts.initialConversationId,
+      ...base,
+      status: "error",
+      error: "The response could not be started. Try again.",
     };
   }
-  return opts?.initialConversationId
-    ? { ...initialChatState, conversationId: opts.initialConversationId }
-    : initialChatState;
+  return {
+    ...base,
+    status: "submitted",
+    ...(turn.runId === null ? {} : { runId: turn.runId }),
+  };
 }
 
 type ChatAction =
@@ -140,15 +162,97 @@ export function useChatStream(opts?: UseChatStreamOptions) {
   stateRef.current = state;
   const lastOptsRef = useRef<SendOptions | undefined>(undefined);
   const abortRef = useRef<AbortController | null>(null);
+  const stopRequestedRef = useRef(false);
   const onConversationChangeRef = useRef(opts?.onConversationChange);
   onConversationChangeRef.current = opts?.onConversationChange;
   const navigate = useNavigate();
   const navigateRef = useRef(navigate);
   navigateRef.current = navigate;
 
+  useEffect(
+    () => () => {
+      abortRef.current?.abort();
+    },
+    []
+  );
+
+  const initialConversationId = opts?.initialConversationId;
+  const initialTurn = opts?.initialTurn;
+  const replayInitialTurn = needsRunReplay(opts);
+
+  useEffect(() => {
+    if (!replayInitialTurn || !initialConversationId || !initialTurn) return;
+    if (
+      initialTurn.status === "start_failed" ||
+      (initialTurn.status === "failed" && initialTurn.runId === null)
+    ) {
+      return;
+    }
+
+    const controller = new AbortController();
+    const conversationId = initialConversationId;
+    const restoredTurn = initialTurn;
+    abortRef.current = controller;
+    stopRequestedRef.current = false;
+
+    async function restore(): Promise<void> {
+      let turn: ConversationTurn = restoredTurn;
+      while (turn.runId === null && turn.status === "pending") {
+        await new Promise((resolve) => setTimeout(resolve, 250));
+        if (controller.signal.aborted) return;
+        const conversation = await getConversation(conversationId);
+        if (!conversation.latestTurn) {
+          throw new Error("The response state could not be restored. Try again.");
+        }
+        turn = conversation.latestTurn;
+      }
+
+      if (turn.status === "start_failed" || turn.runId === null) {
+        throw new Error("The response could not be started. Try again.");
+      }
+
+      dispatch({ type: "meta", meta: { runId: turn.runId } });
+      await resumeRun(turn.runId, {
+        signal: controller.signal,
+        onEvent: (event) => {
+          if (event.type === "client-action") {
+            handleClientAction(event.data, navigateRef.current);
+            return;
+          }
+          dispatch(event);
+          if (event.type === "finish") {
+            onConversationChangeRef.current?.(conversationIdRef.current);
+          }
+        },
+        onConnectionState: setConnectionState,
+      });
+    }
+
+    void restore()
+      .catch((error) => {
+        if (controller.signal.aborted) {
+          if (stopRequestedRef.current) dispatch({ type: "stopped" });
+          return;
+        }
+        dispatch({
+          type: "error",
+          data: { message: error instanceof Error ? error.message : "stream failed" },
+        });
+      })
+      .finally(() => {
+        if (abortRef.current === controller) abortRef.current = null;
+        stopRequestedRef.current = false;
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, [initialConversationId, initialTurn, replayInitialTurn]);
+
   const runStream = useCallback(async (text: string, opts?: SendOptions) => {
     const controller = new AbortController();
     abortRef.current = controller;
+    stopRequestedRef.current = false;
     const idempotencyKey = randomUUID();
     try {
       await postChat(
@@ -200,6 +304,7 @@ export function useChatStream(opts?: UseChatStreamOptions) {
       }
     } finally {
       abortRef.current = null;
+      stopRequestedRef.current = false;
     }
   }, []);
 
@@ -238,6 +343,7 @@ export function useChatStream(opts?: UseChatStreamOptions) {
   const stop = useCallback(() => {
     const runId = stateRef.current.runId;
     if (runId) void stopChatRun(runId).catch(() => {});
+    stopRequestedRef.current = true;
     abortRef.current?.abort();
   }, []);
 

--- a/apps/web/app/lib/conversations.ts
+++ b/apps/web/app/lib/conversations.ts
@@ -1,3 +1,4 @@
+import type { ConversationDetail, ConversationTurn } from "@tulipfarm/schema";
 import { apiDelete, apiGet, apiWrite } from "./api";
 
 /*
@@ -15,10 +16,8 @@ export type ConversationSummary = {
   updatedAt: string;
 };
 
-export type Conversation = ConversationSummary & {
-  userId: string | null;
-  model: string | null;
-};
+export type Conversation = ConversationSummary & ConversationDetail;
+export type { ConversationTurn };
 
 export type WireMessagePart =
   | { type: "text"; text: string }

--- a/apps/web/app/routes/_app.chat.$id.tsx
+++ b/apps/web/app/routes/_app.chat.$id.tsx
@@ -59,11 +59,13 @@ export async function clientLoader({ params }: ClientLoaderFunctionArgs) {
     agentId,
     defaultModel,
     messages: messagesToTimeline(messages, votes),
+    latestTurn: convo.latestTurn,
   };
 }
 
 export default function ChatConversationRoute() {
-  const { id, title, agentId, defaultModel, messages } = useLoaderData<typeof clientLoader>();
+  const { id, title, agentId, defaultModel, messages, latestTurn } =
+    useLoaderData<typeof clientLoader>();
   const { refresh, setActiveChatTitle } = useConversations();
   // The top bar names the conversation. Publish the loader's title so it is right immediately, and
   // stays right for chats older than the sidebar's Recent list.
@@ -77,6 +79,7 @@ export default function ChatConversationRoute() {
       defaultModel={defaultModel}
       initialConversationId={id}
       initialMessages={messages}
+      initialTurn={latestTurn}
       onConversationChange={refresh}
     />
   );

--- a/apps/web/app/routes/_app.chat.routes.test.tsx
+++ b/apps/web/app/routes/_app.chat.routes.test.tsx
@@ -40,6 +40,7 @@ test("clientLoader hydrates the conversation transcript", async () => {
     starred: false,
     createdAt: "t",
     updatedAt: "t",
+    latestTurn: null,
   });
   vi.mocked(conversations.getConversationMessages).mockResolvedValue([
     { _id: "m1", conversationId: "c1", role: "user", content: "hello world", createdAt: "t" },

--- a/packages/schema/AGENTS.md
+++ b/packages/schema/AGENTS.md
@@ -13,6 +13,7 @@ Run event/request vocabularies, canonical hashes, Secret references, and resourc
 | Path | Owns |
 | --- | --- |
 | `src/index.ts` | Public exports; do not mirror the list here. |
+| `src/chat.ts` | Chat metadata and resumable Turn wire contracts. |
 | `src/definitions/` | TypeBox Soul definition schemas and file snapshots. |
 | `src/artifacts.ts` | `ARTIFACT_LAYOUTS`: Soul paths, companions, temporal class. |
 | `src/registry.ts` | Strict `apiVersion`/`kind` dispatch and fail-closed YAML parsing. |

--- a/packages/schema/src/chat.ts
+++ b/packages/schema/src/chat.ts
@@ -1,0 +1,35 @@
+import { type Static, Type } from "@sinclair/typebox";
+
+export const CONVERSATION_TURN_STATUSES = [
+  "pending",
+  "running",
+  "start_failed",
+  "succeeded",
+  "failed",
+] as const;
+
+const ConversationTurnStatusSchema = Type.Unsafe<(typeof CONVERSATION_TURN_STATUSES)[number]>({
+  type: "string",
+  enum: [...CONVERSATION_TURN_STATUSES],
+});
+
+export const ConversationTurnSchema = Type.Object({
+  id: Type.String(),
+  runId: Type.Union([Type.String(), Type.Null()]),
+  status: ConversationTurnStatusSchema,
+});
+
+export const ConversationDetailSchema = Type.Object({
+  id: Type.String(),
+  userId: Type.Union([Type.String(), Type.Null()]),
+  agentId: Type.Union([Type.String(), Type.Null()]),
+  model: Type.Union([Type.String(), Type.Null()]),
+  title: Type.Union([Type.String(), Type.Null()]),
+  starred: Type.Boolean(),
+  createdAt: Type.String(),
+  updatedAt: Type.String(),
+  latestTurn: Type.Union([ConversationTurnSchema, Type.Null()]),
+});
+
+export type ConversationTurn = Static<typeof ConversationTurnSchema>;
+export type ConversationDetail = Static<typeof ConversationDetailSchema>;

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -41,6 +41,12 @@ export {
 export type { ValidationBoundary } from "./boundaries";
 export { BOUNDARIES } from "./boundaries";
 export { CANONICAL_HASH_ALGORITHM, canonicalHash, canonicalize } from "./canonicalize";
+export type { ConversationDetail, ConversationTurn } from "./chat";
+export {
+  CONVERSATION_TURN_STATUSES,
+  ConversationDetailSchema,
+  ConversationTurnSchema,
+} from "./chat";
 export type { ModelProfileDenialReason } from "./definitions";
 export * from "./definitions";
 export * as definitions from "./definitions";

--- a/packages/storage/AGENTS.md
+++ b/packages/storage/AGENTS.md
@@ -22,6 +22,7 @@ publication, approvals, integrations, events, and blob/vector/cache/queue ports.
 | `src/runs/` | Runs, States, Attempts, waits/signals, budgets, concurrency, children, events. |
 | `src/auth/` | Principals, roles, sessions, guests, JIT users, recertification, identities. |
 | `src/integrations/` | Integration install/state and channel inbound/delivery stores. |
+| `src/conversations/` | Conversation Turn read models used to restore Chat state. |
 | `src/approvals/`, `src/events/` | Approval persistence and generic event store. |
 | `src/kill-switches/` | Durable mutation kill switches backing the effect-plane emergency stop. |
 | `src/curator/` | Curator jobs, pinned input manifests and context pins, effect ledger, per-user work queue, daily spend admission, the claim-and-reserve mint transaction, stale-job reconciliation, and the read-only shadow review queries (`review.ts`, which writes nothing by design). |

--- a/packages/storage/src/conversations/index.ts
+++ b/packages/storage/src/conversations/index.ts
@@ -1,0 +1,1 @@
+export * from "./latest-turn";

--- a/packages/storage/src/conversations/latest-turn.ts
+++ b/packages/storage/src/conversations/latest-turn.ts
@@ -1,0 +1,22 @@
+import type { ConversationTurn } from "@tulipfarm/schema";
+import type { Queryable } from "../ports";
+
+export async function findLatestConversationTurn(
+  queryable: Queryable,
+  conversationId: string
+): Promise<ConversationTurn | undefined> {
+  const { rows } = await queryable.query<{
+    id: string;
+    run_id: string | null;
+    status: ConversationTurn["status"];
+  }>(
+    `SELECT id, run_id, status
+       FROM conversation_turns
+      WHERE conversation_id = $1
+      ORDER BY created_at DESC, id DESC
+      LIMIT 1`,
+    [conversationId]
+  );
+  const row = rows[0];
+  return row ? { id: row.id, runId: row.run_id, status: row.status } : undefined;
+}

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./approvals";
 export * from "./artifacts";
 export * from "./auth";
+export * from "./conversations";
 export * from "./curator";
 export * from "./events";
 export * from "./integrations";


### PR DESCRIPTION
## Summary

- Return the latest Turn with Chat metadata so the browser can recover its durable Run.
- Replay Run events after navigation to restore loading, streamed text, Tool activity, approvals, and failures.
- Keep pending Turns loading until their Run is available, and close only the local reader on navigation.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm --filter @tulipfarm/web test` (1,189 tests)
- [x] `pnpm --filter @tulipfarm/api test` (3,171 tests)