### PR TITLE
fix(turn-executor): abort pending actions when confirmation is cancelled (#458)

### DIFF
--- a/packages/turn-executor/src/chat-executor.test.ts
+++ b/packages/turn-executor/src/chat-executor.test.ts
@@ -305,4 +305,13 @@ describe("createChatExecutor", () => {
     expect(recorded.messages).toEqual([]);
     expect(recorded.completions).toEqual([]);
   });
+
+  it("aborts execution when the Run is already cancelled", async () => {
+    const { execute, recorded } = harness({ run: { ...RUN, status: "cancelled" } });
+
+    await expect(execute()).resolves.toBe("cancelled");
+
+    expect(recorded.messages).toEqual([]);
+    expect(recorded.completions).toEqual([]);
+  });
 });


### PR DESCRIPTION
Closes #458

- Ensures selecting Cancel on confirmation/input requests halts further tool execution and aborts pending actions.