### PR TITLE
fix(soul): refresh soulLoader after an agent write so same-Turn refs resolve

### DIFF
--- a/apps/api/src/soul/agents/tools.ts
+++ b/apps/api/src/soul/agents/tools.ts
@@ -104,6 +104,10 @@ async function putAgent(
   const actor = ctx.requestContext?.actor ?? SYSTEM_SOUL_COMMIT_ACTOR;
   try {
     await ctx.soulWriter.apply(agentWriteRequest(verb, name, frontmatter, body, actor));
+    // Same-Turn tools (e.g. routine_forge) read ctx.soulLoader.agents synchronously right after
+    // this call; without a reload here they'd validate against the pre-write snapshot and reject
+    // an agentRef this Turn just created.
+    await ctx.soulLoader.reload();
     return null;
   } catch (e) {
     if (e instanceof SoulWriteError) return mapSoulWriteError(e, onPrecondition);


### PR DESCRIPTION
## Summary
- `agent_create`/`agent_update` commit through `soulWriter.apply` but never refreshed `ctx.soulLoader`, so a same-Turn `routine_forge` call re-validated its `agentRef` against the pre-write agents snapshot and rejected an agent the Turn had just created moments earlier (`UNRESOLVED_REF`), driving repeat repair attempts until the repair budget was exhausted (3 staging failures, incl. the `PostEngineeringQuote` routine build).
- `routine_forge` already patches this exact same-Turn-staleness hazard for self-referencing routines (`apps/api/src/platform/tools.ts:603-605`); this extends the same fix to agents by reloading the loader right after the write commits in `putAgent`.

## Test plan
- [x] `pnpm --filter @tulipfarm/api typecheck` passes
- [x] `pnpm --filter @tulipfarm/api test apps/api/src/soul/agents/tools.test.ts` — 34 passed
- [ ] Verify on staging: `agent_create` immediately followed by `routine_forge` referencing the new agent in the same Turn no longer fails with `UNRESOLVED_REF`