### PR TITLE
fix(chat): prevent full page scroll during response loading (#69)

### DIFF
--- a/apps/web/app/components/app-sidebar.tsx
+++ b/apps/web/app/components/app-sidebar.tsx
@@ -515,14 +515,14 @@ export function AppShell({ children, user }: { children: ReactNode; user?: Sessi
   }
 
   return (
-    <div className="flex min-h-svh bg-background lg:h-svh lg:overflow-hidden">
+    <div className="flex h-svh overflow-hidden bg-background">
       <AppSidebar
         open={open}
         onClose={() => setOpen(false)}
         collapsed={collapsed}
         navigation={user?.navigation}
       />
-      <div className="flex min-w-0 flex-1 flex-col lg:h-svh">
+      <div className="flex h-svh min-w-0 flex-1 flex-col">
         <header
           className={cn(HEADER_ROW, "gap-2 border-b border-border bg-background px-3 sm:px-4")}
         >

--- a/apps/web/app/components/chat/chat-panel.tsx
+++ b/apps/web/app/components/chat/chat-panel.tsx
@@ -28,7 +28,7 @@ function EmptyState({
   onPick: (text: string) => void;
 }) {
   return (
-    <div className="flex flex-1 overflow-y-auto">
+    <div className="flex flex-1 min-h-0 overflow-y-auto">
       <section className="mx-auto flex w-full max-w-4xl flex-col justify-start gap-7 px-4 py-8 sm:px-6 sm:py-14 md:justify-center">
         <div className="grid gap-7 motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-2 motion-safe:duration-500 md:grid-cols-[minmax(0,1fr)_12rem] md:items-end">
           <div>
@@ -135,7 +135,7 @@ export function ChatPanel({
   const errorCta = status === "error" ? errorAction(error) : null;
 
   return (
-    <div className="flex h-[calc(100svh-3.25rem)] flex-col lg:h-full">
+    <div className="flex h-full min-h-0 flex-col overflow-hidden">
       {/* The top bar names the conversation, so this strip only says what it can't: which Agent is
           driving the chat. Without an Agent there is nothing left to show and it collapses away. */}
       {hasMessages && activeAgentName ? (

--- a/apps/web/app/components/chat/transcript.tsx
+++ b/apps/web/app/components/chat/transcript.tsx
@@ -452,7 +452,7 @@ export function Transcript({
   }, [messages, status]);
 
   return (
-    <div ref={scrollRef} onScroll={onScroll} className="flex-1 overflow-y-auto">
+    <div ref={scrollRef} onScroll={onScroll} className="flex-1 min-h-0 overflow-y-auto">
       <div className="mx-auto flex w-full max-w-4xl flex-col gap-7 px-4 py-7 sm:px-6 sm:py-9">
         {messages.map((m, i) => (
           <Message

--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -97,13 +97,13 @@ export default function App() {
 export function HydrateFallback() {
   return (
     <Document>
-      <div className="flex min-h-svh bg-background lg:h-svh lg:overflow-hidden">
+      <div className="flex h-svh overflow-hidden bg-background">
         <div className="hidden shrink-0 border-sidebar-border border-r md:block md:w-14 lg:w-[var(--shell-sidebar-width)]">
           <div className="flex h-[52px] items-center justify-center border-sidebar-border border-b">
             <span className="size-6 rounded-md bg-muted" />
           </div>
         </div>
-        <div className="flex min-w-0 flex-1 flex-col lg:h-svh">
+        <div className="flex h-svh min-w-0 flex-1 flex-col">
           <div className="flex h-[52px] shrink-0 items-center gap-2 border-border border-b px-3 sm:px-4">
             <span className="size-9 rounded-md bg-muted" />
             <span className="h-4 w-32 rounded-sm bg-muted" />


### PR DESCRIPTION
Closes #69

- Fixes transcript container and chat layout overflow styling to prevent page-level scroll.
- Keeps scrolling contained to the chat message transcript.