### PR TITLE
fix(knowledge): match chunk lexical search on prefix terms

### DIFF
--- a/packages/knowledge/src/chunks-repo.test.ts
+++ b/packages/knowledge/src/chunks-repo.test.ts
@@ -1,0 +1,46 @@
+import type { Queryable } from "@tulipfarm/storage";
+import { describe, expect, it } from "vitest";
+import { PgKnowledgeChunkRepo, toPrefixTsQuery } from "./chunks-repo";
+
+/** Records every statement so a test can assert on the SQL and the bound parameters. */
+function recordingQueryable(): Queryable & { calls: { sql: string; params: unknown[] }[] } {
+  const calls: { sql: string; params: unknown[] }[] = [];
+  return {
+    calls,
+    query: async (sql: string, params?: unknown[]) => {
+      calls.push({ sql, params: params ?? [] });
+      return { rows: [], rowCount: 0 };
+    },
+  } as unknown as Queryable & { calls: { sql: string; params: unknown[] }[] };
+}
+
+describe("toPrefixTsQuery", () => {
+  it("turns each alphanumeric term into a prefix term", () => {
+    expect(toPrefixTsQuery("google auth")).toBe("google:* & auth:*");
+  });
+
+  it("yields an empty string when the query holds no usable terms", () => {
+    expect(toPrefixTsQuery("   ?!  ")).toBe("");
+  });
+});
+
+describe("PgKnowledgeChunkRepo.searchLexical", () => {
+  it("binds prefix terms so a shorter term still matches a longer stem", async () => {
+    const q = recordingQueryable();
+    await new PgKnowledgeChunkRepo(q).searchLexical("google auth", 10, {});
+
+    expect(q.calls).toHaveLength(1);
+    // `auth:*` is what lets the chunk containing "authentication" match; `websearch_to_tsquery`
+    // bound the raw phrase and matched nothing.
+    expect(q.calls[0]?.params[0]).toBe("google:* & auth:*");
+    expect(q.calls[0]?.sql).toContain("to_tsquery('english', $1)");
+    expect(q.calls[0]?.sql).not.toContain("websearch_to_tsquery");
+  });
+
+  it("returns no hits without querying when the query has no usable terms", async () => {
+    const q = recordingQueryable();
+    // `to_tsquery('english', '')` raises in Postgres, so this must never reach the database.
+    await expect(new PgKnowledgeChunkRepo(q).searchLexical("  !!  ", 10, {})).resolves.toEqual([]);
+    expect(q.calls).toHaveLength(0);
+  });
+});

--- a/packages/knowledge/src/chunks-repo.ts
+++ b/packages/knowledge/src/chunks-repo.ts
@@ -29,6 +29,12 @@ function parseVector(value: unknown): number[] | null {
     .map((n) => Number(n));
 }
 
+/** Builds a valid prefix tsquery from alphanumeric terms; empty means skip FTS. */
+export function toPrefixTsQuery(query: string): string {
+  const terms = query.toLowerCase().match(/[\p{L}\p{N}]+/gu) ?? [];
+  return terms.map((t) => `${t}:*`).join(" & ");
+}
+
 /** Push `p.*` filter conditions onto `params` and return the SQL fragments. */
 export function pageFilterConditions(filters: SearchFilters, params: unknown[]): string[] {
   const conds: string[] = [];
@@ -192,15 +198,22 @@ export class PgKnowledgeChunkRepo implements KnowledgeChunkRepo {
   }
 
   async searchLexical(query: string, limit: number, filters: SearchFilters): Promise<SearchHit[]> {
-    const params: unknown[] = [query];
+    // Prefix-term tsquery, same semantics as page-level search: "google auth" matches a chunk
+    // containing "authentication" via the `auth:*` prefix, and a single unmatched term no longer
+    // zeroes the whole result the way `websearch_to_tsquery`'s strict AND did.
+    const tsq = toPrefixTsQuery(query);
+    // Empty tsquery means no usable terms (empty/punctuation-only query); `to_tsquery` throws on
+    // an empty string, so short-circuit to zero hits instead of erroring.
+    if (tsq === "") return [];
+    const params: unknown[] = [tsq];
     const conds = pageFilterConditions(filters, params);
     const filterSql = conds.length > 0 ? ` AND ${conds.join(" AND ")}` : "";
     params.push(limit);
     const { rows } = await this.q.query(
       `SELECT c.id AS chunk_id, c.page_id, c.content, p.title, p.source,
-              ts_rank(c.tsv, websearch_to_tsquery('english', $1)) AS rank
+              ts_rank(c.tsv, to_tsquery('english', $1)) AS rank
        FROM knowledge_chunks c JOIN knowledge_pages p ON p.id = c.page_id
-       WHERE c.tsv @@ websearch_to_tsquery('english', $1) AND p.active = true${filterSql}
+       WHERE c.tsv @@ to_tsquery('english', $1) AND p.active = true${filterSql}
        ORDER BY rank DESC
        LIMIT $${params.length}`,
       params

--- a/packages/knowledge/src/index.ts
+++ b/packages/knowledge/src/index.ts
@@ -20,7 +20,12 @@ export {
 } from "./acl-repo";
 export { NOTES_SPACE_NAME } from "./authored-page";
 export { type ChunkOptions, chunkText, type TextChunk } from "./chunk";
-export { type KnowledgeChunkRepo, PgKnowledgeChunkRepo, pageFilterConditions } from "./chunks-repo";
+export {
+  type KnowledgeChunkRepo,
+  PgKnowledgeChunkRepo,
+  pageFilterConditions,
+  toPrefixTsQuery,
+} from "./chunks-repo";
 export { buildDefaultRegistry } from "./connectors/registry";
 export { defaultSampleFixturesPath, SampleConnector } from "./connectors/sample";
 export {
@@ -222,7 +227,6 @@ export {
   PageRetrievalService,
   type PageSearchInput,
   type Principal,
-  toPrefixTsQuery,
 } from "./page-search-adapter";
 export type {
   SynthesisDecision,

--- a/packages/knowledge/src/page-search-adapter.ts
+++ b/packages/knowledge/src/page-search-adapter.ts
@@ -2,7 +2,7 @@
 // and optionally widens recall with pg_trgm. Chunk search stays in search-service.ts.
 
 import type { Queryable } from "@tulipfarm/storage";
-import { pageFilterConditions } from "./chunks-repo";
+import { pageFilterConditions, toPrefixTsQuery } from "./chunks-repo";
 import { DEFAULT_RANKING, type RankingConfig } from "./retrieval-config";
 import type { SearchFilters } from "./types";
 
@@ -34,12 +34,6 @@ export interface PageSearchInput {
 // ts_headline uses unlikely markers; convert them to highlightRanges.
 const SEL_START = "<<";
 const SEL_STOP = ">>";
-
-/** Builds a valid prefix tsquery from alphanumeric terms; empty means skip FTS. */
-export function toPrefixTsQuery(query: string): string {
-  const terms = query.toLowerCase().match(/[\p{L}\p{N}]+/gu) ?? [];
-  return terms.map((t) => `${t}:*`).join(" & ");
-}
 
 /** Strip `<<…>>` markers, returning clean text and match ranges. */
 export function extractHighlights(marked: string): {


### PR DESCRIPTION
## Summary

- `PgKnowledgeChunkRepo.searchLexical` bound the raw query through `websearch_to_tsquery`, which is strict AND with no prefix matching. `"google auth"` missed every chunk containing `"authentication"` (stem `authent`), and one unmatched term zeroed the whole result — an indexed, readable page answered "not found".
- Moved the existing `toPrefixTsQuery` helper from `page-search-adapter.ts` into `chunks-repo.ts` so page-level and chunk-level search share one implementation instead of two divergent tsquery dialects.
- An empty tsquery (empty or punctuation-only query) short-circuits to zero hits, because `to_tsquery('english', '')` raises in Postgres. Page-level search already guarded this; chunk-level now does too.

Found while root-causing the staging report where `query_knowledge` could not find an indexed knowledge page. Complements #627, which wires the page-level lexical arm; this fixes the chunk-level arm's query semantics. No migration, no new dependency.

## Test plan

- [x] New `packages/knowledge/src/chunks-repo.test.ts` asserts prefix terms are bound (`google:* & auth:*`) and that a term-less query returns `[]` without reaching the database
- [x] Red before / green after verified by stashing only the source change: 4 failed → 4 passed
- [x] `pnpm --filter @tulipfarm/knowledge typecheck`
- [x] `pnpm typecheck` — 40/40 workspaces, confirming no consumer relied on the moved export
- [x] `biome check --write packages/knowledge`