### PR TITLE
fix(web): copy plain text from messages and stop links from swallowing adjacent text

### DIFF
--- a/apps/web/app/components/chat/composer.test.tsx
+++ b/apps/web/app/components/chat/composer.test.tsx
@@ -34,6 +34,16 @@ vi.mock("@tiptap/react", () => ({
 vi.mock("@tiptap/react/menus", () => ({ BubbleMenu: () => null }));
 vi.mock("@tiptap/starter-kit", () => ({ default: { configure: () => ({}) } }));
 vi.mock("@tiptap/extension-placeholder", () => ({ default: { configure: () => ({}) } }));
+const linkExtendConfig = vi.hoisted(() => vi.fn());
+const linkConfigure = vi.hoisted(() => vi.fn().mockReturnValue({}));
+vi.mock("@tiptap/extension-link", () => ({
+  default: {
+    extend: (config: { inclusive: () => boolean }) => {
+      linkExtendConfig(config);
+      return { configure: linkConfigure };
+    },
+  },
+}));
 vi.mock("~/components/chat/editor/mentions", () => ({
   buildMentionExtensions: () => [],
   MENTION_PLUGIN_KEYS: [],
@@ -73,6 +83,17 @@ beforeEach(() => {
     }),
     cancel: cancelUpload,
   }));
+});
+
+test("the Link mark does not extend when typing at its edge", () => {
+  render(<Composer onSend={vi.fn()} />);
+
+  // `inclusive` defaults to `autolink`'s value (true) in @tiptap/extension-link — left at that
+  // default, typing at a link's boundary extends the mark onto the new text instead of ending it
+  // (#603). It is a Mark config field, not a `LinkOptions` field, so it must come from `.extend()`.
+  expect(linkExtendConfig).toHaveBeenCalledTimes(1);
+  expect(linkExtendConfig.mock.calls[0][0].inclusive()).toBe(false);
+  expect(linkConfigure).toHaveBeenCalledWith(expect.objectContaining({ autolink: true }));
 });
 
 test("Model Selector sets the per-message effort preset override on send", async () => {

--- a/apps/web/app/components/chat/composer.tsx
+++ b/apps/web/app/components/chat/composer.tsx
@@ -1,3 +1,4 @@
+import Link from "@tiptap/extension-link";
 import Placeholder from "@tiptap/extension-placeholder";
 import { EditorContent, useEditor, useEditorState } from "@tiptap/react";
 import { BubbleMenu } from "@tiptap/react/menus";
@@ -34,6 +35,15 @@ import {
   ModelSelector,
 } from "./model-selector";
 import { useAttachments } from "./use-attachments";
+
+// `inclusive` is a Mark config field, not a `LinkOptions` field — `StarterKit`'s `link: {...}`
+// forwards to `.configure()`, which cannot reach it. Left at its default (`autolink`, i.e. true),
+// typing at a link's edge extends the mark onto whatever comes next instead of ending it.
+const NonInclusiveLink = Link.extend({
+  inclusive() {
+    return false;
+  },
+});
 
 /** What a composed turn carries to the parent: the effort preset plus the resolved mention tags. */
 export type ComposerSendOptions = {
@@ -94,7 +104,12 @@ export function Composer({
     extensions: [
       StarterKit.configure({
         heading: false,
-        link: { openOnClick: false, autolink: true, HTMLAttributes: { class: "tf-editor-link" } },
+        link: false,
+      }),
+      NonInclusiveLink.configure({
+        openOnClick: false,
+        autolink: true,
+        HTMLAttributes: { class: "tf-editor-link" },
       }),
       Placeholder.configure({ placeholder: "Ask anything…" }),
       ...mentionExtensions,

--- a/apps/web/app/components/chat/transcript.test.tsx
+++ b/apps/web/app/components/chat/transcript.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen } from "@testing-library/react";
+import { act, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Transcript } from "~/components/chat/transcript";
@@ -190,6 +190,26 @@ describe("Transcript message actions", () => {
     expect(screen.getAllByRole("button", { name: "copy" }).length).toBeGreaterThanOrEqual(1);
     await user.click(screen.getByRole("button", { name: "regenerate" }));
     expect(onRegenerate).toHaveBeenCalledTimes(1);
+  });
+
+  it("copies the message as it reads, resolving a markdown link to its label", async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    const state = fold(
+      [
+        { type: "text", data: { delta: "See [docs](https://example.com/docs) for more." } },
+        { type: "finish", data: { reason: "stop" } },
+      ],
+      "hi"
+    );
+    render(<Transcript messages={state.messages} status={state.status} onApprove={vi.fn()} />);
+
+    const assistantArticle = screen.getByLabelText("Assistant response");
+    await user.click(within(assistantArticle).getByRole("button", { name: "copy" }));
+
+    expect(writeText).toHaveBeenCalledWith("See docs for more.");
+    vi.unstubAllGlobals();
   });
 
   it("hides the assistant action bar while a turn is still streaming", () => {

--- a/apps/web/app/components/chat/transcript.tsx
+++ b/apps/web/app/components/chat/transcript.tsx
@@ -5,6 +5,7 @@ import { LoadingState } from "~/components/ui/loading-state";
 import { nextEffortPreset } from "~/lib/chat/effort-escalation";
 import type { ChatMessage, ChatStatus, ModelReceipt, TimelinePart } from "~/lib/chat/types";
 import { copyText } from "~/lib/clipboard";
+import { markdownLinksToPlainText } from "~/lib/markdown-to-text";
 import { FileAttachment, RemovedAttachment } from "./file-attachment";
 import { MessagePartView } from "./parts";
 import { PlanTrace } from "./plan-trace";
@@ -138,11 +139,12 @@ function IconAction({
   );
 }
 
-// Copy-to-clipboard icon button, shared by the user and assistant toolbars.
+// Copy-to-clipboard icon button, shared by the user and assistant toolbars. `text` is the raw
+// message markdown; copy it as it reads (link syntax resolved to its label), not as source.
 function CopyButton({ text }: { text: string }) {
   const [copied, setCopied] = useState(false);
   async function copy() {
-    if (!(await copyText(text))) return;
+    if (!(await copyText(markdownLinksToPlainText(text)))) return;
     setCopied(true);
     setTimeout(() => setCopied(false), 1500);
   }

--- a/apps/web/app/lib/markdown-to-text.test.ts
+++ b/apps/web/app/lib/markdown-to-text.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { markdownLinksToPlainText } from "~/lib/markdown-to-text";
+
+describe("markdownLinksToPlainText", () => {
+  it("resolves a markdown link to its label", () => {
+    expect(markdownLinksToPlainText("See [docs](https://example.com/docs).")).toBe("See docs.");
+  });
+
+  it("resolves multiple links in one string", () => {
+    expect(markdownLinksToPlainText("[a](https://a.com) and [b](https://b.com)")).toBe("a and b");
+  });
+
+  it("strips angle-bracket autolinks to the bare URL", () => {
+    expect(markdownLinksToPlainText("Reach us at <mailto:hi@example.com>")).toBe(
+      "Reach us at mailto:hi@example.com"
+    );
+  });
+
+  it("leaves plain text untouched", () => {
+    expect(markdownLinksToPlainText("no links here")).toBe("no links here");
+  });
+});

--- a/apps/web/app/lib/markdown-to-text.ts
+++ b/apps/web/app/lib/markdown-to-text.ts
@@ -1,0 +1,11 @@
+/**
+ * Renders as a clickable link (`MarkdownView` parses it into an `<a>`), so a verbatim copy of the
+ * message should read the same way — not as source syntax. Handles the common inline forms
+ * (`[text](url)`, autolinked bare/angle-bracket URLs) without pulling in a full markdown parser
+ * for what is otherwise a straight passthrough copy.
+ */
+export function markdownLinksToPlainText(markdown: string): string {
+  return markdown
+    .replace(/\[([^\]]*)\]\((?:[^()\s]+)(?:\s+"[^"]*")?\)/g, "$1")
+    .replace(/<((?:https?|mailto):[^>\s]+)>/g, "$1");
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,6 +23,7 @@
     "@shikijs/langs": "4.4.3",
     "@shikijs/themes": "4.4.3",
     "@tiptap/core": "^3.30.2",
+    "@tiptap/extension-link": "^3.30.2",
     "@tiptap/extension-mention": "^3.30.2",
     "@tiptap/extension-placeholder": "^3.30.2",
     "@tiptap/pm": "^3.30.2",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@tulipfarm/schema": "workspace:*",
     "@tiptap/markdown": "3.30.2",
+    "@tiptap/extension-link": "3.30.2",
     "@tiptap/extension-table": "3.30.2",
     "@tiptap/extension-table-row": "3.30.2",
     "@tiptap/extension-table-cell": "3.30.2",

--- a/packages/editor/src/extensions/build-extensions.ts
+++ b/packages/editor/src/extensions/build-extensions.ts
@@ -1,4 +1,5 @@
 import type { AnyExtension } from "@tiptap/core";
+import Link from "@tiptap/extension-link";
 import { TableKit } from "@tiptap/extension-table";
 import TaskItem from "@tiptap/extension-task-item";
 import TaskList from "@tiptap/extension-task-list";
@@ -10,13 +11,27 @@ export interface BuildExtensionsOptions {
   mentionExtensions?: AnyExtension[];
 }
 
+// `inclusive` is a Mark config field, not a `LinkOptions` field — `StarterKit`'s `link: {...}`
+// forwards to `.configure()`, which cannot reach it. Left at its default (`autolink`, i.e. true),
+// typing at a link's edge extends the mark onto whatever comes next instead of ending it.
+const NonInclusiveLink = Link.extend({
+  inclusive() {
+    return false;
+  },
+});
+
 /** Canonical markdown-only content schema shared by `<PageEditor>` and `MarkdownManager`. */
 export function buildContentExtensions(opts: BuildExtensionsOptions = {}): AnyExtension[] {
   return [
     StarterKit.configure({
       heading: { levels: [1, 2, 3] },
       // Keep Link non-auto-opening; do not register `tf:` globally or editors can clobber it.
-      link: { openOnClick: false, autolink: true, HTMLAttributes: { class: "tf-editor-link" } },
+      link: false,
+    }),
+    NonInclusiveLink.configure({
+      openOnClick: false,
+      autolink: true,
+      HTMLAttributes: { class: "tf-editor-link" },
     }),
     TaskList,
     TaskItem.configure({ nested: true }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -522,6 +522,9 @@ importers:
       '@tiptap/core':
         specifier: ^3.30.2
         version: 3.30.2(@tiptap/pm@3.30.2)
+      '@tiptap/extension-link':
+        specifier: ^3.30.2
+        version: 3.30.2(@tiptap/core@3.30.2(@tiptap/pm@3.30.2))(@tiptap/pm@3.30.2)
       '@tiptap/extension-mention':
         specifier: ^3.30.2
         version: 3.30.2(@tiptap/core@3.30.2(@tiptap/pm@3.30.2))(@tiptap/pm@3.30.2)(@tiptap/suggestion@3.30.2(@floating-ui/dom@1.7.6)(@tiptap/core@3.30.2(@tiptap/pm@3.30.2))(@tiptap/pm@3.30.2))
@@ -978,6 +981,9 @@ importers:
       '@tiptap/core':
         specifier: ^3.30.2
         version: 3.30.2(@tiptap/pm@3.30.2)
+      '@tiptap/extension-link':
+        specifier: 3.30.2
+        version: 3.30.2(@tiptap/core@3.30.2(@tiptap/pm@3.30.2))(@tiptap/pm@3.30.2)
       '@tiptap/extension-placeholder':
         specifier: ^3.30.2
         version: 3.30.2(@tiptap/extensions@3.30.2(@tiptap/core@3.30.2(@tiptap/pm@3.30.2))(@tiptap/pm@3.30.2))


### PR DESCRIPTION
## Summary
- Fixes #603, two sub-bugs:
  1. Copying a chat message copied raw markdown (`[text](url)`) instead of readable text — added `markdownLinksToPlainText()` used by the copy button.
  2. Typing at a link's edge extended the link mark instead of stopping at its boundary — TipTap's `Link.inclusive()` defaults to the `autolink` option, so both were `true`. Fixed with an explicit `NonInclusiveLink = Link.extend({ inclusive() { return false } })` in both the composer and the shared editor package.

## Test plan
- [x] `pnpm --filter @tulipfarm/web test app/components/chat app/lib/markdown-to-text` — 267/267 passed
- [x] `pnpm --filter @tulipfarm/editor test` — 47/47 passed
- [x] typecheck, biome clean