### PR TITLE
fix(worker): make routine Run failures visible, from lease to event stream

### DIFF
--- a/apps/worker/src/executors.test.ts
+++ b/apps/worker/src/executors.test.ts
@@ -43,6 +43,8 @@ class FakeRunStore implements RunLeaseStore {
       status: PersistedRunStatus;
       leaseOwner: string | null;
       leaseExpiresAt: string | null;
+      startedAt?: string;
+      finishedAt?: string;
     }
   ): Promise<boolean> {
     if (transition.leaseOwner === null) this.releaseCalls.push(transition);

--- a/apps/worker/src/recovery/run-dispatch.test.ts
+++ b/apps/worker/src/recovery/run-dispatch.test.ts
@@ -58,6 +58,8 @@ class DurableRunStore {
       status: PersistedRunStatus;
       leaseOwner: string | null;
       leaseExpiresAt: string | null;
+      startedAt?: string;
+      finishedAt?: string;
     }
   ): Promise<boolean> {
     const current = this.runs.get(runId);

--- a/apps/worker/src/routine/agent-port.test.ts
+++ b/apps/worker/src/routine/agent-port.test.ts
@@ -1,4 +1,5 @@
 import type {
+  ExposedTool,
   ModelInvocationRequest,
   ModelInvocationResult,
   ModelPort,
@@ -231,7 +232,11 @@ describe("BundleRoutineAgentPort", () => {
   it("keys its events by the State occurrence and the attempt that claimed it", async () => {
     await port().execute(request());
 
-    expect(appended.map((event) => event.eventType)).toEqual(["model.routed", "context.assembled"]);
+    expect(appended.map((event) => event.eventType)).toEqual([
+      "model.routed",
+      "context.assembled",
+      "turn.finished",
+    ]);
     expect(appended.every((event) => event.idempotencyKey.startsWith(`${STATE_KEY}:3:`))).toBe(
       true
     );
@@ -463,6 +468,13 @@ describe("BundleRoutineAgentPort", () => {
 
     expect(result).toEqual({ kind: "failed", reason: "guardrail_input_blocked", retryable: false });
     expect(invoke).not.toHaveBeenCalled();
+    expect(appended).toEqual([
+      {
+        eventType: "turn.finished",
+        idempotencyKey: `${STATE_KEY}:3:finished`,
+        payload: { status: "failed", messageId: null, reason: "guardrail_input_blocked" },
+      },
+    ]);
   });
 
   it("blocks an answer carrying regulated content, before any State reads it", async () => {
@@ -474,6 +486,59 @@ describe("BundleRoutineAgentPort", () => {
       kind: "failed",
       reason: "guardrail_output_blocked",
       retryable: false,
+    });
+    expect(appended.at(-1)).toMatchObject({
+      eventType: "turn.finished",
+      payload: { status: "failed", messageId: null, reason: "guardrail_output_blocked" },
+    });
+  });
+
+  it("surfaces hitting the Tool-call ceiling as a legible, attributable failure", async () => {
+    const tools: ExposedTool[] = [
+      {
+        name: "lookup",
+        description: "Looks something up.",
+        inputSchema: { type: "object", properties: {}, additionalProperties: false },
+      },
+    ];
+    let callCount = 0;
+    invoke = vi.fn<ModelPort["invoke"]>(async () => {
+      callCount += 1;
+      // Two calls per iteration, so the 12-call ceiling is reached after 6 iterations — well under
+      // the 12-iteration ceiling — proving this failure is attributed to the Tool-call limit and
+      // not merely to running out of iterations.
+      return {
+        requestId: `req-${callCount}`,
+        output: {
+          kind: "tool_calls",
+          calls: [
+            { callId: `call-${callCount}-a`, name: "lookup", arguments: {} },
+            { callId: `call-${callCount}-b`, name: "lookup", arguments: {} },
+          ],
+        },
+        usage: { inputTokens: 10, outputTokens: 4 },
+      } as ModelInvocationResult;
+    });
+
+    const result = await port({
+      tools: {
+        dispatch: async (call) => ({
+          status: "succeeded",
+          callId: call.callId,
+          output: "ok",
+        }),
+      },
+      catalog: async () => tools,
+    }).execute(request());
+
+    expect(result).toEqual({
+      kind: "failed",
+      reason: "tool_call_limit",
+      retryable: false,
+    });
+    expect(appended.at(-1)).toMatchObject({
+      eventType: "turn.finished",
+      payload: { status: "failed", messageId: null, reason: "tool_call_limit" },
     });
   });
 

--- a/apps/worker/src/routine/agent-port.ts
+++ b/apps/worker/src/routine/agent-port.ts
@@ -12,6 +12,7 @@ import {
   GuardrailsService,
   InMemoryLoopCheckpointStore,
   type LoopCheckpointStore,
+  type ModelFailureDiagnostic,
   type ModelInvocationFailureReason,
   type ModelPort,
   type ModelProfileCatalog,
@@ -306,11 +307,10 @@ export class BundleRoutineAgentPort implements RoutineAgentPort {
     );
     const question = canonicalize(plan.input);
 
-    const guardedInput = await guardrails.runInput(question, guardContext);
-    if (guardedInput.blocked) {
-      return { kind: "failed", reason: "guardrail_input_blocked", retryable: false };
-    }
-
+    // Built before the first guard runs so every "failed" outcome below — including a blocked
+    // question — can announce a terminal `turn.finished`. Without it, a Routine Run reaching
+    // `failed` leaves only State-level evidence: the Run event stream never says the Run ended,
+    // let alone why.
     const events = new TurnEventWriter({
       events: this.options.events,
       businessId: request.businessId,
@@ -320,6 +320,15 @@ export class BundleRoutineAgentPort implements RoutineAgentPort {
       attempt: request.attempt,
       now: this.now,
     });
+
+    const guardedInput = await guardrails.runInput(question, guardContext);
+    if (guardedInput.blocked) {
+      return this.finished(events, {
+        kind: "failed",
+        reason: "guardrail_input_blocked",
+        retryable: false,
+      });
+    }
 
     // Route through the pinned-bundle catalog; denial parks instead of bypassing profile terms.
     const selection = selectModelProfile(
@@ -345,6 +354,8 @@ export class BundleRoutineAgentPort implements RoutineAgentPort {
         { runId: request.runId, profileId: selection.profileId, reason: selection.reason },
         "routine model profile denied"
       );
+      // "unavailable" parks the State for reconciliation rather than failing the Run, so no
+      // terminal event applies here.
       return { kind: "unavailable", reason: `model_${selection.reason}` };
     }
     const primary = selection.chain[0];
@@ -420,32 +431,81 @@ export class BundleRoutineAgentPort implements RoutineAgentPort {
 
     if (outcome.status === "cancelled") return { kind: "cancelled" };
     if (outcome.status === "failed") {
-      return {
-        kind: "failed",
-        reason: outcome.reason,
-        retryable: isRetryableAgentFailure(outcome.reason),
-      };
+      return this.finished(
+        events,
+        {
+          kind: "failed",
+          reason: outcome.reason,
+          retryable: isRetryableAgentFailure(outcome.reason),
+        },
+        outcome.modelFailure
+      );
     }
     if (outcome.status === "awaiting_approval") {
       return { kind: "awaiting_approval", reason: "approval_required" };
     }
     if (outcome.status === "input_required") {
       // Routine Agents expose no Surface-capable Tools, so this outcome cannot be resumed here.
-      return { kind: "failed", reason: "input_required_without_surface", retryable: false };
+      return this.finished(events, {
+        kind: "failed",
+        reason: "input_required_without_surface",
+        retryable: false,
+      });
     }
     if (outcome.status === "awaiting_child") {
       // Same impossibility as above: a Routine Agent exposes no Tool that can spawn a child, so
       // reaching here means the Tool surface changed without this State learning how to park.
-      return { kind: "failed", reason: "child_spawn_without_wait_support", retryable: false };
+      return this.finished(events, {
+        kind: "failed",
+        reason: "child_spawn_without_wait_support",
+        retryable: false,
+      });
     }
 
     // Last zero-cost refusal point: no State is settled and no downstream effect has run.
     const guardedOutput = await guardrails.runOutput(answerText(outcome.output), guardContext);
     if (guardedOutput.blocked) {
-      return { kind: "failed", reason: "guardrail_output_blocked", retryable: false };
+      return this.finished(events, {
+        kind: "failed",
+        reason: "guardrail_output_blocked",
+        retryable: false,
+      });
     }
 
-    return { kind: "succeeded", output: outcome.output };
+    return this.finished(events, { kind: "succeeded", output: outcome.output });
+  }
+
+  /**
+   * Announces the terminal `turn.finished` this pseudo-turn never had, then hands the outcome
+   * back unchanged.
+   *
+   * Routine Agent States reuse Chat's `TurnEventWriter` for `context.assembled`/`model.routed`,
+   * but until now nothing closed that stream: a Run that reached terminal `failed` here left the
+   * Run event ledger silently truncated after its last `tool.result`, indistinguishable from a
+   * crash. `cancelled`/`awaiting_*`/`unavailable` outcomes are not terminal for the Run — the
+   * executor either leaves them to the cancellation manager or parks the State — so they announce
+   * nothing here.
+   */
+  private async finished(
+    events: TurnEventWriter,
+    outcome: RoutineAgentOutcome,
+    modelFailure?: ModelFailureDiagnostic
+  ): Promise<RoutineAgentOutcome> {
+    if (outcome.kind === "succeeded") {
+      await events.emit("turn.finished", { status: "succeeded", messageId: null }, "finished");
+    } else if (outcome.kind === "failed") {
+      await events.emit(
+        "turn.finished",
+        {
+          status: "failed",
+          messageId: null,
+          reason: outcome.reason,
+          ...(modelFailure === undefined ? {} : { modelFailure }),
+        },
+        "finished"
+      );
+    }
+    return outcome;
   }
 
   /**

--- a/apps/worker/src/run-dispatcher.test.ts
+++ b/apps/worker/src/run-dispatcher.test.ts
@@ -52,6 +52,8 @@ class FakeRunStore implements RunLeaseStore {
       status: PersistedRunStatus;
       leaseOwner: string | null;
       leaseExpiresAt: string | null;
+      startedAt?: string;
+      finishedAt?: string;
       errorEvidenceRef?: string;
     }
   ): Promise<boolean> {

--- a/apps/worker/src/run-dispatcher.ts
+++ b/apps/worker/src/run-dispatcher.ts
@@ -108,6 +108,7 @@ export class RunDispatcher {
           expectedVersion: started.run.version,
           expectedStatus: "running",
           status: outcome,
+          now: this.options.now(),
         });
         if (!released) {
           failed += 1;
@@ -137,6 +138,7 @@ export class RunDispatcher {
           expectedVersion: started.run.version,
           expectedStatus: "running",
           status,
+          now: this.options.now(),
           errorEvidenceRef: exhausted
             ? "dispatch:handler_error_after_requeue"
             : DISPATCH_HANDLER_ERROR_REF,

--- a/packages/curator-host/src/stuck-run.pg.test.ts
+++ b/packages/curator-host/src/stuck-run.pg.test.ts
@@ -133,6 +133,7 @@ describe("a Curator Run parked for reconciliation", () => {
       expectedVersion: started.run.version,
       expectedStatus: "running",
       status: "needs_reconciliation",
+      now: MINTED_AT,
     });
   };
 

--- a/packages/run-kernel/src/lease.test.ts
+++ b/packages/run-kernel/src/lease.test.ts
@@ -50,6 +50,8 @@ class FakeRunStore implements RunLeaseStore {
       status: PersistedRunStatus;
       leaseOwner: string | null;
       leaseExpiresAt: string | null;
+      startedAt?: string;
+      finishedAt?: string;
     }
   ): Promise<boolean> {
     this.transitionCalls.push({ businessId, runId, transition });
@@ -154,6 +156,7 @@ describe("RunLeaseManager", () => {
           status: "running",
           leaseOwner: "worker-1",
           leaseExpiresAt: "2026-07-24T10:01:30.000Z",
+          startedAt: "2026-07-24T10:00:30.000Z",
         },
       },
     ]);
@@ -201,12 +204,14 @@ describe("RunLeaseManager", () => {
     const store = new FakeRunStore();
     const manager = new RunLeaseManager(store);
 
+    const now = new Date("2026-07-24T10:02:00.000Z");
     const released = await manager.release({
       businessId: BUSINESS_ID,
       runId: RUN_ID,
       expectedVersion: 2,
       expectedStatus: "running",
       status: "succeeded",
+      now,
     });
 
     expect(released).toBe(true);
@@ -220,6 +225,7 @@ describe("RunLeaseManager", () => {
           status: "succeeded",
           leaseOwner: null,
           leaseExpiresAt: null,
+          finishedAt: now.toISOString(),
         },
       },
     ]);

--- a/packages/run-kernel/src/lease.ts
+++ b/packages/run-kernel/src/lease.ts
@@ -3,6 +3,9 @@ import { assertRunTransition, type RunStatus } from "./model";
 
 export type LeasedRunStatus = "claimed" | "running";
 
+/** The only statuses a Run does not leave; anything else can still be requeued or resumed. */
+const TERMINAL_RUN_STATUSES: ReadonlySet<RunStatus> = new Set(["succeeded", "failed", "cancelled"]);
+
 export interface RunLeaseStore {
   transitionRun(
     businessId: string,
@@ -13,6 +16,8 @@ export interface RunLeaseStore {
       status: PersistedRunStatus;
       leaseOwner: string | null;
       leaseExpiresAt: string | null;
+      startedAt?: string;
+      finishedAt?: string;
       errorEvidenceRef?: string;
     }
   ): Promise<boolean>;
@@ -68,6 +73,7 @@ export interface ReleaseInput {
   readonly expectedVersion: number;
   readonly expectedStatus: RunStatus;
   readonly status: Exclude<RunStatus, LeasedRunStatus>;
+  readonly now: Date;
   /** Terse reason code for a non-terminal park (e.g. `needs_reconciliation`); never secrets or model content. */
   readonly errorEvidenceRef?: string;
 }
@@ -99,6 +105,7 @@ export class RunLeaseManager {
       status: input.status,
       leaseOwner: input.owner,
       leaseExpiresAt,
+      ...(input.status === "running" ? { startedAt: input.now.toISOString() } : {}),
     });
     if (!claimed) return { claimed: false, run: null };
     return { claimed: true, run: await this.store.find(input.businessId, input.runId) };
@@ -120,6 +127,7 @@ export class RunLeaseManager {
       status: input.status,
       leaseOwner: null,
       leaseExpiresAt: null,
+      ...(TERMINAL_RUN_STATUSES.has(input.status) ? { finishedAt: input.now.toISOString() } : {}),
       ...(input.errorEvidenceRef === undefined ? {} : { errorEvidenceRef: input.errorEvidenceRef }),
     });
   }

--- a/packages/run-kernel/src/resilience/recovery.test.ts
+++ b/packages/run-kernel/src/resilience/recovery.test.ts
@@ -174,6 +174,7 @@ describe("crash while holding a lease", () => {
       expectedVersion: staleVersion,
       expectedStatus: "running",
       status: "succeeded",
+      now: AFTER_LEASE,
     });
     const heartbeat = await leases.heartbeat({
       businessId: BUSINESS_ID,
@@ -199,6 +200,7 @@ describe("crash while holding a lease", () => {
       expectedVersion: 4,
       expectedStatus: "running",
       status: "succeeded",
+      now: T0,
     });
     const replay = await leases.release({
       businessId: BUSINESS_ID,
@@ -206,6 +208,7 @@ describe("crash while holding a lease", () => {
       expectedVersion: 4,
       expectedStatus: "running",
       status: "failed",
+      now: T0,
     });
 
     expect(first).toBe(true);

--- a/packages/run-kernel/src/resilience/simulator.ts
+++ b/packages/run-kernel/src/resilience/simulator.ts
@@ -109,6 +109,8 @@ export class SimulatedRunStore implements RunLeaseStore, RunResumeStore, Reconci
       status: PersistedRunStatus;
       leaseOwner: string | null;
       leaseExpiresAt: string | null;
+      startedAt?: string;
+      finishedAt?: string;
     }
   ): Promise<boolean> {
     this.guard("transitionRun", "before");
@@ -126,6 +128,8 @@ export class SimulatedRunStore implements RunLeaseStore, RunResumeStore, Reconci
       version: run.version + 1,
       leaseOwner: transition.leaseOwner,
       leaseExpiresAt: transition.leaseExpiresAt,
+      startedAt: transition.startedAt ?? run.startedAt,
+      finishedAt: transition.finishedAt ?? run.finishedAt,
     });
     this.transitions.push({
       runId,


### PR DESCRIPTION
## Summary

- `RunLeaseManager.claim()`/`release()` never passed `startedAt`/`finishedAt` to `RunLeaseStore.transitionRun()`, so `runs.started_at`/`finished_at` stayed NULL for every Run source (chat, integration, routine, curator, subagent) even though the storage layer already accepts and COALESCEs both columns.
- `BundleRoutineAgentPort.execute()` used `TurnEventWriter` for `model.routed`/`context.assembled` but never emitted a terminal Run event, so a Routine Agent State reaching `succeeded`/`failed` left the Run event stream silently truncated — reused the existing `turn.finished` event type (same one Chat's `TurnDriver` emits) rather than adding a new one.
- Hitting the Tool-call ceiling (`apps/worker/src/routine/agent-port.ts` `MAX_TOOL_CALLS`, `packages/agent-runtime/src/loop/contract.ts` `tool_call_limit`) now surfaces as a `turn.finished` event carrying `reason: "tool_call_limit"`, instead of the loop stopping with no attributable evidence.

## Root cause (staging evidence)

Routine `slack-knowledge-indexing` failed on every tick (28 failures since 2026-08-30):
- `run_states`: `status = failed`, `error_evidence_ref = routine:agent_tool_call_limit`, `started_at`/`finished_at` populated.
- `runs` (same Run): `status = failed`, but `started_at`/`finished_at` both NULL, `lease_owner` NULL.
- `run_events`: only `tool.result`/`tool.call`/`context.assembled`/`plan.declared`/`model.routed` — no terminal event at all, stream just stops.

File:line evidence:
- `packages/run-kernel/src/lease.ts` — `RunLeaseManager.claim()` (previously never passed `startedAt`), `release()` (previously never passed `finishedAt`, and `ReleaseInput` had no clock field at all).
- `packages/storage/src/runs/run-store.ts` `transitionRun()` — already `COALESCE`s `started_at`/`finished_at`; no migration needed, the gap was entirely in the application layer.
- `packages/turn-executor/src/kernel-ports.ts` `RunStoreStateTransitions.transition()` — the working analog at the State level, which is why `run_states.started_at/finished_at` were already correct while `runs.started_at/finished_at` were not.
- `apps/worker/src/routine/agent-port.ts` `BundleRoutineAgentPort.execute()` — had zero `turn.finished` emissions before this change, on any outcome path.

Two alternatives considered and ruled out:
1. **A migration/SQL bug in `run-store.ts`** — ruled out by reading the actual `UPDATE runs SET ... started_at = COALESCE($6, started_at) ...` SQL; it already handles both columns correctly. The columns were simply never populated because callers never passed the values.
2. **The Routine executor's own State-level transition path is what's broken** — ruled out because staging evidence shows `run_states.started_at/finished_at` (via `RunStoreStateTransitions`) are already correctly stamped; only the parent `runs` row (via `RunLeaseManager`) was not.

## Scope

- Fixes `runs.started_at`/`finished_at` stamping (systemic, all Run sources) and the missing terminal Run event for Routine Agent States (including the `tool_call_limit` path specifically).
- Does **not** touch the underlying reasons the agent burns its Tool-call budget (embeddings unconfigured on staging, the agent's Tool allowlist) — those are separate work items.
- No `soul/` files touched; no DB migration needed (existing columns/SQL already support this).

## Eval Corpus note

No new/updated L3 eval Case: `apps/eval`'s L3 tier only mints `chat`-source Runs (see `apps/eval/src/l3/tier.ts`), and has no Routine execution path at all, so it structurally cannot exercise `BundleRoutineAgentPort` (items 2 & 3) — there is nothing an L3 Case could assert there. The `started_at`/`finished_at` fix in `lease.ts` is Chat-observable too, but L3's `Expectation` vocabulary (`run_status`/`state_status`/`turn_status`/`run_event_emitted`/...) has no kind that reads Run timestamps, so it's covered instead by unit tests in `packages/run-kernel/src/lease.test.ts` (fails before this change, passes after — confirmed by reverting locally). `corpus/` was not edited, so `corpusHash` is unchanged and no Baseline is retired.

## Test plan

- [x] `pnpm exec biome check --write <changed dirs>` — clean
- [x] `pnpm --filter @tulipfarm/worker exec vitest run src/routine/agent-port.test.ts` — 22 passed (includes new `tool_call_limit` → `turn.finished` test, and updated guardrail-blocked assertions)
- [x] `pnpm --filter @tulipfarm/worker exec vitest run src/run-dispatcher.test.ts src/executors.test.ts src/recovery/run-dispatch.test.ts` — 28 passed
- [x] `pnpm --filter @tulipfarm/run-kernel exec vitest run` (full package suite) — 499 passed, including the updated `lease.test.ts` assertion that fails before this change and passes after
- [x] `pnpm --filter @tulipfarm/curator-host exec vitest run src/stuck-run.pg.test.ts` — 5 passed
- [x] `pnpm typecheck` — 41/41 workspaces pass
- [x] `pnpm eval` (scripted tier, whole Corpus) — 44 passed, 0 failed, 0 errored

## Adjacent finding (not fixed here, out of scope)

`RunOutcome` (`packages/turn-executor/src/ports.ts`) carries no evidence, so `run-dispatcher.ts`'s normal-path `release()` call never sets `errorEvidenceRef` on the `runs` row for a semantic (non-crash) failure — only the crash-handling catch block does. `runs.error_evidence_ref` is therefore still only ever populated via the crash path today; `run_states.error_evidence_ref` is the reliable source for a normal failure's reason. Flagging this for a separate follow-up.