### PR TITLE
fix(soul): scope pre-commit ref validation to the changeset, add routine_delete

### DIFF
--- a/apps/api/src/platform/forge-tool.test.ts
+++ b/apps/api/src/platform/forge-tool.test.ts
@@ -1,10 +1,10 @@
 import { DEPLOYMENT_BUSINESS_ID } from "@tulipfarm/constants";
-import type { SoulWriter } from "@tulipfarm/soul";
+import type { RoutineCatalog, SoulRoutine, SoulWriter } from "@tulipfarm/soul";
 import { SoulWriteError, type SoulWriteErrorCode } from "@tulipfarm/soul";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { parse as parseYaml } from "yaml";
 import type { PlatformToolContext } from "./tools";
-import { routineForgeTool } from "./tools";
+import { routineDeleteTool, routineForgeTool } from "./tools";
 
 const VALID_ROUTINE = {
   apiVersion: "tulipfarm.ai/v1",
@@ -229,5 +229,80 @@ describe("routine_forge", () => {
   it("describes canonical Routine and Trigger requirements", () => {
     expect(routineForgeTool.description).toContain("canonical published Routine");
     expect(routineForgeTool.description).toContain("canonical published Trigger");
+  });
+});
+
+describe("routine_delete", () => {
+  let soulWriter: ReturnType<typeof makeSoulWriter>;
+  let onRoutinesChanged: (() => Promise<void>) & ReturnType<typeof vi.fn>;
+  let routineCatalog: RoutineCatalog & { list: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    soulWriter = makeSoulWriter();
+    onRoutinesChanged = vi.fn(async () => {}) as typeof onRoutinesChanged;
+    routineCatalog = { list: vi.fn().mockResolvedValue([]) };
+  });
+
+  function ctx(routines: Map<string, SoulRoutine> = new Map()): PlatformToolContext {
+    return {
+      soulWriter,
+      onRoutinesChanged,
+      routineCatalog,
+      soulLoader: { skills: new Map(), agents: new Map(), routines },
+    };
+  }
+
+  function soulRoutine(name: string): SoulRoutine {
+    return { name, config: {}, hasHooks: false };
+  }
+
+  it("reports not_found for a Routine the Soul does not have", async () => {
+    const result = await routineDeleteTool.handler({ name: "ghost" }, ctx());
+
+    expect(result).toMatchObject({ success: false, error: { code: "not_found" } });
+    expect(soulWriter.apply).not.toHaveBeenCalled();
+  });
+
+  it("deletes a Routine and every Trigger the catalog still lists for it", async () => {
+    routineCatalog.list.mockResolvedValue([
+      {
+        id: "1",
+        slug: "daily-report",
+        displayName: null,
+        authoredVersion: 1,
+        triggers: [{ slug: "daily-report-manual", type: "manual", summary: "manual" }],
+      },
+    ]);
+
+    const result = await routineDeleteTool.handler(
+      { name: "daily-report" },
+      ctx(new Map([["daily-report", soulRoutine("daily-report")]]))
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      data: { name: "daily-report", deleted: true, triggersDeleted: ["daily-report-manual"] },
+    });
+    expect(soulWriter.apply).toHaveBeenCalledOnce();
+    const request = soulWriter.apply.mock.calls[0][0] as { changes: unknown[] };
+    expect(request.changes).toEqual([
+      { op: "deleteArtifact", kind: "Routine", slug: "daily-report" },
+      { op: "deleteArtifact", kind: "Trigger", slug: "daily-report-manual" },
+    ]);
+    expect(onRoutinesChanged).toHaveBeenCalledOnce();
+  });
+
+  it("maps a rejected delete onto the Tool's error vocabulary", async () => {
+    soulWriter.apply.mockRejectedValueOnce(
+      new SoulWriteError("CONFLICT" as SoulWriteErrorCode, "Soul write: base commit stale")
+    );
+
+    const result = await routineDeleteTool.handler(
+      { name: "daily-report" },
+      ctx(new Map([["daily-report", soulRoutine("daily-report")]]))
+    );
+
+    expect(result).toMatchObject({ success: false, error: { code: "unavailable" } });
+    expect(onRoutinesChanged).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/platform/tools.test.ts
+++ b/apps/api/src/platform/tools.test.ts
@@ -619,6 +619,7 @@ describe("PLATFORM_TOOLS registry", () => {
       "trigger_routine",
       "routine_forge",
       "routine_picker",
+      "routine_delete",
       "guardrail_forge",
       "soul_repo_push",
       "call_skill",

--- a/apps/api/src/platform/tools.ts
+++ b/apps/api/src/platform/tools.ts
@@ -436,6 +436,78 @@ export const routinePickerTool = defineApiTool<PlatformToolContext>({
   },
 });
 
+const ROUTINE_DELETE_SCHEMA: Record<string, unknown> = {
+  type: "object",
+  additionalProperties: false,
+  required: ["name"],
+  properties: {
+    name: { type: "string", minLength: 1, description: "Routine name to delete." },
+  },
+};
+const validateRoutineDelete = ajv.compile(ROUTINE_DELETE_SCHEMA);
+
+export const routineDeleteTool = defineApiTool<PlatformToolContext>({
+  name: "routine_delete",
+  requiresAmbient: ["soul"],
+  description:
+    "Delete a routine from the soul repo, along with every Trigger that still references it. Commits atomically to the soul repo.",
+  mutating: true,
+  tier: "platform",
+  inputSchema: ROUTINE_DELETE_SCHEMA,
+  authorization: {
+    action: "platform.routine.delete",
+    resources: ["soul.routine"],
+    targets: (args) => soulTarget(SOUL_ROUTINE_TARGET, args, "name"),
+    dataClasses: ["soul_definition"],
+  },
+  requiresApproval: false,
+  handler: async (args, ctx) => {
+    if (!validateRoutineDelete(args))
+      return err("validation_error", firstError(validateRoutineDelete.errors));
+    const { name } = args as { name: string };
+
+    if (!ctx.soulLoader?.routines?.has(name)) return err("not_found", `routine not found: ${name}`);
+
+    let triggerSlugs: string[] = [];
+    if (ctx.routineCatalog) {
+      try {
+        const listed = await ctx.routineCatalog.list();
+        triggerSlugs = listed.find((r) => r.slug === name)?.triggers.map((t) => t.slug) ?? [];
+      } catch (e) {
+        return err("internal_error", e instanceof Error ? e.message : String(e));
+      }
+    }
+
+    try {
+      await ctx.soulWriter.apply({
+        subject: `soul: remove routine ${name}`,
+        source: "agent",
+        actor: ctx.requestContext?.actor ?? SYSTEM_SOUL_COMMIT_ACTOR,
+        businessId: DEPLOYMENT_BUSINESS_ID,
+        changes: [
+          { op: "deleteArtifact", kind: "Routine", slug: name },
+          ...triggerSlugs.map((slug) => ({
+            op: "deleteArtifact" as const,
+            kind: "Trigger" as const,
+            slug,
+          })),
+        ],
+      });
+    } catch (e) {
+      if (e instanceof SoulWriteError) return mapSoulWriteError(e);
+      return err("internal_error", e instanceof Error ? e.message : String(e));
+    }
+
+    try {
+      await ctx.onRoutinesChanged?.();
+    } catch (e) {
+      return err("internal_error", e instanceof Error ? e.message : String(e));
+    }
+
+    return ok({ name, deleted: true, triggersDeleted: triggerSlugs });
+  },
+});
+
 const SOUL_REPO_PUSH_SCHEMA: Record<string, unknown> = {
   type: "object",
   additionalProperties: false,
@@ -530,6 +602,7 @@ export const PLATFORM_TOOLS: ApiToolDefinition<PlatformToolContext>[] = [
   triggerRoutineTool,
   routineForgeTool,
   routinePickerTool,
+  routineDeleteTool,
   guardrailForgeTool,
   soulRepoPushTool,
   callSkillTool,

--- a/apps/api/src/tools/contract-coverage.test.ts
+++ b/apps/api/src/tools/contract-coverage.test.ts
@@ -133,6 +133,7 @@ const EXPECTED_FAMILY_TOOL_NAMES = [
       "load_skill",
       "load_skill_reference",
       "guardrail_forge",
+      "routine_delete",
       "routine_forge",
       "routine_picker",
       "soul_repo_push",

--- a/packages/soul/src/writer.test.ts
+++ b/packages/soul/src/writer.test.ts
@@ -441,6 +441,45 @@ describe("SoulWriter.apply — cross-definition reference checking", () => {
 
     expect(result.paths).toContain("routines/greet/routine.yaml");
   });
+
+  it("does not block an unrelated write on a pre-existing broken reference elsewhere in the tree", async () => {
+    // Seed a Routine that already references a nonexistent Agent, bypassing SoulWriter so the
+    // tree starts in the same broken state a stale ref left it in.
+    mkdirSync(join(soulPath, "routines/greet"), { recursive: true });
+    writeFileSync(
+      join(soulPath, "routines/greet/routine.yaml"),
+      routineDoc("greet", "ghost-agent")
+    );
+    git("add", "routines/greet/routine.yaml");
+    git("commit", "--quiet", "-m", "seed broken routine");
+
+    const withTreeReader = new SoulWriter(
+      store,
+      logger,
+      { hasRemote: true, push: async () => {} },
+      { reload: async () => {} },
+      undefined,
+      new GitSoulTreeReader(soulPath)
+    );
+
+    const result = await withTreeReader.apply({
+      subject: "soul: add unrelated agent",
+      source: "api",
+      actor: ACTOR,
+      businessId: "biz-1",
+      changes: [
+        {
+          op: "put",
+          target: { kind: "ModelProfile", slug: "default" },
+          content: modelProfileDoc("default"),
+        },
+        { op: "put", target: { kind: "Agent", slug: "triager" }, content: agentDoc("triager") },
+      ],
+    });
+
+    expect(result.paths).toContain("agents/triager/agent.yaml");
+    expect(existsSync(join(soulPath, "routines/greet/routine.yaml"))).toBe(true);
+  });
 });
 
 describe("SoulWriter.apply — atomicity", () => {

--- a/packages/soul/src/writer.ts
+++ b/packages/soul/src/writer.ts
@@ -467,11 +467,18 @@ export class SoulWriter {
       validateSoulSemantics([...kept, ...proposed]);
     } catch (error) {
       if (!(error instanceof SoulSemanticValidationError)) throw error;
+      // A pre-existing definition elsewhere in the tree can already be broken (e.g. a Routine left
+      // pointing at a deleted Agent). That is not this changeset's fault, and blocking an unrelated
+      // write on it leaves the operator unable to fix anything through chat. Only reject when the
+      // changeset itself touches the definition an issue is reported against.
+      const relevant = error.issues.filter((issue) => touched.has(issue.subject.replace(":", " ")));
+      if (relevant.length === 0) return;
+      const relevantError = new SoulSemanticValidationError(relevant);
       throw new SoulWriteError(
         "VALIDATION_FAILED",
-        `Soul write: ${describeSemanticIssues(error)}`,
+        `Soul write: ${describeSemanticIssues(relevantError)}`,
         {
-          cause: error,
+          cause: relevantError,
         }
       );
     }


### PR DESCRIPTION
## Summary
- `SoulWriter.checkReferences` validated the entire soul tree on every write, so a pre-existing broken reference on an untouched Routine blocked any new, unrelated Agent/Routine write with `UNRESOLVED_REF`. Now only rejects issues whose subject is part of the current changeset.
- Routines had no delete tool (only `agent_delete` existed), so a Routine referencing a deleted Agent could neither be removed itself nor unblock the Agent's deletion. Added `routine_delete`, mirroring `agent_delete`, which also removes any Triggers still referencing the Routine.

## Test plan
- [x] `pnpm --filter @tulipfarm/soul exec vitest run src/writer.test.ts` — 52 passed, includes new regression test for the scoping fix
- [x] `pnpm --filter @tulipfarm/api exec vitest run src/platform/tools.test.ts src/platform/forge-tool.test.ts` — 53 passed, includes new `routine_delete` coverage
- [x] `biome check` clean on changed files