### PR TITLE
fix(github): clarify per-user link is separate from App install

### DIFF
--- a/apps/api/src/tools/github/tools.test.ts
+++ b/apps/api/src/tools/github/tools.test.ts
@@ -507,6 +507,25 @@ describe("buildGitHubTools", () => {
     expect(await effects.list(BUSINESS_ID)).toEqual([]);
   });
 
+  it("warns that a successful listing does not imply the caller can act on those repos", () => {
+    // Regression for #552: github_repository_list succeeds off the App installation alone, but
+    // every other GitHub Tool also requires the caller's own connected GitHub account. Without
+    // this warning in the description, a model reasonably treats the list as proof GitHub is
+    // fully usable and reports the later denial as an inconsistency rather than a next step.
+    const tooling = buildGitHubTooling({
+      businessId: BUSINESS_ID,
+      integrations: fakeIntegrationStore(),
+      secrets: fakeSecretsService(),
+      http: fakeHttp({ number: 1, title: "t", state: "open" }),
+    });
+    const tools = buildGitHubTools(BUSINESS_ID, { ...tooling, effects: new MemoryEffectStore() });
+    const tool = tools.find((t) => t.name === "github_repository_list");
+    if (tool === undefined) throw new Error("github_repository_list not registered");
+
+    expect(tool.description).toContain("does not mean");
+    expect(tool.description).toContain("connected their own GitHub account");
+  });
+
   it("requires installation-wide authority to list installed repositories", () => {
     const tooling = buildGitHubTooling({
       businessId: BUSINESS_ID,

--- a/apps/api/src/tools/github/tools.ts
+++ b/apps/api/src/tools/github/tools.ts
@@ -380,7 +380,10 @@ function buildRepositoryListTool(tooling: GitHubTooling): ToolDef {
     mutating: false,
     description:
       "List the GitHub repositories this business has an active installation for. Call this " +
-      "first when the user names no repository, or names one you're not sure is installed.",
+      "first when the user names no repository, or names one you're not sure is installed. This " +
+      "reports only which repositories the workspace's GitHub App can see — it does not mean " +
+      "you personally can act on them. Every other GitHub Tool also requires the calling person " +
+      "to have connected their own GitHub account, separately from that App installation.",
     inputSchema: EMPTY_SCHEMA,
     authorization: {
       action: "github.repository.list",

--- a/packages/tool-host/src/credential-mode.test.ts
+++ b/packages/tool-host/src/credential-mode.test.ts
@@ -154,6 +154,20 @@ describe("CredentialResolver", () => {
     expect(result.use === "denied" && result.reason).toContain("connect");
   });
 
+  it("distinguishes a personal connection from a workspace-level one already in place", async () => {
+    // Regression for #552: a read Tool (e.g. github_repository_list) can succeed off a
+    // service/installation credential while a write Tool is denied for lacking a *personal* one.
+    // The denial must say the two are different credentials, or "but this provider already
+    // works" reads as proof the denial is a bug rather than a separate connection step.
+    const r = resolverFor([oauthProvider]);
+    const result = await r.resolve(human, {
+      name: "acme_search",
+      provider: "acme",
+      credentialMode: "user",
+    });
+    expect(result.use === "denied" && result.reason).toContain("separate from any acme");
+  });
+
   it("refuses rather than downgrading under user_preferred when the provider can issue one", async () => {
     // `preferred` must not silently fall back to the bot for unconnected users.
     const r = resolverFor([oauthProvider]);

--- a/packages/tool-host/src/credential-mode.ts
+++ b/packages/tool-host/src/credential-mode.ts
@@ -46,8 +46,19 @@ function isHumanTriggered(subject: CredentialSubject): boolean {
   return subject.kind === "user";
 }
 
+/**
+ * A workspace can hold a service-level connection to `provider` (an installed App, a shared bot
+ * token) while no individual has connected their own account — the two are unrelated credentials.
+ * Saying so explicitly stops "but this provider is already connected" (true of the service
+ * credential a read-only Tool may have just used) from reading as a reason this denial is wrong.
+ */
 function connectPrompt(provider: string, toolName: string): string {
-  return `"${toolName}" acts on ${provider} as you, and you have not connected your ${provider} account — open Integrations › ${provider} and connect your account, then try again. Do not retry this call until you have.`;
+  return (
+    `"${toolName}" acts on ${provider} as you personally, which is separate from any ${provider} ` +
+    `connection a workspace admin already set up — you have not connected your own ${provider} ` +
+    `account yet. Open Integrations › ${provider} and connect your account, then try again. Do ` +
+    `not retry this call until you have.`
+  );
 }
 
 export class CredentialResolver {


### PR DESCRIPTION
## Summary
- Root cause: PR #544's per-user GitHub entitlement/credential check (`github.issue.create`, etc.) is deliberately separate from `github_repository_list`, which is exempt because it only enumerates what the workspace's GitHub App installation covers — a service-level connection, not a personal one. Both checks are working as designed; nothing was silently bypassed or false-negative.
- The gap is clarity, not authorization: neither the `github_repository_list` description nor the personal-credential denial message said that "GitHub is connected" (true of the App installation) and "you personally connected GitHub" (required for write Tools) are different things, so a model/user sees `github_repository_list` succeed and then reads `github_issue_create`'s denial as an inconsistent/broken check.
- Fix: `github_repository_list`'s description now states up front that a successful listing does not imply personal write access, and the personal-credential denial message (`packages/tool-host/src/credential-mode.ts`) now says explicitly that the personal connection is separate from any admin-level connection already in place.

## Test plan
- [x] `pnpm --filter @tulipfarm/tool-host test src/credential-mode.test.ts` — new test asserts the denial message distinguishes personal vs workspace-level connections
- [x] `pnpm --filter @tulipfarm/api test src/tools/github` — new test asserts `github_repository_list`'s description warns listing doesn't imply write access
- [x] `pnpm --filter @tulipfarm/tool-host typecheck` and `pnpm --filter @tulipfarm/api typecheck`
- [x] `pnpm exec biome check --write packages/tool-host/src apps/api/src/tools/github`

Closes #552