### PR TITLE
feat(web): add client-side report a bug button and modal

### DIFF
--- a/apps/web/app/components/app-sidebar.test.tsx
+++ b/apps/web/app/components/app-sidebar.test.tsx
@@ -317,3 +317,8 @@ test("reduces the signed-in account to a monogram in the top bar", () => {
   expect(account).toHaveTextContent("PN");
   expect(screen.queryByText("priya.nair@northgate.dev")).not.toBeInTheDocument();
 });
+
+test("renders the report a bug button in the top bar", () => {
+  render(<ShellStub initialEntries={["/inbox"]} />);
+  expect(screen.getByRole("button", { name: "Report a bug" })).toBeInTheDocument();
+});

--- a/apps/web/app/components/app-sidebar.tsx
+++ b/apps/web/app/components/app-sidebar.tsx
@@ -12,6 +12,7 @@ import {
 import { type ReactNode, useEffect, useRef, useState } from "react";
 import { KnowledgeTree } from "~/components/knowledge/space-tree";
 import { CompanionMobileTrigger } from "~/components/onboarding/companion";
+import { ReportBugButton } from "~/components/report-bug-button";
 import { ThemeToggle } from "~/components/theme-toggle";
 import { Badge } from "~/components/ui/badge";
 import { Separator } from "~/components/ui/separator";
@@ -561,6 +562,7 @@ export function AppShell({ children, user }: { children: ReactNode; user?: Sessi
               <CompanionMobileTrigger />
             </span>
             <AccountChip user={user} />
+            <ReportBugButton />
             <span className="flex items-center lg:hidden">
               <ThemeToggle iconOnly />
             </span>

--- a/apps/web/app/components/report-bug-button.tsx
+++ b/apps/web/app/components/report-bug-button.tsx
@@ -1,0 +1,60 @@
+import { Bug } from "lucide-react";
+import { useState } from "react";
+import { ReportBugModal } from "~/components/report-bug-modal";
+import { Button } from "~/components/ui/button";
+import { Tooltip } from "~/components/ui/tooltip";
+import { type CapturedScreenshot, captureScreenshot } from "~/lib/report-bug";
+
+export function ReportBugButton({ iconOnly = true }: { iconOnly?: boolean }) {
+  const [open, setOpen] = useState(false);
+  const [screenshot, setScreenshot] = useState<CapturedScreenshot | null>(null);
+  const [capturing, setCapturing] = useState(false);
+
+  async function handleClick() {
+    if (capturing) return;
+    setCapturing(true);
+    try {
+      const shot = await captureScreenshot();
+      setScreenshot(shot);
+      setOpen(true);
+    } catch {
+      setScreenshot(null);
+      setOpen(true);
+    } finally {
+      setCapturing(false);
+    }
+  }
+
+  const trigger = (
+    <Button
+      type="button"
+      variant="ghost"
+      size={iconOnly ? "icon" : "sm"}
+      onClick={handleClick}
+      disabled={capturing}
+      aria-label="Report a bug"
+      className={
+        iconOnly
+          ? "size-8 rounded-sm text-muted-foreground transition-colors duration-150 hover:bg-accent hover:text-foreground"
+          : "gap-2 rounded-sm text-muted-foreground transition-colors duration-150 hover:bg-accent hover:text-foreground"
+      }
+    >
+      <Bug className="size-4" aria-hidden />
+      {!iconOnly ? <span>Report a bug</span> : null}
+    </Button>
+  );
+
+  return (
+    <>
+      <Tooltip content="Report a bug">{trigger}</Tooltip>
+      <ReportBugModal
+        open={open}
+        onClose={() => {
+          setOpen(false);
+          setScreenshot(null);
+        }}
+        screenshot={screenshot}
+      />
+    </>
+  );
+}

--- a/apps/web/app/components/report-bug-modal.test.tsx
+++ b/apps/web/app/components/report-bug-modal.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ReportBugModal } from "~/components/report-bug-modal";
+import * as clipboard from "~/lib/clipboard";
+import * as reportBug from "~/lib/report-bug";
+
+vi.mock("~/lib/clipboard", () => ({
+  copyImageBlob: vi.fn(),
+}));
+const copyImageBlob = vi.mocked(clipboard.copyImageBlob);
+
+vi.mock("~/lib/report-bug", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/lib/report-bug")>();
+  return {
+    ...actual,
+    downloadBlob: vi.fn(),
+  };
+});
+const downloadBlob = vi.mocked(reportBug.downloadBlob);
+
+const mockScreenshot = {
+  blob: new Blob(["fake-image"], { type: "image/png" }),
+  dataUrl: "data:image/png;base64,fake-data",
+};
+
+describe("ReportBugModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders when open with screenshot preview and form inputs", () => {
+    render(<ReportBugModal open={true} onClose={vi.fn()} screenshot={mockScreenshot} />);
+
+    expect(screen.getByRole("heading", { name: "Report a bug" })).toBeInTheDocument();
+    expect(screen.getByAltText("Captured screen preview")).toHaveAttribute(
+      "src",
+      "data:image/png;base64,fake-data"
+    );
+    expect(screen.getByLabelText("Title")).toBeInTheDocument();
+    expect(screen.getByLabelText("Description")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Copy screenshot/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Download PNG/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Open GitHub issue/i })).toBeInTheDocument();
+  });
+
+  it("handles copy screenshot feedback", async () => {
+    const user = userEvent.setup();
+    copyImageBlob.mockResolvedValue(true);
+
+    render(<ReportBugModal open={true} onClose={vi.fn()} screenshot={mockScreenshot} />);
+
+    const copyBtn = screen.getByRole("button", { name: /Copy screenshot/i });
+    await user.click(copyBtn);
+
+    expect(copyImageBlob).toHaveBeenCalledWith(mockScreenshot.blob);
+    expect(screen.getByText("Copied to clipboard")).toBeInTheDocument();
+  });
+
+  it("handles download screenshot", async () => {
+    const user = userEvent.setup();
+    render(<ReportBugModal open={true} onClose={vi.fn()} screenshot={mockScreenshot} />);
+
+    const downloadBtn = screen.getByRole("button", { name: /Download PNG/i });
+    await user.click(downloadBtn);
+
+    expect(downloadBlob).toHaveBeenCalledWith(mockScreenshot.blob);
+  });
+
+  it("opens GitHub issue with user entered title and description", async () => {
+    const user = userEvent.setup();
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+    const onClose = vi.fn();
+
+    render(<ReportBugModal open={true} onClose={onClose} screenshot={mockScreenshot} />);
+
+    await user.type(screen.getByLabelText("Title"), "Broken button");
+    await user.type(screen.getByLabelText("Description"), "Clicked and nothing happened");
+
+    await user.click(screen.getByRole("button", { name: /Open GitHub issue/i }));
+
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    const openedUrl = new URL(openSpy.mock.calls[0][0] as string);
+    expect(openedUrl.searchParams.get("title")).toBe("Broken button");
+    expect(openedUrl.searchParams.get("body")).toContain("Clicked and nothing happened");
+    expect(openedUrl.searchParams.get("labels")).toBe("bug");
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders notice when screenshot is null", () => {
+    render(<ReportBugModal open={true} onClose={vi.fn()} screenshot={null} />);
+
+    expect(screen.getByText(/Screenshot not attached/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/components/report-bug-modal.tsx
+++ b/apps/web/app/components/report-bug-modal.tsx
@@ -1,0 +1,155 @@
+import { Check, Copy, Download, ExternalLink, Image as ImageIcon } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
+import { Modal } from "~/components/ui/modal";
+import { Textarea } from "~/components/ui/textarea";
+import { copyImageBlob } from "~/lib/clipboard";
+import { buildIssueUrl, type CapturedScreenshot, downloadBlob } from "~/lib/report-bug";
+
+export function ReportBugModal({
+  open,
+  onClose,
+  screenshot,
+}: {
+  open: boolean;
+  onClose: () => void;
+  screenshot: CapturedScreenshot | null;
+}) {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [copied, setCopied] = useState(false);
+  const [copyFailed, setCopyFailed] = useState(false);
+
+  useEffect(() => {
+    if (!open) {
+      setTitle("");
+      setDescription("");
+      setCopied(false);
+      setCopyFailed(false);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!copied) return;
+    const timer = setTimeout(() => setCopied(false), 2000);
+    return () => clearTimeout(timer);
+  }, [copied]);
+
+  async function handleCopyScreenshot() {
+    if (!screenshot) return;
+    const ok = await copyImageBlob(screenshot.blob);
+    if (ok) {
+      setCopied(true);
+      setCopyFailed(false);
+    } else {
+      setCopyFailed(true);
+    }
+  }
+
+  function handleDownloadScreenshot() {
+    if (!screenshot) return;
+    downloadBlob(screenshot.blob);
+  }
+
+  function handleOpenIssue() {
+    const url = buildIssueUrl({ title, description });
+    window.open(url, "_blank", "noopener,noreferrer");
+    onClose();
+  }
+
+  return (
+    <Modal open={open} onClose={onClose} title="Report a bug" className="max-w-lg">
+      <div className="flex flex-col gap-4">
+        {screenshot ? (
+          <div className="flex flex-col gap-2">
+            <span className="text-xs font-medium text-muted-foreground">Screenshot preview</span>
+            <div className="relative flex max-h-52 w-full items-center justify-center overflow-hidden rounded-md border border-border bg-muted/40 p-1">
+              <img
+                src={screenshot.dataUrl}
+                alt="Captured screen preview"
+                className="max-h-48 w-auto max-w-full rounded object-contain"
+              />
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={handleCopyScreenshot}
+                className="h-7 text-xs"
+              >
+                {copied ? (
+                  <>
+                    <Check className="size-3.5 text-success" />
+                    Copied to clipboard
+                  </>
+                ) : (
+                  <>
+                    <Copy className="size-3.5" />
+                    Copy screenshot
+                  </>
+                )}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={handleDownloadScreenshot}
+                className="h-7 text-xs"
+              >
+                <Download className="size-3.5" />
+                Download PNG
+              </Button>
+              {copyFailed ? (
+                <span className="text-[0.75rem] text-muted-foreground">
+                  Direct clipboard copy unavailable. Please use Download PNG.
+                </span>
+              ) : null}
+            </div>
+          </div>
+        ) : (
+          <div className="flex items-center gap-2 rounded-md border border-dashed border-border bg-muted/20 p-3 text-xs text-muted-foreground">
+            <ImageIcon className="size-4 shrink-0" />
+            <span>Screenshot not attached. You can still submit your bug report below.</span>
+          </div>
+        )}
+
+        <div className="flex flex-col gap-1.5">
+          <label htmlFor="report-bug-title" className="text-xs font-medium text-foreground">
+            Title
+          </label>
+          <Input
+            id="report-bug-title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Brief summary of the issue"
+          />
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <label htmlFor="report-bug-description" className="text-xs font-medium text-foreground">
+            Description
+          </label>
+          <Textarea
+            id="report-bug-description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="What happened, what did you expect, or steps to reproduce..."
+            rows={4}
+          />
+        </div>
+
+        <div className="flex items-center justify-end gap-2 pt-2">
+          <Button type="button" variant="ghost" size="sm" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button type="button" size="sm" onClick={handleOpenIssue} className="gap-1.5">
+            <ExternalLink className="size-3.5" />
+            Open GitHub issue
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/web/app/lib/clipboard.test.ts
+++ b/apps/web/app/lib/clipboard.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { copyText } from "~/lib/clipboard";
+import { copyImageBlob, copyText } from "~/lib/clipboard";
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -33,5 +33,42 @@ describe("copyText", () => {
     // biome-ignore lint/suspicious/noExplicitAny: execCommand is deprecated and untyped in lib.dom
     (document as any).execCommand = vi.fn().mockReturnValue(false);
     await expect(copyText("hello")).resolves.toBe(false);
+  });
+});
+
+describe("copyImageBlob", () => {
+  it("writes ClipboardItem when API and ClipboardItem are present", async () => {
+    const write = vi.fn().mockResolvedValue(undefined);
+    class MockClipboardItem {
+      // biome-ignore lint/suspicious/noExplicitAny: mock
+      constructor(public data: any) {}
+    }
+    vi.stubGlobal("ClipboardItem", MockClipboardItem);
+    vi.stubGlobal("navigator", { clipboard: { write } });
+
+    const blob = new Blob(["test"], { type: "image/png" });
+    await expect(copyImageBlob(blob)).resolves.toBe(true);
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(write.mock.calls[0][0][0]).toBeInstanceOf(MockClipboardItem);
+  });
+
+  it("returns false when ClipboardItem is missing or clipboard API is missing", async () => {
+    vi.stubGlobal("navigator", {});
+    const blob = new Blob(["test"], { type: "image/png" });
+    await expect(copyImageBlob(blob)).resolves.toBe(false);
+  });
+
+  it("returns false when clipboard write throws", async () => {
+    class MockClipboardItem {
+      // biome-ignore lint/suspicious/noExplicitAny: mock
+      constructor(public data: any) {}
+    }
+    vi.stubGlobal("ClipboardItem", MockClipboardItem);
+    vi.stubGlobal("navigator", {
+      clipboard: { write: vi.fn().mockRejectedValue(new Error("Permission denied")) },
+    });
+
+    const blob = new Blob(["test"], { type: "image/png" });
+    await expect(copyImageBlob(blob)).resolves.toBe(false);
   });
 });

--- a/apps/web/app/lib/clipboard.ts
+++ b/apps/web/app/lib/clipboard.ts
@@ -27,3 +27,15 @@ export async function copyText(text: string): Promise<boolean> {
     textarea.remove();
   }
 }
+
+export async function copyImageBlob(blob: Blob): Promise<boolean> {
+  if (typeof ClipboardItem !== "undefined" && navigator.clipboard?.write) {
+    try {
+      await navigator.clipboard.write([new ClipboardItem({ [blob.type || "image/png"]: blob })]);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}

--- a/apps/web/app/lib/report-bug.test.ts
+++ b/apps/web/app/lib/report-bug.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { buildIssueUrl, captureScreenshot, downloadBlob, GITHUB_REPO_URL } from "~/lib/report-bug";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("buildIssueUrl", () => {
+  it("builds default issue URL with bug label and attachment prompt", () => {
+    const urlString = buildIssueUrl();
+    const url = new URL(urlString);
+    expect(url.origin + url.pathname).toBe(`${GITHUB_REPO_URL}/issues/new`);
+    expect(url.searchParams.get("labels")).toBe("bug");
+    expect(url.searchParams.get("title")).toBeNull();
+    expect(url.searchParams.get("body")).toBe(
+      "(Attach the screenshot copied to your clipboard or downloaded)"
+    );
+  });
+
+  it("includes title and user description when provided", () => {
+    const urlString = buildIssueUrl({
+      title: "Sidebar toggle is broken on mobile",
+      description: "Steps to reproduce:\n1. Click menu\n2. Nothing happens",
+    });
+    const url = new URL(urlString);
+    expect(url.searchParams.get("title")).toBe("Sidebar toggle is broken on mobile");
+    expect(url.searchParams.get("body")).toBe(
+      "Steps to reproduce:\n1. Click menu\n2. Nothing happens\n\n(Attach the screenshot copied to your clipboard or downloaded)"
+    );
+    expect(url.searchParams.get("labels")).toBe("bug");
+  });
+});
+
+describe("downloadBlob", () => {
+  it("creates an anchor and triggers download", () => {
+    const createObjectURL = vi.fn().mockReturnValue("blob:test-url");
+    const revokeObjectURL = vi.fn();
+    vi.stubGlobal("URL", { createObjectURL, revokeObjectURL });
+
+    const clickSpy = vi.fn();
+    const origCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
+      const el = origCreateElement(tag);
+      if (tag === "a") {
+        el.click = clickSpy;
+      }
+      return el;
+    });
+
+    const blob = new Blob(["image-data"], { type: "image/png" });
+    downloadBlob(blob, "custom-screenshot.png");
+
+    expect(createObjectURL).toHaveBeenCalledWith(blob);
+    expect(clickSpy).toHaveBeenCalled();
+  });
+});
+
+describe("captureScreenshot", () => {
+  it("returns null when mediaDevices is missing", async () => {
+    vi.stubGlobal("navigator", {});
+    const result = await captureScreenshot();
+    expect(result).toBeNull();
+  });
+
+  it("returns null when getDisplayMedia rejects (user cancelled)", async () => {
+    vi.stubGlobal("navigator", {
+      mediaDevices: {
+        getDisplayMedia: vi.fn().mockRejectedValue(new Error("Permission denied / cancelled")),
+      },
+    });
+    const result = await captureScreenshot();
+    expect(result).toBeNull();
+  });
+
+  it("captures screenshot, stops tracks, and returns blob with dataUrl", async () => {
+    const stopTrack = vi.fn();
+    const mockTrack = { stop: stopTrack };
+    const mockStream = {
+      getVideoTracks: vi.fn().mockReturnValue([mockTrack]),
+      getTracks: vi.fn().mockReturnValue([mockTrack]),
+    };
+
+    const getDisplayMedia = vi.fn().mockResolvedValue(mockStream);
+    vi.stubGlobal("navigator", {
+      mediaDevices: { getDisplayMedia },
+    });
+
+    // Mock HTMLMediaElement play & video load
+    const origCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
+      const el = origCreateElement(tag);
+      if (tag === "video") {
+        const video = el as HTMLVideoElement;
+        Object.defineProperty(video, "videoWidth", { value: 800, configurable: true });
+        Object.defineProperty(video, "videoHeight", { value: 600, configurable: true });
+        video.play = vi.fn().mockResolvedValue(undefined);
+        // Trigger metadata loaded on next tick
+        setTimeout(() => {
+          if (video.onloadedmetadata) {
+            // biome-ignore lint/suspicious/noExplicitAny: event mock
+            video.onloadedmetadata({} as any);
+          }
+        }, 0);
+      } else if (tag === "canvas") {
+        const canvas = el as HTMLCanvasElement;
+        const mockCtx = {
+          drawImage: vi.fn(),
+        };
+        // biome-ignore lint/suspicious/noExplicitAny: mock
+        canvas.getContext = vi.fn().mockReturnValue(mockCtx) as any;
+        canvas.toDataURL = vi.fn().mockReturnValue("data:image/png;base64,mockpng");
+        canvas.toBlob = vi.fn().mockImplementation((cb: (b: Blob | null) => void) => {
+          cb(new Blob(["mockblob"], { type: "image/png" }));
+        });
+      }
+      return el;
+    });
+
+    const result = await captureScreenshot();
+    expect(result).not.toBeNull();
+    expect(result?.dataUrl).toBe("data:image/png;base64,mockpng");
+    expect(result?.blob).toBeInstanceOf(Blob);
+    expect(stopTrack).toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/lib/report-bug.ts
+++ b/apps/web/app/lib/report-bug.ts
@@ -1,0 +1,109 @@
+export const GITHUB_REPO_URL = "https://github.com/TulipFarm/tulipfarm";
+
+export interface CapturedScreenshot {
+  blob: Blob;
+  dataUrl: string;
+}
+
+export function buildIssueUrl({
+  title,
+  description,
+}: {
+  title?: string;
+  description?: string;
+} = {}): string {
+  const url = new URL(`${GITHUB_REPO_URL}/issues/new`);
+  if (title?.trim()) {
+    url.searchParams.set("title", title.trim());
+  }
+  const bodySections: string[] = [];
+  if (description?.trim()) {
+    bodySections.push(description.trim());
+  }
+  bodySections.push("(Attach the screenshot copied to your clipboard or downloaded)");
+  url.searchParams.set("body", bodySections.join("\n\n"));
+  url.searchParams.set("labels", "bug");
+  return url.toString();
+}
+
+/*
+ * Uses native getDisplayMedia to capture client pixels without adding canvas/dom-to-image dependencies.
+ * Stops all media stream tracks immediately once the video frame is drawn to canvas.
+ */
+export async function captureScreenshot(): Promise<CapturedScreenshot | null> {
+  if (!navigator.mediaDevices?.getDisplayMedia) {
+    return null;
+  }
+
+  let stream: MediaStream | null = null;
+  try {
+    try {
+      stream = await navigator.mediaDevices.getDisplayMedia({
+        video: { displaySurface: "browser" } as MediaTrackConstraints,
+        audio: false,
+      });
+    } catch {
+      stream = await navigator.mediaDevices.getDisplayMedia({
+        video: true,
+        audio: false,
+      });
+    }
+
+    const videoTrack = stream.getVideoTracks()[0];
+    if (!videoTrack) {
+      return null;
+    }
+
+    const video = document.createElement("video");
+    video.srcObject = stream;
+    video.muted = true;
+    video.playsInline = true;
+
+    await new Promise<void>((resolve, reject) => {
+      video.onloadedmetadata = () => {
+        video.play().then(resolve).catch(reject);
+      };
+      video.onerror = () => reject(new Error("Failed to load video stream"));
+    });
+
+    const canvas = document.createElement("canvas");
+    canvas.width = video.videoWidth || 1280;
+    canvas.height = video.videoHeight || 720;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) {
+      return null;
+    }
+
+    ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+    const dataUrl = canvas.toDataURL("image/png");
+
+    const blob = await new Promise<Blob | null>((resolve) => {
+      canvas.toBlob(resolve, "image/png");
+    });
+
+    if (!blob) {
+      return null;
+    }
+
+    return { blob, dataUrl };
+  } catch {
+    return null;
+  } finally {
+    if (stream) {
+      for (const track of stream.getTracks()) {
+        track.stop();
+      }
+    }
+  }
+}
+
+export function downloadBlob(blob: Blob, filename = "tulipfarm-bug-screenshot.png"): void {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}

--- a/scripts/test/check-secure-context-apis.sh
+++ b/scripts/test/check-secure-context-apis.sh
@@ -9,7 +9,7 @@ PATTERNS=(
   "crypto\\.subtle::${NO_FALLBACK}"
   "navigator\\.clipboard::use copyText() from ~/lib/clipboard"
   "navigator\\.credentials::${NO_FALLBACK}"
-  "navigator\\.mediaDevices::${NO_FALLBACK}"
+  "navigator\\.mediaDevices::use captureScreenshot() from ~/lib/report-bug"
   "navigator\\.geolocation::${NO_FALLBACK}"
   "navigator\\.serviceWorker::${NO_FALLBACK}"
   "navigator\\.storage::${NO_FALLBACK}"
@@ -21,7 +21,7 @@ PATTERNS=(
 
 is_exempt() {
   case "$1" in
-    */app/lib/uuid.ts | */app/lib/clipboard.ts) return 0 ;;
+    */app/lib/uuid.ts | */app/lib/clipboard.ts | */app/lib/report-bug.ts) return 0 ;;
     *.test.ts | *.test.tsx) return 0 ;;
     *) return 1 ;;
   esac
@@ -44,7 +44,7 @@ done
 
 if [ "$failed" -eq 1 ]; then
   printf '\nThese are undefined when the app is served over plain http from a LAN IP.\n'
-  printf 'See apps/web/app/lib/uuid.ts and apps/web/app/lib/clipboard.ts for the pattern.\n'
+  printf 'See apps/web/app/lib/uuid.ts, apps/web/app/lib/clipboard.ts, and apps/web/app/lib/report-bug.ts for the pattern.\n'
   exit 1
 fi
 

--- a/scripts/test/check-secure-context-apis.test.ts
+++ b/scripts/test/check-secure-context-apis.test.ts
@@ -27,11 +27,15 @@ describe("secure-context API guard", () => {
     });
   });
 
-  it("keeps the clipboard helper exemption explicit", async () => {
+  it("keeps the clipboard and report-bug helper exemptions explicit", async () => {
     const dir = await mkdtemp(join(tmpdir(), "tf-secure-context-"));
     const helperDir = join(dir, "app/lib");
     await mkdir(helperDir, { recursive: true });
     await writeFile(join(helperDir, "clipboard.ts"), "navigator.clipboard.writeText('x');\n");
+    await writeFile(
+      join(helperDir, "report-bug.ts"),
+      "navigator.mediaDevices.getDisplayMedia({ video: true });\n"
+    );
     await expect(runGuard(dir)).resolves.toMatchObject({
       stdout: expect.stringContaining("ok"),
     });


### PR DESCRIPTION
## Summary

Adds a client-only bug reporting flow to the TulipFarm web shell as specified in \`docs/plans/report-bug-button.md\`.

- **Trigger**: Adds \`ReportBugButton\` to the \`AppShell\` header action cluster with a \`Bug\` icon and tooltip.
- **Native Screen Capture**: Uses native \`getDisplayMedia\` to capture real browser pixels without requiring additional DOM-to-image or canvas dependencies.
- **Preview & Metadata Modal**: \`ReportBugModal\` displays the screenshot thumbnail, lets users enter an issue summary and reproduction details, and provides quick actions.
- **Clipboard & Insecure Context Fallback**: Implements \`copyImageBlob()\` using the standard \`ClipboardItem\` API and provides a direct \`Download PNG\` action for insecure LAN HTTP contexts where direct clipboard writes are restricted.
- **GitHub Target**: Automatically constructs and opens a prefilled GitHub issue URL on \`TulipFarm/tulipfarm\` with description, attachment placeholder, and \`bug\` label.
- **Guardrails & Tests**: Exempts \`report-bug.ts\` from direct secure-context API bans with fallback handling in \`check-secure-context-apis.sh\` and includes comprehensive Vitest unit tests for clipboard, report-bug helpers, modal UI, and sidebar integration.

## Test Plan

- [x] \`pnpm check:secure-context\` passes (no unguarded secure-context APIs)
- [x] \`pnpm lint\` passes across all workspaces
- [x] \`pnpm typecheck\` passes with zero errors
- [x] \`pnpm --filter @tulipfarm/web test\` (all 156 test files, 1211 tests pass)
- [x] Colocated unit tests added and passing:
  - \`apps/web/app/lib/clipboard.test.ts\` (image blob copy, missing ClipboardItem fallback)
  - \`apps/web/app/lib/report-bug.test.ts\` (URL generation, getDisplayMedia capture lifecycle, downloadBlob)
  - \`apps/web/app/components/report-bug-modal.test.tsx\` (preview, form inputs, copy feedback, download, URL launch)
  - \`apps/web/app/components/app-sidebar.test.tsx\` (header button rendering)
  - \`scripts/test/check-secure-context-apis.test.ts\` (exemption test)