### PR TITLE
fix(tools): return web fetch faults as answers the Agent can act on

### DIFF
--- a/apps/api/src/tools/network/tools.test.ts
+++ b/apps/api/src/tools/network/tools.test.ts
@@ -131,6 +131,62 @@ describe("network Tool handlers", () => {
     expect(result).toMatchObject({ success: true });
   });
 
+  it("answers an unreachable destination without spending the model's repair budget", async () => {
+    const ctx = context({
+      http: {
+        send: vi.fn(async () => ({
+          status: 503,
+          headers: { "content-type": "application/json" },
+          body: { error: "network_timeout", message: "the destination did not answer in 30000ms" },
+        })),
+      },
+    });
+    const result = await webFetchTool.handler(
+      { url: "https://docs.example.com/release", prompt: "What version is this?" },
+      ctx
+    );
+    expect(result).toMatchObject({
+      success: true,
+      data: { fetched: false, status: 503, reason: "http_error" },
+    });
+    expect(JSON.stringify(result)).toContain("network_timeout");
+    expect(ctx.extract).not.toHaveBeenCalled();
+  });
+
+  it("answers an empty response instead of raising on a missing body", async () => {
+    const ctx = context({
+      http: { send: vi.fn(async () => ({ status: 204, headers: {}, body: undefined })) },
+    });
+    await expect(
+      webFetchTool.handler({ url: "https://docs.example.com/release", prompt: "Summarize" }, ctx)
+    ).resolves.toMatchObject({ success: true, data: { fetched: false, reason: "empty_response" } });
+    expect(ctx.extract).not.toHaveBeenCalled();
+  });
+
+  it("answers an unreadable content type rather than rejecting the arguments", async () => {
+    const ctx = context({
+      http: {
+        send: vi.fn(async () => ({
+          status: 200,
+          headers: { "content-type": "application/pdf" },
+          body: "%PDF-1.7",
+        })),
+      },
+    });
+    await expect(
+      webFetchTool.handler({ url: "https://docs.example.com/manual.pdf", prompt: "Summarize" }, ctx)
+    ).resolves.toMatchObject({
+      success: true,
+      data: { fetched: false, reason: "unsupported_content_type" },
+    });
+  });
+
+  it("still asks the model to repair a URL it can act on", async () => {
+    await expect(
+      webFetchTool.handler({ url: "not-a-url", prompt: "Summarize" }, context())
+    ).resolves.toMatchObject({ success: false, error: { code: "validation_error" } });
+  });
+
   it("returns a UI-only Secrets setup link when the Credential is missing", async () => {
     const ctx = context({
       useCredential: vi.fn(async () => {

--- a/apps/api/src/tools/network/tools.ts
+++ b/apps/api/src/tools/network/tools.ts
@@ -1,4 +1,4 @@
-import type { IntegrationHttpMethod } from "@tulipfarm/integrations";
+import type { IntegrationHttpMethod, IntegrationHttpResponse } from "@tulipfarm/integrations";
 import {
   classifyGraphqlOperation,
   type EgressHttpPort,
@@ -13,6 +13,8 @@ import { SecretUnavailableError } from "@tulipfarm/secrets";
 import { defineApiTool, err, ok } from "@tulipfarm/tool-host";
 
 const MAX_MODEL_CONTENT_CHARS = 100_000;
+/** Enough of a failing server's own words for the model to choose a next step, not a second page. */
+const MAX_FAILURE_DETAIL_CHARS = 500;
 const FORBIDDEN_HEADERS = new Set([
   "connection",
   "content-length",
@@ -188,6 +190,71 @@ async function performApiRequest(
   );
 }
 
+function isReadableContentType(contentType: string): boolean {
+  return (
+    contentType.includes("text/") ||
+    contentType.includes("application/json") ||
+    contentType.includes("application/problem+json")
+  );
+}
+
+/**
+ * Why this fetch produced no readable text, or `undefined` when it did. A refused fetch is an
+ * answer the model has to reason about — a different URL, a different Tool, or telling the person
+ * it cannot be read — so it is Tool output rather than a Tool error: an error reaches the model
+ * stripped of the status, the destination and the server's own explanation, and the codes that
+ * would carry it are the ones that spend the repair budget on arguments that were never wrong.
+ */
+function unroutableWebResult(
+  requestedUrl: string,
+  result: Exclude<GovernedHttpResult, { readonly kind: "response" }>
+): Record<string, unknown> {
+  if (result.kind === "cross_origin_redirect") {
+    return {
+      fetched: false,
+      url: requestedUrl,
+      reason: "cross_origin_redirect",
+      detail: `${result.from} redirected to ${result.to}, which is a different site; fetch that URL directly if it is the one you want`,
+    };
+  }
+  return {
+    fetched: false,
+    url: result.url,
+    reason: "redirect_limit",
+    detail: "this URL redirects in a loop and never settles on a page",
+  };
+}
+
+function unreadableWebResponse(
+  url: string,
+  response: IntegrationHttpResponse
+): Record<string, unknown> | undefined {
+  const contentType = response.headers["content-type"]?.toLowerCase();
+  if (response.status >= 400) {
+    const served = readableWebContent(contentType, response.body).trim();
+    return {
+      fetched: false,
+      url,
+      status: response.status,
+      reason: "http_error",
+      detail:
+        served.length === 0
+          ? `the server answered ${response.status}`
+          : `the server answered ${response.status}: ${served.slice(0, MAX_FAILURE_DETAIL_CHARS)}`,
+    };
+  }
+  if (contentType !== undefined && !isReadableContentType(contentType)) {
+    return {
+      fetched: false,
+      url,
+      status: response.status,
+      reason: "unsupported_content_type",
+      detail: `this URL served ${contentType}, which has no readable text`,
+    };
+  }
+  return undefined;
+}
+
 export const webFetchTool = defineApiTool<NetworkToolContext>({
   ...WEB_FETCH_TOOL_DECLARATION,
   tier: "platform",
@@ -204,37 +271,48 @@ export const webFetchTool = defineApiTool<NetworkToolContext>({
     destination: normalizedPublicUrl(asApiInput(args).url).origin,
   }),
   handler: async (args, context) => {
+    const input = args as { readonly url: string; readonly prompt: string };
+    // The URL is the only part of this call the model can repair, so it is the only failure that
+    // may spend the repair budget. Everything after it is the network's answer, and asking the
+    // model to reword arguments that were never malformed just burns the budget on retries that
+    // reproduce the same result.
     try {
-      const input = args as { readonly url: string; readonly prompt: string };
       context.assertSkillDestination(normalizedPublicUrl(input.url).origin);
+    } catch (error) {
+      return err("validation_error", error instanceof Error ? error.message : "URL is invalid");
+    }
+    try {
       const result = await sendGovernedRequest(context.http, {
         url: input.url,
         method: "GET",
         headers: { accept: "text/html, text/markdown, text/plain, application/json" },
       });
-      if (result.kind !== "response") return ok(result);
+      if (result.kind !== "response") return ok(unroutableWebResult(input.url, result));
+      const unreadable = unreadableWebResponse(result.url, result.response);
+      if (unreadable !== undefined) return ok(unreadable);
       const contentType = result.response.headers["content-type"]?.toLowerCase();
-      if (
-        contentType !== undefined &&
-        !contentType.includes("text/") &&
-        !contentType.includes("application/json") &&
-        !contentType.includes("application/problem+json")
-      ) {
-        return err("validation_error", `unsupported web content type: ${contentType}`);
+      const content = readableWebContent(contentType, result.response.body)
+        .trim()
+        .slice(0, MAX_MODEL_CONTENT_CHARS);
+      if (content.length === 0) {
+        return ok({
+          fetched: false,
+          url: result.url,
+          status: result.response.status,
+          reason: "empty_response",
+          detail: "the destination answered but carried no readable text",
+        });
       }
-      const content = readableWebContent(contentType, result.response.body).slice(
-        0,
-        MAX_MODEL_CONTENT_CHARS
-      );
       const extracted = await context.extract({ url: result.url, prompt: input.prompt, content });
       return ok({
+        fetched: true,
         url: result.url,
         status: result.response.status,
         contentType: contentType ?? "unknown",
         extracted,
       });
     } catch (error) {
-      return err("validation_error", error instanceof Error ? error.message : "web fetch failed");
+      return err("internal_error", error instanceof Error ? error.message : "web fetch failed");
     }
   },
 });

--- a/packages/integrations/src/egress/fetch-http.test.ts
+++ b/packages/integrations/src/egress/fetch-http.test.ts
@@ -17,6 +17,21 @@ describe("FetchEgressHttp", () => {
     });
   });
 
+  it("carries the cause of a network fault instead of an empty 503", async () => {
+    const timeout = Object.assign(new Error("timed out"), { name: "TimeoutError" });
+    const http = new FetchEgressHttp({
+      fetch: (async () => {
+        throw timeout;
+      }) as typeof globalThis.fetch,
+      timeoutMs: 1_000,
+    });
+    await expect(http.send(request)).resolves.toEqual({
+      status: 503,
+      headers: { "content-type": "application/json" },
+      body: { error: "network_timeout", message: "the destination did not answer in 1000ms" },
+    });
+  });
+
   it("keeps redirects manual so the caller can reauthorize the next origin", async () => {
     const fetch = vi.fn(
       async () =>

--- a/packages/integrations/src/egress/fetch-http.ts
+++ b/packages/integrations/src/egress/fetch-http.ts
@@ -53,9 +53,16 @@ export class FetchEgressHttp implements EgressHttpPort {
         signal: AbortSignal.timeout(this.timeoutMs),
         ...(dispatcher === undefined ? {} : { dispatcher }),
       } as RequestInit);
-    } catch {
+    } catch (error) {
       await dispatcher?.close();
-      return { status: 503, headers: {}, body: undefined };
+      // A network fault must not masquerade as an empty successful response. Readers downstream
+      // treat a 503 with no body as content, and a caller can only choose between retrying and
+      // reporting if the cause survives the transport boundary.
+      return {
+        status: 503,
+        headers: { "content-type": "application/json" },
+        body: networkFault(error, this.timeoutMs),
+      };
     }
 
     try {
@@ -75,6 +82,24 @@ export class FetchEgressHttp implements EgressHttpPort {
 }
 
 const RESPONSE_TOO_LARGE = Symbol("response_too_large");
+
+/** Names a transport fault in terms a caller can act on; provider internals never travel with it. */
+function networkFault(
+  error: unknown,
+  timeoutMs: number
+): { readonly error: string; readonly message: string } {
+  const name = error instanceof Error ? error.name : "";
+  if (name === "TimeoutError") {
+    return {
+      error: "network_timeout",
+      message: `the destination did not answer in ${timeoutMs}ms`,
+    };
+  }
+  if (name === "AbortError") {
+    return { error: "network_aborted", message: "the request was cancelled before it answered" };
+  }
+  return { error: "network_unreachable", message: "the destination could not be reached" };
+}
 
 async function parseBody(response: Response, maxBytes: number): Promise<unknown> {
   const declaredLength = Number(response.headers.get("content-length"));

--- a/packages/integrations/src/egress/network-request.test.ts
+++ b/packages/integrations/src/egress/network-request.test.ts
@@ -78,6 +78,10 @@ describe("sendGovernedRequest", () => {
   });
 });
 
+it("returns a string for a response that carried no body", () => {
+  expect(readableWebContent(undefined, undefined)).toBe("");
+});
+
 it("removes executable HTML while preserving readable content", () => {
   expect(
     readableWebContent(

--- a/packages/integrations/src/egress/network-request.ts
+++ b/packages/integrations/src/egress/network-request.ts
@@ -157,7 +157,9 @@ const HTML_ENTITIES: Readonly<Record<string, string>> = {
 
 /** Bounded, dependency-free readable text for model extraction; scripts and styles never survive. */
 export function readableWebContent(contentType: string | undefined, body: unknown): string {
-  const raw = typeof body === "string" ? body : JSON.stringify(body, null, 2);
+  // `JSON.stringify(undefined)` is `undefined`, not a string: an empty or failed response would
+  // otherwise return a non-string from a `string` signature and crash every caller that slices it.
+  const raw = typeof body === "string" ? body : (JSON.stringify(body, null, 2) ?? "");
   if (!contentType?.toLowerCase().includes("text/html")) return raw;
   return raw
     .replace(/<(script|style|noscript|template)\b[^>]*>[\s\S]*?<\/\1>/gi, " ")


### PR DESCRIPTION
## Summary

- `FetchEgressHttp` turned every network fault (timeout, DNS, TLS, refused connection) into a success-shaped `{ status: 503, headers: {}, body: undefined }`. `readableWebContent` then returned `undefined` from a `string` signature, and `web_fetch` crashed on `.slice(...)` — surfacing to the user as `Cannot read properties of undefined (reading 'slice')`.
- `web_fetch`'s catch-all labelled that crash `validation_error`, which the Tool host maps to `invalid_arguments`. The model treated a network failure as a bad-arguments error, reworded its `prompt` three times, and the Turn ended `repair_budget_exhausted`.
- A refused fetch is now Tool output carrying the status, the destination and the server's own words, so the Agent can choose a different URL, a different Tool, or tell the person. Only an unusable URL — the one thing the model can actually repair — still spends the repair budget.

## Test plan

- [x] `pnpm --filter @tulipfarm/api test src/tools/network` — 14 passed
- [x] `pnpm --filter @tulipfarm/integrations test src/egress` — 86 passed
- [x] The four new Cases fail on `main` and pass here (verified by stashing the source changes: 3 failures without the fix)
- [x] `pnpm typecheck` — 37/37