### PR TITLE
chore(release): v0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.14.1](https://github.com/TulipFarm/tulipfarm/compare/v0.14.0...v0.14.1) (2026-08-22)
+
+### Bug Fixes
+
+* **curator:** repair UUID cast, date-time schema validation, and concurrency handling ([#585](https://github.com/TulipFarm/tulipfarm/issues/585)) ([23a32ae](https://github.com/TulipFarm/tulipfarm/commit/23a32ae9ddbd982345c53477c1fc6f9faed35ac0))
+
 ## [0.14.0](https://github.com/TulipFarm/tulipfarm/compare/v0.13.6...v0.14.0) (2026-08-22)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tulipfarm",
   "private": true,
-  "version": "0.14.0",
+  "version": "0.14.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/TulipFarm/tulipfarm.git"


### PR DESCRIPTION
## Summary

- prepare TulipFarm v0.14.1
- update the package version and generated changelog
- publish the verified GHCR image and GitHub Release automatically after merge

## Test plan

- [ ] Required PR checks pass
- [ ] Version and changelog are approved
