### PR TITLE
fix(curator): repair UUID cast, date-time schema validation, and concurrency handling

### DIFF
--- a/apps/api/src/soul/llm-config/cascade-set.ts
+++ b/apps/api/src/soul/llm-config/cascade-set.ts
@@ -80,26 +80,40 @@ export function makeLlmCascadeOnSecretSet(
       },
     };
 
-    const { content: currentManifest, baseCommit } = await soulWriter.readWithBase("Settings");
-    await soulWriter.apply({
-      subject: `soul: auto-connect ${owner.label} (secret ${setKey} added)`,
-      source: "api",
-      actor,
-      businessId: DEPLOYMENT_BUSINESS_ID,
-      expectedBaseCommit: baseCommit,
-      changes: [
-        {
-          op: "put",
-          target: { kind: "Settings" },
-          content: mergeLlmConfigIntoSoulYaml(currentManifest, nextConfig),
-        },
-      ],
-    });
-    await soulLoader.reload();
-    await llmService.init(soulLoader.llmConfig, secretsService, logger);
+    const maxAttempts = 3;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      const { content: currentManifest, baseCommit } = await soulWriter.readWithBase("Settings");
+      try {
+        await soulWriter.apply({
+          subject: `soul: auto-connect ${owner.label} (secret ${setKey} added)`,
+          source: "api",
+          actor,
+          businessId: DEPLOYMENT_BUSINESS_ID,
+          expectedBaseCommit: baseCommit,
+          changes: [
+            {
+              op: "put",
+              target: { kind: "Settings" },
+              content: mergeLlmConfigIntoSoulYaml(currentManifest, nextConfig),
+            },
+          ],
+        });
+        await soulLoader.reload();
+        await llmService.init(soulLoader.llmConfig, secretsService, logger);
 
-    await kickCuratorSweep(triggerCuratorSweep, logger, `${owner.id} auto-connect`);
+        await kickCuratorSweep(triggerCuratorSweep, logger, `${owner.id} auto-connect`);
 
-    logger.info(`[llm] ${owner.id} auto-connected after secret ${setKey} added`);
+        logger.info(`[llm] ${owner.id} auto-connected after secret ${setKey} added`);
+        return;
+      } catch (err) {
+        const isConflict =
+          err instanceof Error &&
+          (err.message.includes("tree changed") || (err as { code?: string }).code === "CONFLICT");
+        if (isConflict && attempt < maxAttempts - 1) {
+          continue;
+        }
+        throw err;
+      }
+    }
   };
 }

--- a/apps/api/src/soul/llm-config/cascade.test.ts
+++ b/apps/api/src/soul/llm-config/cascade.test.ts
@@ -67,4 +67,31 @@ describe("makeLlmCascadeOnSecretDelete", () => {
       { op: "put", target: { kind: "Settings" }, content: expect.stringContaining("llm") },
     ]);
   });
+
+  it("retries when the Soul write fails due to a tree conflict", async () => {
+    const d = deps();
+    let calls = 0;
+    const origApply = d.soul.writer.apply.bind(d.soul.writer);
+    d.soul.writer.apply = vi.fn(async (params) => {
+      calls++;
+      if (calls === 1) {
+        throw new Error("Soul write: the tree changed under this write");
+      }
+      return origApply(params);
+    });
+
+    const cascade = makeLlmCascadeOnSecretDelete(
+      d.soulLoader,
+      d.soul.writer,
+      d.llmService,
+      d.secretsService,
+      d.logger
+    );
+
+    await cascade("anthropic-api-key", ACTOR);
+
+    expect(calls).toBe(2);
+    expect(d.soulLoader.reload).toHaveBeenCalledTimes(1);
+    expect(d.llmService.init).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/api/src/soul/llm-config/cascade.ts
+++ b/apps/api/src/soul/llm-config/cascade.ts
@@ -33,27 +33,41 @@ export function makeLlmCascadeOnSecretDelete(
 
     const commitMsg = `soul: remove ${owner.id} provider (secret ${deletedKey} deleted)`;
 
-    const { content: currentManifest, baseCommit } = await soulWriter.readWithBase("Settings");
-    const nextManifest =
-      result.action === "update"
-        ? mergeLlmConfigIntoSoulYaml(currentManifest, result.config)
-        : // Pruning left a tier empty; remove the `llm:` key for a clean unconfigured state.
-          removeLlmConfigFromSoulYaml(currentManifest);
-    if (nextManifest === null) return;
+    const maxAttempts = 3;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      const { content: currentManifest, baseCommit } = await soulWriter.readWithBase("Settings");
+      const nextManifest =
+        result.action === "update"
+          ? mergeLlmConfigIntoSoulYaml(currentManifest, result.config)
+          : // Pruning left a tier empty; remove the `llm:` key for a clean unconfigured state.
+            removeLlmConfigFromSoulYaml(currentManifest);
+      if (nextManifest === null) return;
 
-    await soulWriter.apply({
-      subject: commitMsg,
-      source: "api",
-      actor,
-      businessId: DEPLOYMENT_BUSINESS_ID,
-      expectedBaseCommit: baseCommit,
-      changes: [{ op: "put", target: { kind: "Settings" }, content: nextManifest }],
-    });
-    await soulLoader.reload();
-    await llmService.init(soulLoader.llmConfig, secretsService, logger);
+      try {
+        await soulWriter.apply({
+          subject: commitMsg,
+          source: "api",
+          actor,
+          businessId: DEPLOYMENT_BUSINESS_ID,
+          expectedBaseCommit: baseCommit,
+          changes: [{ op: "put", target: { kind: "Settings" }, content: nextManifest }],
+        });
+        await soulLoader.reload();
+        await llmService.init(soulLoader.llmConfig, secretsService, logger);
 
-    logger.info(
-      `[llm] config ${result.action === "update" ? "pruned" : "removed"} after secret ${deletedKey} deleted`
-    );
+        logger.info(
+          `[llm] config ${result.action === "update" ? "pruned" : "removed"} after secret ${deletedKey} deleted`
+        );
+        return;
+      } catch (err) {
+        const isConflict =
+          err instanceof Error &&
+          (err.message.includes("tree changed") || (err as { code?: string }).code === "CONFLICT");
+        if (isConflict && attempt < maxAttempts - 1) {
+          continue;
+        }
+        throw err;
+      }
+    }
   };
 }

--- a/packages/schema/src/ajv.test.ts
+++ b/packages/schema/src/ajv.test.ts
@@ -40,4 +40,19 @@ describe("shared ajv instance", () => {
     };
     expect(() => ajv.compile(draft2020Schema)).not.toThrow();
   });
+
+  it("validates date-time format on compiled schemas", () => {
+    const dateTimeSchema = {
+      type: "object",
+      properties: {
+        remindAt: { type: "string", format: "date-time" },
+      },
+      required: ["remindAt"],
+    };
+    const validate = ajv.compile(dateTimeSchema);
+    expect(validate({ remindAt: "2026-08-22T12:00:00Z" })).toBe(true);
+    expect(validate({ remindAt: "2026-08-22T12:00:00.123+05:30" })).toBe(true);
+    expect(validate({ remindAt: "not-a-date" })).toBe(false);
+    expect(validate({ remindAt: "2026-02-31T12:00:00Z" })).toBe(false);
+  });
 });

--- a/packages/schema/src/ajv.ts
+++ b/packages/schema/src/ajv.ts
@@ -11,3 +11,27 @@ export const ajv = new Ajv2020({ allErrors: true, strict: false });
 // `no schema with key or ref "http://json-schema.org/draft-07/schema#"`.
 ajv.addMetaSchema(draft06MetaSchema);
 ajv.addMetaSchema(draft07MetaSchema);
+
+// ISO 8601 date-time format support
+const ISO_DATE_TIME =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+
+function isValidIsoDateTime(str: string): boolean {
+  const match = str.match(ISO_DATE_TIME);
+  if (!match) return false;
+  const [, yStr, mStr, dStr, hStr, minStr, sStr] = match;
+  const y = Number(yStr);
+  const m = Number(mStr);
+  const d = Number(dStr);
+  const h = Number(hStr);
+  const min = Number(minStr);
+  const s = Number(sStr);
+  if (m < 1 || m > 12 || d < 1 || d > 31 || h > 23 || min > 59 || s > 59) return false;
+  const daysInMonth = new Date(Date.UTC(y, m, 0)).getUTCDate();
+  return d <= daysInMonth;
+}
+
+ajv.addFormat("date-time", {
+  type: "string",
+  validate: isValidIsoDateTime,
+});

--- a/packages/storage/src/curator/turns.pg.test.ts
+++ b/packages/storage/src/curator/turns.pg.test.ts
@@ -1,0 +1,97 @@
+import { PGlite } from "@electric-sql/pglite";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { Queryable } from "../ports";
+import { PgCuratorTurnReader } from "./turns";
+
+describe("PgCuratorTurnReader (PostgreSQL)", () => {
+  let database: PGlite;
+  let reader: PgCuratorTurnReader;
+
+  beforeAll(async () => {
+    database = new PGlite();
+    await database.exec(`
+      CREATE TABLE messages (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        turn_id uuid NOT NULL,
+        role text NOT NULL,
+        content jsonb NOT NULL,
+        created_at timestamptz NOT NULL DEFAULT clock_timestamp()
+      );
+      CREATE TABLE turn_completions (
+        turn_id uuid NOT NULL,
+        message_id uuid NOT NULL,
+        PRIMARY KEY (turn_id, message_id)
+      );
+    `);
+    reader = new PgCuratorTurnReader(database as unknown as Queryable);
+  });
+
+  afterAll(async () => {
+    await database.close();
+  });
+
+  beforeEach(async () => {
+    await database.exec("TRUNCATE messages, turn_completions;");
+  });
+
+  it("returns empty array for empty turnIds", async () => {
+    const turns = await reader.read("business-1", []);
+    expect(turns).toEqual([]);
+  });
+
+  it("reads pinned turns with user and completed assistant messages", async () => {
+    const turn1 = "11111111-1111-1111-1111-111111111111";
+    const turn2 = "22222222-2222-2222-2222-222222222222";
+    const assistantMsg1 = "33333333-3333-3333-3333-333333333333";
+    const uncompletedMsg = "44444444-4444-4444-4444-444444444444";
+
+    // Turn 1: user + completed assistant
+    await database.query(
+      `INSERT INTO messages (id, turn_id, role, content)
+       VALUES ($1, $2, 'user', $3::jsonb)`,
+      [
+        "55555555-5555-5555-5555-555555555555",
+        turn1,
+        JSON.stringify([{ type: "text", text: "Hello assistant" }]),
+      ]
+    );
+    await database.query(
+      `INSERT INTO messages (id, turn_id, role, content)
+       VALUES ($1, $2, 'assistant', $3::jsonb)`,
+      [assistantMsg1, turn1, JSON.stringify([{ type: "text", text: "Hello person" }])]
+    );
+    await database.query(`INSERT INTO turn_completions (turn_id, message_id) VALUES ($1, $2)`, [
+      turn1,
+      assistantMsg1,
+    ]);
+
+    // Turn 2: user + uncompleted assistant (e.g. streaming or interrupted)
+    await database.query(
+      `INSERT INTO messages (id, turn_id, role, content)
+       VALUES ($1, $2, 'user', $3::jsonb)`,
+      [
+        "66666666-6666-6666-6666-666666666666",
+        turn2,
+        JSON.stringify([{ type: "text", text: "Question 2" }]),
+      ]
+    );
+    await database.query(
+      `INSERT INTO messages (id, turn_id, role, content)
+       VALUES ($1, $2, 'assistant', $3::jsonb)`,
+      [uncompletedMsg, turn2, JSON.stringify([{ type: "text", text: "Uncompleted draft" }])]
+    );
+
+    const turns = await reader.read("business-1", [turn1, turn2]);
+    expect(turns).toEqual([
+      {
+        turnId: turn1,
+        userText: "Hello assistant",
+        assistantText: "Hello person",
+      },
+      {
+        turnId: turn2,
+        userText: "Question 2",
+      },
+    ]);
+  });
+});

--- a/packages/storage/src/curator/turns.ts
+++ b/packages/storage/src/curator/turns.ts
@@ -32,7 +32,7 @@ export class PgCuratorTurnReader {
     const { rows } = await this.db.query<Row>(
       `SELECT m.turn_id, m.role, m.content
          FROM messages m
-        WHERE m.turn_id = ANY($1::text[])
+        WHERE m.turn_id = ANY($1::uuid[])
           AND (
             m.role = 'user'
             OR (m.role = 'assistant' AND EXISTS (

--- a/packages/turn-executor/src/agent-state.test.ts
+++ b/packages/turn-executor/src/agent-state.test.ts
@@ -157,6 +157,33 @@ describe("AgentStateRunner", () => {
     expect(result).toMatchObject({ status: "needs_reconciliation" });
   });
 
+  it("still reports needs_reconciliation when transition to needs_reconciliation hits a state conflict", async () => {
+    const agentState = new AgentStateRunner({
+      loop: {
+        run: async () => {
+          throw new Error("worker crashed");
+        },
+      },
+      transitions: {
+        transition: async (input) => {
+          if (input.to === "needs_reconciliation") {
+            throw new StateTransitionConflictError(
+              input.runId,
+              input.stateKey,
+              "running",
+              "needs_reconciliation"
+            );
+          }
+        },
+      },
+      waits: { register: async () => ({ waitId: "wait-1" }) },
+    });
+
+    await expect(agentState.execute(request(), LOOP_INPUT)).resolves.toEqual({
+      status: "needs_reconciliation",
+    });
+  });
+
   it("refuses to start from a terminal State status and never runs the loop", async () => {
     const harness = runner({ status: "completed", output: null, ...counters });
 

--- a/packages/turn-executor/src/agent-state.ts
+++ b/packages/turn-executor/src/agent-state.ts
@@ -78,7 +78,11 @@ export class AgentStateRunner {
       outcome = await this.options.loop.run(input);
     } catch {
       // Effects may or may not have landed; reconciliation decides, not the worker.
-      await this.move(request, "running", "needs_reconciliation", "agent_loop_error");
+      try {
+        await this.move(request, "running", "needs_reconciliation", "agent_loop_error");
+      } catch (error) {
+        if (!(error instanceof StateTransitionConflictError)) throw error;
+      }
       return { status: "needs_reconciliation" };
     }
 


### PR DESCRIPTION
## Summary
- Fix PostgreSQL Error 42883 (`operator does not exist: uuid = text`) in `PgCuratorTurnReader` by casting parameter to `uuid[]`.
- Add ISO 8601 `date-time` format validation to shared Ajv instance to eliminate Fastify schema compilation warnings at boot.
- Add optimistic concurrency retry for Soul writes during secret delete cascades and safely catch `StateTransitionConflictError` during worker turn reconciliation.

## Test Plan
- [x] `pnpm --filter @tulipfarm/storage test src/curator/turns.pg.test.ts`
- [x] `pnpm --filter @tulipfarm/schema test src/ajv.test.ts`
- [x] `pnpm --filter @tulipfarm/api test src/soul/llm-config/cascade.test.ts`
- [x] `pnpm --filter @tulipfarm/turn-executor test src/agent-state.test.ts`
- [x] Full repo `pnpm typecheck` and `pnpm exec biome check`
