### PR TITLE
chore(release): v0.13.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.13.6](https://github.com/TulipFarm/tulipfarm/compare/v0.13.5...v0.13.6) (2026-08-22)
+
+### Maintenance
+
+* **integrations:** keep only Slack, GitHub, and Google Workspace ([#569](https://github.com/TulipFarm/tulipfarm/issues/569)) ([33c7b31](https://github.com/TulipFarm/tulipfarm/commit/33c7b3191c83c74d18e07122c3ea96d6920aea76))
+
 ## [0.13.5](https://github.com/TulipFarm/tulipfarm/compare/v0.13.4...v0.13.5) (2026-08-22)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tulipfarm",
   "private": true,
-  "version": "0.13.5",
+  "version": "0.13.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/TulipFarm/tulipfarm.git"


### PR DESCRIPTION
## Summary

- prepare TulipFarm v0.13.6
- update the package version and generated changelog
- publish the verified GHCR image and GitHub Release automatically after merge

## Test plan

- [ ] Required PR checks pass
- [ ] Version and changelog are approved
