### PR TITLE
fix(curator): accept empty add/remove arrays in memory patches

### DIFF
--- a/packages/curator/src/output.test.ts
+++ b/packages/curator/src/output.test.ts
@@ -97,6 +97,42 @@ describe("parseCuratorUserOutput", () => {
     });
     expect(result.ok && result.output.memory).toHaveLength(1);
   });
+
+  // The prompt tells the model "returning empty arrays is a good answer", so it routinely emits
+  // `"remove": []` alongside a real `add`. `minItems: 1` on that array used to fail the whole
+  // output's schema validation, discarding the valid `add` with it — the staging rejection was
+  // exactly `/memory/0/remove must NOT have fewer than 1 items`. An empty array must be accepted
+  // and treated the same as an absent key.
+  it("keeps a valid add when remove is an empty array, not the whole output", () => {
+    const result = parseCuratorUserOutput({
+      memory: [
+        {
+          section: "identity",
+          add: ["Lives in Bangalore"],
+          remove: [],
+          citations: CITATION,
+        },
+      ],
+    });
+    expect(result).toEqual({
+      ok: true,
+      output: {
+        memory: [
+          { section: "identity", add: ["Lives in Bangalore"], remove: [], citations: CITATION },
+        ],
+        proposals: [],
+        knowledgePromotions: [],
+      },
+    });
+  });
+
+  // Both arrays empty is still a no-op, even though each one is now individually schema-legal.
+  it("drops a patch whose add and remove are both empty arrays", () => {
+    const result = parseCuratorUserOutput({
+      memory: [{ section: "identity", add: [], remove: [], citations: CITATION }],
+    });
+    expect(result.ok && result.output.memory).toHaveLength(0);
+  });
 });
 
 describe("parseCuratorBusinessOutput", () => {

--- a/packages/curator/src/output.ts
+++ b/packages/curator/src/output.ts
@@ -83,9 +83,13 @@ const CITATIONS = {
   },
 } as const;
 
+// `minItems: 0`, not 1: a model that has nothing to add or remove naturally emits `[]` rather than
+// omitting the key, and an empty list is semantically identical to an absent one — the parser
+// below drops a patch that ends up with neither, so `minItems: 1` here would only ever discard a
+// well-formed sibling entry (e.g. a valid `add`) sharing the same output object.
 const ENTRIES = {
   type: "array",
-  minItems: 1,
+  minItems: 0,
   maxItems: 20,
   items: { type: "string", minLength: 1, maxLength: 500 },
 } as const;
@@ -226,7 +230,11 @@ export function parseCuratorUserOutput(raw: unknown): CuratorParseResult<Curator
     return { ok: false, rejection: { reason: "schema", detail: firstError(validateUser.errors) } };
   }
   const output = value as unknown as Partial<CuratorUserOutput>;
-  const memory = (output.memory ?? []).filter((patch) => patch.add || patch.remove);
+  // `patch.add || patch.remove` would keep a patch whose array is present but empty, since `[]` is
+  // truthy — check length so an empty-both patch is dropped as the no-op it is.
+  const memory = (output.memory ?? []).filter(
+    (patch) => (patch.add?.length ?? 0) > 0 || (patch.remove?.length ?? 0) > 0
+  );
   return {
     ok: true,
     output: {


### PR DESCRIPTION
## Summary
- On staging, every one of 12 Curator jobs over 8 days was rejected with `/memory/0/remove must NOT have fewer than 1 items`, so `curator_effect` and `user_memory` have 0 rows.
- Root cause: the `ENTRIES` schema (`packages/curator/src/output.ts`) set `minItems: 1` on both `add` and `remove`, but the Curator prompt tells the model "returning empty arrays is a good answer when nothing durable happened" — so a model with an `add` but nothing to `remove` emits `"remove": []`, which failed ajv validation for the *whole* output object and discarded every proposal in it, including valid `add` entries.
- Fix: loosen `ENTRIES` to `minItems: 0` (empty is now legal, same as omitted), and fix `parseCuratorUserOutput`'s no-op filter — it used `patch.add || patch.remove`, which is always truthy for `[]` — to check array length so a patch with neither `add` nor `remove` content is still correctly dropped as a no-op rather than becoming an empty effect.

## Test plan
- [x] `pnpm --filter @tulipfarm/curator test src/output.test.ts` — added two tests: one reproducing the exact staging rejection (`remove: []` alongside a valid `add`, asserting the `add` is kept), and one confirming a patch with both arrays empty is still dropped. Verified both fail on the pre-fix code and pass after.
- [x] `pnpm exec biome check --write packages/curator/src/output.ts packages/curator/src/output.test.ts`
- [x] `pnpm --filter @tulipfarm/curator typecheck`