### PR TITLE
fix(integrations): fix GitHub webhook 404s and wire bundled ingress

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1030,6 +1030,7 @@ async function boot() {
           threads: integrationThreads,
           integrationEvents,
           soulLoader,
+          bundled: bundledIntegrations,
           identity: new IngressIdentityResolver({
             users: userRepo,
             log,
@@ -1272,6 +1273,7 @@ async function boot() {
       }),
       ingress: {
         soulLoader,
+        bundled: bundledIntegrations,
         deliveries: ingressDeliveries,
         invoke: integrationInvoker(invocations),
         resolveSecret: (value) => resolveSecretRef(value, secretsService),

--- a/apps/api/src/ingress/routes.test.ts
+++ b/apps/api/src/ingress/routes.test.ts
@@ -1,4 +1,4 @@
-import type { SoulIntegration, SoulLoader } from "@tulipfarm/soul";
+import type { BundledIntegration, SoulIntegration, SoulLoader } from "@tulipfarm/soul";
 import type { FastifyInstance, LightMyRequestResponse } from "fastify";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildApp } from "../app";
@@ -57,13 +57,15 @@ describe("POST /api/v1/hooks/integrations/:name", () => {
 
   async function build(
     integrations: SoulIntegration[] = [makeIntegration()],
-    resolveSecret?: (value: string) => Promise<string | undefined>
+    resolveSecret?: (value: string) => Promise<string | undefined>,
+    bundled: ReadonlyMap<string, BundledIntegration> = new Map()
   ) {
     enqueue = vi.fn(async (_job: IngressJobPayload) => {});
     seen = new Set();
     app = await buildApp({
       ingress: {
         soulLoader: makeSoulLoader(integrations),
+        bundled,
         deliveries: {
           recordDelivery: async (slug: string, key: string) => {
             const composite = `${slug}:${key}`;
@@ -305,5 +307,97 @@ describe("POST /api/v1/hooks/integrations/:name", () => {
     });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toEqual({ isBuffer: false, body: { a: 1 } });
+  });
+});
+
+describe("bundled (code-owned) integrations", () => {
+  let app: FastifyInstance;
+  let enqueue: ReturnType<typeof vi.fn>;
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  /**
+   * A bundled integration (github, slack) writes only `connection.yaml` into Soul on install —
+   * never `manifest.yml` (that stays code-owned). So `soulLoader.integrations.get(slug)` alone
+   * returns `{ slug, sourceIntegration, connection }` with no `manifest` and no `ingressHandler`
+   * at all, regardless of what the bundled manifest declares. Regression: the route used to read
+   * only `soulLoader`, so every bundled integration's ingress 404'd unconditionally — this is
+   * exactly what GitHub hit in production (195 webhooks, all 404, zero rows ever ingested).
+   */
+  it("resolves ingress from the bundled manifest merged with live Soul connection state", async () => {
+    enqueue = vi.fn(async (_job: IngressJobPayload) => {});
+    const bundledManifest: BundledIntegration = {
+      manifest: {
+        name: "github",
+        egress: { type: "none" },
+        ingress: {
+          handler: "ingress.ts",
+          webhook: {
+            security: {
+              type: "hmac_sha256",
+              header: "X-Hub-Signature-256",
+              secret_env: "GITHUB_WEBHOOK_SECRET",
+              format: "sha256={hex}",
+            },
+            dedup_header: "X-GitHub-Delivery",
+            context_headers: ["X-GitHub-Event"],
+          },
+        },
+      },
+      ingressHandlerFile: { file: "ingress.ts", raw: "({ classify() {} })" },
+    };
+    // Soul only ever carries connection state for a bundled slug — no manifest, no ingressHandler.
+    const soulOnlyConnection = {
+      slug: "github",
+      sourceIntegration: "github",
+      connection: { enabled: true, env: { GITHUB_WEBHOOK_SECRET: SECRET } },
+    } as SoulIntegration;
+
+    app = await buildApp({
+      ingress: {
+        soulLoader: makeSoulLoader([soulOnlyConnection]),
+        bundled: new Map([["github", bundledManifest]]),
+        deliveries: { recordDelivery: async () => true } as never,
+        invoke: enqueue as (job: IngressJobPayload) => Promise<void>,
+      },
+    });
+
+    const body = JSON.stringify({ action: "opened" });
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/hooks/integrations/github",
+      headers: {
+        "content-type": "application/json",
+        "x-hub-signature-256": computeHmacSignature(body, { format: "sha256={hex}" }, SECRET),
+        "x-github-delivery": "d-1",
+        "x-github-event": "issues",
+      },
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(enqueue).toHaveBeenCalledTimes(1);
+  });
+
+  it("still 404s a bundled slug with no matching Soul connection at all", async () => {
+    enqueue = vi.fn(async (_job: IngressJobPayload) => {});
+    app = await buildApp({
+      ingress: {
+        soulLoader: makeSoulLoader([]),
+        bundled: new Map(),
+        deliveries: { recordDelivery: async () => true } as never,
+        invoke: enqueue as (job: IngressJobPayload) => Promise<void>,
+      },
+    });
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/hooks/integrations/github",
+      headers: { "content-type": "application/json" },
+      payload: "{}",
+    });
+    expect(res.statusCode).toBe(404);
+    expect(enqueue).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/ingress/routes.ts
+++ b/apps/api/src/ingress/routes.ts
@@ -1,7 +1,8 @@
-import type { SoulLoader } from "@tulipfarm/soul";
+import type { BundledIntegration, SoulLoader } from "@tulipfarm/soul";
 import type { FastifyInstance } from "fastify";
 import { ErrorSchema } from "../auth/schemas";
 import { isSecretRef } from "../integrations/connection-env";
+import { resolveIngressIntegration } from "../integrations/ingress-integration";
 import type { IngressDeliveriesRepo } from "./repo";
 import { verifyWebhookRequest } from "./signature";
 import { dotPath, matchesBody, renderBodyTemplate } from "./template";
@@ -14,6 +15,8 @@ export interface IngressJobPayload {
 
 export interface IngressRoutesDeps {
   soulLoader: SoulLoader;
+  /** Bundled (code-owned) integrations, merged with live Soul connection state per delivery. */
+  bundled: ReadonlyMap<string, BundledIntegration>;
   deliveries: IngressDeliveriesRepo;
   invoke: (job: IngressJobPayload) => Promise<void>;
   /** Resolves a `secret://` env value to plaintext; plaintext values need no resolver. */
@@ -65,15 +68,26 @@ export async function registerIngressRoutes(
       },
       async (req, reply) => {
         const { name } = req.params as { name: string };
-        const integration = deps.soulLoader.integrations.get(name);
+        const integration = resolveIngressIntegration(deps.soulLoader, deps.bundled, name);
         if (!integration) return reply.code(404).send(NOT_FOUND);
 
         const ingress = integration.manifest?.ingress;
         if (!ingress?.webhook || !ingress.handler || !integration.ingressHandler) {
+          // Never reveal in the response that `name` names a real, installed integration — but
+          // a delivery arriving for one that genuinely has no ingress support is an operator
+          // misconfiguration (a stale provider-side webhook URL, most likely), not a scan. Log it
+          // so it is visible in server logs even though the response must stay a generic 404.
+          req.log.warn({ integration: name }, "ingress delivery received but no ingress declared");
           return reply.code(404).send(NOT_FOUND);
         }
         const connection = integration.connection;
-        if (!connection?.enabled) return reply.code(404).send(NOT_FOUND);
+        if (!connection?.enabled) {
+          req.log.warn(
+            { integration: name },
+            "ingress delivery received but the integration is not connected"
+          );
+          return reply.code(404).send(NOT_FOUND);
+        }
 
         const security = ingress.webhook.security;
         if (security?.type !== "hmac_sha256" && security?.type !== "shared_secret") {

--- a/apps/api/src/integrations/auth-broker.ts
+++ b/apps/api/src/integrations/auth-broker.ts
@@ -211,7 +211,14 @@ export async function startAuthStep(input: StartAuthStepInput): Promise<AuthStar
     case "app_manifest": {
       const state = await issueState(input, null);
       const org = input.org?.trim();
-      const vars = integrationAuthEndpointVars(input.endpoints, input.env);
+      // `{webhook_url}` is available here too (not just to a `webhook` step) so a provider
+      // manifest that registers its own hook inline — GitHub's `hook_attributes.url` — can point
+      // at this deployment's real ingress route instead of a hand-typed path that can drift from
+      // it (see apps/api/src/ingress/routes.ts's actual route pattern).
+      const vars = {
+        ...integrationAuthEndpointVars(input.endpoints, input.env),
+        webhook_url: ingressWebhookUrl(input.endpoints, input.slug),
+      };
       // An org can only be targeted through a template the step opts into; a step with no
       // create_url_for_org silently falls back to its personal-account create_url.
       const createUrl = org && step.create_url_for_org ? step.create_url_for_org : step.create_url;

--- a/apps/api/src/integrations/ingress-integration.ts
+++ b/apps/api/src/integrations/ingress-integration.ts
@@ -1,0 +1,37 @@
+import { createHash } from "node:crypto";
+import type { BundledIntegration, SoulIntegration, SoulLoader } from "@tulipfarm/soul";
+
+/**
+ * A bundled integration (GitHub, Slack) is code-owned: install writes only `connection.yaml`
+ * into Soul, never `manifest.yml` (`integrations/routes.ts`'s install path refuses to). So
+ * `soulLoader.integrations` alone never carries a bundled integration's `manifest.ingress`
+ * declaration or its classifier source — only live connection state. The ingress webhook route
+ * and the Worker's delivery-host callback both need the bundled manifest and handler merged back
+ * in, and computed live (not cached at boot) so a reinstall or disconnect is reflected
+ * immediately, the same way `soulLoader.integrations` itself is live.
+ */
+export function resolveIngressIntegration(
+  soulLoader: SoulLoader,
+  bundled: ReadonlyMap<string, BundledIntegration>,
+  slug: string
+): SoulIntegration | undefined {
+  const bundledEntry = bundled.get(slug);
+  const soulEntry = soulLoader.integrations.get(slug);
+  if (!bundledEntry) return soulEntry;
+
+  const handlerFile = bundledEntry.ingressHandlerFile;
+  return {
+    slug,
+    sourceIntegration: bundledEntry.manifest.name,
+    manifest: bundledEntry.manifest,
+    connection: soulEntry?.connection,
+    setupGuide: bundledEntry.setupGuide ?? soulEntry?.setupGuide,
+    ingressHandler: handlerFile
+      ? {
+          source: handlerFile.raw,
+          hash: createHash("sha256").update(handlerFile.raw).digest("hex"),
+        }
+      : undefined,
+    egressSpec: bundledEntry.egressSpec,
+  };
+}

--- a/apps/api/src/internal/delivery-host.test.ts
+++ b/apps/api/src/internal/delivery-host.test.ts
@@ -231,6 +231,7 @@ async function harness(
       },
     } as unknown as IntegrationEventsRepo,
     soulLoader: soul,
+    bundled: new Map(),
     identity: {
       resolve:
         options.resolve ??

--- a/apps/api/src/internal/delivery-host.ts
+++ b/apps/api/src/internal/delivery-host.ts
@@ -8,7 +8,12 @@ import {
   requestArtifactId,
 } from "@tulipfarm/run-kernel";
 import { CHAT_REQUEST_SCHEMA_REF, contentText, textContent } from "@tulipfarm/schema";
-import { type ChatIngressConfig, resolveAgent, type SoulLoader } from "@tulipfarm/soul";
+import {
+  type BundledIntegration,
+  type ChatIngressConfig,
+  resolveAgent,
+  type SoulLoader,
+} from "@tulipfarm/soul";
 import { DOMAIN_EVENTS, type IntegrationEventPayload } from "@tulipfarm/storage";
 import { asChatAutonomy, type ChatAutonomy } from "@tulipfarm/tool-host";
 import type { FastifyBaseLogger } from "fastify";
@@ -20,6 +25,7 @@ import type { IntegrationConversationsRepo, IntegrationEventsRepo } from "../ing
 import { postReply } from "../ingress/responder";
 import { dotPath, renderBodyTemplate } from "../ingress/template";
 import { isSecretRef } from "../integrations/connection-env";
+import { resolveIngressIntegration } from "../integrations/ingress-integration";
 import type { HostedRunReader } from "./turn-host";
 
 /** Delivery host: re-derive delivery facts from the Run; never send bind links/text to Worker. */
@@ -98,6 +104,8 @@ export interface IngressDeliveryHostOptions {
   readonly threads: IntegrationConversationsRepo;
   readonly integrationEvents: IntegrationEventsRepo;
   readonly soulLoader: SoulLoader;
+  /** Bundled (code-owned) integrations; see `resolveIngressIntegration`. */
+  readonly bundled: ReadonlyMap<string, BundledIntegration>;
   readonly identity: Pick<IngressIdentityResolver, "resolve">;
   /** The Integration's own MCP tools, used for identity lookups and replies. */
   readonly toolRegistry?: ToolRegistry;
@@ -456,7 +464,11 @@ export class IngressDeliveryHost {
       headers?: Record<string, string>;
     };
 
-    const integration = this.options.soulLoader.integrations.get(envelope.slug);
+    const integration = resolveIngressIntegration(
+      this.options.soulLoader,
+      this.options.bundled,
+      envelope.slug
+    );
     const ingress = integration?.manifest?.ingress;
     const handler = integration?.ingressHandler;
     if (!integration?.connection?.enabled || ingress === undefined || handler === undefined) {

--- a/apps/api/src/soul/integrations/bundled-auth.test.ts
+++ b/apps/api/src/soul/integrations/bundled-auth.test.ts
@@ -265,4 +265,40 @@ describe("slack manifest", () => {
     // Slack lists its bot scopes twice — in the app manifest and again on the authorize URL.
     expect(new Set(labels).size).toBe(labels.length);
   });
+
+  it("declares ingress with a handler and a secret name the auth flow actually seals", async () => {
+    const bundled = await loadBundledIntegrations(logger);
+    const manifest = bundled.get("github")?.manifest;
+    if (!manifest) throw new Error("github is not bundled");
+
+    expect(manifest.ingress?.handler).toBe("ingress.ts");
+    expect(manifest.ingress?.webhook.security.secret_env).toBe("GITHUB_WEBHOOK_SECRET");
+    // Same posture as the Soul loader: a channel that can't verify a delivery must be rejected at
+    // load, not discovered the first time GitHub retries a webhook forever.
+    expect(validateAuthSteps(manifest)).toEqual([]);
+  });
+
+  it("registers the App's webhook at this deployment's real ingress route", async () => {
+    // Regression: hook_attributes.url used to be hand-typed as
+    // `{api_url}/api/v1/integrations/github/webhook`, which resolved to a URL that was never a
+    // registered route (the real one is `/api/v1/hooks/integrations/:name`). GitHub delivered to
+    // it and got 404 forever — this is what `{webhook_url}` now prevents from drifting again.
+    const bundled = await loadBundledIntegrations(logger);
+    const manifest = bundled.get("github")?.manifest;
+    if (!manifest) throw new Error("github is not bundled");
+
+    const action = await startAuthStep({
+      slug: "github",
+      manifest,
+      stepIndex: 0,
+      env: {},
+      endpoints,
+      repo: new MemoryRepo(),
+    });
+    if (action.action !== "form_post") throw new Error("expected form_post");
+    const submitted = JSON.parse(action.value) as { hook_attributes: { url: string } };
+    expect(submitted.hook_attributes.url).toBe(
+      `${endpoints.apiUrl}/api/v1/hooks/integrations/github`
+    );
+  });
 });

--- a/integrations/github/ingress.ts
+++ b/integrations/github/ingress.ts
@@ -1,0 +1,20 @@
+// GitHub ingress classifier for TulipFarm. Runs inside the host's isolated-vm sandbox as a
+// pure function — no network, no filesystem, no timers. GitHub is events-only ingress: every
+// verified webhook delivery becomes an integration.event that routines can trigger on; there
+// is no chat surface. The event name lives in the X-GitHub-Event header (declared via the
+// manifest's context_headers), and the body's `action` narrows it (issues.opened,
+// pull_request.closed, …). Authored as an object-literal expression (same contract as routine
+// hooks.ts).
+({
+  classify(ctx) {
+    const headers = ctx.headers || {};
+    const eventName = String(headers["x-github-event"] == null ? "" : headers["x-github-event"]);
+    if (!eventName) return { kind: "ignore", reason: "missing x-github-event header" };
+    // GitHub's webhook-creation ping — the 200 ack is all it wants.
+    if (eventName === "ping") return { kind: "ignore", reason: "ping" };
+
+    const body = ctx.body || {};
+    const action = typeof body.action === "string" && body.action ? "." + body.action : "";
+    return { kind: "event", eventType: eventName + action, payload: body };
+  },
+});

--- a/integrations/github/manifest.yml
+++ b/integrations/github/manifest.yml
@@ -30,6 +30,21 @@ grants:
     description: Read repository names and settings. GitHub requires this for any App.
 egress:
   type: none
+# GitHub is events-only ingress: every verified webhook delivery becomes an integration.event
+# that routines can trigger on; there is no chat surface, so no `chat` block below. The classifier
+# is `ingress.ts`, vendored byte-identical at apps/api/src/ingress/__fixtures__/github-ingress.hook.txt
+# and asserted against the real sandbox by apps/api/src/ingress/github-parity.fixture.test.ts.
+ingress:
+  handler: ingress.ts
+  webhook:
+    security:
+      type: hmac_sha256
+      header: X-Hub-Signature-256
+      secret_env: GITHUB_WEBHOOK_SECRET
+      format: "sha256={hex}"
+    dedup_header: X-GitHub-Delivery
+    context_headers:
+      - X-GitHub-Event
 auth:
   # 1. GitHub creates the App from this definition and hands back every credential for a one-time
   #    code, so nothing is copied by hand. There is no TulipFarm-owned App: the App this creates
@@ -55,7 +70,10 @@ auth:
       # "Not connected" no matter how many times the operator installs the App.
       setup_url: "{callback_url}"
       hook_attributes:
-        url: "{api_url}/api/v1/integrations/github/webhook"
+        # This deployment's real ingress route (apps/api/src/ingress/routes.ts), supplied by the
+        # host. Was previously hand-typed as a path that was never a registered route at all —
+        # every delivery 404'd and nothing was ever ingested.
+        url: "{webhook_url}"
         active: true
       public: false
       # Mirrors the locked base-install set in docs/architecture/github-app-manifest.md.


### PR DESCRIPTION
## Summary

GitHub delivered 195 webhook POSTs to `https://stg.tulipfarm.site/api/v1/integrations/github/webhook` in a ~15 minute window on 2026-08-30 — all 404. `integration_events` on staging holds 0 rows despite an `active` `github:155744500` integration row. Root cause was two compounding code bugs, not just staging misconfiguration:

- **Wrong URL (the direct cause of the 195×404):** `integrations/github/manifest.yml`'s `hook_attributes.url` was hardcoded to `{api_url}/api/v1/integrations/github/webhook`, which was never a registered route. `renderTemplate` resolves `{api_url}` silently, so the wrong-but-plausible URL never surfaced as an error — it's exactly what GitHub was told to hit and exactly what 404'd.
- **Even the correct route would have 404'd too:** `/api/v1/hooks/integrations/github` genuinely didn't resolve, for two stacked reasons: (1) the manifest declared no `ingress` block at all, despite a fully-tested classifier fixture (`apps/api/src/ingress/__fixtures__/github-ingress.hook.txt` + `github-parity.fixture.test.ts`) sitting unused; (2) even fixing (1), a bundled integration's install only ever writes `connection.yaml` into Soul, never `manifest.yml` — so `soulLoader.integrations.get(name)`, which is all `apps/api/src/ingress/routes.ts` and `apps/api/src/internal/delivery-host.ts` read, never carries a bundled integration's manifest/ingress handler at all, by design (`packages/soul/src/soul-loader.test.ts:83-86` asserts exactly this). This made *every* bundled integration's ingress structurally impossible, not just GitHub's.

- Template GitHub's `hook_attributes.url` from `{webhook_url}`, now made available to `app_manifest` auth steps (previously only `webhook`-kind steps got it), so the URL can never drift from the real route again.
- Declare `github`'s `ingress` block (HMAC security, dedup header, context headers) pointing at the classifier that already existed as a tested fixture but was never wired to a manifest; vendor it as `integrations/github/ingress.ts`.
- Add `resolveIngressIntegration()` (`apps/api/src/integrations/ingress-integration.ts`) to live-merge a bundled integration's manifest/handler with its Soul connection state, and use it in both the ingress route and the Worker delivery-host callback — closing the structural gap for every bundled integration, not just GitHub.

## Manual follow-up required (staging)

The already-created GitHub App (`github:155744500`) has its webhook URL persisted server-side on GitHub's end; this fix only affects *new* App creations going forward. Someone needs to update the existing App's webhook URL by hand in GitHub App settings to:

```
https://stg.tulipfarm.site/api/v1/hooks/integrations/github
```

## Test plan

- [x] `pnpm exec biome check --write <changed dirs>` — clean (one pre-existing info-level style suggestion in the vendored `ingress.ts`, left untouched to match its fixture)
- [x] `pnpm --filter @tulipfarm/api test src/ingress` — 98 passed, including new bundled-merge regression tests (200+enqueue where it previously 404'd; still 404s with no matching connection)
- [x] `pnpm --filter @tulipfarm/api test src/internal src/soul/integrations` — 224 passed
- [x] `pnpm typecheck` — 40/40 workspaces clean
- [x] `pnpm lint` — clean (pre-existing unrelated warnings only)