### PR TITLE
fix(chat): surface model failure diagnostics

### DIFF
--- a/apps/eval/corpus/l3-model-failure-finishes-the-turn.json
+++ b/apps/eval/corpus/l3-model-failure-finishes-the-turn.json
@@ -1,0 +1,33 @@
+{
+  "id": "l3-model-failure-finishes-the-turn",
+  "tier": "l3",
+  "agent": "support",
+  "fault": "model",
+  "context": {
+    "governancePages": []
+  },
+  "input": [
+    {
+      "role": "user",
+      "content": "What are your opening hours?"
+    }
+  ],
+  "expect": [
+    {
+      "kind": "run_status",
+      "status": "failed"
+    },
+    {
+      "kind": "state_status",
+      "status": "failed"
+    },
+    {
+      "kind": "turn_status",
+      "status": "failed"
+    },
+    {
+      "kind": "run_event_emitted",
+      "eventType": "turn.finished"
+    }
+  ]
+}

--- a/apps/eval/src/case.ts
+++ b/apps/eval/src/case.ts
@@ -288,9 +288,10 @@ export interface EvalCase {
    * Every tier otherwise hands the executor working ports, which means the Corpus can only observe
    * a Turn that got as far as the loop. A Turn abandoned *before* the loop — Context unreadable,
    * Soul unreachable — is the one failure a participant can neither see nor retry, so it is worth
-   * the one knob it takes to reach it. `"context"` fails Context resolution.
+   * the one knob it takes to reach it. `"context"` fails Context resolution; `"model"` fails the
+   * Model Port.
    */
-  readonly fault?: "context";
+  readonly fault?: "context" | "model";
   /**
    * L3 only. Roles an admin has assigned this Case's Agent, seeded as `role_assignments` rows.
    *

--- a/apps/eval/src/corpus.ts
+++ b/apps/eval/src/corpus.ts
@@ -175,7 +175,8 @@ function validate(raw: unknown, file: string): EvalCase {
     }
   }
   if (c.fault !== undefined) {
-    require(c.fault === "context", `${file}: unknown fault ${JSON.stringify(c.fault)}`);
+    require(c.fault === "context" ||
+      c.fault === "model", `${file}: unknown fault ${JSON.stringify(c.fault)}`);
     // Only the L3 tier builds the dependency a fault breaks. On an L2 Case the field would be read
     // by nothing and the Case would quietly measure an ordinary Turn.
     require(c.tier ===

--- a/apps/eval/src/l3/tier.ts
+++ b/apps/eval/src/l3/tier.ts
@@ -15,7 +15,12 @@ import { contentText, type MessageContent, normalizeMessageContent } from "@tuli
  */
 
 import { randomUUID } from "node:crypto";
-import type { ModelMessage, ModelUsage, ToolDispatchPort } from "@tulipfarm/agent-runtime";
+import {
+  ModelInvocationError,
+  type ModelMessage,
+  type ModelUsage,
+  type ToolDispatchPort,
+} from "@tulipfarm/agent-runtime";
 import { INVOKE_STATE_KEY } from "@tulipfarm/run-kernel";
 import type { PersistedRun } from "@tulipfarm/storage";
 import {
@@ -286,6 +291,12 @@ async function runOneTurn(
     const port = options.binding.create(options.evalCase);
     const metered = {
       invoke: async (request: Parameters<typeof port.invoke>[0]) => {
+        if (options.evalCase.fault === "model") {
+          throw new ModelInvocationError(
+            "model_not_configured",
+            new Error(`eval fault: Model is unavailable for Case ${options.evalCase.id}`)
+          );
+        }
         const result = await port.invoke(request);
         spend = addSpend(spend, result.usage);
         options.onUsage?.(result.usage);

--- a/apps/web/app/components/chat/chat-panel.test.tsx
+++ b/apps/web/app/components/chat/chat-panel.test.tsx
@@ -7,20 +7,37 @@ import type { Suggestion } from "~/lib/onboarding";
 // ChatPanel drives the conversation through useChatStream; mock it so the empty-state surface
 // renders deterministically and `send` is observable.
 const send = vi.fn();
+const regenerate = vi.fn();
+let stream = {
+  messages: [],
+  status: "ready",
+  error: null,
+  errorDetails: undefined,
+  send,
+  approve: vi.fn(),
+  regenerate,
+  reset: vi.fn(),
+  sendSurfaceInteraction: vi.fn(),
+};
 vi.mock("~/lib/chat/use-chat-stream", () => ({
-  useChatStream: () => ({
+  useChatStream: () => stream,
+}));
+
+beforeEach(() => {
+  send.mockClear();
+  regenerate.mockClear();
+  stream = {
     messages: [],
     status: "ready",
     error: null,
+    errorDetails: undefined,
     send,
     approve: vi.fn(),
-    regenerate: vi.fn(),
+    regenerate,
     reset: vi.fn(),
     sendSurfaceInteraction: vi.fn(),
-  }),
-}));
-
-beforeEach(() => send.mockClear());
+  };
+});
 
 const SUGGESTIONS: Suggestion[] = [
   {
@@ -64,4 +81,26 @@ test("an explicitly selected Agent is identified above the Chat", () => {
   render(<ChatPanel agentId="InventoryPlanner" />);
   expect(screen.getByRole("heading", { name: "Chat with InventoryPlanner" })).toBeInTheDocument();
   expect(screen.getByText("This Chat is using a user-created Agent.")).toBeInTheDocument();
+});
+
+test("shows a safe model-failure reference and retries a temporary model failure", async () => {
+  const user = userEvent.setup();
+  stream = {
+    ...stream,
+    status: "error",
+    error: "The model provider is temporarily unavailable. Try again shortly.",
+    errorDetails: {
+      reason: "model_provider_unavailable",
+      requestId: "run-1:invoke:1",
+      modelId: "gpt-5.6-terra",
+    },
+  };
+
+  render(<ChatPanel />);
+
+  expect(screen.getByRole("alert")).toHaveTextContent(
+    "Class: model_provider_unavailable · Model: gpt-5.6-terra · Reference: run-1:invoke:1"
+  );
+  await user.click(screen.getByRole("button", { name: "Retry" }));
+  expect(regenerate).toHaveBeenCalledOnce();
 });

--- a/apps/web/app/components/chat/chat-panel.test.tsx
+++ b/apps/web/app/components/chat/chat-panel.test.tsx
@@ -8,7 +8,21 @@ import type { Suggestion } from "~/lib/onboarding";
 // renders deterministically and `send` is observable.
 const send = vi.fn();
 const regenerate = vi.fn();
-let stream = {
+let stream: {
+  messages: [];
+  status: string;
+  error: string | null;
+  errorDetails?: {
+    reason?: string;
+    requestId?: string;
+    modelId?: string;
+  };
+  send: typeof send;
+  approve: ReturnType<typeof vi.fn>;
+  regenerate: typeof regenerate;
+  reset: ReturnType<typeof vi.fn>;
+  sendSurfaceInteraction: ReturnType<typeof vi.fn>;
+} = {
   messages: [],
   status: "ready",
   error: null,

--- a/apps/web/app/components/chat/chat-panel.tsx
+++ b/apps/web/app/components/chat/chat-panel.tsx
@@ -100,6 +100,7 @@ export function ChatPanel({
     messages,
     status,
     error,
+    errorDetails,
     currentAgent,
     conversationId,
     send,
@@ -133,6 +134,10 @@ export function ChatPanel({
   const hasMessages = messages.length > 0;
   // Actionable errors (e.g. "LLM not configured") get a deep-link CTA to where the user fixes them.
   const errorCta = status === "error" ? errorAction(error) : null;
+  const retryableFailure =
+    errorDetails?.reason === "model_rate_limited" ||
+    errorDetails?.reason === "model_provider_unavailable" ||
+    errorDetails?.reason === "model_error";
 
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden">
@@ -194,6 +199,22 @@ export function ChatPanel({
                 {errorCta.label}
               </Link>
             </>
+          ) : null}
+          {retryableFailure ? (
+            <button
+              type="button"
+              onClick={() => void regenerate()}
+              className="ml-2 min-h-11 font-medium underline underline-offset-2 hover:text-foreground"
+            >
+              Retry
+            </button>
+          ) : null}
+          {errorDetails ? (
+            <p className="mt-1 font-mono text-xs text-muted-foreground">
+              Class: {errorDetails.reason ?? "unknown"}
+              {errorDetails.modelId ? ` · Model: ${errorDetails.modelId}` : ""}
+              {errorDetails.requestId ? ` · Reference: ${errorDetails.requestId}` : ""}
+            </p>
           ) : null}
         </div>
       ) : null}

--- a/apps/web/app/lib/chat/reducer.ts
+++ b/apps/web/app/lib/chat/reducer.ts
@@ -61,14 +61,20 @@ export function appendUserMessage(
     sealed: true,
     sourceTurn: sourceTurn(text, options),
   };
-  return { ...state, messages: [...state.messages, message], status: "submitted" };
+  return {
+    ...state,
+    messages: [...state.messages, message],
+    status: "submitted",
+    error: undefined,
+    errorDetails: undefined,
+  };
 }
 
 export function rewindLastTurn(state: ChatState): ChatState {
   const messages = state.messages.slice();
   while (messages.length > 0 && messages[messages.length - 1].role === "assistant") messages.pop();
   if (messages.length > 0 && messages[messages.length - 1].role === "user") messages.pop();
-  return { ...state, messages, status: "idle", error: undefined };
+  return { ...state, messages, status: "idle", error: undefined, errorDetails: undefined };
 }
 
 function ensureAssistant(messages: ChatMessage[]): {
@@ -347,7 +353,12 @@ export function chatReducer(state: ChatState, event: ChatEvent): ChatState {
     }
 
     case "error":
-      return { ...state, status: "error", error: event.data.message };
+      return {
+        ...state,
+        status: "error",
+        error: event.data.message,
+        errorDetails: event.data.details,
+      };
 
     case "client-action":
       return state;

--- a/apps/web/app/lib/chat/sse-client.test.ts
+++ b/apps/web/app/lib/chat/sse-client.test.ts
@@ -281,12 +281,36 @@ test("turns allowlisted model failures into actionable participant-safe messages
       data: {
         message:
           "The model provider's API billing is inactive. Activate billing or use another Provider Credential.",
+        details: { reason: "model_billing_inactive" },
       },
     },
   ]);
   expect(modelFailureMessage("untrusted_provider_detail")).toBe(
     "The model request failed. Try again."
   );
+  expect(
+    map({
+      seq: 2,
+      type: "turn.finished",
+      data: {
+        status: "failed",
+        reason: "model_error",
+        modelFailure: { requestId: "run-1:invoke:1", modelId: "gpt-5.6-terra" },
+      },
+    })
+  ).toEqual([
+    {
+      type: "error",
+      data: {
+        message: "The model request failed. Try again.",
+        details: {
+          reason: "model_error",
+          requestId: "run-1:invoke:1",
+          modelId: "gpt-5.6-terra",
+        },
+      },
+    },
+  ]);
   // An instance with no `llm:` config denies routing with `unknown_profile`. That must not land on
   // the generic default above: it is the one failure the reader can actually fix themselves.
   expect(modelFailureMessage("model_not_configured")).toBe(

--- a/apps/web/app/lib/chat/sse-client.ts
+++ b/apps/web/app/lib/chat/sse-client.ts
@@ -86,6 +86,7 @@ type RunEventData = {
   effortApplied?: EffortRung;
   modelCallLatencyMs?: number;
   artifactId?: string;
+  modelFailure?: { requestId?: string; modelId?: string };
 };
 
 /** A turn that ended without an answer, whichever half of the runtime gave up on it. */
@@ -121,6 +122,21 @@ export function modelFailureMessage(reason: string | undefined): string {
   }
 }
 
+function modelFailureDetails(
+  data: RunEventData
+):
+  | { readonly reason?: string; readonly requestId?: string; readonly modelId?: string }
+  | undefined {
+  if (data.reason === undefined && data.modelFailure === undefined) return undefined;
+  return {
+    ...(data.reason === undefined ? {} : { reason: data.reason }),
+    ...(data.modelFailure?.requestId === undefined
+      ? {}
+      : { requestId: data.modelFailure.requestId }),
+    ...(data.modelFailure?.modelId === undefined ? {} : { modelId: data.modelFailure.modelId }),
+  };
+}
+
 function compact<T extends object>(value: T): T {
   return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined)) as T;
 }
@@ -143,7 +159,7 @@ export function createRunEventMapper(): (frame: ParsedFrame) => ChatEvent[] {
       case "text.delta":
         return [{ type: "text", data: { delta: data.text ?? "" } }];
 
-      case "tool.call":
+      case "tool.call": {
         return [
           {
             type: "tool-call",
@@ -163,6 +179,7 @@ export function createRunEventMapper(): (frame: ParsedFrame) => ChatEvent[] {
             }),
           },
         ];
+      }
 
       case "tool.result": {
         const callId = data.callId ?? "";
@@ -246,7 +263,16 @@ export function createRunEventMapper(): (frame: ParsedFrame) => ChatEvent[] {
           ];
         }
         if (data.status === "cancelled") return [{ type: "finish", data: { reason: "cancelled" } }];
-        return [{ type: "error", data: { message: modelFailureMessage(data.reason) } }];
+        const details = modelFailureDetails(data);
+        return [
+          {
+            type: "error",
+            data: {
+              message: modelFailureMessage(data.reason),
+              ...(details === undefined ? {} : { details }),
+            },
+          },
+        ];
       }
 
       case "stream.closed": {

--- a/apps/web/app/lib/chat/types.ts
+++ b/apps/web/app/lib/chat/types.ts
@@ -30,6 +30,12 @@ export type StepStatus = "pending" | "running" | "done" | "error";
 /** Which layer a Tool belongs to. Mirrors the registry's tiering, not a rendering hint. */
 export type ToolTier = "system" | "platform" | "integration";
 
+export type ChatFailureDetails = {
+  reason?: string;
+  requestId?: string;
+  modelId?: string;
+};
+
 /**
  * The bounded, redaction-aware view of a Tool's arguments or output that the wire carries.
  * `json` is already redacted and already truncated when it arrives; the client never un-redacts
@@ -118,7 +124,7 @@ export type ChatEvent =
         receipt?: ModelReceipt;
       };
     }
-  | { type: "error"; data: { message: string } };
+  | { type: "error"; data: { message: string; details?: ChatFailureDetails } };
 
 export type ParsedFrame = { seq: number; type: string; data: unknown };
 
@@ -223,6 +229,7 @@ export type ChatState = {
   runId?: string;
   currentAgent?: string;
   error?: string;
+  errorDetails?: ChatFailureDetails;
 };
 
 import type { ResolvedSurfaceViewNode, SurfaceArtifact } from "@tulipfarm/surface";

--- a/apps/web/app/lib/chat/use-chat-stream.ts
+++ b/apps/web/app/lib/chat/use-chat-stream.ts
@@ -125,7 +125,9 @@ export function surfaceInteractionAnswer(input: Readonly<Record<string, unknown>
 
 function reducer(state: ChatState, action: ChatAction): ChatState {
   if (action.type === "user") return appendUserMessage(state, action.text, action.options);
-  if (action.type === "surface-submit") return { ...state, status: "submitted", error: undefined };
+  if (action.type === "surface-submit") {
+    return { ...state, status: "submitted", error: undefined, errorDetails: undefined };
+  }
   if (action.type === "reset") return initialChatState;
   if (action.type === "stopped") return rewindLastTurn(state);
   if (action.type === "regenerate") {
@@ -133,7 +135,7 @@ function reducer(state: ChatState, action: ChatAction): ChatState {
     while (messages.length > 0 && messages[messages.length - 1].role === "assistant") {
       messages.pop();
     }
-    return { ...state, messages, status: "submitted", error: undefined };
+    return { ...state, messages, status: "submitted", error: undefined, errorDetails: undefined };
   }
   if (action.type === "meta") {
     return {
@@ -391,6 +393,7 @@ export function useChatStream(opts?: UseChatStreamOptions) {
     currentAgent: state.currentAgent,
     conversationId: state.conversationId,
     error: state.error,
+    errorDetails: state.errorDetails,
     connectionState,
     send,
     stop,

--- a/apps/worker/src/llm.ts
+++ b/apps/worker/src/llm.ts
@@ -3,6 +3,7 @@ import { selectModelProfile } from "@tulipfarm/agent-runtime";
 import type {
   CostBasis,
   FallbackCallGate,
+  ModelAttemptRef,
   ModelPrice,
   ModelResponderRef,
   PrincipalRef,
@@ -52,6 +53,8 @@ export type LlmModelResolution =
        * call is about to be made against.
        */
       readonly provider?: string;
+      /** The last chain link that a provider call actually entered. */
+      attemptedModelId?(): string | undefined;
       /**
        * Prices this call against whichever chain link actually answered.
        *
@@ -161,13 +164,22 @@ export class SoulLlm {
   ): Promise<LlmModelResolution> {
     await this.sync();
     const responder: ModelResponderRef = {};
+    const attempted: ModelAttemptRef = {};
     return {
       kind: "available",
-      model: await this.service.chainModelFor(modelIds, principal, undefined, responder, gate),
+      model: await this.service.chainModelFor(
+        modelIds,
+        principal,
+        undefined,
+        responder,
+        gate,
+        attempted
+      ),
       ...(this.providerOf(modelIds[0]) === undefined
         ? {}
         : { provider: this.providerOf(modelIds[0]) }),
       routing,
+      attemptedModelId: () => attempted.modelId,
       price: (tokensIn, tokensOut) => this.priceFor(responder.modelId, tokensIn, tokensOut),
     };
   }
@@ -183,6 +195,7 @@ export class SoulLlm {
 
     const resolved = this.resolveSelector(selector, inference);
     if (resolved.kind === "raw_model") {
+      const attempted: ModelAttemptRef = {};
       return {
         kind: "available",
         model: await this.service.chainModelFor(
@@ -190,7 +203,8 @@ export class SoulLlm {
           principal,
           undefined,
           undefined,
-          gate
+          gate,
+          attempted
         ),
         ...(this.providerOf(resolved.modelId) === undefined
           ? {}
@@ -201,6 +215,7 @@ export class SoulLlm {
           resolution: "raw_model_id",
           modelId: resolved.modelId,
         },
+        attemptedModelId: () => attempted.modelId,
         // A raw model id names exactly one model; nothing else could answer.
         price: (tokensIn, tokensOut) => this.priceFor(resolved.modelId, tokensIn, tokensOut),
       };
@@ -269,10 +284,18 @@ export class SoulLlm {
     }
 
     const responder: ModelResponderRef = {};
+    const attempted: ModelAttemptRef = {};
 
     return {
       kind: "available",
-      model: await this.service.chainModelFor(chain, principal, undefined, responder, gate),
+      model: await this.service.chainModelFor(
+        chain,
+        principal,
+        undefined,
+        responder,
+        gate,
+        attempted
+      ),
       ...(this.providerOf(chain[0]) === undefined ? {} : { provider: this.providerOf(chain[0]) }),
       ...(budgetEvidence === undefined ? {} : { budgetLimits }),
       // Attributed to the link that answered: a chain that rate-limits through to a cheaper model
@@ -292,6 +315,7 @@ export class SoulLlm {
         ...(budgetEvidence === undefined ? {} : { budgetLimits: budgetEvidence }),
         ...evidence,
       },
+      attemptedModelId: () => attempted.modelId,
     };
   }
 

--- a/apps/worker/src/model.test.ts
+++ b/apps/worker/src/model.test.ts
@@ -11,7 +11,12 @@ import {
   ModelInvocationError,
 } from "@tulipfarm/agent-runtime";
 import { type CostBasis, FallbackModel, LlmProviderError } from "@tulipfarm/llm";
-import { type EffortRung, type RunEventEffortInference, textContent } from "@tulipfarm/schema";
+import {
+  type EffortRung,
+  LlmNotConfiguredError,
+  type RunEventEffortInference,
+  textContent,
+} from "@tulipfarm/schema";
 import { APICallError, type LanguageModel } from "ai";
 import { MockLanguageModelV4, simulateReadableStream } from "ai/test";
 import { describe, expect, it, vi } from "vitest";
@@ -136,12 +141,14 @@ describe("LlmModelPort", () => {
           resolution: "raw_model_id",
           modelId: selector,
         },
+        attemptedModelId: () => "gpt-5.6-terra",
       }),
     });
 
     await expect(port.invoke(request())).rejects.toMatchObject({
       name: "ModelInvocationError",
       reason: "model_billing_inactive",
+      modelId: "gpt-5.6-terra",
     });
   });
 
@@ -441,6 +448,19 @@ describe("LlmModelPort", () => {
     expect(port.latestModelCallReceipt()).toBeUndefined();
   });
 
+  it("preserves an unconfigured model route as a participant-safe failure", async () => {
+    const port = new LlmModelPort({
+      model: async () => {
+        throw new LlmNotConfiguredError();
+      },
+    });
+
+    await expect(port.invoke(request({ modelProfileId: "auto" }))).rejects.toMatchObject({
+      name: "ModelInvocationError",
+      reason: "model_not_configured",
+    });
+  });
+
   it("emits denial evidence before refusing a model call", async () => {
     const emitted: unknown[] = [];
     const port = new LlmModelPort({
@@ -462,9 +482,11 @@ describe("LlmModelPort", () => {
       },
     });
 
-    await expect(port.invoke(request({ modelProfileId: "balanced" }))).rejects.toThrow(
-      'model profile "primary" denied: tools_unsupported'
-    );
+    await expect(port.invoke(request({ modelProfileId: "balanced" }))).rejects.toMatchObject({
+      name: "ModelInvocationError",
+      reason: "model_error",
+      cause: new Error('model profile "primary" denied: tools_unsupported'),
+    });
     expect(emitted).toEqual([
       {
         outcome: "denied",

--- a/apps/worker/src/model.ts
+++ b/apps/worker/src/model.ts
@@ -25,9 +25,9 @@ import type { ResolvedLimits } from "@tulipfarm/run-kernel";
 import {
   asEffortPreset,
   contentText,
-  type EffortPreset,
   type EffortRung,
   isEffortRung,
+  LlmNotConfiguredError,
   type RunEventEffortInference,
   type RunEventPayloads,
 } from "@tulipfarm/schema";
@@ -118,13 +118,23 @@ export class LlmModelPort implements ModelPort, ModelCallReceiptSource {
   async *stream(request: ModelInvocationRequest): AsyncIterable<ModelStreamChunk> {
     const requirements = deriveModelRequirements(request, request.policy ?? this.options.policy);
     const inference = await this.inferEffort(request, requirements);
-    const resolution = await this.options.model(
-      request.modelProfileId,
-      requirements,
-      inference,
-      request.principal,
-      this.options.gate
-    );
+    let resolution: LlmModelResolution;
+    try {
+      resolution = await this.options.model(
+        request.modelProfileId,
+        requirements,
+        inference,
+        request.principal,
+        this.options.gate
+      );
+    } catch (error) {
+      throw new ModelInvocationError(
+        error instanceof LlmNotConfiguredError
+          ? "model_not_configured"
+          : classifyProviderError(error),
+        error
+      );
+    }
     if (resolution.kind === "available" && resolution.budgetLimits !== undefined) {
       await this.options.budgets?.open(resolution.budgetLimits);
     }
@@ -134,7 +144,10 @@ export class LlmModelPort implements ModelPort, ModelCallReceiptSource {
       `model:${request.requestId}`
     );
     if (resolution.kind === "denied") {
-      throw new Error(denialMessage(resolution.routing, requirements));
+      throw new ModelInvocationError(
+        resolution.routing.reason === "unknown_profile" ? "model_not_configured" : "model_error",
+        new Error(denialMessage(resolution.routing, requirements))
+      );
     }
 
     try {
@@ -258,8 +271,13 @@ export class LlmModelPort implements ModelPort, ModelCallReceiptSource {
         );
       }
       throw error instanceof ModelInvocationError
-        ? new ModelInvocationError(error.reason, error.cause, partial)
-        : new ModelInvocationError(classifyProviderError(error), error, partial);
+        ? new ModelInvocationError(error.reason, error.cause, partial, error.modelId)
+        : new ModelInvocationError(
+            classifyProviderError(error),
+            error,
+            partial,
+            resolution.attemptedModelId?.()
+          );
     } finally {
       watchdog.close();
     }

--- a/packages/agent-runtime/src/loop/contract.ts
+++ b/packages/agent-runtime/src/loop/contract.ts
@@ -123,6 +123,12 @@ export type AgentLoopFailureReason =
   | ModelInvocationFailureReason
   | "empty_model_output";
 
+/** Participant-safe evidence for a failed model call; provider error bodies never cross this seam. */
+export interface ModelFailureDiagnostic {
+  readonly requestId: string;
+  readonly modelId?: string;
+}
+
 export type AgentLoopOutcome =
   | {
       readonly status: "completed";
@@ -134,6 +140,7 @@ export type AgentLoopOutcome =
   | {
       readonly status: "failed";
       readonly reason: AgentLoopFailureReason;
+      readonly modelFailure?: ModelFailureDiagnostic;
       readonly iterations: number;
       readonly toolCalls: number;
       readonly repairs: number;

--- a/packages/agent-runtime/src/loop/index.ts
+++ b/packages/agent-runtime/src/loop/index.ts
@@ -12,6 +12,7 @@ export type {
   AgentLoopOutcome,
   ExposedTool,
   LoopAttachmentPort,
+  ModelFailureDiagnostic,
   ToolDispatchPort,
   ToolDispatchRequest,
   ToolDispatchResult,

--- a/packages/agent-runtime/src/loop/loop.test.ts
+++ b/packages/agent-runtime/src/loop/loop.test.ts
@@ -708,7 +708,11 @@ describe("AgentLoop", () => {
 
     const outcome = await loop({ model, log: { warn } }).run(input());
 
-    expect(outcome).toMatchObject({ status: "failed", reason: "model_billing_inactive" });
+    expect(outcome).toMatchObject({
+      status: "failed",
+      reason: "model_billing_inactive",
+      modelFailure: { requestId: "run-1:state-1:1" },
+    });
     expect(warn).toHaveBeenCalledWith(
       expect.objectContaining({
         reason: "model_billing_inactive",

--- a/packages/agent-runtime/src/loop/loop.ts
+++ b/packages/agent-runtime/src/loop/loop.ts
@@ -510,7 +510,22 @@ export class AgentLoop {
         if (error instanceof ModelInvocationError && error.usage !== undefined) {
           await chargeUsage(error.usage);
         }
-        return finish({ status: "failed", reason, ...counters }, "failed");
+        return finish(
+          {
+            status: "failed",
+            reason,
+            ...(error instanceof ModelInvocationError
+              ? {
+                  modelFailure: {
+                    requestId: request.requestId,
+                    ...(error.modelId === undefined ? {} : { modelId: error.modelId }),
+                  },
+                }
+              : {}),
+            ...counters,
+          },
+          "failed"
+        );
       }
 
       const spend = await chargeUsage(result.usage);

--- a/packages/agent-runtime/src/ports/model.ts
+++ b/packages/agent-runtime/src/ports/model.ts
@@ -56,6 +56,7 @@ export interface ModelInvocationRequest {
 export type ModelInvocationFailureReason =
   | "model_billing_inactive"
   | "model_authentication_failed"
+  | "model_not_configured"
   | "model_not_found"
   | "model_rate_limited"
   | "model_provider_unavailable"
@@ -73,7 +74,9 @@ export class ModelInvocationError extends Error {
      * output was generated, and the provider bills for both. Without this the Run is charged
      * nothing, so a failure loop can spend without limit against a budget it never touches.
      */
-    readonly usage?: ModelUsage
+    readonly usage?: ModelUsage,
+    /** The provider model whose call began, when the adapter can know it. */
+    readonly modelId?: string
   ) {
     super(reason, { cause });
     this.name = "ModelInvocationError";

--- a/packages/llm/src/fallback.ts
+++ b/packages/llm/src/fallback.ts
@@ -22,6 +22,11 @@ export interface ModelResponderRef {
   modelId?: string;
 }
 
+/** The chain link whose provider call actually began, including a failed final attempt. */
+export interface ModelAttemptRef {
+  modelId?: string;
+}
+
 export interface FallbackCallLease {
   succeeded(): void;
   failed(reason: string): void;
@@ -62,7 +67,8 @@ export class FallbackModel implements LanguageModelV4 {
     /** Records which link served, so cost is attributed to the model that answered. */
     private readonly responder?: ModelResponderRef,
     private readonly gate?: FallbackCallGate,
-    private readonly providerKeys: readonly string[] = models.map((model) => model.provider)
+    private readonly providerKeys: readonly string[] = models.map((model) => model.provider),
+    private readonly attempted?: ModelAttemptRef
   ) {
     const primary = models[0];
     if (!primary) throw new Error("FallbackModel requires at least one model");
@@ -80,6 +86,9 @@ export class FallbackModel implements LanguageModelV4 {
       let lease: FallbackCallLease | undefined;
       try {
         lease = await this.gate?.acquire(this.providerKey(index, model));
+        if ((lease !== undefined || this.gate === undefined) && this.attempted !== undefined) {
+          this.attempted.modelId = model.modelId;
+        }
         const generated = await model.doGenerate(options);
         lease?.succeeded();
         this.commit(model);
@@ -104,6 +113,9 @@ export class FallbackModel implements LanguageModelV4 {
       let result: Awaited<ReturnType<LanguageModelV4["doStream"]>>;
       try {
         lease = await this.gate?.acquire(this.providerKey(index, model));
+        if ((lease !== undefined || this.gate === undefined) && this.attempted !== undefined) {
+          this.attempted.modelId = model.modelId;
+        }
         result = await model.doStream(options);
       } catch (err) {
         if (isHardFailure(err)) {

--- a/packages/llm/src/index.ts
+++ b/packages/llm/src/index.ts
@@ -18,6 +18,7 @@ export {
   type FallbackLogger,
   FallbackModel,
   isHardFailure,
+  type ModelAttemptRef,
   type ModelResponderRef,
 } from "./fallback";
 export type { LlmLogger, ResolvedModelEntry } from "./llm-service";

--- a/packages/llm/src/llm-service.ts
+++ b/packages/llm/src/llm-service.ts
@@ -22,6 +22,7 @@ import {
   type FallbackCallGate,
   type FallbackLogger,
   FallbackModel,
+  type ModelAttemptRef,
   type ModelResponderRef,
 } from "./fallback";
 import { createModel, type PrincipalCredentialResolver, type PrincipalRef } from "./provider";
@@ -235,10 +236,11 @@ export class LlmService {
     principal: PrincipalRef | undefined,
     logger: FallbackLogger = this.logger,
     responder?: ModelResponderRef,
-    gate?: FallbackCallGate
+    gate?: FallbackCallGate,
+    attempted?: ModelAttemptRef
   ): Promise<LanguageModel> {
     if (principal === undefined || this.credentials === undefined) {
-      return this.chainModel(modelIds, logger, responder, gate);
+      return this.chainModel(modelIds, logger, responder, gate, attempted);
     }
     const built = (
       await Promise.all(
@@ -255,7 +257,8 @@ export class LlmService {
       logger,
       responder,
       gate,
-      built.map((link) => this.entryByModelId.get(link.id)?.provider ?? link.model.provider)
+      built.map((link) => this.entryByModelId.get(link.id)?.provider ?? link.model.provider),
+      attempted
     );
   }
 
@@ -300,7 +303,8 @@ export class LlmService {
     modelIds: readonly string[],
     logger: FallbackLogger = this.logger,
     responder?: ModelResponderRef,
-    gate?: FallbackCallGate
+    gate?: FallbackCallGate,
+    attempted?: ModelAttemptRef
   ): LanguageModel {
     if (!this.configured) throw new LlmNotConfiguredError();
     const built = modelIds.flatMap((id) => {
@@ -323,7 +327,8 @@ export class LlmService {
       logger,
       responder,
       gate,
-      built.map((link) => this.entryByModelId.get(link.id)?.provider ?? link.model.provider)
+      built.map((link) => this.entryByModelId.get(link.id)?.provider ?? link.model.provider),
+      attempted
     );
   }
 }

--- a/packages/schema/src/run-events.ts
+++ b/packages/schema/src/run-events.ts
@@ -177,6 +177,15 @@ const TURN_FINISHED_SCHEMA = {
     status: { type: "string", enum: ["succeeded", "failed", "cancelled"] },
     messageId: { type: ["string", "null"] },
     reason: { type: "string" },
+    modelFailure: {
+      type: "object",
+      required: ["requestId"],
+      additionalProperties: false,
+      properties: {
+        requestId: { type: "string", minLength: 1 },
+        modelId: { type: "string", minLength: 1 },
+      },
+    },
     modelId: { type: "string", minLength: 1 },
     effortPreset: { type: "string", enum: EFFORT_PRESETS },
     effortApplied: { type: "string", enum: EFFORT_RUNGS },
@@ -480,6 +489,7 @@ export interface RunEventPayloads {
     readonly status: "succeeded" | "failed" | "cancelled";
     readonly messageId?: string | null;
     readonly reason?: string;
+    readonly modelFailure?: { readonly requestId: string; readonly modelId?: string };
     readonly modelId?: string;
     readonly effortPreset?: EffortPreset;
     readonly effortApplied?: EffortRung;

--- a/packages/turn-executor/src/agent-state.ts
+++ b/packages/turn-executor/src/agent-state.ts
@@ -1,4 +1,8 @@
-import type { AgentLoopInput, AgentLoopOutcome } from "@tulipfarm/agent-runtime";
+import type {
+  AgentLoopInput,
+  AgentLoopOutcome,
+  ModelFailureDiagnostic,
+} from "@tulipfarm/agent-runtime";
 import { assertStateTransition, type StateStatus } from "@tulipfarm/run-kernel";
 import { StateTransitionConflictError } from "./kernel-ports";
 
@@ -44,7 +48,11 @@ export interface AgentStateRunnerOptions {
 
 export type AgentStateResult =
   | { readonly status: "succeeded"; readonly output: unknown }
-  | { readonly status: "failed"; readonly reason: string }
+  | {
+      readonly status: "failed";
+      readonly reason: string;
+      readonly modelFailure?: ModelFailureDiagnostic;
+    }
   | {
       readonly status: "waiting";
       readonly waitId: string;
@@ -81,7 +89,11 @@ export class AgentStateRunner {
 
       case "failed":
         await this.move(request, "running", "failed", outcome.reason);
-        return { status: "failed", reason: outcome.reason };
+        return {
+          status: "failed",
+          reason: outcome.reason,
+          ...(outcome.modelFailure === undefined ? {} : { modelFailure: outcome.modelFailure }),
+        };
 
       case "awaiting_approval": {
         const { waitId } = await this.options.waits.register({

--- a/packages/turn-executor/src/conversation-turn.ts
+++ b/packages/turn-executor/src/conversation-turn.ts
@@ -1,5 +1,6 @@
 /** Complete by `(turnId, attempt)`; redelivery is idempotent and stale attempts cannot win. */
 
+import type { ModelFailureDiagnostic } from "@tulipfarm/agent-runtime";
 import type { ParticipantToolCall } from "@tulipfarm/schema";
 
 export type TurnCompletionStatus = "succeeded" | "failed";
@@ -54,7 +55,11 @@ export interface TurnSurfaceLink {
 
 export type TurnOutcome =
   | { readonly status: "succeeded"; readonly text: string }
-  | { readonly status: "failed"; readonly reason: string }
+  | {
+      readonly status: "failed";
+      readonly reason: string;
+      readonly modelFailure?: ModelFailureDiagnostic;
+    }
   | { readonly status: "input_required"; readonly text: string }
   | { readonly status: "waiting"; readonly waitId: string };
 
@@ -76,7 +81,11 @@ export interface CompleteTurnInput {
 
 export type CompleteTurnResult =
   | { readonly status: "succeeded"; readonly messageId: string | null }
-  | { readonly status: "failed"; readonly reason: string }
+  | {
+      readonly status: "failed";
+      readonly reason: string;
+      readonly modelFailure?: ModelFailureDiagnostic;
+    }
   | { readonly status: "waiting"; readonly waitId: string }
   | { readonly status: "stale" };
 
@@ -114,6 +123,9 @@ export class ConversationTurnCompleter {
         : {
             status: "failed",
             reason: input.outcome.status === "failed" ? input.outcome.reason : "",
+            ...(input.outcome.status === "failed" && input.outcome.modelFailure !== undefined
+              ? { modelFailure: input.outcome.modelFailure }
+              : {}),
           };
     }
 
@@ -124,7 +136,13 @@ export class ConversationTurnCompleter {
         cursor: input.cursor,
         messageId: null,
       });
-      return { status: "failed", reason: input.outcome.reason };
+      return {
+        status: "failed",
+        reason: input.outcome.reason,
+        ...(input.outcome.modelFailure === undefined
+          ? {}
+          : { modelFailure: input.outcome.modelFailure }),
+      };
     }
 
     // A Turn that stops to ask is not a Turn that said nothing: it has run Tools, written prose and

--- a/packages/turn-executor/src/driver.test.ts
+++ b/packages/turn-executor/src/driver.test.ts
@@ -384,6 +384,7 @@ describe("TurnDriver", () => {
     const { driver, events } = harness({
       status: "failed",
       reason: "model_error",
+      modelFailure: { requestId: "run-without-model:invoke:1", modelId: "gpt-5.6-terra" },
       ...counters,
     });
 
@@ -391,7 +392,12 @@ describe("TurnDriver", () => {
 
     expect(events.appended.at(-1)).toEqual({
       eventType: "turn.finished",
-      payload: { status: "failed", messageId: null, reason: "model_error" },
+      payload: {
+        status: "failed",
+        messageId: null,
+        reason: "model_error",
+        modelFailure: { requestId: "run-without-model:invoke:1", modelId: "gpt-5.6-terra" },
+      },
     });
   });
 

--- a/packages/turn-executor/src/driver.ts
+++ b/packages/turn-executor/src/driver.ts
@@ -361,7 +361,14 @@ export class TurnDriver {
     if (completion.status === "failed") {
       await events.emit(
         "turn.finished",
-        { status: "failed", messageId: null, reason: completion.reason },
+        {
+          status: "failed",
+          messageId: null,
+          reason: completion.reason,
+          ...(completion.modelFailure === undefined
+            ? {}
+            : { modelFailure: completion.modelFailure }),
+        },
         "finished"
       );
       this.reportTurn(spend, "error");
@@ -387,7 +394,13 @@ export class TurnDriver {
 function turnOutcome(
   result: Extract<AgentStateResult, { status: "succeeded" | "failed" | "input_required" }>
 ): TurnOutcome {
-  if (result.status === "failed") return { status: "failed", reason: result.reason };
+  if (result.status === "failed") {
+    return {
+      status: "failed",
+      reason: result.reason,
+      ...(result.modelFailure === undefined ? {} : { modelFailure: result.modelFailure }),
+    };
+  }
   if (result.status === "input_required") return { status: "input_required", text: result.text };
   const text = renderAnswer(result.output);
   if (text.length === 0) return { status: "failed", reason: "empty_model_output" };


### PR DESCRIPTION
Fixes #553\n\n- Preserves safe model-failure references and actual attempted model IDs through Chat Turn completion.\n- Shows the failure class, reference, and a Retry action for temporary model failures.\n- Adds unit coverage and an L3 eval Corpus case for failed Turn lifecycle persistence.\n\nTest plan:\n- [x] pnpm lint\n- [x] pnpm typecheck\n- [x] pnpm eval\n- [x] Focused agent-runtime, llm, worker, turn-executor, web, and eval tests\n\nNote: the new Corpus Case changes corpusHash, so existing eval Baselines must be re-promoted before comparison.