### PR TITLE
fix(observability): log tool-call and model-call failures that were silently swallowed

### DIFF
--- a/apps/api/src/broker/tool-adapter.ts
+++ b/apps/api/src/broker/tool-adapter.ts
@@ -9,6 +9,7 @@ import {
   type RequestContext,
   refuseParkedResult,
   type ToolCallResult,
+  type ToolHostLogger,
 } from "@tulipfarm/tool-host";
 import { jsonSchema, type ToolSet, tool } from "ai";
 import type { BatchCoordinator } from "../tools/batch-executor";
@@ -69,7 +70,8 @@ export class ToolRegistry {
     fullResultCache?: Map<string, ToolCallResult>,
     approvalGate?: ApprovalGate,
     runToolCallGuard?: RunToolCallGuard,
-    allowedToolNames?: ReadonlySet<string>
+    allowedToolNames?: ReadonlySet<string>,
+    logger?: ToolHostLogger
   ): ToolSet {
     let presentationValidationFailures = 0;
     const authorized = allowedToolNames
@@ -163,7 +165,8 @@ export class ToolRegistry {
                 await (coordinator ? coordinator.schedule(executeTool, t.mutating) : executeTool()),
                 t.name
               );
-            } catch {
+            } catch (error) {
+              logger?.error(`tool "${t.name}" raised during execution`, error);
               full = err(
                 "internal_error",
                 isPresentationTool

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1007,6 +1007,7 @@ async function boot() {
           identities: externalIdentityRepo,
           githubInstallationToken: githubTooling.installationToken,
           transactions: runTransactions,
+          logger: { error: (message, error) => app.log.error({ err: error }, message) },
         }),
         approvals: {
           // was minted with — never one the Worker names for itself.

--- a/apps/api/src/internal/tool-dispatch.ts
+++ b/apps/api/src/internal/tool-dispatch.ts
@@ -20,6 +20,7 @@ export type DelegatedToolDispatchDeps = Pick<
   | "surfaceActionStore"
   | "guardrails"
   | "authorityLayers"
+  | "logger"
 > & {
   readonly links: DelegatedAuthorityGuardDeps["links"];
   readonly catalog: DelegatedAuthorityGuardDeps["catalog"];

--- a/apps/worker/src/llm.ts
+++ b/apps/worker/src/llm.ts
@@ -8,7 +8,13 @@ import type {
   ModelResponderRef,
   PrincipalRef,
 } from "@tulipfarm/llm";
-import { isPriceable, LlmService, priceCall, SecretsPrincipalCredentials } from "@tulipfarm/llm";
+import {
+  isPriceable,
+  type LlmLogger,
+  LlmService,
+  priceCall,
+  SecretsPrincipalCredentials,
+} from "@tulipfarm/llm";
 import type { ResolvedLimits } from "@tulipfarm/run-kernel";
 import { resolveModelProfileBudgetLimits } from "@tulipfarm/run-kernel";
 import {
@@ -37,6 +43,8 @@ export interface SoulLlmOptions {
    * corrects only reporting. Failure resolves to no overrides rather than failing the turn.
    */
   pricingOverrides?(): Promise<Record<string, ModelPrice>>;
+  /** Defaults to `console` when absent, same as `LlmService.init`. */
+  logger?: LlmLogger;
 }
 
 export type ModelRoutingPayload = RunEventPayloads["model.routed"];
@@ -375,7 +383,12 @@ export class SoulLlm {
       throw error;
     });
     const secrets = await this.secrets;
-    await this.service.init(config, secrets, undefined, new SecretsPrincipalCredentials(secrets));
+    await this.service.init(
+      config,
+      secrets,
+      this.options.logger,
+      new SecretsPrincipalCredentials(secrets)
+    );
     this.rebuildCatalog(config);
     // Price corrections travel with the config they correct. A failure here must not fail the
     // turn: pricing degrades to the pinned specs and the built-in table, which is what the

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -270,6 +270,7 @@ export async function main(): Promise<void> {
     source: () => turnHost.llmConfig(),
     secrets,
     pricingOverrides: () => turnHost.pricingOverrides(),
+    logger,
   });
 
   // Built from the same published config the control plane embeds with, and rebuilt before each
@@ -306,6 +307,7 @@ export async function main(): Promise<void> {
     embeddings: localEmbeddings,
     // `file_create` renders here, not in the API: model-authored content is untrusted input.
     blobs,
+    logger,
   });
   const toolDispatch = new RoutingToolDispatch(localTools, turnHost, turnHost, logger);
 

--- a/apps/worker/src/tools/local-host.ts
+++ b/apps/worker/src/tools/local-host.ts
@@ -26,6 +26,7 @@ import {
   RegistryToolDispatcher,
   type RequestContext,
   ToolApprovalService,
+  type ToolHostLogger,
   type TurnToolDispatcher,
   toToolDef,
 } from "@tulipfarm/tool-host";
@@ -67,6 +68,7 @@ export interface LocalToolHostOptions {
   readonly blobs: BlobPort;
   /** Defaults to `randomUUID`; present so a test can make an id predictable. */
   readonly newId?: () => string;
+  readonly logger?: ToolHostLogger;
 }
 
 export interface LocalToolHost {
@@ -194,6 +196,7 @@ export function buildLocalToolHost(options: LocalToolHostOptions): LocalToolHost
       // No `agents` resolver: this process has no Soul to resolve one from. The Agent's authored
       // autonomy and capability restrictions ride in on `TurnAuthority.agent`, which the control
       // plane fills in from the Soul when the Worker reads the Run's authority.
+      ...(options.logger === undefined ? {} : { logger: options.logger }),
     })
   );
 

--- a/packages/llm/src/fallback.ts
+++ b/packages/llm/src/fallback.ts
@@ -9,6 +9,8 @@ import { classifyProviderError } from "./provider-error";
 /** Minimal logger surface for fallback events (pino/console compatible). */
 export interface FallbackLogger {
   warn(msg: string): void;
+  /** Falls back to `warn` when absent, so an existing caller need not be widened to keep compiling. */
+  error?(msg: string): void;
 }
 
 /**
@@ -309,7 +311,9 @@ export class FallbackModel implements LanguageModelV4 {
   }
 
   private logExhausted(err: unknown): void {
-    this.logger.warn(
+    // Terminal for this call, not routine — captured at error level so it reaches the durable log
+    // store instead of vanishing with the rest of `warn`.
+    (this.logger.error ?? this.logger.warn)(
       `[llm] all providers exhausted models=${this.modelId} reason=${errorReason(err)}`
     );
   }

--- a/packages/tool-host/src/dispatcher.ts
+++ b/packages/tool-host/src/dispatcher.ts
@@ -42,7 +42,7 @@ import type {
 import { type AuthorityPrincipal, principalKindOf } from "./principal";
 import { findChatRequest, presentationContextForAuthority } from "./request";
 import type { SurfaceActionStore, SurfaceArtifactStore } from "./surface-ports";
-import type { ParkableToolDef, RequestContext } from "./types";
+import type { ParkableToolDef, RequestContext, ToolHostLogger } from "./types";
 
 /**
  * Used when no `AgentResolver` was composed. It carries no `toolAllowlist`, which means the whole
@@ -91,6 +91,8 @@ export interface RegistryToolDispatcherOptions {
   readonly executeTimeoutMs?: number;
   /** Host cancellation — Run cancellation or drain — delivered to the Tool as `abortSignal`. */
   readonly abortSignal?: AbortSignal;
+  /** Reports an uncaught Tool throw, which a `ToolCallResult` cannot carry on its own. */
+  readonly logger?: ToolHostLogger;
   now?(): Date;
 }
 
@@ -539,6 +541,7 @@ export class RegistryToolDispatcher implements TurnToolDispatcher {
         : { timeoutMs: this.options.executeTimeoutMs }),
       ...(ledger === undefined ? {} : { ledger }),
       ...(reservation === undefined ? {} : { reservation }),
+      ...(this.options.logger === undefined ? {} : { logger: this.options.logger }),
     });
   }
 }

--- a/packages/tool-host/src/execution.ts
+++ b/packages/tool-host/src/execution.ts
@@ -7,6 +7,7 @@ import type {
   ParkableToolDef,
   RequestContext,
   ToolErrorCode,
+  ToolHostLogger,
 } from "./types";
 import { isIndeterminateFault, isInfrastructureFault, isParked } from "./types";
 
@@ -46,6 +47,7 @@ export interface ToolAttemptInput {
   readonly timeoutMs?: number;
   readonly ledger?: ChatEffectLedger;
   readonly reservation?: EffectReservation;
+  readonly logger?: ToolHostLogger;
 }
 
 /** Retry only infrastructure faults with budget; mutating Tools need explicit `safeToRetry`. */
@@ -93,8 +95,9 @@ export async function runToolAttempts(input: ToolAttemptInput): Promise<HostedTo
         input.context,
         executeTimeoutFor(tool, input.timeoutMs)
       );
-    } catch {
+    } catch (error) {
       // Throws are unknown phase: never retry, and settle ledgered writes as `ambiguous`.
+      input.logger?.error(`tool "${call.name}" raised during execution`, error);
       await settle("ambiguous", "tool_raised");
       return { status: "failed", reason: `tool "${call.name}" raised an internal error` };
     }

--- a/packages/tool-host/src/index.ts
+++ b/packages/tool-host/src/index.ts
@@ -155,6 +155,7 @@ export {
   type ToolCallResult,
   type ToolDef,
   type ToolErrorCode,
+  type ToolHostLogger,
   type ToolPark,
   type ToolTier,
 } from "./types";

--- a/packages/tool-host/src/types.ts
+++ b/packages/tool-host/src/types.ts
@@ -126,6 +126,11 @@ export const err = (code: ToolErrorCode, message: string, connectUrl?: string): 
   error: { code, message, ...(connectUrl === undefined ? {} : { connectUrl }) },
 });
 
+/** Reports a Tool-host failure that a `ToolCallResult` cannot carry, e.g. an uncaught throw. */
+export interface ToolHostLogger {
+  error(message: string, error?: unknown): void;
+}
+
 export type ChatAutonomy = "full" | "supervised" | "approval-required" | "manual";
 export interface ClientContext {
   route?: string;


### PR DESCRIPTION
## Summary
- `runToolAttempts` (tool-host) and the model-facing `ToolRegistry` adapter caught uncaught Tool throws and returned an error to the model with no log line at all.
- LLM fallback exhaustion logged at `warn`, below the `error`/`fatal` threshold the durable `log_event` store captures, so a fully-exhausted chain was invisible to the log viewer.
- The worker built its `LlmService` with no logger, defaulting to raw `console` (the API already passed `app.log`).

Threads a new optional `ToolHostLogger` through `RegistryToolDispatcherOptions`/`ToolAttemptInput` and wires it at both dispatch composition points (`apps/api/src/index.ts` → `app.log`, `apps/worker/src/main.ts` → the worker's structured logger). Promotes `logExhausted` to `error` level. Threads the worker's logger into `SoulLlm` → `LlmService.init`.

## Test plan
- [x] `pnpm --filter @tulipfarm/tool-host typecheck`
- [x] `pnpm --filter @tulipfarm/llm typecheck`
- [x] `pnpm --filter @tulipfarm/api typecheck`
- [x] `pnpm --filter @tulipfarm/worker typecheck`
- [x] `pnpm exec biome check --write` on all touched files
- [ ] Unit tests not run (not requested)