### PR TITLE
fix(llm): make model fallback sticky

### DIFF
--- a/apps/worker/AGENTS.md
+++ b/apps/worker/AGENTS.md
@@ -86,8 +86,8 @@ reconciliation, turn execution, delivery classification, projections, and outbox
 - Delivery classifier isolate gets no grants; keep API and worker hook bundle basenames distinct.
 - Bind links and reply text never cross from API to worker; replies are at-least-once.
 - Effort inference happens once per Run for `auto`; classifier tokens are unmetered.
-- Gate rejections throw `ProviderUnavailableError` from `@tulipfarm/llm`; a worker-local error
-  class classifies as a generic `model_error` and the participant is told nothing useful.
+- Gate each fallback link under its own provider key. Any failed link opens immediately; an open
+  primary must be skipped inside the chain, never reject before its fallback can run.
 - `test/process/` boots the bundled worker; run these tests with `--maxWorkers=1`.
 - Worker process tests can leak dev env through `apps/worker/.env.local`; check before blaming code.
 - May import listed `@tulipfarm/*` packages, never another app; see dependency rules below.

--- a/apps/worker/src/llm.ts
+++ b/apps/worker/src/llm.ts
@@ -1,6 +1,12 @@
 import type { ModelProfileCatalog, ModelRequirements } from "@tulipfarm/agent-runtime";
 import { selectModelProfile } from "@tulipfarm/agent-runtime";
-import type { CostBasis, ModelPrice, ModelResponderRef, PrincipalRef } from "@tulipfarm/llm";
+import type {
+  CostBasis,
+  FallbackCallGate,
+  ModelPrice,
+  ModelResponderRef,
+  PrincipalRef,
+} from "@tulipfarm/llm";
 import { isPriceable, LlmService, priceCall, SecretsPrincipalCredentials } from "@tulipfarm/llm";
 import type { ResolvedLimits } from "@tulipfarm/run-kernel";
 import { resolveModelProfileBudgetLimits } from "@tulipfarm/run-kernel";
@@ -121,8 +127,12 @@ export class SoulLlm {
   }
 
   /** Resolves selectors to the full selected chain; raw model ids bypass profile checks. */
-  async model(selector: string, requirements: ModelRequirements): Promise<LanguageModel> {
-    const resolution = await this.resolveModel(selector, requirements);
+  async model(
+    selector: string,
+    requirements: ModelRequirements,
+    gate?: FallbackCallGate
+  ): Promise<LanguageModel> {
+    const resolution = await this.resolveModel(selector, requirements, undefined, undefined, gate);
     if (resolution.kind === "denied") {
       throw new ModelProfileDeniedError(
         resolution.routing.profileId,
@@ -134,9 +144,9 @@ export class SoulLlm {
   }
 
   /** Builds an already-routed Routine chain without re-resolving against current config. */
-  async chainModel(modelIds: readonly string[]): Promise<LanguageModel> {
+  async chainModel(modelIds: readonly string[], gate?: FallbackCallGate): Promise<LanguageModel> {
     await this.sync();
-    return this.service.chainModel(modelIds);
+    return this.service.chainModel(modelIds, undefined, undefined, gate);
   }
 
   /**
@@ -146,13 +156,14 @@ export class SoulLlm {
   async resolveChain(
     modelIds: readonly string[],
     routing: ModelRoutingPayload,
-    principal?: PrincipalRef
+    principal?: PrincipalRef,
+    gate?: FallbackCallGate
   ): Promise<LlmModelResolution> {
     await this.sync();
     const responder: ModelResponderRef = {};
     return {
       kind: "available",
-      model: await this.service.chainModelFor(modelIds, principal, undefined, responder),
+      model: await this.service.chainModelFor(modelIds, principal, undefined, responder, gate),
       ...(this.providerOf(modelIds[0]) === undefined
         ? {}
         : { provider: this.providerOf(modelIds[0]) }),
@@ -165,7 +176,8 @@ export class SoulLlm {
     selector: string,
     requirements: ModelRequirements,
     inference?: RunEventEffortInference,
-    principal?: PrincipalRef
+    principal?: PrincipalRef,
+    gate?: FallbackCallGate
   ): Promise<LlmModelResolution> {
     await this.sync();
 
@@ -173,7 +185,13 @@ export class SoulLlm {
     if (resolved.kind === "raw_model") {
       return {
         kind: "available",
-        model: await this.service.chainModelFor([resolved.modelId], principal, undefined),
+        model: await this.service.chainModelFor(
+          [resolved.modelId],
+          principal,
+          undefined,
+          undefined,
+          gate
+        ),
         ...(this.providerOf(resolved.modelId) === undefined
           ? {}
           : { provider: this.providerOf(resolved.modelId) }),
@@ -254,7 +272,7 @@ export class SoulLlm {
 
     return {
       kind: "available",
-      model: await this.service.chainModelFor(chain, principal, undefined, responder),
+      model: await this.service.chainModelFor(chain, principal, undefined, responder, gate),
       ...(this.providerOf(chain[0]) === undefined ? {} : { provider: this.providerOf(chain[0]) }),
       ...(budgetEvidence === undefined ? {} : { budgetLimits }),
       // Attributed to the link that answered: a chain that rate-limits through to a cheaper model

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -328,8 +328,8 @@ export async function main(): Promise<void> {
     checkpoints: loopCheckpointStore,
     model: ({ events, budgets, businessId, runId, conversationId }) =>
       new LlmModelPort({
-        model: (selector, requirements, inference, principal) =>
-          llm.resolveModel(selector, requirements, inference, principal),
+        model: (selector, requirements, inference, principal, gate) =>
+          llm.resolveModel(selector, requirements, inference, principal, gate),
         signal,
         gate: modelGate,
         spend: spendSink,
@@ -418,8 +418,8 @@ export async function main(): Promise<void> {
           new LlmModelPort({
             // Through `resolveChain`, so a Routine call is priced by the same authority as a Chat
             // call. Building the resolution inline here is what left Routine spend reported free.
-            model: async (_selector, _requirements, _inference, principal) =>
-              llm.resolveChain(modelIds, routing, principal),
+            model: async (_selector, _requirements, _inference, principal, gate) =>
+              llm.resolveChain(modelIds, routing, principal, gate),
             signal,
             gate: modelGate,
             spend: spendSink,

--- a/apps/worker/src/model-gate.test.ts
+++ b/apps/worker/src/model-gate.test.ts
@@ -84,16 +84,14 @@ describe("ProviderGate", () => {
     await expect(gate.acquire("openai")).rejects.toBeInstanceOf(ProviderUnavailableError);
   });
 
-  it("does not shed a provider over failures that are the request's fault", async () => {
-    const gate = new ProviderGate({ failureThreshold: 2 });
+  it("sheds a provider after any model failure", async () => {
+    const gate = new ProviderGate();
 
-    for (let i = 0; i < 5; i += 1) {
-      const lease = await gate.acquire("openai");
-      lease.failed("model_not_found");
-      lease.release();
-    }
+    const lease = await gate.acquire("openai");
+    lease.failed("model_billing_inactive");
+    lease.release();
 
-    await expect(gate.acquire("openai")).resolves.toBeDefined();
+    await expect(gate.acquire("openai")).rejects.toBeInstanceOf(ProviderUnavailableError);
   });
 
   it("lets one probe through after the recovery window and reopens on success", async () => {

--- a/apps/worker/src/model-gate.ts
+++ b/apps/worker/src/model-gate.ts
@@ -1,11 +1,15 @@
-import { ProviderUnavailableError } from "@tulipfarm/llm";
+import {
+  type FallbackCallGate,
+  type FallbackCallLease,
+  ProviderUnavailableError,
+} from "@tulipfarm/llm";
 import { CircuitBreaker } from "@tulipfarm/observability";
 
 /** Parallel in-flight calls allowed against one provider before further turns queue. */
 const DEFAULT_MAX_CONCURRENCY = 8;
 
-/** Consecutive infrastructure failures before a provider is shed rather than retried. */
-const DEFAULT_FAILURE_THRESHOLD = 5;
+/** One failed link is enough to move new calls to its configured fallback. */
+const DEFAULT_FAILURE_THRESHOLD = 1;
 
 /** How long a shed provider is left alone before one probe call is allowed through. */
 const DEFAULT_RECOVERY_MS = 30_000;
@@ -13,24 +17,8 @@ const DEFAULT_RECOVERY_MS = 30_000;
 /** Longest a turn waits for a slot before it is better to fail than to keep holding a lease. */
 const DEFAULT_QUEUE_TIMEOUT_MS = 30_000;
 
-/** Failures that say something about the *provider*, as opposed to this one request. */
-const INFRASTRUCTURE_FAILURES = new Set([
-  "model_provider_unavailable",
-  "model_rate_limited",
-  "model_error",
-]);
-
-/** A held slot. `release` must run exactly once, or the provider leaks capacity. */
-export interface ModelCallLease {
-  succeeded(): void;
-  /** `reason` decides whether this counts against the provider or only against the request. */
-  failed(reason: string): void;
-  release(): void;
-}
-
-export interface ModelCallGate {
-  acquire(provider: string): Promise<ModelCallLease>;
-}
+export type ModelCallLease = FallbackCallLease;
+export type ModelCallGate = FallbackCallGate;
 
 export interface ProviderGateOptions {
   readonly maxConcurrency?: number;
@@ -90,11 +78,7 @@ export class ProviderGate implements ModelCallGate {
     let settled = false;
     return {
       succeeded: () => state.breaker.recordSuccess(),
-      failed: (reason: string) => {
-        // A model that does not exist, or a request this key may not make, says nothing about
-        // whether the provider is healthy. Counting it would shed a provider over a config error.
-        if (INFRASTRUCTURE_FAILURES.has(reason)) state.breaker.recordFailure();
-      },
+      failed: () => state.breaker.recordFailure(),
       release: () => {
         if (settled) return;
         settled = true;

--- a/apps/worker/src/model.test.ts
+++ b/apps/worker/src/model.test.ts
@@ -10,7 +10,7 @@ import {
   InMemoryLoopCheckpointStore,
   ModelInvocationError,
 } from "@tulipfarm/agent-runtime";
-import { type CostBasis, LlmProviderError } from "@tulipfarm/llm";
+import { type CostBasis, FallbackModel, LlmProviderError } from "@tulipfarm/llm";
 import { type EffortRung, type RunEventEffortInference, textContent } from "@tulipfarm/schema";
 import { APICallError, type LanguageModel } from "ai";
 import { MockLanguageModelV4, simulateReadableStream } from "ai/test";
@@ -1194,11 +1194,19 @@ describe("LlmModelPort — a call the provider gate refused", () => {
   const gatedPort = (gate: ModelCallGate, mock: MockLanguageModelV4): LlmModelPort =>
     new LlmModelPort({
       gate,
-      model: async (selector): Promise<LlmModelResolution> => ({
+      model: async (
+        selector,
+        _requirements,
+        _inference,
+        _principal,
+        linkGate
+      ): Promise<LlmModelResolution> => ({
         kind: "available",
         price: TEST_PRICE,
         provider: "openai",
-        model: mock as unknown as LanguageModel,
+        model: new FallbackModel([mock], undefined, undefined, linkGate, [
+          "openai",
+        ]) as LanguageModel,
         routing: {
           outcome: "raw_model",
           selector,
@@ -1234,6 +1242,49 @@ describe("LlmModelPort — a call the provider gate refused", () => {
         }),
       }),
     });
+
+  it("keeps later chats on the fallback while the primary circuit is open", async () => {
+    const gate = new ProviderGate({ recoveryAfterMs: 60_000 });
+    const sonnet = failingModel();
+    const terra = healthyModel();
+    const port = (): LlmModelPort =>
+      new LlmModelPort({
+        gate,
+        model: async (
+          selector,
+          _requirements,
+          _inference,
+          _principal,
+          linkGate
+        ): Promise<LlmModelResolution> => ({
+          kind: "available",
+          price: TEST_PRICE,
+          provider: "anthropic",
+          model: new FallbackModel([sonnet, terra], undefined, undefined, linkGate, [
+            "anthropic",
+            "codex",
+          ]) as LanguageModel,
+          routing: {
+            outcome: "selected",
+            selector,
+            resolution: "profile_ref",
+            profileId: "balanced",
+            chain: [
+              { profileId: "balanced", modelId: "sonnet" },
+              { profileId: "balanced-fallback-1", modelId: "terra" },
+            ],
+            cacheAllowed: false,
+            rejectedFallbacks: [],
+          },
+        }),
+      });
+
+    await expect(port().invoke(request())).resolves.toBeDefined();
+    await expect(port().invoke(request())).resolves.toBeDefined();
+
+    expect(sonnet.doStreamCalls).toHaveLength(1);
+    expect(terra.doStreamCalls).toHaveLength(2);
+  });
 
   it("reports a shed provider as unavailable, not as a generic model failure", async () => {
     const gate = new ProviderGate({ failureThreshold: 1, recoveryAfterMs: 60_000 });

--- a/apps/worker/src/model.ts
+++ b/apps/worker/src/model.ts
@@ -46,7 +46,8 @@ export interface LlmModelPortOptions {
     selector: string,
     requirements: ModelRequirements,
     inference?: RunEventEffortInference,
-    principal?: PrincipalRef
+    principal?: PrincipalRef,
+    gate?: ModelCallGate
   ): Promise<LlmModelResolution>;
   /** Optional `auto` effort inference; consulted once per Turn-attempt port instance. */
   readonly effort?: EffortInferencePort;
@@ -121,7 +122,8 @@ export class LlmModelPort implements ModelPort, ModelCallReceiptSource {
       request.modelProfileId,
       requirements,
       inference,
-      request.principal
+      request.principal,
+      this.options.gate
     );
     if (resolution.kind === "available" && resolution.budgetLimits !== undefined) {
       await this.options.budgets?.open(resolution.budgetLimits);
@@ -178,9 +180,6 @@ export class LlmModelPort implements ModelPort, ModelCallReceiptSource {
       })
     );
     const startedAt = this.now();
-    // Held for the whole call: releasing early would let the next turn in while this one is
-    // still occupying a provider connection.
-    const lease = await this.options.gate?.acquire(resolution.provider ?? "unknown");
     const watchdog = new ModelCallWatchdog({
       ...(this.options.signal === undefined ? {} : { signal: this.options.signal }),
       ...(this.options.stallTimeoutMs === undefined
@@ -242,7 +241,6 @@ export class LlmModelPort implements ModelPort, ModelCallReceiptSource {
       if (streamError !== undefined) throw streamError;
 
       [calls, text, usage] = await Promise.all([result.toolCalls, result.text, result.usage]);
-      lease?.succeeded();
     } catch (error) {
       // A watchdog abort must not be reported as a generic provider error: the operator needs to
       // know the call was cut off here, and by which bound.
@@ -253,20 +251,17 @@ export class LlmModelPort implements ModelPort, ModelCallReceiptSource {
       );
       this.reportSpend(request, resolution, "error", partial, this.now() - startedAt);
       if (watchdog.expired !== undefined) {
-        lease?.failed("model_provider_unavailable");
         throw new ModelInvocationError(
           "model_provider_unavailable",
           new Error(`${watchdog.message()} — model call aborted`, { cause: error }),
           partial
         );
       }
-      lease?.failed(classifyProviderError(error));
       throw error instanceof ModelInvocationError
         ? new ModelInvocationError(error.reason, error.cause, partial)
         : new ModelInvocationError(classifyProviderError(error), error, partial);
     } finally {
       watchdog.close();
-      lease?.release();
     }
 
     const finishedAt = this.now();

--- a/packages/llm/AGENTS.md
+++ b/packages/llm/AGENTS.md
@@ -31,7 +31,8 @@ subscription-CLI model adapters.
   block would take every working chain down with it and leave no page from which to delete it.
 - `chainModel(ids)` must execute the whole selected chain; do not collapse fallback to the head.
 - API-keyed providers read `entry.api_key_ref`: `env://VAR` from env, else `secrets.get(ref)`.
-- Fallback hard failures propagate: auth, `404`, abort. `429`, `5xx`, timeout fall through.
+- Every model/provider failure advances fallback; only caller cancellation stops the chain. A
+  streamed attempt commits only after clean completion, so partial output never mixes providers.
 - Bad Subscription Provider credentials throw `LlmProviderError("model_authentication_failed")`.
 - CLI usage reports are running totals, not deltas; never sum them. A turn's totals come from the
   terminal `result` message where the CLI sends one: an `assistant` message carries the snapshot

--- a/packages/llm/src/cli/claude-code.test.ts
+++ b/packages/llm/src/cli/claude-code.test.ts
@@ -44,7 +44,9 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
   })),
 }));
 
-const { ClaudeCodeModel, isAuthFailure, stripMcpPrefix } = await import("./claude-code");
+const { ClaudeCodeModel, isAuthFailure, isBillingFailure, stripMcpPrefix } = await import(
+  "./claude-code"
+);
 
 const lastOptions = () => calls[calls.length - 1]?.options ?? {};
 
@@ -125,7 +127,6 @@ describe("isAuthFailure", () => {
     "401 Unauthorized",
     "403 Forbidden",
     "authentication_error",
-    "Your credit balance is too low to access the Anthropic API",
     // Captured from linux-arm64 claude 2.1.211: invalid OAuth returned `success` plus 401 error.
     "Failed to authenticate. API Error: 401 OAuth access token is invalid",
   ])("classifies %j as an auth failure", (text) => {
@@ -138,6 +139,20 @@ describe("isAuthFailure", () => {
     "context length exceeded",
   ])("does not classify %j as an auth failure", (text) => {
     expect(isAuthFailure(text)).toBe(false);
+  });
+});
+
+describe("isBillingFailure", () => {
+  it.each([
+    "Your credit balance is too low to access the Anthropic API",
+    "You've hit your limit · resets 8pm",
+    "Claude subscription usage limit reached",
+  ])("classifies %j as exhausted billing", (text) => {
+    expect(isBillingFailure(text)).toBe(true);
+  });
+
+  it("does not mistake an invalid credential for exhausted billing", () => {
+    expect(isBillingFailure("401 Unauthorized")).toBe(false);
   });
 });
 
@@ -376,6 +391,15 @@ describe("ClaudeCodeModel — turn translation", () => {
 });
 
 describe("ClaudeCodeModel — failure classification", () => {
+  it("classifies an exhausted subscription as inactive billing", async () => {
+    script = [result({ is_error: true, result: "You've hit your limit · resets 8pm" })];
+    const model = new ClaudeCodeModel("sonnet", "tok");
+
+    await expect(model.doGenerate(callOptions())).rejects.toMatchObject({
+      reason: "model_billing_inactive",
+    });
+  });
+
   it("raises a hard authentication failure for a rejected credential", async () => {
     // A2: observed live shape was `success` plus `is_error`; both must be checked.
     script = [

--- a/packages/llm/src/cli/claude-code.ts
+++ b/packages/llm/src/cli/claude-code.ts
@@ -72,13 +72,23 @@ const AUTH_FAILURE_PATTERNS = [
   /authentication_error/i,
   /\b401\b/,
   /\b403\b/,
-  /credit balance/i,
   /please run \/login/i,
   /run `claude setup-token`/i,
 ] as const;
 
+const BILLING_FAILURE_PATTERNS = [
+  /credit balance/i,
+  /hit your (?:usage )?limit/i,
+  /usage limit/i,
+  /subscription.*(?:expired|exhausted|limit)/i,
+] as const;
+
 export function isAuthFailure(text: string): boolean {
   return AUTH_FAILURE_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+export function isBillingFailure(text: string): boolean {
+  return BILLING_FAILURE_PATTERNS.some((pattern) => pattern.test(text));
 }
 
 /** Remediation the operator can act on, surfaced alongside the classified failure. */
@@ -256,6 +266,9 @@ export class ClaudeCodeModel extends CliLanguageModel {
           // `result` text distinguish it from a real completion, so both must be checked.
           if (result.subtype !== "success" || result.is_error) {
             const text = result.result ?? result.subtype ?? "Claude Code turn failed";
+            if (isBillingFailure(text)) {
+              throw new LlmProviderError("model_billing_inactive", new Error(text));
+            }
             if (isAuthFailure(text)) {
               // `LlmProviderError` keeps only its reason participant-visible; the cause is
               // operator-only, and `AgentLoop`'s `deepestErrorMessage` surfaces it in the log —

--- a/packages/llm/src/fallback.test.ts
+++ b/packages/llm/src/fallback.test.ts
@@ -1,7 +1,7 @@
 import type { LanguageModelV4, LanguageModelV4CallOptions } from "@ai-sdk/provider";
 import { APICallError, LoadAPIKeyError } from "ai";
 import { describe, expect, it, vi } from "vitest";
-import { FallbackModel, isHardFailure } from "./fallback";
+import { type FallbackCallGate, FallbackModel, isHardFailure } from "./fallback";
 import { LlmProviderError } from "./provider-error";
 
 const opts = {} as LanguageModelV4CallOptions;
@@ -116,19 +116,20 @@ describe("FallbackModel.doStream", () => {
     expect((value as unknown as { textDelta: string }).textDelta).toBe("fallback");
   });
 
-  it("does not fall back after first chunk received", async () => {
+  it("falls back when a model fails after streaming has started", async () => {
     const streamResult = makeStreamResult(
       [{ type: "text-delta", textDelta: "partial" }],
       1 // error after first chunk
     );
     const m1 = makeModel({ doStream: vi.fn().mockResolvedValue(streamResult) });
-    const m2 = makeModel();
+    const fallbackResult = makeStreamResult([{ type: "text-delta", textDelta: "complete" }]);
+    const m2 = makeModel({ doStream: vi.fn().mockResolvedValue(fallbackResult) });
     const fallback = new FallbackModel([m1, m2]);
     const result = await fallback.doStream(opts);
     const reader = result.stream.getReader();
-    await reader.read(); // first chunk ok
-    await expect(reader.read()).rejects.toThrow("stream error");
-    expect(m2.doStream).not.toHaveBeenCalled();
+    const { value } = await reader.read();
+    expect((value as unknown as { textDelta: string }).textDelta).toBe("complete");
+    expect(m2.doStream).toHaveBeenCalledOnce();
   });
 
   it("propagates AbortError immediately in doStream", async () => {
@@ -140,13 +141,14 @@ describe("FallbackModel.doStream", () => {
     expect(m2.doStream).not.toHaveBeenCalled();
   });
 
-  it("aborts without fallback on a hard (401) error before any chunk", async () => {
+  it("falls back on a non-retryable 401 error before any chunk", async () => {
     const err = apiError(401, false);
     const m1 = makeModel({ doStream: vi.fn().mockRejectedValue(err) });
-    const m2 = makeModel({ doStream: vi.fn().mockResolvedValue(makeStreamResult([])) });
+    const result = makeStreamResult([{ type: "text-delta", textDelta: "fallback" }]);
+    const m2 = makeModel({ doStream: vi.fn().mockResolvedValue(result) });
     const fallback = new FallbackModel([m1, m2]);
-    await expect(fallback.doStream(opts)).rejects.toBe(err);
-    expect(m2.doStream).not.toHaveBeenCalled();
+    await expect(fallback.doStream(opts)).resolves.toBeDefined();
+    expect(m2.doStream).toHaveBeenCalledOnce();
   });
 
   it("falls back on a transient (429) stream error before any chunk", async () => {
@@ -162,31 +164,48 @@ describe("FallbackModel.doStream", () => {
 });
 
 describe("FallbackModel error classification", () => {
-  it("aborts without fallback on a 401 auth error", async () => {
+  it("falls back on a 401 auth error", async () => {
     const err = apiError(401, false);
     const m1 = makeModel({ doGenerate: vi.fn().mockRejectedValue(err) });
-    const m2 = makeModel({ doGenerate: vi.fn().mockResolvedValue({}) });
+    const result = { text: "fallback", finishReason: "stop", usage: {}, rawCall: {} };
+    const m2 = makeModel({ doGenerate: vi.fn().mockResolvedValue(result) });
     const fallback = new FallbackModel([m1, m2]);
-    await expect(fallback.doGenerate(opts)).rejects.toBe(err);
-    expect(m2.doGenerate).not.toHaveBeenCalled();
+    await expect(fallback.doGenerate(opts)).resolves.toBe(result);
+    expect(m2.doGenerate).toHaveBeenCalledOnce();
   });
 
-  it("aborts without fallback on a 404 model-not-found error", async () => {
+  it("falls back on a 404 model-not-found error", async () => {
     const err = apiError(404, false);
     const m1 = makeModel({ doGenerate: vi.fn().mockRejectedValue(err) });
-    const m2 = makeModel({ doGenerate: vi.fn().mockResolvedValue({}) });
+    const result = { text: "fallback", finishReason: "stop", usage: {}, rawCall: {} };
+    const m2 = makeModel({ doGenerate: vi.fn().mockResolvedValue(result) });
     const fallback = new FallbackModel([m1, m2]);
-    await expect(fallback.doGenerate(opts)).rejects.toBe(err);
-    expect(m2.doGenerate).not.toHaveBeenCalled();
+    await expect(fallback.doGenerate(opts)).resolves.toBe(result);
+    expect(m2.doGenerate).toHaveBeenCalledOnce();
   });
 
-  it("aborts without fallback on a missing/invalid API key", async () => {
+  it("falls back on a missing or invalid API key", async () => {
     const err = new LoadAPIKeyError({ message: "no key" });
     const m1 = makeModel({ doGenerate: vi.fn().mockRejectedValue(err) });
-    const m2 = makeModel({ doGenerate: vi.fn().mockResolvedValue({}) });
+    const result = { text: "fallback", finishReason: "stop", usage: {}, rawCall: {} };
+    const m2 = makeModel({ doGenerate: vi.fn().mockResolvedValue(result) });
     const fallback = new FallbackModel([m1, m2]);
-    await expect(fallback.doGenerate(opts)).rejects.toBe(err);
-    expect(m2.doGenerate).not.toHaveBeenCalled();
+    await expect(fallback.doGenerate(opts)).resolves.toBe(result);
+    expect(m2.doGenerate).toHaveBeenCalledOnce();
+  });
+
+  it("falls back when the primary subscription has no credit", async () => {
+    const exhausted = new LlmProviderError(
+      "model_billing_inactive",
+      new Error("subscription exhausted")
+    );
+    const result = { text: "fallback", finishReason: "stop", usage: {}, rawCall: {} };
+    const m1 = makeModel({ doGenerate: vi.fn().mockRejectedValue(exhausted) });
+    const m2 = makeModel({ doGenerate: vi.fn().mockResolvedValue(result) });
+    const fallback = new FallbackModel([m1, m2]);
+
+    await expect(fallback.doGenerate(opts)).resolves.toBe(result);
+    expect(m2.doGenerate).toHaveBeenCalledOnce();
   });
 
   it("falls back on a transient (429) rate-limit error", async () => {
@@ -232,28 +251,26 @@ describe("FallbackModel logging", () => {
     expect(messages.some((m) => m.includes("all providers exhausted"))).toBe(true);
   });
 
-  it("does not log a fallback event on a hard error", async () => {
+  it("logs a fallback event for a non-retryable provider error", async () => {
     const m1 = makeModel({ doGenerate: vi.fn().mockRejectedValue(apiError(401, false)) });
+    const m2 = makeModel({ doGenerate: vi.fn().mockResolvedValue({}) });
     const logger = { warn: vi.fn() };
-    const fallback = new FallbackModel([m1], logger);
-    await expect(fallback.doGenerate(opts)).rejects.toBeInstanceOf(APICallError);
-    expect(logger.warn).not.toHaveBeenCalled();
+    const fallback = new FallbackModel([m1, m2], logger);
+    await fallback.doGenerate(opts);
+    expect(logger.warn).toHaveBeenCalledOnce();
   });
 });
 
 describe("isHardFailure", () => {
-  it("classifies abort and credential errors as hard", () => {
+  it("classifies only caller cancellation as hard", () => {
     expect(isHardFailure(new DOMException("aborted", "AbortError"))).toBe(true);
-    expect(isHardFailure(new LoadAPIKeyError({ message: "no key" }))).toBe(true);
+    expect(isHardFailure(new LoadAPIKeyError({ message: "no key" }))).toBe(false);
     expect(
       isHardFailure(new LlmProviderError("model_billing_inactive", new Error("provider response")))
-    ).toBe(true);
-  });
-
-  it("classifies non-retryable API errors (401/404/400) as hard", () => {
-    expect(isHardFailure(apiError(401, false))).toBe(true);
-    expect(isHardFailure(apiError(404, false))).toBe(true);
-    expect(isHardFailure(apiError(400, false))).toBe(true);
+    ).toBe(false);
+    expect(isHardFailure(apiError(401, false))).toBe(false);
+    expect(isHardFailure(apiError(404, false))).toBe(false);
+    expect(isHardFailure(apiError(400, false))).toBe(false);
   });
 
   it("classifies retryable API errors, network and unknown errors as transient", () => {
@@ -261,5 +278,39 @@ describe("isHardFailure", () => {
     expect(isHardFailure(apiError(500, true))).toBe(false);
     expect(isHardFailure(new Error("ECONNREFUSED"))).toBe(false);
     expect(isHardFailure("weird")).toBe(false);
+  });
+});
+
+describe("FallbackModel link health", () => {
+  it("skips a failed primary on later calls and records the fallback separately", async () => {
+    const blocked = new Set<string>();
+    const calls: string[] = [];
+    const gate: FallbackCallGate = {
+      async acquire(provider) {
+        calls.push(provider);
+        if (blocked.has(provider)) throw new Error(`${provider} unavailable`);
+        return {
+          succeeded() {},
+          failed() {
+            blocked.add(provider);
+          },
+          release() {},
+        };
+      },
+    };
+    const sonnet = makeModel({ doGenerate: vi.fn().mockRejectedValue(new Error("no credits")) });
+    const terraResult = { text: "terra", finishReason: "stop", usage: {}, rawCall: {} };
+    const terra = makeModel({ doGenerate: vi.fn().mockResolvedValue(terraResult) });
+    const fallback = new FallbackModel([sonnet, terra], undefined, undefined, gate, [
+      "anthropic",
+      "codex",
+    ]);
+
+    await expect(fallback.doGenerate(opts)).resolves.toBe(terraResult);
+    await expect(fallback.doGenerate(opts)).resolves.toBe(terraResult);
+
+    expect(sonnet.doGenerate).toHaveBeenCalledOnce();
+    expect(terra.doGenerate).toHaveBeenCalledTimes(2);
+    expect(calls).toEqual(["anthropic", "codex", "anthropic", "codex"]);
   });
 });

--- a/packages/llm/src/fallback.ts
+++ b/packages/llm/src/fallback.ts
@@ -3,8 +3,8 @@ import type {
   LanguageModelV4CallOptions,
   LanguageModelV4StreamPart,
 } from "@ai-sdk/provider";
-import { APICallError, LoadAPIKeyError } from "ai";
-import { LlmProviderError } from "./provider-error";
+import { APICallError } from "ai";
+import { classifyProviderError } from "./provider-error";
 
 /** Minimal logger surface for fallback events (pino/console compatible). */
 export interface FallbackLogger {
@@ -22,19 +22,26 @@ export interface ModelResponderRef {
   modelId?: string;
 }
 
+export interface FallbackCallLease {
+  succeeded(): void;
+  failed(reason: string): void;
+  release(): void;
+}
+
+/** Per-link admission control shared across model chains in one process. */
+export interface FallbackCallGate {
+  acquire(provider: string): Promise<FallbackCallLease>;
+}
+
 const noopLogger: FallbackLogger = { warn() {} };
 
 function isAbortError(err: unknown): boolean {
   return err instanceof Error && err.name === "AbortError";
 }
 
-/** Hard failures abort fallback; 429/5xx/timeouts/network/unknown try the next provider. */
+/** Caller cancellation ends the whole request; every model/provider failure advances the chain. */
 export function isHardFailure(err: unknown): boolean {
-  if (isAbortError(err)) return true;
-  if (err instanceof LlmProviderError) return true;
-  if (LoadAPIKeyError.isInstance(err)) return true;
-  if (APICallError.isInstance(err)) return err.isRetryable === false;
-  return false;
+  return isAbortError(err);
 }
 
 function errorReason(err: unknown): string {
@@ -53,7 +60,9 @@ export class FallbackModel implements LanguageModelV4 {
     private readonly models: LanguageModelV4[],
     private readonly logger: FallbackLogger = noopLogger,
     /** Records which link served, so cost is attributed to the model that answered. */
-    private readonly responder?: ModelResponderRef
+    private readonly responder?: ModelResponderRef,
+    private readonly gate?: FallbackCallGate,
+    private readonly providerKeys: readonly string[] = models.map((model) => model.provider)
   ) {
     const primary = models[0];
     if (!primary) throw new Error("FallbackModel requires at least one model");
@@ -67,15 +76,21 @@ export class FallbackModel implements LanguageModelV4 {
 
   async doGenerate(options: LanguageModelV4CallOptions) {
     let lastError: unknown;
-    for (const model of this.models) {
+    for (const [index, model] of this.models.entries()) {
+      let lease: FallbackCallLease | undefined;
       try {
+        lease = await this.gate?.acquire(this.providerKey(index, model));
         const generated = await model.doGenerate(options);
+        lease?.succeeded();
         this.commit(model);
         return generated;
       } catch (err) {
         if (isHardFailure(err)) throw err;
+        lease?.failed(classifyProviderError(err));
         lastError = err;
         this.logFallback(model, err);
+      } finally {
+        lease?.release();
       }
     }
     this.logExhausted(lastError);
@@ -84,47 +99,52 @@ export class FallbackModel implements LanguageModelV4 {
 
   async doStream(options: LanguageModelV4CallOptions) {
     let lastError: unknown;
-    for (const model of this.models) {
+    for (const [index, model] of this.models.entries()) {
+      let lease: FallbackCallLease | undefined;
       let result: Awaited<ReturnType<LanguageModelV4["doStream"]>>;
       try {
+        lease = await this.gate?.acquire(this.providerKey(index, model));
         result = await model.doStream(options);
       } catch (err) {
-        if (isHardFailure(err)) throw err;
+        if (isHardFailure(err)) {
+          lease?.release();
+          throw err;
+        }
+        lease?.failed(classifyProviderError(err));
+        lease?.release();
         lastError = err;
         this.logFallback(model, err);
         continue;
       }
 
       const reader = result.stream.getReader();
-      let firstChunk: Awaited<ReturnType<typeof reader.read>>;
+      const chunks: LanguageModelV4StreamPart[] = [];
       try {
-        firstChunk = await reader.read();
+        while (true) {
+          const chunk = await reader.read();
+          if (chunk.done) break;
+          chunks.push(chunk.value);
+        }
       } catch (err) {
         reader.cancel().catch(() => {});
-        if (isHardFailure(err)) throw err;
+        if (isHardFailure(err)) {
+          lease?.release();
+          throw err;
+        }
+        lease?.failed(classifyProviderError(err));
+        lease?.release();
         lastError = err;
         this.logFallback(model, err);
         continue;
       }
 
-      // First chunk received — stream is committed, reconstruct with remaining
+      lease?.succeeded();
+      lease?.release();
       this.commit(model);
       const stream = new ReadableStream<LanguageModelV4StreamPart>({
-        async start(controller) {
-          if (!firstChunk.done) controller.enqueue(firstChunk.value);
-          try {
-            while (true) {
-              const { done, value } = await reader.read();
-              if (done) break;
-              controller.enqueue(value);
-            }
-            controller.close();
-          } catch (err) {
-            controller.error(err);
-          }
-        },
-        cancel() {
-          return reader.cancel();
+        start(controller) {
+          for (const chunk of chunks) controller.enqueue(chunk);
+          controller.close();
         },
       });
 
@@ -132,6 +152,10 @@ export class FallbackModel implements LanguageModelV4 {
     }
     this.logExhausted(lastError);
     throw lastError;
+  }
+
+  private providerKey(index: number, model: LanguageModelV4): string {
+    return this.providerKeys[index] ?? model.provider;
   }
 
   private logFallback(model: LanguageModelV4, err: unknown): void {

--- a/packages/llm/src/index.ts
+++ b/packages/llm/src/index.ts
@@ -13,6 +13,8 @@ export {
   type EmbeddingUsageSink,
 } from "./embeddings";
 export {
+  type FallbackCallGate,
+  type FallbackCallLease,
   type FallbackLogger,
   FallbackModel,
   isHardFailure,

--- a/packages/llm/src/llm-service.ts
+++ b/packages/llm/src/llm-service.ts
@@ -18,7 +18,12 @@ import {
 } from "@tulipfarm/schema";
 import type { SecretsService } from "@tulipfarm/secrets";
 import type { LanguageModel } from "ai";
-import { type FallbackLogger, FallbackModel, type ModelResponderRef } from "./fallback";
+import {
+  type FallbackCallGate,
+  type FallbackLogger,
+  FallbackModel,
+  type ModelResponderRef,
+} from "./fallback";
 import { createModel, type PrincipalCredentialResolver, type PrincipalRef } from "./provider";
 
 /**
@@ -229,20 +234,29 @@ export class LlmService {
     modelIds: readonly string[],
     principal: PrincipalRef | undefined,
     logger: FallbackLogger = this.logger,
-    responder?: ModelResponderRef
+    responder?: ModelResponderRef,
+    gate?: FallbackCallGate
   ): Promise<LanguageModel> {
     if (principal === undefined || this.credentials === undefined) {
-      return this.chainModel(modelIds, logger, responder);
+      return this.chainModel(modelIds, logger, responder, gate);
     }
     const built = (
-      await Promise.all(modelIds.map((id) => this.principalModel(id, principal)))
-    ).filter((m) => m !== undefined);
+      await Promise.all(
+        modelIds.map(async (id) => ({ id, model: await this.principalModel(id, principal) }))
+      )
+    ).filter((link): link is { id: string; model: LanguageModelV4 } => link.model !== undefined);
     if (built.length === 0) throw new LlmNotConfiguredError();
-    if (built.length === 1) {
-      if (responder !== undefined) responder.modelId = built[0].modelId;
-      return built[0];
+    if (built.length === 1 && gate === undefined) {
+      if (responder !== undefined) responder.modelId = built[0].model.modelId;
+      return built[0].model;
     }
-    return new FallbackModel(built, logger, responder);
+    return new FallbackModel(
+      built.map((link) => link.model),
+      logger,
+      responder,
+      gate,
+      built.map((link) => this.entryByModelId.get(link.id)?.provider ?? link.model.provider)
+    );
   }
 
   /** One model built for one principal, cached; falls back to the shared model when they have none. */
@@ -285,10 +299,14 @@ export class LlmService {
   chainModel(
     modelIds: readonly string[],
     logger: FallbackLogger = this.logger,
-    responder?: ModelResponderRef
+    responder?: ModelResponderRef,
+    gate?: FallbackCallGate
   ): LanguageModel {
     if (!this.configured) throw new LlmNotConfiguredError();
-    const built = modelIds.map((id) => this.byModelId.get(id)).filter((m) => m !== undefined);
+    const built = modelIds.flatMap((id) => {
+      const model = this.byModelId.get(id);
+      return model === undefined ? [] : [{ id, model }];
+    });
     // The ids came from the catalog, so an empty chain means every provider behind them failed to
     // build — a configuration or credential fault, not an unknown model. Callers surface the two
     // very differently, and telling an operator their configured model is "unknown" sends them
@@ -296,10 +314,16 @@ export class LlmService {
     if (built.length === 0) throw new LlmNotConfiguredError();
     // A single link needs no wrapper — and wrapping would hide a genuinely unconfigured chain.
     // Its responder is known without executing anything: there is nothing else that could answer.
-    if (built.length === 1) {
-      if (responder !== undefined) responder.modelId = built[0].modelId;
-      return built[0];
+    if (built.length === 1 && gate === undefined) {
+      if (responder !== undefined) responder.modelId = built[0].model.modelId;
+      return built[0].model;
     }
-    return new FallbackModel(built, logger, responder);
+    return new FallbackModel(
+      built.map((link) => link.model),
+      logger,
+      responder,
+      gate,
+      built.map((link) => this.entryByModelId.get(link.id)?.provider ?? link.model.provider)
+    );
   }
 }

--- a/scripts/model-path-authz.test.ts
+++ b/scripts/model-path-authz.test.ts
@@ -115,13 +115,19 @@ describe("model path — liveness fitness", () => {
     expect(main).toContain("spend: spendSink,\n    log: logger,");
   });
 
-  it("only trips the breaker on failures that indict the provider", () => {
-    // A missing model or a rejected key is a config error. Counting those would shed a healthy
-    // provider for every turn in the process because one Agent named a model that does not exist.
+  it("trips each failed fallback link immediately and holds its lease for that attempt", () => {
+    // A failed primary must move later chats to its fallback after one error, including billing or
+    // credential exhaustion. A higher threshold would make every new chat retry a known-dead link.
     const gate = read("apps/worker/src/model-gate.ts");
-    expect(gate).toContain("INFRASTRUCTURE_FAILURES.has(reason)");
-    // The lease must outlive the call, so the slot is held for as long as the provider is busy.
-    expect(read("apps/worker/src/model.ts")).toContain("lease?.release();");
+    expect(gate).toContain("DEFAULT_FAILURE_THRESHOLD = 1");
+    expect(gate).toContain("failed: () => state.breaker.recordFailure()");
+
+    // Admission belongs inside the chain. A lease around the composite call would attribute a
+    // fallback's success to the failed primary and an open primary would prevent fallback.
+    const fallback = read("packages/llm/src/fallback.ts");
+    expect(fallback).toContain("lease = await this.gate?.acquire(this.providerKey(index, model))");
+    expect(fallback).toContain("lease?.failed(classifyProviderError(err))");
+    expect(fallback).toContain("lease?.release()");
   });
 
   it("forwards the acting principal from every production model port", () => {


### PR DESCRIPTION
## Summary

- fall through on every model/provider failure, including exhausted billing and late stream errors
- buffer provider attempts so partial output never mixes models
- track circuit health per chain link so later chats skip a failed primary until its recovery probe

## Test plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm eval`
- [x] `pnpm --filter @tulipfarm/llm test`
- [x] `pnpm --filter @tulipfarm/worker test src/model-gate.test.ts src/model.test.ts src/llm.test.ts`
- [ ] Full Worker suite stopped after 60 seconds without progress, per repository test rules