### PR TITLE
fix(integrations): pin egress connections to resolved addresses correctly

### DIFF
--- a/packages/integrations/src/egress/fetch-http.test.ts
+++ b/packages/integrations/src/egress/fetch-http.test.ts
@@ -1,3 +1,5 @@
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
 import { describe, expect, it, vi } from "vitest";
 import { FetchEgressHttp } from "./fetch-http";
 
@@ -49,5 +51,26 @@ describe("FetchEgressHttp", () => {
       request.url,
       expect.objectContaining({ redirect: "manual" })
     );
+  });
+
+  it("connects over a pinned address instead of reporting a spurious network fault", async () => {
+    const server = createServer((_req, res) => res.end("ok"));
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const port = (server.address() as AddressInfo).port;
+    try {
+      const http = new FetchEgressHttp();
+      // A named host, pinned to a resolved address the way GuardedEgressHttp does it — undici's
+      // connector only exercises the custom `lookup` when the URL host isn't already a literal IP.
+      await expect(
+        http.send({
+          url: `http://pinned.invalid:${port}/`,
+          method: "GET",
+          headers: {},
+          pinnedAddresses: ["127.0.0.1"],
+        })
+      ).resolves.toMatchObject({ status: 200 });
+    } finally {
+      await new Promise((resolve) => server.close(resolve));
+    }
   });
 });

--- a/packages/integrations/src/egress/fetch-http.ts
+++ b/packages/integrations/src/egress/fetch-http.ts
@@ -33,8 +33,16 @@ export class FetchEgressHttp implements EgressHttpPort {
         ? undefined
         : new Agent({
             connect: {
-              lookup: (_hostname, _options, callback) => {
-                callback(null, pinned, pinned.includes(":") ? 6 : 4);
+              // undici's connector requests `{ all: true }` and expects an address array back in
+              // that case; handing back a bare string makes it throw `Invalid IP address:
+              // undefined`, which this class then reports as a spurious `network_unreachable`.
+              lookup: (_hostname, options, callback) => {
+                const family = pinned.includes(":") ? 6 : 4;
+                if (options.all) {
+                  callback(null, [{ address: pinned, family }]);
+                } else {
+                  callback(null, pinned, family);
+                }
               },
             },
           });


### PR DESCRIPTION
## Summary
- `FetchEgressHttp`'s pinned-address `lookup` callback always answered undici's connector with a bare string; undici (v7.29) requests `{ all: true }` and expects an address array back, so it threw `Invalid IP address: undefined` on every pinned request
- The generic error mapper caught that as a spurious `network_unreachable`/503, denying all manifest and web-fetch egress once `GuardedEgressHttp` resolved a destination and pinned to it — reproduced 100% on the staging VM against cursor.com, google.com, github.com

## Test plan
- [x] New regression test in `fetch-http.test.ts` fails on the pre-fix code (503) and passes on the fix (200)
- [x] `pnpm exec vitest run packages/integrations` — 396 passing
- [x] `pnpm --filter @tulipfarm/integrations typecheck` — clean
- [x] `pnpm exec biome check` on changed files — clean