### PR TITLE
feat(integrations): add Jira Cloud integration

### DIFF
--- a/apps/api/src/tools/declarative/bundled-manifests.test.ts
+++ b/apps/api/src/tools/declarative/bundled-manifests.test.ts
@@ -45,6 +45,7 @@ describe("bundled integrations", () => {
       "google",
       "google-docs",
       "google-drive",
+      "jira",
       "notion",
       "slack",
       "telegram",

--- a/apps/api/src/tools/declarative/jira.test.ts
+++ b/apps/api/src/tools/declarative/jira.test.ts
@@ -1,0 +1,94 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { SecretsService } from "@tulipfarm/secrets";
+import type { IntegrationManifest, SoulIntegration } from "@tulipfarm/soul";
+import {
+  bundledIntegrationsDir,
+  validateAuthSteps,
+  validateThirdPartyManifest,
+} from "@tulipfarm/soul";
+import { MemoryEffectStore } from "@tulipfarm/tool-broker";
+import { beforeAll, describe, expect, it } from "vitest";
+import { parse as parseYaml } from "yaml";
+import { buildDeclarativeTools } from "./tools";
+
+describe("jira bundled integration", () => {
+  let manifest: IntegrationManifest;
+  let spec: unknown;
+
+  beforeAll(async () => {
+    const dir = join(bundledIntegrationsDir(), "jira");
+    manifest = parseYaml(await readFile(join(dir, "manifest.yml"), "utf8")) as IntegrationManifest;
+    spec = parseYaml(await readFile(join(dir, "openapi.json"), "utf8"));
+  });
+
+  const integration = (): SoulIntegration =>
+    ({
+      slug: "jira",
+      sourceIntegration: "jira",
+      manifest,
+      egressSpec: spec,
+      connection: { enabled: true, env: { JIRA_CLOUD_ID: "cloud-123" } },
+    }) as SoulIntegration;
+
+  const build = () =>
+    buildDeclarativeTools([integration()], {
+      businessId: "biz",
+      effects: new MemoryEffectStore(),
+      secrets: async () => ({}) as SecretsService,
+      http: { send: async () => ({ status: 200, headers: {}, body: {} }) },
+    });
+
+  it("uses the declarative Jira Cloud gateway path", () => {
+    expect(manifest.egress?.type).toBe("openapi");
+    expect(manifest.egress?.type === "openapi" && manifest.egress.base_url).toBe(
+      "https://api.atlassian.com/ex/jira/{JIRA_CLOUD_ID}/rest/api/3"
+    );
+  });
+
+  it("passes the same trust and connect-flow checks as a third-party manifest", () => {
+    expect(validateThirdPartyManifest(manifest)).toEqual([]);
+    expect(validateAuthSteps(manifest)).toEqual([]);
+  });
+
+  it("compiles the PM copilot Tool set with no problems", () => {
+    const { tools, problems } = build();
+    expect(problems).toEqual([]);
+    expect(tools.map((tool) => tool.name).sort()).toEqual([
+      "jira_create_issue",
+      "jira_list_priorities",
+      "jira_list_transitions",
+      "jira_read_issue",
+      "jira_search_issues",
+      "jira_transition_issue",
+      "jira_update_issue",
+    ]);
+  });
+
+  it("gates Jira writes while keeping JQL search readable", () => {
+    const mutating = Object.fromEntries(build().tools.map((tool) => [tool.name, tool.mutating]));
+    expect(mutating.jira_search_issues).toBe(false);
+    expect(mutating.jira_read_issue).toBe(false);
+    expect(mutating.jira_list_priorities).toBe(false);
+    expect(mutating.jira_list_transitions).toBe(false);
+    expect(mutating.jira_create_issue).toBe(true);
+    expect(mutating.jira_update_issue).toBe(true);
+    expect(mutating.jira_transition_issue).toBe(true);
+  });
+
+  it("derives schemas that require a JQL query and an issue key", () => {
+    const tools = new Map(build().tools.map((tool) => [tool.name, tool]));
+    const search = tools.get("jira_search_issues")?.inputSchema as {
+      properties: { body?: { required?: string[]; properties?: Record<string, unknown> } };
+    };
+    const read = tools.get("jira_read_issue")?.inputSchema as {
+      required?: string[];
+      properties?: Record<string, unknown>;
+    };
+
+    expect(search.properties.body?.required).toContain("jql");
+    expect(search.properties.body?.properties).toHaveProperty("jql");
+    expect(read.required).toContain("issueIdOrKey");
+    expect(read.properties).toHaveProperty("issueIdOrKey");
+  });
+});

--- a/docs/qa/playbooks/journey-jira-pm.md
+++ b/docs/qa/playbooks/journey-jira-pm.md
@@ -3,8 +3,8 @@ id: journey-jira-pm
 area: Journeys
 suites: [journeys]
 routes: ["/", "/chat", "/integrations", "/agents/:name", "/routines"]
-preconditions: signed-in session; no real JIRA credentials available — this journey tests up to the
-  integration gap, not a live JIRA connection
+preconditions: signed-in session; Jira Cloud OAuth credentials available for the full connection
+  check, or no credentials for the catalog-only check
 blast_radius: creates a qa-journeys-* Agent (left in place), no destructive actions
 est_minutes: 20
 smoke_scenarios: []
@@ -20,9 +20,10 @@ task priority, and generates cycle-time/lead-time reports — "auto product mana
 | # | Action | Expected |
 | --- | --- | --- |
 | 1 | `navigate /integrations` | Catalog renders within 5s |
-| 2 | `expect` a JIRA or generic issue-tracker integration listed | If absent, this is the journey's central finding — record it, then continue the rest of the journey with chat-only tools |
-| 3 | `click` `Install from git` | Dialog asks for a git repository URL — `note` whether an operator with no engineering background could realistically produce one |
-| 4 | `capture` screenshot | — |
+| 2 | `expect` the Jira integration listed | Jira is visible with a productivity category and a description covering search, issue creation, estimation, priority, and workflow transitions |
+| 3 | `click` the Jira row | The integration detail page renders its Cloud ID and OAuth access-token connect steps |
+| 4 | With test credentials, complete the connect flow | The connection succeeds and declares its Jira Tools; skip this step when credentials are unavailable |
+| 5 | `capture` screenshot | — |
 
 ## S2 — Build the PM Copilot agent via chat
 
@@ -30,21 +31,20 @@ task priority, and generates cycle-time/lead-time reports — "auto product mana
 | --- | --- | --- |
 | 1 | `navigate /`, `type` message describing the PM Copilot agent (create/estimate/prioritize JIRA tasks, generate cycle-time/lead-time reports), ask it to set up as far as possible and name any blocker | Agent responds; if it asks a clarifying question (e.g. autonomy level), answer it |
 | 2 | `wait-until` a terminal assistant turn (max 60s) | Streaming completes; `expect` an `agent_create` tool call in the transcript |
-| 3 | `expect` the response explicitly and honestly names the missing JIRA connection as a blocker, rather than fabricating tool access or fake data | This is the key correctness assertion — a P1 finding if it fabricates instead |
+| 3 | Without a connected Jira integration, `expect` the response explicitly and honestly names the missing connection as a blocker, rather than fabricating tool access or fake data | This is a correctness assertion — a P1 finding if it fabricates instead |
 | 4 | `navigate /agents/<created-agent-slug>` | Config renders: role, decision principles, constraints reflect the JIRA PM use case |
 | 5 | `capture` screenshot of the agent config | — |
 
-## S3 — Reports and estimation without historical data
+## S3 — Reports and estimation with Jira data
 
 | # | Action | Expected |
 | --- | --- | --- |
-| 1 | In chat, ask PM Copilot to generate a cycle-time report | `expect` it declines or asks for a data source rather than inventing numbers, consistent with its "Constraints" section |
-| 2 | `note` whether a Resource type or Knowledge store was proposed as the historical-estimation data source | Recorded — this is the primitive TulipFarm would need for "estimate based on past learning" absent a live JIRA connection |
+| 1 | With a connected Jira integration, ask PM Copilot to generate a cycle-time report | It searches Jira first and bases the report on returned issue fields or changelog data; it does not invent numbers |
+| 2 | Without a connected Jira integration, ask the same question | It declines or asks for a data source rather than inventing numbers |
 | 3 | `capture` screenshot, console delta | — |
 
 ## Notes for the runner
 
-- Real JIRA OAuth is never completed. This journey's value is entirely in S1 (does the primitive
-  exist) and S2.3 (does the agent behave honestly when it doesn't).
-- If a JIRA integration is later added to the catalog, S1 should be re-run in full — remove the
-  "expected absent" framing.
+- Do not complete the connection against a production Jira site during ordinary smoke testing.
+- The disconnected path in S2.3 remains important: an agent must never claim it has Jira data when
+  the integration is not connected.

--- a/integrations/jira/manifest.yml
+++ b/integrations/jira/manifest.yml
@@ -1,0 +1,90 @@
+name: jira
+version: "1.0.0"
+description: Let TulipFarm agents search, estimate, prioritize, and create Jira Cloud issues using
+  your Atlassian OAuth token.
+maintainer: TulipFarm
+icon: jira
+capabilities:
+  - Search issues with JQL, including their fields and changelog for delivery analysis
+  - Read issue details, priorities, and available workflow transitions
+  - Create issues and update their fields, including priority and estimates
+  - Move issues through the workflow after approval
+grants:
+  - label: Jira issues and projects
+    access: read
+    description: Search and read issues, priorities, and workflow transitions the token can access.
+  - label: Jira issues
+    access: write
+    description: Create issues, update their fields, and transition them in projects the token can edit.
+
+# Jira Cloud's per-site Cloud ID belongs in the path, while the literal Atlassian gateway host keeps
+# the egress destination pinned. This intentionally supports Jira Cloud, not Jira Server.
+egress:
+  type: openapi
+  spec: openapi.json
+  base_url: https://api.atlassian.com/ex/jira/{JIRA_CLOUD_ID}/rest/api/3
+  auth:
+    token_env: JIRA_ACCESS_TOKEN
+  operations:
+    - operation: searchIssues
+      name: search_issues
+      description: Search Jira issues with JQL. Use this before estimating or reporting so the
+        result is based on the matching issues, their dates, and their changelog rather than guesses.
+      # Jira models JQL search as POST even though it only reads data.
+      mutating: false
+    - operation: getIssue
+      name: read_issue
+      description: Read one Jira issue by key or ID. Request fields and expand=changelog when you
+        need its estimates, priority, status changes, cycle time, or lead time.
+    - operation: getPriorities
+      name: list_priorities
+      description: List the Jira priorities available to this token. Read this before changing an
+        issue priority when you do not know the exact priority ID to use.
+    - operation: createIssue
+      name: create_issue
+      description: Create one Jira issue. Set the project, issue type, summary, and any known fields
+        in the request body; this is a write and requires approval.
+      mutating: true
+    - operation: editIssue
+      name: update_issue
+      description: Update fields on one Jira issue, including priority or an estimate. Read the
+        issue first when the field ID or allowed value is not already known; this requires approval.
+      mutating: true
+    - operation: getTransitions
+      name: list_transitions
+      description: List the workflow transitions available for one Jira issue. Read this before
+        moving the issue because each Jira project can use different transition IDs.
+    - operation: doTransition
+      name: transition_issue
+      description: Move one Jira issue using a transition ID returned by list_transitions. This
+        changes provider state and requires approval.
+      mutating: true
+
+auth:
+  - kind: fields
+    title: Connect your Jira Cloud site
+    description: Paste an Atlassian OAuth access token and the Cloud ID for the Jira Cloud site it
+      can access. The setup guide shows where to get both values.
+    fields:
+      - name: JIRA_CLOUD_ID
+        label: Cloud ID
+        description: Atlassian Cloud ID for the Jira Cloud site. It forms part of the API address.
+        secret: false
+        setup_url: https://admin.atlassian.com
+        steps:
+          - Open Atlassian Administration for the site and copy its Cloud ID. If you cannot find it
+            there, visit https://<your-site>.atlassian.net/_edge/tenant_info while signed in and
+            copy the cloudId value.
+          - Paste the Cloud ID below. It identifies the Jira Cloud site this connection can reach.
+      - name: JIRA_ACCESS_TOKEN
+        label: OAuth Access Token
+        description: Atlassian OAuth bearer token with Jira read and write scopes for this site.
+        secret: true
+        setup_url: https://developer.atlassian.com/console/myapps/
+        steps:
+          - In the Atlassian developer console, create or open an OAuth 2.0 integration for this
+            deployment and add Jira API read and write scopes.
+          - Authorize the integration for this Jira Cloud site, then copy a current access token and
+            paste it below.
+
+setup_guide_path: setup-guide.md

--- a/integrations/jira/openapi.json
+++ b/integrations/jira/openapi.json
@@ -1,0 +1,186 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Jira Cloud REST API",
+    "version": "3"
+  },
+  "paths": {
+    "/search/jql": {
+      "post": {
+        "operationId": "searchIssues",
+        "summary": "Search for issues using JQL",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["jql"],
+                "properties": {
+                  "jql": { "type": "string", "minLength": 1 },
+                  "maxResults": { "type": "integer", "minimum": 1, "maximum": 100 },
+                  "nextPageToken": { "type": "string" },
+                  "fields": { "type": "array", "items": { "type": "string" } },
+                  "expand": { "type": "string" }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Matching issues" }
+        }
+      }
+    },
+    "/issue/{issueIdOrKey}": {
+      "get": {
+        "operationId": "getIssue",
+        "summary": "Get issue",
+        "parameters": [
+          {
+            "name": "issueIdOrKey",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "minLength": 1 }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "schema": { "type": "string" },
+            "description": "Comma-separated field names."
+          },
+          {
+            "name": "expand",
+            "in": "query",
+            "schema": { "type": "string" },
+            "description": "Use changelog to retrieve status-change history."
+          }
+        ],
+        "responses": {
+          "200": { "description": "Issue details" }
+        }
+      },
+      "put": {
+        "operationId": "editIssue",
+        "summary": "Edit issue",
+        "parameters": [
+          {
+            "name": "issueIdOrKey",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "minLength": 1 }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "fields": { "type": "object", "additionalProperties": true },
+                  "update": { "type": "object", "additionalProperties": true }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": { "description": "Issue updated" }
+        }
+      }
+    },
+    "/issue": {
+      "post": {
+        "operationId": "createIssue",
+        "summary": "Create issue",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["fields"],
+                "properties": {
+                  "fields": { "type": "object", "additionalProperties": true },
+                  "update": { "type": "object", "additionalProperties": true }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": { "description": "Issue created" }
+        }
+      }
+    },
+    "/priority": {
+      "get": {
+        "operationId": "getPriorities",
+        "summary": "Get priorities",
+        "responses": {
+          "200": { "description": "Available priorities" }
+        }
+      }
+    },
+    "/issue/{issueIdOrKey}/transitions": {
+      "get": {
+        "operationId": "getTransitions",
+        "summary": "Get transitions",
+        "parameters": [
+          {
+            "name": "issueIdOrKey",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "minLength": 1 }
+          }
+        ],
+        "responses": {
+          "200": { "description": "Available transitions" }
+        }
+      },
+      "post": {
+        "operationId": "doTransition",
+        "summary": "Transition issue",
+        "parameters": [
+          {
+            "name": "issueIdOrKey",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "minLength": 1 }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["transition"],
+                "properties": {
+                  "transition": {
+                    "type": "object",
+                    "required": ["id"],
+                    "properties": {
+                      "id": { "type": "string", "minLength": 1 }
+                    },
+                    "additionalProperties": true
+                  },
+                  "fields": { "type": "object", "additionalProperties": true },
+                  "update": { "type": "object", "additionalProperties": true }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": { "description": "Issue transitioned" }
+        }
+      }
+    }
+  }
+}

--- a/integrations/jira/setup-guide.md
+++ b/integrations/jira/setup-guide.md
@@ -1,0 +1,42 @@
+# Connect Jira Cloud
+
+This integration connects one Jira Cloud site to TulipFarm. Its agents can search and read issues,
+then create, update, prioritize, estimate, or move issues only after the required approval.
+
+## 1. Create an Atlassian OAuth integration
+
+1. Open the [Atlassian developer console](https://developer.atlassian.com/console/myapps/) and
+   create an **OAuth 2.0 integration** for this TulipFarm deployment.
+2. Under **Permissions**, add Jira API read and write scopes. The token needs read access to search
+   issues and their history, and write access to create, edit, and transition issues.
+3. Authorize the integration for the Jira Cloud site you want TulipFarm to use, then copy a current
+   OAuth access token.
+
+## 2. Find the Cloud ID
+
+While signed in to Jira, open:
+
+```
+https://<your-site>.atlassian.net/_edge/tenant_info
+```
+
+Copy the `cloudId` value. TulipFarm uses it with Atlassian's fixed API gateway, so the connection
+cannot be redirected to another host.
+
+## 3. Connect in TulipFarm
+
+Open **Integrations → Jira** and paste the Cloud ID and OAuth access token. TulipFarm seals the
+token in its Secrets store. The Cloud ID is not secret; it only selects your Jira Cloud site.
+
+## What agents can do
+
+- Search issues with JQL and read their fields or changelog for estimates and cycle-time reports.
+- Create issues and update fields such as priority or estimates.
+- List valid workflow transitions before moving an issue.
+
+Searches and reads run without approval. Every create, update, or transition asks for approval.
+
+## Scope
+
+This is a Jira Cloud integration. Jira Server and Data Center use a site-specific API host, which
+TulipFarm intentionally does not accept for credentialed egress.

--- a/integrations/registry.yml
+++ b/integrations/registry.yml
@@ -33,6 +33,13 @@ integrations:
     homepage: https://github.com
     description: Read and write repositories, issues, and pull requests.
 
+  - name: jira
+    title: Jira
+    icon: jira
+    category: productivity
+    homepage: https://www.atlassian.com/software/jira
+    description: Search, create, estimate, prioritize, and transition Jira Cloud issues.
+
   - name: notion
     title: Notion
     icon: notion

--- a/packages/soul/src/integrations/registry.test.ts
+++ b/packages/soul/src/integrations/registry.test.ts
@@ -60,7 +60,7 @@ describe("loadIntegrationRegistry", () => {
   describe("the shipped catalog", () => {
     it("lists every bundled integration, so nothing ships without a display name", async () => {
       const registry = await loadIntegrationRegistry(logger, bundledIntegrationsDir());
-      for (const name of ["slack", "github"]) {
+      for (const name of ["slack", "github", "jira"]) {
         expect(registry.get(name)?.title).toBeTruthy();
         expect(registry.get(name)?.category).toBeTruthy();
       }


### PR DESCRIPTION
Fixes #416

- Add a bundled Jira Cloud integration with declarative JQL search, issue reads, create/update, priority, and workflow transition Tools.
- Add its catalog entry, connect guide, focused compiler tests, and updated PM-copilot QA journey.

## Test plan
- [x] `pnpm --filter @tulipfarm/schema test src/integration-manifest.test.ts`
- [x] `pnpm --filter @tulipfarm/api test src/tools/declarative`
- [x] `pnpm --filter @tulipfarm/soul test src/integrations`
- [x] `pnpm lint`
- [x] `pnpm typecheck`