### PR TITLE
fix(web): show pending state on sidebar nav during route transition

### DIFF
--- a/apps/web/app/components/app-sidebar.test.tsx
+++ b/apps/web/app/components/app-sidebar.test.tsx
@@ -118,6 +118,25 @@ test("marks the destination matching the current page, and only that one", () =>
   ).toEqual(["Agents"]);
 });
 
+test("shows pending feedback on a nav row while its destination is still loading", async () => {
+  const PendingSidebarStub = createRemixStub([
+    { path: "/chats", Component: AppSidebar },
+    {
+      path: "/routines",
+      Component: AppSidebar,
+      // Never resolves, so the row stays in the pending state for the assertion below.
+      loader: () => new Promise(() => {}),
+    },
+  ]);
+  render(<PendingSidebarStub initialEntries={["/chats"]} />);
+  const nav = screen.getByRole("navigation", { name: "Main" });
+  const routinesLink = within(nav).getByRole("link", { name: /Routines/i });
+
+  expect(routinesLink.className).not.toMatch(/animate-pulse/);
+  await userEvent.click(routinesLink);
+  expect(routinesLink.className).toMatch(/animate-pulse/);
+});
+
 test("carries the live approval count on Inbox", () => {
   useApprovals.mockReturnValue({
     approvals: [],

--- a/apps/web/app/components/app-sidebar.tsx
+++ b/apps/web/app/components/app-sidebar.tsx
@@ -1,4 +1,4 @@
-import { Link, NavLink, useLocation, useNavigate } from "@remix-run/react";
+import { Link, NavLink, useLocation, useNavigate, useNavigation } from "@remix-run/react";
 import {
   ChevronsUpDown,
   LogOut,
@@ -45,6 +45,9 @@ const ROW_BASE =
   "flex min-h-9 items-center gap-2.5 rounded-md border border-transparent px-3 text-sm transition-colors duration-150";
 const ROW_ACTIVE = "bg-sidebar-primary/12 font-medium text-sidebar-primary";
 const ROW_IDLE = "text-sidebar-foreground hover:bg-sidebar-accent";
+/* Shown for the row Remix is navigating to but whose loader hasn't resolved: isActive only flips
+ * once the destination's data is in, so without this a click gives no feedback until it lands. */
+const ROW_PENDING = "animate-pulse bg-sidebar-accent text-sidebar-foreground";
 /* Collapsed, a row is a square so it matches the avatar chip below it rather than out-widing it. */
 const ROW_NARROW = "size-9 shrink-0 justify-center px-0 mx-auto";
 
@@ -124,13 +127,20 @@ function NavRow({
   collapsed: boolean;
   onNavigate: () => void;
 }) {
+  const navigation = useNavigation();
+  const isPending = navigation.state === "loading" && navigation.location.pathname.startsWith(to);
   const row = (
     <NavLink
       to={to}
       onClick={onNavigate}
       aria-label={collapsed ? (count ? `${label}, ${count} awaiting you` : label) : undefined}
       className={({ isActive }) =>
-        cn(ROW_BASE, "group", collapsed && ROW_NARROW, isActive ? ROW_ACTIVE : ROW_IDLE)
+        cn(
+          ROW_BASE,
+          "group",
+          collapsed && ROW_NARROW,
+          isActive ? ROW_ACTIVE : isPending ? ROW_PENDING : ROW_IDLE
+        )
       }
     >
       <span className="relative flex shrink-0 items-center">


### PR DESCRIPTION
## Summary
- Fixes #652 — clicking a sidebar nav item gave zero feedback for ~2.5s before the new page swapped in.
- Wired `useNavigation()` into `app-sidebar.tsx` so the clicked row shows a pending style while its route is loading.
- Loader-side latency itself is out of scope (not explained by any inefficiency in the code — needs separate runtime profiling).

## Test plan
- [x] `pnpm --filter @tulipfarm/web test app/components/app-sidebar` — 31/31 passed
- [x] typecheck, biome clean