### PR TITLE
fix(tools): stop flagging api-version headers as credentials

### DIFF
--- a/apps/api/src/tools/network/tools.test.ts
+++ b/apps/api/src/tools/network/tools.test.ts
@@ -281,6 +281,23 @@ describe("network Tool handlers", () => {
     }
   );
 
+  it.each(["X-GitHub-Api-Version", "X-Api-Version"])(
+    "allows %s, since naming an api version is not carrying a credential",
+    async (header) => {
+      const send = vi.fn(async () => ({
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: { ok: true },
+      }));
+      await apiRequestTool.handler(
+        { url: "https://api.example.com/me", method: "GET", headers: { [header]: "2022-11-28" } },
+        context({ http: { send } })
+      );
+
+      expect(send).toHaveBeenCalled();
+    }
+  );
+
   it.each(["accept", "content-type", "user-agent", "x-request-id", "if-none-match"])(
     "still allows the ordinary header %s",
     async (header) => {

--- a/apps/api/src/tools/network/tools.ts
+++ b/apps/api/src/tools/network/tools.ts
@@ -70,9 +70,17 @@ const CREDENTIAL_HEADERS = new Set([
   "x-goog-api-key",
 ]);
 
-/** The words that make a header name a credential, whatever separator a vendor chose. */
+/**
+ * The words that make a header name a credential, whatever separator a vendor chose.
+ *
+ * Deliberately excludes the bare word "api": it names a namespace or a version
+ * (`X-GitHub-Api-Version`, `X-Api-Version`), not a secret, and every vendor header that actually
+ * carries one pairs "api" with a word already in this list (`x-api-key`, `x-goog-api-key`), so
+ * dropping "api" alone loses no real credential while it stops flagging version/negotiation
+ * headers.
+ */
 const CREDENTIAL_WORDS =
-  /(^|-)(api|access|auth|authentication|authorization|bearer|credential|jwt|key|passwd|password|secret|session|signature|token)(-|$)/;
+  /(^|-)(access|auth|authentication|authorization|bearer|credential|jwt|key|passwd|password|secret|session|signature|token)(-|$)/;
 
 /**
  * Any header whose name reads as a key, token, secret or password, in any vendor's spelling.


### PR DESCRIPTION
## Summary
- The network Tool's credential heuristic (`CREDENTIAL_WORDS` in `apps/api/src/tools/network/tools.ts`) matched the bare word `api` in any header name, so `X-GitHub-Api-Version` was refused as if it carried a secret — 5 denials observed on staging blocked legitimate GitHub API calls.
- Removed `api` from `CREDENTIAL_WORDS`. Every header that genuinely carries a credential already pairs `api` with another cred word in the list (`key`, `auth`, `token`, `secret`) — e.g. `x-api-key`, `x-goog-api-key`, `x-amz-security-token` — so this loses no real detection while no longer flagging version/negotiation headers.
- Added colocated Vitest cases asserting `X-GitHub-Api-Version` and `X-Api-Version` are allowed, alongside the existing coverage that credential-bearing headers (`X-Api-Key`, `X_API_KEY`, `X-AuthToken`, etc.) are still rejected.

## Staging evidence
5 occurrences of the denial on staging:
```
header "X-GitHub-Api-Version" carries a credential: name a stored Credential in "credential" instead, so the Secret is leased, approved and audited
```

## Test plan
- [x] `pnpm exec biome check --write apps/api/src/tools/network` — no issues
- [x] `pnpm --filter @tulipfarm/api test src/tools/network` — 53/53 passed
- [x] New test verified to fail before the fix (stashed `tools.ts`) and pass after
- [x] `pnpm typecheck` — all 40 workspaces pass