### PR TITLE
fix(soul): provide canonical reference examples and narrowing for routine-forge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,9 +17,10 @@ tasks/
 !apps/api/src/tasks/
 !packages/storage/src/tasks/
 cookies.txt
-references
+/references
 !/.agents/skills/tulipfarm-design-system/references/
 !/.agents/skills/tulipfarm-design-system/references/design-system.md
+!skills/**/references/
 .absolute-work
 .codex/
 .claude/logs

--- a/apps/api/src/platform/tools.test.ts
+++ b/apps/api/src/platform/tools.test.ts
@@ -316,6 +316,40 @@ describe("loadSkillReferenceTool", () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  it("loads routine-forge reference examples from the real bundled tree", async () => {
+    const { loadBundledSkills } = await import("@tulipfarm/soul");
+    const bundled = await loadBundledSkills({ info() {}, warn() {}, error() {} });
+    const ctx: PlatformToolContext = {
+      soulWriter: makeSoulWriter(),
+      bundledSkills: bundled,
+    };
+    const examples = await loadSkillReferenceTool.handler(
+      { skill: "routine-forge", reference: "examples.md" },
+      ctx
+    );
+    expect(examples).toMatchObject({
+      success: true,
+      data: {
+        skill: "routine-forge",
+        reference: "examples.md",
+        content: expect.stringContaining("Routine & Trigger Canonical Examples"),
+      },
+    });
+
+    const canonicalExamples = await loadSkillReferenceTool.handler(
+      { skill: "routine-forge", reference: "canonical-examples.md" },
+      ctx
+    );
+    expect(canonicalExamples).toMatchObject({
+      success: true,
+      data: {
+        skill: "routine-forge",
+        reference: "canonical-examples.md",
+        content: expect.stringContaining("Routine & Trigger Canonical Examples"),
+      },
+    });
+  });
 });
 
 // ── delegate_to_agent ─────────────────────────────────────────────────────────

--- a/apps/api/src/platform/tools.ts
+++ b/apps/api/src/platform/tools.ts
@@ -240,7 +240,8 @@ const ROUTINE_FORGE_SCHEMA: Record<string, unknown> = {
     },
     definition: {
       type: "object",
-      description: "Canonical published Routine definition. metadata.slug must match name.",
+      description:
+        "Canonical published Routine definition. metadata.slug must match name. spec.states must be an array of State objects [{ name, type, ... }].",
     },
     triggers: {
       type: "array",
@@ -261,7 +262,8 @@ export const routineForgeTool = defineApiTool<PlatformToolContext>({
     "not skill_create, whenever the user asks to 'create a routine' / 'automate X' / 'every " +
     "morning do Y' / 'when X happens do Y'. `definition` MUST be a canonical published Routine " +
     "document: apiVersion `tulipfarm.ai/v1`, kind `Routine`, and metadata with id, slug (matching " +
-    "name), schemaVersion, authoredVersion, and lifecycle `published`. `triggers` MUST contain " +
+    "name), schemaVersion, authoredVersion, and lifecycle `published`. `definition.spec.states` " +
+    "MUST be an array of State objects with name and type (not an object/map). `triggers` MUST contain " +
     "canonical published Trigger documents with their own metadata and a spec.routineRef naming this " +
     "Routine at its authored version. Use a `manual` Trigger when the user needs to run it from the " +
     "Routines UI; cron, interval, and datetime Triggers schedule themselves. Load the routine-forge " +

--- a/packages/agent-runtime/src/loop/loop.test.ts
+++ b/packages/agent-runtime/src/loop/loop.test.ts
@@ -1000,6 +1000,7 @@ describe("AgentLoop concurrent dispatch", () => {
 describe("AgentLoop skill-scoped tool narrowing", () => {
   const catalog = [
     { name: "load_skill", inputSchema: { type: "object" } },
+    { name: "load_skill_reference", inputSchema: { type: "object" } },
     { name: "complete_task", inputSchema: { type: "object" } },
     { name: "routine_forge", inputSchema: { type: "object" } },
     { name: "record_search", inputSchema: { type: "object" } },
@@ -1037,7 +1038,12 @@ describe("AgentLoop skill-scoped tool narrowing", () => {
     expect(model.toolNamesByRequest[0]).toEqual(catalog.map((t) => t.name));
     // Iteration 2 is narrowed to the declared scope plus the always-exposed baseline.
     expect(model.toolNamesByRequest[1]).toEqual(
-      expect.arrayContaining(["load_skill", "complete_task", "routine_forge"])
+      expect.arrayContaining([
+        "load_skill",
+        "load_skill_reference",
+        "complete_task",
+        "routine_forge",
+      ])
     );
     expect(model.toolNamesByRequest[1]).not.toContain("record_search");
     expect(model.toolNamesByRequest[1]).not.toContain("agent_list");

--- a/packages/agent-runtime/src/loop/narrowing.ts
+++ b/packages/agent-runtime/src/loop/narrowing.ts
@@ -12,6 +12,7 @@ import type { ExposedTool } from "./contract";
  */
 const ALWAYS_EXPOSED_TOOL_NAMES: ReadonlySet<string> = new Set([
   "load_skill",
+  "load_skill_reference",
   "complete_task",
   "delegate_to_agent",
   "present",

--- a/packages/soul/src/skills/bundled.test.ts
+++ b/packages/soul/src/skills/bundled.test.ts
@@ -128,6 +128,11 @@ describe("loadBundledSkills", () => {
     }
   });
 
+  it("ships Routine Forge with canonical examples references", async () => {
+    const routineForge = (await loadBundledSkills(makeLogger())).get("routine-forge");
+    expect(routineForge?.references).toEqual(["canonical-examples.md", "examples.md"]);
+  });
+
   it("ships Agent Forge with the guidance that makes capability restrictions reachable", async () => {
     const agentForge = (await loadBundledSkills(makeLogger())).get("agent-forge");
     const body = agentForge?.body ?? "";

--- a/skills/forge/routine-forge/SKILL.md
+++ b/skills/forge/routine-forge/SKILL.md
@@ -2,7 +2,7 @@
 name: routine-forge
 description: "Forge a canonical Routine and its Triggers."
 category: forge
-tools: [routine_forge, routine_picker, trigger_routine, agent_list, agent_get, record_search, record_get, send_slack_message, present, request_input]
+tools: [routine_forge, routine_picker, trigger_routine, load_skill_reference, agent_list, agent_get, record_search, record_get, send_slack_message, present, request_input]
 ---
 # Routine Forge Workflow
 
@@ -10,6 +10,9 @@ Use this Skill to create or change a **Routine** and its **Triggers** through Ch
 canonical published Soul definitions, not the retired Serverless Workflow format.
 
 {{FORGE_EXECUTION_CONTRACT}}
+
+For complete schema templates, Cron/interval/webhook trigger examples, and State patterns, call
+`load_skill_reference` with `skill: "routine-forge"` and `reference: "examples.md"` (or `"canonical-examples.md"`).
 
 1. Ask only for missing business choices: the owner, the Trigger type and schedule, and any Tool
    or Agent reference. Do not invent a destination, principal, or credential.
@@ -22,12 +25,12 @@ canonical published Soul definitions, not the retired Serverless Workflow format
    - `authoredVersion`: **integer**, starts at `1` — never a semver string like `"1.0.0"`.
    - `lifecycle`: `published`.
    Its `spec` needs `owner`, `start` (the name of the first State to run), and `states` — a **JSON
-   array** of State objects, never a map keyed by name. Every State key — `start`, each State's
-   own `name`, and every `transition`/`branches`/`body`/`forState` reference to another State —
-   must match `^[A-Za-z][A-Za-z0-9_]*$`: letters, digits, underscore only, **no hyphens**. Use
-   PascalCase or snake_case (e.g. `ReadIssue`, `send_reply`), never the hyphenated style used for
-   the Routine's own `slug`/`name`. An `agent` State's `agentRef` and a `tool` State's `toolRef`
-   are always an **object** `{ name, version }` (both strings; `id` optional) — never a bare
+   array** of State objects (`[{ name: "...", type: "...", ... }]`), never a map/object keyed by name.
+   Every State key — `start`, each State's own `name`, and every `transition`/`branches`/`body`/`forState`
+   reference to another State — must match `^[A-Za-z][A-Za-z0-9_]*$`: letters, digits, underscore only,
+   **no hyphens**. Use PascalCase or snake_case (e.g. `ReadIssue`, `send_reply`), never the hyphenated
+   style used for the Routine's own `slug`/`name`. An `agent` State's `agentRef` and a `tool` State's
+   `toolRef` are always an **object** `{ name, version }` (both strings; `id` optional) — never a bare
    string like `"joke-bot"`.
 3. Build one or more canonical `Trigger` documents. Each uses the same `metadata` rules as step 2
    (fresh `id`, matching `slug`, `lifecycle: published`). A Trigger is discriminated by

--- a/skills/forge/routine-forge/references/canonical-examples.md
+++ b/skills/forge/routine-forge/references/canonical-examples.md
@@ -1,0 +1,481 @@
+# Routine & Trigger Canonical Examples
+
+Every Routine and Trigger published to the Soul must conform to `apiVersion: tulipfarm.ai/v1`.
+
+## General Rules & Constraints
+
+- Routine and Trigger documents are separate canonical Soul definitions, committed together atomically via `routine_forge`.
+- `metadata.id`: fresh UUID (`8f14e...` / `11111111-1111-4111-8111-111111111111`).
+- `metadata.slug`: lowercase kebab-case (`^[a-z0-9]+(-[a-z0-9]+)*$`), matching the Routine or Trigger name.
+- `metadata.schemaVersion`: `1`
+- `metadata.authoredVersion`: `1` (integer, incremented when updating).
+- `metadata.lifecycle`: `"published"`
+- All State names (`start`, state `name`, `transition`, branch conditions `transition`, `body`, `forState`, etc.) must match `^[A-Za-z][A-Za-z0-9_]*$`: letters, digits, and underscores only (**no hyphens**). PascalCase or snake_case is standard.
+
+---
+
+## 1. Minimal Routine with Manual Trigger
+
+### Routine Document
+```yaml
+apiVersion: tulipfarm.ai/v1
+kind: Routine
+metadata:
+  id: 11111111-1111-4111-8111-111111111111
+  slug: daily-report
+  displayName: Daily Report Generation
+  schemaVersion: 1
+  authoredVersion: 1
+  lifecycle: published
+spec:
+  owner: operations
+  start: RunReport
+  states:
+    - name: RunReport
+      type: tool
+      toolRef:
+        name: record_search
+        version: "1"
+      action: record_search
+      input:
+        type: report
+      end: true
+```
+
+### Trigger Document
+```yaml
+apiVersion: tulipfarm.ai/v1
+kind: Trigger
+metadata:
+  id: 22222222-2222-4222-8222-222222222222
+  slug: daily-report-manual
+  displayName: Manual Trigger for Daily Report
+  schemaVersion: 1
+  authoredVersion: 1
+  lifecycle: published
+spec:
+  type: manual
+  routineRef:
+    name: daily-report
+    version: "1"
+  eventType: routine.manual
+  eventVersion: 1
+  backgroundIdentity:
+    principalKind: service
+    principalId: routine-runner
+  deduplication:
+    key: daily-report-manual
+```
+
+---
+
+## 2. Scheduled Cron Routine with Branching & Approvals
+
+### Routine Document
+```yaml
+apiVersion: tulipfarm.ai/v1
+kind: Routine
+metadata:
+  id: 33333333-3333-4333-8333-333333333333
+  slug: stale-ticket-sweep
+  displayName: Stale Ticket Sweep
+  schemaVersion: 1
+  authoredVersion: 1
+  lifecycle: published
+spec:
+  owner: support-ops
+  start: FindStaleTickets
+  states:
+    - name: FindStaleTickets
+      type: tool
+      toolRef:
+        name: record_search
+        version: "1"
+      action: record_search
+      input:
+        type: ticket
+        filter: "status == 'open' && updatedAt < now - 7d"
+      transition: EvaluateTickets
+
+    - name: EvaluateTickets
+      type: agent
+      agentRef:
+        name: support-triage
+        version: "1"
+      input:
+        tickets: "${states.FindStaleTickets.output.records}"
+      output:
+        type: object
+        required: [shouldClose, ticketIds, reason]
+        properties:
+          shouldClose:
+            type: boolean
+          ticketIds:
+            type: array
+            items:
+              type: string
+          reason:
+            type: string
+      transition: RouteDecision
+
+    - name: RouteDecision
+      type: branch
+      conditions:
+        - condition: "${states.EvaluateTickets.output.shouldClose} == true"
+          transition: RequestClosureApproval
+      default:
+        end: true
+
+    - name: RequestClosureApproval
+      type: approval
+      approverRoles:
+        - support-lead
+        - admin
+      transition: CloseStaleTickets
+
+    - name: CloseStaleTickets
+      type: tool
+      toolRef:
+        name: record_update
+        version: "1"
+      action: record_update
+      input:
+        type: ticket
+        ids: "${states.EvaluateTickets.output.ticketIds}"
+        patch:
+          status: closed
+          closureReason: "${states.EvaluateTickets.output.reason}"
+      end: true
+```
+
+### Cron Trigger Document
+```yaml
+apiVersion: tulipfarm.ai/v1
+kind: Trigger
+metadata:
+  id: 44444444-4444-4444-8444-444444444444
+  slug: stale-ticket-sweep-cron
+  displayName: Nightly Stale Ticket Sweep Cron
+  schemaVersion: 1
+  authoredVersion: 1
+  lifecycle: published
+spec:
+  type: cron
+  expression: "0 2 * * *"
+  timezone: "UTC"
+  routineRef:
+    name: stale-ticket-sweep
+    version: "1"
+  eventType: routine.cron
+  eventVersion: 1
+  backgroundIdentity:
+    principalKind: service
+    principalId: routine-runner
+  deduplication:
+    key: "stale-ticket-sweep-${scheduledTime}"
+  schedule:
+    missedRunPolicy: run_once
+    overlapPolicy: skip
+```
+
+---
+
+## 3. Webhook Triggered Automation
+
+### Routine Document
+```yaml
+apiVersion: tulipfarm.ai/v1
+kind: Routine
+metadata:
+  id: 55555555-5555-4555-8555-555555555555
+  slug: webhook-issue-triage
+  displayName: Webhook Issue Triage
+  schemaVersion: 1
+  authoredVersion: 1
+  lifecycle: published
+spec:
+  owner: engineering
+  start: ReadWebhookPayload
+  states:
+    - name: ReadWebhookPayload
+      type: tool
+      toolRef:
+        name: github.issue.read
+        version: "1.0.0"
+      action: github.issue.read
+      destination: github
+      credentialRef: secret://integrations/github/app
+      input:
+        repository: "${trigger.repository}"
+        issueNumber: "${trigger.issueNumber}"
+      transition: AnalyzeIssue
+
+    - name: AnalyzeIssue
+      type: agent
+      agentRef:
+        name: issue-classifier
+        version: "1"
+      input:
+        issue: "${states.ReadWebhookPayload.output}"
+      output:
+        type: object
+        required: [labels, reply]
+        properties:
+          labels:
+            type: array
+            items:
+              type: string
+          reply:
+            type: string
+      transition: ApplyLabels
+
+    - name: ApplyLabels
+      type: tool
+      toolRef:
+        name: github.issue.label
+        version: "1.0.0"
+      action: github.issue.label
+      destination: github
+      credentialRef: secret://integrations/github/app
+      input:
+        repository: "${trigger.repository}"
+        issueNumber: "${trigger.issueNumber}"
+        labels: "${states.AnalyzeIssue.output.labels}"
+      end: true
+```
+
+### Webhook Trigger Document
+```yaml
+apiVersion: tulipfarm.ai/v1
+kind: Trigger
+metadata:
+  id: 66666666-6666-4666-8666-666666666666
+  slug: github-issues-webhook
+  displayName: GitHub Issues Webhook Trigger
+  schemaVersion: 1
+  authoredVersion: 1
+  lifecycle: published
+spec:
+  type: webhook
+  provider: github
+  routineRef:
+    name: webhook-issue-triage
+    version: "1"
+  eventType: github.issues.opened
+  eventVersion: 1
+  verification:
+    method: hmac_sha256
+    secretRef: secret://integrations/github/webhook-secret
+    signatureHeader: X-Hub-Signature-256
+  backgroundIdentity:
+    principalKind: service
+    principalId: routine-runner
+  deduplication:
+    key: "github-issue-${trigger.deliveryId}"
+```
+
+---
+
+## 4. Interval Trigger Example
+
+```yaml
+apiVersion: tulipfarm.ai/v1
+kind: Trigger
+metadata:
+  id: 77777777-7777-4777-8777-777777777777
+  slug: sync-every-15m
+  displayName: Sync Every 15 Minutes
+  schemaVersion: 1
+  authoredVersion: 1
+  lifecycle: published
+spec:
+  type: interval
+  everyMs: 900000
+  routineRef:
+    name: daily-report
+    version: "1"
+  eventType: routine.interval
+  eventVersion: 1
+  backgroundIdentity:
+    principalKind: service
+    principalId: routine-runner
+  deduplication:
+    key: "daily-report-interval-${scheduledTime}"
+  schedule:
+    missedRunPolicy: skip
+    overlapPolicy: skip
+```
+
+---
+
+## 5. State Types Reference & Patterns
+
+### `tool`
+Calls an exposed or platform tool:
+```yaml
+name: SendNotification
+type: tool
+toolRef:
+  name: send_slack_message
+  version: "1"
+action: send_slack_message
+input:
+  channel: "#general"
+  text: "Routine completed."
+end: true
+```
+
+### `agent`
+Delegates structured reasoning to an Agent:
+```yaml
+name: TriageStep
+type: agent
+agentRef:
+  name: triage-agent
+  version: "1"
+input:
+  summary: "${states.FetchStep.output}"
+output:
+  type: object
+  required: [priority]
+  properties:
+    priority:
+      type: string
+      enum: [low, medium, high]
+transition: NextStep
+```
+
+### `branch`
+Routes conditionally based on prior state output:
+```yaml
+name: CheckPriority
+type: branch
+conditions:
+  - condition: "${states.TriageStep.output.priority} == 'high'"
+    transition: EscalateImmediately
+  - condition: "${states.TriageStep.output.priority} == 'medium'"
+    transition: StandardNotification
+default:
+  transition: LogLowPriority
+```
+
+### `approval`
+Gated human authorization step:
+```yaml
+name: AwaitApproval
+type: approval
+approverRoles:
+  - ops-lead
+  - admin
+transition: DeployChanges
+```
+
+### `wait`
+Durable timer or external event pause:
+```yaml
+name: DelayOneHour
+type: wait
+waitFor:
+  kind: timer
+  durationMs: 3600000
+transition: NextCheck
+```
+
+### `foreach`
+Fan-out across an array of items:
+```yaml
+name: ProcessBatch
+type: foreach
+items: "${states.FindRecords.output.items}"
+body: ProcessSingleRecord
+maxItems: 100
+maxConcurrency: 5
+transition: SummaryStep
+```
+
+### Error Handling & Retries
+```yaml
+name: ResilientStep
+type: tool
+toolRef:
+  name: record_search
+  version: "1"
+action: record_search
+input:
+  type: ticket
+retry:
+  maxAttempts: 3
+  backoffMs: 1000
+  multiplier: 2
+onError:
+  - errorRef: RateLimitError
+    transition: DelayAndRetry
+  - errorRef: "*"
+    end: true
+transition: NextState
+```
+
+---
+
+## 6. How to Invoke `routine_forge`
+
+Pass the routine `name`, the canonical Routine as `definition`, and all Triggers in the `triggers` array:
+
+```json
+{
+  "name": "daily-report",
+  "definition": {
+    "apiVersion": "tulipfarm.ai/v1",
+    "kind": "Routine",
+    "metadata": {
+      "id": "11111111-1111-4111-8111-111111111111",
+      "slug": "daily-report",
+      "displayName": "Daily Report",
+      "schemaVersion": 1,
+      "authoredVersion": 1,
+      "lifecycle": "published"
+    },
+    "spec": {
+      "owner": "operations",
+      "start": "RunReport",
+      "states": [
+        {
+          "name": "RunReport",
+          "type": "tool",
+          "toolRef": { "name": "record_search", "version": "1" },
+          "action": "record_search",
+          "input": { "type": "report" },
+          "end": true
+        }
+      ]
+    }
+  },
+  "triggers": [
+    {
+      "apiVersion": "tulipfarm.ai/v1",
+      "kind": "Trigger",
+      "metadata": {
+        "id": "22222222-2222-4222-8222-222222222222",
+        "slug": "daily-report-manual",
+        "displayName": "Manual Trigger",
+        "schemaVersion": 1,
+        "authoredVersion": 1,
+        "lifecycle": "published"
+      },
+      "spec": {
+        "type": "manual",
+        "routineRef": { "name": "daily-report", "version": "1" },
+        "eventType": "routine.manual",
+        "eventVersion": 1,
+        "backgroundIdentity": {
+          "principalKind": "service",
+          "principalId": "routine-runner"
+        },
+        "deduplication": {
+          "key": "daily-report-manual"
+        }
+      }
+    }
+  ]
+}
+```

--- a/skills/forge/routine-forge/references/examples.md
+++ b/skills/forge/routine-forge/references/examples.md
@@ -1,0 +1,481 @@
+# Routine & Trigger Canonical Examples
+
+Every Routine and Trigger published to the Soul must conform to `apiVersion: tulipfarm.ai/v1`.
+
+## General Rules & Constraints
+
+- Routine and Trigger documents are separate canonical Soul definitions, committed together atomically via `routine_forge`.
+- `metadata.id`: fresh UUID (`8f14e...` / `11111111-1111-4111-8111-111111111111`).
+- `metadata.slug`: lowercase kebab-case (`^[a-z0-9]+(-[a-z0-9]+)*$`), matching the Routine or Trigger name.
+- `metadata.schemaVersion`: `1`
+- `metadata.authoredVersion`: `1` (integer, incremented when updating).
+- `metadata.lifecycle`: `"published"`
+- All State names (`start`, state `name`, `transition`, branch conditions `transition`, `body`, `forState`, etc.) must match `^[A-Za-z][A-Za-z0-9_]*$`: letters, digits, and underscores only (**no hyphens**). PascalCase or snake_case is standard.
+
+---
+
+## 1. Minimal Routine with Manual Trigger
+
+### Routine Document
+```yaml
+apiVersion: tulipfarm.ai/v1
+kind: Routine
+metadata:
+  id: 11111111-1111-4111-8111-111111111111
+  slug: daily-report
+  displayName: Daily Report Generation
+  schemaVersion: 1
+  authoredVersion: 1
+  lifecycle: published
+spec:
+  owner: operations
+  start: RunReport
+  states:
+    - name: RunReport
+      type: tool
+      toolRef:
+        name: record_search
+        version: "1"
+      action: record_search
+      input:
+        type: report
+      end: true
+```
+
+### Trigger Document
+```yaml
+apiVersion: tulipfarm.ai/v1
+kind: Trigger
+metadata:
+  id: 22222222-2222-4222-8222-222222222222
+  slug: daily-report-manual
+  displayName: Manual Trigger for Daily Report
+  schemaVersion: 1
+  authoredVersion: 1
+  lifecycle: published
+spec:
+  type: manual
+  routineRef:
+    name: daily-report
+    version: "1"
+  eventType: routine.manual
+  eventVersion: 1
+  backgroundIdentity:
+    principalKind: service
+    principalId: routine-runner
+  deduplication:
+    key: daily-report-manual
+```
+
+---
+
+## 2. Scheduled Cron Routine with Branching & Approvals
+
+### Routine Document
+```yaml
+apiVersion: tulipfarm.ai/v1
+kind: Routine
+metadata:
+  id: 33333333-3333-4333-8333-333333333333
+  slug: stale-ticket-sweep
+  displayName: Stale Ticket Sweep
+  schemaVersion: 1
+  authoredVersion: 1
+  lifecycle: published
+spec:
+  owner: support-ops
+  start: FindStaleTickets
+  states:
+    - name: FindStaleTickets
+      type: tool
+      toolRef:
+        name: record_search
+        version: "1"
+      action: record_search
+      input:
+        type: ticket
+        filter: "status == 'open' && updatedAt < now - 7d"
+      transition: EvaluateTickets
+
+    - name: EvaluateTickets
+      type: agent
+      agentRef:
+        name: support-triage
+        version: "1"
+      input:
+        tickets: "${states.FindStaleTickets.output.records}"
+      output:
+        type: object
+        required: [shouldClose, ticketIds, reason]
+        properties:
+          shouldClose:
+            type: boolean
+          ticketIds:
+            type: array
+            items:
+              type: string
+          reason:
+            type: string
+      transition: RouteDecision
+
+    - name: RouteDecision
+      type: branch
+      conditions:
+        - condition: "${states.EvaluateTickets.output.shouldClose} == true"
+          transition: RequestClosureApproval
+      default:
+        end: true
+
+    - name: RequestClosureApproval
+      type: approval
+      approverRoles:
+        - support-lead
+        - admin
+      transition: CloseStaleTickets
+
+    - name: CloseStaleTickets
+      type: tool
+      toolRef:
+        name: record_update
+        version: "1"
+      action: record_update
+      input:
+        type: ticket
+        ids: "${states.EvaluateTickets.output.ticketIds}"
+        patch:
+          status: closed
+          closureReason: "${states.EvaluateTickets.output.reason}"
+      end: true
+```
+
+### Cron Trigger Document
+```yaml
+apiVersion: tulipfarm.ai/v1
+kind: Trigger
+metadata:
+  id: 44444444-4444-4444-8444-444444444444
+  slug: stale-ticket-sweep-cron
+  displayName: Nightly Stale Ticket Sweep Cron
+  schemaVersion: 1
+  authoredVersion: 1
+  lifecycle: published
+spec:
+  type: cron
+  expression: "0 2 * * *"
+  timezone: "UTC"
+  routineRef:
+    name: stale-ticket-sweep
+    version: "1"
+  eventType: routine.cron
+  eventVersion: 1
+  backgroundIdentity:
+    principalKind: service
+    principalId: routine-runner
+  deduplication:
+    key: "stale-ticket-sweep-${scheduledTime}"
+  schedule:
+    missedRunPolicy: run_once
+    overlapPolicy: skip
+```
+
+---
+
+## 3. Webhook Triggered Automation
+
+### Routine Document
+```yaml
+apiVersion: tulipfarm.ai/v1
+kind: Routine
+metadata:
+  id: 55555555-5555-4555-8555-555555555555
+  slug: webhook-issue-triage
+  displayName: Webhook Issue Triage
+  schemaVersion: 1
+  authoredVersion: 1
+  lifecycle: published
+spec:
+  owner: engineering
+  start: ReadWebhookPayload
+  states:
+    - name: ReadWebhookPayload
+      type: tool
+      toolRef:
+        name: github.issue.read
+        version: "1.0.0"
+      action: github.issue.read
+      destination: github
+      credentialRef: secret://integrations/github/app
+      input:
+        repository: "${trigger.repository}"
+        issueNumber: "${trigger.issueNumber}"
+      transition: AnalyzeIssue
+
+    - name: AnalyzeIssue
+      type: agent
+      agentRef:
+        name: issue-classifier
+        version: "1"
+      input:
+        issue: "${states.ReadWebhookPayload.output}"
+      output:
+        type: object
+        required: [labels, reply]
+        properties:
+          labels:
+            type: array
+            items:
+              type: string
+          reply:
+            type: string
+      transition: ApplyLabels
+
+    - name: ApplyLabels
+      type: tool
+      toolRef:
+        name: github.issue.label
+        version: "1.0.0"
+      action: github.issue.label
+      destination: github
+      credentialRef: secret://integrations/github/app
+      input:
+        repository: "${trigger.repository}"
+        issueNumber: "${trigger.issueNumber}"
+        labels: "${states.AnalyzeIssue.output.labels}"
+      end: true
+```
+
+### Webhook Trigger Document
+```yaml
+apiVersion: tulipfarm.ai/v1
+kind: Trigger
+metadata:
+  id: 66666666-6666-4666-8666-666666666666
+  slug: github-issues-webhook
+  displayName: GitHub Issues Webhook Trigger
+  schemaVersion: 1
+  authoredVersion: 1
+  lifecycle: published
+spec:
+  type: webhook
+  provider: github
+  routineRef:
+    name: webhook-issue-triage
+    version: "1"
+  eventType: github.issues.opened
+  eventVersion: 1
+  verification:
+    method: hmac_sha256
+    secretRef: secret://integrations/github/webhook-secret
+    signatureHeader: X-Hub-Signature-256
+  backgroundIdentity:
+    principalKind: service
+    principalId: routine-runner
+  deduplication:
+    key: "github-issue-${trigger.deliveryId}"
+```
+
+---
+
+## 4. Interval Trigger Example
+
+```yaml
+apiVersion: tulipfarm.ai/v1
+kind: Trigger
+metadata:
+  id: 77777777-7777-4777-8777-777777777777
+  slug: sync-every-15m
+  displayName: Sync Every 15 Minutes
+  schemaVersion: 1
+  authoredVersion: 1
+  lifecycle: published
+spec:
+  type: interval
+  everyMs: 900000
+  routineRef:
+    name: daily-report
+    version: "1"
+  eventType: routine.interval
+  eventVersion: 1
+  backgroundIdentity:
+    principalKind: service
+    principalId: routine-runner
+  deduplication:
+    key: "daily-report-interval-${scheduledTime}"
+  schedule:
+    missedRunPolicy: skip
+    overlapPolicy: skip
+```
+
+---
+
+## 5. State Types Reference & Patterns
+
+### `tool`
+Calls an exposed or platform tool:
+```yaml
+name: SendNotification
+type: tool
+toolRef:
+  name: send_slack_message
+  version: "1"
+action: send_slack_message
+input:
+  channel: "#general"
+  text: "Routine completed."
+end: true
+```
+
+### `agent`
+Delegates structured reasoning to an Agent:
+```yaml
+name: TriageStep
+type: agent
+agentRef:
+  name: triage-agent
+  version: "1"
+input:
+  summary: "${states.FetchStep.output}"
+output:
+  type: object
+  required: [priority]
+  properties:
+    priority:
+      type: string
+      enum: [low, medium, high]
+transition: NextStep
+```
+
+### `branch`
+Routes conditionally based on prior state output:
+```yaml
+name: CheckPriority
+type: branch
+conditions:
+  - condition: "${states.TriageStep.output.priority} == 'high'"
+    transition: EscalateImmediately
+  - condition: "${states.TriageStep.output.priority} == 'medium'"
+    transition: StandardNotification
+default:
+  transition: LogLowPriority
+```
+
+### `approval`
+Gated human authorization step:
+```yaml
+name: AwaitApproval
+type: approval
+approverRoles:
+  - ops-lead
+  - admin
+transition: DeployChanges
+```
+
+### `wait`
+Durable timer or external event pause:
+```yaml
+name: DelayOneHour
+type: wait
+waitFor:
+  kind: timer
+  durationMs: 3600000
+transition: NextCheck
+```
+
+### `foreach`
+Fan-out across an array of items:
+```yaml
+name: ProcessBatch
+type: foreach
+items: "${states.FindRecords.output.items}"
+body: ProcessSingleRecord
+maxItems: 100
+maxConcurrency: 5
+transition: SummaryStep
+```
+
+### Error Handling & Retries
+```yaml
+name: ResilientStep
+type: tool
+toolRef:
+  name: record_search
+  version: "1"
+action: record_search
+input:
+  type: ticket
+retry:
+  maxAttempts: 3
+  backoffMs: 1000
+  multiplier: 2
+onError:
+  - errorRef: RateLimitError
+    transition: DelayAndRetry
+  - errorRef: "*"
+    end: true
+transition: NextState
+```
+
+---
+
+## 6. How to Invoke `routine_forge`
+
+Pass the routine `name`, the canonical Routine as `definition`, and all Triggers in the `triggers` array:
+
+```json
+{
+  "name": "daily-report",
+  "definition": {
+    "apiVersion": "tulipfarm.ai/v1",
+    "kind": "Routine",
+    "metadata": {
+      "id": "11111111-1111-4111-8111-111111111111",
+      "slug": "daily-report",
+      "displayName": "Daily Report",
+      "schemaVersion": 1,
+      "authoredVersion": 1,
+      "lifecycle": "published"
+    },
+    "spec": {
+      "owner": "operations",
+      "start": "RunReport",
+      "states": [
+        {
+          "name": "RunReport",
+          "type": "tool",
+          "toolRef": { "name": "record_search", "version": "1" },
+          "action": "record_search",
+          "input": { "type": "report" },
+          "end": true
+        }
+      ]
+    }
+  },
+  "triggers": [
+    {
+      "apiVersion": "tulipfarm.ai/v1",
+      "kind": "Trigger",
+      "metadata": {
+        "id": "22222222-2222-4222-8222-222222222222",
+        "slug": "daily-report-manual",
+        "displayName": "Manual Trigger",
+        "schemaVersion": 1,
+        "authoredVersion": 1,
+        "lifecycle": "published"
+      },
+      "spec": {
+        "type": "manual",
+        "routineRef": { "name": "daily-report", "version": "1" },
+        "eventType": "routine.manual",
+        "eventVersion": 1,
+        "backgroundIdentity": {
+          "principalKind": "service",
+          "principalId": "routine-runner"
+        },
+        "deduplication": {
+          "key": "daily-report-manual"
+        }
+      }
+    }
+  ]
+}
+```


### PR DESCRIPTION
## Summary

Fixes the issues where:
1. The model invoked `load_skill_reference` for `routine-forge` with `examples.md` and `canonical-examples.md` (as instructed by `routine_forge` tool description), but received `Reference "examples.md" not found for skill "routine-forge"` because no reference documents existed and `.gitignore` was ignoring `references/` directories.
2. In the absence of canonical examples, the model guessed schema shapes such as formatting `spec.states` as a dictionary/map rather than an array of State objects, triggering `Schema validation failed for tulipfarm.ai/v1/Routine at /spec/states: must be array`.

## Key Changes

- **Canonical Reference Documents**: Added `skills/forge/routine-forge/references/examples.md` and `canonical-examples.md` containing complete, valid canonical examples for Routine and Trigger definitions across various triggers (manual, cron, interval, webhook), state types (tool, agent, branch, approval, wait, foreach, onError, retry), and `routine_forge` payload structure.
- **Skill Documentation & Scoping**: Updated `skills/forge/routine-forge/SKILL.md` to include `load_skill_reference` in `tools:` frontmatter, document reference loading via `load_skill_reference`, and explicitly emphasize that `spec.states` must be a JSON array of State objects.
- **Tool Narrowing Baseline**: Added `load_skill_reference` to `ALWAYS_EXPOSED_TOOL_NAMES` in `packages/agent-runtime/src/loop/narrowing.ts` so that once a skill is active, the agent can always reach its companion reference materials without being narrowed away.
- **Tool Schema & Description**: Clarified in `apps/api/src/platform/tools.ts` that `definition.spec.states` must be an array of State objects.
- **Git Ignore Fix**: Updated `.gitignore` so that bundled skill `references/` directories are not ignored by the top-level references rule.
- **Test Coverage**: Added test coverage in `packages/soul/src/skills/bundled.test.ts`, `packages/agent-runtime/src/loop/loop.test.ts`, and `apps/api/src/platform/tools.test.ts`.

## Test Plan

- [x] `pnpm exec biome check .` — passed with 0 errors
- [x] `pnpm --filter @tulipfarm/soul --filter @tulipfarm/agent-runtime --filter @tulipfarm/api typecheck` — passed clean
- [x] `pnpm --filter @tulipfarm/soul test` — 43 files passed, 606 tests passed
- [x] `pnpm --filter @tulipfarm/agent-runtime test` — 21 files passed, 380 tests passed
- [x] `pnpm --filter @tulipfarm/api test src/platform/tools.test.ts src/platform/forge-tool.test.ts` — 2 files passed, 50 tests passed