### PR TITLE
fix(api): Run event notify + feat(web): word-blur streaming reveal

### DIFF
--- a/apps/api/src/chat/routes.ts
+++ b/apps/api/src/chat/routes.ts
@@ -37,7 +37,10 @@ export interface ChatRunCanceller {
 
 /** Reads the Run this turn produced. The same reader `GET /runs/:id/events` reconnects against. */
 export interface ChatStreamDeps
-  extends Pick<RunEventStreamDeps, "events" | "runs" | "pollIntervalMs" | "pageSize"> {
+  extends Pick<
+    RunEventStreamDeps,
+    "events" | "runs" | "pollIntervalMs" | "pageSize" | "waitForNotify"
+  > {
   /** Re-evaluated on every poll, so a revoked grant closes the stream mid-turn. */
   authorize(req: FastifyRequest, runId: string): Promise<RunStreamGrant | null>;
 }
@@ -224,6 +227,7 @@ export function registerChatRoutes(
           ...(stream.pollIntervalMs === undefined ? {} : { pollIntervalMs: stream.pollIntervalMs }),
           keepaliveMs: SSE_KEEPALIVE_MS,
           ...(stream.pageSize === undefined ? {} : { pageSize: stream.pageSize }),
+          ...(stream.waitForNotify === undefined ? {} : { waitForNotify: stream.waitForNotify }),
         },
         { runId, after: 0 }
       );

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -216,6 +216,7 @@ import { startDelivery } from "./resources/outbox";
 import { reconcileResourceTables, registerResourceReconcile } from "./resources/reconcile";
 import { PgCounterStore, PgResourceRepoFactory } from "./resources/repo";
 import { runCanceller } from "./runs/cancel";
+import { RunEventNotifyListener } from "./runs/notify-listener";
 import {
   integrationInvoker,
   manualRoutineTrigger,
@@ -335,6 +336,17 @@ async function boot() {
     // invalid by an interrupted build is invisible to the planner but still costs every write.
     await ensureEmbeddingIndexes(migrationPool, (msg) => console.log(msg));
     const pool = await startRuntimePool(migrationPool);
+    const runEventNotifyListener = new RunEventNotifyListener({
+      connectionString: process.env.DATABASE_URL as string,
+      ...(runtimePoolOptions() === undefined ? {} : { options: runtimePoolOptions() as string }),
+    });
+    await runEventNotifyListener
+      .start((msg) => console.error(msg))
+      .catch((err) =>
+        console.error(
+          `run event listener failed to start (falling back to polling only): ${err instanceof Error ? err.message : err}`
+        )
+      );
     const publicOrigins = new PublicOriginsService(
       new PublicOriginStore(pool),
       DEPLOYMENT_BUSINESS_ID
@@ -1182,6 +1194,7 @@ async function boot() {
       runEvents: {
         events: runEventStore,
         runs: runStore,
+        waitForNotify: (runId) => runEventNotifyListener.waitForNotify(runId),
         authorize: async (req) => {
           const principal = req.principal;
           if (!principal) return null;
@@ -1457,6 +1470,7 @@ async function boot() {
         await hookExecutor?.close();
         await resourceSampler.stop();
         await logSink.stop();
+        await runEventNotifyListener.close();
         await pool.end();
       } catch (err) {
         app.log.error(`Shutdown error: ${err instanceof Error ? err.message : String(err)}`);

--- a/apps/api/src/runs/events.test.ts
+++ b/apps/api/src/runs/events.test.ts
@@ -237,6 +237,50 @@ describe("streamRunEvents", () => {
     expect(reader.calls.map((call) => call.after)).toEqual([0, 1]);
   });
 
+  it("shortcuts a slow poll sleep once waitForNotify resolves, and cancels it after", async () => {
+    const sink = new RecordingSink();
+    const events = [record(1)];
+    const reader = new FakeEventReader(events);
+    let polls = 0;
+    let cancelled = false;
+    let resolveNotify: () => void = () => {};
+
+    const outcome = await streamRunEvents(
+      sink,
+      {
+        events: reader,
+        runs: {
+          async find() {
+            polls += 1;
+            if (polls === 1) {
+              events.push(record(2));
+              return { status: "running" };
+            }
+            return { status: "succeeded" };
+          },
+        },
+        authorize: async () => GRANT,
+        // Never resolves on its own: the test fails by timeout if the notify shortcut is not taken.
+        sleep: () => new Promise(() => {}),
+        waitForNotify: () => ({
+          promise: new Promise<void>((resolve) => {
+            resolveNotify = resolve;
+            queueMicrotask(resolve);
+          }),
+          cancel: () => {
+            cancelled = true;
+          },
+        }),
+      },
+      { runId: RUN_ID, after: 0 }
+    );
+
+    expect(outcome).toBe("completed");
+    expect(ids(sink)).toEqual([1, 2, 2]);
+    expect(cancelled).toBe(true);
+    expect(resolveNotify).toBeDefined();
+  });
+
   it("ends the stream when the Run cannot be read, without inventing an outcome", async () => {
     const sink = new RecordingSink();
 

--- a/apps/api/src/runs/events.ts
+++ b/apps/api/src/runs/events.ts
@@ -53,6 +53,11 @@ export interface RunEventStreamDeps {
   readonly pageSize?: number;
   /** Silence budget: an idle stream writes a comment this often so no proxy calls it a dead origin. */
   readonly keepaliveMs?: number;
+  /**
+   * Shortcuts the poll sleep when a new event lands. Optional: without it the stream still works,
+   * just at full `pollIntervalMs` latency — the poll itself always remains the source of truth.
+   */
+  readonly waitForNotify?: (runId: string) => { promise: Promise<void>; cancel: () => void };
   now?(): number;
 }
 
@@ -139,7 +144,14 @@ export async function streamRunEvents(
       sink.write(": keepalive\n\n");
       lastWriteAt = now();
     }
-    await deps.sleep(deps.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS);
+    const pollWait = deps.sleep(deps.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS);
+    if (deps.waitForNotify) {
+      const notify = deps.waitForNotify(request.runId);
+      await Promise.race([pollWait, notify.promise]);
+      notify.cancel();
+    } else {
+      await pollWait;
+    }
   }
 }
 
@@ -158,6 +170,7 @@ export interface RunEventRouteDeps {
   readonly authorize: (req: FastifyRequest, runId: string) => Promise<RunStreamGrant | null>;
   readonly pollIntervalMs?: number;
   readonly pageSize?: number;
+  readonly waitForNotify?: RunEventStreamDeps["waitForNotify"];
 }
 
 /** Parses the reconnect cursor: an explicit `?after=` wins, else the SSE `Last-Event-ID` header. */
@@ -263,6 +276,7 @@ export function registerRunEventRoutes(
           pollIntervalMs: deps.pollIntervalMs,
           pageSize: deps.pageSize,
           keepaliveMs: SSE_KEEPALIVE_MS,
+          ...(deps.waitForNotify ? { waitForNotify: deps.waitForNotify } : {}),
         },
         { runId: id, after }
       );

--- a/apps/api/src/runs/notify-listener.ts
+++ b/apps/api/src/runs/notify-listener.ts
@@ -1,0 +1,69 @@
+import { EventEmitter } from "node:events";
+import { RUN_EVENT_NOTIFY_CHANNEL } from "@tulipfarm/storage";
+import { Client } from "pg";
+
+const RECONNECT_DELAY_MS = 1000;
+
+export interface NotifyWait {
+  readonly promise: Promise<void>;
+  /** Detaches the listener; safe to call whether or not `promise` already settled. */
+  cancel(): void;
+}
+
+/**
+ * Dedicated LISTEN connection for `run_events` NOTIFYs (trigger: `packages/storage/src/runs/events.ts`).
+ * A caller's poll loop stays the source of truth — this only shortcuts its sleep, so a missed
+ * notification (a reconnect gap, a dropped Client) costs at most one poll interval, never a stuck
+ * stream.
+ */
+export class RunEventNotifyListener {
+  private readonly emitter = new EventEmitter();
+  private client: Client | undefined;
+  private closed = false;
+
+  constructor(private readonly connectionOptions: { connectionString: string; options?: string }) {
+    this.emitter.setMaxListeners(0);
+  }
+
+  async start(log: (msg: string) => void = () => {}): Promise<void> {
+    if (this.closed) return;
+    const client = new Client(this.connectionOptions);
+    this.client = client;
+    client.on("notification", (msg) => {
+      const runId = msg.payload?.split(":")[0];
+      if (runId) this.emitter.emit(runId);
+    });
+    client.on("error", (err) => {
+      log(`run event listener error: ${err instanceof Error ? err.message : String(err)}`);
+      this.reconnect(log);
+    });
+    client.on("end", () => this.reconnect(log));
+    await client.connect();
+    await client.query(`LISTEN ${RUN_EVENT_NOTIFY_CHANNEL}`);
+  }
+
+  private reconnect(log: (msg: string) => void): void {
+    if (this.closed || this.client === undefined) return;
+    this.client = undefined;
+    setTimeout(() => {
+      this.start(log).catch((err) =>
+        log(`run event listener reconnect failed: ${err instanceof Error ? err.message : err}`)
+      );
+    }, RECONNECT_DELAY_MS).unref();
+  }
+
+  /** Resolves on the next notification for `runId`; never rejects, so a stuck LISTEN never hangs a poll. */
+  waitForNotify(runId: string): NotifyWait {
+    let handler: () => void = () => {};
+    const promise = new Promise<void>((resolve) => {
+      handler = resolve;
+      this.emitter.once(runId, handler);
+    });
+    return { promise, cancel: () => this.emitter.removeListener(runId, handler) };
+  }
+
+  async close(): Promise<void> {
+    this.closed = true;
+    await this.client?.end().catch(() => {});
+  }
+}

--- a/apps/web/app/app.css
+++ b/apps/web/app/app.css
@@ -150,6 +150,36 @@
 }
 
 /*
+ * Per-word reveal for streamed response text (components/chat/response.tsx via
+ * lib/rehype-stream-words). `--word-delay` is set per span so a whole freshly-arrived chunk
+ * cascades in one wavefront instead of every word popping at once; already-seen words render as
+ * plain text and never carry this class, so they cannot replay it on a later re-render.
+ */
+@keyframes word-in {
+  from {
+    opacity: 0;
+    filter: blur(4px);
+    transform: translateY(2px);
+  }
+  to {
+    opacity: 1;
+    filter: blur(0);
+    transform: none;
+  }
+}
+
+.tf-word-in {
+  display: inline-block;
+  animation: word-in 420ms var(--ease-snappy) var(--word-delay, 0ms) both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tf-word-in {
+    animation: none;
+  }
+}
+
+/*
  * Indeterminate rail for a tool call that is still running. Motion here reports real execution
  * state, which is the only thing that justifies a loop. Collapses to a static tinted rail under
  * reduced motion so the state is still legible without movement.

--- a/apps/web/app/components/chat/response.tsx
+++ b/apps/web/app/components/chat/response.tsx
@@ -1,8 +1,11 @@
+import { useEffect, useRef } from "react";
 import { MarkdownView } from "~/components/markdown-view";
+import type { StreamWordCounter } from "~/lib/rehype-stream-words";
 
 /**
  * Assistant text rendered as terminal-native markdown (reuses the shared MarkdownView so code, lists,
- * and tables match the rest of the app), with a blinking ruby cursor appended while the turn streams.
+ * and tables match the rest of the app): each newly streamed word blurs into place, settled words
+ * stay put, and a blinking ruby cursor trails the edge while the turn streams.
  */
 export function Response({
   text,
@@ -14,9 +17,24 @@ export function Response({
   /** Inline `[n]` → cited-page link map, derived from the message's sources part. */
   citations?: { ref: number; url: string }[];
 }) {
+  // `revealed` has to lag one render behind `counter.total`: this render still needs the *previous*
+  // pass's word count to know which words are new, so the ref only advances after commit.
+  const revealed = useRef(0);
+  const counter = useRef<StreamWordCounter>({ total: 0 });
+  useEffect(() => {
+    revealed.current = counter.current.total;
+  });
+
   return (
     <div className="text-sm">
-      {text ? <MarkdownView citations={citations}>{text}</MarkdownView> : null}
+      {text ? (
+        <MarkdownView
+          citations={citations}
+          streamWords={streaming ? { from: revealed.current, counter: counter.current } : undefined}
+        >
+          {text}
+        </MarkdownView>
+      ) : null}
       {streaming ? (
         <span aria-hidden className="animate-cursor text-primary">
           ▍

--- a/apps/web/app/components/chat/tool-trace.test.tsx
+++ b/apps/web/app/components/chat/tool-trace.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { ToolTrace } from "~/components/chat/tool-trace";
+import { LOADER_LABELS } from "~/components/ui/loading-state";
 import type { TimelinePart } from "~/lib/chat/types";
 
 type ToolPart = Extract<TimelinePart, { kind: "tool" }>;
@@ -188,7 +189,9 @@ describe("ToolTrace", () => {
     );
 
     // Every call has landed, but the Turn has not — a column of ticks would read as finished.
-    expect(screen.getByText("Thinking")).toBeInTheDocument();
+    // The fallback label is drawn at random from LOADER_LABELS, so match membership, not a literal.
+    const label = LOADER_LABELS.find((word) => screen.queryByText(word) !== null);
+    expect(label).toBeDefined();
   });
 
   it("folds to its header once the run is no longer the live edge", () => {
@@ -208,7 +211,9 @@ describe("ToolTrace", () => {
       "aria-expanded",
       "false"
     );
-    expect(screen.queryByText("Thinking")).toBeNull();
+    for (const word of LOADER_LABELS) {
+      expect(screen.queryByText(word)).toBeNull();
+    }
   });
 
   it("counts the failures in its settled header, which is what lets a failed run fold", () => {

--- a/apps/web/app/components/chat/tool-trace.tsx
+++ b/apps/web/app/components/chat/tool-trace.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@remix-run/react";
 import { PenLine } from "lucide-react";
-import { Fragment } from "react";
+import { Fragment, useState } from "react";
+import { LOADER_LABELS, pick } from "~/components/ui/loading-state";
 import { Trace, TraceStep } from "~/components/ui/trace";
 import type { TimelinePart } from "~/lib/chat/types";
 import { ApprovalCard } from "./approval-card";
@@ -42,6 +43,7 @@ export function ToolTrace({
   foldable: boolean;
   onApprove: (approvalId: string, decision: "approve" | "deny") => void;
 }) {
+  const [betweenCallsLabel] = useState(() => pick(LOADER_LABELS));
   const settled = parts.filter((part) => part.status === "done").length;
   const failed = parts.filter((part) => part.status === "done" && part.outcome === "error").length;
   const countLabel = `Ran ${parts.length} ${parts.length === 1 ? "tool" : "tools"}`;
@@ -110,7 +112,9 @@ export function ToolTrace({
        * Turn is still working, and a row that says so is the difference between following along
        * and watching a static list of ticks until the next result snaps in already finished.
        */}
-      {pending && running === undefined ? <TraceStep status="running" label="Thinking" /> : null}
+      {pending && running === undefined ? (
+        <TraceStep status="running" label={betweenCallsLabel} />
+      ) : null}
       {/* Progress the reader can check against the rows above, not a claim the trace cannot back. */}
       <span className="sr-only">{`${settled} of ${parts.length} finished`}</span>
     </Trace>

--- a/apps/web/app/components/markdown-view.tsx
+++ b/apps/web/app/components/markdown-view.tsx
@@ -4,6 +4,7 @@ import ReactMarkdown, { type Components, defaultUrlTransform, type Options } fro
 import remarkGfm from "remark-gfm";
 import { rehypeCallouts } from "~/lib/rehype-callouts";
 import { rehypeCitations } from "~/lib/rehype-citations";
+import { rehypeStreamWords, type StreamWordCounter } from "~/lib/rehype-stream-words";
 import { rehypeTags } from "~/lib/rehype-tags";
 import { mentionComponents } from "./chat/mention-chip";
 import { rehypeMentions } from "./chat/mention-highlight";
@@ -198,12 +199,15 @@ export function MarkdownView({
   mentions,
   wikiLinks,
   citations,
+  streamWords,
 }: {
   children: string;
   mentions?: MentionEntry[];
   /** Knowledge-wiki mode: render internal `/…` hrefs as client links and `#tag` text as chip links. */
   wikiLinks?: boolean;
   citations?: { ref: number; url: string }[];
+  /** While a Turn streams: blur-reveal words past `from`, and report this pass's count via `counter`. */
+  streamWords?: { from: number; counter: StreamWordCounter };
 }) {
   const list = mentions ?? NO_MENTIONS;
   const active = list.length > 0;
@@ -224,8 +228,9 @@ export function MarkdownView({
     if (active) plugins.push([rehypeMentions, { phrases: list.map((m) => m.phrase) }]);
     if (wikiLinks) plugins.push([rehypeTags, { tagBase: TAG_BASE }]);
     if (citationsOn) plugins.push([rehypeCitations, { refs }]);
+    if (streamWords) plugins.push([rehypeStreamWords, streamWords]);
     return plugins;
-  }, [active, list, wikiLinks, citationsOn, refs]);
+  }, [active, list, wikiLinks, citationsOn, refs, streamWords]);
   const resolvedComponents = useMemo<Components>(() => {
     let resolved: Components = components;
     if (active) resolved = { ...resolved, ...mentionComponents(byPhrase) };

--- a/apps/web/app/components/ui/loading-state.tsx
+++ b/apps/web/app/components/ui/loading-state.tsx
@@ -56,7 +56,7 @@ export const LOADER_LABELS = [
   "Coming up",
 ] as const;
 
-function pick<T>(items: readonly T[]): T {
+export function pick<T>(items: readonly T[]): T {
   return items[Math.floor(Math.random() * items.length)] as T;
 }
 

--- a/apps/web/app/lib/rehype-stream-words.ts
+++ b/apps/web/app/lib/rehype-stream-words.ts
@@ -1,0 +1,47 @@
+import { type HastNode, walkTextNodes } from "./hast-text-walk";
+
+const WORD_RE = /\S+\s*|\s+/g;
+
+export interface StreamWordCounter {
+  /** Visible word count from this render pass; the caller reads it after render to advance `from`. */
+  total: number;
+}
+
+/**
+ * Wraps each word past `from` in a `.tf-word-in` span so newly streamed text blurs into place;
+ * words at or before `from` render as plain text since the reader already saw them animate. Hast
+ * has no per-word identity across passes to diff against, so `counter.total` carries this pass's
+ * count out for the caller to use as next pass's `from`. Runs after every other rehype plugin so
+ * link/mention/citation text (already wrapped in `<a>`) stays untouched — `walkTextNodes` skips it.
+ */
+export function rehypeStreamWords(options: { from: number; counter: StreamWordCounter }) {
+  return (tree: HastNode): void => {
+    let index = 0;
+    walkTextNodes(tree, (text) => {
+      const out: HastNode[] = [];
+      const chunks = text.match(WORD_RE) ?? [text];
+      for (const chunk of chunks) {
+        if (chunk.trim() === "") {
+          out.push({ type: "text", value: chunk });
+          continue;
+        }
+        const wordIndex = index++;
+        if (wordIndex < options.from) {
+          out.push({ type: "text", value: chunk });
+          continue;
+        }
+        out.push({
+          type: "element",
+          tagName: "span",
+          properties: {
+            className: ["tf-word-in"],
+            style: `--word-delay: ${(wordIndex - options.from) * 16}ms`,
+          },
+          children: [{ type: "text", value: chunk }],
+        });
+      }
+      return out;
+    });
+    options.counter.total = index;
+  };
+}


### PR DESCRIPTION
## Summary
- `fix(api)`: `RunEventNotifyListener` (Postgres LISTEN/NOTIFY) races against `streamRunEvents`' poll sleep so in-progress tool-call state reaches SSE clients immediately instead of at full poll-interval latency; falls back to polling only if the listener fails to start.
- `feat(web)`: streamed assistant text now blur-reveals word by word (`rehypeStreamWords`) instead of just growing with a trailing cursor; also randomizes `ToolTrace`'s between-calls fallback label from the same `LOADER_LABELS` pool the main spinner uses.

## Test plan
- [ ] `pnpm --filter @tulipfarm/api test apps/api/src/runs/events.test.ts`
- [ ] `pnpm --filter @tulipfarm/web test app/components/chat`
- [ ] Manual: `pnpm dev`, open a chat, send a message, watch tool-call state update live and response text blur-reveal
- [ ] Known stale: `apps/web/app/components/chat/tool-trace.test.tsx` asserts literal `"Thinking"` for the fallback label — needs updating since it's now randomized