### PR TITLE
fix(deploy): reclaim the image each update orphans

### DIFF
--- a/apps/docs/content/docs/reference/commands.mdx
+++ b/apps/docs/content/docs/reference/commands.mdx
@@ -17,6 +17,7 @@ TulipFarm ships both a self-hosted Docker Compose lane and a pnpm + Turborepo so
 | `curl -fsSLO {{SITE_URL}}/env.example` | Downloads the documented production environment template. |
 | `docker compose up -d` | Starts or updates the self-hosted stack from the current `docker-compose.yml` and `.env`. |
 | `docker compose pull` | Pulls newer images for the stack. run before `docker compose up -d` when updating manually. |
+| `docker image prune -f` | Deletes untagged images, reclaiming the one each update replaced. Run after `docker compose up -d`; tagged images are never touched. |
 | `docker compose logs -f app` | Follows API/app logs for a self-hosted stack. |
 | `docker compose logs -f worker` | Follows durable run worker logs. |
 | `docker compose logs -f integration-worker` | Follows integration-worker logs. |

--- a/apps/docs/content/docs/self-hosting/docker-compose.mdx
+++ b/apps/docs/content/docs/self-hosting/docker-compose.mdx
@@ -197,8 +197,12 @@ both workers wait for healthy `app` because they never migrate.
 Migrations apply automatically on boot, and there are **no down-migrations**. Read
 [Updating and rollback](/docs/self-hosting/updating) before your first upgrade.
 
+The trailing `image prune` reclaims the image this update replaced. Without it every update
+leaves a whole orphaned image (~4.5 GB) on disk, and a regularly updated instance runs out.
+It removes only untagged images, so anything else on the same engine keeps its images.
+
 ```bash
-docker compose pull && docker compose up -d
+docker compose pull && docker compose up -d && docker image prune -f
 ```
 
 > **Verify.** `http://localhost:8080/readyz` answers `200` within 120s.

--- a/apps/docs/content/docs/self-hosting/updating.mdx
+++ b/apps/docs/content/docs/self-hosting/updating.mdx
@@ -44,8 +44,14 @@ curl -fsSL {{SITE_URL}}/install.sh | sudo bash
 **Docker Compose:**
 
 ```bash
-docker compose pull && docker compose up -d
+docker compose pull && docker compose up -d && docker image prune -f
 ```
+
+The `docker compose pull` moves the `latest` tag to the new image and leaves the old one
+behind, untagged. Nothing reclaims it on its own, so without the trailing `docker image
+prune -f` each update costs another ~4.5 GB and a regularly updated instance eventually
+fills its disk. The prune removes only *untagged* images, never one another stack still
+references by tag.
 
 **Pinned installs:** bump `TULIPFARM_VERSION` in `.env` first, then pull and up. The
 Compose file uses that one value for `app`, `worker`, and `integration-worker`, keeping the

--- a/deploy/deploy.txt
+++ b/deploy/deploy.txt
@@ -770,7 +770,11 @@ Step 8: Update
 Migrations apply automatically on boot, and there are **no down-migrations**. Read
 [Updating and rollback](https://tulipfarm.site/docs/self-hosting/updating) before your first upgrade.
 
-  run: docker compose pull && docker compose up -d
+The trailing `image prune` reclaims the image this update replaced. Without it every update
+leaves a whole orphaned image (~4.5 GB) on disk, and a regularly updated instance runs out.
+It removes only untagged images, so anything else on the same engine keeps its images.
+
+  run: docker compose pull && docker compose up -d && docker image prune -f
   Verify (http): GET http://localhost:8080/readyz returns 200 within 120s.
   On fail: https://tulipfarm.site/docs/self-hosting/when-install-fails#readyz
 

--- a/deploy/targets/docker-compose/manifest.yml
+++ b/deploy/targets/docker-compose/manifest.yml
@@ -210,7 +210,11 @@ steps:
     body: |
       Migrations apply automatically on boot, and there are **no down-migrations**. Read
       [Updating and rollback](/docs/self-hosting/updating) before your first upgrade.
-    run: docker compose pull && docker compose up -d
+
+      The trailing `image prune` reclaims the image this update replaced. Without it every update
+      leaves a whole orphaned image (~4.5 GB) on disk, and a regularly updated instance runs out.
+      It removes only untagged images, so anything else on the same engine keeps its images.
+    run: docker compose pull && docker compose up -d && docker image prune -f
     verify:
       kind: http
       url: http://localhost:8080/readyz

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -450,6 +450,16 @@ bring_up() {
   compose up -d || die "compose up failed — see logs above"
 }
 
+# `compose pull` leaves the image it replaced on disk with its tag moved away, and nothing else
+# ever reclaims it. An instance that updates daily grew by a whole image (~4.5 GB) each time until
+# a later pull ran the disk out. Dangling-only by design: `-f` without `-a` skips every tagged
+# image, so a co-tenant stack on the same engine keeps its images.
+prune_orphaned_images() {
+  log "Removing images orphaned by this update…"
+  $SUDO $ENGINE image prune -f >/dev/null 2>&1 \
+    || warn "could not prune orphaned images — reclaim them later with '${ENGINE} image prune -f'"
+}
+
 wait_health() {
   log "Waiting for TulipFarm to become healthy…"
   local _
@@ -483,6 +493,7 @@ main() {
   write_install_marker
   bring_up
   wait_health
+  prune_orphaned_images
 }
 
 if [[ -z "${BASH_SOURCE[0]:-}" || "${BASH_SOURCE[0]}" = "$0" ]]; then


### PR DESCRIPTION
## Summary

- `docker compose pull` retags to the new image and leaves the old one untagged; nothing reclaimed it, so each update cost another ~4.5 GB.
- Staging hit **91% full** — 19.27 GB across five orphaned images, one update short of running out of disk mid-pull.
- Prune dangling images after the stack reports healthy, in the installer and in every documented update path.

## Why dangling-only, and why after health

`docker image prune -f` (no `-a`) skips every tagged image, so another stack sharing the engine keeps its images. Running it after `wait_health` means a failed update still has the image it replaced sitting there to fall back on.

## Test plan

- [x] `bash -n scripts/install.sh`
- [x] `pnpm exec vitest run scripts/deploy-prompt.test.ts scripts/installer-project-name.test.ts scripts/deploy-wizard.test.ts` — 194 passed
- [x] `pnpm --filter @tulipfarm/deploy-render test` — 25 passed
- [x] `deploy/deploy.txt` + generated docs regenerated, drift test green
- [x] `biome check` clean
- [x] Prune verified on staging: 91% → 27%, 19.27 GB reclaimed, all 5 containers still running