### PR TITLE
feat(curator): deliver task proposals

### DIFF
--- a/apps/api/src/curator/compose.ts
+++ b/apps/api/src/curator/compose.ts
@@ -1,6 +1,11 @@
 import type { EventEmitter } from "node:events";
 import { isCuratorDedupeKey, soulDigest, soulSubjects, soulSummary } from "@tulipfarm/curator";
-import { CuratorHost, CuratorMinter, CuratorRecovery } from "@tulipfarm/curator-host";
+import {
+  CuratorHost,
+  CuratorMinter,
+  CuratorRecovery,
+  CuratorTaskDelivery,
+} from "@tulipfarm/curator-host";
 import type { LlmService } from "@tulipfarm/llm";
 import type { MemoryDocumentRepo } from "@tulipfarm/memory";
 import type { DurableInvocationGateway } from "@tulipfarm/run-kernel";
@@ -74,6 +79,7 @@ export function buildCurator(deps: CuratorDeps): Pick<AppOptions, "curator" | "c
         minter,
         now: () => new Date(),
       }),
+      delivery: new CuratorTaskDelivery({ repo, tasks, now: () => new Date() }),
       observe: events
         ? (payload) => void events.emit(DOMAIN_EVENTS.CURATOR_OBSERVED, payload)
         : undefined,

--- a/apps/api/src/curator/routes.test.ts
+++ b/apps/api/src/curator/routes.test.ts
@@ -3,6 +3,7 @@ import {
   CuratorHostError,
   type CuratorMinter,
   type CuratorRecovery,
+  type CuratorTaskDelivery,
 } from "@tulipfarm/curator-host";
 import type { CuratorObservedPayload } from "@tulipfarm/storage";
 import Fastify, { type FastifyInstance } from "fastify";
@@ -46,11 +47,21 @@ class FakeMinter {
   }
 }
 
+class FakeDelivery {
+  calls: string[] = [];
+
+  async run(businessId: string) {
+    this.calls.push(businessId);
+    return { delivered: 1, retryableFailed: 0, terminalRejected: 0 };
+  }
+}
+
 async function buildServer(
   host: FakeHost,
   principalKind: "service" | "user" | undefined,
   minter: FakeMinter = new FakeMinter(),
-  extra: Partial<CuratorRouteDeps> = {}
+  extra: Partial<CuratorRouteDeps> = {},
+  delivery: FakeDelivery = new FakeDelivery()
 ): Promise<FastifyInstance> {
   const app = Fastify();
   registerCuratorRoutes(
@@ -59,6 +70,7 @@ async function buildServer(
       host: host as unknown as CuratorHost,
       minter: minter as unknown as CuratorMinter,
       recovery: { run: async () => ({ recovered: 1, abandoned: 0 }) } as unknown as CuratorRecovery,
+      delivery: delivery as unknown as CuratorTaskDelivery,
       ...extra,
     },
     BUSINESS,
@@ -103,6 +115,16 @@ describe("curator internal routes", () => {
     });
     expect(res.statusCode).toBe(403);
     expect(host.contextCalls).toEqual([]);
+  });
+
+  it("delivers pending Proposal Tasks only for a service principal", async () => {
+    const delivery = new FakeDelivery();
+    app = await buildServer(host, "service", new FakeMinter(), {}, delivery);
+    const res = await app.inject({ method: "POST", url: "/api/v1/internal/curator/deliver" });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ delivered: 1, retryableFailed: 0, terminalRejected: 0 });
+    expect(delivery.calls).toEqual([BUSINESS]);
   });
 
   it("maps an unknown job to 404", async () => {

--- a/apps/api/src/curator/routes.ts
+++ b/apps/api/src/curator/routes.ts
@@ -4,6 +4,7 @@ import {
   CuratorHostError,
   type CuratorMinter,
   type CuratorRecovery,
+  type CuratorTaskDelivery,
 } from "@tulipfarm/curator-host";
 import type { CuratorObservedPayload } from "@tulipfarm/storage";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
@@ -39,6 +40,7 @@ export interface CuratorRouteDeps {
   readonly host: CuratorHost;
   readonly minter: CuratorMinter;
   readonly recovery: CuratorRecovery;
+  readonly delivery: CuratorTaskDelivery;
   /** Metrics only, and never a subject id — see `CuratorObservedPayload`. Swallowed below, so a
    *  broken exporter can never refuse a settlement. */
   readonly observe?: (payload: CuratorObservedPayload) => void;
@@ -53,6 +55,7 @@ export function registerCuratorRoutes(
   requireAuth: PreHandler
 ): void {
   const { host, minter, recovery, observe, backlogAgeSeconds } = deps;
+  const { delivery } = deps;
   /** Telemetry never fails the work it describes, but a broken subscriber is still a defect. */
   const report = (payload: CuratorObservedPayload): void => {
     try {
@@ -84,6 +87,34 @@ export function registerCuratorRoutes(
       throw error;
     }
   };
+
+  app.post(
+    "/api/v1/internal/curator/deliver",
+    {
+      preHandler,
+      schema: {
+        description:
+          "Claims validated Curator Proposal effects and delivers them as direct-user Tasks. " +
+          "All other Curator effects remain in the shadow ledger.",
+        tags: ["internal"],
+        security: [{ sessionCookie: [] }, { bearerToken: [] }],
+        response: {
+          200: {
+            type: "object",
+            required: ["delivered", "retryableFailed", "terminalRejected"],
+            additionalProperties: false,
+            properties: {
+              delivered: { type: "integer" },
+              retryableFailed: { type: "integer" },
+              terminalRejected: { type: "integer" },
+            },
+          },
+          ...SERVICE_ERRORS,
+        },
+      },
+    },
+    async (_req, reply) => guard(reply, () => delivery.run(businessId))
+  );
 
   app.post(
     "/api/v1/internal/curator/reconcile",

--- a/apps/eval/corpus/l3-curator-proposal-reaches-task.json
+++ b/apps/eval/corpus/l3-curator-proposal-reaches-task.json
@@ -1,0 +1,50 @@
+{
+  "id": "l3-curator-proposal-reaches-task",
+  "tier": "l3",
+  "agent": "support",
+  "context": {
+    "governancePages": []
+  },
+  "input": [
+    {
+      "role": "user",
+      "content": "I need a way to manage support tickets."
+    }
+  ],
+  "script": [
+    {
+      "kind": "text",
+      "text": "I can help you set that up."
+    }
+  ],
+  "curator": {
+    "output": {
+      "memory": [],
+      "proposals": [
+        {
+          "kind": "create_resource_type",
+          "subjectId": "tickets",
+          "rationale": "The participant wants to manage support tickets.",
+          "deliver": ["task"],
+          "citations": [
+            {
+              "turnId": "eval-curator-turn",
+              "quote": "I need a way to manage support tickets."
+            }
+          ]
+        }
+      ],
+      "knowledgePromotions": []
+    }
+  },
+  "expect": [
+    {
+      "kind": "curator_task_visible",
+      "title": "Set up ticket management"
+    },
+    {
+      "kind": "run_status",
+      "status": "succeeded"
+    }
+  ]
+}

--- a/apps/eval/package.json
+++ b/apps/eval/package.json
@@ -16,6 +16,8 @@
   },
   "dependencies": {
     "@tulipfarm/agent-runtime": "workspace:*",
+    "@tulipfarm/curator": "workspace:*",
+    "@tulipfarm/curator-host": "workspace:*",
     "@tulipfarm/files": "workspace:*",
     "@tulipfarm/llm": "workspace:*",
     "@tulipfarm/model-adapter": "workspace:*",

--- a/apps/eval/src/case.ts
+++ b/apps/eval/src/case.ts
@@ -88,7 +88,9 @@ export type Expectation =
    */
   | { readonly kind: "generated_file_readable_by"; readonly grantee: string }
   /** L3 only. The counterpart: the audience widened this far and no further. */
-  | { readonly kind: "generated_file_not_readable_by"; readonly grantee: string };
+  | { readonly kind: "generated_file_not_readable_by"; readonly grantee: string }
+  /** L3 only. A validated Curator Proposal reached its participant as a Task. */
+  | { readonly kind: "curator_task_visible"; readonly title: string };
 
 /** Expectations that read persisted state, which only the L3 tier can observe. */
 const PERSISTED_KINDS: ReadonlySet<string> = new Set([
@@ -100,6 +102,7 @@ const PERSISTED_KINDS: ReadonlySet<string> = new Set([
   "soul_published",
   "generated_file_readable_by",
   "generated_file_not_readable_by",
+  "curator_task_visible",
 ]);
 
 export function isPersisted(expectation: Expectation): boolean {
@@ -239,6 +242,8 @@ export interface EvalCase {
   /** What feeds the real Context assembler. The assembler's output is what the model sees. */
   readonly context: AssembleContext;
   readonly input: readonly ModelMessage[];
+  /** A deterministic Curator response applied after the L3 Chat Turn settles. */
+  readonly curator?: { readonly output: unknown };
   /**
    * The Files resolved for *this* Turn, as the Context assembler would resolve them.
    *

--- a/apps/eval/src/corpus.ts
+++ b/apps/eval/src/corpus.ts
@@ -124,6 +124,13 @@ function validate(raw: unknown, file: string): EvalCase {
   require(c.tier === "l2" ||
     c.tier ===
       "l3", `${file}: tier ${JSON.stringify(c.tier)} is not runnable; expected "l2" or "l3"`);
+  if (c.curator !== undefined) {
+    require(c.tier ===
+      "l3", `${file}: "curator" needs tier "l3"; this Case is tier ${JSON.stringify(c.tier)}`);
+    require(typeof c.curator === "object" &&
+      c.curator !== null &&
+      "output" in c.curator, `${file}: "curator" must contain an "output" fixture`);
+  }
   require(typeof c.context === "object" && c.context !== null, `${file}: missing "context"`);
   require(Array.isArray(c.input) &&
     c.input.length > 0, `${file}: "input" must be a non-empty array`);

--- a/apps/eval/src/expectation-shape.ts
+++ b/apps/eval/src/expectation-shape.ts
@@ -63,6 +63,7 @@ const EXPECTATION_FIELDS: Record<string, readonly [string, FieldType][]> = {
   soul_published: [["artifact", "string"]],
   generated_file_readable_by: [["grantee", "string"]],
   generated_file_not_readable_by: [["grantee", "string"]],
+  curator_task_visible: [["title", "string"]],
 };
 
 export function isKnownExpectationKind(kind: unknown): kind is string {

--- a/apps/eval/src/l3/database.ts
+++ b/apps/eval/src/l3/database.ts
@@ -22,11 +22,14 @@ import {
   AUTHORIZATION_STORAGE_STATEMENTS,
   BUDGET_STORAGE_STATEMENTS,
   BudgetStore,
+  CURATOR_STORAGE_STATEMENTS,
+  CURATOR_WORK_STORAGE_STATEMENTS,
   type Queryable,
   RUN_EVENT_STORAGE_STATEMENTS,
   RUN_STORAGE_STATEMENTS,
   RunEventStore,
   RunStore,
+  TASK_STORAGE_STATEMENTS,
   type TransactionPort,
   WAIT_STORAGE_STATEMENTS,
 } from "@tulipfarm/storage";
@@ -99,6 +102,9 @@ async function migratedSnapshot(): Promise<Blob | File> {
       ...WAIT_STORAGE_STATEMENTS,
       ...RUN_EVENT_STORAGE_STATEMENTS,
       ...BUDGET_STORAGE_STATEMENTS,
+      ...TASK_STORAGE_STATEMENTS,
+      ...CURATOR_STORAGE_STATEMENTS,
+      ...CURATOR_WORK_STORAGE_STATEMENTS,
       ...CONVERSATION_STATEMENTS,
       // A generated File's audience is decided by the Roles its authoring Agent holds, and those
       // are rows: `role_assignments` against a registered Principal. Seeding the answer instead

--- a/apps/eval/src/l3/tier.ts
+++ b/apps/eval/src/l3/tier.ts
@@ -16,8 +16,10 @@ import { contentText, type MessageContent, normalizeMessageContent } from "@tuli
 
 import { randomUUID } from "node:crypto";
 import type { ModelMessage, ModelUsage, ToolDispatchPort } from "@tulipfarm/agent-runtime";
+import { soulDigest, soulSubjects, soulSummary } from "@tulipfarm/curator";
+import { CuratorHost, CuratorTaskDelivery } from "@tulipfarm/curator-host";
 import { INVOKE_STATE_KEY } from "@tulipfarm/run-kernel";
-import type { PersistedRun } from "@tulipfarm/storage";
+import { CuratorRepo, type PersistedRun, TaskRepo } from "@tulipfarm/storage";
 import {
   type ApprovalWaitPort,
   createChatExecutor,
@@ -48,6 +50,7 @@ import { evalTurnHost } from "./turn-host.ts";
 const BUSINESS_ID = "eval";
 /** The person every L3 Turn runs for, and so the one reader a generated File always has. */
 const PARTICIPANT_ID = "eval";
+const CURATOR_TURN_ID = "eval-curator-turn";
 
 /** One dispatched Tool call, as a Case's Tool Expectations read it. */
 export interface ToolCall {
@@ -88,6 +91,8 @@ export interface PersistedTurn {
   readonly publishedArtifacts: readonly string[];
   /** Files the Turn generated, each with the audience `FileService` gave it. */
   readonly generatedFiles: readonly GeneratedFile[];
+  /** Tasks the Curator delivered after this Turn completed. */
+  readonly curatorTasks?: readonly { readonly title: string }[];
   /** The prompt the real Context assembler produced, so `prompt_contains` works at L3 too. */
   readonly systemPrompt: string;
   /**
@@ -175,6 +180,7 @@ async function readBack(
     soulCommits: readonly SoulCommit[];
     publishedArtifacts: readonly string[];
     generatedFiles: readonly GeneratedFile[];
+    curatorTasks: readonly { readonly title: string }[];
     systemPrompt: string;
     spend: Spend;
   }
@@ -209,6 +215,7 @@ async function readBack(
     soulCommits: observed.soulCommits,
     publishedArtifacts: observed.publishedArtifacts,
     generatedFiles: observed.generatedFiles,
+    curatorTasks: observed.curatorTasks,
     systemPrompt: observed.systemPrompt,
   };
 }
@@ -322,15 +329,67 @@ async function runOneTurn(
       leaseExpiresAt: null,
     });
 
+    const curatorTasks = await deliverCurator({
+      database,
+      soul,
+      evalCase: options.evalCase,
+      input: shared.submit,
+    });
+
     return await readBack(database, runId, turnId, {
       toolCalls: [...scripted.calls],
       soulCommits: soulWrites.commits.slice(committedBefore),
       publishedArtifacts: await soulWrites.published(),
       generatedFiles: files.generated.slice(generatedBefore),
+      curatorTasks,
       systemPrompt: context.systemPrompt,
       spend,
     });
   }
+}
+
+async function deliverCurator(input: {
+  readonly database: EvalDatabase;
+  readonly soul: EvalSoul;
+  readonly evalCase: EvalCase;
+  readonly input: readonly ModelMessage[];
+}): Promise<readonly { readonly title: string }[]> {
+  if (input.evalCase.curator === undefined) return [];
+
+  const repo = new CuratorRepo(input.database.queryable);
+  const tasks = new TaskRepo(input.database.transactions);
+  const job = await repo.insertJob(input.database.queryable, {
+    businessId: BUSINESS_ID,
+    scope: "user",
+    userId: PARTICIPANT_ID,
+    state: "running",
+    executionMode: "shadow",
+    manifestDigest: CURATOR_TURN_ID,
+    manifest: { work: [], turnIds: [CURATOR_TURN_ID], candidateIds: [] },
+  });
+  if (!job) throw new Error("Eval Curator job did not mint");
+
+  const turns = input.input
+    .filter((message) => message.role === "user")
+    .map((message) => ({ turnId: CURATOR_TURN_ID, userText: contentText(message.content) }));
+  const host = new CuratorHost({
+    repo,
+    documents: { read: async () => null } as never,
+    turns: { read: async () => turns },
+    subjects: () => soulSubjects(input.soul.loader),
+    openProposalKeys: async (businessId, userId) =>
+      (await tasks.listForPrincipal(businessId, userId, [], true)).map((task) => task.dedupeKey),
+    soulDigest: () => soulDigest(input.soul.loader),
+    soulSummary: () => soulSummary(input.soul.loader),
+  });
+  const context = await host.context(BUSINESS_ID, job.id);
+  const contextDigest = context.contextDigest;
+  if (typeof contextDigest !== "string") throw new Error("Eval Curator context has no digest");
+  await host.submit(BUSINESS_ID, job.id, contextDigest, input.evalCase.curator.output);
+  await new CuratorTaskDelivery({ repo, tasks, now: () => new Date() }).run(BUSINESS_ID);
+  return (await tasks.listForPrincipal(BUSINESS_ID, PARTICIPANT_ID, [], false)).map((task) => ({
+    title: task.title,
+  }));
 }
 
 /**

--- a/apps/eval/src/runner.ts
+++ b/apps/eval/src/runner.ts
@@ -272,6 +272,7 @@ async function runL3Trial(
         soulCommits: turn.soulCommits,
         publishedArtifacts: turn.publishedArtifacts,
         generatedFiles: turn.generatedFiles,
+        curatorTasks: turn.curatorTasks,
       },
     });
   } catch (cause) {

--- a/apps/eval/src/scorer.ts
+++ b/apps/eval/src/scorer.ts
@@ -41,6 +41,7 @@ export interface PersistedState {
     readonly filename: string;
     readonly readableBy: readonly string[];
   }[];
+  readonly curatorTasks?: readonly { readonly title: string }[];
 }
 
 export interface ExpectationResult {
@@ -272,6 +273,14 @@ function evaluate(a: Expectation, obs: Observation): { passed: boolean; detail: 
           )
           .join("; ")}`,
       };
+    }
+
+    case "curator_task_visible": {
+      const persisted = obs.persisted;
+      if (persisted === undefined) return notPersisted(a.kind);
+      return (persisted.curatorTasks ?? []).some((task) => task.title === a.title)
+        ? { passed: true, detail: `Curator delivered Task "${a.title}"` }
+        : { passed: false, detail: `no Curator Task titled "${a.title}"` };
     }
 
     // Answered by a Judge in `scoreJudged`, not here. Reaching this arm means a judged Expectation

--- a/apps/worker/src/curator/sweep.test.ts
+++ b/apps/worker/src/curator/sweep.test.ts
@@ -1,14 +1,18 @@
 import { beforeEach, expect, test, vi } from "vitest";
-import { sweepCurator } from "./sweep";
+import { CURATOR_DELIVERY_PATH, sweepCurator } from "./sweep";
 
 const backlog = vi.fn();
 const log = { info: vi.fn(), error: vi.fn() };
 
 const RECONCILE = "/api/v1/internal/curator/reconcile";
 
-function makeApi(mint: unknown = { outcome: "minted" }, repair: unknown = {}) {
+function makeApi(
+  mint: unknown = { outcome: "minted" },
+  repair: unknown = {},
+  delivery: unknown = {}
+) {
   const require = vi.fn(async (_method: string, path: string, _body?: unknown) =>
-    path === RECONCILE ? repair : mint
+    path === RECONCILE ? repair : path === CURATOR_DELIVERY_PATH ? delivery : mint
   );
   return { require: require as never };
 }
@@ -20,7 +24,7 @@ function allCalls(api: { require: unknown }) {
 /** The bodies of the mint posts only, so a test asserts fan-out without restating the repair. */
 function mintBodies(api: { require: unknown }) {
   return allCalls(api)
-    .filter(([, path]) => path !== RECONCILE)
+    .filter(([, path]) => path !== RECONCILE && path !== CURATOR_DELIVERY_PATH)
     .map(([, , body]) => body);
 }
 
@@ -41,6 +45,20 @@ test("mints one job per user with a backlog, then one for the business", async (
     { scope: "business" },
   ]);
   expect(result.minted).toBe(3);
+});
+
+test("delivers pending Proposal Tasks before reconciling and minting", async () => {
+  const order: string[] = [];
+  const api = {
+    require: vi.fn(async (_method: string, path: string) => {
+      order.push(path);
+      return path === RECONCILE ? {} : { outcome: "minted" };
+    }) as never,
+  };
+
+  await sweepCurator({ businessId: "biz", backlog, api });
+
+  expect(order.slice(0, 2)).toEqual([CURATOR_DELIVERY_PATH, RECONCILE]);
 });
 
 // The business half is what keeps knowledge promotion alive when nobody has chatted.
@@ -95,7 +113,9 @@ test("says nothing when the sweep found nothing to do", async () => {
 test("repairs stalled jobs before reading the backlog, so a freed target mints this tick", async () => {
   const order: string[] = [];
   const require = vi.fn(async (_method: string, path: string) => {
-    order.push(path === RECONCILE ? "reconcile" : "mint");
+    order.push(
+      path === CURATOR_DELIVERY_PATH ? "deliver" : path === RECONCILE ? "reconcile" : "mint"
+    );
     return path === RECONCILE ? { recovered: 2, abandoned: 1 } : { outcome: "minted" };
   });
   backlog.mockImplementation(async () => {
@@ -109,7 +129,7 @@ test("repairs stalled jobs before reading the backlog, so a freed target mints t
     api: { require: require as never },
   });
 
-  expect(order).toEqual(["reconcile", "backlog", "mint", "mint"]);
+  expect(order).toEqual(["deliver", "reconcile", "backlog", "mint", "mint"]);
   expect(result.recovered).toBe(2);
   expect(result.abandoned).toBe(1);
 });

--- a/apps/worker/src/curator/sweep.ts
+++ b/apps/worker/src/curator/sweep.ts
@@ -1,10 +1,11 @@
 /**
  * The Curator's fan-out half of the five-minute sweep.
  *
- * It carries no reasoning and no policy: it repairs jobs that stopped making progress, asks which
- * users have a backlog, then posts one mint per user and one for the business. Every refusal that
- * matters — a live job for the same target, an exhausted budget, an admission cap — is decided by
- * the API, so a sweep that runs twice or races another process cannot mint the same target twice.
+ * It carries no reasoning and no policy: it delivers ready Proposal Tasks, repairs jobs that
+ * stopped making progress, asks which users have a backlog, then posts one mint per user and one
+ * for the business. Every refusal that matters — a live job for the same target, an exhausted
+ * budget, an admission cap — is decided by the API, so a sweep that runs twice or races another
+ * process cannot mint the same target twice.
  */
 
 /**
@@ -16,6 +17,8 @@ export const CURATOR_SWEEP_USER_LIMIT = 25;
 export interface CuratorSweepApi {
   require<T>(method: "GET" | "POST", path: string, body?: unknown): Promise<T>;
 }
+
+export const CURATOR_DELIVERY_PATH = "/api/v1/internal/curator/deliver";
 
 /** Narrow port over `listUsersWithDueWork`, composed in `main.ts` where the pool is typed. */
 export type CuratorBacklogReader = (input: {
@@ -50,6 +53,11 @@ export async function sweepCurator(options: CuratorSweepOptions): Promise<Curato
   // for and refused every tick until something frees it. Repairing first lets the same tick mint.
   let recovered = 0;
   let abandoned = 0;
+  try {
+    await api.require("POST", CURATOR_DELIVERY_PATH);
+  } catch (error) {
+    log?.error(`[curator] proposal delivery failed — ${message(error)}`);
+  }
   try {
     const repair = await api.require<ReconcileOutcome>(
       "POST",

--- a/packages/curator-host/AGENTS.md
+++ b/packages/curator-host/AGENTS.md
@@ -7,7 +7,8 @@ package because none of it touches Fastify — `apps/api` keeps only routes and 
 
 ## Read on
 
-Minting a job, starting or recovering its Run, resolving pinned context, or accepting model output.
+Minting a job, starting or recovering its Run, resolving pinned context, accepting model output, or
+delivering an approved Proposal as a Task.
 
 ## Skip
 
@@ -20,6 +21,7 @@ Prompts, output schemas and citation rules (`packages/curator`), SQL and table s
 | --- | --- |
 | `src/mint.ts` | `CuratorMinter` — provider preflight, claim-and-reserve via `CuratorMintStore`, `gateway.start()` under a per-job idempotency key, `recover()`, atomic `abandon()` |
 | `src/host.ts` | `CuratorHost` — context pinning and drift detection, then revalidation of submitted output and exactly-once settlement |
+| `src/delivery.ts` | `CuratorTaskDelivery` — claims applyable Proposal effects, upserts direct-user Tasks, and records retryable or terminal outcomes |
 | `src/recovery.ts` | `CuratorRecovery` — replays a mint that crashed before the gateway, frees a target whose Run died |
 
 ## Rules

--- a/packages/curator-host/src/delivery.pg.test.ts
+++ b/packages/curator-host/src/delivery.pg.test.ts
@@ -1,0 +1,190 @@
+import { PGlite } from "@electric-sql/pglite";
+import { type CuratorEffect, curatorDedupeKey, type ProposalKind } from "@tulipfarm/curator";
+import {
+  CURATOR_STORAGE_STATEMENTS,
+  CURATOR_WORK_STORAGE_STATEMENTS,
+  type CuratorJobRecord,
+  CuratorRepo,
+  TASK_STORAGE_STATEMENTS,
+  TaskRepo,
+  type TaskStore,
+  type TaskStoreError,
+  type TransactionPort,
+} from "@tulipfarm/storage";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { CuratorTaskDelivery } from "./delivery";
+
+const BUSINESS = "business-1";
+const USER = "user-1";
+const NOW = new Date("2026-08-21T00:00:00.000Z");
+
+function transactions(database: PGlite): TransactionPort {
+  return { withTransaction: (operation) => database.transaction((tx) => operation(tx as never)) };
+}
+
+function proposal(
+  kind: ProposalKind = "create_agent_for_integration"
+): Extract<CuratorEffect, { kind: "proposal" }> {
+  const subjectId = "github";
+  return {
+    kind: "proposal",
+    proposalKind: kind,
+    subjectId,
+    subjectLabel: "GitHub",
+    deliver: ["task"],
+    dedupeKey: curatorDedupeKey(kind, subjectId),
+    rationale: "An agent can handle incoming GitHub work.",
+    citations: [{ turnId: "turn-1", quote: "Please handle our GitHub issues." }],
+  };
+}
+
+describe("CuratorTaskDelivery (PostgreSQL)", () => {
+  let database: PGlite;
+  let curator: CuratorRepo;
+  let tasks: TaskRepo;
+
+  async function seed(effect: CuratorEffect = proposal()): Promise<CuratorJobRecord> {
+    const job = await curator.insertJob(database as never, {
+      businessId: BUSINESS,
+      scope: "user",
+      userId: USER,
+      state: "running",
+      executionMode: "shadow",
+      manifestDigest: "digest-1",
+      manifest: { work: [], turnIds: [], candidateIds: [] },
+    });
+    if (!job) throw new Error("expected job");
+    await curator.settle({
+      job,
+      outputDigest: `output-${job.id}`,
+      generation: 1,
+      effects: [
+        {
+          kind: effect.kind,
+          payload: effect,
+          executionMode:
+            effect.kind === "proposal" && effect.deliver.includes("task") ? "apply" : "shadow",
+        },
+      ],
+      rejections: [],
+    });
+    return job;
+  }
+
+  function delivery(taskStore: TaskStore = tasks) {
+    return new CuratorTaskDelivery({ repo: curator, tasks: taskStore, now: () => NOW });
+  }
+
+  beforeAll(async () => {
+    database = new PGlite();
+    for (const sql of [
+      ...TASK_STORAGE_STATEMENTS,
+      ...CURATOR_STORAGE_STATEMENTS,
+      ...CURATOR_WORK_STORAGE_STATEMENTS,
+    ]) {
+      await database.exec(sql);
+    }
+    curator = new CuratorRepo(database as never);
+    tasks = new TaskRepo(transactions(database));
+  });
+
+  afterAll(async () => {
+    await database.close();
+  });
+
+  beforeEach(async () => {
+    await database.exec(
+      "DELETE FROM curator_task_metadata; DELETE FROM curator_job; DELETE FROM tasks;"
+    );
+  });
+
+  it("creates one direct-user Task from a pending Proposal and records its delivery", async () => {
+    const job = await seed();
+
+    await expect(delivery().run(BUSINESS)).resolves.toEqual({
+      delivered: 1,
+      retryableFailed: 0,
+      terminalRejected: 0,
+    });
+
+    const [effect] = await curator.listEffects(job.id);
+    expect(effect).toMatchObject({ executionMode: "apply", state: "succeeded" });
+    const visible = await tasks.listForPrincipal(BUSINESS, USER, [], false);
+    expect(visible).toHaveLength(1);
+    expect(visible[0]).toMatchObject({
+      assigneeKind: "user",
+      assigneeId: USER,
+      title: "Create an agent for GitHub",
+      action: { kind: "chat", prompt: "Help me create an agent that works my GitHub integration." },
+    });
+    const metadata = await database.query<{ kind: string; rationale: string }>(
+      "SELECT kind, rationale FROM curator_task_metadata WHERE task_id = $1",
+      [visible[0]?.id]
+    );
+    expect(metadata.rows).toEqual([
+      {
+        kind: "create_agent_for_integration",
+        rationale: "An agent can handle incoming GitHub work.",
+      },
+    ]);
+  });
+
+  it("retries a crash after the idempotent Task upsert without creating a duplicate", async () => {
+    const job = await seed();
+    let fail = true;
+    const failAfterWrite = Object.assign(Object.create(tasks), {
+      upsertOpen: async (...args: Parameters<TaskRepo["upsertOpen"]>) => {
+        const task = await tasks.upsertOpen(...args);
+        if (fail) {
+          fail = false;
+          throw new Error("crashed after task write");
+        }
+        return task;
+      },
+    }) as TaskStore;
+
+    await expect(delivery(failAfterWrite).run(BUSINESS)).resolves.toMatchObject({
+      retryableFailed: 1,
+    });
+    await expect(delivery().run(BUSINESS)).resolves.toMatchObject({ delivered: 1 });
+
+    const [effect] = await curator.listEffects(job.id);
+    expect(effect?.state).toBe("succeeded");
+    expect(await tasks.listForPrincipal(BUSINESS, USER, [], false)).toHaveLength(1);
+  });
+
+  it("preserves a permanent dismissal instead of recreating the Task", async () => {
+    const effect = proposal();
+    const existing = await tasks.upsertOpen(
+      {
+        businessId: BUSINESS,
+        assigneeKind: "user",
+        assigneeId: USER,
+        dedupeKey: effect.dedupeKey,
+        title: "Old suggestion",
+        action: { kind: "ack" },
+      },
+      NOW
+    );
+    await tasks.dismiss(BUSINESS, existing.id, NOW);
+    const job = await seed(effect);
+
+    await expect(delivery().run(BUSINESS)).resolves.toMatchObject({ terminalRejected: 1 });
+
+    const [stored] = await curator.listEffects(job.id);
+    expect(stored?.state).toBe("terminal_rejected");
+    await expect(
+      tasks.upsertOpen(
+        {
+          businessId: BUSINESS,
+          assigneeKind: "user",
+          assigneeId: USER,
+          dedupeKey: effect.dedupeKey,
+          title: "Never recreate",
+          action: { kind: "ack" },
+        },
+        NOW
+      )
+    ).rejects.toMatchObject({ code: "dismissed_permanently" } satisfies Partial<TaskStoreError>);
+  });
+});

--- a/packages/curator-host/src/delivery.ts
+++ b/packages/curator-host/src/delivery.ts
@@ -1,0 +1,135 @@
+import {
+  type CuratorCitation,
+  curatorDedupeKey,
+  PROPOSAL_KINDS,
+  PROPOSAL_SUBJECT_KIND,
+  type ProposalDelivery,
+  type ProposalKind,
+  templateProposal,
+} from "@tulipfarm/curator";
+import {
+  type CuratorProposalTaskEffect,
+  type CuratorRepo,
+  type TaskStore,
+  TaskStoreError,
+} from "@tulipfarm/storage";
+
+const DELIVERY_LIMIT = 25;
+const APPLY_LEASE_MS = 5 * 60_000;
+
+export interface CuratorTaskDeliveryDeps {
+  readonly repo: CuratorRepo;
+  readonly tasks: TaskStore;
+  now(): Date;
+}
+
+export interface CuratorTaskDeliveryResult {
+  readonly delivered: number;
+  readonly retryableFailed: number;
+  readonly terminalRejected: number;
+}
+
+interface ProposalPayload {
+  readonly proposalKind: ProposalKind;
+  readonly subjectId: string;
+  readonly subjectLabel: string;
+  readonly deliver: readonly ProposalDelivery[];
+  readonly dedupeKey: string;
+  readonly rationale: string;
+  readonly citations: readonly CuratorCitation[];
+}
+
+/**
+ * Delivers the narrowly approved Curator pilot: server-templated Proposals as direct-user Tasks.
+ *
+ * Task creation is intentionally outside the model and idempotent on the reserved dedupe key. A
+ * crash after the Task upsert but before effect settlement retries the same upsert and leaves one
+ * Task. Everything other than a Proposal that explicitly requests Task delivery remains shadowed.
+ */
+export class CuratorTaskDelivery {
+  constructor(private readonly deps: CuratorTaskDeliveryDeps) {}
+
+  async run(businessId: string, limit = DELIVERY_LIMIT): Promise<CuratorTaskDeliveryResult> {
+    const now = this.deps.now();
+    const effects = await this.deps.repo.claimProposalTasks({
+      businessId,
+      limit,
+      staleBefore: new Date(now.getTime() - APPLY_LEASE_MS),
+    });
+    let delivered = 0;
+    let retryableFailed = 0;
+    let terminalRejected = 0;
+
+    for (const effect of effects) {
+      const proposal = proposalPayload(effect);
+      if (!proposal) {
+        if (await this.deps.repo.rejectProposalTask(effect.id)) terminalRejected += 1;
+        continue;
+      }
+      const template = templateProposal({
+        kind: proposal.proposalKind,
+        subjectId: proposal.subjectId,
+        subjectLabel: proposal.subjectLabel,
+      });
+      try {
+        const task = await this.deps.tasks.upsertOpen(
+          {
+            businessId: effect.businessId,
+            assigneeKind: "user",
+            assigneeId: effect.userId,
+            dedupeKey: proposal.dedupeKey,
+            title: template.title,
+            detail: template.detail,
+            action: template.action,
+            subject: {
+              kind: PROPOSAL_SUBJECT_KIND[proposal.proposalKind],
+              id: proposal.subjectId,
+            },
+          },
+          now
+        );
+        if (
+          await this.deps.repo.completeProposalTask({
+            effectId: effect.id,
+            taskId: task.id,
+            kind: proposal.proposalKind,
+            deliver: proposal.deliver,
+            citations: proposal.citations,
+            rationale: proposal.rationale,
+          })
+        ) {
+          delivered += 1;
+        }
+      } catch (error) {
+        if (error instanceof TaskStoreError && error.code === "dismissed_permanently") {
+          if (await this.deps.repo.rejectProposalTask(effect.id)) terminalRejected += 1;
+        } else if (await this.deps.repo.retryProposalTask(effect.id)) {
+          retryableFailed += 1;
+        }
+      }
+    }
+    return { delivered, retryableFailed, terminalRejected };
+  }
+}
+
+function proposalPayload(effect: CuratorProposalTaskEffect): ProposalPayload | undefined {
+  const payload = effect.payload as Partial<ProposalPayload> | null;
+  if (!payload || typeof payload !== "object") return undefined;
+  if (!PROPOSAL_KINDS.includes(payload.proposalKind as ProposalKind)) return undefined;
+  if (typeof payload.subjectId !== "string" || typeof payload.subjectLabel !== "string") {
+    return undefined;
+  }
+  if (!Array.isArray(payload.deliver) || !payload.deliver.includes("task")) return undefined;
+  if (typeof payload.rationale !== "string" || !Array.isArray(payload.citations)) return undefined;
+  const proposalKind = payload.proposalKind as ProposalKind;
+  if (payload.dedupeKey !== curatorDedupeKey(proposalKind, payload.subjectId)) return undefined;
+  return {
+    proposalKind,
+    subjectId: payload.subjectId,
+    subjectLabel: payload.subjectLabel,
+    deliver: payload.deliver as ProposalDelivery[],
+    dedupeKey: payload.dedupeKey,
+    rationale: payload.rationale,
+    citations: payload.citations as CuratorCitation[],
+  };
+}

--- a/packages/curator-host/src/host.test.ts
+++ b/packages/curator-host/src/host.test.ts
@@ -18,6 +18,7 @@ const DIGEST = "digest-1";
 interface RecordedEffect {
   readonly kind: CuratorEffectKind;
   readonly payload: unknown;
+  readonly executionMode?: "shadow" | "apply";
 }
 
 class FakeCuratorRepo {
@@ -27,6 +28,7 @@ class FakeCuratorRepo {
   settled: string[] = [];
   candidates: { id: string; payload: unknown }[] = [];
   conflict = false;
+  reorderPinnedSectionHashes = false;
 
   async getJob(businessId: string, jobId: string): Promise<CuratorJobRecord | undefined> {
     const job = this.jobs.get(jobId);
@@ -37,8 +39,11 @@ class FakeCuratorRepo {
     if (!job) throw new Error(`no job ${jobId}`);
     const existing = job.contextPin;
     if (existing) return existing;
-    this.jobs.set(jobId, { ...job, contextPin: pin });
-    return pin;
+    const stored = this.reorderPinnedSectionHashes
+      ? { ...pin, sectionHashes: Object.fromEntries(Object.entries(pin.sectionHashes).reverse()) }
+      : pin;
+    this.jobs.set(jobId, { ...job, contextPin: stored });
+    return stored;
   }
   async readCandidates(
     _businessId: string,
@@ -178,6 +183,12 @@ describe("CuratorHost", () => {
       await expect(host.context(BUSINESS, "job-1")).resolves.toBeDefined();
     });
 
+    it("accepts an equivalent pin when JSON storage changes its key order", async () => {
+      repo.reorderPinnedSectionHashes = true;
+      repo.jobs.set("job-1", job());
+      await expect(host.context(BUSINESS, "job-1")).resolves.toBeDefined();
+    });
+
     it("serves only the candidates the job pinned, never whatever is open now", async () => {
       repo.jobs.set(
         "job-1",
@@ -301,7 +312,7 @@ describe("CuratorHost", () => {
         knowledgePromotions: [],
       });
       expect(result.recorded).toBe(1);
-      expect(repo.effects[0]?.kind).toBe("memory_patch");
+      expect(repo.effects[0]).toMatchObject({ kind: "memory_patch", executionMode: "shadow" });
       expect(repo.settled).toHaveLength(1);
     });
 
@@ -358,7 +369,25 @@ describe("CuratorHost", () => {
         knowledgePromotions: [],
       });
       expect(result.recorded).toBe(1);
-      expect(repo.effects[0]?.kind).toBe("proposal");
+      expect(repo.effects[0]).toMatchObject({ kind: "proposal", executionMode: "apply" });
+    });
+
+    it("keeps a pill-only Proposal in shadow mode", async () => {
+      await seed();
+      await host.submit(BUSINESS, "job-1", DIGEST, {
+        memory: [],
+        proposals: [
+          {
+            kind: "create_agent_for_integration",
+            subjectId: "github",
+            rationale: "GitHub was connected",
+            deliver: ["pill"],
+            citations: [{ turnId: "turn-1", quote: "I work on the payments team" }],
+          },
+        ],
+        knowledgePromotions: [],
+      });
+      expect(repo.effects[0]).toMatchObject({ kind: "proposal", executionMode: "shadow" });
     });
 
     it("plans a business job from its pinned candidates", async () => {

--- a/packages/curator-host/src/host.ts
+++ b/packages/curator-host/src/host.ts
@@ -64,6 +64,10 @@ interface Plan {
   readonly rejections: readonly { effect: string; reason: string; detail?: string }[];
 }
 
+function executionMode(effect: CuratorEffect): "apply" | "shadow" {
+  return effect.kind === "proposal" && effect.deliver.includes("task") ? "apply" : "shadow";
+}
+
 /**
  * Serves the pinned half of the Curator protocol.
  *
@@ -193,6 +197,7 @@ export class CuratorHost {
     const effects = kept.map((effect) => ({
       kind: effect.kind as CuratorEffectKind,
       payload: effect,
+      executionMode: executionMode(effect),
     }));
     try {
       const { recorded, rejected } = await this.deps.repo.settle({
@@ -270,7 +275,7 @@ function samePin(a: CuratorContextPin, b: CuratorContextPin): boolean {
     a.candidateDigest === b.candidateDigest &&
     a.seedDigest === b.seedDigest &&
     a.soulDigest === b.soulDigest &&
-    JSON.stringify(a.sectionHashes) === JSON.stringify(b.sectionHashes)
+    MEMORY_SECTION_KEYS.every((key) => a.sectionHashes[key] === b.sectionHashes[key])
   );
 }
 

--- a/packages/curator-host/src/index.ts
+++ b/packages/curator-host/src/index.ts
@@ -1,4 +1,9 @@
 export {
+  CuratorTaskDelivery,
+  type CuratorTaskDeliveryDeps,
+  type CuratorTaskDeliveryResult,
+} from "./delivery";
+export {
   CuratorHost,
   type CuratorHostDenial,
   type CuratorHostDeps,

--- a/packages/storage/src/curator/index.ts
+++ b/packages/storage/src/curator/index.ts
@@ -18,6 +18,7 @@ export type {
   CuratorJobRecord,
   CuratorJobState,
   CuratorManifest,
+  CuratorProposalTaskEffect,
   CuratorRejectionRecord,
   CuratorScope,
   StaleCuratorJob,

--- a/packages/storage/src/curator/repo.ts
+++ b/packages/storage/src/curator/repo.ts
@@ -102,6 +102,15 @@ export interface CuratorEffectRecord {
   readonly createdAt: Date;
 }
 
+/** An applyable Proposal effect claimed for delivery to its subject's Task queue. */
+export interface CuratorProposalTaskEffect {
+  readonly id: string;
+  readonly jobId: string;
+  readonly businessId: string;
+  readonly userId: string;
+  readonly payload: unknown;
+}
+
 /** A dropped claim. Recorded, never inferred from an absence — "why" is the loop's own metric. */
 export interface CuratorRejectionRecord {
   readonly jobId: string;
@@ -337,7 +346,12 @@ export class CuratorRepo {
     readonly job: CuratorJobRecord;
     readonly outputDigest: string;
     readonly generation: number;
-    readonly effects: readonly { readonly kind: CuratorEffectKind; readonly payload: unknown }[];
+    readonly effects: readonly {
+      readonly kind: CuratorEffectKind;
+      readonly payload: unknown;
+      /** Omitted only by legacy callers, which inherit the job's immutable mode. */
+      readonly executionMode?: CuratorExecutionMode;
+    }[];
     readonly rejections: readonly {
       readonly effect: string;
       readonly reason: string;
@@ -373,8 +387,9 @@ export class CuratorRepo {
         };
       }
 
-      const state: CuratorEffectState = job.executionMode === "shadow" ? "shadowed" : "pending";
       for (const [ordinal, effect] of effects.entries()) {
+        const executionMode = effect.executionMode ?? job.executionMode;
+        const state: CuratorEffectState = executionMode === "shadow" ? "shadowed" : "pending";
         await tx.query(
           `INSERT INTO curator_effect
              (id, job_id, business_id, kind, generation, execution_mode, state, payload)
@@ -385,7 +400,7 @@ export class CuratorRepo {
             job.businessId,
             effect.kind,
             generation,
-            job.executionMode,
+            executionMode,
             state,
             JSON.stringify(effect.payload),
           ]
@@ -402,6 +417,120 @@ export class CuratorRepo {
       await completeCuratorWork(tx, job.id, new Date());
       return { recorded: effects.length, rejected: rejections.length, replayed: false };
     });
+  }
+
+  /**
+   * Claims a bounded batch of Proposal effects for delivery as Tasks.
+   *
+   * An applying row is retried only after its lease window. The Task upsert is idempotent on the
+   * Curator-owned dedupe key, so reclaiming after a crash between the Task write and settlement
+   * cannot create a duplicate Task.
+   */
+  async claimProposalTasks(input: {
+    readonly businessId: string;
+    readonly limit: number;
+    readonly staleBefore: Date;
+  }): Promise<CuratorProposalTaskEffect[]> {
+    const { rows } = await withTransaction(this.db, (tx) =>
+      tx.query<{
+        id: string;
+        job_id: string;
+        business_id: string;
+        user_id: string;
+        payload: unknown;
+      }>(
+        `WITH candidates AS (
+           SELECT e.id
+             FROM curator_effect AS e
+             JOIN curator_job AS j ON j.id = e.job_id
+            WHERE e.business_id = $1
+              AND e.kind = 'proposal'
+              AND e.execution_mode = 'apply'
+              AND j.scope = 'user'
+              AND j.user_id IS NOT NULL
+              AND (
+                e.state IN ('pending', 'retryable_failed')
+                OR (e.state = 'applying' AND e.updated_at < $2)
+              )
+            ORDER BY e.created_at, e.id
+            FOR UPDATE OF e SKIP LOCKED
+            LIMIT $3
+         )
+         UPDATE curator_effect AS e
+            SET state = 'applying', updated_at = now()
+           FROM candidates, curator_job AS j
+          WHERE e.id = candidates.id AND j.id = e.job_id
+          RETURNING e.id, e.job_id, e.business_id, j.user_id, e.payload`,
+        [input.businessId, input.staleBefore, Math.max(0, input.limit)]
+      )
+    );
+    return rows.map((row) => ({
+      id: row.id,
+      jobId: row.job_id,
+      businessId: row.business_id,
+      userId: row.user_id,
+      payload: row.payload,
+    }));
+  }
+
+  /** Records the Task projection and settles the claimed effect in one transaction. */
+  async completeProposalTask(input: {
+    readonly effectId: string;
+    readonly taskId: string;
+    readonly kind: string;
+    readonly deliver: readonly string[];
+    readonly citations: unknown;
+    readonly rationale: string;
+  }): Promise<boolean> {
+    return await withTransaction(this.db, async (tx) => {
+      const effect = await tx.query<{ business_id: string }>(
+        `UPDATE curator_effect
+            SET state = 'succeeded', updated_at = now()
+          WHERE id = $1 AND state = 'applying'
+          RETURNING business_id`,
+        [input.effectId]
+      );
+      const businessId = effect.rows[0]?.business_id;
+      if (!businessId) return false;
+      await tx.query(
+        `INSERT INTO curator_task_metadata (task_id, business_id, kind, deliver, citations, rationale)
+         VALUES ($1, $2, $3, $4, $5, $6)
+         ON CONFLICT (task_id) DO NOTHING`,
+        [
+          input.taskId,
+          businessId,
+          input.kind,
+          input.deliver,
+          JSON.stringify(input.citations),
+          input.rationale,
+        ]
+      );
+      return true;
+    });
+  }
+
+  /** A malformed or permanently dismissed Proposal is evidence, not work to retry forever. */
+  async rejectProposalTask(effectId: string): Promise<boolean> {
+    const { rows } = await this.db.query<{ id: string }>(
+      `UPDATE curator_effect
+          SET state = 'terminal_rejected', updated_at = now()
+        WHERE id = $1 AND state = 'applying'
+        RETURNING id`,
+      [effectId]
+    );
+    return rows.length > 0;
+  }
+
+  /** A transient Task-store failure leaves durable retry evidence for the next sweep. */
+  async retryProposalTask(effectId: string): Promise<boolean> {
+    const { rows } = await this.db.query<{ id: string }>(
+      `UPDATE curator_effect
+          SET state = 'retryable_failed', updated_at = now()
+        WHERE id = $1 AND state = 'applying'
+        RETURNING id`,
+      [effectId]
+    );
+    return rows.length > 0;
   }
 
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -352,6 +352,12 @@ importers:
       '@tulipfarm/agent-runtime':
         specifier: workspace:*
         version: link:../../packages/agent-runtime
+      '@tulipfarm/curator':
+        specifier: workspace:*
+        version: link:../../packages/curator
+      '@tulipfarm/curator-host':
+        specifier: workspace:*
+        version: link:../../packages/curator-host
       '@tulipfarm/files':
         specifier: workspace:*
         version: link:../../packages/files


### PR DESCRIPTION
Fixes #423

- Deliver user-scope Curator Proposals requesting Task delivery through a leased, idempotent Task projection.
- Keep every other Curator effect shadowed and record proposal metadata for auditability.
- Add direct delivery/retry coverage and an L3 eval that proves a Curator Proposal reaches a visible Task.

The Eval Corpus changed (hash `b0b7d613da0c44c0`), so existing baselines require re-promotion before comparison.

## Test plan

- [x] `pnpm --filter @tulipfarm/curator-host test`
- [x] `pnpm --filter @tulipfarm/storage test src/curator`
- [x] `pnpm --filter @tulipfarm/api test src/curator`
- [x] `pnpm --filter @tulipfarm/worker test src/curator`
- [x] `pnpm --filter @tulipfarm/eval test`
- [x] `pnpm eval`
- [x] `pnpm lint`
- [x] `pnpm typecheck`