### PR TITLE
feat(web): add drag-and-drop file upload and friendly upload error messages

### DIFF
--- a/apps/web/app/components/chat/composer.test.tsx
+++ b/apps/web/app/components/chat/composer.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, expect, test, vi } from "vitest";
 import { Composer } from "~/components/chat/composer";
@@ -259,6 +259,22 @@ test("a message will not send while an upload is still in flight", async () => {
 
   await user.click(screen.getByRole("button", { name: "Send prompt" }));
   expect(onSend).not.toHaveBeenCalled();
+});
+
+test("dropping a file onto the composer stages and uploads it, same as the file picker", async () => {
+  const onSend = vi.fn();
+  doc = textDoc("what is this?");
+  const { container } = render(<Composer onSend={onSend} />);
+
+  const dropZone = container.querySelector(".rounded-lg.border") as HTMLElement;
+  expect(dropZone).not.toBeNull();
+  const file = new File(["png-bytes"], "dropped.png", { type: "image/png" });
+
+  fireEvent.dragOver(dropZone);
+  fireEvent.drop(dropZone, { dataTransfer: { files: [file] } });
+
+  expect(await screen.findByText("dropped.png")).toBeTruthy();
+  expect(uploadFile).toHaveBeenCalledWith(file, expect.any(Function));
 });
 
 test("a Suggested prompt drafts editable text without sending", async () => {

--- a/apps/web/app/components/chat/composer.tsx
+++ b/apps/web/app/components/chat/composer.tsx
@@ -156,6 +156,9 @@ export function Composer({
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const { attachments, add, addExisting, remove, clear, readyFiles, uploading } = useAttachments();
+  // Only for the border highlight while a drag is over the composer; `onDrop` re-uses the same
+  // `add` the file input and paste already call, so there is no second upload path to keep in sync.
+  const [dragActive, setDragActive] = useState(false);
 
   // A File the Files library handed over, staged without re-uploading its bytes. The id arrives as
   // a prop rather than being read from the URL here: the composer is rendered outside a router in
@@ -261,7 +264,27 @@ export function Composer({
             </>
           ) : null}
         </div>
-        <div className="overflow-hidden rounded-lg border border-input bg-card transition-[border-color,box-shadow] focus-within:border-primary focus-within:ring-[3px] focus-within:ring-ring/15">
+        {/* biome-ignore lint/a11y/noStaticElementInteractions: a drop target for files, mirroring the paperclip picker; there is no interactive-element equivalent for a drag-and-drop zone. */}
+        <div
+          className={`overflow-hidden rounded-lg border bg-card transition-[border-color,box-shadow] focus-within:border-primary focus-within:ring-[3px] focus-within:ring-ring/15 ${
+            dragActive ? "border-primary ring-[3px] ring-ring/15" : "border-input"
+          }`}
+          onDragEnter={(event) => {
+            event.preventDefault();
+            setDragActive(true);
+          }}
+          onDragLeave={(event) => {
+            event.preventDefault();
+            if (event.currentTarget.contains(event.relatedTarget as Node | null)) return;
+            setDragActive(false);
+          }}
+          onDragOver={(event) => event.preventDefault()}
+          onDrop={(event) => {
+            event.preventDefault();
+            setDragActive(false);
+            add(Array.from(event.dataTransfer?.files ?? []));
+          }}
+        >
           {editor ? (
             <BubbleMenu
               editor={editor}

--- a/apps/web/app/lib/files.test.ts
+++ b/apps/web/app/lib/files.test.ts
@@ -1,0 +1,85 @@
+import { expect, test, vi } from "vitest";
+import { uploadFile } from "./files";
+
+/**
+ * A minimal fake `XMLHttpRequest` that lets a test drive `uploadFile` to a chosen status without
+ * a real network. Only the surface `uploadFile` touches is implemented.
+ */
+class FakeXhr {
+  status = 0;
+  responseText = "";
+  upload = { addEventListener: vi.fn() };
+  private listeners = new Map<string, () => void>();
+
+  open = vi.fn();
+  setRequestHeader = vi.fn();
+  abort = vi.fn();
+
+  addEventListener(type: string, listener: () => void) {
+    this.listeners.set(type, listener);
+  }
+
+  send() {
+    // Real `send()` starts an async request; the test drives the response by calling `respond`
+    // after `uploadFile` has returned, so firing `load` here would race ahead of the status.
+  }
+
+  respond(status: number, body: string) {
+    this.status = status;
+    this.responseText = body;
+    this.listeners.get("load")?.();
+  }
+}
+
+function stubXhr(): FakeXhr {
+  const xhr = new FakeXhr();
+  vi.stubGlobal(
+    "XMLHttpRequest",
+    vi.fn(function XMLHttpRequestStub() {
+      return xhr;
+    })
+  );
+  return xhr;
+}
+
+test("a 403 upload failure shows a friendly permission message, never the raw server body", async () => {
+  const xhr = stubXhr();
+
+  const handle = uploadFile(new File(["x"], "shot.png", { type: "image/png" }));
+  xhr.respond(403, JSON.stringify({ error: "ROLE_GRANT_MISSING_UPLOAD_SCOPE" }));
+
+  await expect(handle.done).rejects.toMatchObject({
+    status: 403,
+    message: "You don't have permission to upload files.",
+  });
+
+  vi.unstubAllGlobals();
+});
+
+test("a 401 upload failure prompts signing in again", async () => {
+  const xhr = stubXhr();
+
+  const handle = uploadFile(new File(["x"], "shot.png", { type: "image/png" }));
+  xhr.respond(401, JSON.stringify({ error: "SESSION_EXPIRED" }));
+
+  await expect(handle.done).rejects.toMatchObject({
+    status: 401,
+    message: "Your session expired — sign in again.",
+  });
+
+  vi.unstubAllGlobals();
+});
+
+test("an unrecognized status still gets a generic friendly message, not the raw body", async () => {
+  const xhr = stubXhr();
+
+  const handle = uploadFile(new File(["x"], "shot.png", { type: "image/png" }));
+  xhr.respond(500, JSON.stringify({ error: "INTERNAL_STORAGE_UNAVAILABLE" }));
+
+  await expect(handle.done).rejects.toMatchObject({
+    status: 500,
+    message: "The upload failed. Try again.",
+  });
+
+  vi.unstubAllGlobals();
+});

--- a/apps/web/app/lib/files.ts
+++ b/apps/web/app/lib/files.ts
@@ -47,16 +47,19 @@ export class UploadFailed extends Error {
   }
 }
 
-function messageFor(status: number, raw: string): string {
-  try {
-    const parsed = JSON.parse(raw) as { error?: string };
-    if (typeof parsed.error === "string") return parsed.error;
-  } catch {
-    // A non-JSON body means the failure came from somewhere above the route.
-  }
+/**
+ * A friendly message for a failed upload, keyed on HTTP status only.
+ *
+ * The server's `error` body is never shown verbatim: it is an internal code meant for logs, not
+ * prose meant for a chat chip, and surfacing it raw leaked implementation detail (and, for a 403,
+ * a confusing permission code) straight into the UI. Every status maps to a fixed sentence.
+ */
+function messageFor(status: number): string {
+  if (status === 401) return "Your session expired — sign in again.";
+  if (status === 403) return "You don't have permission to upload files.";
   if (status === 413) return "That file is too large.";
   if (status === 415) return "That file type is not supported.";
-  return "The upload failed.";
+  return "The upload failed. Try again.";
 }
 
 export function uploadFile(file: File, onProgress?: (fraction: number) => void): UploadHandle {
@@ -87,7 +90,7 @@ export function uploadFile(file: File, onProgress?: (fraction: number) => void):
         resolve(JSON.parse(request.responseText) as UploadedFile);
         return;
       }
-      reject(new UploadFailed(request.status, messageFor(request.status, request.responseText)));
+      reject(new UploadFailed(request.status, messageFor(request.status)));
     });
 
     request.send(file);


### PR DESCRIPTION
## Summary
- Fixes #649 — composer had no drag-and-drop upload, and rejected uploads showed the raw API error code (e.g. "forbidden") verbatim.
- Added drag/drop handlers to the composer reusing the existing `add()` upload path.
- `messageFor()` in `apps/web/app/lib/files.ts` now maps status codes to friendly messages instead of passing through the server's raw error string.

## Test plan
- [x] `pnpm --filter @tulipfarm/web test app/components/chat` — 262/262 passed
- [x] typecheck, biome clean