### PR TITLE
fix(knowledge): wire the lexical arm of query_knowledge

### DIFF
--- a/apps/api/src/app-options.ts
+++ b/apps/api/src/app-options.ts
@@ -4,7 +4,11 @@ import type { EventEmitter } from "node:events";
 import type { GuardrailsService } from "@tulipfarm/agent-runtime";
 import type { FileService } from "@tulipfarm/files";
 import type { PublicOriginsService } from "@tulipfarm/integrations";
-import type { KnowledgeDenialSink, KnowledgeService } from "@tulipfarm/knowledge";
+import type {
+  KnowledgeDenialSink,
+  KnowledgeService,
+  PageRetrievalService,
+} from "@tulipfarm/knowledge";
 import type { KvService } from "@tulipfarm/kv";
 import type { LlmService } from "@tulipfarm/llm";
 import type { MemoryDocumentRepo } from "@tulipfarm/memory";
@@ -190,6 +194,11 @@ export interface AppOptions {
    * serves Pages without a gate would serve every Page to everybody.
    */
   knowledgePageGate?: PageReadAuthorizer;
+  /**
+   * Page-level lexical retrieval, shared with `knowledgeService`. Absent leaves page search
+   * vector-only, which returns nothing at all on an instance with no embedding provider.
+   */
+  knowledgeRetrieval?: PageRetrievalService;
   /** Records refused Knowledge writes, so path-probing leaves a trail. */
   knowledgeDenialSink?: KnowledgeDenialSink;
   knowledgeAuthorLabeller?: AuthorLabeller;

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -568,7 +568,7 @@ export async function buildApp(opts: AppOptions = {}) {
         requireAuth,
         requireAuthorization,
         opts.knowledgePageGate,
-        undefined,
+        opts.knowledgeRetrieval,
         opts.activityService,
         opts.knowledgeAuthorLabeller,
         opts.knowledgeReaderDirectory,

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -14,6 +14,7 @@ import {
   enqueueIndex,
   KnowledgeService,
   makeIndexQueueStats,
+  PageRetrievalService,
   PgConnectorStateRepo,
   PgKnowledgeAclRepo,
   PgKnowledgeChunkRepo,
@@ -686,6 +687,11 @@ async function boot() {
     const knowledgeSourceStore = new PgKnowledgeSourceStore(pool);
     const knowledgeIndexStore = new PgKnowledgeIndexStore(pool, embeddingService);
 
+    // The lexical arm of `hybridSearchPages`. Without it `query_knowledge` is vector-only, so an
+    // instance with no embedding provider — or with chunks not yet backfilled — answers every
+    // question "not found" while the page sits indexed and readable.
+    const knowledgeRetrieval = new PageRetrievalService(pool);
+
     const knowledgeService = new KnowledgeService({
       pages: new PgKnowledgePageRepo(pool),
       chunks: new PgKnowledgeChunkRepo(pool),
@@ -694,6 +700,7 @@ async function boot() {
       links: new PgKnowledgeLinksRepo(pool),
       overrides: new PgKnowledgeSpaceOverrideRepo(pool),
       embeddings: embeddingService,
+      retrieval: knowledgeRetrieval,
       acl: new PgKnowledgeAclRepo(pool),
       // Without this the Page-ACL surfaces degrade silently rather than fail: `visibility` 404s,
       // every listing badge reads "business", and a move reports no readership change — so the
@@ -1156,6 +1163,7 @@ async function boot() {
         events: domainEventEmitter,
       }),
       knowledgeService,
+      knowledgeRetrieval,
       knowledgePageGate,
       knowledgeDenialSink,
       knowledgeAuthorLabeller,


### PR DESCRIPTION
## Summary

- `PageRetrievalService` had **zero non-test instantiations**. `buildApp` passed `undefined` for the `retrieval` argument of `registerKnowledgeRoutes` (`apps/api/src/app.ts`), and the `KnowledgeService` in `apps/api/src/index.ts` was built without a `retrieval` dep — so `hybridSearchPages`' lexical arm (`packages/knowledge/src/service-search.ts:112`) always short-circuited to `[]`.
- That made `query_knowledge` vector-only. On staging the API logs `[embeddings] not configured — lexical fallback` and all 92 rows in `knowledge_chunks` have `embedding IS NULL`, so both arms returned nothing and the agent answered "I couldn't find a recorded decision" for a page that is placed, granted, chunked and lexically matchable (raw SQL ranks it 0.246 for `websearch_to_tsquery('english','Google OAuth')`).
- Now one `PageRetrievalService` is built in `index.ts` and handed to both the service and the routes, via a new `knowledgeRetrieval` app option.

## Test plan

- [x] `pnpm --filter @tulipfarm/api typecheck`
- [x] `pnpm exec biome check` on the changed files
- [ ] On an instance with no embedding provider, ask an agent a question answerable only from a wiki page and confirm `query_knowledge` now returns it

## Note — not fixed here

Staging still has no embedding model configured, so semantic search stays off until one is added through the product's model-config surface. This PR is what makes that a degradation rather than a total outage.