### PR TITLE
fix(web): prevent chat multi-scroll and empty bottom void

### DIFF
--- a/apps/web/app/app.css
+++ b/apps/web/app/app.css
@@ -109,6 +109,11 @@
   * {
     @apply border-border outline-ring/50;
   }
+  html,
+  body {
+    height: 100%;
+    overflow: hidden;
+  }
   html {
     font-family: var(--font-sans);
   }

--- a/apps/web/app/components/app-sidebar.tsx
+++ b/apps/web/app/components/app-sidebar.tsx
@@ -568,7 +568,7 @@ export function AppShell({ children, user }: { children: ReactNode; user?: Sessi
             </span>
           </div>
         </header>
-        <main id="main-content" tabIndex={-1} className="min-h-0 min-w-0 flex-1 overflow-auto">
+        <main id="main-content" tabIndex={-1} className="min-h-0 min-w-0 flex-1 overflow-hidden">
           {children}
         </main>
       </div>

--- a/apps/web/app/components/resource-panel.tsx
+++ b/apps/web/app/components/resource-panel.tsx
@@ -7,32 +7,34 @@ export function ResourcePanel({ crumbs, children }: { crumbs: Crumb[]; children:
   const ownsPageHeading = crumbs.length === 1 && crumbs[0]?.to === undefined;
 
   return (
-    <section className="mx-auto flex w-full max-w-4xl flex-col px-6 py-10">
-      <div className="rounded-sm border border-border bg-card motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-2 motion-safe:duration-500">
-        <nav aria-label="Breadcrumb" className="border-b border-border px-4 py-2">
-          <ol className="flex items-center gap-1 text-[0.625rem] font-medium uppercase tracking-[0.2em] text-muted-foreground">
-            {crumbs.map((crumb, i) => (
-              <li key={crumb.label} className="flex items-center gap-1">
-                {i > 0 ? (
-                  <span aria-hidden className="opacity-40">
-                    /
-                  </span>
-                ) : null}
-                {crumb.to ? (
-                  <Link to={crumb.to} className="transition-colors hover:text-foreground">
-                    {crumb.label}
-                  </Link>
-                ) : ownsPageHeading ? (
-                  <h1 className="text-[inherit] font-[inherit] text-foreground">{crumb.label}</h1>
-                ) : (
-                  <span className="text-foreground">{crumb.label}</span>
-                )}
-              </li>
-            ))}
-          </ol>
-        </nav>
-        <div className="flex flex-col gap-4 px-4 py-6 text-sm">{children}</div>
-      </div>
-    </section>
+    <div className="h-full min-h-0 overflow-y-auto">
+      <section className="mx-auto flex w-full max-w-4xl flex-col px-6 py-10">
+        <div className="rounded-sm border border-border bg-card motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-2 motion-safe:duration-500">
+          <nav aria-label="Breadcrumb" className="border-b border-border px-4 py-2">
+            <ol className="flex items-center gap-1 text-[0.625rem] font-medium uppercase tracking-[0.2em] text-muted-foreground">
+              {crumbs.map((crumb, i) => (
+                <li key={crumb.label} className="flex items-center gap-1">
+                  {i > 0 ? (
+                    <span aria-hidden className="opacity-40">
+                      /
+                    </span>
+                  ) : null}
+                  {crumb.to ? (
+                    <Link to={crumb.to} className="transition-colors hover:text-foreground">
+                      {crumb.label}
+                    </Link>
+                  ) : ownsPageHeading ? (
+                    <h1 className="text-[inherit] font-[inherit] text-foreground">{crumb.label}</h1>
+                  ) : (
+                    <span className="text-foreground">{crumb.label}</span>
+                  )}
+                </li>
+              ))}
+            </ol>
+          </nav>
+          <div className="flex flex-col gap-4 px-4 py-6 text-sm">{children}</div>
+        </div>
+      </section>
+    </div>
   );
 }

--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -42,7 +42,7 @@ function Document({ children }: { children: ReactNode }) {
   return (
     // suppressHydrationWarning: the pre-hydration themeInit script sets [data-theme] on <html>
     // before React hydrates, which would otherwise log a hydration mismatch and be stripped.
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en" className="h-full overflow-hidden" suppressHydrationWarning>
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -51,7 +51,7 @@ function Document({ children }: { children: ReactNode }) {
         {/* biome-ignore lint/security/noDangerouslySetInnerHtml: no-flash theme init must run pre-hydration */}
         <script dangerouslySetInnerHTML={{ __html: themeInit }} />
       </head>
-      <body>
+      <body className="h-full overflow-hidden">
         {children}
         <ScrollRestoration />
         <Scripts />

--- a/apps/web/app/routes/_app.chats.tsx
+++ b/apps/web/app/routes/_app.chats.tsx
@@ -122,110 +122,112 @@ export default function ChatsRoute() {
   const recent = sorted.filter((chat) => !chat.starred);
 
   return (
-    <div className="mx-auto flex w-full max-w-5xl flex-col px-4 py-8 sm:px-6 sm:py-10">
-      <header className="flex flex-col gap-5 border-b border-border pb-7 sm:flex-row sm:items-end sm:justify-between">
-        <div>
-          <p className="text-sm font-medium text-primary">Chat history</p>
-          <h1 className="mt-2 text-3xl font-semibold tracking-tight">Your chats</h1>
-          <p className="mt-2 max-w-xl text-sm leading-6 text-muted-foreground">
-            Return to previous work, pin important chats, or rename them for easier scanning.
-          </p>
-        </div>
-        <Button asChild className="self-start sm:self-auto">
-          <Link to="/">
-            <Plus aria-hidden />
-            New chat
-          </Link>
-        </Button>
-      </header>
-
-      <section aria-label="Chat history" className="pt-6">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-          <label className="relative block min-w-0 flex-1">
-            <span className="sr-only">Search chats</span>
-            <Search
-              aria-hidden
-              className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
-            />
-            <input
-              type="search"
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              placeholder="Search by title"
-              aria-label="search chats"
-              className={inputClass}
-            />
-          </label>
-          <p aria-live="polite" className="shrink-0 text-xs text-muted-foreground tabular-nums">
-            {searching
-              ? "Searching…"
-              : `${sorted.length} ${sorted.length === 1 ? "chat" : "chats"}`}
-          </p>
-        </div>
-
-        {error ? (
-          <p
-            role="alert"
-            className="mt-4 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive"
-          >
-            Request failed. {error}
-          </p>
-        ) : null}
-
-        {sorted.length === 0 ? (
-          <div className="mt-8 flex flex-col items-start rounded-md bg-muted/50 px-5 py-8">
-            <MessageSquare aria-hidden className="size-5 text-muted-foreground" />
-            <h2 className="mt-4 text-base font-semibold">
-              {query.trim() ? "No matching chats" : "No chats yet"}
-            </h2>
-            <p className="mt-1 max-w-md text-sm leading-6 text-muted-foreground">
-              {query.trim()
-                ? "Try a different title or clear the search."
-                : "Start a chat and it will appear here for you to revisit."}
+    <div className="h-full min-h-0 overflow-y-auto">
+      <div className="mx-auto flex w-full max-w-5xl flex-col px-4 py-8 sm:px-6 sm:py-10">
+        <header className="flex flex-col gap-5 border-b border-border pb-7 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <p className="text-sm font-medium text-primary">Chat history</p>
+            <h1 className="mt-2 text-3xl font-semibold tracking-tight">Your chats</h1>
+            <p className="mt-2 max-w-xl text-sm leading-6 text-muted-foreground">
+              Return to previous work, pin important chats, or rename them for easier scanning.
             </p>
-            {!query.trim() ? (
-              <Link to="/" className="mt-4 text-sm font-medium text-primary hover:underline">
-                Start a new chat
-              </Link>
-            ) : null}
           </div>
-        ) : (
-          <div className="mt-8 space-y-8">
-            {starred.length > 0 ? (
-              <ChatGroup
-                title="Starred"
-                items={starred}
-                renamingId={renamingId}
-                onRename={onRename}
-                onCancelRename={() => setRenamingId(null)}
-                onToggleStar={onToggleStar}
-                onStartRename={setRenamingId}
-                onDelete={setPendingDelete}
+          <Button asChild className="self-start sm:self-auto">
+            <Link to="/">
+              <Plus aria-hidden />
+              New chat
+            </Link>
+          </Button>
+        </header>
+
+        <section aria-label="Chat history" className="pt-6">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+            <label className="relative block min-w-0 flex-1">
+              <span className="sr-only">Search chats</span>
+              <Search
+                aria-hidden
+                className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
               />
-            ) : null}
-            {recent.length > 0 ? (
-              <ChatGroup
-                title="Recent"
-                items={recent}
-                renamingId={renamingId}
-                onRename={onRename}
-                onCancelRename={() => setRenamingId(null)}
-                onToggleStar={onToggleStar}
-                onStartRename={setRenamingId}
-                onDelete={setPendingDelete}
+              <input
+                type="search"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Search by title"
+                aria-label="search chats"
+                className={inputClass}
               />
-            ) : null}
+            </label>
+            <p aria-live="polite" className="shrink-0 text-xs text-muted-foreground tabular-nums">
+              {searching
+                ? "Searching…"
+                : `${sorted.length} ${sorted.length === 1 ? "chat" : "chats"}`}
+            </p>
           </div>
-        )}
-      </section>
-      <ConfirmModal
-        open={pendingDelete !== null}
-        onClose={() => setPendingDelete(null)}
-        onConfirm={() => void onDelete()}
-        title="Delete chat"
-        description={`Permanently delete “${pendingDelete?.title ?? "New chat"}” and all of its messages? This cannot be undone.`}
-        busy={deleting}
-      />
+
+          {error ? (
+            <p
+              role="alert"
+              className="mt-4 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive"
+            >
+              Request failed. {error}
+            </p>
+          ) : null}
+
+          {sorted.length === 0 ? (
+            <div className="mt-8 flex flex-col items-start rounded-md bg-muted/50 px-5 py-8">
+              <MessageSquare aria-hidden className="size-5 text-muted-foreground" />
+              <h2 className="mt-4 text-base font-semibold">
+                {query.trim() ? "No matching chats" : "No chats yet"}
+              </h2>
+              <p className="mt-1 max-w-md text-sm leading-6 text-muted-foreground">
+                {query.trim()
+                  ? "Try a different title or clear the search."
+                  : "Start a chat and it will appear here for you to revisit."}
+              </p>
+              {!query.trim() ? (
+                <Link to="/" className="mt-4 text-sm font-medium text-primary hover:underline">
+                  Start a new chat
+                </Link>
+              ) : null}
+            </div>
+          ) : (
+            <div className="mt-8 space-y-8">
+              {starred.length > 0 ? (
+                <ChatGroup
+                  title="Starred"
+                  items={starred}
+                  renamingId={renamingId}
+                  onRename={onRename}
+                  onCancelRename={() => setRenamingId(null)}
+                  onToggleStar={onToggleStar}
+                  onStartRename={setRenamingId}
+                  onDelete={setPendingDelete}
+                />
+              ) : null}
+              {recent.length > 0 ? (
+                <ChatGroup
+                  title="Recent"
+                  items={recent}
+                  renamingId={renamingId}
+                  onRename={onRename}
+                  onCancelRename={() => setRenamingId(null)}
+                  onToggleStar={onToggleStar}
+                  onStartRename={setRenamingId}
+                  onDelete={setPendingDelete}
+                />
+              ) : null}
+            </div>
+          )}
+        </section>
+        <ConfirmModal
+          open={pendingDelete !== null}
+          onClose={() => setPendingDelete(null)}
+          onConfirm={() => void onDelete()}
+          title="Delete chat"
+          description={`Permanently delete “${pendingDelete?.title ?? "New chat"}” and all of its messages? This cannot be undone.`}
+          busy={deleting}
+        />
+      </div>
     </div>
   );
 }

--- a/apps/web/app/routes/_app.design-guide.tsx
+++ b/apps/web/app/routes/_app.design-guide.tsx
@@ -54,76 +54,78 @@ const GUIDE_LINKS = [
 
 export default function DesignGuideRoute() {
   return (
-    <div className="mx-auto w-full max-w-6xl px-5 py-8 sm:px-8">
-      <header className="max-w-3xl pb-6">
-        <Badge variant="primary">Internal reference</Badge>
-        <h1 className="mt-3 text-3xl font-semibold tracking-tight">TulipFarm design guide</h1>
-        <p className="mt-2 text-base text-muted-foreground">
-          The live showcase for tokens, typography, reusable components, and composition patterns.
-        </p>
-      </header>
+    <div className="h-full min-h-0 overflow-y-auto">
+      <div className="mx-auto w-full max-w-6xl px-5 py-8 sm:px-8">
+        <header className="max-w-3xl pb-6">
+          <Badge variant="primary">Internal reference</Badge>
+          <h1 className="mt-3 text-3xl font-semibold tracking-tight">TulipFarm design guide</h1>
+          <p className="mt-2 text-base text-muted-foreground">
+            The live showcase for tokens, typography, reusable components, and composition patterns.
+          </p>
+        </header>
 
-      <nav
-        aria-label="Design guide sections"
-        className="grid gap-1 rounded-md border border-border p-2 sm:grid-cols-2 lg:grid-cols-3"
-      >
-        {GUIDE_LINKS.map(([id, label], index) => (
-          <a
-            key={id}
-            href={`#${id}`}
-            className="rounded-md px-3 py-2 text-sm text-muted-foreground hover:bg-accent hover:text-foreground"
-          >
-            <span className="mr-2 font-mono text-xs text-primary">{index + 1}.</span>
-            {label}
-          </a>
-        ))}
-      </nav>
-
-      <GuideSection
-        id="principles"
-        title="Design principles"
-        description="Work-surface first, neutral by default, reusable at the correct layer, and accessible in every state."
-      >
-        <ul className="grid gap-3 text-sm sm:grid-cols-2">
-          {[
-            "Use one clear primary action per view.",
-            "Build hierarchy with type, spacing, and structure.",
-            "Reserve coral for brand, selection, focus, and primary action.",
-            "Treat keyboard, contrast, motion, and long content as component states.",
-          ].map((item) => (
-            <li key={item} className="rounded-md border border-border bg-card px-4 py-3">
-              {item}
-            </li>
+        <nav
+          aria-label="Design guide sections"
+          className="grid gap-1 rounded-md border border-border p-2 sm:grid-cols-2 lg:grid-cols-3"
+        >
+          {GUIDE_LINKS.map(([id, label], index) => (
+            <a
+              key={id}
+              href={`#${id}`}
+              className="rounded-md px-3 py-2 text-sm text-muted-foreground hover:bg-accent hover:text-foreground"
+            >
+              <span className="mr-2 font-mono text-xs text-primary">{index + 1}.</span>
+              {label}
+            </a>
           ))}
-        </ul>
-      </GuideSection>
+        </nav>
 
-      <GuideSection
-        id="stack"
-        title="Tech stack"
-        description="Remix SPA, React 19, TypeScript, Tailwind v4, CVA, Lucide, and app-local shadcn-style primitives."
-      >
-        <p className="max-w-3xl font-mono text-sm text-muted-foreground">
-          Remix · React · TypeScript · Tailwind CSS · Vitest · Testing Library
+        <GuideSection
+          id="principles"
+          title="Design principles"
+          description="Work-surface first, neutral by default, reusable at the correct layer, and accessible in every state."
+        >
+          <ul className="grid gap-3 text-sm sm:grid-cols-2">
+            {[
+              "Use one clear primary action per view.",
+              "Build hierarchy with type, spacing, and structure.",
+              "Reserve coral for brand, selection, focus, and primary action.",
+              "Treat keyboard, contrast, motion, and long content as component states.",
+            ].map((item) => (
+              <li key={item} className="rounded-md border border-border bg-card px-4 py-3">
+                {item}
+              </li>
+            ))}
+          </ul>
+        </GuideSection>
+
+        <GuideSection
+          id="stack"
+          title="Tech stack"
+          description="Remix SPA, React 19, TypeScript, Tailwind v4, CVA, Lucide, and app-local shadcn-style primitives."
+        >
+          <p className="max-w-3xl font-mono text-sm text-muted-foreground">
+            Remix · React · TypeScript · Tailwind CSS · Vitest · Testing Library
+          </p>
+        </GuideSection>
+
+        <ColorSections />
+        <FoundationsSections />
+        <AgentRunSections />
+        <TraceSections />
+        <DecisionSections />
+        <BrandOnboardingSections />
+
+        <FarmSections />
+        <ComponentSections />
+        <CompositionSections />
+        <ReferenceSections />
+
+        <Separator />
+        <p className="py-6 font-mono text-xs text-muted-foreground">
+          Update this page whenever the public component vocabulary changes.
         </p>
-      </GuideSection>
-
-      <ColorSections />
-      <FoundationsSections />
-      <AgentRunSections />
-      <TraceSections />
-      <DecisionSections />
-      <BrandOnboardingSections />
-
-      <FarmSections />
-      <ComponentSections />
-      <CompositionSections />
-      <ReferenceSections />
-
-      <Separator />
-      <p className="py-6 font-mono text-xs text-muted-foreground">
-        Update this page whenever the public component vocabulary changes.
-      </p>
+      </div>
     </div>
   );
 }

--- a/apps/web/app/routes/_app.inbox.tsx
+++ b/apps/web/app/routes/_app.inbox.tsx
@@ -24,29 +24,31 @@ export default function InboxRoute() {
     );
   }
   return (
-    <div className="mx-auto flex max-w-4xl flex-col gap-4 px-4 py-6 sm:px-6">
-      <header>
-        <h1 className="text-lg font-semibold">Inbox</h1>
-        <p className="text-xs text-muted-foreground">
-          Exact server-authorized decisions and waiting work.
-        </p>
-      </header>
-      {items.map((item) => (
-        <InboxItem
-          key={item.id}
-          item={item}
-          busy={busyId === item.id}
-          onDecision={async (decision) => {
-            setBusyId(item.id);
-            try {
-              await decideApproval(item, decision);
-              revalidator.revalidate();
-            } finally {
-              setBusyId(undefined);
-            }
-          }}
-        />
-      ))}
+    <div className="h-full min-h-0 overflow-y-auto">
+      <div className="mx-auto flex max-w-4xl flex-col gap-4 px-4 py-6 sm:px-6">
+        <header>
+          <h1 className="text-lg font-semibold">Inbox</h1>
+          <p className="text-xs text-muted-foreground">
+            Exact server-authorized decisions and waiting work.
+          </p>
+        </header>
+        {items.map((item) => (
+          <InboxItem
+            key={item.id}
+            item={item}
+            busy={busyId === item.id}
+            onDecision={async (decision) => {
+              setBusyId(item.id);
+              try {
+                await decideApproval(item, decision);
+                revalidator.revalidate();
+              } finally {
+                setBusyId(undefined);
+              }
+            }}
+          />
+        ))}
+      </div>
     </div>
   );
 }

--- a/apps/web/app/routes/_app.knowledge._index.tsx
+++ b/apps/web/app/routes/_app.knowledge._index.tsx
@@ -23,80 +23,86 @@ export default function KnowledgeIndex() {
 
   if (spaces.length === 0) {
     return (
-      <div className="mx-auto flex h-full max-w-md flex-col items-center justify-center gap-4 px-6 py-16 text-center">
-        <BookText className="size-8 text-muted-foreground" aria-hidden />
-        <div className="flex flex-col gap-1">
-          <h1 className="text-base font-bold text-foreground">Knowledge</h1>
-          <p className="text-sm text-muted-foreground">
-            Pick a page from the tree on the left, or create a new space to start a wiki.
-          </p>
+      <div className="h-full min-h-0 overflow-y-auto">
+        <div className="mx-auto flex min-h-full max-w-md flex-col items-center justify-center gap-4 px-6 py-16 text-center">
+          <BookText className="size-8 text-muted-foreground" aria-hidden />
+          <div className="flex flex-col gap-1">
+            <h1 className="text-base font-bold text-foreground">Knowledge</h1>
+            <p className="text-sm text-muted-foreground">
+              Pick a page from the tree on the left, or create a new space to start a wiki.
+            </p>
+          </div>
+          <NewSpaceLink />
         </div>
-        <NewSpaceLink />
       </div>
     );
   }
 
   return (
-    <div className="mx-auto flex w-full max-w-3xl flex-col gap-8 px-6 py-8">
-      <section className="flex flex-col gap-3">
-        <header className="flex items-center justify-between">
-          <h1 className="text-base font-bold text-foreground">Spaces</h1>
-          <div className="flex items-center gap-2">
-            <GraphLink />
-            <NewSpaceLink />
-          </div>
-        </header>
-        <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-          {spaces.map((s) => (
-            <li key={s.id}>
-              <Link
-                to={`/knowledge/spaces/${encodeURIComponent(s.id)}`}
-                className="flex h-full cursor-pointer flex-col gap-2 rounded-sm border border-border bg-card px-4 py-3 transition-colors hover:border-primary/50 hover:bg-accent"
-              >
-                <span className="flex items-center gap-2 text-sm font-semibold text-foreground">
-                  <BookText className="size-4 shrink-0 text-muted-foreground" aria-hidden />
-                  {s.name}
-                </span>
-                {s.description ? (
-                  <span className="line-clamp-2 text-xs text-muted-foreground">
-                    {s.description}
-                  </span>
-                ) : null}
-                <span className="mt-auto text-[0.7rem] text-muted-foreground">
-                  {s.pageCount} {s.pageCount === 1 ? "page" : "pages"} · {timeAgo(s.lastActivity)}
-                </span>
-              </Link>
-            </li>
-          ))}
-        </ul>
-      </section>
-
-      {recent.length ? (
+    <div className="h-full min-h-0 overflow-y-auto">
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-8 px-6 py-8">
         <section className="flex flex-col gap-3">
-          <h2 className="text-base font-bold text-foreground">Recently edited</h2>
-          <ul className="flex flex-col divide-y divide-border rounded-sm border border-border">
-            {recent.map((p) => (
-              <li key={p.pageId}>
+          <header className="flex items-center justify-between">
+            <h1 className="text-base font-bold text-foreground">Spaces</h1>
+            <div className="flex items-center gap-2">
+              <GraphLink />
+              <NewSpaceLink />
+            </div>
+          </header>
+          <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {spaces.map((s) => (
+              <li key={s.id}>
                 <Link
-                  to={pageHref(p.pageId, p.path)}
-                  className="flex cursor-pointer items-center gap-3 px-3 py-2 transition-colors hover:bg-accent"
+                  to={`/knowledge/spaces/${encodeURIComponent(s.id)}`}
+                  className="flex h-full cursor-pointer flex-col gap-2 rounded-sm border border-border bg-card px-4 py-3 transition-colors hover:border-primary/50 hover:bg-accent"
                 >
-                  <FileText className="size-4 shrink-0 text-muted-foreground" aria-hidden />
-                  <span className="min-w-0 flex-1 truncate text-sm text-foreground">{p.title}</span>
-                  <AgentAuthoredBadge authorKind={p.authorKind} />
-                  {p.visibility && p.visibility !== "business" ? (
-                    <VisibilityBadge visibility={p.visibility} compact />
+                  <span className="flex items-center gap-2 text-sm font-semibold text-foreground">
+                    <BookText className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+                    {s.name}
+                  </span>
+                  {s.description ? (
+                    <span className="line-clamp-2 text-xs text-muted-foreground">
+                      {s.description}
+                    </span>
                   ) : null}
-                  <span className="shrink-0 text-xs text-muted-foreground">{p.spaceName}</span>
-                  <span className="shrink-0 text-xs text-muted-foreground">
-                    · {timeAgo(p.updatedAt)}
+                  <span className="mt-auto text-[0.7rem] text-muted-foreground">
+                    {s.pageCount} {s.pageCount === 1 ? "page" : "pages"} · {timeAgo(s.lastActivity)}
                   </span>
                 </Link>
               </li>
             ))}
           </ul>
         </section>
-      ) : null}
+
+        {recent.length ? (
+          <section className="flex flex-col gap-3">
+            <h2 className="text-base font-bold text-foreground">Recently edited</h2>
+            <ul className="flex flex-col divide-y divide-border rounded-sm border border-border">
+              {recent.map((p) => (
+                <li key={p.pageId}>
+                  <Link
+                    to={pageHref(p.pageId, p.path)}
+                    className="flex cursor-pointer items-center gap-3 px-3 py-2 transition-colors hover:bg-accent"
+                  >
+                    <FileText className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+                    <span className="min-w-0 flex-1 truncate text-sm text-foreground">
+                      {p.title}
+                    </span>
+                    <AgentAuthoredBadge authorKind={p.authorKind} />
+                    {p.visibility && p.visibility !== "business" ? (
+                      <VisibilityBadge visibility={p.visibility} compact />
+                    ) : null}
+                    <span className="shrink-0 text-xs text-muted-foreground">{p.spaceName}</span>
+                    <span className="shrink-0 text-xs text-muted-foreground">
+                      · {timeAgo(p.updatedAt)}
+                    </span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/apps/web/app/routes/_app.knowledge.graph.tsx
+++ b/apps/web/app/routes/_app.knowledge.graph.tsx
@@ -14,26 +14,28 @@ export default function KnowledgeGraphRoute() {
   const { graph } = useLoaderData<typeof clientLoader>();
 
   return (
-    <div className="mx-auto flex w-full max-w-5xl flex-col gap-4 px-6 py-8">
-      <nav
-        aria-label="Breadcrumb"
-        className="flex items-center gap-1 text-[0.625rem] font-medium uppercase tracking-[0.2em] text-muted-foreground"
-      >
-        <Link to="/knowledge" className="transition-colors hover:text-foreground">
-          Knowledge
-        </Link>
-        <span aria-hidden className="opacity-40">
-          /
-        </span>
-        <span className="text-foreground">graph</span>
-      </nav>
-      <header className="flex flex-col gap-1">
-        <h1 className="text-base font-bold text-foreground">How your knowledge is connected</h1>
-        <p className="text-sm text-muted-foreground">
-          Every page you can read, and the links between them, across all spaces.
-        </p>
-      </header>
-      <KnowledgeGraphView graph={graph} />
+    <div className="h-full min-h-0 overflow-y-auto">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-4 px-6 py-8">
+        <nav
+          aria-label="Breadcrumb"
+          className="flex items-center gap-1 text-[0.625rem] font-medium uppercase tracking-[0.2em] text-muted-foreground"
+        >
+          <Link to="/knowledge" className="transition-colors hover:text-foreground">
+            Knowledge
+          </Link>
+          <span aria-hidden className="opacity-40">
+            /
+          </span>
+          <span className="text-foreground">graph</span>
+        </nav>
+        <header className="flex flex-col gap-1">
+          <h1 className="text-base font-bold text-foreground">How your knowledge is connected</h1>
+          <p className="text-sm text-muted-foreground">
+            Every page you can read, and the links between them, across all spaces.
+          </p>
+        </header>
+        <KnowledgeGraphView graph={graph} />
+      </div>
     </div>
   );
 }

--- a/apps/web/app/routes/_app.knowledge.pages.$pageId.$.tsx
+++ b/apps/web/app/routes/_app.knowledge.pages.$pageId.$.tsx
@@ -99,57 +99,59 @@ export default function PageDetailRoute() {
   }
 
   return (
-    <article className="flex w-full flex-col gap-4 px-6 py-8">
-      <nav
-        aria-label="Breadcrumb"
-        className="flex items-center gap-1 text-[0.625rem] font-medium uppercase tracking-[0.2em] text-muted-foreground"
-      >
-        <Link to={base} className="transition-colors hover:text-foreground">
-          {space.name}
-        </Link>
-        {path.split("/").map((seg, i, all) => (
-          <span key={all.slice(0, i + 1).join("/")} className="flex items-center gap-1">
-            <span aria-hidden className="opacity-40">
-              /
+    <div className="h-full min-h-0 overflow-y-auto">
+      <article className="flex w-full flex-col gap-4 px-6 py-8">
+        <nav
+          aria-label="Breadcrumb"
+          className="flex items-center gap-1 text-[0.625rem] font-medium uppercase tracking-[0.2em] text-muted-foreground"
+        >
+          <Link to={base} className="transition-colors hover:text-foreground">
+            {space.name}
+          </Link>
+          {path.split("/").map((seg, i, all) => (
+            <span key={all.slice(0, i + 1).join("/")} className="flex items-center gap-1">
+              <span aria-hidden className="opacity-40">
+                /
+              </span>
+              <span className={i === all.length - 1 ? "text-foreground" : ""}>{seg}</span>
             </span>
-            <span className={i === all.length - 1 ? "text-foreground" : ""}>{seg}</span>
-          </span>
-        ))}
-      </nav>
-      {error ? <p className="text-sm text-destructive">error: {error}</p> : null}
-      <div className="flex justify-end">
-        <Button type="button" variant="ghost" onClick={() => void openShare()}>
-          <Users aria-hidden className="size-4" /> Who can read this
-        </Button>
-      </div>
-      {visibility && directory ? (
-        <RestrictDialog
-          open={sharing}
-          subjectLabel={doc.title}
-          visibility={visibility}
-          directory={directory}
-          onRestrict={async (subjects) => {
-            await restrictPage(doc.id, subjects);
-            refresh();
-          }}
-          onClear={async () => {
-            await unrestrictPage(doc.id);
-            refresh();
-          }}
-          onClose={() => setSharing(false)}
+          ))}
+        </nav>
+        {error ? <p className="text-sm text-destructive">error: {error}</p> : null}
+        <div className="flex justify-end">
+          <Button type="button" variant="ghost" onClick={() => void openShare()}>
+            <Users aria-hidden className="size-4" /> Who can read this
+          </Button>
+        </div>
+        {visibility && directory ? (
+          <RestrictDialog
+            open={sharing}
+            subjectLabel={doc.title}
+            visibility={visibility}
+            directory={directory}
+            onRestrict={async (subjects) => {
+              await restrictPage(doc.id, subjects);
+              refresh();
+            }}
+            onClear={async () => {
+              await unrestrictPage(doc.id);
+              refresh();
+            }}
+            onClose={() => setSharing(false)}
+          />
+        ) : null}
+        <PageDetail
+          spaceId={space.id}
+          doc={doc}
+          path={path}
+          editTo={`/knowledge/pages/${encodeURIComponent(doc.id)}/edit`}
+          onDelete={onDelete}
+          deleting={deleting}
+          backlinks={backlinks}
+          resolver={resolver}
         />
-      ) : null}
-      <PageDetail
-        spaceId={space.id}
-        doc={doc}
-        path={path}
-        editTo={`/knowledge/pages/${encodeURIComponent(doc.id)}/edit`}
-        onDelete={onDelete}
-        deleting={deleting}
-        backlinks={backlinks}
-        resolver={resolver}
-      />
-    </article>
+      </article>
+    </div>
   );
 }
 

--- a/apps/web/app/routes/_app.knowledge.spaces.$id._index.tsx
+++ b/apps/web/app/routes/_app.knowledge.spaces.$id._index.tsx
@@ -54,91 +54,93 @@ export default function SpaceHome() {
   }
 
   return (
-    <article className="mx-auto flex w-full max-w-3xl flex-col gap-5 px-6 py-8">
-      <header className="flex flex-col gap-2">
-        <h1 className="text-2xl font-bold tracking-tight text-foreground">{space.name}</h1>
-        {space.description ? (
-          <p className="text-sm text-muted-foreground">{space.description}</p>
-        ) : null}
-      </header>
+    <div className="h-full min-h-0 overflow-y-auto">
+      <article className="mx-auto flex w-full max-w-3xl flex-col gap-5 px-6 py-8">
+        <header className="flex flex-col gap-2">
+          <h1 className="text-2xl font-bold tracking-tight text-foreground">{space.name}</h1>
+          {space.description ? (
+            <p className="text-sm text-muted-foreground">{space.description}</p>
+          ) : null}
+        </header>
 
-      <div className="flex flex-wrap items-center gap-1.5 border-y border-border py-2.5">
-        <Button asChild size="sm" className="cursor-pointer">
-          <Link to={`${base}/pages/new`}>
-            <Plus aria-hidden />
-            New page
-          </Link>
-        </Button>
-        <Button asChild variant="ghost" size="sm" className="cursor-pointer">
-          <Link to={`${base}/pages/new?path=index`}>
-            <Pencil aria-hidden />
-            Edit front page
-          </Link>
-        </Button>
-        <Button asChild variant="ghost" size="sm" className="cursor-pointer">
-          <Link to={`${base}/graph`}>
-            <Network aria-hidden />
-            Graph
-          </Link>
-        </Button>
-
-        <div className="ml-auto flex items-center gap-1">
-          <Button
-            asChild
-            variant="ghost"
-            size="icon"
-            className="size-8 cursor-pointer"
-            aria-label="Space settings"
-            title="Space settings"
-          >
-            <Link to={`${base}/edit`}>
-              <Settings aria-hidden />
+        <div className="flex flex-wrap items-center gap-1.5 border-y border-border py-2.5">
+          <Button asChild size="sm" className="cursor-pointer">
+            <Link to={`${base}/pages/new`}>
+              <Plus aria-hidden />
+              New page
+            </Link>
+          </Button>
+          <Button asChild variant="ghost" size="sm" className="cursor-pointer">
+            <Link to={`${base}/pages/new?path=index`}>
+              <Pencil aria-hidden />
+              Edit front page
+            </Link>
+          </Button>
+          <Button asChild variant="ghost" size="sm" className="cursor-pointer">
+            <Link to={`${base}/graph`}>
+              <Network aria-hidden />
+              Graph
             </Link>
           </Button>
 
-          <Divider />
-          {confirming ? (
-            <>
-              <Button
-                variant="destructive"
-                size="sm"
-                className="cursor-pointer"
-                onClick={onDelete}
-                disabled={deleting}
-              >
-                {deleting ? "deleting…" : "Confirm delete"}
-              </Button>
+          <div className="ml-auto flex items-center gap-1">
+            <Button
+              asChild
+              variant="ghost"
+              size="icon"
+              className="size-8 cursor-pointer"
+              aria-label="Space settings"
+              title="Space settings"
+            >
+              <Link to={`${base}/edit`}>
+                <Settings aria-hidden />
+              </Link>
+            </Button>
+
+            <Divider />
+            {confirming ? (
+              <>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  className="cursor-pointer"
+                  onClick={onDelete}
+                  disabled={deleting}
+                >
+                  {deleting ? "deleting…" : "Confirm delete"}
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="cursor-pointer"
+                  onClick={() => setConfirming(false)}
+                  disabled={deleting}
+                >
+                  Cancel
+                </Button>
+              </>
+            ) : (
               <Button
                 variant="ghost"
                 size="sm"
-                className="cursor-pointer"
-                onClick={() => setConfirming(false)}
-                disabled={deleting}
+                className="cursor-pointer text-destructive hover:bg-destructive/10 hover:text-destructive"
+                onClick={() => setConfirming(true)}
               >
-                Cancel
+                <Trash2 aria-hidden />
+                Delete
               </Button>
-            </>
-          ) : (
-            <Button
-              variant="ghost"
-              size="sm"
-              className="cursor-pointer text-destructive hover:bg-destructive/10 hover:text-destructive"
-              onClick={() => setConfirming(true)}
-            >
-              <Trash2 aria-hidden />
-              Delete
-            </Button>
-          )}
+            )}
+          </div>
         </div>
-      </div>
 
-      {error ? <p className="text-sm text-destructive">error: {error}</p> : null}
+        {error ? <p className="text-sm text-destructive">error: {error}</p> : null}
 
-      {/* wikiLinks: the rewritten `/knowledge/...` page links render as in-SPA <Link>s, not new tabs. */}
-      <MarkdownView wikiLinks>
-        {rewriteOkfLinks(listing, space.id, buildPageResolver(pages))}
-      </MarkdownView>
-    </article>
+        {/* wikiLinks: the rewritten `/knowledge/...` page links render as in-SPA <Link>s, not new tabs. */}
+        <MarkdownView wikiLinks>
+          {rewriteOkfLinks(listing, space.id, buildPageResolver(pages))}
+        </MarkdownView>
+      </article>
+    </div>
   );
 }
 

--- a/apps/web/app/routes/_app.knowledge.spaces.$id.graph.tsx
+++ b/apps/web/app/routes/_app.knowledge.spaces.$id.graph.tsx
@@ -30,21 +30,23 @@ export default function SpaceGraphRoute() {
   const base = `/knowledge/spaces/${encodeURIComponent(space.id)}`;
 
   return (
-    <div className="mx-auto flex w-full max-w-4xl flex-col gap-4 px-6 py-8">
-      <nav
-        aria-label="Breadcrumb"
-        className="flex items-center gap-1 text-[0.625rem] font-medium uppercase tracking-[0.2em] text-muted-foreground"
-      >
-        <Link to={base} className="transition-colors hover:text-foreground">
-          {space.name}
-        </Link>
-        <span aria-hidden className="opacity-40">
-          /
-        </span>
-        <span className="text-foreground">graph</span>
-      </nav>
-      <h1 className="text-base font-bold text-foreground">Cross-link graph</h1>
-      <SpaceGraphView graph={graph} pages={pages} />
+    <div className="h-full min-h-0 overflow-y-auto">
+      <div className="mx-auto flex w-full max-w-4xl flex-col gap-4 px-6 py-8">
+        <nav
+          aria-label="Breadcrumb"
+          className="flex items-center gap-1 text-[0.625rem] font-medium uppercase tracking-[0.2em] text-muted-foreground"
+        >
+          <Link to={base} className="transition-colors hover:text-foreground">
+            {space.name}
+          </Link>
+          <span aria-hidden className="opacity-40">
+            /
+          </span>
+          <span className="text-foreground">graph</span>
+        </nav>
+        <h1 className="text-base font-bold text-foreground">Cross-link graph</h1>
+        <SpaceGraphView graph={graph} pages={pages} />
+      </div>
     </div>
   );
 }

--- a/apps/web/app/routes/_app.knowledge.tags.$tag.tsx
+++ b/apps/web/app/routes/_app.knowledge.tags.$tag.tsx
@@ -28,49 +28,51 @@ export async function clientLoader({ params }: ClientLoaderFunctionArgs) {
 export default function TagListing() {
   const { tag, items } = useLoaderData<typeof clientLoader>();
   return (
-    <article className="mx-auto flex w-full max-w-3xl flex-col gap-4 px-6 py-8">
-      <header className="flex flex-wrap items-center gap-2">
-        <span className="tf-tag-chip">#{tag}</span>
-        <h1 className="text-base font-bold text-foreground">tagged pages</h1>
-      </header>
-      {items.length === 0 ? (
-        <p className="text-sm text-muted-foreground">No pages tagged #{tag}.</p>
-      ) : (
-        <ul className="flex flex-col divide-y divide-border rounded-sm border border-border">
-          {items.map((d) => {
-            const to = d.spaceId && d.path ? pageHref(d.id, d.path) : null;
-            return (
-              <li key={d.id} className="flex flex-wrap items-center gap-2 px-3 py-2 text-sm">
-                {to ? (
-                  <Link
-                    to={to}
-                    className="cursor-pointer text-primary underline underline-offset-2 hover:opacity-80"
-                  >
-                    {d.title}
-                  </Link>
-                ) : (
-                  <span className="text-foreground">{d.title}</span>
-                )}
-                <AgentAuthoredBadge authorKind={d.authorKind} />
-                {d.tags.length ? (
-                  <span className="text-xs text-muted-foreground">
-                    {d.tags.map((t) => `#${t}`).join(" ")}
-                  </span>
-                ) : null}
-              </li>
-            );
-          })}
-        </ul>
-      )}
-      <p className="text-xs text-muted-foreground">
-        <Link
-          to="/knowledge"
-          className="cursor-pointer underline underline-offset-2 hover:text-foreground"
-        >
-          ← knowledge
-        </Link>
-      </p>
-    </article>
+    <div className="h-full min-h-0 overflow-y-auto">
+      <article className="mx-auto flex w-full max-w-3xl flex-col gap-4 px-6 py-8">
+        <header className="flex flex-wrap items-center gap-2">
+          <span className="tf-tag-chip">#{tag}</span>
+          <h1 className="text-base font-bold text-foreground">tagged pages</h1>
+        </header>
+        {items.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No pages tagged #{tag}.</p>
+        ) : (
+          <ul className="flex flex-col divide-y divide-border rounded-sm border border-border">
+            {items.map((d) => {
+              const to = d.spaceId && d.path ? pageHref(d.id, d.path) : null;
+              return (
+                <li key={d.id} className="flex flex-wrap items-center gap-2 px-3 py-2 text-sm">
+                  {to ? (
+                    <Link
+                      to={to}
+                      className="cursor-pointer text-primary underline underline-offset-2 hover:opacity-80"
+                    >
+                      {d.title}
+                    </Link>
+                  ) : (
+                    <span className="text-foreground">{d.title}</span>
+                  )}
+                  <AgentAuthoredBadge authorKind={d.authorKind} />
+                  {d.tags.length ? (
+                    <span className="text-xs text-muted-foreground">
+                      {d.tags.map((t) => `#${t}`).join(" ")}
+                    </span>
+                  ) : null}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+        <p className="text-xs text-muted-foreground">
+          <Link
+            to="/knowledge"
+            className="cursor-pointer underline underline-offset-2 hover:text-foreground"
+          >
+            ← knowledge
+          </Link>
+        </p>
+      </article>
+    </div>
   );
 }
 

--- a/apps/web/app/routes/_app.link-channel.tsx
+++ b/apps/web/app/routes/_app.link-channel.tsx
@@ -85,14 +85,16 @@ export default function LinkChannelRoute() {
 
 function Card({ children }: { children: React.ReactNode }) {
   return (
-    <section className="mx-auto flex h-full max-w-xl flex-col justify-center px-6 py-16">
-      <div className="rounded-sm border border-border bg-card">
-        <p className="border-b border-border px-4 py-2 text-[0.625rem] font-medium uppercase tracking-[0.2em] text-muted-foreground">
-          link channel
-        </p>
-        <div className="flex flex-col gap-4 px-4 py-6 text-sm">{children}</div>
-      </div>
-    </section>
+    <div className="h-full min-h-0 overflow-y-auto">
+      <section className="mx-auto flex min-h-full max-w-xl flex-col justify-center px-6 py-16">
+        <div className="rounded-sm border border-border bg-card">
+          <p className="border-b border-border px-4 py-2 text-[0.625rem] font-medium uppercase tracking-[0.2em] text-muted-foreground">
+            link channel
+          </p>
+          <div className="flex flex-col gap-4 px-4 py-6 text-sm">{children}</div>
+        </div>
+      </section>
+    </div>
   );
 }
 

--- a/apps/web/app/routes/_app.operations.tsx
+++ b/apps/web/app/routes/_app.operations.tsx
@@ -32,16 +32,18 @@ export default function OperationsRoute() {
     }
   }
   return (
-    <div className="mx-auto max-w-6xl space-y-4 px-4 py-6 sm:px-6">
-      {killSwitches ? (
-        <KillSwitchPanel model={killSwitches} onChanged={() => revalidator.revalidate()} />
-      ) : null}
-      <OperationsConsole
-        model={model}
-        busy={busy}
-        onCommand={command}
-        onRefresh={() => revalidator.revalidate()}
-      />
+    <div className="h-full min-h-0 overflow-y-auto">
+      <div className="mx-auto max-w-6xl space-y-4 px-4 py-6 sm:px-6">
+        {killSwitches ? (
+          <KillSwitchPanel model={killSwitches} onChanged={() => revalidator.revalidate()} />
+        ) : null}
+        <OperationsConsole
+          model={model}
+          busy={busy}
+          onCommand={command}
+          onRefresh={() => revalidator.revalidate()}
+        />
+      </div>
     </div>
   );
 }

--- a/apps/web/app/routes/_app.runs.$id.tsx
+++ b/apps/web/app/routes/_app.runs.$id.tsx
@@ -92,10 +92,12 @@ export default function OperationalRunRoute() {
   }
 
   return (
-    <div className="mx-auto flex max-w-6xl flex-col gap-4 px-4 py-6 sm:px-6">
-      {connection === "reconnecting" ? <ConnectionStatus state="reconnecting" /> : null}
-      <RunInspector run={run} busy={busy} unavailable={unavailable} onCommand={submit} />
-      <RunBudgets state={budgets} />
+    <div className="h-full min-h-0 overflow-y-auto">
+      <div className="mx-auto flex max-w-6xl flex-col gap-4 px-4 py-6 sm:px-6">
+        {connection === "reconnecting" ? <ConnectionStatus state="reconnecting" /> : null}
+        <RunInspector run={run} busy={busy} unavailable={unavailable} onCommand={submit} />
+        <RunBudgets state={budgets} />
+      </div>
     </div>
   );
 }

--- a/apps/web/app/routes/_app.runs._index.tsx
+++ b/apps/web/app/routes/_app.runs._index.tsx
@@ -44,39 +44,43 @@ export default function RunsRoute() {
   }
 
   return (
-    <div className="mx-auto flex max-w-6xl flex-col gap-4 px-4 py-6 sm:px-6">
-      <h1 className="text-sm font-medium uppercase tracking-[0.2em] text-muted-foreground">Runs</h1>
-      <ul className="divide-y divide-border border border-border bg-card">
-        {runs.map((run) => (
-          <li key={run.id}>
-            <Link
-              to={`/runs/${encodeURIComponent(run.id)}`}
-              className="grid gap-1 px-3 py-2 text-xs hover:bg-muted sm:grid-cols-4 sm:items-center"
-            >
-              <span className="rounded-sm border border-border px-2 py-1 text-center">
-                {run.status}
-              </span>
-              <strong className="truncate">
-                {run.routineId}@{run.routineVersion}
-              </strong>
-              <code className="truncate text-muted-foreground">{run.id}</code>
-              <span className="text-muted-foreground sm:text-right">
-                {timestamp(run.createdAt)}
-              </span>
-            </Link>
-          </li>
-        ))}
-      </ul>
-      {cursor ? (
-        <button
-          type="button"
-          disabled={busy}
-          onClick={loadMore}
-          className="self-start rounded-sm border border-border px-2.5 py-1.5 text-xs hover:bg-muted disabled:opacity-60"
-        >
-          {busy ? "Loading…" : "Load more"}
-        </button>
-      ) : null}
+    <div className="h-full min-h-0 overflow-y-auto">
+      <div className="mx-auto flex max-w-6xl flex-col gap-4 px-4 py-6 sm:px-6">
+        <h1 className="text-sm font-medium uppercase tracking-[0.2em] text-muted-foreground">
+          Runs
+        </h1>
+        <ul className="divide-y divide-border border border-border bg-card">
+          {runs.map((run) => (
+            <li key={run.id}>
+              <Link
+                to={`/runs/${encodeURIComponent(run.id)}`}
+                className="grid gap-1 px-3 py-2 text-xs hover:bg-muted sm:grid-cols-4 sm:items-center"
+              >
+                <span className="rounded-sm border border-border px-2 py-1 text-center">
+                  {run.status}
+                </span>
+                <strong className="truncate">
+                  {run.routineId}@{run.routineVersion}
+                </strong>
+                <code className="truncate text-muted-foreground">{run.id}</code>
+                <span className="text-muted-foreground sm:text-right">
+                  {timestamp(run.createdAt)}
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+        {cursor ? (
+          <button
+            type="button"
+            disabled={busy}
+            onClick={loadMore}
+            className="self-start rounded-sm border border-border px-2.5 py-1.5 text-xs hover:bg-muted disabled:opacity-60"
+          >
+            {busy ? "Loading…" : "Load more"}
+          </button>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/apps/web/app/routes/accept-invite.tsx
+++ b/apps/web/app/routes/accept-invite.tsx
@@ -78,73 +78,75 @@ export default function AcceptInvite() {
   }
 
   return (
-    <section className="mx-auto flex min-h-svh max-w-sm flex-col justify-center px-6 py-16">
-      <p className="text-[0.625rem] font-medium uppercase tracking-[0.2em] text-primary">
-        [ ACCEPT INVITE ]
-      </p>
-      <h1 className="mt-1 text-2xl font-semibold text-foreground">Choose your password</h1>
+    <div className="h-full min-h-0 overflow-y-auto">
+      <section className="mx-auto flex min-h-full max-w-sm flex-col justify-center px-6 py-16">
+        <p className="text-[0.625rem] font-medium uppercase tracking-[0.2em] text-primary">
+          [ ACCEPT INVITE ]
+        </p>
+        <h1 className="mt-1 text-2xl font-semibold text-foreground">Choose your password</h1>
 
-      {loading ? (
-        <p className="mt-1 text-sm text-muted-foreground">Checking this link…</p>
-      ) : dead ? (
-        <>
-          <p role="alert" className="mt-1 text-sm text-destructive">
-            error: {error}
-          </p>
-          <p className="mt-3 text-sm text-muted-foreground">
-            Invite links are single-use and expire. Ask an admin for a new one.
-          </p>
-        </>
-      ) : (
-        <>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Setting the password for <strong className="text-foreground">{email}</strong>.
-          </p>
+        {loading ? (
+          <p className="mt-1 text-sm text-muted-foreground">Checking this link…</p>
+        ) : dead ? (
+          <>
+            <p role="alert" className="mt-1 text-sm text-destructive">
+              error: {error}
+            </p>
+            <p className="mt-3 text-sm text-muted-foreground">
+              Invite links are single-use and expire. Ask an admin for a new one.
+            </p>
+          </>
+        ) : (
+          <>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Setting the password for <strong className="text-foreground">{email}</strong>.
+            </p>
 
-          <form onSubmit={onSubmit} className="mt-8 flex flex-col gap-3">
-            {error ? (
-              <p
-                role="alert"
-                className="rounded-sm border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+            <form onSubmit={onSubmit} className="mt-8 flex flex-col gap-3">
+              {error ? (
+                <p
+                  role="alert"
+                  className="rounded-sm border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+                >
+                  error: {error}
+                </p>
+              ) : null}
+
+              <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+                password
+                <input
+                  type="password"
+                  autoComplete="new-password"
+                  className={inputClass}
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  aria-label="password"
+                />
+              </label>
+
+              <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+                confirm password
+                <input
+                  type="password"
+                  autoComplete="new-password"
+                  className={inputClass}
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  aria-label="confirm password"
+                />
+              </label>
+
+              <Button
+                type="submit"
+                className="mt-1 rounded-sm"
+                disabled={busy || password.length === 0 || confirmPassword.length === 0}
               >
-                error: {error}
-              </p>
-            ) : null}
-
-            <label className="flex flex-col gap-1 text-xs text-muted-foreground">
-              password
-              <input
-                type="password"
-                autoComplete="new-password"
-                className={inputClass}
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                aria-label="password"
-              />
-            </label>
-
-            <label className="flex flex-col gap-1 text-xs text-muted-foreground">
-              confirm password
-              <input
-                type="password"
-                autoComplete="new-password"
-                className={inputClass}
-                value={confirmPassword}
-                onChange={(e) => setConfirmPassword(e.target.value)}
-                aria-label="confirm password"
-              />
-            </label>
-
-            <Button
-              type="submit"
-              className="mt-1 rounded-sm"
-              disabled={busy || password.length === 0 || confirmPassword.length === 0}
-            >
-              {busy ? "Setting password…" : "Set password and sign in"}
-            </Button>
-          </form>
-        </>
-      )}
-    </section>
+                {busy ? "Setting password…" : "Set password and sign in"}
+              </Button>
+            </form>
+          </>
+        )}
+      </section>
+    </div>
   );
 }

--- a/apps/web/app/routes/dev.surfaces.tsx
+++ b/apps/web/app/routes/dev.surfaces.tsx
@@ -112,313 +112,319 @@ export default function DevelopmentSurfacesRoute() {
   const presetSelectId = useId();
 
   return (
-    <div className="mx-auto w-full max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
-      {/* Top Header */}
-      <header className="mb-6 flex flex-col gap-2 border-b border-border pb-6">
-        <div className="flex flex-wrap items-center gap-2">
-          <Badge variant="primary">TSP v1.0</Badge>
-          <Badge variant="neutral">Dev Sandbox</Badge>
-          <Badge variant="info">Multi-Renderer</Badge>
-        </div>
-        <h1 className="text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
-          Tulip Surface Protocol Sandbox
-        </h1>
-        <p className="max-w-3xl text-sm text-muted-foreground">
-          Live testing environment for rendering dynamic AI-generated user interfaces across native
-          React web surfaces, Slack Block Kit, and GitHub Check Run/Comment cards.
-        </p>
-      </header>
-
-      {/* Control Bar: Preset Selector & Viewport Selector */}
-      <div className="mb-6 flex flex-wrap items-center justify-between gap-4 rounded-lg border border-border bg-card p-4 shadow-xs">
-        <div className="flex flex-wrap items-center gap-3">
-          <label
-            htmlFor={presetSelectId}
-            className="text-xs font-semibold text-foreground shrink-0"
-          >
-            Template Preset:
-          </label>
-          <div className="w-56 sm:w-64">
-            <Select
-              id={presetSelectId}
-              aria-label="Template preset selector"
-              value={selectedPresetId}
-              onChange={(e) => handleSelectPreset(e.target.value)}
-            >
-              {PRESETS.map((preset) => (
-                <option key={preset.id} value={preset.id}>
-                  {preset.name}
-                </option>
-              ))}
-            </Select>
+    <div className="h-full min-h-0 overflow-y-auto">
+      <div className="mx-auto w-full max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+        {/* Top Header */}
+        <header className="mb-6 flex flex-col gap-2 border-b border-border pb-6">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant="primary">TSP v1.0</Badge>
+            <Badge variant="neutral">Dev Sandbox</Badge>
+            <Badge variant="info">Multi-Renderer</Badge>
           </div>
-          <span className="text-xs text-muted-foreground hidden lg:inline">
-            {activePreset.description}
-          </span>
-        </div>
+          <h1 className="text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
+            Tulip Surface Protocol Sandbox
+          </h1>
+          <p className="max-w-3xl text-sm text-muted-foreground">
+            Live testing environment for rendering dynamic AI-generated user interfaces across
+            native React web surfaces, Slack Block Kit, and GitHub Check Run/Comment cards.
+          </p>
+        </header>
 
-        {/* Viewport Simulation Selector */}
-        <div className="flex items-center gap-1 rounded-md border border-border bg-muted/40 p-0.5 text-xs">
-          <button
-            type="button"
-            onClick={() => setViewport("desktop")}
-            className={`flex items-center gap-1 rounded px-2.5 py-1 font-medium transition-colors ${
-              viewport === "desktop"
-                ? "bg-background text-foreground shadow-xs"
-                : "text-muted-foreground hover:text-foreground"
-            }`}
-            title="Desktop 100%"
-          >
-            <Laptop className="size-3.5" />
-            <span className="hidden sm:inline">Desktop</span>
-          </button>
-          <button
-            type="button"
-            onClick={() => setViewport("tablet")}
-            className={`flex items-center gap-1 rounded px-2.5 py-1 font-medium transition-colors ${
-              viewport === "tablet"
-                ? "bg-background text-foreground shadow-xs"
-                : "text-muted-foreground hover:text-foreground"
-            }`}
-            title="Tablet 768px"
-          >
-            <Tablet className="size-3.5" />
-            <span className="hidden sm:inline">Tablet</span>
-          </button>
-          <button
-            type="button"
-            onClick={() => setViewport("mobile")}
-            className={`flex items-center gap-1 rounded px-2.5 py-1 font-medium transition-colors ${
-              viewport === "mobile"
-                ? "bg-background text-foreground shadow-xs"
-                : "text-muted-foreground hover:text-foreground"
-            }`}
-            title="Mobile 375px"
-          >
-            <Smartphone className="size-3.5" />
-            <span className="hidden sm:inline">Mobile (375px)</span>
-          </button>
-        </div>
-      </div>
-
-      {/* Preset Quick Chips Bar */}
-      <div className="mb-6 flex flex-wrap items-center gap-1.5">
-        <span className="text-xs font-medium text-muted-foreground mr-1">Presets:</span>
-        {PRESETS.map((p) => (
-          <button
-            key={p.id}
-            type="button"
-            onClick={() => handleSelectPreset(p.id)}
-            className={`rounded-md border px-2.5 py-1 text-xs font-medium transition-colors ${
-              p.id === selectedPresetId
-                ? "border-primary bg-primary/10 text-primary"
-                : "border-border bg-card text-muted-foreground hover:bg-accent hover:text-foreground"
-            }`}
-          >
-            {p.name}
-          </button>
-        ))}
-      </div>
-
-      {/* Main Split Grid */}
-      <div className="grid grid-cols-1 gap-6 lg:grid-cols-12">
-        {/* Left Column: Multi-Renderer & Event Inspector (7 cols) */}
-        <div className="flex flex-col gap-6 lg:col-span-7">
-          {/* Renderer Container Card */}
-          <section
-            aria-label="Multi-renderer surface preview"
-            className="rounded-lg border border-border bg-card shadow-xs overflow-hidden"
-          >
-            {/* Multi-Renderer Tabs Bar */}
-            <div
-              role="tablist"
-              aria-label="Surface renderer targets"
-              className="flex flex-wrap items-center gap-1 border-b border-border bg-muted/30 p-2"
+        {/* Control Bar: Preset Selector & Viewport Selector */}
+        <div className="mb-6 flex flex-wrap items-center justify-between gap-4 rounded-lg border border-border bg-card p-4 shadow-xs">
+          <div className="flex flex-wrap items-center gap-3">
+            <label
+              htmlFor={presetSelectId}
+              className="text-xs font-semibold text-foreground shrink-0"
             >
-              <button
-                type="button"
-                role="tab"
-                aria-selected={activeTab === "react"}
-                onClick={() => setActiveTab("react")}
-                className={`flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors focus-visible:ring-2 ${
-                  activeTab === "react"
-                    ? "bg-background text-foreground shadow-xs font-semibold"
-                    : "text-muted-foreground hover:text-foreground"
-                }`}
+              Template Preset:
+            </label>
+            <div className="w-56 sm:w-64">
+              <Select
+                id={presetSelectId}
+                aria-label="Template preset selector"
+                value={selectedPresetId}
+                onChange={(e) => handleSelectPreset(e.target.value)}
               >
-                <Layers className="size-3.5 text-primary" />
-                React (Web)
-              </button>
-
-              <button
-                type="button"
-                role="tab"
-                aria-selected={activeTab === "slack"}
-                onClick={() => setActiveTab("slack")}
-                className={`flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors focus-visible:ring-2 ${
-                  activeTab === "slack"
-                    ? "bg-background text-foreground shadow-xs font-semibold"
-                    : "text-muted-foreground hover:text-foreground"
-                }`}
-              >
-                <Boxes className="size-3.5 text-[#4A154B]" />
-                Slack (Block Kit)
-              </button>
-
-              <button
-                type="button"
-                role="tab"
-                aria-selected={activeTab === "github"}
-                onClick={() => setActiveTab("github")}
-                className={`flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors focus-visible:ring-2 ${
-                  activeTab === "github"
-                    ? "bg-background text-foreground shadow-xs font-semibold"
-                    : "text-muted-foreground hover:text-foreground"
-                }`}
-              >
-                <Eye className="size-3.5 text-foreground" />
-                GitHub
-              </button>
+                {PRESETS.map((preset) => (
+                  <option key={preset.id} value={preset.id}>
+                    {preset.name}
+                  </option>
+                ))}
+              </Select>
             </div>
+            <span className="text-xs text-muted-foreground hidden lg:inline">
+              {activePreset.description}
+            </span>
+          </div>
 
-            {/* Preview Viewport Canvas */}
-            <div className="p-4 sm:p-6 bg-muted/10 min-h-[380px] flex flex-col justify-start">
-              <div
-                className={`w-full transition-all duration-200 ${
-                  viewport === "mobile"
-                    ? "max-w-[375px] mx-auto border-x border-dashed border-border px-2 py-4 rounded bg-background shadow-xs"
-                    : viewport === "tablet"
-                      ? "max-w-[768px] mx-auto border-x border-dashed border-border px-4 py-4 rounded bg-background shadow-xs"
-                      : ""
-                }`}
-              >
-                {parsedArtifact ? (
-                  activeTab === "react" ? (
-                    <div data-testid="react-renderer-preview" className="space-y-4">
-                      <SurfaceView
-                        artifact={parsedArtifact}
-                        onInteraction={(handle, payload) => handleInteraction(handle, payload)}
-                        actionHandleFor={(action) => action.event}
-                      />
-                    </div>
-                  ) : activeTab === "slack" ? (
-                    <div data-testid="slack-renderer-preview">
-                      <SlackPreview
-                        artifact={parsedArtifact}
-                        onInteraction={(actionId, payload) => handleInteraction(actionId, payload)}
-                      />
-                    </div>
-                  ) : (
-                    <div data-testid="github-renderer-preview">
-                      <GitHubPreview
-                        artifact={parsedArtifact}
-                        onInteraction={(actionId, payload) => handleInteraction(actionId, payload)}
-                      />
-                    </div>
-                  )
-                ) : (
-                  /* ErrorState Fallback */
-                  <div
-                    role="alert"
-                    data-testid="schema-error-state"
-                    className="flex flex-col items-center justify-center rounded-lg border border-status-danger/40 bg-status-danger/10 p-8 text-center"
-                  >
-                    <AlertTriangle className="size-8 text-status-danger" />
-                    <h3 className="mt-2 text-sm font-semibold text-status-danger">
-                      Schema Error Fallback: Invalid Surface Artifact
-                    </h3>
-                    <p className="mt-1 max-w-md text-xs text-muted-foreground">
-                      {syntaxError
-                        ? `JSON Syntax Error: ${syntaxError}`
-                        : validationIssues.length > 0
-                          ? `The current payload has ${validationIssues.length} schema validation ${
-                              validationIssues.length === 1 ? "issue" : "issues"
-                            }. Correct the JSON or restore a valid preset.`
-                          : "Payload is empty or missing required Tulip Surface Protocol fields."}
-                    </p>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      onClick={handleResetPreset}
-                      className="mt-4 gap-1.5 text-xs"
-                    >
-                      <RotateCcw className="size-3.5" />
-                      Restore Valid Preset
-                    </Button>
-                  </div>
-                )}
-              </div>
-            </div>
-          </section>
-
-          {/* Event Inspector Panel */}
-          <EventInspector events={events} onClear={() => setEvents([])} />
+          {/* Viewport Simulation Selector */}
+          <div className="flex items-center gap-1 rounded-md border border-border bg-muted/40 p-0.5 text-xs">
+            <button
+              type="button"
+              onClick={() => setViewport("desktop")}
+              className={`flex items-center gap-1 rounded px-2.5 py-1 font-medium transition-colors ${
+                viewport === "desktop"
+                  ? "bg-background text-foreground shadow-xs"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+              title="Desktop 100%"
+            >
+              <Laptop className="size-3.5" />
+              <span className="hidden sm:inline">Desktop</span>
+            </button>
+            <button
+              type="button"
+              onClick={() => setViewport("tablet")}
+              className={`flex items-center gap-1 rounded px-2.5 py-1 font-medium transition-colors ${
+                viewport === "tablet"
+                  ? "bg-background text-foreground shadow-xs"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+              title="Tablet 768px"
+            >
+              <Tablet className="size-3.5" />
+              <span className="hidden sm:inline">Tablet</span>
+            </button>
+            <button
+              type="button"
+              onClick={() => setViewport("mobile")}
+              className={`flex items-center gap-1 rounded px-2.5 py-1 font-medium transition-colors ${
+                viewport === "mobile"
+                  ? "bg-background text-foreground shadow-xs"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+              title="Mobile 375px"
+            >
+              <Smartphone className="size-3.5" />
+              <span className="hidden sm:inline">Mobile (375px)</span>
+            </button>
+          </div>
         </div>
 
-        {/* Right Column: Raw JSON Editor & Metadata (5 cols) */}
-        <div className="flex flex-col gap-6 lg:col-span-5">
-          {/* JSON Payload Editor */}
-          <section
-            aria-label="Raw JSON Payload Editor"
-            className="rounded-lg border border-border bg-card p-4 shadow-xs"
-          >
-            <JsonEditor
-              value={jsonText}
-              onChange={setJsonText}
-              onResetPreset={handleResetPreset}
-              validationIssues={validationIssues}
-              syntaxError={syntaxError}
-              isValid={isValid}
-            />
-          </section>
+        {/* Preset Quick Chips Bar */}
+        <div className="mb-6 flex flex-wrap items-center gap-1.5">
+          <span className="text-xs font-medium text-muted-foreground mr-1">Presets:</span>
+          {PRESETS.map((p) => (
+            <button
+              key={p.id}
+              type="button"
+              onClick={() => handleSelectPreset(p.id)}
+              className={`rounded-md border px-2.5 py-1 text-xs font-medium transition-colors ${
+                p.id === selectedPresetId
+                  ? "border-primary bg-primary/10 text-primary"
+                  : "border-border bg-card text-muted-foreground hover:bg-accent hover:text-foreground"
+              }`}
+            >
+              {p.name}
+            </button>
+          ))}
+        </div>
 
-          {/* Artifact Metadata / Catalog Card */}
-          <section
-            aria-label="Artifact metadata and catalog info"
-            className="rounded-lg border border-border bg-card p-4 text-xs text-muted-foreground shadow-xs"
-          >
-            <div className="flex items-center justify-between border-b border-border pb-2">
-              <span className="font-semibold text-foreground">Active Artifact Specification</span>
-              <Badge variant="neutral">TSP Catalog 1.2</Badge>
-            </div>
-            {parsedArtifact ? (
-              <dl className="mt-3 grid grid-cols-2 gap-x-4 gap-y-2">
-                <div>
-                  <dt className="text-muted-foreground">Component</dt>
-                  <dd className="font-semibold text-foreground font-mono">
-                    {parsedArtifact.component.name}@{parsedArtifact.component.version}
-                  </dd>
+        {/* Main Split Grid */}
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-12">
+          {/* Left Column: Multi-Renderer & Event Inspector (7 cols) */}
+          <div className="flex flex-col gap-6 lg:col-span-7">
+            {/* Renderer Container Card */}
+            <section
+              aria-label="Multi-renderer surface preview"
+              className="rounded-lg border border-border bg-card shadow-xs overflow-hidden"
+            >
+              {/* Multi-Renderer Tabs Bar */}
+              <div
+                role="tablist"
+                aria-label="Surface renderer targets"
+                className="flex flex-wrap items-center gap-1 border-b border-border bg-muted/30 p-2"
+              >
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={activeTab === "react"}
+                  onClick={() => setActiveTab("react")}
+                  className={`flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors focus-visible:ring-2 ${
+                    activeTab === "react"
+                      ? "bg-background text-foreground shadow-xs font-semibold"
+                      : "text-muted-foreground hover:text-foreground"
+                  }`}
+                >
+                  <Layers className="size-3.5 text-primary" />
+                  React (Web)
+                </button>
+
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={activeTab === "slack"}
+                  onClick={() => setActiveTab("slack")}
+                  className={`flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors focus-visible:ring-2 ${
+                    activeTab === "slack"
+                      ? "bg-background text-foreground shadow-xs font-semibold"
+                      : "text-muted-foreground hover:text-foreground"
+                  }`}
+                >
+                  <Boxes className="size-3.5 text-[#4A154B]" />
+                  Slack (Block Kit)
+                </button>
+
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={activeTab === "github"}
+                  onClick={() => setActiveTab("github")}
+                  className={`flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors focus-visible:ring-2 ${
+                    activeTab === "github"
+                      ? "bg-background text-foreground shadow-xs font-semibold"
+                      : "text-muted-foreground hover:text-foreground"
+                  }`}
+                >
+                  <Eye className="size-3.5 text-foreground" />
+                  GitHub
+                </button>
+              </div>
+
+              {/* Preview Viewport Canvas */}
+              <div className="p-4 sm:p-6 bg-muted/10 min-h-[380px] flex flex-col justify-start">
+                <div
+                  className={`w-full transition-all duration-200 ${
+                    viewport === "mobile"
+                      ? "max-w-[375px] mx-auto border-x border-dashed border-border px-2 py-4 rounded bg-background shadow-xs"
+                      : viewport === "tablet"
+                        ? "max-w-[768px] mx-auto border-x border-dashed border-border px-4 py-4 rounded bg-background shadow-xs"
+                        : ""
+                  }`}
+                >
+                  {parsedArtifact ? (
+                    activeTab === "react" ? (
+                      <div data-testid="react-renderer-preview" className="space-y-4">
+                        <SurfaceView
+                          artifact={parsedArtifact}
+                          onInteraction={(handle, payload) => handleInteraction(handle, payload)}
+                          actionHandleFor={(action) => action.event}
+                        />
+                      </div>
+                    ) : activeTab === "slack" ? (
+                      <div data-testid="slack-renderer-preview">
+                        <SlackPreview
+                          artifact={parsedArtifact}
+                          onInteraction={(actionId, payload) =>
+                            handleInteraction(actionId, payload)
+                          }
+                        />
+                      </div>
+                    ) : (
+                      <div data-testid="github-renderer-preview">
+                        <GitHubPreview
+                          artifact={parsedArtifact}
+                          onInteraction={(actionId, payload) =>
+                            handleInteraction(actionId, payload)
+                          }
+                        />
+                      </div>
+                    )
+                  ) : (
+                    /* ErrorState Fallback */
+                    <div
+                      role="alert"
+                      data-testid="schema-error-state"
+                      className="flex flex-col items-center justify-center rounded-lg border border-status-danger/40 bg-status-danger/10 p-8 text-center"
+                    >
+                      <AlertTriangle className="size-8 text-status-danger" />
+                      <h3 className="mt-2 text-sm font-semibold text-status-danger">
+                        Schema Error Fallback: Invalid Surface Artifact
+                      </h3>
+                      <p className="mt-1 max-w-md text-xs text-muted-foreground">
+                        {syntaxError
+                          ? `JSON Syntax Error: ${syntaxError}`
+                          : validationIssues.length > 0
+                            ? `The current payload has ${validationIssues.length} schema validation ${
+                                validationIssues.length === 1 ? "issue" : "issues"
+                              }. Correct the JSON or restore a valid preset.`
+                            : "Payload is empty or missing required Tulip Surface Protocol fields."}
+                      </p>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={handleResetPreset}
+                        className="mt-4 gap-1.5 text-xs"
+                      >
+                        <RotateCcw className="size-3.5" />
+                        Restore Valid Preset
+                      </Button>
+                    </div>
+                  )}
                 </div>
-                <div>
-                  <dt className="text-muted-foreground">Artifact ID</dt>
-                  <dd className="font-semibold text-foreground font-mono">{parsedArtifact.id}</dd>
-                </div>
-                <div>
-                  <dt className="text-muted-foreground">Target Channel</dt>
-                  <dd className="font-semibold text-foreground font-mono">
-                    {parsedArtifact.target.channel}:{parsedArtifact.target.surface}
-                  </dd>
-                </div>
-                <div>
-                  <dt className="text-muted-foreground">Classification</dt>
-                  <dd className="font-semibold text-foreground capitalize">
-                    {parsedArtifact.classification}
-                  </dd>
-                </div>
-                <div className="col-span-2">
-                  <dt className="text-muted-foreground">Audience</dt>
-                  <dd className="font-semibold text-foreground font-mono">
-                    [{parsedArtifact.audience.join(", ")}]
-                  </dd>
-                </div>
-              </dl>
-            ) : (
-              <p className="mt-2 text-status-warning">
-                Specifications unavailable for invalid payload.
-              </p>
-            )}
-          </section>
+              </div>
+            </section>
+
+            {/* Event Inspector Panel */}
+            <EventInspector events={events} onClear={() => setEvents([])} />
+          </div>
+
+          {/* Right Column: Raw JSON Editor & Metadata (5 cols) */}
+          <div className="flex flex-col gap-6 lg:col-span-5">
+            {/* JSON Payload Editor */}
+            <section
+              aria-label="Raw JSON Payload Editor"
+              className="rounded-lg border border-border bg-card p-4 shadow-xs"
+            >
+              <JsonEditor
+                value={jsonText}
+                onChange={setJsonText}
+                onResetPreset={handleResetPreset}
+                validationIssues={validationIssues}
+                syntaxError={syntaxError}
+                isValid={isValid}
+              />
+            </section>
+
+            {/* Artifact Metadata / Catalog Card */}
+            <section
+              aria-label="Artifact metadata and catalog info"
+              className="rounded-lg border border-border bg-card p-4 text-xs text-muted-foreground shadow-xs"
+            >
+              <div className="flex items-center justify-between border-b border-border pb-2">
+                <span className="font-semibold text-foreground">Active Artifact Specification</span>
+                <Badge variant="neutral">TSP Catalog 1.2</Badge>
+              </div>
+              {parsedArtifact ? (
+                <dl className="mt-3 grid grid-cols-2 gap-x-4 gap-y-2">
+                  <div>
+                    <dt className="text-muted-foreground">Component</dt>
+                    <dd className="font-semibold text-foreground font-mono">
+                      {parsedArtifact.component.name}@{parsedArtifact.component.version}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-muted-foreground">Artifact ID</dt>
+                    <dd className="font-semibold text-foreground font-mono">{parsedArtifact.id}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-muted-foreground">Target Channel</dt>
+                    <dd className="font-semibold text-foreground font-mono">
+                      {parsedArtifact.target.channel}:{parsedArtifact.target.surface}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-muted-foreground">Classification</dt>
+                    <dd className="font-semibold text-foreground capitalize">
+                      {parsedArtifact.classification}
+                    </dd>
+                  </div>
+                  <div className="col-span-2">
+                    <dt className="text-muted-foreground">Audience</dt>
+                    <dd className="font-semibold text-foreground font-mono">
+                      [{parsedArtifact.audience.join(", ")}]
+                    </dd>
+                  </div>
+                </dl>
+              ) : (
+                <p className="mt-2 text-status-warning">
+                  Specifications unavailable for invalid payload.
+                </p>
+              )}
+            </section>
+          </div>
         </div>
       </div>
     </div>

--- a/apps/web/app/routes/login.tsx
+++ b/apps/web/app/routes/login.tsx
@@ -39,55 +39,57 @@ export default function Login() {
   }
 
   return (
-    <section className="mx-auto flex min-h-svh max-w-sm flex-col justify-center px-6 py-16">
-      <p className="text-[0.625rem] font-medium uppercase tracking-[0.2em] text-primary">
-        [ SIGN IN ]
-      </p>
-      <h1 className="mt-1 text-2xl font-semibold text-foreground">tulipfarm</h1>
-      <p className="mt-1 text-sm text-muted-foreground">Sign in to this tenant.</p>
+    <div className="h-full min-h-0 overflow-y-auto">
+      <section className="mx-auto flex min-h-full max-w-sm flex-col justify-center px-6 py-16">
+        <p className="text-[0.625rem] font-medium uppercase tracking-[0.2em] text-primary">
+          [ SIGN IN ]
+        </p>
+        <h1 className="mt-1 text-2xl font-semibold text-foreground">tulipfarm</h1>
+        <p className="mt-1 text-sm text-muted-foreground">Sign in to this tenant.</p>
 
-      <form onSubmit={onSubmit} className="mt-8 flex flex-col gap-3">
-        {error ? (
-          <p
-            role="alert"
-            className="rounded-sm border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+        <form onSubmit={onSubmit} className="mt-8 flex flex-col gap-3">
+          {error ? (
+            <p
+              role="alert"
+              className="rounded-sm border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+            >
+              error: {error}
+            </p>
+          ) : null}
+
+          <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+            email
+            <input
+              type="email"
+              autoComplete="username"
+              className={inputClass}
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              aria-label="email"
+            />
+          </label>
+
+          <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+            password
+            <input
+              type="password"
+              autoComplete="current-password"
+              className={inputClass}
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              aria-label="password"
+            />
+          </label>
+
+          <Button
+            type="submit"
+            className="mt-1 rounded-sm"
+            disabled={busy || email.trim().length === 0 || password.length === 0}
           >
-            error: {error}
-          </p>
-        ) : null}
-
-        <label className="flex flex-col gap-1 text-xs text-muted-foreground">
-          email
-          <input
-            type="email"
-            autoComplete="username"
-            className={inputClass}
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            aria-label="email"
-          />
-        </label>
-
-        <label className="flex flex-col gap-1 text-xs text-muted-foreground">
-          password
-          <input
-            type="password"
-            autoComplete="current-password"
-            className={inputClass}
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            aria-label="password"
-          />
-        </label>
-
-        <Button
-          type="submit"
-          className="mt-1 rounded-sm"
-          disabled={busy || email.trim().length === 0 || password.length === 0}
-        >
-          {busy ? "Signing in…" : "Sign in"}
-        </Button>
-      </form>
-    </section>
+            {busy ? "Signing in…" : "Sign in"}
+          </Button>
+        </form>
+      </section>
+    </div>
   );
 }

--- a/apps/web/app/routes/setup.tsx
+++ b/apps/web/app/routes/setup.tsx
@@ -154,65 +154,67 @@ export default function SetupRoute() {
   const disabled = question === 2 ? password.length < 8 : values[question]?.trim().length === 0;
 
   return (
-    <main className="flex min-h-svh flex-col items-center justify-center gap-10 px-6 py-12">
-      <TulipGrowth stage={stage} />
-      <p role="status" className="sr-only">
-        {question} of 4 answered
-      </p>
+    <main className="h-full min-h-0 overflow-y-auto">
+      <div className="flex min-h-full flex-col items-center justify-center gap-10 px-6 py-12">
+        <TulipGrowth stage={stage} />
+        <p role="status" className="sr-only">
+          {question} of 4 answered
+        </p>
 
-      <div className="flex w-full max-w-sm flex-col gap-6">
-        <h1
-          ref={headingRef}
-          tabIndex={-1}
-          className="text-center text-xl font-semibold text-foreground outline-none"
-        >
-          Let's get your account set up
-        </h1>
+        <div className="flex w-full max-w-sm flex-col gap-6">
+          <h1
+            ref={headingRef}
+            tabIndex={-1}
+            className="text-center text-xl font-semibold text-foreground outline-none"
+          >
+            Let's get your account set up
+          </h1>
 
-        {error && <ErrorAlert message={error} />}
+          {error && <ErrorAlert message={error} />}
 
-        <form onSubmit={onSubmit} className="flex flex-col gap-4">
-          <PromptField
-            ref={inputRef}
-            label={current.label}
-            hint={current.hint}
-            type={current.type}
-            autoComplete={current.autoComplete}
-            controlClassName={controlClass}
-            value={values[question] ?? ""}
-            onChange={setValue}
-          />
-          <div className={cn("flex gap-2", question === 0 && "justify-end")}>
-            {question > 0 ? (
+          <form onSubmit={onSubmit} className="flex flex-col gap-4">
+            <PromptField
+              ref={inputRef}
+              label={current.label}
+              hint={current.hint}
+              type={current.type}
+              autoComplete={current.autoComplete}
+              controlClassName={controlClass}
+              value={values[question] ?? ""}
+              onChange={setValue}
+            />
+            <div className={cn("flex gap-2", question === 0 && "justify-end")}>
+              {question > 0 ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="h-11 px-4 active:translate-y-px sm:h-10"
+                  onClick={back}
+                  disabled={busy}
+                >
+                  <ArrowLeft aria-hidden />
+                  Back
+                </Button>
+              ) : null}
               <Button
-                type="button"
-                variant="outline"
-                className="h-11 px-4 active:translate-y-px sm:h-10"
-                onClick={back}
-                disabled={busy}
+                type="submit"
+                className="h-11 flex-1 active:translate-y-px sm:h-10"
+                disabled={busy || disabled}
               >
-                <ArrowLeft aria-hidden />
-                Back
+                {busy ? (
+                  <>
+                    <Loader2 aria-hidden className="size-4 motion-safe:animate-spin" />
+                    Setting things up…
+                  </>
+                ) : question === LAST_QUESTION ? (
+                  "Finish"
+                ) : (
+                  "Continue"
+                )}
               </Button>
-            ) : null}
-            <Button
-              type="submit"
-              className="h-11 flex-1 active:translate-y-px sm:h-10"
-              disabled={busy || disabled}
-            >
-              {busy ? (
-                <>
-                  <Loader2 aria-hidden className="size-4 motion-safe:animate-spin" />
-                  Setting things up…
-                </>
-              ) : question === LAST_QUESTION ? (
-                "Finish"
-              ) : (
-                "Continue"
-              )}
-            </Button>
-          </div>
-        </form>
+            </div>
+          </form>
+        </div>
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary
- Lock `html` and `body` with `height: 100%` and `overflow: hidden` to eliminate document-level bounce and window scrolling.
- Change `AppShell` `<main>` container from `overflow-auto` to `min-h-0 min-w-0 flex-1 overflow-hidden` to prevent nested competing scrollbars around full-height views.
- Add `h-full min-h-0 overflow-y-auto` containers across standalone views, ResourcePanel, and routes to ensure isolated, clean scrolling everywhere without empty voids.

## Test Plan
- [x] Biome check passed: `pnpm exec biome check apps/web`
- [x] Typecheck passed: `pnpm --filter @tulipfarm/web typecheck`
- [x] Web test suite passed: `pnpm --filter @tulipfarm/web test` (156 test files, 1,224 tests passing)
- [x] Visual and interaction verification via `agent-browser` on local dev instance