### PR TITLE
fix: personal GitHub connect — clickable link, correct gating, clearer error

### DIFF
--- a/apps/api/src/integrations/auth-broker.test.ts
+++ b/apps/api/src/integrations/auth-broker.test.ts
@@ -180,6 +180,45 @@ describe("startAuthStep", () => {
     ).rejects.toMatchObject({ reason: "missing_credentials" });
   });
 
+  it("names the fields step that owns the missing client id, not the raw env var", async () => {
+    await expect(
+      startAuthStep({
+        slug: "notion",
+        manifest: manifestWith([
+          {
+            kind: "fields",
+            title: "Configure personal Notion access",
+            fields: [{ name: "NOTION_CLIENT_ID", label: "Client ID" }],
+          },
+          oauthStep,
+        ]),
+        stepIndex: 1,
+        env: {},
+        endpoints,
+        repo: new MemoryAuthRequestRepo(),
+      })
+    ).rejects.toMatchObject({
+      reason: "missing_credentials",
+      message: expect.stringContaining('"Configure personal Notion access"'),
+    });
+  });
+
+  it("falls back to a generic message when no fields step owns the missing client id", async () => {
+    await expect(
+      startAuthStep({
+        slug: "notion",
+        manifest: manifestWith([oauthStep]),
+        stepIndex: 0,
+        env: {},
+        endpoints,
+        repo: new MemoryAuthRequestRepo(),
+      })
+    ).rejects.toMatchObject({
+      reason: "missing_credentials",
+      message: expect.not.stringContaining("NOTION_CLIENT_ID"),
+    });
+  });
+
   it("rejects a step index the manifest does not declare", async () => {
     await expect(
       startAuthStep({

--- a/apps/api/src/integrations/auth-broker.ts
+++ b/apps/api/src/integrations/auth-broker.ts
@@ -11,6 +11,7 @@ import {
   renderTemplate,
 } from "@tulipfarm/integrations";
 import type {
+  AuthFieldsStep,
   AuthOAuth2Step,
   AuthStep,
   AuthWebhookStep,
@@ -179,6 +180,18 @@ async function readJsonBody(response: Response): Promise<Record<string, unknown>
   }
 }
 
+/** Names the `fields` step that owns a missing oauth2 credential, instead of its raw env var. */
+function missingCredentialsMessage(input: StartAuthStepInput, step: AuthOAuth2Step): string {
+  const owner = resolveAuthSteps(input.manifest).find(
+    (candidate): candidate is AuthFieldsStep =>
+      candidate.kind === "fields" &&
+      candidate.fields.some((field) => field.name === step.client_id_env)
+  );
+  return owner?.title
+    ? `Complete "${owner.title}" first — it supplies this step's credentials.`
+    : "An earlier setup step must be completed before this one.";
+}
+
 /** Prepares one step, persisting the one-use state any provider round trip will come back with. */
 export async function startAuthStep(input: StartAuthStepInput): Promise<AuthStartAction> {
   const step = stepAt(input.manifest, input.stepIndex);
@@ -224,10 +237,7 @@ export async function startAuthStep(input: StartAuthStepInput): Promise<AuthStar
     case "oauth2": {
       const clientId = input.env[step.client_id_env];
       if (!clientId) {
-        throw new AuthBrokerError(
-          "missing_credentials",
-          `${step.client_id_env} is not set; an earlier auth step must supply it`
-        );
+        throw new AuthBrokerError("missing_credentials", missingCredentialsMessage(input, step));
       }
       const usePkce = step.pkce !== false;
       const codeVerifier = usePkce ? randomBytes(32).toString("base64url") : null;

--- a/apps/api/src/internal/schemas.ts
+++ b/apps/api/src/internal/schemas.ts
@@ -241,6 +241,7 @@ export const InternalTurnToolResultResponseSchema = {
     output: {},
     reason: { type: "string" },
     approvalId: { type: "string" },
+    connectUrl: { type: "string", minLength: 1 },
   },
 } as const;
 

--- a/apps/api/src/internal/turn-host.ts
+++ b/apps/api/src/internal/turn-host.ts
@@ -123,7 +123,7 @@ export interface HostedToolCall {
 /** Mirrors the loop's `ToolDispatchResult`, minus the `callId` the caller already holds. */
 export type HostedToolResult =
   | { readonly status: "succeeded"; readonly output: unknown }
-  | { readonly status: "denied"; readonly reason: string }
+  | { readonly status: "denied"; readonly reason: string; readonly connectUrl?: string }
   | { readonly status: "invalid_arguments"; readonly reason: string }
   | { readonly status: "failed"; readonly reason: string }
   | { readonly status: "awaiting_approval"; readonly approvalId: string };

--- a/apps/web/app/components/chat/tool-trace.tsx
+++ b/apps/web/app/components/chat/tool-trace.tsx
@@ -1,3 +1,4 @@
+import { Link } from "@remix-run/react";
 import { PenLine } from "lucide-react";
 import { Fragment } from "react";
 import { Trace, TraceStep } from "~/components/ui/trace";
@@ -125,7 +126,14 @@ function detailOf(part: ToolPart, status: "running" | "done" | "error") {
   const hint = status === "done" ? describeToolResult(part) : undefined;
   const duration = formatDuration(part.meta?.durationMs);
   const inspectable = toolHasDetails(part);
-  if (code === undefined && hint === undefined && duration === undefined && !inspectable) {
+  const connectUrl = status === "error" ? part.meta?.connectUrl : undefined;
+  if (
+    code === undefined &&
+    hint === undefined &&
+    duration === undefined &&
+    connectUrl === undefined &&
+    !inspectable
+  ) {
     return undefined;
   }
   return (
@@ -138,6 +146,11 @@ function detailOf(part: ToolPart, status: "running" | "done" | "error") {
             <span className="font-mono tabular-nums">{duration}</span>
           )}
         </span>
+      )}
+      {connectUrl === undefined ? null : (
+        <Link to={connectUrl} className="block text-primary hover:underline">
+          Connect your account →
+        </Link>
       )}
       {inspectable ? <ToolInspector part={part} /> : null}
     </div>

--- a/apps/web/app/lib/chat/sse-client.ts
+++ b/apps/web/app/lib/chat/sse-client.ts
@@ -77,6 +77,7 @@ type RunEventData = {
   status?: string;
   summary?: string;
   errorCode?: string;
+  connectUrl?: string;
   intentId?: string;
   stage?: string;
   reason?: string;
@@ -199,6 +200,7 @@ export function createRunEventMapper(): (frame: ParsedFrame) => ChatEvent[] {
                 durationMs: data.durationMs,
                 errorCode: data.errorCode,
                 summary: data.summary,
+                connectUrl: data.connectUrl,
               }),
             }),
           },

--- a/apps/web/app/lib/chat/types.ts
+++ b/apps/web/app/lib/chat/types.ts
@@ -56,6 +56,8 @@ export type ToolMeta = {
   durationMs?: number;
   errorCode?: string;
   summary?: string;
+  /** UI-only deep link to a connect page; never sent to the model. */
+  connectUrl?: string;
 };
 
 export type PlanStep = { id: string; label: string; status: StepStatus };

--- a/apps/web/app/routes/_app.integrations.$name.tsx
+++ b/apps/web/app/routes/_app.integrations.$name.tsx
@@ -70,7 +70,7 @@ const CALLBACK_REASON: Record<string, string> = {
   unknown_step: "That setup step no longer exists. Reload the page and start again.",
   invalid_state: "This setup link expired or was already used. Start the step again.",
   missing_credentials:
-    "A credential from an earlier step is missing. Complete the earlier steps first.",
+    "An earlier setup step is missing its credentials. Complete that step first.",
   exchange_failed: "The provider rejected the request. Start the step again.",
 };
 
@@ -234,6 +234,12 @@ export default function IntegrationDetailPage() {
   const authSteps = (integration.auth ?? []).filter((step) => !step.personal);
   const isConnected = integration.connected;
   const installStep = authSteps.find((step) => step.kind === "install");
+  const personalStep = integration.auth?.find((step) => step.personal);
+  const personalStepReady =
+    personalStep !== undefined &&
+    (integration.auth ?? [])
+      .filter((step) => step.index < personalStep.index && !step.personal)
+      .every((step) => step.satisfied);
   const name = displayName(integration);
 
   // The single auth callback returns here with the outcome of the step the operator just left for.
@@ -486,7 +492,7 @@ export default function IntegrationDetailPage() {
           </section>
         )}
 
-        {integration.name === "github" && isConnected && (
+        {integration.name === "github" && personalStepReady && (
           <GitHubPersonalAccount
             integration={integration}
             callbackError={callbackError}

--- a/apps/web/app/routes/integrations.detail.test.tsx
+++ b/apps/web/app/routes/integrations.detail.test.tsx
@@ -231,6 +231,70 @@ test("offers every signed-in user their own GitHub connect action", async () => 
   expect(screen.getByText(/never fall back to the business's GitHub App/i)).toBeInTheDocument();
 });
 
+test("hides the personal connect button until the fields step it depends on is satisfied", async () => {
+  admin = false;
+  renderDetail(
+    detail({
+      // `connected` reflects App-install status (a different, later step) and must not gate this.
+      connected: true,
+      status: "connected",
+      auth: [
+        {
+          index: 1,
+          kind: "fields",
+          title: "Configure personal GitHub access",
+          satisfied: false,
+          producesEnv: true,
+          fields: [{ name: "GITHUB_OAUTH_CLIENT_ID", label: "Client ID" }],
+        },
+        {
+          index: 3,
+          kind: "oauth2",
+          personal: true,
+          satisfied: false,
+          producesEnv: true,
+        },
+      ],
+    })
+  );
+
+  await screen.findByRole("heading", { level: 1 });
+  expect(
+    screen.queryByRole("button", { name: "Connect your GitHub account" })
+  ).not.toBeInTheDocument();
+});
+
+test("shows the personal connect button once the fields step it depends on is satisfied", async () => {
+  admin = false;
+  renderDetail(
+    detail({
+      connected: false,
+      status: "disconnected",
+      auth: [
+        {
+          index: 1,
+          kind: "fields",
+          title: "Configure personal GitHub access",
+          satisfied: true,
+          producesEnv: true,
+          fields: [{ name: "GITHUB_OAUTH_CLIENT_ID", label: "Client ID" }],
+        },
+        {
+          index: 3,
+          kind: "oauth2",
+          personal: true,
+          satisfied: false,
+          producesEnv: true,
+        },
+      ],
+    })
+  );
+
+  expect(
+    await screen.findByRole("button", { name: "Connect your GitHub account" })
+  ).toBeInTheDocument();
+});
+
 test("keeps a personal OAuth step out of the administrator's business setup rail", async () => {
   renderDetail(
     detail({

--- a/apps/worker/src/internal/turn-host.ts
+++ b/apps/worker/src/internal/turn-host.ts
@@ -39,7 +39,7 @@ export interface TaskReconcileSignals {
 /** A dispatch outcome as the host reports it: the caller already holds the `callId`. */
 type RemoteToolResult =
   | { readonly status: "succeeded"; readonly output: unknown }
-  | { readonly status: "denied"; readonly reason: string }
+  | { readonly status: "denied"; readonly reason: string; readonly connectUrl?: string }
   | { readonly status: "invalid_arguments"; readonly reason: string }
   | { readonly status: "failed"; readonly reason: string }
   | { readonly status: "awaiting_approval"; readonly approvalId: string };
@@ -51,6 +51,8 @@ function withCallId(callId: string, result: RemoteToolResult): ToolDispatchResul
       return { status: "succeeded", callId, output: result.output };
     case "awaiting_approval":
       return { status: "awaiting_approval", callId, approvalId: result.approvalId };
+    case "denied":
+      return { status: "denied", callId, reason: result.reason, connectUrl: result.connectUrl };
     default:
       return { status: result.status, callId, reason: result.reason };
   }

--- a/apps/worker/src/tools/routing-dispatch.ts
+++ b/apps/worker/src/tools/routing-dispatch.ts
@@ -90,6 +90,8 @@ function withCallId(callId: string, result: HostedToolResult): ToolDispatchResul
       return { status: "succeeded", callId, output: result.output };
     case "awaiting_approval":
       return { status: "awaiting_approval", callId, approvalId: result.approvalId };
+    case "denied":
+      return { status: "denied", callId, reason: result.reason, connectUrl: result.connectUrl };
     default:
       return { status: result.status, callId, reason: result.reason };
   }

--- a/packages/agent-runtime/src/loop/contract.ts
+++ b/packages/agent-runtime/src/loop/contract.ts
@@ -63,7 +63,13 @@ export interface ToolDispatchRequest {
 
 export type ToolDispatchResult =
   | { readonly status: "succeeded"; readonly callId: string; readonly output: unknown }
-  | { readonly status: "denied"; readonly callId: string; readonly reason: string }
+  | {
+      readonly status: "denied";
+      readonly callId: string;
+      readonly reason: string;
+      /** UI-only deep link to the provider's connect page; never surfaced to the model. */
+      readonly connectUrl?: string;
+    }
   | { readonly status: "invalid_arguments"; readonly callId: string; readonly reason: string }
   | { readonly status: "failed"; readonly callId: string; readonly reason: string }
   | {

--- a/packages/schema/src/run-events.test.ts
+++ b/packages/schema/src/run-events.test.ts
@@ -193,6 +193,21 @@ describe("run event vocabulary", () => {
     expect(accepts("turn.finished", { status: "cancelled", messageId: null })).toBe(true);
   });
 
+  it("carries a UI-only connect link on a denied tool.result, and rejects it once trimmed", () => {
+    // A person behind a denied call gets a deep link to fix it; the field must survive validation.
+    expect(
+      accepts("tool.result", {
+        callId: "c1",
+        status: "error",
+        errorCode: "denied",
+        connectUrl: "/integrations/github",
+      })
+    ).toBe(true);
+    expect(
+      accepts("tool.result", { callId: "c1", status: "error", errorCode: "denied", connectUrl: "" })
+    ).toBe(false);
+  });
+
   it("rejects a payload missing a field its reader depends on", () => {
     expect(accepts("text.delta", { text: "hello" })).toBe(false);
     expect(accepts("turn.started", { turnId: "t1", attempt: 0 })).toBe(false);

--- a/packages/schema/src/run-events.ts
+++ b/packages/schema/src/run-events.ts
@@ -131,6 +131,7 @@ const TOOL_RESULT_SCHEMA = {
     errorCode: { type: "string", minLength: 1 },
     resultPreview: TOOL_PREVIEW_SCHEMA,
     durationMs: { type: "integer", minimum: 0 },
+    connectUrl: { type: "string", minLength: 1 },
   },
 } as const;
 
@@ -472,6 +473,8 @@ export interface RunEventPayloads {
     readonly errorCode?: string;
     readonly resultPreview?: RunEventToolPreview;
     readonly durationMs?: number;
+    /** UI-only deep link to a connect page; never surfaced to the model. */
+    readonly connectUrl?: string;
   };
   readonly "surface.emitted": { readonly artifactId: string; readonly componentId?: string };
   readonly "approval.requested": {

--- a/packages/tool-host/src/authority.ts
+++ b/packages/tool-host/src/authority.ts
@@ -46,7 +46,7 @@ export interface HostedToolCall {
 /** Mirrors the loop's `ToolDispatchResult`, minus the `callId` the caller already holds. */
 export type HostedToolResult =
   | { readonly status: "succeeded"; readonly output: unknown }
-  | { readonly status: "denied"; readonly reason: string }
+  | { readonly status: "denied"; readonly reason: string; readonly connectUrl?: string }
   | { readonly status: "invalid_arguments"; readonly reason: string }
   | { readonly status: "failed"; readonly reason: string }
   | { readonly status: "awaiting_approval"; readonly approvalId: string };

--- a/packages/tool-host/src/credential-mode.test.ts
+++ b/packages/tool-host/src/credential-mode.test.ts
@@ -152,6 +152,8 @@ describe("CredentialResolver", () => {
     expect(result.use).toBe("denied");
     // The refusal has to tell them how to fix it, or the model retries a call that cannot succeed.
     expect(result.use === "denied" && result.reason).toContain("connect");
+    // A person behind this call can act on a UI-only deep link to the provider's connect page.
+    expect(result.use === "denied" && result.connectUrl).toBe("/integrations/acme");
   });
 
   it("distinguishes a personal connection from a workspace-level one already in place", async () => {
@@ -171,15 +173,13 @@ describe("CredentialResolver", () => {
   it("refuses rather than downgrading under user_preferred when the provider can issue one", async () => {
     // `preferred` must not silently fall back to the bot for unconnected users.
     const r = resolverFor([oauthProvider]);
-    expect(
-      (
-        await r.resolve(human, {
-          name: "acme_search",
-          provider: "acme",
-          credentialMode: "user_preferred",
-        })
-      ).use
-    ).toBe("denied");
+    const result = await r.resolve(human, {
+      name: "acme_search",
+      provider: "acme",
+      credentialMode: "user_preferred",
+    });
+    expect(result.use).toBe("denied");
+    expect(result.use === "denied" && result.connectUrl).toBe("/integrations/acme");
   });
 
   it("falls back to service under user_preferred when the provider cannot issue a personal credential", async () => {
@@ -249,6 +249,8 @@ describe("CredentialResolver", () => {
       credentialMode: "user",
     });
     expect(result.use).toBe("denied");
+    // No person is behind this call, so there is no one to send a connect link to.
+    expect(result.use === "denied" && result.connectUrl).toBeUndefined();
   });
 
   it("stops spending a personal credential the moment it is revoked", async () => {

--- a/packages/tool-host/src/credential-mode.ts
+++ b/packages/tool-host/src/credential-mode.ts
@@ -20,8 +20,11 @@ export type CredentialResolution =
       readonly use: "principal";
       readonly principal: { readonly kind: string; readonly id: string };
     }
-  /** The call may not proceed; `reason` is user- and model-facing. */
-  | { readonly use: "denied"; readonly reason: string };
+  /**
+   * The call may not proceed; `reason` is user- and model-facing. `connectUrl`, when present, is
+   * UI-only — a relative path to the provider's connect page for a person who can act on it.
+   */
+  | { readonly use: "denied"; readonly reason: string; readonly connectUrl?: string };
 
 export interface CredentialSubject {
   readonly kind: string;
@@ -93,7 +96,13 @@ export class CredentialResolver {
     if (token !== null)
       return { use: "principal", principal: { kind: subject.kind, id: subject.id } };
 
-    if (strict) return { use: "denied", reason: connectPrompt(provider, tool.name) };
+    if (strict) {
+      return {
+        use: "denied",
+        reason: connectPrompt(provider, tool.name),
+        connectUrl: `/integrations/${provider}`,
+      };
+    }
 
     // `user_preferred`: refuse only where connecting is possible. An unresolvable integration is
     // treated as unable to issue one — the Tool exists, so denying it on a catalog miss would be a
@@ -103,7 +112,11 @@ export class CredentialResolver {
       this.deps.personalCredentialProviders?.has(provider) === true ||
       (integration !== undefined && providerSupportsPersonalCredential(integration))
     ) {
-      return { use: "denied", reason: connectPrompt(provider, tool.name) };
+      return {
+        use: "denied",
+        reason: connectPrompt(provider, tool.name),
+        connectUrl: `/integrations/${provider}`,
+      };
     }
     return { use: "service" };
   }

--- a/packages/tool-host/src/dispatcher.ts
+++ b/packages/tool-host/src/dispatcher.ts
@@ -356,7 +356,11 @@ export class RegistryToolDispatcher implements TurnToolDispatcher {
     // Resolve credentials before approval; do not ask humans to approve calls that cannot run.
     const credential = await this.resolveCredential(authority, definition);
     if (credential.use === "denied") {
-      return { status: "denied", reason: credential.reason };
+      return {
+        status: "denied",
+        reason: credential.reason,
+        ...(credential.connectUrl === undefined ? {} : { connectUrl: credential.connectUrl }),
+      };
     }
 
     const denial = await this.entitlementDenial(authority, definition, call);

--- a/packages/turn-executor/src/tool-events.ts
+++ b/packages/turn-executor/src/tool-events.ts
@@ -83,6 +83,9 @@ export function announceToolCalls(
               summary: result.reason,
               errorCode: result.status,
               durationMs,
+              ...(result.status === "denied" && result.connectUrl !== undefined
+                ? { connectUrl: result.connectUrl }
+                : {}),
             },
         `tool:result:${request.callId}`
       );


### PR DESCRIPTION
## Summary
- Chat denials for a missing personal credential now carry a UI-only `connectUrl` that renders as a clickable "Connect your account" link in tool-trace, instead of prose only. Field never reaches the model — verified no call site spreads it into `toolMessage()`.
- `/integrations/github`'s personal connect button is now gated on its real prerequisite (the manifest's `fields` step being `satisfied`), not on unrelated business App-install status.
- The oauth2 `missing_credentials` error now names the setup step ("Configure personal GitHub access") instead of a raw env var like `GITHUB_OAUTH_CLIENT_ID`.

## Test plan
- [x] `pnpm typecheck` clean across all 38 workspaces
- [x] `pnpm --filter @tulipfarm/tool-host test` — credential-mode denial carries/omits `connectUrl` correctly
- [x] `pnpm --filter @tulipfarm/api test` — auth-broker names the step title, not the env var; all 293 files pass
- [x] `pnpm --filter @tulipfarm/web test` — button gating keyed on the fields step, not `connected`
- [x] `pnpm --filter @tulipfarm/schema test` — `connectUrl` round-trips through `TOOL_RESULT_SCHEMA`, rejects empty string
- [x] `pnpm --filter @tulipfarm/worker test`, `@tulipfarm/agent-runtime test`, `@tulipfarm/turn-executor test` all pass
- [x] Two-axis `/code-review` (standards + spec) run against `main`, no hard findings; one nit (missing `minLength: 1` on the internal API schema's `connectUrl`) found and fixed
- [ ] Manual browser QA not performed this session (dev server port conflict with another running session) — automated component tests exercise the same render logic via `@testing-library/react`