### PR TITLE
fix(soul): validate cross-definition refs before commit in SoulWriter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,12 @@ pnpm build
 pnpm reset:dev                   # wipe local db + soul, re-run setup
 ```
 
+For manual/browser verification, start all four with `pnpm dev`, not a subset. Chat Turn
+execution runs in the Worker, not the API — API-only (`dev:api` + `dev:web`) leaves a Run stuck
+mid-stream, which triggers reconnect paths that are otherwise never exercised in normal dev and
+can surface unrelated latent bugs (e.g. a CORS header gap on the SSE resume route) that look
+branch-specific but are not.
+
 Single workspace: `pnpm --filter @tulipfarm/api <script>` — **the default for `test` and
 `typecheck`**.
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -394,8 +394,9 @@ async function boot() {
       console
     );
     let gitSync: GitSyncService;
+    const soulTreeReader = new GitSoulTreeReader(soulPath);
     const soulPublisher = new SoulPublisher({
-      treeReader: new GitSoulTreeReader(soulPath),
+      treeReader: soulTreeReader,
       compiler: compileExecutionBundle,
       signer: soulBundleSigner,
       coordinator: soulPublications,
@@ -457,6 +458,7 @@ async function boot() {
       gitSync,
       reload: () => soulLoader.load(),
       publisher: soulPublisher,
+      treeReader: soulTreeReader,
     });
     const bundledSkills = await loadBundledSkills(console);
     const disabledBundledSkills = await loadDisabledBundledSkills(soulPath, console);

--- a/apps/api/src/runtime/soul-writer.ts
+++ b/apps/api/src/runtime/soul-writer.ts
@@ -6,6 +6,7 @@ import {
   type Logger,
   type SoulBundlePublishPort,
   SoulGitStore,
+  type SoulTreeReader,
   SoulWriter,
 } from "@tulipfarm/soul";
 import { resolveSigningKey, type SigningKeyStore } from "../identity/signed-token";
@@ -60,6 +61,8 @@ export interface SoulWriterDeps {
    * composition that forgets this leaves the Runtime executing the previous tree.
    */
   readonly publisher: SoulBundlePublishPort;
+  /** Checks a changeset's cross-definition references against the tree before it is committed. */
+  readonly treeReader: Pick<SoulTreeReader, "readDefinitions">;
 }
 
 export function createSoulWriter(deps: SoulWriterDeps): SoulWriter {
@@ -76,6 +79,7 @@ export function createSoulWriter(deps: SoulWriterDeps): SoulWriter {
       push: () => deps.gitSync.push(),
     },
     { reload: deps.reload },
-    deps.publisher
+    deps.publisher,
+    deps.treeReader
   );
 }

--- a/packages/soul/src/write-errors.ts
+++ b/packages/soul/src/write-errors.ts
@@ -38,7 +38,7 @@ export function soulWriteHttpError(error: SoulWriteError): SoulWriteHttpError {
           error:
             error.issues.length > 0
               ? `invalid soul definition: ${error.issues.map((i) => `${i.path} ${i.code}${i.field ? ` at ${i.field}` : ""}`).join("; ")}`
-              : "invalid soul definition",
+              : `invalid soul definition: ${reason(error)}`,
         },
       };
     case "CONFLICT":

--- a/packages/soul/src/writer.test.ts
+++ b/packages/soul/src/writer.test.ts
@@ -14,6 +14,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CommitActor, CommitSigner } from "./commit-signing";
 import { SoulGitStore } from "./git-store";
+import { GitSoulTreeReader } from "./tree-reader";
 import type { Logger } from "./types";
 import { artifactWriteTarget, type SoulWrite, SoulWriteError, SoulWriter } from "./writer";
 
@@ -66,6 +67,62 @@ function skillDoc(slug: string): string {
     "  instructions:",
     "    path: SKILL.md",
     "  trustTier: business_authored",
+    "",
+  ].join("\n");
+}
+
+function routineDoc(slug: string, agentRefName: string): string {
+  return [
+    "apiVersion: tulipfarm.ai/v1",
+    "kind: Routine",
+    "metadata:",
+    "  id: 01HQ2X8G3K4M5N6P7Q8R9S0TEF",
+    `  slug: ${slug}`,
+    "  schemaVersion: 1",
+    "  authoredVersion: 1",
+    "  lifecycle: draft",
+    "spec:",
+    "  owner: ada@example.com",
+    "  input:",
+    "    type: object",
+    "    additionalProperties: false",
+    "  output:",
+    "    type: object",
+    "    additionalProperties: false",
+    "  start: Classify",
+    "  states:",
+    "    - type: agent",
+    "      name: Classify",
+    "      agentRef:",
+    `        name: ${agentRefName}`,
+    "        version: latest",
+    "      output:",
+    "        type: object",
+    "        additionalProperties: false",
+    "      end: true",
+    "",
+  ].join("\n");
+}
+
+function modelProfileDoc(slug: string): string {
+  return [
+    "apiVersion: tulipfarm.ai/v1",
+    "kind: ModelProfile",
+    "metadata:",
+    "  id: 01HQ2X8G3K4M5N6P7Q8R9S0TGH",
+    `  slug: ${slug}`,
+    "  schemaVersion: 1",
+    "  authoredVersion: 1",
+    "  lifecycle: published",
+    "spec:",
+    "  provider: openai",
+    "  model: gpt-5.6-sol",
+    "  reasoning: high",
+    "  supports:",
+    "    tools: true",
+    "    structuredOutput: true",
+    "    contextWindowTokens: 400000",
+    "  allowCaching: false",
     "",
   ].join("\n");
 }
@@ -232,6 +289,157 @@ describe("SoulWriter.apply — validation gate", () => {
     await expect(apply([put("dup"), put("dup")])).rejects.toMatchObject({
       code: "INVALID_TARGET",
     });
+  });
+});
+
+describe("SoulWriter.apply — cross-definition reference checking", () => {
+  it("rejects a Routine whose agentRef names an Agent that does not exist", async () => {
+    const withTreeReader = new SoulWriter(
+      store,
+      logger,
+      { hasRemote: true, push: async () => {} },
+      { reload: async () => {} },
+      undefined,
+      new GitSoulTreeReader(soulPath)
+    );
+
+    await expect(
+      withTreeReader.apply({
+        subject: "soul: add routine",
+        source: "api",
+        actor: ACTOR,
+        businessId: "biz-1",
+        changes: [
+          {
+            op: "put",
+            target: { kind: "Routine", slug: "greet" },
+            content: routineDoc("greet", "ghost-agent"),
+          },
+        ],
+      })
+    ).rejects.toMatchObject({ code: "VALIDATION_FAILED" });
+
+    expect(await store.baseCommit()).toBe("0".repeat(40));
+    expect(existsSync(join(soulPath, "routines/greet/routine.yaml"))).toBe(false);
+  });
+
+  it("accepts the same Routine once its agentRef resolves", async () => {
+    const withTreeReader = new SoulWriter(
+      store,
+      logger,
+      { hasRemote: true, push: async () => {} },
+      { reload: async () => {} },
+      undefined,
+      new GitSoulTreeReader(soulPath)
+    );
+
+    const result = await withTreeReader.apply({
+      subject: "soul: add routine",
+      source: "api",
+      actor: ACTOR,
+      businessId: "biz-1",
+      changes: [
+        {
+          op: "put",
+          target: { kind: "ModelProfile", slug: "default" },
+          content: modelProfileDoc("default"),
+        },
+        { op: "put", target: { kind: "Agent", slug: "triager" }, content: agentDoc("triager") },
+        {
+          op: "put",
+          target: { kind: "Routine", slug: "greet" },
+          content: routineDoc("greet", "triager"),
+        },
+      ],
+    });
+
+    expect(result.paths).toContain("routines/greet/routine.yaml");
+  });
+
+  it("resolves an agentRef against an Agent committed in an earlier write", async () => {
+    const withTreeReader = new SoulWriter(
+      store,
+      logger,
+      { hasRemote: true, push: async () => {} },
+      { reload: async () => {} },
+      undefined,
+      new GitSoulTreeReader(soulPath)
+    );
+
+    await withTreeReader.apply({
+      subject: "soul: add agent",
+      source: "api",
+      actor: ACTOR,
+      businessId: "biz-1",
+      changes: [
+        {
+          op: "put",
+          target: { kind: "ModelProfile", slug: "default" },
+          content: modelProfileDoc("default"),
+        },
+        { op: "put", target: { kind: "Agent", slug: "triager" }, content: agentDoc("triager") },
+      ],
+    });
+
+    const result = await withTreeReader.apply({
+      subject: "soul: add routine",
+      source: "api",
+      actor: ACTOR,
+      businessId: "biz-1",
+      changes: [
+        {
+          op: "put",
+          target: { kind: "Routine", slug: "greet" },
+          content: routineDoc("greet", "triager"),
+        },
+      ],
+    });
+
+    expect(result.paths).toContain("routines/greet/routine.yaml");
+  });
+
+  it("does not validate a Routine edit against its own stale prior version", async () => {
+    const withTreeReader = new SoulWriter(
+      store,
+      logger,
+      { hasRemote: true, push: async () => {} },
+      { reload: async () => {} },
+      undefined,
+      new GitSoulTreeReader(soulPath)
+    );
+
+    await withTreeReader.apply({
+      subject: "soul: add routine",
+      source: "api",
+      actor: ACTOR,
+      businessId: "biz-1",
+      changes: [
+        {
+          op: "put",
+          target: { kind: "ModelProfile", slug: "default" },
+          content: modelProfileDoc("default"),
+        },
+        { op: "put", target: { kind: "Agent", slug: "triager" }, content: agentDoc("triager") },
+        {
+          op: "put",
+          target: { kind: "Routine", slug: "greet" },
+          content: routineDoc("greet", "triager"),
+        },
+      ],
+    });
+
+    // Renaming the same Routine's only state must not collide with the state name the prior
+    // committed version of this same Routine still carries.
+    const renamed = routineDoc("greet", "triager").replace(/Classify/g, "Triage");
+    const result = await withTreeReader.apply({
+      subject: "soul: rename routine state",
+      source: "api",
+      actor: ACTOR,
+      businessId: "biz-1",
+      changes: [{ op: "put", target: { kind: "Routine", slug: "greet" }, content: renamed }],
+    });
+
+    expect(result.paths).toContain("routines/greet/routine.yaml");
   });
 });
 

--- a/packages/soul/src/writer.ts
+++ b/packages/soul/src/writer.ts
@@ -3,11 +3,13 @@ import {
   type ArtifactKind,
   artifactDirectory,
   artifactLayout,
+  classifySoulPath,
   companionPath,
   definitionPath,
   legacyDefinitionPaths,
 } from "@tulipfarm/schema";
 import {
+  isUnbornBase,
   type SoulChangeset,
   type SoulChangesetSource,
   SoulChangesetValidationError,
@@ -18,7 +20,12 @@ import {
 import type { CommitActor, CommitApproval } from "./commit-signing";
 import type { SoulCommitResult, SoulGitStore } from "./git-store";
 import { SoulGitStoreError } from "./git-store";
+import type { SoulTreeReader } from "./publication";
+import { asAuthored, SoulSemanticValidationError } from "./refs";
+import { validateSoulSemantics } from "./semantic";
+import { isBundledDefinitionPath } from "./tree-reader";
 import type { Logger } from "./types";
+import { validateChangesetFiles } from "./validate";
 
 /**
  * Which file a write addresses. Callers name the *artifact*, never a path — the layout registry
@@ -170,7 +177,14 @@ export class SoulWriter {
     private readonly logger: Logger,
     private readonly push?: SoulPushPort,
     private readonly reload?: SoulReloadPort,
-    private readonly publisher?: SoulBundlePublishPort
+    private readonly publisher?: SoulBundlePublishPort,
+    /**
+     * Reads the authored tree at a commit, so a changeset's cross-definition references (a
+     * Routine's `agentRef`/`toolRef`/`formRef`/`child_routine.routineRef`, an Agent's `roles`, …)
+     * can be checked before committing. Without it, a bad reference still lands in the Soul commit
+     * and is only discovered later — as an opaque post-commit publication failure.
+     */
+    private readonly treeReader?: Pick<SoulTreeReader, "readDefinitions">
   ) {}
 
   /** Whether a collection artifact currently exists (its definition file is present). */
@@ -234,6 +248,7 @@ export class SoulWriter {
     this.checkPreconditions(request.preconditions ?? []);
 
     const currentBaseCommit = await this.store.baseCommit();
+    await this.checkReferences(files, currentBaseCommit);
     const expectedBaseCommit = request.expectedBaseCommit ?? currentBaseCommit;
     const changeset: SoulChangeset = {
       id: randomUUID(),
@@ -414,6 +429,54 @@ export class SoulWriter {
     }
   }
 
+  /**
+   * Reject an unresolvable cross-definition reference before it is committed. Malformed content is
+   * left to {@link validateSoulChangeset} — this only re-checks reference edges of files that
+   * already parse, against the tree those files are about to land on.
+   *
+   * Uses the same `treeReader.readDefinitions` source as {@link SoulPublisher}'s post-commit
+   * compiler, so it shares that source's blind spot: a still-legacy-format definition (`AGENT.md`,
+   * `schema.yml`, `manifest.yml`) is invisible to both. This check is exactly as accurate as the
+   * bundle compiler that would otherwise catch the same reference later — no less, no more.
+   */
+  private async checkReferences(
+    files: readonly SoulFileChange[],
+    baseCommit: string
+  ): Promise<void> {
+    if (this.treeReader === undefined) return;
+    const { files: parsed, issues } = validateChangesetFiles(files);
+    if (issues.length > 0) return;
+
+    const touched = new Set<string>();
+    for (const file of files) {
+      if (!isBundledDefinitionPath(file.path)) continue;
+      const location = classifySoulPath(file.path);
+      if (location) touched.add(`${location.kind} ${location.slug ?? ""}`);
+    }
+
+    const existing = isUnbornBase(baseCommit)
+      ? []
+      : await this.treeReader.readDefinitions(baseCommit);
+    const kept = existing.filter((doc) => {
+      const def = asAuthored(doc);
+      return def === undefined || !touched.has(`${def.kind} ${def.slug}`);
+    });
+    const proposed = parsed.flatMap((file) => (file.definition ? [file.definition.document] : []));
+
+    try {
+      validateSoulSemantics([...kept, ...proposed]);
+    } catch (error) {
+      if (!(error instanceof SoulSemanticValidationError)) throw error;
+      throw new SoulWriteError(
+        "VALIDATION_FAILED",
+        `Soul write: ${describeSemanticIssues(error)}`,
+        {
+          cause: error,
+        }
+      );
+    }
+  }
+
   private async publish(changesetId: string): Promise<boolean> {
     if (this.push === undefined || !this.push.hasRemote) return false;
     try {
@@ -501,4 +564,12 @@ function toWriteError(error: unknown): SoulWriteError {
 
 function errText(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function describeSemanticIssues(error: SoulSemanticValidationError): string {
+  const described = error.issues.map(
+    (issue) =>
+      `${issue.subject} ${issue.code}${issue.ref ? ` (${issue.ref})` : ""}${issue.field ? ` at ${issue.field}` : ""}`
+  );
+  return `${error.message}: ${described.join("; ")}`;
 }


### PR DESCRIPTION
## Summary
- `SoulWriter.apply()` now runs `validateSoulSemantics()` pre-commit, so a Routine (or any definition) referencing an agent/tool/form that doesn't resolve is rejected with a structured 422 before it ever lands in git — no more silent post-commit bundle-publication failure.
- `soulWriteHttpError()` surfaces `error.issues` (path/code/field) instead of a bare generic message.

## Test plan
- [x] `pnpm --filter @tulipfarm/soul test` — 610/610 passed
- [x] `pnpm --filter @tulipfarm/api test` — 3194/3194 passed
- [x] `pnpm typecheck` — clean
- [x] `pnpm exec biome check` — clean
- [x] Live verified via Claude-in-Chrome: created a Routine through Chat with unresolved refs (bad `agentRef`/`toolRef`) three separate times — each attempt was cleanly rejected pre-commit with the exact unresolved refs listed, reproducing the original bug's fix end-to-end through the real product surface