### PR TITLE
fix(worker): carry semantic failure evidence onto the Run

### DIFF
--- a/apps/eval/src/l3/tier.ts
+++ b/apps/eval/src/l3/tier.ts
@@ -340,10 +340,13 @@ async function runOneTurn(
     await database.runs.transitionRun(BUSINESS_ID, runId, {
       expectedVersion: settled?.version ?? run.version,
       expectedStatus: settled?.status ?? run.status,
-      status: outcome,
+      status: outcome.status,
       finishedAt: new Date().toISOString(),
       leaseOwner: null,
       leaseExpiresAt: null,
+      ...(outcome.errorEvidenceRef === undefined
+        ? {}
+        : { errorEvidenceRef: outcome.errorEvidenceRef }),
     });
 
     const curatorTasks = await deliverCurator({

--- a/apps/worker/src/curator/executor.test.ts
+++ b/apps/worker/src/curator/executor.test.ts
@@ -45,7 +45,7 @@ test("resolves context, reasons once, and submits under the pinned digest", asyn
   const api = makeApi();
   const outcome = await createCuratorExecutor({ api, models, artifacts: JOB_ARTIFACT })(RUN);
 
-  expect(outcome).toBe("succeeded");
+  expect(outcome).toEqual({ status: "succeeded" });
   expect(api.calls.mock.calls[0]).toEqual(["GET", "/api/v1/internal/curator/jobs/job-1/context"]);
   const [method, path, body] = api.calls.mock.calls[1] ?? [];
   expect(method).toBe("POST");
@@ -56,9 +56,10 @@ test("resolves context, reasons once, and submits under the pinned digest", asyn
 // The request Artifact names a job, never the inputs. Without one there is nothing to point at.
 test("fails a Run whose request Artifact names no job rather than guessing", async () => {
   const api = makeApi();
-  expect(await createCuratorExecutor({ api, models, artifacts: makeArtifacts({}) })(RUN)).toBe(
-    "failed"
-  );
+  expect(await createCuratorExecutor({ api, models, artifacts: makeArtifacts({}) })(RUN)).toEqual({
+    status: "failed",
+    errorEvidenceRef: "curator:missing_job_id",
+  });
   expect(api.calls).not.toHaveBeenCalled();
 });
 
@@ -66,13 +67,19 @@ test("fails a Run whose request Artifact names no job rather than guessing", asy
 test("fails a Run whose request Artifact is not a Curator request", async () => {
   const api = makeApi();
   const artifacts = makeArtifacts({ jobId: "job-1" }, "tulip.invocation.manual-request.v1");
-  expect(await createCuratorExecutor({ api, models, artifacts })(RUN)).toBe("failed");
+  expect(await createCuratorExecutor({ api, models, artifacts })(RUN)).toEqual({
+    status: "failed",
+    errorEvidenceRef: "curator:missing_job_id",
+  });
   expect(api.calls).not.toHaveBeenCalled();
 });
 
 test("fails without submitting when the context carries no digest", async () => {
   const api = makeApi({ jobId: "job-1", scope: "user" });
-  expect(await createCuratorExecutor({ api, models, artifacts: JOB_ARTIFACT })(RUN)).toBe("failed");
+  expect(await createCuratorExecutor({ api, models, artifacts: JOB_ARTIFACT })(RUN)).toEqual({
+    status: "failed",
+    errorEvidenceRef: "curator:missing_context_digest",
+  });
   expect(api.calls).toHaveBeenCalledTimes(1);
 });
 
@@ -109,7 +116,7 @@ test("submits unparsable output verbatim so the API records the rejection", asyn
   const api = makeApi();
   const outcome = await createCuratorExecutor({ api, models, artifacts: JOB_ARTIFACT })(RUN);
 
-  expect(outcome).toBe("succeeded");
+  expect(outcome).toEqual({ status: "succeeded" });
   expect(api.calls.mock.calls[1]?.[2]).toEqual({
     contextDigest: "digest-1",
     output: "I refuse to answer.",
@@ -159,7 +166,7 @@ test("returns failed on transient API failure instead of throwing", async () => 
     }) as never,
   };
   const outcome = await createCuratorExecutor({ api, models, artifacts: JOB_ARTIFACT })(RUN);
-  expect(outcome).toBe("failed");
+  expect(outcome).toEqual({ status: "failed", errorEvidenceRef: "curator:execution_failed" });
 });
 
 test("progresses invoke state from pending to succeeded when transitions are provided", async () => {
@@ -196,7 +203,7 @@ test("progresses invoke state from pending to succeeded when transitions are pro
     transitions: fakeTransitions as never,
   })(RUN);
 
-  expect(outcome).toBe("succeeded");
+  expect(outcome).toEqual({ status: "succeeded" });
   expect(stateTransitions).toEqual([
     { from: "pending", to: "ready", reason: undefined },
     { from: "ready", to: "claimed", reason: undefined },
@@ -244,7 +251,7 @@ test("progresses invoke state from pending to failed when execution fails", asyn
     transitions: fakeTransitions as never,
   })(RUN);
 
-  expect(outcome).toBe("failed");
+  expect(outcome).toEqual({ status: "failed", errorEvidenceRef: "curator:execution_failed" });
   expect(stateTransitions).toEqual([
     { from: "pending", to: "ready", reason: undefined },
     { from: "ready", to: "claimed", reason: undefined },

--- a/apps/worker/src/curator/executor.ts
+++ b/apps/worker/src/curator/executor.ts
@@ -131,7 +131,7 @@ export function createCuratorExecutor(
             reason: "missing_job_id",
           });
         }
-        return "failed";
+        return { status: "failed", errorEvidenceRef: "curator:missing_job_id" };
       }
 
       const context = await api.require<ResolvedContext>(
@@ -150,7 +150,7 @@ export function createCuratorExecutor(
             reason: "missing_context_digest",
           });
         }
-        return "failed";
+        return { status: "failed", errorEvidenceRef: "curator:missing_context_digest" };
       }
 
       const prompt =
@@ -190,7 +190,7 @@ ${OUTPUT_INSTRUCTION}`,
         });
       }
 
-      return "succeeded";
+      return { status: "succeeded" };
     } catch (error) {
       log?.error?.(`curator run failed for runId=${run.id}`, error);
       if (transitions && stateRunning) {
@@ -207,7 +207,9 @@ ${OUTPUT_INSTRUCTION}`,
           // Failure to transition state on error should still return "failed"
         }
       }
-      return "failed";
+      // The exception message went to the State's own reason above; the Run-level evidence ref
+      // stays a fixed, terse code so a provider or SDK error message never reaches this column.
+      return { status: "failed", errorEvidenceRef: "curator:execution_failed" };
     }
   };
 }

--- a/apps/worker/src/executors.test.ts
+++ b/apps/worker/src/executors.test.ts
@@ -78,18 +78,18 @@ describe("RunExecutorRegistry", () => {
     const seen: string[] = [];
     registry.register("chat", async (run) => {
       seen.push(run.id);
-      return "succeeded";
+      return { status: "succeeded" };
     });
 
-    await expect(registry.execute(persistedRun())).resolves.toBe("succeeded");
+    await expect(registry.execute(persistedRun())).resolves.toEqual({ status: "succeeded" });
     expect(seen).toEqual([persistedRun().id]);
     expect(registry.size).toBe(1);
   });
 
   it("rejects a duplicate registration rather than silently replacing an executor", () => {
     const registry = new RunExecutorRegistry();
-    registry.register("chat", async () => "succeeded");
-    expect(() => registry.register("chat", async () => "failed")).toThrow(
+    registry.register("chat", async () => ({ status: "succeeded" }));
+    expect(() => registry.register("chat", async () => ({ status: "failed" }))).toThrow(
       'duplicate executor registered for Run source "chat"'
     );
   });

--- a/apps/worker/src/recovery/run-dispatch.test.ts
+++ b/apps/worker/src/recovery/run-dispatch.test.ts
@@ -226,7 +226,7 @@ describe("Run dispatch recovery", () => {
       SURVIVOR,
       async (dispatched) => {
         handled.push(dispatched.id);
-        return "succeeded";
+        return { status: "succeeded" };
       },
       () => AFTER_LEASE
     ).dispatchBatch();
@@ -252,7 +252,7 @@ describe("Run dispatch recovery", () => {
     const handled: string[] = [];
     const handler = async (dispatched: PersistedRun): Promise<RunOutcome> => {
       handled.push(dispatched.leaseOwner ?? "");
-      return "succeeded";
+      return { status: "succeeded" };
     };
 
     // Both workers claim the same batch; only the first `claimed`->`running` CAS can win.

--- a/apps/worker/src/routine/executor.test.ts
+++ b/apps/worker/src/routine/executor.test.ts
@@ -217,7 +217,7 @@ describe("createRoutineExecutor", () => {
       harness
     );
 
-    await expect(execute(run())).resolves.toBe("succeeded");
+    await expect(execute(run())).resolves.toEqual({ status: "succeeded" });
     expect(harness.transitions).toEqual([
       "Start:pending->ready",
       "Start:ready->claimed",
@@ -247,7 +247,7 @@ describe("createRoutineExecutor", () => {
       harness
     );
 
-    await expect(execute(run())).resolves.toBe("succeeded");
+    await expect(execute(run())).resolves.toEqual({ status: "succeeded" });
     expect(harness.states.get("Finish")?.resolvedInput).toEqual({ copiedRegion: "west" });
     expect(harness.inserted).toBe(1);
     expect(harness.events.indexOf("Finish:scheduled")).toBeLessThan(
@@ -279,7 +279,7 @@ describe("createRoutineExecutor", () => {
     await expect(execute(run())).rejects.toThrow("injected crash");
     expect(harness.states.get("Start")?.status).toBe("running");
     expect(harness.states.get("Finish")?.status).toBe("pending");
-    await expect(execute(run())).resolves.toBe("succeeded");
+    await expect(execute(run())).resolves.toEqual({ status: "succeeded" });
     expect(harness.inserted).toBe(1);
     expect(harness.states.get("Finish")?.status).toBe("succeeded");
   });
@@ -298,7 +298,7 @@ describe("createRoutineExecutor", () => {
       harness
     );
 
-    await expect(execute(run())).resolves.toBe("needs_reconciliation");
+    await expect(execute(run())).resolves.toEqual({ status: "needs_reconciliation" });
     expect(harness.states.get("Start")).toMatchObject({
       status: "needs_reconciliation",
       errorEvidenceRef: "routine:unsupported_state",
@@ -330,7 +330,7 @@ describe("createRoutineExecutor", () => {
       harness
     );
 
-    await expect(execute(run())).resolves.toBe("succeeded");
+    await expect(execute(run())).resolves.toEqual({ status: "succeeded" });
     expect(harness.states.get("Route")?.resolvedInput).toEqual({ carried: "need-triage" });
     expect(harness.transitions).toContain("Matched:running->succeeded");
     expect(harness.states.has("Missed")).toBe(false);
@@ -360,7 +360,7 @@ describe("createRoutineExecutor", () => {
       harness
     );
 
-    await expect(execute(run())).resolves.toBe("succeeded");
+    await expect(execute(run())).resolves.toEqual({ status: "succeeded" });
     expect(harness.transitions).toContain("Matched:running->succeeded");
     expect(harness.states.has("Missed")).toBe(false);
   });
@@ -379,7 +379,7 @@ describe("createRoutineExecutor", () => {
       harness
     );
 
-    await expect(execute(run())).resolves.toBe("needs_reconciliation");
+    await expect(execute(run())).resolves.toEqual({ status: "needs_reconciliation" });
     expect(harness.states.get("Start")).toMatchObject({
       status: "needs_reconciliation",
       errorEvidenceRef: "routine:input_not_evaluable",
@@ -404,7 +404,9 @@ describe("createRoutineExecutor — durable waits", () => {
   it("opens a timer and parks the Run on it", async () => {
     const harness = new StateHarness([state("Start")]);
 
-    await expect(executor(waitDefinition(), harness)(run())).resolves.toBe("waiting");
+    await expect(executor(waitDefinition(), harness)(run())).resolves.toEqual({
+      status: "waiting",
+    });
     expect(harness.transitions).toEqual([
       "Start:pending->ready",
       "Start:ready->claimed",
@@ -420,8 +422,8 @@ describe("createRoutineExecutor — durable waits", () => {
     const harness = new StateHarness([state("Start")]);
     const execute = executor(waitDefinition(), harness);
 
-    await expect(execute(run())).resolves.toBe("waiting");
-    await expect(execute(run())).resolves.toBe("waiting");
+    await expect(execute(run())).resolves.toEqual({ status: "waiting" });
+    await expect(execute(run())).resolves.toEqual({ status: "waiting" });
     expect(harness.waits.size).toBe(1);
     expect(harness.events.filter((event) => event === "Start:wait-opened")).toHaveLength(1);
   });
@@ -446,9 +448,9 @@ describe("createRoutineExecutor — durable waits", () => {
       harness
     );
 
-    await expect(withSuccessor(run())).resolves.toBe("waiting");
+    await expect(withSuccessor(run())).resolves.toEqual({ status: "waiting" });
     harness.resolveWait("Start", "satisfied");
-    await expect(withSuccessor(run())).resolves.toBe("succeeded");
+    await expect(withSuccessor(run())).resolves.toEqual({ status: "succeeded" });
     expect(harness.transitions.slice(4)).toEqual([
       "Start:waiting->ready",
       "Start:ready->claimed",
@@ -468,18 +470,18 @@ describe("createRoutineExecutor — durable waits", () => {
       harness
     );
 
-    await expect(execute(run())).resolves.toBe("waiting");
+    await expect(execute(run())).resolves.toEqual({ status: "waiting" });
     harness.resolveWait("Start", "timed_out");
-    await expect(execute(run())).resolves.toBe("succeeded");
+    await expect(execute(run())).resolves.toEqual({ status: "succeeded" });
   });
 
   it("parks an expired timer the Routine declared no handler for", async () => {
     const harness = new StateHarness([state("Start")]);
     const execute = executor(waitDefinition(), harness);
 
-    await expect(execute(run())).resolves.toBe("waiting");
+    await expect(execute(run())).resolves.toEqual({ status: "waiting" });
     harness.resolveWait("Start", "timed_out");
-    await expect(execute(run())).resolves.toBe("needs_reconciliation");
+    await expect(execute(run())).resolves.toEqual({ status: "needs_reconciliation" });
     expect(harness.states.get("Start")?.errorEvidenceRef).toBe("routine:wait_timed_out");
   });
 
@@ -490,7 +492,7 @@ describe("createRoutineExecutor — durable waits", () => {
       harness
     );
 
-    await expect(execute(run())).resolves.toBe("needs_reconciliation");
+    await expect(execute(run())).resolves.toEqual({ status: "needs_reconciliation" });
     expect(harness.states.get("Start")?.errorEvidenceRef).toBe("routine:unsupported_wait");
     expect(harness.waits.size).toBe(0);
   });
@@ -525,7 +527,9 @@ describe("createRoutineExecutor — bounded fan-out", () => {
   it("executes every branch under its own occurrence key", async () => {
     const harness = new StateHarness([state("Start")]);
 
-    await expect(executor(parallelDefinition(), harness)(run())).resolves.toBe("succeeded");
+    await expect(executor(parallelDefinition(), harness)(run())).resolves.toEqual({
+      status: "succeeded",
+    });
     expect(harness.states.get("Start#Left/Left")?.status).toBe("succeeded");
     expect(harness.states.get("Start#Right/Right")?.status).toBe("succeeded");
     expect(harness.inserted).toBe(2);
@@ -538,7 +542,7 @@ describe("createRoutineExecutor — bounded fan-out", () => {
     const harness = new StateHarness([state("Start")]);
     const execute = executor(parallelDefinition({ maxConcurrency: 1 }), harness);
 
-    await expect(execute(run())).resolves.toBe("succeeded");
+    await expect(execute(run())).resolves.toEqual({ status: "succeeded" });
     expect(harness.events.indexOf("Start#Left/Left:running->succeeded")).toBeLessThan(
       harness.events.indexOf("Start#Right/Right:scheduled")
     );
@@ -551,7 +555,7 @@ describe("createRoutineExecutor — bounded fan-out", () => {
 
     await expect(execute(run())).rejects.toThrow("injected crash");
     expect(harness.states.get("Start#Left/Left")?.status).toBe("succeeded");
-    await expect(execute(run())).resolves.toBe("succeeded");
+    await expect(execute(run())).resolves.toEqual({ status: "succeeded" });
     expect(harness.inserted).toBe(2);
   });
 
@@ -579,7 +583,7 @@ describe("createRoutineExecutor — bounded fan-out", () => {
       harness
     );
 
-    await expect(execute(run())).resolves.toBe("succeeded");
+    await expect(execute(run())).resolves.toEqual({ status: "succeeded" });
     expect(harness.states.get("Start#0/Body")?.resolvedInput).toEqual({ tag: "a" });
     expect(harness.states.get("Start#1/Body")?.resolvedInput).toEqual({ tag: "b" });
     expect(harness.inserted).toBe(2);
@@ -603,7 +607,7 @@ describe("createRoutineExecutor — bounded fan-out", () => {
       harness
     );
 
-    await expect(execute(run())).resolves.toBe("succeeded");
+    await expect(execute(run())).resolves.toEqual({ status: "succeeded" });
     expect([...harness.states.keys()]).toEqual(["Start", "Start#0/Body", "Start#1/Body"]);
   });
 
@@ -625,7 +629,7 @@ describe("createRoutineExecutor — bounded fan-out", () => {
       harness
     );
 
-    await expect(execute(run())).resolves.toBe("needs_reconciliation");
+    await expect(execute(run())).resolves.toEqual({ status: "needs_reconciliation" });
     expect(harness.states.get("Start")?.errorEvidenceRef).toBe("routine:iteration_cap_exceeded");
   });
 });
@@ -679,7 +683,7 @@ describe("createRoutineExecutor — tool States", () => {
       calls
     );
 
-    await expect(execute(run())).resolves.toBe("succeeded");
+    await expect(execute(run())).resolves.toEqual({ status: "succeeded" });
     expect(harness.transitions).toEqual([
       "Start:pending->ready",
       "Start:ready->claimed",
@@ -707,7 +711,7 @@ describe("createRoutineExecutor — tool States", () => {
       now: () => new Date(STARTED_AT),
     });
 
-    await expect(execute(run())).resolves.toBe("needs_reconciliation");
+    await expect(execute(run())).resolves.toEqual({ status: "needs_reconciliation" });
     expect(harness.states.get("Start")?.errorEvidenceRef).toBe("routine:unsupported_state");
   });
 
@@ -718,7 +722,7 @@ describe("createRoutineExecutor — tool States", () => {
       reason: "approval_required",
     });
 
-    await expect(execute(run())).resolves.toBe("needs_reconciliation");
+    await expect(execute(run())).resolves.toEqual({ status: "needs_reconciliation" });
     expect(harness.states.get("Start")?.errorEvidenceRef).toBe("routine:approval_required");
   });
 
@@ -729,7 +733,7 @@ describe("createRoutineExecutor — tool States", () => {
       reason: "effect_ambiguous",
     });
 
-    await expect(execute(run())).resolves.toBe("needs_reconciliation");
+    await expect(execute(run())).resolves.toEqual({ status: "needs_reconciliation" });
     expect(harness.states.get("Start")?.errorEvidenceRef).toBe("routine:effect_ambiguous");
   });
 
@@ -753,7 +757,7 @@ describe("createRoutineExecutor — tool States", () => {
       { kind: "failed", reason: "guardrail_denied" }
     );
 
-    await expect(execute(run())).resolves.toBe("succeeded");
+    await expect(execute(run())).resolves.toEqual({ status: "succeeded" });
     expect(harness.events).toContain("Fallback:scheduled");
   });
 
@@ -764,7 +768,10 @@ describe("createRoutineExecutor — tool States", () => {
       reason: "dispatch_failed",
     });
 
-    await expect(execute(run())).resolves.toBe("failed");
+    await expect(execute(run())).resolves.toEqual({
+      status: "failed",
+      errorEvidenceRef: "routine:tool_dispatch_failed",
+    });
     expect(harness.transitions).toContain("Start:running->failed");
   });
 });
@@ -820,7 +827,7 @@ describe("createRoutineExecutor — agent States", () => {
       calls
     );
 
-    await expect(execute(run())).resolves.toBe("succeeded");
+    await expect(execute(run())).resolves.toEqual({ status: "succeeded" });
     expect(harness.transitions).toEqual([
       "Start:pending->ready",
       "Start:ready->claimed",
@@ -861,7 +868,7 @@ describe("createRoutineExecutor — agent States", () => {
       []
     );
 
-    await expect(execute(run())).resolves.toBe("succeeded");
+    await expect(execute(run())).resolves.toEqual({ status: "succeeded" });
     // Before State outputs were durable this resolved to null and the successor never saw a value.
     expect(harness.states.get("Record")?.resolvedInput).toEqual({ chosen: "billing" });
     expect(harness.states.get("Start")?.output).toEqual({ category: "billing" });
@@ -914,7 +921,7 @@ describe("createRoutineExecutor — agent States", () => {
       now: () => new Date(STARTED_AT),
     });
 
-    await expect(execute(run())).resolves.toBe("succeeded");
+    await expect(execute(run())).resolves.toEqual({ status: "succeeded" });
     // Before State outputs were durable the replayed Agent republished null and this resolved to
     // nothing, so the whole tail of the Routine ran on empty Context.
     expect(harness.states.get("Final")?.resolvedInput).toEqual({ echo: "billing" });
@@ -935,7 +942,7 @@ describe("createRoutineExecutor — agent States", () => {
       now: () => new Date(STARTED_AT),
     });
 
-    await expect(execute(run())).resolves.toBe("needs_reconciliation");
+    await expect(execute(run())).resolves.toEqual({ status: "needs_reconciliation" });
     expect(harness.states.get("Start")?.errorEvidenceRef).toBe("routine:unsupported_state");
   });
 
@@ -946,7 +953,7 @@ describe("createRoutineExecutor — agent States", () => {
       reason: "agent_not_in_bundle",
     });
 
-    await expect(execute(run())).resolves.toBe("needs_reconciliation");
+    await expect(execute(run())).resolves.toEqual({ status: "needs_reconciliation" });
     expect(harness.states.get("Start")?.errorEvidenceRef).toBe("routine:agent_not_in_bundle");
   });
 
@@ -957,7 +964,7 @@ describe("createRoutineExecutor — agent States", () => {
       reason: "approval_required",
     });
 
-    await expect(execute(run())).resolves.toBe("needs_reconciliation");
+    await expect(execute(run())).resolves.toEqual({ status: "needs_reconciliation" });
     expect(harness.states.get("Start")?.errorEvidenceRef).toBe("routine:approval_required");
   });
 
@@ -965,7 +972,7 @@ describe("createRoutineExecutor — agent States", () => {
     const harness = new StateHarness([state("Start")]);
     const execute = agentExecutor(definition([classifyState]), harness, { kind: "cancelled" });
 
-    await expect(execute(run())).resolves.toBe("cancelled");
+    await expect(execute(run())).resolves.toEqual({ status: "cancelled" });
     expect(harness.transitions).not.toContain("Start:running->failed");
   });
 
@@ -989,7 +996,7 @@ describe("createRoutineExecutor — agent States", () => {
       { kind: "failed", reason: "guardrail_output_blocked", retryable: false }
     );
 
-    await expect(execute(run())).resolves.toBe("succeeded");
+    await expect(execute(run())).resolves.toEqual({ status: "succeeded" });
     expect(harness.events).toContain("Fallback:scheduled");
   });
 
@@ -1001,8 +1008,29 @@ describe("createRoutineExecutor — agent States", () => {
       retryable: true,
     });
 
-    await expect(execute(run())).resolves.toBe("failed");
+    await expect(execute(run())).resolves.toEqual({
+      status: "failed",
+      errorEvidenceRef: "routine:agent_model_error",
+    });
     expect(harness.transitions).toContain("Start:running->failed");
+  });
+
+  it("carries a tool-call-limit exhaustion from the State onto the Run's own evidence ref", async () => {
+    // Staging evidence: `run_states.error_evidence_ref` was set to `routine:agent_tool_call_limit`
+    // on 28 failed Runs while `runs.error_evidence_ref` stayed null — a semantic failure (the Agent
+    // loop returns "failed" rather than throwing) that never reached the Run row.
+    const harness = new StateHarness([state("Start")]);
+    const execute = agentExecutor(definition([classifyState]), harness, {
+      kind: "failed",
+      reason: "tool_call_limit",
+      retryable: false,
+    });
+
+    await expect(execute(run())).resolves.toEqual({
+      status: "failed",
+      errorEvidenceRef: "routine:agent_tool_call_limit",
+    });
+    expect(harness.states.get("Start")?.errorEvidenceRef).toBe("routine:agent_tool_call_limit");
   });
 });
 
@@ -1087,7 +1115,7 @@ describe("createRoutineExecutor — approval States", () => {
 
     await expect(
       approvalExecutor(approvalDefinition(), harness, approvals.port)(run())
-    ).resolves.toBe("waiting");
+    ).resolves.toEqual({ status: "waiting" });
     expect(harness.transitions).toEqual([
       "Start:pending->ready",
       "Start:ready->claimed",
@@ -1110,8 +1138,8 @@ describe("createRoutineExecutor — approval States", () => {
     const approvals = new ApprovalHarness();
     const execute = approvalExecutor(approvalDefinition(), harness, approvals.port);
 
-    await expect(execute(run())).resolves.toBe("waiting");
-    await expect(execute(run())).resolves.toBe("waiting");
+    await expect(execute(run())).resolves.toEqual({ status: "waiting" });
+    await expect(execute(run())).resolves.toEqual({ status: "waiting" });
     expect(approvals.opened).toHaveLength(1);
   });
 
@@ -1120,9 +1148,9 @@ describe("createRoutineExecutor — approval States", () => {
     const approvals = new ApprovalHarness();
     const execute = approvalExecutor(approvalDefinition(), harness, approvals.port);
 
-    await expect(execute(run())).resolves.toBe("waiting");
+    await expect(execute(run())).resolves.toEqual({ status: "waiting" });
     approvals.decide("Start", "approved");
-    await expect(execute(run())).resolves.toBe("succeeded");
+    await expect(execute(run())).resolves.toEqual({ status: "succeeded" });
     expect(harness.transitions.slice(4)).toEqual([
       "Start:waiting->ready",
       "Start:ready->claimed",
@@ -1136,9 +1164,9 @@ describe("createRoutineExecutor — approval States", () => {
     const approvals = new ApprovalHarness();
     const execute = approvalExecutor(approvalDefinition(), harness, approvals.port);
 
-    await expect(execute(run())).resolves.toBe("waiting");
+    await expect(execute(run())).resolves.toEqual({ status: "waiting" });
     approvals.decide("Start", "denied");
-    await expect(execute(run())).resolves.toBe("failed");
+    await expect(execute(run())).resolves.toEqual({ status: "failed" });
     expect(harness.states.get("Start")?.errorEvidenceRef).toBe("routine:approval_rejected");
   });
 
@@ -1157,9 +1185,9 @@ describe("createRoutineExecutor — approval States", () => {
       approvals.port
     );
 
-    await expect(execute(run())).resolves.toBe("waiting");
+    await expect(execute(run())).resolves.toEqual({ status: "waiting" });
     approvals.decide("Start", "denied");
-    await expect(execute(run())).resolves.toBe("succeeded");
+    await expect(execute(run())).resolves.toEqual({ status: "succeeded" });
     expect(harness.events).toContain("Denied:scheduled");
   });
 
@@ -1168,18 +1196,18 @@ describe("createRoutineExecutor — approval States", () => {
     const approvals = new ApprovalHarness();
     const execute = approvalExecutor(approvalDefinition(), harness, approvals.port);
 
-    await expect(execute(run())).resolves.toBe("waiting");
+    await expect(execute(run())).resolves.toEqual({ status: "waiting" });
     approvals.decide("Start", "expired");
-    await expect(execute(run())).resolves.toBe("needs_reconciliation");
+    await expect(execute(run())).resolves.toEqual({ status: "needs_reconciliation" });
     expect(harness.states.get("Start")?.errorEvidenceRef).toBe("routine:wait_expired");
   });
 
   it("parks an approval State when no decision surface is composed", async () => {
     const harness = new StateHarness([state("Start")]);
 
-    await expect(approvalExecutor(approvalDefinition(), harness)(run())).resolves.toBe(
-      "needs_reconciliation"
-    );
+    await expect(approvalExecutor(approvalDefinition(), harness)(run())).resolves.toEqual({
+      status: "needs_reconciliation",
+    });
     expect(harness.states.get("Start")?.errorEvidenceRef).toBe("routine:unsupported_state");
   });
 });
@@ -1240,7 +1268,7 @@ describe("createRoutineExecutor — retry policy", () => {
       retries,
     });
 
-    await expect(execute(run())).resolves.toBe("succeeded");
+    await expect(execute(run())).resolves.toEqual({ status: "succeeded" });
     expect(calls).toBe(2);
     expect((await retries.load("business-1", run().id, "Start"))?.attempts).toBe(2);
     expect(harness.transitions).toContain("Start:running->succeeded");
@@ -1264,7 +1292,10 @@ describe("createRoutineExecutor — retry policy", () => {
       retries,
     });
 
-    await expect(execute(run())).resolves.toBe("failed");
+    await expect(execute(run())).resolves.toEqual({
+      status: "failed",
+      errorEvidenceRef: "routine:agent_model_rate_limited",
+    });
     expect(calls).toBe(2);
     expect((await retries.load("business-1", run().id, "Start"))?.attempts).toBe(2);
     expect(harness.transitions).toContain("Start:running->failed");
@@ -1288,7 +1319,10 @@ describe("createRoutineExecutor — retry policy", () => {
       retries,
     });
 
-    await expect(execute(run())).resolves.toBe("failed");
+    await expect(execute(run())).resolves.toEqual({
+      status: "failed",
+      errorEvidenceRef: "routine:agent_guardrail_output_blocked",
+    });
     expect(calls).toBe(1);
     expect(harness.transitions).toContain("Start:running->failed");
   });
@@ -1317,7 +1351,7 @@ describe("createRoutineExecutor — retry policy", () => {
       },
     });
 
-    await expect(execute(run())).resolves.toBe("succeeded");
+    await expect(execute(run())).resolves.toEqual({ status: "succeeded" });
     expect(calls).toBe(3);
     expect(delays).toEqual([100, 100]);
   });
@@ -1349,7 +1383,10 @@ describe("createRoutineExecutor — retry policy", () => {
     resumed = true;
     // The resumed State must continue from the 2 attempts already spent, not restart at zero:
     // 3 more physical attempts (3rd, 4th, 5th) reach the ceiling — a refund would take 5 more.
-    await expect(execute(run())).resolves.toBe("failed");
+    await expect(execute(run())).resolves.toEqual({
+      status: "failed",
+      errorEvidenceRef: "routine:agent_model_error",
+    });
     expect(calls).toBe(5);
     expect((await retries.load("business-1", run().id, "Start"))?.attempts).toBe(5);
     expect(harness.transitions).toContain("Start:running->failed");
@@ -1423,7 +1460,7 @@ describe("createRoutineExecutor — concurrencyKey", () => {
     };
 
     const execute = keyedExecutor({ harness, agent, concurrency, concurrencyKey: "digest" });
-    await expect(execute(run())).resolves.toBe("succeeded");
+    await expect(execute(run())).resolves.toEqual({ status: "succeeded" });
 
     expect(heldDuringExecution).toBe("busy");
     // Released on settle, so the next Run to want the key gets it immediately.
@@ -1447,7 +1484,10 @@ describe("createRoutineExecutor — concurrencyKey", () => {
     };
 
     const execute = keyedExecutor({ harness, agent, concurrency, concurrencyKey: "digest" });
-    await expect(execute(run())).resolves.toBe("failed");
+    await expect(execute(run())).resolves.toEqual({
+      status: "failed",
+      errorEvidenceRef: "routine:agent_model_error",
+    });
     await expect(
       concurrency.acquire({
         businessId: "business-1",
@@ -1486,7 +1526,7 @@ describe("createRoutineExecutor — concurrencyKey", () => {
       concurrencyKey: "digest",
       delay: async () => {},
     });
-    await expect(execute(run())).resolves.toBe("waiting");
+    await expect(execute(run())).resolves.toEqual({ status: "waiting" });
     expect(calls).toBe(0);
     expect(harness.transitions).toContain("Start:running->waiting");
     expect(harness.transitions).not.toContain("Start:running->needs_reconciliation");
@@ -1525,10 +1565,10 @@ describe("createRoutineExecutor — concurrencyKey", () => {
 
     // Each pass opens one backoff, fires it, and comes back into execution to try the key again.
     for (let pass = 1; pass <= STATE_CONCURRENCY_MAX_WAITS; pass += 1) {
-      await expect(execute(run())).resolves.toBe("waiting");
+      await expect(execute(run())).resolves.toEqual({ status: "waiting" });
       harness.resolveConcurrencyWait("Start", pass);
     }
-    await expect(execute(run())).resolves.toBe("needs_reconciliation");
+    await expect(execute(run())).resolves.toEqual({ status: "needs_reconciliation" });
 
     expect(calls).toBe(0);
     expect(harness.transitions).toContain("Start:running->needs_reconciliation");
@@ -1567,14 +1607,14 @@ describe("createRoutineExecutor — concurrencyKey", () => {
       delay: async () => {},
     });
 
-    await expect(execute(run())).resolves.toBe("waiting");
+    await expect(execute(run())).resolves.toEqual({ status: "waiting" });
     expect(calls).toBe(0);
 
     // Holder releases, sweep fires the timer, contender is requeued.
     await concurrency.release("business-1", "digest", OTHER_RUN, "Start");
     harness.resolveConcurrencyWait("Start", 1);
 
-    await expect(execute(run())).resolves.toBe("succeeded");
+    await expect(execute(run())).resolves.toEqual({ status: "succeeded" });
     // Resuming *into* the State: its effect ran exactly once, it was not skipped as satisfied.
     expect(calls).toBe(1);
     expect(harness.transitions).toContain("Start:waiting->ready");
@@ -1601,10 +1641,10 @@ describe("createRoutineExecutor — concurrencyKey", () => {
       delay: async () => {},
     });
 
-    await expect(execute(run())).resolves.toBe("waiting");
+    await expect(execute(run())).resolves.toEqual({ status: "waiting" });
     // Crash-and-reclaim before the sweep fires: the State is back at `running`, its wait pending.
     harness.states.set("Start", { ...state("Start", "running"), version: 9 });
-    await expect(execute(run())).resolves.toBe("waiting");
+    await expect(execute(run())).resolves.toEqual({ status: "waiting" });
 
     await expect(contention.load("business-1", run().id, "Start")).resolves.toMatchObject({
       waits: 1,
@@ -1630,7 +1670,7 @@ describe("createRoutineExecutor — concurrencyKey", () => {
       concurrency,
       concurrencyKey: "digest",
     });
-    await expect(execute(run())).resolves.toBe("succeeded");
+    await expect(execute(run())).resolves.toEqual({ status: "succeeded" });
   });
 
   it("never touches the store for a State that authored no key", async () => {
@@ -1638,7 +1678,7 @@ describe("createRoutineExecutor — concurrencyKey", () => {
     const concurrency = new InMemoryStateConcurrencyStore();
     const execute = keyedExecutor({ harness, agent: succeedingAgent, concurrency });
 
-    await expect(execute(run())).resolves.toBe("succeeded");
+    await expect(execute(run())).resolves.toEqual({ status: "succeeded" });
     await expect(
       concurrency.acquire({
         businessId: "business-1",
@@ -1730,9 +1770,9 @@ describe("createRoutineExecutor — child_routine States", () => {
     const harness = new StateHarness([state("Start")]);
     const children = new ChildRoutineHarness();
 
-    await expect(childExecutor(childDefinition(), harness, children.port)(run())).resolves.toBe(
-      "waiting"
-    );
+    await expect(childExecutor(childDefinition(), harness, children.port)(run())).resolves.toEqual({
+      status: "waiting",
+    });
     expect(harness.transitions).toEqual([
       "Start:pending->ready",
       "Start:ready->claimed",
@@ -1759,7 +1799,7 @@ describe("createRoutineExecutor — child_routine States", () => {
         harness,
         children.port
       )(run())
-    ).resolves.toBe("waiting");
+    ).resolves.toEqual({ status: "waiting" });
     expect(children.started[0]?.input).toEqual({ region: "west" });
   });
 
@@ -1768,8 +1808,8 @@ describe("createRoutineExecutor — child_routine States", () => {
     const children = new ChildRoutineHarness();
     const execute = childExecutor(childDefinition(), harness, children.port);
 
-    await expect(execute(run())).resolves.toBe("waiting");
-    await expect(execute(run())).resolves.toBe("waiting");
+    await expect(execute(run())).resolves.toEqual({ status: "waiting" });
+    await expect(execute(run())).resolves.toEqual({ status: "waiting" });
     expect(children.started).toHaveLength(1);
   });
 
@@ -1778,9 +1818,9 @@ describe("createRoutineExecutor — child_routine States", () => {
     const children = new ChildRoutineHarness();
     const execute = childExecutor(childDefinition(), harness, children.port);
 
-    await expect(execute(run())).resolves.toBe("waiting");
+    await expect(execute(run())).resolves.toEqual({ status: "waiting" });
     children.settle("Start", "succeeded");
-    await expect(execute(run())).resolves.toBe("succeeded");
+    await expect(execute(run())).resolves.toEqual({ status: "succeeded" });
     expect(harness.transitions.slice(4)).toEqual([
       "Start:waiting->ready",
       "Start:ready->claimed",
@@ -1794,9 +1834,9 @@ describe("createRoutineExecutor — child_routine States", () => {
     const children = new ChildRoutineHarness();
     const execute = childExecutor(childDefinition(), harness, children.port);
 
-    await expect(execute(run())).resolves.toBe("waiting");
+    await expect(execute(run())).resolves.toEqual({ status: "waiting" });
     children.settle("Start", "failed");
-    await expect(execute(run())).resolves.toBe("failed");
+    await expect(execute(run())).resolves.toEqual({ status: "failed" });
     expect(harness.states.get("Start")?.errorEvidenceRef).toBe("routine:child_failed");
   });
 
@@ -1812,9 +1852,9 @@ describe("createRoutineExecutor — child_routine States", () => {
       children.port
     );
 
-    await expect(execute(run())).resolves.toBe("waiting");
+    await expect(execute(run())).resolves.toEqual({ status: "waiting" });
     children.settle("Start", "failed");
-    await expect(execute(run())).resolves.toBe("succeeded");
+    await expect(execute(run())).resolves.toEqual({ status: "succeeded" });
     expect(harness.events).toContain("Recovered:scheduled");
   });
 
@@ -1823,9 +1863,9 @@ describe("createRoutineExecutor — child_routine States", () => {
     const children = new ChildRoutineHarness();
     const execute = childExecutor(childDefinition(), harness, children.port);
 
-    await expect(execute(run())).resolves.toBe("waiting");
+    await expect(execute(run())).resolves.toEqual({ status: "waiting" });
     children.settle("Start", "cancelled");
-    await expect(execute(run())).resolves.toBe("needs_reconciliation");
+    await expect(execute(run())).resolves.toEqual({ status: "needs_reconciliation" });
     expect(harness.states.get("Start")?.errorEvidenceRef).toBe("routine:child_cancelled");
   });
 
@@ -1834,9 +1874,9 @@ describe("createRoutineExecutor — child_routine States", () => {
     const children = new ChildRoutineHarness();
     const execute = childExecutor(childDefinition(), harness, children.port);
 
-    await expect(execute(run())).resolves.toBe("waiting");
+    await expect(execute(run())).resolves.toEqual({ status: "waiting" });
     children.settle("Start", "expired");
-    await expect(execute(run())).resolves.toBe("needs_reconciliation");
+    await expect(execute(run())).resolves.toEqual({ status: "needs_reconciliation" });
     expect(harness.states.get("Start")?.errorEvidenceRef).toBe("routine:wait_expired");
   });
 
@@ -1850,7 +1890,7 @@ describe("createRoutineExecutor — child_routine States", () => {
         harness,
         children.port
       )(run())
-    ).resolves.toBe("succeeded");
+    ).resolves.toEqual({ status: "succeeded" });
     expect(children.started[0]).toMatchObject({ mode: "detach" });
     expect(children.started[0]?.deadlineMs).toBeUndefined();
     expect(harness.transitions).toEqual([
@@ -1865,9 +1905,9 @@ describe("createRoutineExecutor — child_routine States", () => {
     const harness = new StateHarness([state("Start")]);
     const children = new ChildRoutineHarness("succeeded");
 
-    await expect(childExecutor(childDefinition(), harness, children.port)(run())).resolves.toBe(
-      "succeeded"
-    );
+    await expect(childExecutor(childDefinition(), harness, children.port)(run())).resolves.toEqual({
+      status: "succeeded",
+    });
     expect(harness.transitions).toEqual([
       "Start:pending->ready",
       "Start:ready->claimed",
@@ -1882,16 +1922,16 @@ describe("createRoutineExecutor — child_routine States", () => {
 
     await expect(
       childExecutor(childDefinition({ deadlineMs: undefined }), harness, children.port)(run())
-    ).resolves.toBe("needs_reconciliation");
+    ).resolves.toEqual({ status: "needs_reconciliation" });
     expect(children.started).toHaveLength(0);
   });
 
   it("parks a child_routine State when no child surface is composed", async () => {
     const harness = new StateHarness([state("Start")]);
 
-    await expect(childExecutor(childDefinition(), harness)(run())).resolves.toBe(
-      "needs_reconciliation"
-    );
+    await expect(childExecutor(childDefinition(), harness)(run())).resolves.toEqual({
+      status: "needs_reconciliation",
+    });
     expect(harness.states.get("Start")?.errorEvidenceRef).toBe("routine:unsupported_state");
   });
 });
@@ -1948,9 +1988,9 @@ describe("createRoutineExecutor — emit States", () => {
     const harness = new StateHarness([state("Start")]);
     const emissions = new EmitHarness();
 
-    await expect(emitExecutor(emitDefinition(), harness, emissions.port)(run())).resolves.toBe(
-      "succeeded"
-    );
+    await expect(emitExecutor(emitDefinition(), harness, emissions.port)(run())).resolves.toEqual({
+      status: "succeeded",
+    });
     expect(harness.transitions).toEqual([
       "Start:pending->ready",
       "Start:ready->claimed",
@@ -1979,7 +2019,7 @@ describe("createRoutineExecutor — emit States", () => {
         harness,
         emissions.port
       )(run())
-    ).resolves.toBe("succeeded");
+    ).resolves.toEqual({ status: "succeeded" });
     expect(emissions.announced[0]?.data).toEqual({ region: "west" });
   });
 
@@ -1987,17 +2027,17 @@ describe("createRoutineExecutor — emit States", () => {
     const harness = new StateHarness([state("Start")]);
     const emissions = new EmitHarness("no_match");
 
-    await expect(emitExecutor(emitDefinition(), harness, emissions.port)(run())).resolves.toBe(
-      "succeeded"
-    );
+    await expect(emitExecutor(emitDefinition(), harness, emissions.port)(run())).resolves.toEqual({
+      status: "succeeded",
+    });
   });
 
   it("parks an emit State when no emission surface is composed", async () => {
     const harness = new StateHarness([state("Start")]);
 
-    await expect(emitExecutor(emitDefinition(), harness)(run())).resolves.toBe(
-      "needs_reconciliation"
-    );
+    await expect(emitExecutor(emitDefinition(), harness)(run())).resolves.toEqual({
+      status: "needs_reconciliation",
+    });
     expect(harness.states.get("Start")?.errorEvidenceRef).toBe("routine:unsupported_state");
   });
 
@@ -2011,7 +2051,7 @@ describe("createRoutineExecutor — emit States", () => {
         harness,
         emissions.port
       )(run())
-    ).resolves.toBe("needs_reconciliation");
+    ).resolves.toEqual({ status: "needs_reconciliation" });
     expect(emissions.announced).toHaveLength(0);
   });
 });
@@ -2083,7 +2123,7 @@ describe("createRoutineExecutor — deterministic States", () => {
       now: () => new Date(STARTED_AT),
     });
 
-    await expect(execute(run())).resolves.toBe("succeeded");
+    await expect(execute(run())).resolves.toEqual({ status: "succeeded" });
     expect(harness.states.get("Extract")?.output).toEqual({ stars: 4321 });
     // A fresh Record each tick carrying the value the script derived — never an Agent's guess.
     expect(dispatched).toEqual([
@@ -2129,7 +2169,7 @@ describe("createRoutineExecutor — deterministic States", () => {
       now: () => new Date(STARTED_AT),
     });
 
-    await expect(execute(run())).resolves.toBe("succeeded");
+    await expect(execute(run())).resolves.toEqual({ status: "succeeded" });
     // `record_create` is `mutating`, so it compiles to `medium`; a `low` ceiling refuses it.
     expect(ceilings).toEqual(["high", "high"]);
   });
@@ -2165,7 +2205,10 @@ describe("createRoutineExecutor — deterministic States", () => {
       now: () => new Date(STARTED_AT),
     });
 
-    await expect(execute(run())).resolves.toBe("failed");
+    await expect(execute(run())).resolves.toEqual({
+      status: "failed",
+      errorEvidenceRef: "routine:action_unknown_resource_type",
+    });
     expect(harness.states.get("Save")?.errorEvidenceRef).toBe(
       "routine:action_unknown_resource_type"
     );
@@ -2197,6 +2240,9 @@ describe("createRoutineExecutor — deterministic States", () => {
       now: () => new Date(STARTED_AT),
     });
 
-    await expect(execute(run())).resolves.toBe("failed");
+    await expect(execute(run())).resolves.toEqual({
+      status: "failed",
+      errorEvidenceRef: "routine:script_rejected_source",
+    });
   });
 });

--- a/apps/worker/src/routine/executor.ts
+++ b/apps/worker/src/routine/executor.ts
@@ -204,7 +204,7 @@ export function createRoutineExecutor(options: RoutineExecutorOptions): RunExecu
       (await options.runs.listStates(run.businessId, run.id)).map((state) => [state.key, state])
     );
     const start = persisted.get(routine.start);
-    if (start === undefined) return "needs_reconciliation";
+    if (start === undefined) return { status: "needs_reconciliation" };
 
     const requestArtifact = await options.artifacts.read({
       businessId: run.businessId,
@@ -214,10 +214,10 @@ export function createRoutineExecutor(options: RoutineExecutorOptions): RunExecu
       now: now(),
     });
     if (requestArtifact.schemaRef !== MANUAL_REQUEST_SCHEMA_REF) {
-      return "needs_reconciliation";
+      return { status: "needs_reconciliation" };
     }
     const request = manualRequest(requestArtifact.content, start.key);
-    if (request.slug !== routine.slug) return "needs_reconciliation";
+    if (request.slug !== routine.slug) return { status: "needs_reconciliation" };
 
     const execution = new RoutineExecution({
       run,
@@ -233,7 +233,11 @@ export function createRoutineExecutor(options: RoutineExecutorOptions): RunExecu
       now,
     });
     // `waiting` holds no lease; replay starts from durable rows after the sweep requeues it.
-    return execution.runChain(routine.start, "", {}, {}, 0);
+    const outcome = await execution.runChain(routine.start, "", {}, {}, 0);
+    if (outcome === "failed") {
+      return { status: "failed", errorEvidenceRef: execution.failureEvidenceRef };
+    }
+    return { status: outcome };
   };
 }
 
@@ -268,7 +272,20 @@ class RoutineExecution {
    */
   private readonly failureReasons = new Map<string, string>();
 
+  /**
+   * The evidence ref of the State that just failed the chain, so `createRoutineExecutor`'s
+   * wrapper can carry it onto the Run's own `error_evidence_ref` rather than leaving it stranded
+   * on the State row. Only one State ever fails a chain per attempt, so last-write is exact, not
+   * approximate.
+   */
+  private lastFailureEvidenceRef: string | undefined;
+
   constructor(private readonly ctx: ExecutionContext) {}
+
+  /** The evidence ref of whichever State most recently failed this chain, if any. */
+  get failureEvidenceRef(): string | undefined {
+    return this.lastFailureEvidenceRef;
+  }
 
   /**
    * What `states.<name>.output` resolves to: recomputed for a pure State, otherwise the value this
@@ -301,7 +318,10 @@ class RoutineExecution {
       const row = this.ctx.persisted.get(key);
       if (state === undefined || row === undefined) return "needs_reconciliation";
 
-      if (row.status === "failed") return "failed";
+      if (row.status === "failed") {
+        this.lastFailureEvidenceRef = row.errorEvidenceRef ?? undefined;
+        return "failed";
+      }
       if (row.status === "cancelled" || row.status === "cancelling") return "cancelled";
       if (row.status === "needs_reconciliation" || row.status === "skipped") {
         return "needs_reconciliation";
@@ -413,12 +433,9 @@ class RoutineExecution {
     }
     if (outcome === null) return { kind: "waiting" };
     if (outcome === "failed") {
-      await this.transition(
-        key,
-        "running",
-        "failed",
-        this.failureReasons.get(key) ?? `routine:${state.name}`
-      );
+      const evidenceRef = this.failureReasons.get(key) ?? `routine:${state.name}`;
+      await this.transition(key, "running", "failed", evidenceRef);
+      this.lastFailureEvidenceRef = evidenceRef;
       return { kind: "failed" };
     }
     if (typeof outcome !== "object") return { kind: outcome };

--- a/apps/worker/src/run-dispatcher.test.ts
+++ b/apps/worker/src/run-dispatcher.test.ts
@@ -4,6 +4,7 @@ import {
   type PersistedRun,
   type PersistedRunStatus,
 } from "@tulipfarm/storage";
+import type { RunOutcomeStatus } from "@tulipfarm/turn-executor";
 import { describe, expect, it } from "vitest";
 import { RunDispatcher, type RunDispatcherOptions, type RunOutcome } from "./run-dispatcher";
 
@@ -99,7 +100,7 @@ describe("RunDispatcher", () => {
       now: () => new Date("2026-07-24T10:00:00.000Z"),
       handler: async (run) => {
         dispatched.push(run.id);
-        return "succeeded";
+        return { status: "succeeded" };
       },
     });
 
@@ -127,7 +128,7 @@ describe("RunDispatcher", () => {
       businessId: BUSINESS_ID,
       owner: "worker-1",
       now: () => new Date("2026-07-24T10:00:00.000Z"),
-      handler: async () => "waiting",
+      handler: async () => ({ status: "waiting" }),
     });
 
     const result = await dispatcher.dispatchBatch();
@@ -153,7 +154,7 @@ describe("RunDispatcher", () => {
       businessId: BUSINESS_ID,
       owner: "worker-1",
       now: () => new Date("2026-07-24T10:00:00.000Z"),
-      handler: async () => "cancelled",
+      handler: async () => ({ status: "cancelled" }),
     });
 
     const result = await dispatcher.dispatchBatch();
@@ -222,7 +223,7 @@ describe("RunDispatcher", () => {
       businessId: BUSINESS_ID,
       owner: "worker-1",
       now: () => new Date("2026-07-24T10:00:00.000Z"),
-      handler: async () => "succeeded",
+      handler: async () => ({ status: "succeeded" }),
     });
 
     const result = await dispatcher.dispatchBatch();
@@ -246,7 +247,7 @@ describe("RunDispatcher", () => {
       businessId: BUSINESS_ID,
       owner: "worker-1",
       now: () => new Date("2026-07-24T10:00:00.000Z"),
-      handler: async () => "succeeded",
+      handler: async () => ({ status: "succeeded" }),
     });
 
     await expect(dispatcher.dispatchBatch()).resolves.toEqual({
@@ -261,7 +262,7 @@ describe("RunDispatcher", () => {
 
   describe("onTerminal", () => {
     function dispatcherWith(
-      outcome: RunOutcome,
+      status: RunOutcomeStatus,
       onTerminal: RunDispatcherOptions["onTerminal"],
       releaseResult = true
     ) {
@@ -273,7 +274,7 @@ describe("RunDispatcher", () => {
         businessId: BUSINESS_ID,
         owner: "worker-1",
         now: () => new Date("2026-07-24T10:00:00.000Z"),
-        handler: async () => outcome,
+        handler: async (): Promise<RunOutcome> => ({ status }),
         onTerminal,
       });
     }
@@ -339,7 +340,7 @@ describe("RunDispatcher", () => {
 
   describe("onWaiting", () => {
     function dispatcherWith(
-      outcome: RunOutcome,
+      status: RunOutcomeStatus,
       onWaiting: RunDispatcherOptions["onWaiting"],
       releaseResult = true
     ) {
@@ -353,7 +354,7 @@ describe("RunDispatcher", () => {
           businessId: BUSINESS_ID,
           owner: "worker-1",
           now: () => new Date("2026-07-24T10:00:00.000Z"),
-          handler: async () => outcome,
+          handler: async (): Promise<RunOutcome> => ({ status }),
           onWaiting,
         }),
       };
@@ -425,7 +426,7 @@ describe("RunDispatcher", () => {
       businessId: BUSINESS_ID,
       owner: "worker-1",
       now: () => new Date("2026-07-24T10:00:00.000Z"),
-      handler: async () => "succeeded",
+      handler: async () => ({ status: "succeeded" }),
     });
 
     const result = await dispatcher.dispatchBatch();

--- a/apps/worker/src/run-dispatcher.ts
+++ b/apps/worker/src/run-dispatcher.ts
@@ -6,7 +6,7 @@ import {
 } from "@tulipfarm/storage";
 import type { RunOutcome } from "@tulipfarm/turn-executor";
 
-export type { RunOutcome } from "@tulipfarm/turn-executor";
+export type { RunOutcome, RunOutcomeStatus } from "@tulipfarm/turn-executor";
 
 export interface RunDispatcherOptions {
   leases: RunLeaseManager;
@@ -97,7 +97,7 @@ export class RunDispatcher {
 
       try {
         const outcome = await this.options.handler(started.run);
-        if (outcome === "cancelled") {
+        if (outcome.status === "cancelled") {
           // Cancellation manager owns this transition; do not race it here.
           waiting += 1;
           continue;
@@ -107,20 +107,23 @@ export class RunDispatcher {
           runId: run.id,
           expectedVersion: started.run.version,
           expectedStatus: "running",
-          status: outcome,
+          status: outcome.status,
           now: this.options.now(),
+          ...(outcome.errorEvidenceRef === undefined
+            ? {}
+            : { errorEvidenceRef: outcome.errorEvidenceRef }),
         });
         if (!released) {
           failed += 1;
           continue;
         }
-        if (outcome === "succeeded") dispatched += 1;
-        else if (outcome === "waiting") waiting += 1;
+        if (outcome.status === "succeeded") dispatched += 1;
+        else if (outcome.status === "waiting") waiting += 1;
         else failed += 1;
-        if (outcome === "succeeded" || outcome === "failed") {
-          await this.notifyTerminal(started.run, outcome);
+        if (outcome.status === "succeeded" || outcome.status === "failed") {
+          await this.notifyTerminal(started.run, outcome.status);
         }
-        if (outcome === "waiting") {
+        if (outcome.status === "waiting") {
           await this.notifyWaiting(started.run);
         }
       } catch (error) {

--- a/apps/worker/src/subagent/executor.test.ts
+++ b/apps/worker/src/subagent/executor.test.ts
@@ -144,7 +144,7 @@ describe("createSubagentExecutor", () => {
   it("answers into an Artifact rather than a Conversation Message", async () => {
     const { execute, published } = harness();
 
-    await expect(execute()).resolves.toBe("succeeded");
+    await expect(execute()).resolves.toEqual({ status: "succeeded" });
 
     expect(published).toHaveLength(1);
     expect(published[0]?.id).toBe(subagentAnswerArtifactId(RUN_ID));
@@ -187,7 +187,7 @@ describe("createSubagentExecutor", () => {
   it("does not answer twice when a redelivered attempt finds an answer already published", async () => {
     const { execute, published } = harness({ answered: true });
 
-    await expect(execute()).resolves.toBe("succeeded");
+    await expect(execute()).resolves.toEqual({ status: "succeeded" });
 
     expect(published).toEqual([]);
   });
@@ -195,7 +195,7 @@ describe("createSubagentExecutor", () => {
   it("fails closed when the Run carries no invoke State to run on", async () => {
     const { execute, published } = harness({ state: null });
 
-    await expect(execute()).resolves.toBe("needs_reconciliation");
+    await expect(execute()).resolves.toEqual({ status: "needs_reconciliation" });
     expect(published).toEqual([]);
   });
 });

--- a/apps/worker/src/turn/integration-executor.test.ts
+++ b/apps/worker/src/turn/integration-executor.test.ts
@@ -6,7 +6,7 @@ import type {
   RemoteDelivery,
   RemoteEventResult,
 } from "../internal/delivery-host";
-import type { RunOutcome } from "../run-dispatcher";
+import type { RunOutcome, RunOutcomeStatus } from "../run-dispatcher";
 import { createIntegrationExecutor, type IntegrationExecutorOptions } from "./integration-executor";
 
 const RUN: PersistedRun = {
@@ -64,7 +64,7 @@ function harness(
     classifyThrows?: Error;
     attach?: RemoteAttachResult;
     event?: RemoteEventResult;
-    outcome?: RunOutcome;
+    outcome?: RunOutcomeStatus;
   } = {}
 ): { execute: () => Promise<RunOutcome>; recorded: Recorded } {
   const events: Recorded["events"] = [];
@@ -113,7 +113,7 @@ function harness(
     } satisfies RunEventAppendPort,
     turn: async () => {
       turns += 1;
-      return over.outcome ?? "succeeded";
+      return { status: over.outcome ?? "succeeded" };
     },
     now: () => new Date("2026-01-01T00:00:00.000Z"),
   });
@@ -159,7 +159,7 @@ describe("createIntegrationExecutor", () => {
   it("answers a chat decision on this same Run and replies to the channel", async () => {
     const { execute, recorded } = harness();
 
-    await expect(execute()).resolves.toBe("succeeded");
+    await expect(execute()).resolves.toEqual({ status: "succeeded" });
 
     expect(recorded.attached).toEqual([
       {
@@ -199,7 +199,7 @@ describe("createIntegrationExecutor", () => {
   it("closes an ignored delivery with the classifier's reason and runs no turn", async () => {
     const { execute, recorded } = harness({ decision: { kind: "ignore", reason: "bot message" } });
 
-    await expect(execute()).resolves.toBe("succeeded");
+    await expect(execute()).resolves.toEqual({ status: "succeeded" });
 
     expect(recorded.turns).toBe(0);
     expect(recorded.replies).toEqual([]);
@@ -211,7 +211,7 @@ describe("createIntegrationExecutor", () => {
       decision: { kind: "event", eventType: "member_joined", payload: { user: "U2" } },
     });
 
-    await expect(execute()).resolves.toBe("succeeded");
+    await expect(execute()).resolves.toEqual({ status: "succeeded" });
 
     expect(recorded.recordedEvents).toEqual([
       { eventType: "member_joined", payload: { user: "U2" } },
@@ -241,7 +241,7 @@ describe("createIntegrationExecutor", () => {
     // Malformed output is deterministic: a retry reproduces it, so the Run is closed on the record.
     const { execute, recorded } = harness({ decision: { kind: "chat", sender: 42 } });
 
-    await expect(execute()).resolves.toBe("succeeded");
+    await expect(execute()).resolves.toEqual({ status: "succeeded" });
 
     expect(recorded.events[0]?.payload).toEqual({ decision: "invalid" });
     expect(recorded.turns).toBe(0);
@@ -258,7 +258,7 @@ describe("createIntegrationExecutor", () => {
   it("runs no turn for an unlinked sender and never learns the bind link", async () => {
     const { execute, recorded } = harness({ attach: { outcome: "unlinked" } });
 
-    await expect(execute()).resolves.toBe("succeeded");
+    await expect(execute()).resolves.toEqual({ status: "succeeded" });
 
     expect(recorded.turns).toBe(0);
     expect(recorded.replies).toEqual([]);
@@ -287,7 +287,7 @@ describe("createIntegrationExecutor", () => {
       delivery: { ...DELIVERY, chatEnabled: false },
     });
 
-    await expect(execute()).resolves.toBe("succeeded");
+    await expect(execute()).resolves.toEqual({ status: "succeeded" });
 
     expect(recorded.attached).toEqual([]);
     expect(recorded.events[0]?.payload).toEqual({
@@ -299,15 +299,15 @@ describe("createIntegrationExecutor", () => {
   it("posts nothing while the turn is still open, and the failure reply when it broke", async () => {
     // A parked approval has not answered anything yet; replying would answer an open question.
     const waiting = harness({ outcome: "waiting" });
-    await expect(waiting.execute()).resolves.toBe("waiting");
+    await expect(waiting.execute()).resolves.toEqual({ status: "waiting" });
     expect(waiting.recorded.replies).toEqual([]);
 
     const cancelled = harness({ outcome: "cancelled" });
-    await expect(cancelled.execute()).resolves.toBe("cancelled");
+    await expect(cancelled.execute()).resolves.toEqual({ status: "cancelled" });
     expect(cancelled.recorded.replies).toEqual([]);
 
     const failed = harness({ outcome: "failed" });
-    await expect(failed.execute()).resolves.toBe("failed");
+    await expect(failed.execute()).resolves.toEqual({ status: "failed" });
     expect(failed.recorded.replies).toEqual([
       { attempt: 1, outcome: "failed", binding: "default", vars: { channel: "C1" } },
     ]);
@@ -316,7 +316,7 @@ describe("createIntegrationExecutor", () => {
   it("succeeds without a record when the Run is no longer a live delivery", async () => {
     const { execute, recorded } = harness({ delivery: undefined });
 
-    await expect(execute()).resolves.toBe("succeeded");
+    await expect(execute()).resolves.toEqual({ status: "succeeded" });
 
     expect(recorded.classified).toEqual([]);
     expect(recorded.events).toEqual([]);

--- a/apps/worker/src/turn/integration-executor.ts
+++ b/apps/worker/src/turn/integration-executor.ts
@@ -40,7 +40,7 @@ export function createIntegrationExecutor(options: IntegrationExecutorOptions): 
     const delivery = await options.deliveries.describe(run.id);
     if (delivery === undefined) {
       // No delivery is owed; do not report a channel failure that did not happen.
-      return "succeeded";
+      return { status: "succeeded" };
     }
 
     const writer = new TurnEventWriter({
@@ -100,7 +100,7 @@ async function classify(
   payload: { decision: ClassifiedDecision; reason?: string; eventType?: string }
 ): Promise<RunOutcome> {
   await writer.emit("delivery.classified", payload, "classified");
-  return "succeeded";
+  return { status: "succeeded" };
 }
 
 /** Chat replies are at-least-once; durable Turn inputs are idempotent, but posts can repeat. */
@@ -152,7 +152,7 @@ async function runChat(
 
 /** How the turn ended, as the channel should hear it. `null` means it has not ended. */
 function replyOutcome(outcome: RunOutcome): RemoteReplyOutcome | null {
-  if (outcome === "succeeded") return "answered";
-  if (outcome === "waiting" || outcome === "cancelled") return null;
+  if (outcome.status === "succeeded") return "answered";
+  if (outcome.status === "waiting" || outcome.status === "cancelled") return null;
   return "failed";
 }

--- a/packages/turn-executor/src/chat-executor.checkpoint.test.ts
+++ b/packages/turn-executor/src/chat-executor.checkpoint.test.ts
@@ -179,13 +179,16 @@ describe("createChatExecutor durable loop counters", () => {
     const scenario = harness(checkpoints);
 
     // First dispatch spends the single allowed Tool call and parks awaiting approval.
-    await expect(scenario.park()).resolves.toBe("waiting");
+    await expect(scenario.park()).resolves.toEqual({ status: "waiting" });
     expect(scenario.dispatched).toEqual(["call-1"]);
 
     // Reclaimed after approval: the parked dispatch never executed, so its charge was refunded and
     // the approved call is replayed once — which spends the ceiling for real. The next Tool call is
     // then refused before it reaches the broker, and the loop fails on the limit.
-    await expect(scenario.resume()).resolves.toBe("failed");
+    await expect(scenario.resume()).resolves.toEqual({
+      status: "failed",
+      errorEvidenceRef: "agent:tool_call_limit",
+    });
     expect(scenario.dispatched).toEqual(["call-1", "call-1"]);
   });
 });

--- a/packages/turn-executor/src/chat-executor.test.ts
+++ b/packages/turn-executor/src/chat-executor.test.ts
@@ -12,6 +12,7 @@ import { describe, expect, it } from "vitest";
 import { type ChatExecutorHost, createChatExecutor } from "./chat-executor";
 import type { TurnCompletionRecord, TurnCompletionStore } from "./conversation-turn";
 import type { ResolvedTurnContext, TurnContextPort } from "./driver";
+import type { RunOutcomeStatus } from "./ports";
 import type { RunEventAppendPort } from "./run-events";
 
 const RUN: PersistedRun = {
@@ -81,7 +82,7 @@ function harness(
     run?: PersistedRun;
     contextError?: Error;
   } = {}
-): { execute: () => Promise<string>; recorded: Recorded } {
+): { execute: () => Promise<RunOutcomeStatus>; recorded: Recorded } {
   const events: Recorded["events"] = [];
   const messages: string[] = [];
   const completions: Recorded["completions"] = [];
@@ -158,7 +159,7 @@ function harness(
   });
 
   return {
-    execute: () => executor(over.run ?? RUN),
+    execute: async () => (await executor(over.run ?? RUN)).status,
     recorded: {
       events,
       messages,

--- a/packages/turn-executor/src/chat-executor.ts
+++ b/packages/turn-executor/src/chat-executor.ts
@@ -118,7 +118,7 @@ export function createChatExecutor(options: ChatExecutorOptions): RunExecutor {
     const identity = await options.host.findTurn(run.id);
     if (identity === undefined) {
       // No Turn means superseded or already answered; nothing is owed.
-      return "succeeded";
+      return { status: "succeeded" };
     }
 
     const writer = new TurnEventWriter({
@@ -158,7 +158,7 @@ async function announceTurnFailure(
   } catch (error) {
     log.warn({ error }, "chat turn failure could not be announced");
   }
-  return "needs_reconciliation";
+  return { status: "needs_reconciliation" };
 }
 
 async function executeTurn(

--- a/packages/turn-executor/src/driver.test.ts
+++ b/packages/turn-executor/src/driver.test.ts
@@ -213,7 +213,7 @@ describe("TurnDriver", () => {
     });
     const outcome = await driver.run(request());
 
-    expect(outcome).toBe("succeeded");
+    expect(outcome).toEqual({ status: "succeeded" });
     expect(store.messages).toEqual([{ content: "the answer", attempt: 1 }]);
     // A reader that sees `turn.finished` can fetch the Message it names.
     expect(events.appended.at(-1)).toEqual({
@@ -333,7 +333,7 @@ describe("TurnDriver", () => {
     });
     const outcome = await driver.run(request());
 
-    expect(outcome).toBe("waiting");
+    expect(outcome).toEqual({ status: "waiting" });
     expect(store.messages).toEqual([]);
     expect(store.completed).toEqual([]);
     // The held call is named, so a reader shows the decision against the Tool call it belongs to.
@@ -354,7 +354,7 @@ describe("TurnDriver", () => {
     });
     const outcome = await driver.run(request());
 
-    expect(outcome).toBe("succeeded");
+    expect(outcome).toEqual({ status: "succeeded" });
     expect(store.messages).toEqual([{ attempt: 1, content: "Two things before I start." }]);
     expect(store.completed).toEqual([{ status: "succeeded", cursor: 2, messageId: "msg-1" }]);
     expect(events.appended.at(-1)).toEqual({
@@ -371,7 +371,7 @@ describe("TurnDriver", () => {
     });
     const outcome = await driver.run(request());
 
-    expect(outcome).toBe("failed");
+    expect(outcome).toEqual({ status: "failed", errorEvidenceRef: "agent:iteration_limit" });
     expect(store.messages).toEqual([]);
     expect(store.completed).toEqual([{ status: "failed", cursor: 2, messageId: null }]);
     expect(events.appended.at(-1)).toEqual({
@@ -407,7 +407,7 @@ describe("TurnDriver", () => {
       throw new Error("worker crashed");
     });
 
-    expect(await driver.run(request())).toBe("needs_reconciliation");
+    expect(await driver.run(request())).toEqual({ status: "needs_reconciliation" });
     expect(store.messages).toEqual([]);
     expect(events.appended.at(-1)).toEqual({
       eventType: "turn.finished",
@@ -420,7 +420,7 @@ describe("TurnDriver", () => {
     const before = events.appended.length;
     const outcome = await driver.run(request());
 
-    expect(outcome).toBe("cancelled");
+    expect(outcome).toEqual({ status: "cancelled" });
     expect(store.completed).toEqual([]);
     // Only the two pre-loop events; no terminal event contradicting the manager's transition.
     expect(events.appended.length).toBe(before + 2);
@@ -430,7 +430,7 @@ describe("TurnDriver", () => {
     const { driver, store } = harness({ status: "completed", output: "", ...counters });
     const outcome = await driver.run(request());
 
-    expect(outcome).toBe("failed");
+    expect(outcome).toEqual({ status: "failed", errorEvidenceRef: "agent:empty_model_output" });
     expect(store.messages).toEqual([]);
     expect(store.completed).toEqual([{ status: "failed", cursor: 2, messageId: null }]);
   });
@@ -439,7 +439,7 @@ describe("TurnDriver", () => {
     const { driver, store } = harness({ status: "completed", output: null, ...counters });
     const outcome = await driver.run(request());
 
-    expect(outcome).toBe("failed");
+    expect(outcome).toEqual({ status: "failed", errorEvidenceRef: "agent:empty_model_output" });
     expect(store.messages).toEqual([]);
   });
 
@@ -468,7 +468,7 @@ describe("TurnDriver", () => {
       }
     );
 
-    expect(await driver.run(request())).toBe("succeeded");
+    expect(await driver.run(request())).toEqual({ status: "succeeded" });
     expect(seen).toEqual([]);
     expect(store.messages).toEqual([
       { content: "This request was blocked by a safety guardrail.", attempt: 1 },
@@ -500,7 +500,7 @@ describe("TurnDriver", () => {
       ...counters,
     });
 
-    expect(await driver.run(request())).toBe("succeeded");
+    expect(await driver.run(request())).toEqual({ status: "succeeded" });
     expect(store.messages).toEqual([
       { content: "The response was blocked by a content guardrail.", attempt: 1 },
     ]);
@@ -529,7 +529,7 @@ describe("TurnDriver", () => {
     });
     const outcome = await driver.run(request({ attempt: 1, latestAttempt: 2 }));
 
-    expect(outcome).toBe("succeeded");
+    expect(outcome).toEqual({ status: "succeeded" });
     expect(store.messages).toEqual([]);
     expect(events.appended).toEqual([]);
     // The point of the early check: no Context resolved, so no model call and no Tool dispatch.

--- a/packages/turn-executor/src/driver.ts
+++ b/packages/turn-executor/src/driver.ts
@@ -132,7 +132,7 @@ export class TurnDriver {
   async run(request: TurnRequest): Promise<RunOutcome> {
     if (this.options.completer.isStale(request)) {
       // Superseded attempts must not spend model/tool work.
-      return "succeeded";
+      return { status: "succeeded" };
     }
 
     const startedAt = Date.now();
@@ -225,7 +225,7 @@ export class TurnDriver {
 
     if (result.status === "cancelled") {
       // Cancellation manager owns this Run; do not record another outcome.
-      return "cancelled";
+      return { status: "cancelled" };
     }
 
     if (result.status === "needs_reconciliation") {
@@ -235,7 +235,7 @@ export class TurnDriver {
         { status: "failed", messageId: null, reason: "needs_reconciliation" },
         "finished"
       );
-      return "needs_reconciliation";
+      return { status: "needs_reconciliation" };
     }
 
     if (result.status === "waiting") {
@@ -245,14 +245,14 @@ export class TurnDriver {
           { waitId: result.waitId, childRunId: result.childRunId, callId: result.callId },
           "child"
         );
-        return "waiting";
+        return { status: "waiting" };
       }
       await events.emit(
         "approval.requested",
         { waitId: result.waitId, intentId: result.approvalId, callId: result.callId },
         "approval"
       );
-      return "waiting";
+      return { status: "waiting" };
     }
 
     return this.complete(request, events, result, spend);
@@ -352,7 +352,7 @@ export class TurnDriver {
   ): Promise<RunOutcome> {
     if (completion.status === "stale") {
       // A newer attempt already answered; do not announce this one.
-      return "succeeded";
+      return { status: "succeeded" };
     }
 
     if (completion.status === "succeeded") {
@@ -363,7 +363,7 @@ export class TurnDriver {
         "finished"
       );
       this.reportTurn(spend, "ok");
-      return "succeeded";
+      return { status: "succeeded" };
     }
 
     if (completion.status === "failed") {
@@ -380,7 +380,10 @@ export class TurnDriver {
         "finished"
       );
       this.reportTurn(spend, "error");
-      return "failed";
+      // `completion.reason` is always an `AgentLoopFailureReason` (or `"empty_model_output"`) —
+      // the same bounded value `AgentStateRunner` already writes as the State's own
+      // `error_evidence_ref` — never model output or a raw exception message.
+      return { status: "failed", errorEvidenceRef: `agent:${completion.reason}` };
     }
 
     // `waiting` cannot appear after completion is attempted.

--- a/packages/turn-executor/src/index.ts
+++ b/packages/turn-executor/src/index.ts
@@ -44,6 +44,7 @@ export type {
   ModelCallReceiptSource,
   RunExecutor,
   RunOutcome,
+  RunOutcomeStatus,
   SpendSink,
   TurnRecord,
 } from "./ports";

--- a/packages/turn-executor/src/ports.ts
+++ b/packages/turn-executor/src/ports.ts
@@ -9,8 +9,32 @@ import type { PersistedRun } from "@tulipfarm/storage";
  * the offline eval harness — can satisfy them without importing an app.
  */
 
-/** Executor outcome; `waiting` parks, and `cancelled` is left to RunCancellationManager. */
-export type RunOutcome = "succeeded" | "failed" | "waiting" | "needs_reconciliation" | "cancelled";
+/** The terminal or parking status a Run executor settles into. */
+export type RunOutcomeStatus =
+  | "succeeded"
+  | "failed"
+  | "waiting"
+  | "needs_reconciliation"
+  | "cancelled";
+
+/**
+ * Executor outcome; `waiting` parks, and `cancelled` is left to RunCancellationManager.
+ *
+ * An object rather than a bare status so a semantic failure — one the executor detects and
+ * reports itself, as opposed to a thrown error the dispatcher catches — has a channel to say
+ * *why*. Widened deliberately over a discriminated union: every existing call site returned a
+ * bare string, so a plain object with an optional field is the smallest change that still fails
+ * the build at every site that has not been converted to the new shape.
+ *
+ * `errorEvidenceRef` is an operator-facing breadcrumb, not a payload: keep it a terse, bounded,
+ * enumerable code in the existing `namespace:reason` style (`routine:agent_tool_call_limit`,
+ * `dispatch:handler_error`). It is read by operators and travels into audit surfaces, so it must
+ * never carry model output, tool arguments, user content, or a raw exception message.
+ */
+export interface RunOutcome {
+  readonly status: RunOutcomeStatus;
+  readonly errorEvidenceRef?: string;
+}
 
 /** Executes one claimed Run to a terminal outcome. Registered per Run source at composition. */
 export type RunExecutor = (run: PersistedRun, signal?: AbortSignal) => Promise<RunOutcome>;


### PR DESCRIPTION
Follow-up to #638, which added `runs.error_evidence_ref` plumbing but left the normal dispatch path unable to fill it.

## Summary

- `RunOutcome` was a bare status union (`packages/turn-executor/src/ports.ts`), so `RunDispatcher`'s normal `release()` call had nothing to pass as `errorEvidenceRef`. Only the catch path — a *thrown* handler error — ever wrote the column, so every **semantic** failure (Agent tool-call limit, a failed Routine State, a Curator run missing its job id) left a failed Run with no reason on it.
- Widen `RunOutcome` to `{ status, errorEvidenceRef? }`, deliberately an object rather than a discriminated union so every unconverted call site becomes a compile error.
- Thread the ref from the failing State through `TurnDriver`, the Routine chain (`RoutineExecution.failureEvidenceRef`) and the Curator executor into the normal-path `release()`.
- The ref stays a terse, enumerable `namespace:reason` code. Model output, tool arguments and raw exception text never reach the column: the Curator's exception message goes to the State's own reason, and the Run gets a fixed `curator:execution_failed`.

No eval Case: no Expectation type asserts `error_evidence_ref`, and `apps/eval/src/l3/tier.ts` only ever dispatches `source: "chat"`, so the Routine and Curator paths this change touches are unreachable from the Corpus. Unit tests cover them instead.

## Test plan

- [x] `pnpm exec biome check packages/turn-executor/src apps/worker/src apps/eval/src`
- [x] `pnpm typecheck` — 40/40
- [x] `pnpm --filter @tulipfarm/turn-executor test` — 127 passed
- [x] worker scoped: `run-dispatcher`, `routine/executor`, `curator/executor`, `turn/integration-executor`, `executors`, `recovery/run-dispatch` — 130 passed
- [x] `pnpm eval` — 44 passed, 0 failed