### PR TITLE
ci(release): enable auto-merge on release pull requests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,11 +114,12 @@ jobs:
             echo "- [ ] Required PR checks pass"
             echo "- [ ] Version and changelog are approved"
           } > "$BODY_FILE"
-          gh pr create \
+          pr_url="$(gh pr create \
             --base main \
             --head "$branch" \
             --title "chore(release): v$VERSION" \
-            --body-file "$BODY_FILE"
+            --body-file "$BODY_FILE")"
+          gh pr merge "$pr_url" --auto --squash
       - name: Start CI when using the workflow token
         if: ${{ env.RELEASE_TOKEN == '' }}
         run: |
@@ -139,5 +140,5 @@ jobs:
           {
             echo "## Release v$VERSION proposed"
             echo
-            echo "Review and merge the release PR. Publication starts automatically after merge."
+            echo "Auto-merge is enabled on the release PR. Publication starts automatically after merge."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -54,10 +54,10 @@ The command authenticates with `gh` and dispatches the **Prepare release** workf
 It does not change the local checkout, create a tag, publish an image, or create a GitHub Release.
 
 The workflow freezes the current `main` commit, opens a ready-for-review PR named
-`chore(release): v<version>`, and generates `package.json` and `CHANGELOG.md` for that exact
-snapshot. Review both files, wait for the required checks, and merge the PR. That merge is the
-maintainer's publication approval. No command, workflow dispatch, or approval is required after
-the merge.
+`chore(release): v<version>` with auto-merge enabled, and generates `package.json` and
+`CHANGELOG.md` for that exact snapshot. Review both files and ensure required checks pass. Merging
+that PR (or letting auto-merge complete once approved/passing) is the maintainer's publication
+approval. No command, workflow dispatch, or approval is required after the merge.
 
 Version increments such as `minor` are intentionally rejected. An exact version keeps the proposed
 release explicit and reviewable.
@@ -135,8 +135,9 @@ Configure these controls once:
    permissions and allow GitHub Actions to create pull requests. Alternatively, configure a
    `RELEASE_TOKEN` secret that can write repository contents, open pull requests, and dispatch
    workflows.
-3. Add a tag ruleset for `v*` that restricts creation, updates, and deletion to release automation.
-4. Keep the GHCR package linked to this repository and grant Actions write access to it.
+3. In **Settings → General → Pull Requests**, enable **Allow auto-merge**.
+4. Add a tag ruleset for `v*` that restricts creation, updates, and deletion to release automation.
+5. Keep the GHCR package linked to this repository and grant Actions write access to it.
 
 When `RELEASE_TOKEN` is absent, **Prepare release** explicitly dispatches CI for the generated
 branch. GitHub suppresses ordinary push and pull-request workflow events created by its default

--- a/scripts/request-release.ts
+++ b/scripts/request-release.ts
@@ -71,7 +71,9 @@ function main(): void {
   }
 
   console.log(`Release v${version} requested.`);
-  console.log("The workflow will open a release PR; merging it starts publication automatically.");
+  console.log(
+    "The workflow will open a release PR with auto-merge enabled; merging it starts publication automatically."
+  );
 }
 
 const entrypoint = process.argv[1];


### PR DESCRIPTION
## Summary

- enable squash auto-merge on release PRs created by the `Prepare release` workflow
- update release CLI messaging and documentation to reflect the auto-merge behavior

## Test plan

- [x] Ran unit tests for release request tooling (`scripts/request-release.test.ts`, `scripts/release-changelog.test.ts`)
- [x] Ran `pnpm typecheck` across all workspaces
- [x] Ran `pnpm lint` (Biome)