### PR TITLE
fix(agent-runtime): stop repairing a rejection that never changes

### DIFF
--- a/apps/eval/corpus/support-stops-repairing-an-unchanging-rejection.json
+++ b/apps/eval/corpus/support-stops-repairing-an-unchanging-rejection.json
@@ -1,0 +1,72 @@
+{
+  "id": "support-stops-repairing-an-unchanging-rejection",
+  "tier": "l2",
+  "agent": "support",
+  "context": {
+    "governancePages": []
+  },
+  "input": [
+    {
+      "role": "user",
+      "content": "Summarize https://docs.example.com/releases/2.0 for me"
+    }
+  ],
+  "platformTools": ["web_fetch"],
+  "toolResults": [
+    {
+      "name": "web_fetch",
+      "invalidArguments": "the destination could not be reached"
+    }
+  ],
+  "script": [
+    {
+      "kind": "tool_calls",
+      "calls": [
+        {
+          "callId": "c1",
+          "name": "web_fetch",
+          "arguments": {
+            "url": "https://docs.example.com/releases/2.0",
+            "prompt": "Summarize this page."
+          }
+        }
+      ]
+    },
+    {
+      "kind": "tool_calls",
+      "calls": [
+        {
+          "callId": "c2",
+          "name": "web_fetch",
+          "arguments": {
+            "url": "https://docs.example.com/releases/2.0",
+            "prompt": "Summarize the key points and conclusions of this page."
+          }
+        }
+      ]
+    },
+    {
+      "kind": "tool_calls",
+      "calls": [
+        {
+          "callId": "c3",
+          "name": "web_fetch",
+          "arguments": {
+            "url": "https://docs.example.com/releases/2.0",
+            "prompt": "Read this page."
+          }
+        }
+      ]
+    },
+    {
+      "kind": "text",
+      "text": "I could not read that page - the destination could not be reached. Please check the link or paste the text here."
+    }
+  ],
+  "expect": [
+    { "kind": "tool_called", "name": "web_fetch" },
+    { "kind": "tool_call_count", "count": 3 },
+    { "kind": "output_contains", "text": "could not be reached" },
+    { "kind": "loop_status", "status": "completed" }
+  ]
+}

--- a/apps/eval/src/case.ts
+++ b/apps/eval/src/case.ts
@@ -126,6 +126,12 @@ export interface ScriptedToolResult {
   readonly output?: unknown;
   /** Present to script a Tool that fails, so refusal and recovery behaviour can be measured. */
   readonly error?: string;
+  /**
+   * Present to script a Tool that rejects the call's arguments. Distinct from `error`: only this
+   * outcome reaches the loop's repair path, so it is the only way a Case can measure what the
+   * model is asked to correct — and what the loop stops asking it to correct.
+   */
+  readonly invalidArguments?: string;
 }
 
 /**

--- a/apps/eval/src/dispatch.ts
+++ b/apps/eval/src/dispatch.ts
@@ -43,6 +43,13 @@ export function toolDispatcher(evalCase: EvalCase) {
             reason: `the Eval Case scripts no result for Tool "${request.name}"`,
           };
         }
+        if (result.invalidArguments !== undefined) {
+          return {
+            status: "invalid_arguments",
+            callId: request.callId,
+            reason: result.invalidArguments,
+          };
+        }
         return result.error === undefined
           ? { status: "succeeded", callId: request.callId, output: result.output ?? {} }
           : { status: "failed", callId: request.callId, reason: result.error };

--- a/packages/agent-runtime/src/loop/loop.test.ts
+++ b/packages/agent-runtime/src/loop/loop.test.ts
@@ -256,9 +256,9 @@ describe("AgentLoop", () => {
 
   it("fails closed once the repair budget is spent", async () => {
     const tools = dispatcher(
-      { status: "invalid_arguments", callId: "call-1", reason: "invalid_arguments" },
-      { status: "invalid_arguments", callId: "call-2", reason: "invalid_arguments" },
-      { status: "invalid_arguments", callId: "call-3", reason: "invalid_arguments" }
+      { status: "invalid_arguments", callId: "call-1", reason: "body is required" },
+      { status: "invalid_arguments", callId: "call-2", reason: "body must be a string" },
+      { status: "invalid_arguments", callId: "call-3", reason: "body is too long" }
     );
     const outcome = await loop({
       model: scriptedModel(
@@ -270,6 +270,66 @@ describe("AgentLoop", () => {
     }).run(input());
 
     expect(outcome).toMatchObject({ status: "failed", reason: "repair_budget_exhausted" });
+  });
+
+  it("stops repairing a rejection that does not move when the arguments do", async () => {
+    const warn = vi.fn();
+    const tools = dispatcher(
+      { status: "invalid_arguments", callId: "call-1", reason: "the destination is unreachable" },
+      { status: "invalid_arguments", callId: "call-2", reason: "the destination is unreachable" },
+      { status: "invalid_arguments", callId: "call-3", reason: "the destination is unreachable" }
+    );
+    const outcome = await loop({
+      model: scriptedModel(
+        toolCallResult([
+          { callId: "call-1", name: "github.issue.comment", arguments: { body: "a" } },
+        ]),
+        toolCallResult([
+          { callId: "call-2", name: "github.issue.comment", arguments: { body: "b" } },
+        ]),
+        toolCallResult([
+          { callId: "call-3", name: "github.issue.comment", arguments: { body: "c" } },
+        ]),
+        textResult("that destination cannot be reached")
+      ),
+      tools,
+      log: { warn },
+    }).run(input());
+
+    // The third identical rejection is data, not a repair, so the Turn reports the obstacle
+    // instead of dying on a budget it spent proving the answer would not change.
+    expect(outcome).toMatchObject({ status: "completed", repairs: 2 });
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "agent_loop.rejection_not_repairable",
+        callId: "call-3",
+        occurrences: 3,
+      }),
+      expect.any(String)
+    );
+  });
+
+  it("keeps repairing when the same Tool rejects for a different reason each time", async () => {
+    const tools = dispatcher(
+      { status: "invalid_arguments", callId: "call-1", reason: "body is required" },
+      { status: "invalid_arguments", callId: "call-2", reason: "body must be a string" },
+      { status: "succeeded", callId: "call-3", output: {} }
+    );
+    const outcome = await loop({
+      model: scriptedModel(
+        toolCallResult([{ callId: "call-1", name: "github.issue.comment", arguments: {} }]),
+        toolCallResult([
+          { callId: "call-2", name: "github.issue.comment", arguments: { body: 1 } },
+        ]),
+        toolCallResult([
+          { callId: "call-3", name: "github.issue.comment", arguments: { body: "hi" } },
+        ]),
+        textResult("fixed")
+      ),
+      tools,
+    }).run(input());
+
+    expect(outcome).toMatchObject({ status: "completed", repairs: 2 });
   });
 
   it("retries a blank final completion within the repair budget", async () => {

--- a/packages/agent-runtime/src/loop/loop.ts
+++ b/packages/agent-runtime/src/loop/loop.ts
@@ -47,6 +47,13 @@ import {
 
 const ITERATION_BUDGET_KEY = "iterations";
 
+/**
+ * How many times one Tool may answer with the same rejection before the loop stops treating it as
+ * an argument the model can repair. Two, so the model still gets one deliberate correction at a
+ * reason it has seen: a genuine schema complaint usually moves on the first retry.
+ */
+const REPEATED_REJECTION_LIMIT = 2;
+
 export class AgentLoop {
   constructor(private readonly deps: AgentLoopDependencies) {}
 
@@ -79,6 +86,10 @@ export class AgentLoop {
     let reread: readonly RereadFile[] = recovered?.rereadFiles ?? [];
     // A report cannot describe an effect that lands after it, so a reported Turn may not write.
     let reported = recovered?.reported ?? false;
+    // How often each Tool has answered with the same rejection this attempt. Deliberately not
+    // checkpointed: a resume replays the transcript, so the model can see the repetition itself,
+    // and `repairs` — which is persisted — still bounds what a resumed Turn may spend.
+    const rejectionCounts = new Map<string, number>();
 
     const toolsForIteration = (): readonly ExposedTool[] =>
       narrowToolsToSkill(input.tools, activeSkillName, input.skillToolScopes);
@@ -235,6 +246,31 @@ export class AgentLoop {
         }
 
         if (dispatched.status === "invalid_arguments") {
+          const signature = `${call.name} ${dispatched.reason}`;
+          const seen = (rejectionCounts.get(signature) ?? 0) + 1;
+          rejectionCounts.set(signature, seen);
+          // A rejection the model has now provoked past the limit is not tracking its arguments:
+          // it changed them and the answer did not move. Repairing again can only reproduce it,
+          // and spending the rest of the budget doing so is how a Tool that is broken — or simply
+          // reporting an obstacle in the wrong shape — ends the Turn as `repair_budget_exhausted`
+          // instead of letting the model route around it. Past the limit it is data the model must
+          // reason about, like any other failure.
+          if (seen > REPEATED_REJECTION_LIMIT) {
+            this.deps.log?.warn(
+              {
+                event: "agent_loop.rejection_not_repairable",
+                runId: input.runId,
+                stateId: input.stateId,
+                iteration: counters.iterations,
+                callId: call.callId,
+                toolName: call.name,
+                occurrences: seen,
+              },
+              "tool rejection repeated unchanged; handing it to the model as a failure"
+            );
+            messages.push(toolMessage(call.callId, { error: "failed", detail: dispatched.reason }));
+            return { kind: "continue" };
+          }
           counters.repairs += 1;
           if (counters.repairs > input.limits.maxRepairAttempts) {
             return { kind: "fail", reason: "repair_budget_exhausted" };


### PR DESCRIPTION
Follow-up to #587, which fixed the one Tool that provoked this. The loop still had no way to notice it happening.

## Summary

- `invalid_arguments` is the loop's repair signal: it tells the model its arguments were wrong and spends a repair. A Tool that answers `invalid_arguments` for a reason the arguments do not control — an unreachable host, a broken dependency — makes the model reword them until the budget is gone and the Turn dies `repair_budget_exhausted`.
- A Tool that now returns the **same** rejection more than twice is no longer tracking its arguments: the model changed them and the answer did not move. Past that limit the rejection is handed to the model as a failure it must reason about, the way a denial already is, so it can report the obstacle or take another route. A rejection that differs each time still repairs, and the repair budget still bounds the Turn.
- The counter is per-attempt and deliberately not checkpointed — a resume replays the transcript, and the persisted `repairs` counter still bounds what a resumed Turn may spend.

## Eval Corpus

- The harness could only script `succeeded` or `failed`, so **no Case could reach the repair path at all**. `ScriptedToolResult.invalidArguments` adds the outcome, and `support-stops-repairing-an-unchanging-rejection` asserts the Turn completes instead of exhausting.
- ⚠️ Editing `corpus/` moves `corpusHash`, so **every Baseline is retired** and a maintainer has to re-promote against the new Corpus before the gate compares anything again.

## Behaviour change to note in review

`loop.test.ts` "fails closed once the repair budget is spent" scripted three *identical* rejection reasons. It now scripts three different ones — the property under test is the budget, and identical reasons are exactly the case this PR changes. Fail-closed on the budget is otherwise untouched.

## Test plan

- [x] `pnpm --filter @tulipfarm/agent-runtime test` — 382 passed
- [x] `pnpm --filter @tulipfarm/eval test` — 472 passed
- [x] `pnpm eval` — 41 passed, 0 failed
- [x] The new Case and unit test fail on `main` and pass here (verified by stashing `loop.ts`: eval 40/1, unit 71/1)
- [x] `pnpm --filter @tulipfarm/worker test src/routine/agent-port.test.ts` — the one consumer asserting `repair_budget_exhausted`, 21 passed
- [x] `pnpm typecheck` — 37/37