### PR TITLE
fix(integrations): encode bare Slack channel/user IDs as mentions

### DIFF
--- a/packages/integrations/src/slack/mentions.test.ts
+++ b/packages/integrations/src/slack/mentions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   encodeMentionsInText,
+  encodeRawIdsInText,
   resolveMentionsInText,
   type SlackMentionResolverPort,
   type SlackUserLookupPort,
@@ -84,5 +85,42 @@ describe("encodeMentionsInText", () => {
   it("is a no-op when there are no @names", async () => {
     const result = await encodeMentionsInText("no mentions here", lookupFrom({}));
     expect(result).toBe("no mentions here");
+  });
+});
+
+describe("encodeRawIdsInText", () => {
+  it("wraps a bare channel id in <#ID> syntax", () => {
+    const result = encodeRawIdsInText("posted in C0BTL0YP4AF for updates");
+    expect(result).toBe("posted in <#C0BTL0YP4AF> for updates");
+  });
+
+  it("wraps a bare user id in <@ID> syntax", () => {
+    const result = encodeRawIdsInText("ping U0AMFGRAKLY about this");
+    expect(result).toBe("ping <@U0AMFGRAKLY> about this");
+  });
+
+  it("leaves an already-correct <#ID> mention untouched", () => {
+    const result = encodeRawIdsInText("posted in <#C0BTL0YP4AF> for updates");
+    expect(result).toBe("posted in <#C0BTL0YP4AF> for updates");
+  });
+
+  it("leaves an already-correct <@ID|label> mention untouched", () => {
+    const result = encodeRawIdsInText("task for <@U0AMFGRAKLY|mohit>");
+    expect(result).toBe("task for <@U0AMFGRAKLY|mohit>");
+  });
+
+  it("leaves an id inside a backtick code span untouched", () => {
+    const result = encodeRawIdsInText("the raw id is `C0BTL0YP4AF`");
+    expect(result).toBe("the raw id is `C0BTL0YP4AF`");
+  });
+
+  it("leaves unrelated text untouched", () => {
+    const result = encodeRawIdsInText("no ids here, just prose");
+    expect(result).toBe("no ids here, just prose");
+  });
+
+  it("is a no-op when there are no bare ids", () => {
+    const result = encodeRawIdsInText("hello world");
+    expect(result).toBe("hello world");
   });
 });

--- a/packages/integrations/src/slack/mentions.ts
+++ b/packages/integrations/src/slack/mentions.ts
@@ -70,3 +70,25 @@ export async function encodeMentionsInText(
     return id ? `<@${id}>` : whole;
   });
 }
+
+// Matches a bare Slack channel or user id sitting as a standalone token in prose — e.g. an id
+// pulled straight from routine/integration config and interpolated into the agent's output text.
+// Excludes ids already inside `<#ID>`/`<@ID|label>` mention syntax (lookbehind rules out the `<`,
+// `@`, `#` that precede an id there; lookahead rules out the trailing `>` or `|`) and ids inside
+// backtick code spans. Channel ids start with C/G/D (public/private/DM, matching `isChannelId` in
+// tool-adapter.ts); user ids start with U. Both require a word boundary so an id embedded in a
+// longer alphanumeric token is left alone.
+const RAW_ID_PATTERN = /(?<![<@#`\w])([CGD][A-Z0-9]{8,}|U[A-Z0-9]{8,})(?![>|\w`])/g;
+
+/**
+ * Wraps bare Slack channel/user ids (as opposed to prose `@name`, handled by
+ * {@link encodeMentionsInText}) in `<#ID>`/`<@ID>` mention syntax, so Slack renders them as
+ * `#channel-name`/`@person` instead of printing the raw id. Ids already in mention syntax, or
+ * inside a code span, are left untouched.
+ */
+export function encodeRawIdsInText(text: string): string {
+  return text.replace(RAW_ID_PATTERN, (whole, id: string) => {
+    const sigil = id.startsWith("U") ? "@" : "#";
+    return `<${sigil}${id}>`;
+  });
+}

--- a/packages/integrations/src/slack/tool-adapter.ts
+++ b/packages/integrations/src/slack/tool-adapter.ts
@@ -8,7 +8,7 @@ import {
   PaginationBoundError,
 } from "../http";
 import { SLACK_TOOL_IDS } from "./contracts";
-import { encodeMentionsInText, type SlackUserLookupPort } from "./mentions";
+import { encodeMentionsInText, encodeRawIdsInText, type SlackUserLookupPort } from "./mentions";
 
 /**
  * Dispatches `slack.message.send`; resolves names to channel ids and uses `client_msg_id` for
@@ -95,7 +95,10 @@ export class SlackToolAdapter implements ToolAdapter {
     const channelId = isChannelId(channel)
       ? channel
       : await this.resolveChannelId(normalizeChannelName(channel), credential);
-    const encodedText = await encodeMentionsInText(text, this.userLookup(credential));
+    const encodedText = await encodeMentionsInText(
+      encodeRawIdsInText(text),
+      this.userLookup(credential)
+    );
     const threadTs = await this.originatingThreadTs(request, channelId, credential);
 
     const response = await this.deps.http.send(


### PR DESCRIPTION
## Summary
- Fixes #647 — agent replies in Slack showed raw IDs (`C0BTL0YP4AF`) instead of clickable `#channel`/`@person` mentions.
- Added `encodeRawIdsInText` in `packages/integrations/src/slack/mentions.ts`, wired before the existing prose-mention encoder in `tool-adapter.ts`.

## Test plan
- [x] `pnpm --filter @tulipfarm/integrations exec vitest run src/slack/mentions.test.ts src/slack/tool-adapter.test.ts` — 27/27 passed
- [x] typecheck, biome clean