### PR TITLE
feat(identity): reply into Slack channel once a bind confirms

### DIFF
--- a/apps/api/src/identity/channel-link.ts
+++ b/apps/api/src/identity/channel-link.ts
@@ -96,7 +96,7 @@ export interface ChannelBindOffer {
 /** Write the nonce before returning the token so every token has a row to spend. */
 export async function issueChannelBindToken(
   deps: ChannelBindDeps,
-  input: { slug: string; senderId: string }
+  input: { slug: string; senderId: string; channelId?: string; threadId?: string }
 ): Promise<IssuedChannelBind> {
   const now = (deps.now ?? (() => new Date()))();
   const expiresAt = new Date(now.getTime() + (deps.ttlMs ?? CHANNEL_BIND_TTL_MS));
@@ -110,6 +110,8 @@ export async function issueChannelBindToken(
     expiresAt,
     consumedAt: null,
     consumedBy: null,
+    channelId: input.channelId ?? null,
+    threadId: input.threadId ?? null,
   });
 
   const claims: ChannelBindClaims = {
@@ -156,12 +158,18 @@ export async function previewChannelBind(
   return { slug: claims.slug, senderId: claims.senderId, expiresAt: row.expiresAt };
 }
 
+/** The mapping just written, plus the offer's delivery ref, so a caller can reply where it was sent. */
+export interface RedeemedChannelBind extends ExternalIdentityMappingDoc {
+  channelId: string | null;
+  threadId: string | null;
+}
+
 /** Spend the nonce before writing the mapping so concurrent clicks cannot bind twice. */
 export async function redeemChannelBindToken(
   deps: ChannelBindDeps,
   token: string,
   userId: string
-): Promise<ExternalIdentityMappingDoc> {
+): Promise<RedeemedChannelBind> {
   const { claims } = await openOffer(deps, token);
   const spent = await deps.repo.consumeBindToken(hashNonce(claims.nonce), userId);
   if (!spent) {
@@ -176,5 +184,5 @@ export async function redeemChannelBindToken(
     verifiedVia: "bind_link",
   };
   await deps.repo.upsertMapping(mapping);
-  return mapping;
+  return { ...mapping, channelId: spent.channelId, threadId: spent.threadId };
 }

--- a/apps/api/src/identity/external-links.ts
+++ b/apps/api/src/identity/external-links.ts
@@ -70,6 +70,9 @@ export interface ChannelBindTokenDoc {
   expiresAt: Date;
   consumedAt: Date | null;
   consumedBy: string | null;
+  /** Where the offer was sent, so a confirmed bind can reply into the same place. Offer-only. */
+  channelId: string | null;
+  threadId: string | null;
 }
 
 export interface ExternalIdentityRepo {
@@ -122,6 +125,8 @@ function rowToBindToken(row: Record<string, unknown>): ChannelBindTokenDoc {
     expiresAt: row.expires_at as Date,
     consumedAt: (row.consumed_at as Date | null) ?? null,
     consumedBy: (row.consumed_by as string | null) ?? null,
+    channelId: (row.channel_id as string | null) ?? null,
+    threadId: (row.thread_id as string | null) ?? null,
   };
 }
 
@@ -223,8 +228,8 @@ export class PgExternalIdentityRepo implements ExternalIdentityRepo {
   async createBindToken(token: ChannelBindTokenDoc): Promise<void> {
     await this.q.query(
       `INSERT INTO channel_bind_tokens
-         (nonce_hash, integration_slug, external_sender_id, issued_at, expires_at, consumed_at, consumed_by)
-       VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+         (nonce_hash, integration_slug, external_sender_id, issued_at, expires_at, consumed_at, consumed_by, channel_id, thread_id)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
       [
         token.nonceHash,
         token.integrationSlug,
@@ -233,6 +238,8 @@ export class PgExternalIdentityRepo implements ExternalIdentityRepo {
         token.expiresAt,
         token.consumedAt,
         token.consumedBy,
+        token.channelId,
+        token.threadId,
       ]
     );
   }

--- a/apps/api/src/identity/routes.test.ts
+++ b/apps/api/src/identity/routes.test.ts
@@ -76,7 +76,13 @@ interface Harness {
 
 const REDIRECT_URI = "https://app.example/api/v1/auth/oidc/callback";
 
-async function makeHarness(options: { withOidc?: boolean; mfa?: MfaVerifier[] } = {}) {
+async function makeHarness(
+  options: {
+    withOidc?: boolean;
+    mfa?: MfaVerifier[];
+    channelBindSecrets?: { get(key: string): Promise<string> };
+  } = {}
+) {
   const store = new MemorySessionStore();
   const users = new FakeUserRepo();
   const admin = await createUser(users, "admin@example.com", PASSWORD, "admin");
@@ -99,6 +105,7 @@ async function makeHarness(options: { withOidc?: boolean; mfa?: MfaVerifier[] } 
       apiClientRepo: apiClients,
       externalIdentityRepo: external,
       channelBind: { repo: external, signingKey: async () => Buffer.alloc(32, 3) },
+      ...(options.channelBindSecrets ? { channelBindSecrets: options.channelBindSecrets } : {}),
       ...(options.withOidc
         ? { oidc: { provider, requestRepo: oidcRequests, redirectUri: REDIRECT_URI } }
         : {}),
@@ -722,5 +729,89 @@ describe("channel identity bind links", () => {
 
     expect(response.statusCode).toBe(400);
     expect(response.json()).toEqual({ error: "bind link is not usable" });
+  });
+});
+
+describe("channel bind confirm: reply into the offer's channel", () => {
+  let harness: Harness;
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  const post = (path: string, token: string, session?: { sid: string; csrf: string }) =>
+    harness.app.inject({
+      method: "POST",
+      url: `/api/v1/identity/channel-links/${path}`,
+      payload: { token },
+      ...(session
+        ? {
+            cookies: { [SESSION_COOKIE]: session.sid, [CSRF_COOKIE]: session.csrf },
+            headers: { [CSRF_HEADER]: session.csrf },
+          }
+        : {}),
+    });
+
+  beforeEach(() => {
+    fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+  });
+
+  afterEach(async () => {
+    fetchSpy.mockRestore();
+    await harness.app.close();
+  });
+
+  it("posts a confirmation to Slack when the offer named a channel", async () => {
+    harness = await makeHarness({
+      channelBindSecrets: { get: async () => "xoxb-test-token" },
+    });
+    const session = await login(harness, "member@example.com");
+    const { token } = await issueChannelBindToken(
+      { repo: harness.external, signingKey: async () => Buffer.alloc(32, 3) },
+      { slug: "slack", senderId: "U1", channelId: "C1", threadId: "T1" }
+    );
+
+    const response = await post("confirm", token, session);
+
+    expect(response.statusCode).toBe(201);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://slack.com/api/chat.postMessage",
+      expect.objectContaining({
+        body: JSON.stringify({
+          channel: "C1",
+          text: "Account connected. You can ask me again.",
+          thread_ts: "T1",
+        }),
+      })
+    );
+  });
+
+  it("skips the reply for a non-Slack provider", async () => {
+    harness = await makeHarness({
+      channelBindSecrets: { get: async () => "xoxb-test-token" },
+    });
+    const session = await login(harness, "member@example.com");
+    const { token } = await issueChannelBindToken(
+      { repo: harness.external, signingKey: async () => Buffer.alloc(32, 3) },
+      { slug: "chatapp", senderId: "EXT1", channelId: "C1" }
+    );
+
+    const response = await post("confirm", token, session);
+
+    expect(response.statusCode).toBe(201);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("still binds when no secret store is configured, skipping the reply", async () => {
+    harness = await makeHarness();
+    const session = await login(harness, "member@example.com");
+    const { token } = await issueChannelBindToken(
+      { repo: harness.external, signingKey: async () => Buffer.alloc(32, 3) },
+      { slug: "slack", senderId: "U1", channelId: "C1" }
+    );
+
+    const response = await post("confirm", token, session);
+
+    expect(response.statusCode).toBe(201);
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/identity/routes.ts
+++ b/apps/api/src/identity/routes.ts
@@ -11,6 +11,7 @@ import {
 } from "../auth/session-store";
 import { toPublicUser, type UserRepo } from "../auth/users";
 import type { RequireAuthorization, RouteAuthorization } from "../authz/route-gate";
+import { integrationSecretKey } from "../integrations/connection-env";
 import { MemoryRateLimiter, makeRateLimitHook } from "../rate-limit";
 import {
   type ApiClientRepo,
@@ -46,6 +47,10 @@ import * as S from "./schemas";
 import type { MfaVerifierRegistry } from "./step-up";
 
 type PreHandler = (req: FastifyRequest, reply: FastifyReply) => Promise<void>;
+/** Just enough of `SecretsService` to read the sealed Slack bot token (narrow for testability). */
+export interface IdentityBindSecretStore {
+  get(key: string): Promise<string>;
+}
 export interface OidcConfig {
   readonly provider: OidcProvider;
   readonly requestRepo: OidcAuthRequestRepo;
@@ -57,6 +62,8 @@ export interface IdentityRouteDeps {
   apiClientRepo?: ApiClientRepo;
   externalIdentityRepo?: ExternalIdentityRepo;
   channelBind?: ChannelBindDeps;
+  /** Resolves the sealed Slack bot token; absent → confirm still binds, just skips the reply. */
+  channelBindSecrets?: IdentityBindSecretStore;
   oidc?: OidcConfig;
   mfa?: MfaVerifierRegistry;
   ttlSeconds?: number;
@@ -84,6 +91,45 @@ const toLink = (mapping: {
 });
 function isAuthMethod(value: unknown): value is AuthMethod {
   return typeof value === "string" && (AUTH_METHODS as string[]).includes(value);
+}
+
+/**
+ * Best-effort reply into the channel a bind offer was sent to, once the bind is confirmed.
+ *
+ * Mirrors the bind-offer route's self-posting exception (`apps/api/src/internal/channel-routes.ts`):
+ * the offer's channel/thread never leaves this process, so this process posts the confirmation
+ * itself rather than handing the ref to a Worker. Never throws — a failed reply must not undo an
+ * already-successful bind.
+ */
+async function postBindConfirmation(
+  deps: IdentityRouteDeps,
+  mapping: { provider: string; channelId: string | null; threadId: string | null },
+  log: FastifyRequest["log"]
+): Promise<void> {
+  if (mapping.provider !== "slack" || !mapping.channelId || !deps.channelBindSecrets) return;
+  try {
+    const botToken = await deps.channelBindSecrets.get(
+      integrationSecretKey("slack", "SLACK_BOT_TOKEN")
+    );
+    const res = await fetch("https://slack.com/api/chat.postMessage", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${botToken}`,
+        "content-type": "application/json; charset=utf-8",
+      },
+      body: JSON.stringify({
+        channel: mapping.channelId,
+        text: "Account connected. You can ask me again.",
+        ...(mapping.threadId ? { thread_ts: mapping.threadId } : {}),
+      }),
+    });
+    const body = (await res.json()) as { ok: boolean; error?: string };
+    if (!body.ok) {
+      log?.warn({ error: body.error }, "slack bind-confirm reply failed");
+    }
+  } catch (err) {
+    log?.warn({ err }, "slack bind-confirm reply failed");
+  }
 }
 export function registerIdentityRoutes(
   app: FastifyInstance,
@@ -544,7 +590,8 @@ function registerChannelBindRoutes(
       preHandler: chain(deps.credentialRateLimitHook, requireAuth),
       schema: {
         description:
-          "Bind the channel identity named by a bind link to the signed-in account. Single use.",
+          "Bind the channel identity named by a bind link to the signed-in account. Single use. " +
+          "Best-effort posts a confirmation back into the channel the offer came from.",
         ...S.ChannelBindConfirmRouteSchema,
       },
     },
@@ -561,6 +608,7 @@ function registerChannelBindRoutes(
           { event: "identity.bind.confirmed", provider: mapping.provider },
           "channel identity bound"
         );
+        await postBindConfirmation(deps, mapping, req.log);
         return reply.code(201).send({ link: toLink(mapping) });
       } catch (error) {
         if (error instanceof ChannelBindDeniedError) {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1093,6 +1093,7 @@ async function boot() {
         apiClientRepo,
         externalIdentityRepo,
         channelBind,
+        channelBindSecrets: secretsService,
       },
       rateLimiter,
       secretsService,

--- a/apps/api/src/ingress/identity.ts
+++ b/apps/api/src/ingress/identity.ts
@@ -86,6 +86,9 @@ export class IngressIdentityResolver {
     registry?: ToolRegistry;
     /** The routed Agent's autonomy ceiling; the identity binding runs no higher than it. */
     autonomy?: ChatAutonomy;
+    /** Where the sender messaged from, so a bind offer can be replied to once confirmed. */
+    channelId?: string;
+    threadId?: string;
   }): Promise<ChannelSenderResolution> {
     const linked = await this.findLinkedUser(opts.slug, opts.sender);
     if (linked) return senderAuthority(linked.user, opts.slug, opts.sender, linked.verifiedVia);
@@ -94,7 +97,10 @@ export class IngressIdentityResolver {
     // Always guest-grade: the row this just wrote is `manifest_email` by construction.
     if (claimed) return senderAuthority(claimed, opts.slug, opts.sender, "manifest_email");
 
-    return { outcome: "unlinked", bindOffer: await this.offerBind(opts.slug, opts.sender) };
+    return {
+      outcome: "unlinked",
+      bindOffer: await this.offerBind(opts.slug, opts.sender, opts.channelId, opts.threadId),
+    };
   }
 
   /** Step 1 — an existing verified mapping, checked by the same guard every other subject faces. */
@@ -196,10 +202,20 @@ export class IngressIdentityResolver {
   }
 
   /** Step 3 — what an unlinked sender is given instead of an answer. */
-  private async offerBind(slug: string, sender: string): Promise<IssuedChannelBind | null> {
+  private async offerBind(
+    slug: string,
+    sender: string,
+    channelId?: string,
+    threadId?: string
+  ): Promise<IssuedChannelBind | null> {
     if (!this.deps.bind) return null;
     try {
-      return await issueChannelBindToken(this.deps.bind, { slug, senderId: sender });
+      return await issueChannelBindToken(this.deps.bind, {
+        slug,
+        senderId: sender,
+        ...(channelId === undefined ? {} : { channelId }),
+        ...(threadId === undefined ? {} : { threadId }),
+      });
     } catch (err) {
       // The denial stands either way; failing to offer a way out must not turn into a failed turn.
       this.deps.log.warn({ err, slug, sender }, "could not issue a channel bind link");

--- a/apps/api/src/internal/channel-routes.ts
+++ b/apps/api/src/internal/channel-routes.ts
@@ -196,7 +196,7 @@ export function registerChannelInternalRoutes(
       preHandler,
       schema: {
         description:
-          "Answers an unmapped Slack sender with a single-use bind link, posted to Slack from this process. The bind token is a bearer credential and must never cross into a Worker process (see `apps/api/src/internal/delivery-host.ts`'s module doc), so this route resolves the offer and posts the reply itself rather than handing the token back.",
+          "Answers an unmapped Slack sender with a single-use bind link, posted to Slack from this process. The bind token is a bearer credential and must never cross into a Worker process (see `apps/api/src/internal/delivery-host.ts`'s module doc), so this route resolves the offer and posts the reply itself rather than handing the token back. The offer's channel/thread is persisted on the bind token row so `POST /api/v1/identity/channel-links/confirm` can reply into the same place once bound (`apps/api/src/identity/routes.ts`) — the same self-posting exception, for the same reason.",
         tags: ["internal"],
         security: [{ bearerToken: [] }],
         body: ChannelSchemas.ChannelIdentityBindOfferBodySchema,
@@ -214,7 +214,12 @@ export function registerChannelInternalRoutes(
         channelId: string;
         threadId?: string;
       };
-      const resolution = await deps.identity.resolve({ slug: provider, sender: externalSubject });
+      const resolution = await deps.identity.resolve({
+        slug: provider,
+        sender: externalSubject,
+        channelId,
+        ...(threadId === undefined ? {} : { threadId }),
+      });
       if (resolution.outcome === "linked" || resolution.bindOffer === null) {
         return reply.send({ outcome: "no_offer" });
       }

--- a/apps/api/src/pg-migrate.test.ts
+++ b/apps/api/src/pg-migrate.test.ts
@@ -51,6 +51,22 @@ async function seedApprovalsAlterTarget(db: PGlite): Promise<void> {
   )`);
 }
 
+/**
+ * The `channel_bind_tokens` table that migration v17 creates and v83 later alters. Fixtures
+ * whose floor is above v17 must stand it in.
+ */
+async function seedChannelBindTokensAlterTarget(db: PGlite): Promise<void> {
+  await db.query(`CREATE TABLE IF NOT EXISTS channel_bind_tokens (
+    nonce_hash         text PRIMARY KEY,
+    integration_slug   text NOT NULL,
+    external_sender_id text NOT NULL,
+    issued_at          timestamptz NOT NULL,
+    expires_at         timestamptz NOT NULL,
+    consumed_at        timestamptz,
+    consumed_by        uuid
+  )`);
+}
+
 describe("the migration ledger is append-only", () => {
   it("assigns every migration a distinct version", () => {
     const seen = new Map<number, string[]>();
@@ -94,6 +110,7 @@ describe("runPgMigrations", () => {
     await db.query("CREATE TABLE users (id uuid PRIMARY KEY, password_hash text NOT NULL)");
     await seedRunsFkTarget(db);
     await seedApprovalsAlterTarget(db);
+    await seedChannelBindTokensAlterTarget(db);
     await db.query("CREATE TABLE run_events (run_id uuid NOT NULL, sequence bigint NOT NULL)");
     await db.query(`CREATE TABLE api_clients (
       id            uuid PRIMARY KEY,
@@ -385,6 +402,7 @@ describe("runPgMigrations", () => {
       await db.query("INSERT INTO schema_version (id, version) VALUES (true, 48)");
       await seedRunsFkTarget(db);
       await seedApprovalsAlterTarget(db);
+      await seedChannelBindTokensAlterTarget(db);
       await db.query(`INSERT INTO soul_execution_bundles (
         digest, business_id, changeset_id, commit_sha, bundle, signature
       ) VALUES (
@@ -457,6 +475,7 @@ describe("runPgMigrations", () => {
       await db.query("CREATE EXTENSION IF NOT EXISTS vector");
       await seedRunsFkTarget(db);
       await seedApprovalsAlterTarget(db);
+      await seedChannelBindTokensAlterTarget(db);
       await db.query(`INSERT INTO runs (id, bundle)
         VALUES ('00000000-0000-4000-8000-000000000001', '{"routineId":"chat"}'::jsonb)`);
       await db.query(`CREATE TABLE schema_version (
@@ -529,6 +548,7 @@ describe("runPgMigrations", () => {
       await seedEmbeddingTablesAsOf(db, 31);
       await seedRunsFkTarget(db);
       await seedApprovalsAlterTarget(db);
+      await seedChannelBindTokensAlterTarget(db);
 
       await runPgMigrations(db, undefined, () => {});
 
@@ -554,6 +574,7 @@ describe("runPgMigrations", () => {
       await seedEmbeddingTablesAsOf(db, 31);
       await seedRunsFkTarget(db);
       await seedApprovalsAlterTarget(db);
+      await seedChannelBindTokensAlterTarget(db);
 
       await expect(runPgMigrations(db, undefined, () => {})).resolves.not.toThrow();
     });
@@ -791,6 +812,7 @@ describe("runPgMigrations concurrency and atomicity", () => {
       await db.query("INSERT INTO schema_version (id, version) VALUES (true, 49)");
       await seedRunsFkTarget(db);
       await seedApprovalsAlterTarget(db);
+      await seedChannelBindTokensAlterTarget(db);
 
       await runPgMigrations(db, undefined, NOOP_LOG);
 

--- a/apps/api/src/pg-migrations/index.ts
+++ b/apps/api/src/pg-migrations/index.ts
@@ -2261,4 +2261,13 @@ export const PG_MIGRATIONS: PgMigration[] = [
       "integration_events: unique on (slug, type, external_id) so a replay reuses its id",
     up: applyStatements(INTEGRATION_EVENT_DEDUP_STATEMENTS),
   },
+  {
+    version: 83,
+    description:
+      "channel_bind_tokens: carry the offer's channel/thread so a confirmed bind can reply there",
+    up: async (q) => {
+      await q.query("ALTER TABLE channel_bind_tokens ADD COLUMN IF NOT EXISTS channel_id text");
+      await q.query("ALTER TABLE channel_bind_tokens ADD COLUMN IF NOT EXISTS thread_id text");
+    },
+  },
 ];


### PR DESCRIPTION
## Summary
- Persist the bind offer's channel/thread on `channel_bind_tokens` (migration 83) so a confirmed bind knows where to reply.
- Thread `channelId`/`threadId` through issue → offer → redeem, and post a best-effort `chat.postMessage` confirmation from the confirm route (`apps/api/src/identity/routes.ts`), mirroring the existing api-side Slack-posting exception used for bind offers.

## Test plan
- [x] `pnpm --filter @tulipfarm/api test src/identity/channel-link.test.ts src/identity/routes.test.ts src/ingress/identity.test.ts src/internal/channel-routes.test.ts` — 89 passing (incl. 3 new)
- [x] `pnpm --filter @tulipfarm/api typecheck`
- [x] `pnpm exec biome check apps/api/src/identity apps/api/src/index.ts apps/api/src/ingress apps/api/src/internal apps/api/src/pg-migrations`