### PR TITLE
fix(worker): resolve real Soul agent for internal Run tool exposure

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -63,6 +63,7 @@ import {
   loadBundledSkills,
   loadDisabledBundledSkills,
   PgBundleStore,
+  resolveAgent,
   resolveAuthSteps,
   resolveSoulPath,
   runSoulMigrations,
@@ -135,7 +136,7 @@ import {
 import { AuthzAdminService } from "./authz/service";
 import { PgConversationRepo } from "./chat/conversations";
 import { PgMessageRepo } from "./chat/messages";
-import { allowedToolNamesFor } from "./chat/turn-helpers";
+import { allowedToolNamesFor, toolAgentFor } from "./chat/turn-helpers";
 import { PgConversationStore } from "./conversations/store.pg";
 import { buildCurator } from "./curator/compose";
 import { CURATOR_SWEEP_QUEUE, registerCuratorSweepSchedule } from "./curator/sweep-schedule";
@@ -941,7 +942,9 @@ async function boot() {
         // No presentation context: a Run that assembles its own context has no surface, so the
         // Tools that require one are filtered out here rather than refused at dispatch.
         agentTools: (agentName) => {
-          const allowed = allowedToolNamesFor(toolRegistry, getDefaultAssistant(agentName ?? ""));
+          const agent = resolveAgent(soulLoader, agentName);
+          const toolAgent = toolAgentFor(getDefaultAssistant(agent.name), agent);
+          const allowed = allowedToolNamesFor(toolRegistry, toolAgent);
           return (toolRegistry?.getAll() ?? [])
             .filter((tool) => allowed === undefined || allowed.has(tool.name))
             .map((tool) => ({


### PR DESCRIPTION
## Summary
- `InternalTurnHost`'s `agentTools` resolver called `getDefaultAssistant(agentName)` directly, which only recognizes the hardcoded default assistant name — any real Soul agent got `undefined` back, so tool exposure fell through to "every registered tool" instead of the agent's declared `capabilityRestrictions.tools.allow` list.
- Dispatch-time authorization still enforced the real restriction, so a restricted routine agent (e.g. `IndexSlackKnowledge`'s 4-tool allowlist) repeatedly picked tools it was shown but always denied, burning its fixed per-state tool-call budget on guaranteed failures and hitting `agent_tool_call_limit` before completing its task — 48 failures on staging over one day.
- Fix mirrors the pattern `ChatTurnContextResolver` already uses: `resolveAgent` + `toolAgentFor` to merge the real Soul agent's `capabilityRestrictions` in before computing the allowed tool set.

## Test plan
- [x] `pnpm --filter @tulipfarm/api typecheck` passes
- [x] `pnpm exec biome check` clean on changed lines
- [ ] Verify on staging: a restricted routine agent (e.g. `IndexSlackKnowledge`) no longer sees/attempts tools outside its `capabilityRestrictions.tools.allow`