### PR TITLE
fix(soul): name what resolves when a Routine ref is unresolved

### DIFF
--- a/apps/eval/corpus/l3-a-routine-unresolved-toolref-names-what-resolves.json
+++ b/apps/eval/corpus/l3-a-routine-unresolved-toolref-names-what-resolves.json
@@ -1,0 +1,147 @@
+{
+  "id": "l3-a-routine-unresolved-toolref-names-what-resolves",
+  "tier": "l3",
+  "agent": "support",
+  "input": [
+    {
+      "role": "user",
+      "content": "Create a published ToolContract named refund-lookup: toolId refund-lookup, toolVersion \"1\", action lookup, riskClass low, mutating false, dryRun true, idempotency strategy none, adapter kind native with ref refund-lookup, empty inputSchema and outputSchema. Call soul_write once with definitionMode canonical. Do not ask me to confirm."
+    }
+  ],
+  "tools": [
+    {
+      "name": "soul_write",
+      "description": "Commit one Soul definition. Set definitionMode to canonical for canonical YAML.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "type": "string"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "definitionMode": {
+            "type": "string"
+          }
+        },
+        "required": ["kind", "slug", "content", "definitionMode"]
+      }
+    }
+  ],
+  "script": [
+    {
+      "kind": "tool_calls",
+      "calls": [
+        {
+          "callId": "tool-contract",
+          "name": "soul_write",
+          "arguments": {
+            "kind": "ToolContract",
+            "slug": "refund-lookup",
+            "definitionMode": "canonical",
+            "content": "apiVersion: tulipfarm.ai/v1\nkind: ToolContract\nmetadata:\n  id: 33333333-3333-4333-8333-333333333333\n  slug: refund-lookup\n  schemaVersion: 1\n  authoredVersion: 1\n  lifecycle: published\nspec:\n  toolId: refund-lookup\n  toolVersion: \"1\"\n  action: lookup\n  inputSchema: {}\n  outputSchema: {}\n  riskClass: low\n  mutating: false\n  dryRun: true\n  idempotency:\n    strategy: none\n  adapter:\n    kind: native\n    ref: refund-lookup\n"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "text",
+      "text": "Created the refund-lookup ToolContract."
+    }
+  ],
+  "journey": [
+    {
+      "input": [
+        {
+          "role": "user",
+          "content": "Now create a published Routine named refund-follow-up whose one State calls the refund-lokup Tool. Call soul_write once with definitionMode canonical. Do not ask me to confirm."
+        }
+      ],
+      "script": [
+        {
+          "kind": "tool_calls",
+          "calls": [
+            {
+              "callId": "routine-bad-ref",
+              "name": "soul_write",
+              "arguments": {
+                "kind": "Routine",
+                "slug": "refund-follow-up",
+                "definitionMode": "canonical",
+                "content": "apiVersion: tulipfarm.ai/v1\nkind: Routine\nmetadata:\n  id: 22222222-2222-4222-8222-222222222222\n  slug: refund-follow-up\n  schemaVersion: 1\n  authoredVersion: 1\n  lifecycle: published\nspec:\n  owner: support\n  input:\n    type: object\n    additionalProperties: false\n  output:\n    type: object\n    additionalProperties: false\n  start: Lookup\n  states:\n    - name: Lookup\n      type: tool\n      toolRef:\n        name: refund-lokup\n        version: latest\n      action: lookup\n      end: true\n  triggers:\n    - name: refund-follow-up-manual\n      type: manual\n      eventType: routine.manual\n      eventVersion: 1\n      backgroundIdentity:\n        principalKind: service\n        principalId: routine-runner\n      deduplication:\n        key: refund-follow-up-manual\n"
+              }
+            }
+          ]
+        },
+        {
+          "kind": "text",
+          "text": "That Tool reference didn't resolve. I'll check the ToolContract names and retry."
+        }
+      ]
+    },
+    {
+      "input": [
+        {
+          "role": "user",
+          "content": "The ToolContract slug is refund-lookup. Retry the write once more with that corrected toolRef."
+        }
+      ],
+      "script": [
+        {
+          "kind": "tool_calls",
+          "calls": [
+            {
+              "callId": "routine-good-ref",
+              "name": "soul_write",
+              "arguments": {
+                "kind": "Routine",
+                "slug": "refund-follow-up",
+                "definitionMode": "canonical",
+                "content": "apiVersion: tulipfarm.ai/v1\nkind: Routine\nmetadata:\n  id: 22222222-2222-4222-8222-222222222222\n  slug: refund-follow-up\n  schemaVersion: 1\n  authoredVersion: 1\n  lifecycle: published\nspec:\n  owner: support\n  input:\n    type: object\n    additionalProperties: false\n  output:\n    type: object\n    additionalProperties: false\n  start: Lookup\n  states:\n    - name: Lookup\n      type: tool\n      toolRef:\n        name: refund-lookup\n        version: latest\n      action: lookup\n      end: true\n  triggers:\n    - name: refund-follow-up-manual\n      type: manual\n      eventType: routine.manual\n      eventVersion: 1\n      backgroundIdentity:\n        principalKind: service\n        principalId: routine-runner\n      deduplication:\n        key: refund-follow-up-manual\n"
+              }
+            }
+          ]
+        },
+        {
+          "kind": "text",
+          "text": "Done — refund-follow-up now calls refund-lookup."
+        }
+      ]
+    }
+  ],
+  "expect": [
+    {
+      "kind": "tool_denial_contains",
+      "name": "soul_write",
+      "text": "did you mean one of: refund-lookup"
+    },
+    {
+      "kind": "soul_committed",
+      "path": "tools/refund-lookup/tool.yaml"
+    },
+    {
+      "kind": "soul_committed",
+      "path": "routines/refund-follow-up/routine.yaml"
+    },
+    {
+      "kind": "soul_published",
+      "artifact": "ToolContract:refund-lookup"
+    },
+    {
+      "kind": "soul_published",
+      "artifact": "Routine:refund-follow-up"
+    },
+    {
+      "kind": "tool_call_count",
+      "count": 3
+    },
+    {
+      "kind": "run_status",
+      "status": "succeeded"
+    }
+  ]
+}

--- a/apps/eval/src/case.ts
+++ b/apps/eval/src/case.ts
@@ -113,7 +113,16 @@ export type Expectation =
   /** L3 only. The counterpart: the audience widened this far and no further. */
   | { readonly kind: "generated_file_not_readable_by"; readonly grantee: string }
   /** L3 only. A validated Curator Proposal reached its participant as a Task. */
-  | { readonly kind: "curator_task_visible"; readonly title: string };
+  | { readonly kind: "curator_task_visible"; readonly title: string }
+  /**
+   * L3 only. The named Tool's real dispatch was denied, and the reason it gave back contains this
+   * text.
+   *
+   * The one place a Case can measure a real refusal's wording rather than its outcome — `soul_write`
+   * and `file_create` are the only Tools L3 runs for real, so this is the only Expectation that can
+   * tell a rejection that names what would have resolved apart from one that only says no.
+   */
+  | { readonly kind: "tool_denial_contains"; readonly name: string; readonly text: string };
 
 /** Expectations that read persisted state, which only the L3 tier can observe. */
 const PERSISTED_KINDS: ReadonlySet<string> = new Set([
@@ -126,6 +135,7 @@ const PERSISTED_KINDS: ReadonlySet<string> = new Set([
   "generated_file_readable_by",
   "generated_file_not_readable_by",
   "curator_task_visible",
+  "tool_denial_contains",
 ]);
 
 export function isPersisted(expectation: Expectation): boolean {

--- a/apps/eval/src/expectation-shape.ts
+++ b/apps/eval/src/expectation-shape.ts
@@ -78,6 +78,10 @@ const EXPECTATION_FIELDS: Record<string, readonly [string, FieldType][]> = {
   generated_file_readable_by: [["grantee", "string"]],
   generated_file_not_readable_by: [["grantee", "string"]],
   curator_task_visible: [["title", "string"]],
+  tool_denial_contains: [
+    ["name", "string"],
+    ["text", "string"],
+  ],
 };
 
 export function isKnownExpectationKind(kind: unknown): kind is string {

--- a/apps/eval/src/l3/soul-write.ts
+++ b/apps/eval/src/l3/soul-write.ts
@@ -45,6 +45,12 @@ export interface SoulWriterTool {
   /** Commits this Trial landed, in order. Empty means the Turn changed no configuration. */
   readonly commits: readonly SoulCommit[];
   /**
+   * Reasons the real writer refused a write, in order — the exact text a `denied` dispatch handed
+   * back, not the shorter one this file also returns to the model. A Case asserting on refusal
+   * wording needs the real thing, or it would only ever be checking this file's own paraphrase.
+   */
+  readonly denials: readonly string[];
+  /**
    * The artifacts the Runtime is actually serving, written `Kind:slug`.
    *
    * Read from the *active* publication, never from the commit. A committed artifact that never
@@ -88,6 +94,7 @@ interface WriteArguments {
  */
 export function soulWriterTool(soul: EvalSoul): SoulWriterTool {
   const commits: SoulCommit[] = [];
+  const denials: string[] = [];
   // `hermeticGitEnv` is not optional. An exported GIT_DIR — which every Git hook, `rebase --exec`
   // and `bisect run` sets — overrides `cwd` entirely, so without it `base` would be the
   // maintainer's own HEAD and `reset` would `git reset --hard` and `git clean -fd` their checkout,
@@ -114,8 +121,11 @@ export function soulWriterTool(soul: EvalSoul): SoulWriterTool {
       publicKeyPem: publicKey.export({ format: "pem", type: "spki" }).toString(),
     },
   ]);
+  // Shared with the writer below: both need the same view of the authored tree, and production
+  // wires the identical reader to each (`apps/api/src/runtime/soul-writer.ts`).
+  const treeReader = new GitSoulTreeReader(soul.path);
   const publisher = new SoulPublisher({
-    treeReader: new GitSoulTreeReader(soul.path),
+    treeReader,
     compiler: compileExecutionBundle,
     signer: createEd25519BundleSigner(
       EVAL_BUNDLE_KEY,
@@ -125,16 +135,22 @@ export function soulWriterTool(soul: EvalSoul): SoulWriterTool {
     logger: SILENT,
     businessId: EVAL_BUSINESS,
   });
+  // Without this, `checkReferences` short-circuits (`SoulWriter` treats a missing `treeReader` as
+  // "cannot check, so don't"), so a bad `agentRef`/`toolRef` would commit here and fail only later,
+  // silently, at publish — the opposite of what production does and exactly the path this Case
+  // exists to cover.
   const writer = new SoulWriter(
     store,
     SILENT,
     undefined,
     { reload: () => soul.loader.load() },
-    publisher
+    publisher,
+    treeReader
   );
 
   return {
     commits,
+    denials,
     published: async () => {
       const bundle = await publications.activeBundle(EVAL_BUSINESS, verifier);
       return bundle?.definitions.map((definition) => `${definition.kind}:${definition.slug}`) ?? [];
@@ -204,14 +220,12 @@ export function soulWriterTool(soul: EvalSoul): SoulWriterTool {
                   : `${issue.code} at ${issue.path}.${issue.field}`
               )
               .join("; ");
-            return {
-              status: "denied",
-              callId: call.callId,
-              reason:
-                issues.length === 0
-                  ? `${cause.code}: ${cause.message}`
-                  : `${cause.code}: ${cause.message} — ${issues}`,
-            };
+            const reason =
+              issues.length === 0
+                ? `${cause.code}: ${cause.message}`
+                : `${cause.code}: ${cause.message} — ${issues}`;
+            denials.push(reason);
+            return { status: "denied", callId: call.callId, reason };
           }
           throw cause;
         }

--- a/apps/eval/src/l3/tier.test.ts
+++ b/apps/eval/src/l3/tier.test.ts
@@ -340,6 +340,7 @@ describe("folding a journey into one result", () => {
     soulCommits: [],
     publishedArtifacts: [],
     generatedFiles: [],
+    toolDenials: [],
     systemPrompt: "",
     ...over,
   });

--- a/apps/eval/src/l3/tier.ts
+++ b/apps/eval/src/l3/tier.ts
@@ -99,6 +99,8 @@ export interface PersistedTurn {
   readonly generatedFiles: readonly GeneratedFile[];
   /** Tasks the Curator delivered after this Turn completed. */
   readonly curatorTasks?: readonly { readonly title: string }[];
+  /** Real Tool dispatches this Turn's writer denied, with the exact reason it gave back. */
+  readonly toolDenials: readonly { readonly name: string; readonly reason: string }[];
   /** The prompt the real Context assembler produced, so `prompt_contains` works at L3 too. */
   readonly systemPrompt: string;
   /**
@@ -187,6 +189,7 @@ async function readBack(
     publishedArtifacts: readonly string[];
     generatedFiles: readonly GeneratedFile[];
     curatorTasks: readonly { readonly title: string }[];
+    toolDenials: readonly { readonly name: string; readonly reason: string }[];
     systemPrompt: string;
     spend: Spend;
   }
@@ -222,6 +225,7 @@ async function readBack(
     publishedArtifacts: observed.publishedArtifacts,
     generatedFiles: observed.generatedFiles,
     curatorTasks: observed.curatorTasks,
+    toolDenials: observed.toolDenials,
     systemPrompt: observed.systemPrompt,
   };
 }
@@ -286,6 +290,7 @@ async function runOneTurn(
     // The writer is shared across a journey so its reset restores the pre-journey commit, which
     // means its `commits` accumulate. Only this Turn's slice belongs to this Turn.
     const committedBefore = soulWrites.commits.length;
+    const deniedBefore = soulWrites.denials.length;
     // The File store is shared across a journey for the same reason, so its `generated` accumulate
     // and only this Turn's slice belongs to this Turn.
     const generatedBefore = files.generated.length;
@@ -354,6 +359,9 @@ async function runOneTurn(
       publishedArtifacts: await soulWrites.published(),
       generatedFiles: files.generated.slice(generatedBefore),
       curatorTasks,
+      toolDenials: soulWrites.denials
+        .slice(deniedBefore)
+        .map((reason) => ({ name: SOUL_WRITE_TOOL, reason })),
       systemPrompt: context.systemPrompt,
       spend,
     });
@@ -468,6 +476,7 @@ export function foldJourney(turns: readonly PersistedTurn[]): PersistedTurn {
     toolCalls: turns.flatMap((turn) => turn.toolCalls),
     soulCommits: turns.flatMap((turn) => turn.soulCommits),
     generatedFiles: turns.flatMap((turn) => turn.generatedFiles),
+    toolDenials: turns.flatMap((turn) => turn.toolDenials),
     spend: turns.reduce<Spend>((total, turn) => mergeSpend(total, turn.spend), NO_SPEND),
   };
 }

--- a/apps/eval/src/runner.ts
+++ b/apps/eval/src/runner.ts
@@ -273,6 +273,7 @@ async function runL3Trial(
         publishedArtifacts: turn.publishedArtifacts,
         generatedFiles: turn.generatedFiles,
         curatorTasks: turn.curatorTasks,
+        toolDenials: turn.toolDenials,
       },
     });
   } catch (cause) {

--- a/apps/eval/src/scorer.ts
+++ b/apps/eval/src/scorer.ts
@@ -50,6 +50,8 @@ export interface PersistedState {
     readonly readableBy: readonly string[];
   }[];
   readonly curatorTasks?: readonly { readonly title: string }[];
+  /** Real Tool dispatches that were denied, with the reason the dispatcher gave back. */
+  readonly toolDenials?: readonly { readonly name: string; readonly reason: string }[];
 }
 
 export interface ExpectationResult {
@@ -289,6 +291,23 @@ function evaluate(a: Expectation, obs: Observation): { passed: boolean; detail: 
       return (persisted.curatorTasks ?? []).some((task) => task.title === a.title)
         ? { passed: true, detail: `Curator delivered Task "${a.title}"` }
         : { passed: false, detail: `no Curator Task titled "${a.title}"` };
+    }
+
+    case "tool_denial_contains": {
+      const persisted = obs.persisted;
+      if (persisted === undefined) return notPersisted(a.kind);
+      const denials = (persisted.toolDenials ?? []).filter((d) => d.name === a.name);
+      if (denials.length === 0) {
+        return { passed: false, detail: `${a.name} was never denied` };
+      }
+      return denials.some((d) => d.reason.includes(a.text))
+        ? { passed: true, detail: `${a.name} denial mentions ${show(a.text)}` }
+        : {
+            passed: false,
+            detail: `${a.name} denial did not mention ${show(a.text)}; reason was ${denials
+              .map((d) => d.reason)
+              .join(" | ")}`,
+          };
     }
 
     // Answered by a Judge in `scoreJudged`, not here. Reaching this arm means a judged Expectation

--- a/packages/soul/src/index.ts
+++ b/packages/soul/src/index.ts
@@ -172,7 +172,7 @@ export type {
 } from "./publisher";
 export { SoulPublisher } from "./publisher";
 export type { SoulSemanticIssue, SoulSemanticIssueCode } from "./refs";
-export { SoulSemanticValidationError } from "./refs";
+export { MAX_REF_SUGGESTIONS, SoulSemanticValidationError } from "./refs";
 export type { ResourceTypePayload } from "./resource-types/definition";
 export {
   RESOURCE_DOMAIN_RE,

--- a/packages/soul/src/refs.ts
+++ b/packages/soul/src/refs.ts
@@ -28,7 +28,20 @@ export interface SoulSemanticIssue {
   readonly ref?: string;
   /** JSON pointer into the owning definition's document. */
   readonly field?: string;
+  /**
+   * For `UNRESOLVED_REF` only: slugs of the referenced kind that already resolve in this same
+   * proposed tree, nearest-match first, capped at {@link MAX_REF_SUGGESTIONS}. Drawn only from the
+   * definitions already in this changeset's own tree — never a wider or cross-business catalog —
+   * so the list can only repeat back what the caller's own write already made visible to it.
+   */
+  readonly candidates?: readonly string[];
 }
+
+/**
+ * Cap on `SoulSemanticIssue.candidates`. A bundle can hold hundreds of Agents or ToolContracts;
+ * without a cap the error message itself becomes an unbounded catalog dump.
+ */
+export const MAX_REF_SUGGESTIONS = 8;
 
 /** A deterministic, payload-safe semantic rejection suitable for gateway boundary evidence. */
 export class SoulSemanticValidationError extends Error {
@@ -158,6 +171,43 @@ export class DefinitionIndex {
   get(id: string): AuthoredDefinition | undefined {
     return this.byId.get(id);
   }
+
+  /** Every distinct slug already authored for `kind` in this tree, for ref-suggestion purposes. */
+  slugsOfKind(kind: string): string[] {
+    return [...new Set(this.ofKind(kind).map((d) => d.slug))];
+  }
+}
+
+/** Levenshtein edit distance, used only to rank ref-guess suggestions — no external dependency. */
+function editDistance(a: string, b: string): number {
+  const rows = a.length + 1;
+  const cols = b.length + 1;
+  const dp: number[][] = Array.from({ length: rows }, () => new Array<number>(cols).fill(0));
+  for (let i = 0; i < rows; i += 1) dp[i][0] = i;
+  for (let j = 0; j < cols; j += 1) dp[0][j] = j;
+  for (let i = 1; i < rows; i += 1) {
+    for (let j = 1; j < cols; j += 1) {
+      dp[i][j] =
+        a[i - 1] === b[j - 1]
+          ? dp[i - 1][j - 1]
+          : 1 + Math.min(dp[i - 1][j - 1], dp[i - 1][j], dp[i][j - 1]);
+    }
+  }
+  return dp[a.length][b.length];
+}
+
+/**
+ * The slugs of `kind` already resolvable in `index`, nearest-guess first and capped at
+ * {@link MAX_REF_SUGGESTIONS}. The only input is the index the failed lookup itself already
+ * consulted, so this can never surface a name the caller's own changeset could not already see.
+ */
+function suggestSlugs(index: DefinitionIndex, kind: string, guess: string): string[] {
+  return index
+    .slugsOfKind(kind)
+    .map((slug) => ({ slug, distance: editDistance(guess, slug) }))
+    .sort((a, b) => a.distance - b.distance || a.slug.localeCompare(b.slug))
+    .slice(0, MAX_REF_SUGGESTIONS)
+    .map((entry) => entry.slug);
 }
 
 // ── Reference resolution (SPEC §8.2 step 7) ─────────────────────────────────────
@@ -204,7 +254,13 @@ function resolveVersionedRef(
   const candidates = index.candidates(ref.name, kind);
   if (candidates.length === 0) {
     return [
-      { code: "UNRESOLVED_REF", subject: def.subject, ref: ref.name, field: `${field}/name` },
+      {
+        code: "UNRESOLVED_REF",
+        subject: def.subject,
+        ref: ref.name,
+        field: `${field}/name`,
+        candidates: suggestSlugs(index, kind, ref.name),
+      },
     ];
   }
   if (!versionSatisfied(candidates, ref.version)) {
@@ -336,6 +392,7 @@ export function resolveReferences(index: DefinitionIndex): SoulSemanticIssue[] {
             subject: def.subject,
             ref: edge.value,
             field: edge.field,
+            candidates: suggestSlugs(index, edge.kind, edge.value),
           });
         }
         continue;

--- a/packages/soul/src/semantic.test.ts
+++ b/packages/soul/src/semantic.test.ts
@@ -1,6 +1,8 @@
 import type { VersionedSchemaDocument } from "@tulipfarm/schema";
 import { describe, expect, it } from "vitest";
 import {
+  MAX_REF_SUGGESTIONS,
+  type SoulSemanticIssue,
   type SoulSemanticIssueCode,
   SoulSemanticValidationError,
   validateSoulSemantics,
@@ -53,6 +55,17 @@ function tool(slug: string, spec: Record<string, unknown> = {}): VersionedSchema
     adapter: { kind: "native", ref: "x" },
     ...spec,
   });
+}
+
+/** Catch and return the thrown error's issues, or fail if nothing was thrown. */
+function issuesOf(fn: () => void): readonly SoulSemanticIssue[] {
+  try {
+    fn();
+  } catch (err) {
+    if (err instanceof SoulSemanticValidationError) return err.issues;
+    throw err;
+  }
+  throw new Error("expected SoulSemanticValidationError");
 }
 
 /** Catch and return the thrown error's issue codes, or fail if nothing was thrown. */
@@ -152,6 +165,74 @@ describe("validateSoulSemantics", () => {
       }),
     ];
     expect(codes(() => validateSoulSemantics(docs))).toEqual(["UNRESOLVED_REF"]);
+  });
+
+  it("suggests the resolvable Skill names on an unresolved reference", () => {
+    const docs = [
+      model("fast"),
+      def("Skill", "invoicing", { instructions: { path: "i.md" } }),
+      def("Skill", "onboarding", { instructions: { path: "i.md" } }),
+      def("Agent", "a", {
+        owner: "u",
+        instructions: { path: "i.md" },
+        modelProfile: "fast",
+        skills: ["invoicng"],
+        autonomy: "answer_only",
+        trustTier: "first_party",
+      }),
+    ];
+    const [issue] = issuesOf(() => validateSoulSemantics(docs));
+    expect(issue.code).toBe("UNRESOLVED_REF");
+    // The closer edit-distance match ("invoicing") sorts ahead of the unrelated "onboarding".
+    expect(issue.candidates).toEqual(["invoicing", "onboarding"]);
+  });
+
+  it("caps unresolved-reference suggestions at MAX_REF_SUGGESTIONS", () => {
+    const skillCount = MAX_REF_SUGGESTIONS + 5;
+    const docs: VersionedSchemaDocument[] = [
+      model("fast"),
+      ...Array.from({ length: skillCount }, (_, i) =>
+        def("Skill", `skill-${i}`, { instructions: { path: "i.md" } })
+      ),
+      def("Agent", "a", {
+        owner: "u",
+        instructions: { path: "i.md" },
+        modelProfile: "fast",
+        skills: ["does-not-exist"],
+        autonomy: "answer_only",
+        trustTier: "first_party",
+      }),
+    ];
+    const [issue] = issuesOf(() => validateSoulSemantics(docs));
+    expect(issue.code).toBe("UNRESOLVED_REF");
+    expect(issue.candidates?.length).toBe(MAX_REF_SUGGESTIONS);
+  });
+
+  it("never suggests a name of a different kind than the unresolved reference", () => {
+    const docs = [
+      model("fast"),
+      def("ModelProfile", "decoy", {
+        provider: "p",
+        model: "m",
+        reasoning: "low",
+        supports: { tools: true, structuredOutput: true, contextWindowTokens: 1 },
+        allowCaching: false,
+      }),
+      def("Agent", "a", {
+        owner: "u",
+        instructions: { path: "i.md" },
+        modelProfile: "fast",
+        // "missing" resolves against no Skill, so the ModelProfile named "decoy" — even one that
+        // exists in the same tree — must never appear in this Skill-kind suggestion list.
+        skills: ["missing"],
+        autonomy: "answer_only",
+        trustTier: "first_party",
+      }),
+    ];
+    const [issue] = issuesOf(() => validateSoulSemantics(docs));
+    expect(issue.code).toBe("UNRESOLVED_REF");
+    expect(issue.candidates).toEqual([]);
+    expect(issue.candidates).not.toContain("decoy");
   });
 
   it("rejects an unsatisfied version constraint", () => {
@@ -344,10 +425,15 @@ describe("validateSoulSemantics", () => {
     }
     const keys = issues.map((i) => `${i.subject} ${i.code} ${i.field ?? ""} ${i.ref ?? ""}`);
     expect(keys).toEqual([...keys].sort());
-    // Payload-safe: no definition content leaks — only authored identifiers/pointers.
+    // Payload-safe: no definition content leaks — only authored identifiers/pointers, plus the
+    // candidates array UNRESOLVED_REF carries (itself only ever authored slugs, never content).
     for (const issue of issues) {
       expect(issue.subject).toBe("Agent:a");
-      expect(Object.keys(issue).sort()).toEqual(["code", "field", "ref", "subject"]);
+      const expectedKeys =
+        issue.code === "UNRESOLVED_REF"
+          ? ["candidates", "code", "field", "ref", "subject"]
+          : ["code", "field", "ref", "subject"];
+      expect(Object.keys(issue).sort()).toEqual(expectedKeys);
     }
   });
 });

--- a/packages/soul/src/writer.test.ts
+++ b/packages/soul/src/writer.test.ts
@@ -343,7 +343,54 @@ describe("SoulWriter.apply — cross-definition reference checking", () => {
           },
         ],
       })
-    ).rejects.toThrow(/does not exist in the Soul — create it first/);
+    ).rejects.toThrow(/no definition of this kind exists in the Soul yet — create it first/);
+  });
+
+  it("suggests an existing Agent slug instead of a bare rejection when one is close", async () => {
+    const withTreeReader = new SoulWriter(
+      store,
+      logger,
+      { hasRemote: true, push: async () => {} },
+      { reload: async () => {} },
+      undefined,
+      new GitSoulTreeReader(soulPath)
+    );
+
+    await withTreeReader.apply({
+      subject: "soul: add agent",
+      source: "api",
+      actor: ACTOR,
+      businessId: "biz-1",
+      changes: [
+        {
+          op: "put",
+          target: { kind: "ModelProfile", slug: "default" },
+          content: modelProfileDoc("default"),
+        },
+        {
+          op: "put",
+          target: { kind: "Agent", slug: "greeter" },
+          content: agentDoc("greeter"),
+        },
+      ],
+    });
+
+    await expect(
+      withTreeReader.apply({
+        subject: "soul: add routine",
+        source: "api",
+        actor: ACTOR,
+        businessId: "biz-1",
+        changes: [
+          {
+            op: "put",
+            // One character off from the Agent that actually exists.
+            target: { kind: "Routine", slug: "greet" },
+            content: routineDoc("greet", "greetre"),
+          },
+        ],
+      })
+    ).rejects.toThrow(/did you mean one of: greeter\?/);
   });
 
   it("accepts the same Routine once its agentRef resolves", async () => {

--- a/packages/soul/src/writer.ts
+++ b/packages/soul/src/writer.ts
@@ -577,11 +577,12 @@ function errText(error: unknown): string {
  * What an issue code means for the caller. A pointer alone ("UNRESOLVED_REF at /spec/states/0") says
  * where the writer stopped but not what to do, and an authoring Agent answers that by guessing at
  * the reference's shape until its repair budget is gone. Naming the cause ends the guessing.
+ *
+ * `UNRESOLVED_REF` has no entry here: it is misleading to say once and for all that "the
+ * definition does not exist" when it may simply be misnamed, so {@link describeSemanticIssues}
+ * answers per issue instead, from that issue's own `candidates`.
  */
 const ISSUE_REMEDIES: Partial<Record<SoulSemanticIssue["code"], string>> = {
-  UNRESOLVED_REF:
-    "the referenced definition does not exist in the Soul — create it first, then write the " +
-    "definition that references it",
   VERSION_UNSATISFIED:
     "the referenced definition exists at a different authored version — reference the version it " +
     "actually has",
@@ -589,11 +590,29 @@ const ISSUE_REMEDIES: Partial<Record<SoulSemanticIssue["code"], string>> = {
   ROUTINE_TRANSITION_UNKNOWN: "a transition names a State that does not exist",
 };
 
+/**
+ * `UNRESOLVED_REF` guidance for one issue. Lists what the caller could have meant instead of
+ * repeating the unhelpful "it does not exist" — the reference may well be a plain misnaming — and
+ * only ever from `issue.candidates`, which is already scoped to this same changeset's own tree
+ * (see {@link SoulSemanticIssue.candidates}), never a wider catalog.
+ */
+function unresolvedRefGuidance(issue: SoulSemanticIssue): string {
+  if (issue.candidates === undefined || issue.candidates.length === 0) {
+    return (
+      "no definition of this kind exists in the Soul yet — create it first, then write the " +
+      "definition that references it"
+    );
+  }
+  return `did you mean one of: ${issue.candidates.join(", ")}?`;
+}
+
 function describeSemanticIssues(error: SoulSemanticValidationError): string {
-  const described = error.issues.map(
-    (issue) =>
-      `${issue.subject} ${issue.code}${issue.ref ? ` (${issue.ref})` : ""}${issue.field ? ` at ${issue.field}` : ""}`
-  );
+  const described = error.issues.map((issue) => {
+    const pointer = `${issue.subject} ${issue.code}${issue.ref ? ` (${issue.ref})` : ""}${issue.field ? ` at ${issue.field}` : ""}`;
+    return issue.code === "UNRESOLVED_REF"
+      ? `${pointer} — ${unresolvedRefGuidance(issue)}`
+      : pointer;
+  });
   const remedies = [
     ...new Set(
       error.issues.flatMap((issue) => {

--- a/packages/testkit/src/blob.test.ts
+++ b/packages/testkit/src/blob.test.ts
@@ -32,9 +32,11 @@ describe("InMemoryBlobPort conformance", () => {
   const make = async (): Promise<BlobPort> => new InMemoryBlobPort();
 
   for (const check of BLOB_CONFORMANCE) {
+    // The large-object checks byte-compare a multi-megabyte payload; under coverage
+    // instrumentation on a loaded CI runner that comfortably clears vitest's 5000ms default.
     it(check.name, async () => {
       await check.run(make);
-    });
+    }, 20_000);
   }
 
   for (const check of TAMPER_CONFORMANCE) {

--- a/packages/tool-host/src/capability-restrictions.test.ts
+++ b/packages/tool-host/src/capability-restrictions.test.ts
@@ -63,6 +63,33 @@ describe("agentCapabilityDenial", () => {
     ).toBeUndefined();
   });
 
+  it("names the allowed Tools in the denial, since the author already granted them", () => {
+    const restrictions: AgentCapabilityRestrictions = {
+      tools: { allow: ["record_list", "record_get"] },
+    };
+    const denial = agentCapabilityDenial(restrictions, { name: "record_get", mutating: false }, {});
+    expect(denial).toBeUndefined();
+    const otherDenial = agentCapabilityDenial(
+      restrictions,
+      { name: "record_delete", mutating: true },
+      {}
+    );
+    expect(otherDenial).toContain("record_list, record_get");
+  });
+
+  it("caps how many allowed Tool names a denial repeats back", () => {
+    const allow = Array.from({ length: 25 }, (_, i) => `tool_${i}`);
+    const restrictions: AgentCapabilityRestrictions = { tools: { allow } };
+    const denial = agentCapabilityDenial(
+      restrictions,
+      { name: "not_allowed", mutating: false },
+      {}
+    );
+    expect(denial).toContain("tool_0, tool_1");
+    expect(denial).toContain("+5 more");
+    expect(denial).not.toContain("tool_24");
+  });
+
   it("denies a record action named in the deny list", () => {
     const restrictions: AgentCapabilityRestrictions = {
       records: { actions: { deny: ["delete"] } },

--- a/packages/tool-host/src/capability-restrictions.ts
+++ b/packages/tool-host/src/capability-restrictions.ts
@@ -68,6 +68,25 @@ const RESOURCE_TYPE_TOOL_ACTIONS: Readonly<Record<string, string>> = {
  */
 const SKILL_TOOL_NAME = "skill";
 
+/**
+ * Cap on how many allowed Tool names a denial message repeats back. `restriction.allow` is data
+ * an Agent's own author wrote, so the caller was never blind to it, but a long allowlist would
+ * still balloon this message — cap it the same way an unresolved Soul reference is capped.
+ */
+const MAX_DENIAL_HINTS = 20;
+
+/**
+ * The allowlist a denial can safely repeat back — it is exactly what this Agent's author already
+ * granted it, not a wider catalog, so naming it cannot disclose a Tool the caller could not already
+ * see in its own configuration.
+ */
+function describeAllowedTools(allow: readonly string[]): string {
+  if (allow.length === 0) return "(none)";
+  const shown = allow.slice(0, MAX_DENIAL_HINTS);
+  const more = allow.length - shown.length;
+  return more > 0 ? `${shown.join(", ")} (+${more} more)` : shown.join(", ");
+}
+
 function toolDenied(tool: ToolShape, restriction: ToolRestriction | undefined): string | undefined {
   if (restriction === undefined) return undefined;
   if (restriction.deny?.includes(tool.name)) {
@@ -75,7 +94,10 @@ function toolDenied(tool: ToolShape, restriction: ToolRestriction | undefined): 
   }
   if (FLOW_CONTROL_TOOL_NAMES.has(tool.name)) return undefined;
   if (restriction.allow !== undefined && !restriction.allow.includes(tool.name)) {
-    return `tool "${tool.name}" is outside this Agent's allowed Tools`;
+    return (
+      `tool "${tool.name}" is outside this Agent's allowed Tools: ` +
+      `${describeAllowedTools(restriction.allow)}`
+    );
   }
   if (restriction.allowMutating === false && tool.mutating) {
     return `mutating tool "${tool.name}" is denied by this Agent's capability restrictions`;


### PR DESCRIPTION
## Summary

- `UNRESOLVED_REF` on a misnamed `agentRef`/`toolRef` gave an authoring Agent no signal of what
  names actually resolve, so it guessed repeatedly in staging — 5 consecutive rejected
  `routine_forge` calls on `engineering-motivation-quotes`, each an identical, uninformative
  `UNRESOLVED_REF` rejection. The same failure shape existed in `tool-host`'s
  `capability-restrictions.ts` "outside allowed Tools" denial.
- `SoulSemanticIssue` now carries `candidates`: the nearest-matching slugs of the referenced kind
  (edit-distance ranked, capped), drawn only from this same changeset's own proposed + kept tree
  (`packages/soul/src/refs.ts`) — never a wider catalog, so the message can only repeat back what
  the caller's own write already made visible to it. `capability-restrictions.ts` gets the same
  treatment: it names only the caller's own already-authored `allow` list, nothing else.
- Added an L3 `journey` eval Case
  (`apps/eval/corpus/l3-a-routine-unresolved-toolref-names-what-resolves.json`) proving this
  end-to-end against the real `SoulWriter`. Building it surfaced that the eval harness's
  `soul_write` Tool never wired a `treeReader` into `SoulWriter`, so `checkReferences` silently
  no-opped and a bad reference only ever failed later, invisibly, at publish —
  `apps/eval/src/l3/soul-write.ts` now wires the same `treeReader` production does. Also added a
  `tool_denial_contains` Expectation kind so a Case can assert on a real Tool denial's wording —
  the only way to make this fix's regression coverage genuine rather than a scripted model
  repeating its own script back.

**Security boundary**: candidate/allowed-Tool suggestions are drawn only from what the caller's own
changeset or own `allow` list already makes visible — never from the whole Soul or a wider catalog
— so the improved error message cannot become a disclosure channel for agents, tools, or artifacts
the caller isn't authorized to see.

**Note**: editing `apps/eval/corpus/` moves `corpusHash`; a maintainer needs to re-promote
Baselines against it before the gate compares anything again.

## Test plan

- [x] `pnpm exec biome check --write <changed dirs>` — clean (2 pre-existing warnings in untouched files)
- [x] `pnpm --filter @tulipfarm/soul test` — 737 passed, 1 skipped (53 files)
- [x] `pnpm --filter @tulipfarm/tool-host test` — 142 passed (8 files)
- [x] `pnpm --filter @tulipfarm/eval test` — 476 passed (30 files)
- [x] `pnpm eval` (scripted tier, whole Corpus) — 45 passed, 0 failed
- [x] New L3 Case verified fail-before/pass-after via `git stash` on `refs.ts`/`writer.ts`
- [x] `pnpm lint` — 40/40 tasks successful
- [x] `pnpm typecheck` — 40/40 workspaces clean