### PR TITLE
feat(routines): add routine_get and interpolate expressions in strings

### DIFF
--- a/apps/api/src/platform/tools.test.ts
+++ b/apps/api/src/platform/tools.test.ts
@@ -2,13 +2,21 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DelegationError } from "@tulipfarm/agent-runtime";
-import type { BundledSkill, SoulAgent, SoulRoutine, SoulSkill, SoulWriter } from "@tulipfarm/soul";
+import type {
+  BundledSkill,
+  RoutineCatalog,
+  SoulAgent,
+  SoulRoutine,
+  SoulSkill,
+  SoulWriter,
+} from "@tulipfarm/soul";
 import { describe, expect, it, vi } from "vitest";
 import { delegateToAgentTool } from "./delegate-tool";
 import {
   PLATFORM_TOOLS,
   type PlatformToolContext,
   routineForgeTool,
+  routineGetTool,
   routinePickerTool,
   skillTool,
   soulRepoPushTool,
@@ -845,6 +853,96 @@ describe("routinePickerTool", () => {
   });
 });
 
+// ── routine_get ───────────────────────────────────────────────────────────────
+
+describe("routineGetTool", () => {
+  const detail = {
+    id: "01ARZ3NDEKTSV4RRFFQ69G5FC2",
+    slug: "send-report",
+    displayName: "Send Report",
+    authoredVersion: 3,
+    triggers: [{ slug: "send-report-daily", type: "cron", summary: "cron 0 9 * * *" }],
+    definition: {
+      apiVersion: "tulipfarm.ai/v1",
+      kind: "Routine",
+      metadata: { slug: "send-report", lifecycle: "published" },
+      spec: { start: "Send", states: [{ type: "action", name: "Send", end: true }] },
+    },
+    bundleDigest: "sha256:deadbeef",
+  };
+
+  function ctxWithCatalog(
+    get: (slug: string) => Promise<typeof detail | undefined>,
+    routines: Record<string, SoulRoutine> = {}
+  ): PlatformToolContext {
+    return {
+      ...makeCtx({}, {}, undefined, routines),
+      routineCatalog: { list: async () => [], get } as unknown as RoutineCatalog,
+    };
+  }
+
+  it("returns the published document, its Triggers and the bundle digest", async () => {
+    const res = await routineGetTool.handler(
+      { name: "send-report" },
+      ctxWithCatalog(async () => detail)
+    );
+    expect(res).toEqual({
+      success: true,
+      data: {
+        name: "send-report",
+        id: detail.id,
+        displayName: "Send Report",
+        authoredVersion: 3,
+        triggers: detail.triggers,
+        definition: detail.definition,
+        bundleDigest: "sha256:deadbeef",
+      },
+    });
+  });
+
+  it("says a Soul-present Routine is unpublished rather than missing", async () => {
+    const res = await routineGetTool.handler(
+      { name: "send-report" },
+      ctxWithCatalog(async () => undefined, { "send-report": makeRoutine("send-report") })
+    );
+    expect(res).toMatchObject({ success: false, error: { code: "not_found" } });
+    if (res.success) throw new Error("expected failure");
+    expect(res.error.message).toContain("not published");
+  });
+
+  it("returns not_found when neither the bundle nor the Soul has it", async () => {
+    const res = await routineGetTool.handler(
+      { name: "nope" },
+      ctxWithCatalog(async () => undefined)
+    );
+    expect(res).toMatchObject({
+      success: false,
+      error: { code: "not_found", message: "routine not found: nope" },
+    });
+  });
+
+  it("returns internal_error when the catalogue read throws", async () => {
+    const res = await routineGetTool.handler(
+      { name: "send-report" },
+      ctxWithCatalog(async () => {
+        throw new Error("bundle unreadable");
+      })
+    );
+    expect(res).toMatchObject({
+      success: false,
+      error: { code: "internal_error", message: "bundle unreadable" },
+    });
+  });
+
+  it("returns validation_error for a missing name", async () => {
+    const res = await routineGetTool.handler(
+      {},
+      ctxWithCatalog(async () => detail)
+    );
+    expect(res).toMatchObject({ success: false, error: { code: "validation_error" } });
+  });
+});
+
 // ── soul_repo_push ────────────────────────────────────────────────────────────
 
 describe("soulRepoPushTool", () => {
@@ -890,6 +988,7 @@ describe("PLATFORM_TOOLS registry", () => {
       "trigger_routine",
       "routine_forge",
       "routine_picker",
+      "routine_get",
       "routine_delete",
       "guardrail_forge",
       "soul_repo_push",

--- a/apps/api/src/platform/tools.ts
+++ b/apps/api/src/platform/tools.ts
@@ -23,6 +23,7 @@ import {
   isSkillDefinitionFile,
   lockProvenance,
   type RoutineCatalog,
+  type RoutineCatalogDetail,
   readSkillsLock,
   resolveSkill,
   SKILL_TOOL_DECLARATION,
@@ -561,7 +562,9 @@ export const routineForgeTool = defineApiTool<PlatformToolContext>({
   description:
     "Create or update a ROUTINE (a scheduled/triggered automation) in the soul repo. Use this, " +
     "not skill_create, whenever the user asks to 'create a routine' / 'automate X' / 'every " +
-    "morning do Y' / 'when X happens do Y'. `definition` MUST be a canonical published Routine " +
+    "morning do Y' / 'when X happens do Y'. Updating an existing Routine replaces its whole " +
+    "document, so call `routine_get` first and forge the full definition back, or every State and " +
+    "Trigger you did not restate is deleted. `definition` MUST be a canonical published Routine " +
     "document: apiVersion `tulipfarm.ai/v1`, kind `Routine`, and metadata with id, slug (matching " +
     "name), schemaVersion, authoredVersion, and lifecycle `published`. `definition.spec.states` " +
     "MUST be an array of State objects with name and type (not an object/map). Triggers belong to " +
@@ -709,6 +712,80 @@ export const routinePickerTool = defineApiTool<PlatformToolContext>({
   },
 });
 
+const ROUTINE_GET_SCHEMA: Record<string, unknown> = {
+  type: "object",
+  additionalProperties: false,
+  required: ["name"],
+  properties: {
+    name: {
+      type: "string",
+      minLength: 1,
+      description: "Routine slug, as `routine_picker` lists it.",
+    },
+  },
+};
+const validateRoutineGet = ajv.compile(ROUTINE_GET_SCHEMA);
+
+export const routineGetTool = defineApiTool<PlatformToolContext>({
+  name: "routine_get",
+  requiresAmbient: ["soul"],
+  description:
+    "Read one Routine's full configuration: the canonical Routine document (metadata, spec.states " +
+    "and spec.triggers) plus the Triggers currently scheduling it. `routine_picker` returns only " +
+    "names, so this is the only way to see what a Routine actually does. Call it before every " +
+    "`routine_forge` edit: forge replaces the whole document, so an update written without reading " +
+    "first silently deletes every State and Trigger it did not restate. Reads the verified active " +
+    "Soul bundle, so it returns the Routine a Run would actually execute rather than an authored draft.",
+  mutating: false,
+  tier: "platform",
+  inputSchema: ROUTINE_GET_SCHEMA,
+  authorization: {
+    action: "platform.routine.read",
+    resources: ["soul.routine"],
+    targets: (args) => soulTarget(SOUL_ROUTINE_TARGET, args, "name"),
+    dataClasses: ["soul_definition"],
+  },
+  requiresApproval: false,
+  handler: async (args, ctx) => {
+    if (!validateRoutineGet(args))
+      return err("validation_error", firstError(validateRoutineGet.errors));
+    const { name } = args as { name: string };
+    if (ctx.routineCatalog === undefined)
+      return err(
+        "internal_error",
+        "The Routines surface is unavailable, so no Routine can be read."
+      );
+
+    let detail: RoutineCatalogDetail | undefined;
+    try {
+      detail = await ctx.routineCatalog.get(name);
+    } catch (e) {
+      return err("internal_error", e instanceof Error ? e.message : String(e));
+    }
+
+    if (detail === undefined) {
+      // A Routine that is in the Soul but absent from the active bundle failed publication, and
+      // reporting that as a plain miss makes an Agent forge a duplicate instead of repairing it.
+      return ctx.soulLoader?.routines?.has(name)
+        ? err(
+            "not_found",
+            `Routine ${name} exists in the Soul but is not in the active bundle, so it is not published and cannot run.`
+          )
+        : err("not_found", `routine not found: ${name}`);
+    }
+
+    return ok({
+      name: detail.slug,
+      id: detail.id,
+      displayName: detail.displayName,
+      authoredVersion: detail.authoredVersion,
+      triggers: detail.triggers,
+      definition: detail.definition,
+      bundleDigest: detail.bundleDigest,
+    });
+  },
+});
+
 const ROUTINE_DELETE_SCHEMA: Record<string, unknown> = {
   type: "object",
   additionalProperties: false,
@@ -822,6 +899,7 @@ export const PLATFORM_TOOLS: ParkableApiToolDefinition<PlatformToolContext>[] = 
   triggerRoutineTool,
   routineForgeTool,
   routinePickerTool,
+  routineGetTool,
   routineDeleteTool,
   guardrailForgeTool,
   soulRepoPushTool,

--- a/apps/api/src/tools/contract-coverage.test.ts
+++ b/apps/api/src/tools/contract-coverage.test.ts
@@ -142,6 +142,7 @@ const EXPECTED_FAMILY_TOOL_NAMES = [
       "plan_declare",
       "routine_delete",
       "routine_forge",
+      "routine_get",
       "routine_picker",
       "skill",
       "soul_repo_push",

--- a/apps/docs/content/docs/reference/tool-catalog.mdx
+++ b/apps/docs/content/docs/reference/tool-catalog.mdx
@@ -130,6 +130,7 @@ How work is handed to another agent, automated, and reported on while it runs.
 | `plan_declare` | No | Show the person the shape of the work before you do it. |
 | `routine_delete` | Yes | Delete a routine from the soul repo. |
 | `routine_forge` | Yes | Create or update a ROUTINE (a scheduled/triggered automation) in the soul repo. |
+| `routine_get` | No | Read one Routine's full configuration: the canonical Routine document (metadata, spec.states and spec.triggers) plus the Triggers currently scheduling it. |
 | `routine_picker` | No | List all available routines from the soul so the user can pick one to trigger. |
 | `skill` | No | The one door to a Skill: read it, or run the code it documents. |
 | `soul_repo_push` | Yes | Push committed soul changes to the configured git remote. |

--- a/packages/agent-runtime/src/context/soul-reminder.ts
+++ b/packages/agent-runtime/src/context/soul-reminder.ts
@@ -135,6 +135,7 @@ export const SOUL_REMINDER_SECTIONS: readonly SoulReminderSection[] = [
     resourceType: "soul.routine",
     actions: [
       "platform.routine.list",
+      "platform.routine.read",
       "platform.routine.trigger",
       "platform.routine.forge",
       "platform.routine.delete",

--- a/packages/run-kernel/src/routine/compiler.ts
+++ b/packages/run-kernel/src/routine/compiler.ts
@@ -3,7 +3,13 @@ import { canonicalHash } from "@tulipfarm/schema";
 import { type LimitSet, resolveLimits } from "../limits";
 import type { JsonObject, OutputSchemaRegistration } from "../outputs";
 import { mapAuthoredLimits } from "./authored-limits";
-import { type CompiledExpression, compileExpression, ExpressionError } from "./expressions";
+import {
+  type CompiledExpression,
+  compileExpression,
+  ExpressionError,
+  parseTemplate,
+  type TemplateSegment,
+} from "./expressions";
 import { narrowBoundsByLimits, narrowRetryByLimits } from "./limit-enforcement";
 
 /**
@@ -62,17 +68,24 @@ export interface IdentityCeiling {
   readonly maxRiskClass: RiskClass;
 }
 
+/** One piece of an interpolated string, compiled. */
+export type CompiledInterpolationPart =
+  | { readonly kind: "text"; readonly value: string }
+  | { readonly kind: "expression"; readonly expression: CompiledExpression };
+
 /**
  * One authored input value, compiled.
  *
  * A value is a tree, not a scalar, because the Tools a Routine calls take structured arguments —
  * `record_create` carries its `fields` one level down. Compiling only the top level would let a
  * nested `${...}` reach the provider as the literal text of its own expression, which is a silent
- * wrong value rather than a refusal.
+ * wrong value rather than a refusal. A `${...}` embedded in surrounding text is the same hazard in
+ * one dimension further in, and compiles to `interpolation` for the same reason.
  */
 export type CompiledInputNode =
   | { readonly kind: "literal"; readonly value: unknown }
   | { readonly kind: "expression"; readonly expression: CompiledExpression }
+  | { readonly kind: "interpolation"; readonly parts: readonly CompiledInterpolationPart[] }
   | { readonly kind: "object"; readonly entries: readonly (readonly [string, CompiledInputNode])[] }
   | { readonly kind: "array"; readonly items: readonly CompiledInputNode[] };
 
@@ -86,6 +99,8 @@ export function inputNodeExpressions(node: CompiledInputNode): readonly Compiled
   switch (node.kind) {
     case "expression":
       return [node.expression];
+    case "interpolation":
+      return node.parts.flatMap((part) => (part.kind === "expression" ? [part.expression] : []));
     case "object":
       return node.entries.flatMap(([, child]) => inputNodeExpressions(child));
     case "array":
@@ -205,11 +220,18 @@ function stripUndefined<T>(value: T): T {
   return result as T;
 }
 
-const EXPRESSION_PATTERN = /^\$\{([\s\S]*)\}$/;
-
 function compileAt(source: string, path: string): CompiledExpression {
   try {
     return compileExpression(source);
+  } catch (error) {
+    if (error instanceof ExpressionError) throw new RoutineCompileError("invalid_expression", path);
+    throw error;
+  }
+}
+
+function parseTemplateAt(source: string, path: string): readonly TemplateSegment[] {
+  try {
+    return parseTemplate(source);
   } catch (error) {
     if (error instanceof ExpressionError) throw new RoutineCompileError("invalid_expression", path);
     throw error;
@@ -503,11 +525,31 @@ export function compileRoutine(
 
     const compileInputNode = (value: unknown, at: string): CompiledInputNode => {
       if (typeof value === "string") {
-        const match = EXPRESSION_PATTERN.exec(value);
-        if (match === null) return { kind: "literal", value };
-        const expression = compileAt(match[1] as string, at);
-        proveReferences(expression, state.name, at);
-        return { kind: "expression", expression };
+        const segments = parseTemplateAt(value, at);
+        const expressionAt = (source: string): CompiledExpression => {
+          const expression = compileAt(source, at);
+          proveReferences(expression, state.name, at);
+          return expression;
+        };
+        // A string that is exactly one expression keeps that expression's own type: `${ n }` on a
+        // number must stay a number, or every numeric Tool argument silently becomes a string.
+        const only = segments.length === 1 ? segments[0] : undefined;
+        if (only?.kind === "expression") {
+          return { kind: "expression", expression: expressionAt(only.source) };
+        }
+        if (!segments.some((segment) => segment.kind === "expression")) {
+          // Nothing to interpolate; `parseTemplate` has already unescaped any `$${`.
+          const text = segments.map((segment) => (segment.kind === "text" ? segment.value : ""));
+          return { kind: "literal", value: text.join("") };
+        }
+        return {
+          kind: "interpolation",
+          parts: segments.map((segment) =>
+            segment.kind === "text"
+              ? { kind: "text" as const, value: segment.value }
+              : { kind: "expression" as const, expression: expressionAt(segment.source) }
+          ),
+        };
       }
       if (Array.isArray(value)) {
         return {

--- a/packages/run-kernel/src/routine/expressions.test.ts
+++ b/packages/run-kernel/src/routine/expressions.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { compileExpression, ExpressionError } from "./expressions";
+import {
+  compileExpression,
+  ExpressionError,
+  parseTemplate,
+  renderInterpolated,
+} from "./expressions";
 
 const scope = {
   input: { issue: { id: 42, title: "Crash on save", labels: ["bug", "p1"] } },
@@ -88,6 +93,60 @@ describe("compileExpression", () => {
       throw new Error("expected denial");
     } catch (error) {
       expect((error as ExpressionError).message).toBe("expression_unknown_root:secretRoot");
+    }
+  });
+});
+
+describe("parseTemplate", () => {
+  it("splits text around an embedded expression", () => {
+    expect(parseTemplate("stars: ${ n } today")).toEqual([
+      { kind: "text", value: "stars: " },
+      { kind: "expression", source: " n " },
+      { kind: "text", value: " today" },
+    ]);
+  });
+
+  it("reads every expression in the string, not just the first", () => {
+    expect(parseTemplate("${a} is ${b}")).toEqual([
+      { kind: "expression", source: "a" },
+      { kind: "text", value: " is " },
+      { kind: "expression", source: "b" },
+    ]);
+  });
+
+  it("treats a string with no placeholder as one piece of text", () => {
+    expect(parseTemplate("plain")).toEqual([{ kind: "text", value: "plain" }]);
+  });
+
+  it("unescapes $${ to a literal placeholder that is never evaluated", () => {
+    expect(parseTemplate("$${ n }")).toEqual([{ kind: "text", value: "${ n }" }]);
+  });
+
+  it("ignores a closing brace inside a quoted string", () => {
+    expect(parseTemplate("${ coalesce(x, '}') }")).toEqual([
+      { kind: "expression", source: " coalesce(x, '}') " },
+    ]);
+  });
+
+  it("refuses a placeholder that is never closed", () => {
+    expect(() => parseTemplate("stars: ${ n")).toThrow(
+      new ExpressionError("expression_syntax", "template")
+    );
+  });
+});
+
+describe("renderInterpolated", () => {
+  it("renders the scalars a message can carry", () => {
+    expect(renderInterpolated("tulip")).toBe("tulip");
+    expect(renderInterpolated(7)).toBe("7");
+    expect(renderInterpolated(true)).toBe("true");
+  });
+
+  it("refuses values that would coerce to a wrong-looking message", () => {
+    for (const value of [null, undefined, { a: 1 }, [1, 2], Number.NaN]) {
+      expect(() => renderInterpolated(value)).toThrow(
+        new ExpressionError("expression_type", "interpolation")
+      );
     }
   });
 });

--- a/packages/run-kernel/src/routine/expressions.ts
+++ b/packages/run-kernel/src/routine/expressions.ts
@@ -510,3 +510,89 @@ export function evaluateCondition(
 ): boolean {
   return Boolean(expression.evaluate(scope));
 }
+
+/** One piece of an authored string: fixed text, or an expression to evaluate and render into it. */
+export type TemplateSegment =
+  | { readonly kind: "text"; readonly value: string }
+  | { readonly kind: "expression"; readonly source: string };
+
+const TEMPLATE_OPEN = "${";
+
+/**
+ * The index of the `}` that closes an expression opened at `from`.
+ *
+ * Quoted runs are skipped rather than scanned, because `}` is legal inside a string literal —
+ * `${ coalesce(x, '}') }` — and the language has no `{` punctuation, so the first unquoted `}`
+ * is always the right one.
+ */
+function closingBrace(source: string, from: number): number {
+  let index = from;
+  while (index < source.length) {
+    const char = source[index];
+    if (char === "'" || char === '"') {
+      index += 1;
+      while (index < source.length && source[index] !== char) {
+        index += source[index] === "\\" ? 2 : 1;
+      }
+      if (index >= source.length) throw new ExpressionError("expression_syntax", "template");
+      index += 1;
+      continue;
+    }
+    if (char === "}") return index;
+    index += 1;
+  }
+  throw new ExpressionError("expression_syntax", "template");
+}
+
+/**
+ * Split an authored string into its fixed text and its `${ ... }` expressions.
+ *
+ * An expression may sit anywhere in the string, so `"stars: ${ n } today"` is two texts around one
+ * expression rather than one opaque literal. Write `$${` for a literal `${`; nothing else is
+ * escaped, so a lone `$` stays a `$`.
+ *
+ * @throws ExpressionError when a `${` is never closed.
+ */
+export function parseTemplate(source: string): readonly TemplateSegment[] {
+  const segments: TemplateSegment[] = [];
+  let text = "";
+  let index = 0;
+  while (index < source.length) {
+    if (source.startsWith(`$${TEMPLATE_OPEN}`, index)) {
+      text += TEMPLATE_OPEN;
+      index += 3;
+      continue;
+    }
+    if (!source.startsWith(TEMPLATE_OPEN, index)) {
+      text += source[index];
+      index += 1;
+      continue;
+    }
+    const end = closingBrace(source, index + TEMPLATE_OPEN.length);
+    if (text.length > 0) {
+      segments.push({ kind: "text", value: text });
+      text = "";
+    }
+    segments.push({ kind: "expression", source: source.slice(index + TEMPLATE_OPEN.length, end) });
+    index = end + 1;
+  }
+  if (text.length > 0) segments.push({ kind: "text", value: text });
+  return segments;
+}
+
+/**
+ * One interpolated value, rendered into the text around it.
+ *
+ * Only finite scalars render. `null`, `undefined`, objects and arrays are refused rather than
+ * coerced, because `String({})` is `"[object Object]"` and `String(null)` is `"null"` — a Routine
+ * that posts either to a channel has sent a wrong message rather than failed to send one. An
+ * author who wants a placeholder writes one: `${ coalesce(x, 'unknown') }`.
+ *
+ * @throws ExpressionError naming the reason only, never the offending value.
+ */
+export function renderInterpolated(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (typeof value === "boolean") return String(value);
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  throw new ExpressionError("expression_type", "interpolation");
+}

--- a/packages/run-kernel/src/routine/input.test.ts
+++ b/packages/run-kernel/src/routine/input.test.ts
@@ -35,3 +35,58 @@ describe("resolveRoutineStateInput", () => {
     );
   });
 });
+
+/**
+ * An expression surrounded by text used to compile to a literal, so a Routine sent the text of its
+ * own expression to a provider — a Slack message reading `stars: ${states.Count.output.n}`.
+ */
+describe("resolveRoutineStateInput with interpolated strings", () => {
+  function notifyState(text: string) {
+    const compiled = compileStates(
+      [
+        {
+          type: "action",
+          name: "Notify",
+          action: "send_slack_message",
+          input: { text },
+          end: true,
+        },
+      ],
+      "Notify"
+    ).states.get("Notify");
+    if (compiled === undefined) throw new Error("missing Notify");
+    return compiled;
+  }
+
+  const scope = { input: { stars: 7, repo: "tulipfarm", nothing: null, shape: { a: 1 } } };
+
+  it("substitutes an expression that sits inside surrounding text", () => {
+    expect(
+      resolveRoutineStateInput(notifyState("TulipFarm stars: ${ input.stars } (ok)"), scope)
+    ).toEqual({ text: "TulipFarm stars: 7 (ok)" });
+  });
+
+  it("substitutes every expression in the string", () => {
+    expect(
+      resolveRoutineStateInput(notifyState("${ input.repo } has ${ input.stars } stars"), scope)
+    ).toEqual({ text: "tulipfarm has 7 stars" });
+  });
+
+  it("keeps a whole-string expression's own type so a number stays a number", () => {
+    expect(resolveRoutineStateInput(notifyState("${ input.stars }"), scope)).toEqual({ text: 7 });
+  });
+
+  it("leaves an escaped placeholder as text", () => {
+    expect(resolveRoutineStateInput(notifyState("$${ input.stars }"), scope)).toEqual({
+      text: "${ input.stars }",
+    });
+  });
+
+  it("refuses rather than writing null or [object Object] into the message", () => {
+    for (const text of ["got ${ input.nothing }", "got ${ input.shape }"]) {
+      expect(() => resolveRoutineStateInput(notifyState(text), scope)).toThrow(
+        new RoutineInputResolutionError("input_not_evaluable", "Notify")
+      );
+    }
+  });
+});

--- a/packages/run-kernel/src/routine/input.ts
+++ b/packages/run-kernel/src/routine/input.ts
@@ -1,5 +1,5 @@
 import type { CompiledInputNode, CompiledState } from "./compiler";
-import { ExpressionError } from "./expressions";
+import { ExpressionError, renderInterpolated } from "./expressions";
 
 export type RoutineInputResolutionErrorCode = "input_not_evaluable";
 
@@ -28,6 +28,12 @@ export function resolveRoutineStateInput(
         return Object.fromEntries(node.entries.map(([key, child]) => [key, resolve(child)]));
       case "array":
         return node.items.map(resolve);
+      case "interpolation":
+        return node.parts
+          .map((part) =>
+            part.kind === "text" ? part.value : renderInterpolated(part.expression.evaluate(scope))
+          )
+          .join("");
       default: {
         const resolved = node.expression.evaluate(scope);
         // `undefined` is not a value the Context can hold: it would serialize away and reach a

--- a/skills/forge/routine-forge/SKILL.md
+++ b/skills/forge/routine-forge/SKILL.md
@@ -2,12 +2,15 @@
 name: routine-forge
 description: "Forge a canonical Routine and its Triggers."
 category: forge
-tools: [routine_forge, routine_picker, trigger_routine, skill, agent_list, agent_get, api_request, record_search, record_get, send_slack_message, present, request_input]
+tools: [routine_forge, routine_picker, routine_get, trigger_routine, skill, agent_list, agent_get, api_request, record_search, record_get, send_slack_message, present, request_input]
 ---
 # Routine Forge Workflow
 
 Use this Skill to create or change a **Routine** and its **Triggers** through Chat. The output is
 canonical published Soul definitions, not the retired Serverless Workflow format.
+
+**Changing an existing Routine starts with `routine_get`.** `routine_forge` replaces the whole
+document, so an edit written from memory deletes every State and Trigger it did not restate.
 
 {{FORGE_EXECUTION_CONTRACT}}
 
@@ -101,8 +104,9 @@ no `triggers` argument. `interval` counts in **milliseconds**, so every 2 minute
   guessed name fails the Run at that State. Check the Tool's schema rather than inventing one.
 - **`api_request` returns its body as text, never parsed.** `states.X.output.body` is a string, so
   a `script` that reads JSON must `JSON.parse(input.body)` first.
-- Expressions resolve **at any depth** inside `input`, so nested arguments like `record_create`'s
-  `data` may reference earlier States.
+- Expressions resolve **at any depth** inside `input`, and one may sit **inside a longer string** —
+  `"Stars: ${ states.X.output.n } today"` interpolates. A string that is *exactly* one expression
+  instead keeps that value's type, so `stars: "${ states.X.output.n }"` stays a number.
 - **There is no `trigger` root inside a Routine.** `${trigger.scheduledTime}` and friends are
   refused when the Routine compiles. A Trigger's payload crosses into the Run only through that
   Trigger's `inputMapping`, which the States then read as `${input.<key>}`. You almost never need

--- a/skills/forge/routine-forge/references/canonical-examples.md
+++ b/skills/forge/routine-forge/references/canonical-examples.md
@@ -316,6 +316,33 @@ input:
 end: true
 ```
 
+**An expression may sit inside a longer string.** A value is not limited to being one whole
+expression — text around it, and several expressions in one string, both interpolate:
+
+```yaml
+name: NotifySlack
+type: action
+action: send_slack_message
+input:
+  channel: C0BMFUD0HM5
+  text: "TulipFarm stars: ${states.Extract.output.stars} (up ${states.Extract.output.delta} today)"
+end: true
+```
+
+Four rules govern it:
+
+- **A string that is *exactly* one expression keeps that expression's type.** `stars:
+  "${states.Extract.output.stars}"` stays the **number** `42`, which is what `record_create` needs;
+  `"Stars: ${states.Extract.output.stars}"` becomes the **string** `"Stars: 42"`. Never wrap a
+  numeric or boolean argument in surrounding text unless you mean to send text.
+- **Only scalars render.** A part that evaluates to `null`, a list or an object **fails the State**
+  rather than writing `null` or `[object Object]` into the message. Guard a value that may be
+  missing with `${ coalesce(states.X.output.name, 'unknown') }`.
+- **Write `$${` for a literal `${`.** A `${ … }` you meant as plain text is otherwise compiled,
+  and an unknown root fails the forge with `invalid_expression`.
+- **Prefer interpolation over a `script` that only builds a sentence.** A `compute` or `action`
+  State can format the message itself; do not spend an isolate on string concatenation.
+
 **Appending vs overwriting is yours to author.** A snapshot Routine that should keep history ends
 in `record_create`. Use `record_search` + `record_update` only when you actually mean to mutate one
 existing row.


### PR DESCRIPTION
## Summary

<!-- What changed, and why. Link the driving issue if one exists. -->

## Test plan

<!-- Commands you ran, or manual steps / screenshots for UI changes. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (or the scoped `--filter` you actually ran)

## Checklist

- [ ] PR title follows Conventional Commits (`type(scope): subject`) — CI checks this
- [ ] Scoped to one logical change
- [ ] Tests added/updated for the behavior that changed
