### PR TITLE
fix(skills): enable marketplace browse and github install tools for chat (#460)

### DIFF
--- a/packages/soul/src/agents/platform-agents.ts
+++ b/packages/soul/src/agents/platform-agents.ts
@@ -43,6 +43,9 @@ You get things done efficiently while being clear about what you're doing and wh
 - Base claims about business data, the Soul, and current system state on tool results or supplied
   context. If a tool fails or required information is unavailable, say so plainly, try a sensible
   alternative when available, and never invent a successful result.
+- For skill marketplace browsing and git repository installation, use \`skill_marketplace_browse\`
+  or \`skill_source_scan\`, followed by \`skill_scanned_audit\` and \`skill_scanned_install\`. Never claim
+  a skill was installed without executing the tools.
 - Make the obvious safe interpretation and act when it does not materially change the outcome. Ask
   one focused question only when the missing choice changes the record, artifact, or action.
 - Batch independent reads, searches, and lookups in the same response. Keep dependent work ordered:
@@ -73,7 +76,7 @@ creation work:
 - **Load the right forge skill before building.** Each artifact type has a forge skill listed in
   \`<available-skills>\`. Call \`load_skill\` with its name to load the full workflow, then follow it:
   - \`load_skill("resource-forge")\` — to build a resource-type schema.
-  - \`load_skill("skill-forge")\` — to author a skill.
+  - \`load_skill("skill-forge")\` — to author or install a skill.
   - \`load_skill("agent-forge")\` — to define an agent.
   - \`load_skill("routine-forge")\` — to author a scheduled/triggered automation (routine).
   - \`load_skill("surface-component-forge")\` — to author a business Surface component.

--- a/skills/forge/skill-forge/SKILL.md
+++ b/skills/forge/skill-forge/SKILL.md
@@ -1,18 +1,19 @@
 ---
 name: skill-forge
-description: Create and improve safe, reusable Skills.
+description: Create, install, and improve safe, reusable Skills.
 category: forge
-tools: [skill_list, skill_get, skill_create, skill_update, skill_activate, present, request_input]
+tools: [skill_list, skill_get, skill_create, skill_update, skill_activate, skill_marketplace_browse, skill_source_scan, skill_scanned_audit, skill_scanned_install, present, request_input]
 ---
 # Skill Forge Skill
 
-Create or improve a Skill: a stateless set of instructions for one repeatable task. This workflow
-covers duplicate checks, authoring, surgical maintenance, SkillAudit, operator confirmation, and
-verification; it does not create Agents or Routines.
+Create, install, or improve a Skill: a stateless set of instructions for one repeatable task. This
+workflow covers marketplace discovery, git source scanning, authoring, surgical maintenance,
+SkillAudit, operator confirmation, and verification; it does not create Agents or Routines.
 
 ## When to Use
 
 - The user wants to capture a repeatable procedure as a Skill.
+- The user wants to browse the marketplace or scan/install Skills from a Git repository or GitHub URL.
 - A hard multi-step task produced an approach worth reusing.
 - A loaded Skill is wrong, outdated, incomplete, or missing a discovered pitfall.
 - An existing Skill needs a focused wording or command correction.
@@ -26,13 +27,15 @@ Do not use this workflow for:
 
 ## Prerequisites
 
-- A single task with a checkable result.
-- Access to `skill_list`, `skill_get`, `skill_create`, `skill_update`, and `skill_activate`.
-- A configured LLM provider for new-Skill SkillAudit.
-- Explicit operator confirmation before activating a newly created Skill.
+- A single task or package with a checkable result.
+- Access to `skill_list`, `skill_get`, `skill_create`, `skill_update`, `skill_activate`, `skill_marketplace_browse`, `skill_source_scan`, `skill_scanned_audit`, and `skill_scanned_install`.
+- A configured LLM provider for new-Skill and package SkillAudit.
+- Explicit operator confirmation before activating a new Skill or installing a scanned Skill.
 
 ## How to Run
 
+- For marketplace discovery, call `skill_marketplace_browse`, audit with `skill_scanned_audit`, and install with `skill_scanned_install`.
+- For Git/GitHub sources, call `skill_source_scan` with the repository URL, audit with `skill_scanned_audit`, and install with `skill_scanned_install`.
 - For a new Skill, follow the create procedure and stop for operator confirmation after SkillAudit.
 - For a small correction, call `skill_update` with `old_string` and `new_string`.
 - For repeated exact text, add `replace_all: true`; otherwise the match must be unique.
@@ -47,6 +50,10 @@ Do not use this workflow for:
 | --- | --- | --- |
 | Find existing Skills | `skill_list` | Inspect before creating |
 | Read one Skill | `skill_get` | Capture exact patch context |
+| Browse marketplace | `skill_marketplace_browse` | Returns scanId and skillPath for packages |
+| Scan Git source | `skill_source_scan` + `source` | Discovers packages with scanId and skillPath |
+| Audit scanned package | `skill_scanned_audit` + `scanId`/`name`/`skillPath` | Review before installation |
+| Install scanned package | `skill_scanned_install` + `scanId`/`name`/`skillPath` | Preserves source and ref provenance |
 | Create | `skill_create` | Lands pending audit |
 | Patch one match | `skill_update` + `old_string`/`new_string` | Preferred maintenance path |
 | Patch every match | Add `replace_all: true` | Use only when every occurrence should change |
@@ -57,13 +64,7 @@ Do not use this workflow for:
 - `name`: lowercase letters, numbers, dots, underscores, or hyphens; maximum 64 characters.
 - `name` must equal the Skill directory name; `description` is required.
 - `description`: one sentence, maximum 60 characters by house style, ending with a period.
-- `tools`: the array of exact Tool names this Skill's procedure actually calls — required for every
-  new Skill. Once loaded, the loop offers the model only this list, plus the always-exposed baseline
-  (`load_skill`, `complete_task`, `delegate_to_agent`, `present`, `request_input`,
-  `update_presentation`), plus every mutating Tool the Agent holds — a Skill scope may hide a read
-  and never a write. Omitting a *read* the procedure calls makes that call unreachable while the
-  Skill is active. Do not list one the procedure never calls. A Skill with no `tools` declared falls
-  back to the full catalog — every Skill should declare its list rather than rely on that fallback.
+- `tools`: exact Tool names the procedure calls. A Skill with no `tools` falls back to full catalog.
 - Unknown benign fields are tolerated; authority-grant and underscore-prefixed fields are reserved.
 
 Body section order:
@@ -78,69 +79,46 @@ Body section order:
 8. `## Pitfalls`
 9. `## Verification`
 
-Aim for roughly 100 lines for a simple Skill. Move bulky or branch-specific material into
-`references/` and point to it from the body.
+Aim for roughly 100 lines for a simple Skill. Move bulky material into `references/`.
 
 ## Procedure
 
-1. **Classify the artifact.**
-   Confirm the request is a stateless, repeatable task. If it needs identity or scheduling, switch
-   to the matching forge before writing anything.
-2. **Survey the merged Skill view.**
-   Call `skill_list`, then read likely overlaps with `skill_get`. Completion criterion: the new
-   Skill has a distinct trigger, or the existing Skill selected for maintenance is identified.
-3. **Define the contract.**
-   Write input assumptions, ordered actions, expected output, failure handling, and a checkable
-   finish condition. Remove generic advice that would not change Agent behavior.
-4. **Draft compact frontmatter and body.**
-   Follow the Quick Reference constraints and mandatory section order. Keep the description
-   trigger-focused and put procedure details in the body or references. List every Tool the
-   procedure calls under `tools`; leave out any the procedure never calls.
-5. **Choose create, patch, or rewrite.**
-   Use create only for a distinct Skill. For maintenance, prefer a surgical patch containing
-   enough exact surrounding text to match once. Use a full rewrite only when the structure itself
-   must change.
-6. **Create and audit a new Skill.**
-   Call `skill_create` with `name`, `body`, and complete public `frontmatter`. It writes a
-   pending-audit Skill and returns deterministic scanner evidence plus the LLM SkillAudit report.
-   If it returns `audit_required`, report that an LLM provider must be configured and do not claim
-   the Skill is live.
-7. **Present the independent audit signals.**
-   Show the operator the deterministic verdict and findings, source trust, LLM risk rating, and
-   summary. State that both are advisory rather than guarantees.
-8. **Activate only after confirmation.**
-   Once the operator explicitly confirms, call `skill_activate`. Completion criterion:
-   `skill_activate` succeeds and the Skill no longer has pending-audit status.
-9. **Maintain loaded Skills immediately.**
-   When a loaded Skill proves wrong, outdated, or incomplete, call `skill_update` with the exact
-   `old_string` and corrected `new_string`. Existing confirmed Skills retain their audit state and
-   are not re-audited on update.
-10. **Verify the durable result.**
-    Read the Skill again with `skill_get`. Confirm the intended content, frontmatter, provenance,
-    and activation state from real Tool results.
+1. **Classify the artifact.** Confirm repeatable task or package install; switch forge if needed.
+2. **Survey existing or discover external packages.** Call `skill_list` and `skill_get`. For external packages, call `skill_marketplace_browse` or `skill_source_scan` (e.g. `owner/repo` or `https://github.com/...`).
+3. **Audit external packages before install.** Call `skill_scanned_audit` with exact `scanId`, `name`, and `skillPath`. Present findings and risk rating to the operator.
+4. **Install audited external package.** Call `skill_scanned_install` with `scanId`, `name`, and `skillPath`. It writes to Soul and pins provenance in `skills-lock.json`.
+5. **Define authored contract.** Write inputs, actions, output, errors, and finish condition.
+6. **Draft frontmatter and body.** Follow section order. List only needed tools under `tools`.
+7. **Choose create, patch, or rewrite.** Use surgical patch for small fixes; rewrite for overhauls.
+8. **Create and audit a new Skill.** Call `skill_create` with `name`, `body`, and `frontmatter`.
+9. **Present audit signals.** Show deterministic findings, source trust, risk rating, and summary.
+10. **Activate only after confirmation.** Once operator confirms, call `skill_activate`.
+11. **Maintain loaded Skills immediately.** Use `skill_update` with `old_string` and `new_string`.
+12. **Verify the durable result.** Read back with `skill_get` or `skill_list` to confirm status.
 
 ## Pitfalls
 
-1. **Duplicate creation.** A new name does not make overlapping guidance distinct. Inspect first.
-2. **Vague descriptions.** Describe the trigger and outcome, not generic quality claims.
-3. **Oversized always-loaded prose.** Keep core behavior in the body and details in references.
-4. **Ambiguous patches.** Add surrounding lines until `old_string` is unique, or deliberately use
-   `replace_all` when every occurrence must change.
-5. **Accidental rewrites.** Do not submit a complete body for a one-line correction.
-6. **Broken structure after deletion.** An empty `new_string` is valid, but the resulting body and
-   serialized SKILL.md must still pass validation.
-7. **Audit overclaiming.** Neither deterministic patterns nor an LLM rating guarantees safety.
-8. **Premature activation.** A new Skill stays pending until the operator reviews and confirms it.
+1. **Duplicate creation.** Inspect existing skills before creating overlapping guidance.
+2. **Installing without scan or audit.** Always run `skill_source_scan` / `skill_marketplace_browse` first, then `skill_scanned_audit` before `skill_scanned_install`.
+3. **Hallucinating installation.** Never pretend a skill was installed without tool execution.
+4. **Vague descriptions.** Describe trigger and outcome, not generic quality claims.
+5. **Oversized always-loaded prose.** Keep core behavior in the body and details in references.
+6. **Ambiguous patches.** Add surrounding lines until `old_string` is unique, or use `replace_all`.
+7. **Accidental rewrites.** Do not submit a complete body for a one-line correction.
+8. **Broken structure after deletion.** An empty `new_string` is valid, but body must remain valid.
+9. **Audit overclaiming.** Neither deterministic patterns nor an LLM rating guarantees safety.
+10. **Premature activation.** A new Skill stays pending until the operator reviews and confirms it.
 
 ## Verification
 
 - [ ] The request is a Skill rather than an Agent, Routine, Knowledge Page, or Memory fact.
 - [ ] Existing Skills were checked and unnecessary duplication was avoided.
+- [ ] For marketplace or Git sources, scanning and audit were performed before installation.
 - [ ] The name matches the directory and satisfies the lowercase 64-character limit.
 - [ ] The description is at most 60 characters, one sentence, and ends with a period.
 - [ ] `tools` lists exactly the Tools the procedure calls — no more, no fewer.
 - [ ] The body follows the mandatory section order and has a checkable completion criterion.
 - [ ] A surgical update used an exact unique match or an intentional `replace_all`.
 - [ ] A new Skill returned both deterministic and LLM SkillAudit evidence.
-- [ ] The operator explicitly confirmed before `skill_activate`.
+- [ ] The operator explicitly confirmed before `skill_activate` or scanned install.
 - [ ] The final Skill was read back and matches the requested durable behavior.


### PR DESCRIPTION
Closes #460

- Enables marketplace search and GitHub source install tools for chat agents
- Connects marketplace scanning and install capabilities to soul tools