### PR TITLE
fix(skills): teach routine-forge the canonical Routine/Trigger shape

### DIFF
--- a/packages/soul/src/skills/bundled.test.ts
+++ b/packages/soul/src/skills/bundled.test.ts
@@ -1,7 +1,9 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { definitions } from "@tulipfarm/schema";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { parse as parseYaml } from "yaml";
 import type { Logger } from "../types";
 import {
   bundledSkillsDir,
@@ -135,6 +137,25 @@ describe("loadBundledSkills", () => {
       expect(body, `agent-forge must teach ${key}`).toContain(key);
     }
     expect(body).toMatch(/never|must not|read-only/i);
+  });
+
+  it("ships Routine Forge with a worked example that round-trips through the canonical schema", async () => {
+    const routineForge = (await loadBundledSkills(makeLogger())).get("routine-forge");
+    const body = routineForge?.body ?? "";
+
+    const yamlBlocks = [...body.matchAll(/```yaml\n([\s\S]*?)```/g)].map((match) => match[1]);
+    expect(yamlBlocks).toHaveLength(2);
+
+    const [routineDoc, triggerDoc] = yamlBlocks.map((block) => parseYaml(block));
+
+    const routine = definitions.routine.validateRoutineDefinition(routineDoc).document;
+    const trigger = definitions.trigger.validateTriggerDefinition(triggerDoc).document;
+
+    // Mirrors the cross-document checks `routine_forge` enforces in
+    // apps/api/src/platform/tools.ts beyond per-document schema validation.
+    expect(trigger.metadata.lifecycle).toBe("published");
+    expect(trigger.spec.routineRef.name).toBe(routine.metadata.slug);
+    expect(trigger.spec.routineRef.version).toBe(String(routine.metadata.authoredVersion));
   });
 
   it("ships Skill Forge with the compact description and mandatory authoring section order", async () => {

--- a/skills/forge/routine-forge/SKILL.md
+++ b/skills/forge/routine-forge/SKILL.md
@@ -15,20 +15,88 @@ canonical published Soul definitions, not the retired Serverless Workflow format
    or Agent reference. Do not invent a destination, principal, or credential.
 2. Build a canonical `Routine` document with `apiVersion: tulipfarm.ai/v1`, `kind: Routine`, and
    `metadata` with exactly these keys — no others, the schema rejects additional properties:
-   - `id`: a fresh UUID or ULID (`8f14e...` / `01ARZ3...`), never the routine slug or a made-up
-     string.
+   - `id`: a fresh UUID or ULID (`8f14e...` / `01ARZ3...`), **never** the routine slug or a
+     made-up string.
    - `slug`: lowercase kebab-case, matching the tool's `name` argument.
-   - `schemaVersion: 1`, `authoredVersion` (integer, starts at `1`), `lifecycle: published`.
-   Its `spec` needs `owner` and one or more canonical States. Every State key — `start`, each
-   State's own `name`, and every `transition`/`branches`/`body`/`forState` reference to another
-   State — must match `^[A-Za-z][A-Za-z0-9_]*$`: letters, digits, underscore only, **no hyphens**.
-   Use PascalCase or snake_case (e.g. `ReadIssue`, `send_reply`), never the hyphenated style used
-   for the Routine's own `slug`/`name`.
+   - `schemaVersion`: integer `1`.
+   - `authoredVersion`: **integer**, starts at `1` — never a semver string like `"1.0.0"`.
+   - `lifecycle`: `published`.
+   Its `spec` needs `owner`, `start` (the name of the first State to run), and `states` — a **JSON
+   array** of State objects, never a map keyed by name. Every State key — `start`, each State's
+   own `name`, and every `transition`/`branches`/`body`/`forState` reference to another State —
+   must match `^[A-Za-z][A-Za-z0-9_]*$`: letters, digits, underscore only, **no hyphens**. Use
+   PascalCase or snake_case (e.g. `ReadIssue`, `send_reply`), never the hyphenated style used for
+   the Routine's own `slug`/`name`. An `agent` State's `agentRef` and a `tool` State's `toolRef`
+   are always an **object** `{ name, version }` (both strings; `id` optional) — never a bare
+   string like `"joke-bot"`.
 3. Build one or more canonical `Trigger` documents. Each uses the same `metadata` rules as step 2
-   (fresh `id`, matching `slug`, `lifecycle: published`); its `spec.routineRef` must use the
-   Routine slug and authored version. Every Trigger needs `backgroundIdentity`, `deduplication`,
-   `eventType`, and `eventVersion`. Add a `manual` Trigger when the user needs a Routines UI entry
-   point. `cron`, `interval`, and `datetime` Triggers run automatically after publication.
+   (fresh `id`, matching `slug`, `lifecycle: published`). A Trigger is discriminated by
+   `spec.type` (`manual`, `cron`, `interval`, `datetime`, `webhook`, `integration_event`, `form`,
+   `internal_event`, `internal_api`) — each `type` requires its own extra fields, e.g. `interval`
+   needs `everyMs` (milliseconds, integer — a 5-minute cadence is `everyMs: 300000`, never
+   `every: "PT5M"`). Every Trigger, regardless of `type`, also needs:
+   - `spec.routineRef`: `{ name, version }` — `name` is the Routine's `slug` and `version` is the
+     Routine's `authoredVersion` **cast to a string** (e.g. `authoredVersion: 1` → `version:
+     "1"`), never `{ slug, authoredVersion }`.
+   - `spec.eventType` (string) and `spec.eventVersion` (**integer**, e.g. `1` — never a semver
+     string).
+   - `spec.backgroundIdentity`: `{ principalKind, principalId }`.
+   - `spec.deduplication`: `{ key, windowMs? }` — never `{ strategy, window }`.
+   Add a `manual` Trigger when the user needs a Routines UI entry point. `cron`, `interval`, and
+   `datetime` Triggers run automatically after publication.
+
+## Worked example — "post a joke every 5 minutes"
+
+Routine (`spec.owner` is a placeholder; ask the user for the real owner):
+
+```yaml
+apiVersion: tulipfarm.ai/v1
+kind: Routine
+metadata:
+  id: 01ARZ3NDEKTSV4RRFFQ69G5FAV
+  slug: post-a-joke
+  schemaVersion: 1
+  authoredVersion: 1
+  lifecycle: published
+spec:
+  owner: ops-team
+  start: PostJoke
+  states:
+    - type: tool
+      name: PostJoke
+      toolRef:
+        name: send_slack_message
+        version: "1"
+      action: send_message
+      end: true
+```
+
+Trigger (fires every 5 minutes, references the Routine above at its authored version):
+
+```yaml
+apiVersion: tulipfarm.ai/v1
+kind: Trigger
+metadata:
+  id: 01ARZ3NDEKTSV4RRFFQ69G5FAX
+  slug: post-a-joke-every-5-minutes
+  schemaVersion: 1
+  authoredVersion: 1
+  lifecycle: published
+spec:
+  type: interval
+  everyMs: 300000
+  routineRef:
+    name: post-a-joke
+    version: "1"
+  eventType: routine.trigger.interval
+  eventVersion: 1
+  backgroundIdentity:
+    principalKind: agent
+    principalId: ops-team
+  deduplication:
+    key: post-a-joke-interval
+```
+
 4. Preview purpose, Triggers, and State flow. Get the user's approval.
 5. Call `routine_forge` with `name`, the canonical Routine as `definition`, and all canonical
    Trigger documents as `triggers`. It writes them in one atomic Soul changeset.


### PR DESCRIPTION
## Summary
- `skills/forge/routine-forge/SKILL.md` only listed field *names* for the canonical `Routine`/`Trigger` shape, never their types or a full worked example, so the model reconstructed a plausible-but-wrong (Kubernetes/Serverless-Workflow-style) document — semver-string `authoredVersion`, `metadata.id` set to the slug, `states` as a map instead of an array, bare-string `agentRef`/`toolRef`, `routineRef` shaped `{ slug, authoredVersion }` instead of `{ name, version: "<authoredVersion>" }`, `deduplication.strategy/window` instead of `{ key, windowMs }` — which the canonical schema (`packages/schema/src/definitions/{routine,trigger,common}.ts`) and the `routine_forge` Tool (`apps/api/src/platform/tools.ts`) reject.
- A prior fix (#541) had already documented the metadata field list and the no-hyphen State-key pattern, but left every other trap (field types, Trigger `type` discriminator, `agentRef`/`toolRef` object shape, `routineRef.version` as a string) undocumented — this PR closes the remaining gap the issue describes, following the same worked-example pattern `agent-forge` already uses.
- Added a regression test (`packages/soul/src/skills/bundled.test.ts`) that extracts the Skill's two YAML code blocks and validates them through `validateRoutineDefinition`/`validateTriggerDefinition`, plus the cross-document checks `routine_forge` enforces (`routineRef.name`/`version` matching the Routine).

## Test plan
- [x] `pnpm exec biome check --write skills/forge/routine-forge/SKILL.md packages/soul/src/skills/bundled.test.ts`
- [x] `pnpm --filter @tulipfarm/soul typecheck`
- [x] `pnpm --filter @tulipfarm/soul test src/skills/bundled.test.ts` — new test fails on the pre-fix SKILL.md, passes after
- [x] `pnpm --filter @tulipfarm/soul test` (full package suite)
- [x] `pnpm typecheck` (repo-wide, cache hit)

Closes #540