### PR TITLE
fix(worker): recover Runs parked by a crashed dispatch handler

### DIFF
--- a/apps/worker/src/executors.test.ts
+++ b/apps/worker/src/executors.test.ts
@@ -57,6 +57,10 @@ class FakeRunStore implements RunLeaseStore {
     return [];
   }
 
+  async requeueParkedRuns(): Promise<readonly PersistedRun[]> {
+    return [];
+  }
+
   async claimNextQueued(): Promise<readonly PersistedRun[]> {
     return this.claimBatchResult;
   }

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -516,6 +516,7 @@ export async function main(): Promise<void> {
     now: () => new Date(),
     leaseDurationMs: config.leaseDurationMs,
     batchSize: config.batchSize,
+    log: logger,
     onTerminal: async (run, status) => {
       const outcome = await signalChildCompletion(
         { ancestry: childAncestry, waits },

--- a/apps/worker/src/recovery/run-dispatch.test.ts
+++ b/apps/worker/src/recovery/run-dispatch.test.ts
@@ -1,5 +1,10 @@
 import { RunLeaseManager } from "@tulipfarm/run-kernel";
-import type { PersistedRun, PersistedRunStatus } from "@tulipfarm/storage";
+import {
+  DISPATCH_HANDLER_ERROR_REF,
+  DISPATCH_REQUEUED_ONCE_REF,
+  type PersistedRun,
+  type PersistedRunStatus,
+} from "@tulipfarm/storage";
 import { describe, expect, it } from "vitest";
 import { RunDispatcher, type RunOutcome } from "../run-dispatcher";
 
@@ -112,6 +117,27 @@ class DurableRunStore {
     return reclaimed;
   }
 
+  async requeueParkedRuns(_businessId: string, limit: number): Promise<readonly PersistedRun[]> {
+    const requeuedRuns: PersistedRun[] = [];
+    for (const current of this.runs.values()) {
+      if (requeuedRuns.length >= limit) break;
+      if (current.status !== "needs_reconciliation") continue;
+      if (current.errorEvidenceRef !== DISPATCH_HANDLER_ERROR_REF) continue;
+      const requeued: PersistedRun = {
+        ...current,
+        status: "queued",
+        version: current.version + 1,
+        errorEvidenceRef: DISPATCH_REQUEUED_ONCE_REF,
+        leaseOwner: null,
+        leaseExpiresAt: null,
+      };
+      this.runs.set(current.id, requeued);
+      this.commits.push({ from: current.status, to: "queued" });
+      requeuedRuns.push(requeued);
+    }
+    return requeuedRuns;
+  }
+
   async claimNextQueued(
     _businessId: string,
     owner: string,
@@ -168,7 +194,14 @@ describe("Run dispatch recovery", () => {
       throw new Error("effect ambiguous");
     }).dispatchBatch();
 
-    expect(result).toEqual({ reclaimed: 0, claimed: 1, dispatched: 0, waiting: 0, failed: 1 });
+    expect(result).toEqual({
+      reclaimed: 0,
+      requeuedParked: 0,
+      claimed: 1,
+      dispatched: 0,
+      waiting: 0,
+      failed: 1,
+    });
     expect(await store.find(BUSINESS_ID, RUN_ID)).toMatchObject({
       status: "needs_reconciliation",
       leaseOwner: null,
@@ -196,7 +229,14 @@ describe("Run dispatch recovery", () => {
       () => AFTER_LEASE
     ).dispatchBatch();
 
-    expect(recovered).toEqual({ reclaimed: 1, claimed: 1, dispatched: 1, waiting: 0, failed: 0 });
+    expect(recovered).toEqual({
+      reclaimed: 1,
+      requeuedParked: 0,
+      claimed: 1,
+      dispatched: 1,
+      waiting: 0,
+      failed: 0,
+    });
     expect(handled).toEqual([RUN_ID]);
     expect(await store.find(BUSINESS_ID, RUN_ID)).toMatchObject({
       status: "succeeded",
@@ -218,8 +258,22 @@ describe("Run dispatch recovery", () => {
     const current = dispatcher(store, SURVIVOR, handler);
     const [first, second] = [await stale.dispatchBatch(), await current.dispatchBatch()];
 
-    expect(first).toEqual({ reclaimed: 0, claimed: 1, dispatched: 1, waiting: 0, failed: 0 });
-    expect(second).toEqual({ reclaimed: 0, claimed: 0, dispatched: 0, waiting: 0, failed: 0 });
+    expect(first).toEqual({
+      reclaimed: 0,
+      requeuedParked: 0,
+      claimed: 1,
+      dispatched: 1,
+      waiting: 0,
+      failed: 0,
+    });
+    expect(second).toEqual({
+      reclaimed: 0,
+      requeuedParked: 0,
+      claimed: 0,
+      dispatched: 0,
+      waiting: 0,
+      failed: 0,
+    });
     expect(handled).toEqual([OWNER]);
     expect(store.commits.filter((commit) => commit.to === "succeeded")).toHaveLength(1);
   });

--- a/apps/worker/src/run-dispatcher.test.ts
+++ b/apps/worker/src/run-dispatcher.test.ts
@@ -1,5 +1,9 @@
 import { RunLeaseManager, type RunLeaseStore } from "@tulipfarm/run-kernel";
-import type { PersistedRun, PersistedRunStatus } from "@tulipfarm/storage";
+import {
+  DISPATCH_REQUEUED_ONCE_REF,
+  type PersistedRun,
+  type PersistedRunStatus,
+} from "@tulipfarm/storage";
 import { describe, expect, it } from "vitest";
 import { RunDispatcher, type RunDispatcherOptions, type RunOutcome } from "./run-dispatcher";
 
@@ -34,6 +38,10 @@ class FakeRunStore implements RunLeaseStore {
   releaseResult = true;
   claimBatchResult: readonly PersistedRun[] = [];
   reclaimResult: readonly PersistedRun[] = [];
+  requeueParkedCalls: { businessId: string; limit: number }[] = [];
+  requeueParkedResult: readonly PersistedRun[] = [];
+  /** Applied to whatever `find` returns, so a test can stage the Run the dispatcher re-reads. */
+  findOverrides: Partial<PersistedRun> = {};
 
   async transitionRun(
     _businessId: string,
@@ -44,6 +52,7 @@ class FakeRunStore implements RunLeaseStore {
       status: PersistedRunStatus;
       leaseOwner: string | null;
       leaseExpiresAt: string | null;
+      errorEvidenceRef?: string;
     }
   ): Promise<boolean> {
     if (transition.leaseOwner === null) {
@@ -61,12 +70,17 @@ class FakeRunStore implements RunLeaseStore {
     return this.reclaimResult;
   }
 
+  async requeueParkedRuns(businessId: string, limit: number): Promise<readonly PersistedRun[]> {
+    this.requeueParkedCalls.push({ businessId, limit });
+    return this.requeueParkedResult;
+  }
+
   async claimNextQueued(): Promise<readonly PersistedRun[]> {
     return this.claimBatchResult;
   }
 
   async find(_businessId: string, runId: string): Promise<PersistedRun | null> {
-    return persistedRun({ id: runId, status: "running", version: 2 });
+    return persistedRun({ id: runId, status: "running", version: 2, ...this.findOverrides });
   }
 }
 
@@ -89,7 +103,14 @@ describe("RunDispatcher", () => {
 
     const result = await dispatcher.dispatchBatch();
 
-    expect(result).toEqual({ reclaimed: 0, claimed: 1, dispatched: 1, waiting: 0, failed: 0 });
+    expect(result).toEqual({
+      reclaimed: 0,
+      requeuedParked: 0,
+      claimed: 1,
+      dispatched: 1,
+      waiting: 0,
+      failed: 0,
+    });
     expect(dispatched).toEqual([persistedRun().id]);
     expect(store.releaseCalls).toEqual([
       expect.objectContaining({ status: "succeeded", leaseOwner: null, leaseExpiresAt: null }),
@@ -109,7 +130,14 @@ describe("RunDispatcher", () => {
 
     const result = await dispatcher.dispatchBatch();
 
-    expect(result).toEqual({ reclaimed: 0, claimed: 1, dispatched: 0, waiting: 1, failed: 0 });
+    expect(result).toEqual({
+      reclaimed: 0,
+      requeuedParked: 0,
+      claimed: 1,
+      dispatched: 0,
+      waiting: 1,
+      failed: 0,
+    });
     expect(store.releaseCalls).toEqual([
       expect.objectContaining({ status: "waiting", leaseOwner: null, leaseExpiresAt: null }),
     ]);
@@ -128,30 +156,58 @@ describe("RunDispatcher", () => {
 
     const result = await dispatcher.dispatchBatch();
 
-    expect(result).toEqual({ reclaimed: 0, claimed: 1, dispatched: 0, waiting: 1, failed: 0 });
+    expect(result).toEqual({
+      reclaimed: 0,
+      requeuedParked: 0,
+      claimed: 1,
+      dispatched: 0,
+      waiting: 1,
+      failed: 0,
+    });
     expect(store.releaseCalls).toEqual([]);
   });
 
-  it("releases to needs_reconciliation when the handler throws", async () => {
+  it("releases to needs_reconciliation when the handler throws, logging and recording the reason", async () => {
     const store = new FakeRunStore();
     store.claimBatchResult = [persistedRun()];
     const leases = new RunLeaseManager(store);
+    const logged: Array<{ message: string; error: unknown }> = [];
+    const boom = new Error("boom");
     const dispatcher = new RunDispatcher({
       leases,
       businessId: BUSINESS_ID,
       owner: "worker-1",
       now: () => new Date("2026-07-24T10:00:00.000Z"),
+      log: {
+        error: (message, error) => {
+          logged.push({ message, error });
+        },
+      },
       handler: async () => {
-        throw new Error("boom");
+        throw boom;
       },
     });
 
     const result = await dispatcher.dispatchBatch();
 
-    expect(result).toEqual({ reclaimed: 0, claimed: 1, dispatched: 0, waiting: 0, failed: 1 });
+    expect(result).toEqual({
+      reclaimed: 0,
+      requeuedParked: 0,
+      claimed: 1,
+      dispatched: 0,
+      waiting: 0,
+      failed: 1,
+    });
     expect(store.releaseCalls).toEqual([
-      expect.objectContaining({ status: "needs_reconciliation" }),
+      expect.objectContaining({
+        status: "needs_reconciliation",
+        errorEvidenceRef: "dispatch:handler_error",
+      }),
     ]);
+    expect(logged).toHaveLength(1);
+    expect(logged[0]?.error).toBe(boom);
+    expect(logged[0]?.message).toContain(persistedRun().id);
+    expect(logged[0]?.message).toContain(BUSINESS_ID);
   });
 
   it("skips a Run whose lease was lost before it could advance to running", async () => {
@@ -169,7 +225,14 @@ describe("RunDispatcher", () => {
 
     const result = await dispatcher.dispatchBatch();
 
-    expect(result).toEqual({ reclaimed: 0, claimed: 1, dispatched: 0, waiting: 0, failed: 0 });
+    expect(result).toEqual({
+      reclaimed: 0,
+      requeuedParked: 0,
+      claimed: 1,
+      dispatched: 0,
+      waiting: 0,
+      failed: 0,
+    });
   });
 
   it("does not report success when the terminal compare-and-swap loses the lease", async () => {
@@ -186,6 +249,7 @@ describe("RunDispatcher", () => {
 
     await expect(dispatcher.dispatchBatch()).resolves.toEqual({
       reclaimed: 0,
+      requeuedParked: 0,
       claimed: 1,
       dispatched: 0,
       waiting: 0,
@@ -262,6 +326,7 @@ describe("RunDispatcher", () => {
 
       await expect(dispatcher.dispatchBatch()).resolves.toEqual({
         reclaimed: 0,
+        requeuedParked: 0,
         claimed: 1,
         dispatched: 1,
         waiting: 0,
@@ -341,11 +406,56 @@ describe("RunDispatcher", () => {
 
       await expect(dispatcher.dispatchBatch()).resolves.toEqual({
         reclaimed: 0,
+        requeuedParked: 0,
         claimed: 1,
         dispatched: 0,
         waiting: 1,
         failed: 0,
       });
     });
+  });
+
+  it("returns Runs parked by a crashed handler to the queue before claiming", async () => {
+    const store = new FakeRunStore();
+    store.requeueParkedResult = [persistedRun({ status: "queued", version: 2 })];
+    const dispatcher = new RunDispatcher({
+      leases: new RunLeaseManager(store),
+      businessId: BUSINESS_ID,
+      owner: "worker-1",
+      now: () => new Date("2026-07-24T10:00:00.000Z"),
+      handler: async () => "succeeded",
+    });
+
+    const result = await dispatcher.dispatchBatch();
+
+    // Nothing else moves a Run out of `needs_reconciliation`, so without this sweep the Run is
+    // parked for good.
+    expect(store.requeueParkedCalls).toEqual([{ businessId: BUSINESS_ID, limit: 25 }]);
+    expect(result.requeuedParked).toBe(1);
+  });
+
+  it("fails a Run that throws again after already being requeued once", async () => {
+    const store = new FakeRunStore();
+    store.claimBatchResult = [persistedRun()];
+    store.findOverrides = { errorEvidenceRef: DISPATCH_REQUEUED_ONCE_REF };
+    const dispatcher = new RunDispatcher({
+      leases: new RunLeaseManager(store),
+      businessId: BUSINESS_ID,
+      owner: "worker-1",
+      now: () => new Date("2026-07-24T10:00:00.000Z"),
+      handler: async () => {
+        throw new Error("boom again");
+      },
+    });
+
+    await dispatcher.dispatchBatch();
+
+    // Parking it again would feed it straight back to the sweep it just came from.
+    expect(store.releaseCalls).toEqual([
+      expect.objectContaining({
+        status: "failed",
+        errorEvidenceRef: "dispatch:handler_error_after_requeue",
+      }),
+    ]);
   });
 });

--- a/apps/worker/src/run-dispatcher.ts
+++ b/apps/worker/src/run-dispatcher.ts
@@ -1,5 +1,9 @@
 import type { RunLeaseManager } from "@tulipfarm/run-kernel";
-import type { PersistedRun } from "@tulipfarm/storage";
+import {
+  DISPATCH_HANDLER_ERROR_REF,
+  DISPATCH_REQUEUED_ONCE_REF,
+  type PersistedRun,
+} from "@tulipfarm/storage";
 import type { RunOutcome } from "@tulipfarm/turn-executor";
 
 export type { RunOutcome } from "@tulipfarm/turn-executor";
@@ -9,6 +13,12 @@ export interface RunDispatcherOptions {
   businessId: string;
   owner: string;
   handler: (run: PersistedRun) => Promise<RunOutcome>;
+  /**
+   * Reports a handler throw that parked its Run at `needs_reconciliation`. Optional so existing
+   * callers and tests need not wire one, but production always does — an unrecorded throw here is
+   * unrecoverable information (the Run's own event ledger never sees it).
+   */
+  log?: { error(message: string, error?: unknown): void };
   /**
    * Fired after a Run durably reaches `succeeded` or `failed`, so a parent parked on it can be
    * resumed. Never fired for `waiting`, `cancelled`, or `needs_reconciliation` — those Runs are
@@ -31,6 +41,8 @@ export interface RunDispatcherOptions {
 
 export interface DispatchRunsResult {
   reclaimed: number;
+  /** Runs a crashed handler had parked at `needs_reconciliation`, returned to the queue. */
+  requeuedParked: number;
   claimed: number;
   dispatched: number;
   /** Runs parked on a durable wait, plus those left to the cancellation manager. */
@@ -45,6 +57,13 @@ export class RunDispatcher {
   async dispatchBatch(): Promise<DispatchRunsResult> {
     const limit = this.options.batchSize ?? 25;
     const leaseDurationMs = this.options.leaseDurationMs ?? 60_000;
+
+    // Before claiming, return Runs a crashed handler parked to the queue. They are indistinguishable
+    // from queued work once requeued, so this must happen ahead of the claim in the same batch.
+    const requeuedParked = await this.options.leases.requeueParked({
+      businessId: this.options.businessId,
+      limit,
+    });
 
     const reclaimed = await this.options.leases.reclaimExpired({
       businessId: this.options.businessId,
@@ -103,19 +122,37 @@ export class RunDispatcher {
         if (outcome === "waiting") {
           await this.notifyWaiting(started.run);
         }
-      } catch {
+      } catch (error) {
+        // A Run already requeued once has now thrown twice. Parking it again would put it straight
+        // back in front of the sweep it just came from, so it fails here with the reason recorded.
+        const exhausted = started.run.errorEvidenceRef === DISPATCH_REQUEUED_ONCE_REF;
+        const status = exhausted ? "failed" : "needs_reconciliation";
+        this.options.log?.error(
+          `run dispatch failed run=${run.id} business=${this.options.businessId} source=${run.source} — ${exhausted ? "already requeued once, failing" : "parking at needs_reconciliation"}`,
+          error
+        );
         await this.options.leases.release({
           businessId: this.options.businessId,
           runId: run.id,
           expectedVersion: started.run.version,
           expectedStatus: "running",
-          status: "needs_reconciliation",
+          status,
+          errorEvidenceRef: exhausted
+            ? "dispatch:handler_error_after_requeue"
+            : DISPATCH_HANDLER_ERROR_REF,
         });
         failed += 1;
       }
     }
 
-    return { reclaimed: reclaimed.length, claimed: claimed.length, dispatched, waiting, failed };
+    return {
+      reclaimed: reclaimed.length,
+      requeuedParked: requeuedParked.length,
+      claimed: claimed.length,
+      dispatched,
+      waiting,
+      failed,
+    };
   }
 
   /**

--- a/packages/run-kernel/src/lease.test.ts
+++ b/packages/run-kernel/src/lease.test.ts
@@ -75,6 +75,14 @@ class FakeRunStore implements RunLeaseStore {
     return this.reclaimResult;
   }
 
+  requeueParkedCalls: { businessId: string; limit: number }[] = [];
+  requeueParkedResult: readonly PersistedRun[] = [];
+
+  async requeueParkedRuns(businessId: string, limit: number): Promise<readonly PersistedRun[]> {
+    this.requeueParkedCalls.push({ businessId, limit });
+    return this.requeueParkedResult;
+  }
+
   async claimNextQueued(
     businessId: string,
     owner: string,

--- a/packages/run-kernel/src/lease.ts
+++ b/packages/run-kernel/src/lease.ts
@@ -13,6 +13,7 @@ export interface RunLeaseStore {
       status: PersistedRunStatus;
       leaseOwner: string | null;
       leaseExpiresAt: string | null;
+      errorEvidenceRef?: string;
     }
   ): Promise<boolean>;
   heartbeat(
@@ -26,6 +27,8 @@ export interface RunLeaseStore {
     now: string,
     limit: number
   ): Promise<readonly PersistedRun[]>;
+  /** Requeues Runs parked by a crashed dispatch handler; bounded to once per Run by the store. */
+  requeueParkedRuns(businessId: string, limit: number): Promise<readonly PersistedRun[]>;
   claimNextQueued(
     businessId: string,
     owner: string,
@@ -65,6 +68,8 @@ export interface ReleaseInput {
   readonly expectedVersion: number;
   readonly expectedStatus: RunStatus;
   readonly status: Exclude<RunStatus, LeasedRunStatus>;
+  /** Terse reason code for a non-terminal park (e.g. `needs_reconciliation`); never secrets or model content. */
+  readonly errorEvidenceRef?: string;
 }
 
 export interface ReclaimInput {
@@ -115,11 +120,23 @@ export class RunLeaseManager {
       status: input.status,
       leaseOwner: null,
       leaseExpiresAt: null,
+      ...(input.errorEvidenceRef === undefined ? {} : { errorEvidenceRef: input.errorEvidenceRef }),
     });
   }
 
   async reclaimExpired(input: ReclaimInput): Promise<readonly PersistedRun[]> {
     return this.store.reclaimExpiredRuns(input.businessId, input.now.toISOString(), input.limit);
+  }
+
+  /**
+   * Returns Runs a crashed handler parked at `needs_reconciliation` to `queued`. Nothing else
+   * moves a Run out of that status, so without this the Run is parked for good.
+   */
+  async requeueParked(input: {
+    businessId: string;
+    limit: number;
+  }): Promise<readonly PersistedRun[]> {
+    return this.store.requeueParkedRuns(input.businessId, input.limit);
   }
 
   async claimBatch(input: ClaimBatchInput): Promise<readonly PersistedRun[]> {

--- a/packages/run-kernel/src/resilience/simulator.ts
+++ b/packages/run-kernel/src/resilience/simulator.ts
@@ -1,4 +1,9 @@
-import type { PersistedRun, PersistedRunStatus } from "@tulipfarm/storage";
+import {
+  DISPATCH_HANDLER_ERROR_REF,
+  DISPATCH_REQUEUED_ONCE_REF,
+  type PersistedRun,
+  type PersistedRunStatus,
+} from "@tulipfarm/storage";
 import type { RunLeaseStore } from "../lease";
 import type { ReconcilableStateStore } from "../reconcile-state";
 import type { RunResumeStore } from "../resume";
@@ -175,6 +180,34 @@ export class SimulatedRunStore implements RunLeaseStore, RunResumeStore, Reconci
     }
     this.guard("reclaimExpiredRuns", "after");
     return reclaimed;
+  }
+
+  async requeueParkedRuns(_businessId: string, limit: number): Promise<readonly PersistedRun[]> {
+    this.guard("requeueParkedRuns", "before");
+    const requeuedRuns: PersistedRun[] = [];
+    for (const run of this.runs.values()) {
+      if (requeuedRuns.length >= limit) break;
+      if (run.status !== "needs_reconciliation") continue;
+      if (run.errorEvidenceRef !== DISPATCH_HANDLER_ERROR_REF) continue;
+      const requeued: PersistedRun = {
+        ...run,
+        status: "queued",
+        version: run.version + 1,
+        errorEvidenceRef: DISPATCH_REQUEUED_ONCE_REF,
+        leaseOwner: null,
+        leaseExpiresAt: null,
+      };
+      this.runs.set(run.id, requeued);
+      this.transitions.push({
+        runId: run.id,
+        from: run.status,
+        to: "queued",
+        version: requeued.version,
+      });
+      requeuedRuns.push(requeued);
+    }
+    this.guard("requeueParkedRuns", "after");
+    return requeuedRuns;
   }
 
   async claimNextQueued(

--- a/packages/storage/src/runs/index.ts
+++ b/packages/storage/src/runs/index.ts
@@ -49,6 +49,10 @@ export {
   RunLoopCheckpointStore,
 } from "./loop-checkpoint-store";
 export { MemoryWaitStore } from "./memory-wait-store";
+export {
+  DISPATCH_HANDLER_ERROR_REF,
+  DISPATCH_REQUEUED_ONCE_REF,
+} from "./run-lease-store";
 export type {
   AppendAttemptInput,
   AppendAttemptResult,

--- a/packages/storage/src/runs/run-lease-store.ts
+++ b/packages/storage/src/runs/run-lease-store.ts
@@ -116,3 +116,57 @@ export async function requeueWaitingRunRow(
   );
   return result.rows.length === 1;
 }
+
+/**
+ * The evidence ref the dispatcher records when a handler throw parks a Run, and the only ref
+ * `requeueParkedRunRows` will act on. A Run parked for any other reason may have an effect in
+ * flight, and requeueing it could double-apply that effect.
+ */
+export const DISPATCH_HANDLER_ERROR_REF = "dispatch:handler_error";
+
+/**
+ * Stamped in place of {@link DISPATCH_HANDLER_ERROR_REF} once a Run has been requeued. It is what
+ * makes the requeue bounded: the sweep's own `WHERE` no longer matches, so a Run can never be
+ * requeued twice, and the dispatcher reads it to fail a second throw outright.
+ */
+export const DISPATCH_REQUEUED_ONCE_REF = "dispatch:requeued_once";
+
+/**
+ * Requeues Runs parked by a crashed dispatch handler so a worker picks them up again.
+ *
+ * Nothing else moves a Run out of `needs_reconciliation`, so before this a handler throw parked
+ * the Run forever. Bounded by construction: the update both requires
+ * `DISPATCH_HANDLER_ERROR_REF` and overwrites it, so a second sweep matches nothing.
+ */
+export async function requeueParkedRunRows(
+  transaction: Queryable,
+  businessId: string,
+  limit: number
+): Promise<readonly PersistedRun[]> {
+  const result = await transaction.query<RunRow>(
+    `WITH candidates AS (
+       SELECT id
+         FROM runs
+        WHERE business_id = $1
+          AND status = 'needs_reconciliation'
+          AND error_evidence_ref = $2
+        ORDER BY created_at
+        FOR UPDATE SKIP LOCKED
+        LIMIT $4
+     )
+     UPDATE runs
+        SET status = 'queued',
+            version = version + 1,
+            error_evidence_ref = $3,
+            lease_owner = NULL,
+            lease_expires_at = NULL
+       FROM candidates
+      WHERE runs.id = candidates.id
+     RETURNING runs.id, runs.business_id, runs.source, runs.bundle, runs.identity,
+               runs.status, runs.version, runs.created_at, runs.started_at, runs.finished_at,
+               runs.result_artifact_id, runs.error_evidence_ref, runs.lease_owner,
+               runs.lease_expires_at`,
+    [businessId, DISPATCH_HANDLER_ERROR_REF, DISPATCH_REQUEUED_ONCE_REF, Math.max(0, limit)]
+  );
+  return result.rows.map(persistedRun);
+}

--- a/packages/storage/src/runs/run-store.pg.test.ts
+++ b/packages/storage/src/runs/run-store.pg.test.ts
@@ -1,6 +1,7 @@
 import { PGlite } from "@electric-sql/pglite";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import type { Queryable, TransactionPort } from "../ports";
+import { DISPATCH_HANDLER_ERROR_REF, DISPATCH_REQUEUED_ONCE_REF } from "./run-lease-store";
 import {
   type AttemptEvidence,
   RUN_STORAGE_STATEMENTS,
@@ -362,6 +363,62 @@ describe("RunStore (PostgreSQL)", () => {
       version: 2,
       leaseOwner: null,
       leaseExpiresAt: null,
+    });
+  });
+
+  it("requeues a Run a crashed dispatch handler parked, exactly once", async () => {
+    await store.start(run());
+    await store.transitionRun("business-1", run().id, {
+      expectedVersion: 0,
+      expectedStatus: "queued",
+      status: "claimed",
+      leaseOwner: "worker-1",
+      leaseExpiresAt: "2026-07-24T10:01:00.000Z",
+    });
+    await store.transitionRun("business-1", run().id, {
+      expectedVersion: 1,
+      expectedStatus: "claimed",
+      status: "needs_reconciliation",
+      leaseOwner: null,
+      leaseExpiresAt: null,
+      errorEvidenceRef: DISPATCH_HANDLER_ERROR_REF,
+    });
+
+    const first = await store.requeueParkedRuns("business-1", 10);
+
+    expect(first).toEqual([
+      expect.objectContaining({
+        id: run().id,
+        status: "queued",
+        errorEvidenceRef: DISPATCH_REQUEUED_ONCE_REF,
+      }),
+    ]);
+    // The update consumes the ref it matches on, so a Run can never be requeued a second time.
+    expect(await store.requeueParkedRuns("business-1", 10)).toEqual([]);
+  });
+
+  it("leaves a Run parked for any reason other than a crashed dispatch handler", async () => {
+    await store.start(run());
+    await store.transitionRun("business-1", run().id, {
+      expectedVersion: 0,
+      expectedStatus: "queued",
+      status: "claimed",
+      leaseOwner: "worker-1",
+      leaseExpiresAt: "2026-07-24T10:01:00.000Z",
+    });
+    // An effect may be in flight, so requeueing this Run could double-apply it.
+    await store.transitionRun("business-1", run().id, {
+      expectedVersion: 1,
+      expectedStatus: "claimed",
+      status: "needs_reconciliation",
+      leaseOwner: null,
+      leaseExpiresAt: null,
+      errorEvidenceRef: "tool:ambiguous_effect",
+    });
+
+    expect(await store.requeueParkedRuns("business-1", 10)).toEqual([]);
+    expect(await store.find("business-1", run().id)).toMatchObject({
+      status: "needs_reconciliation",
     });
   });
 

--- a/packages/storage/src/runs/run-store.ts
+++ b/packages/storage/src/runs/run-store.ts
@@ -15,6 +15,7 @@ import {
   claimNextQueuedRunRows,
   heartbeatRun,
   reclaimExpiredRunRows,
+  requeueParkedRunRows,
   requeueWaitingRunRow,
 } from "./run-lease-store";
 import { RunPersistenceError } from "./run-persistence-error";
@@ -562,6 +563,16 @@ export class RunStore {
   ): Promise<readonly PersistedRun[]> {
     return this.transactions.withTransaction((transaction) =>
       reclaimExpiredRunRows(transaction, businessId, now, limit)
+    );
+  }
+
+  /**
+   * Requeues Runs parked by a crashed dispatch handler. Bounded to one requeue per Run by the
+   * evidence ref the update itself consumes.
+   */
+  async requeueParkedRuns(businessId: string, limit: number): Promise<readonly PersistedRun[]> {
+    return this.transactions.withTransaction((transaction) =>
+      requeueParkedRunRows(transaction, businessId, limit)
     );
   }
 


### PR DESCRIPTION
## Summary

- **The error was destroyed.** `RunDispatcher`'s bare `catch {}` parked the Run at `needs_reconciliation` without logging anything, so the only record of why a Run stopped was gone. It now logs run id, business id, source and the error, and records `dispatch:handler_error` as the Run's evidence ref.
- **The park was permanent.** Nothing moves a Run out of `needs_reconciliation`. `reconcile-state.ts` is a *State*-level effect settler — its vocabulary is `succeeded` / `cancelled` / stay-parked, with no path back to `queued` — so it cannot serve this. A new `RunStore.requeueParkedRuns` sweep returns those Runs to `queued` at the top of each dispatch batch. `needs_reconciliation → queued` was already a declared-legal Run transition (`packages/run-kernel/src/model/run.ts:63`); no state-machine change, no migration.
- **Bounded to one requeue, and narrow.** The update both requires `dispatch:handler_error` and overwrites it with `dispatch:requeued_once`, so a second sweep matches nothing. The dispatcher reads that marker and fails a second throw outright (`dispatch:handler_error_after_requeue`) rather than re-parking it in front of the sweep it just came from. A Run parked for any other reason may have an effect in flight and is never touched, so a requeue cannot double-apply one.

Found on staging: a Run whose `child_run` wait was already `satisfied` with `token_consumed_at` set sat parked indefinitely, needing nothing but re-dispatch. `apps/worker/src/routine/concurrency-guard.ts:21` already carried a comment admitting nothing requeues a parked Run.

## Test plan

- [x] `run-dispatcher.test.ts` — handler throw logs run/business/source + error and records the ref; a Run already requeued once fails instead of re-parking
- [x] `run-dispatcher.test.ts` — the sweep runs before claiming and is reported in the batch result
- [x] `run-store.pg.test.ts` — real SQL: a parked Run requeues exactly once, and a Run parked for another reason is left alone
- [x] Red before / green after verified for every new test by stashing only the source change
- [x] `pnpm typecheck` — 40/40 workspaces
- [x] `@tulipfarm/run-kernel` 497 passed · `@tulipfarm/storage` 480 passed · `@tulipfarm/worker` 482 passed
- [x] `test/process/worker.test.ts` failed once under full-suite parallel load, passes alone (6/6) — the env-leak flake AGENTS.md documents, not this diff
- [x] `biome check --write` on all three touched trees