### PR TITLE
feat(web): redesign the integrations catalog as a brand tile grid

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -36,7 +36,9 @@ Terminology is binding: [`metadata/terminologies.md`](metadata/terminologies.md)
 - **Neutral by default.** Achromatic surfaces, quiet hairlines. Ruby is for brand, selection,
   focus, links, and primary actions. Destructive red is for danger. Nothing else.
 - **Structure before decoration.** Hierarchy comes from layout, type, and spacing. Not from
-  gradients, glass, shadows, or card grids without a content reason.
+  gradients, glass, shadows, or card grids without a content reason. The integrations catalog is
+  the one place both a card grid and a hairline lift are sanctioned, on grounds named in §6 and in
+  "The integrations catalog".
 - **Color never carries meaning alone.** Every tone ships with a label, an icon, or a shape.
 - **Motion must report real state.** An animation that runs regardless of what is happening is
   decoration, and decoration is not permitted. See §7.
@@ -274,8 +276,15 @@ Title for a heading the content area owns, and only when it says something the t
 
 ## 6. Shape, depth, and material
 
-- **No shadows, anywhere.** Both apps zero the entire Tailwind shadow scale. Depth comes from
-  hairline borders and lifted surfaces.
+- **No shadows, anywhere, with one named exception.** Both apps zero the entire Tailwind shadow
+  scale. Depth comes from hairline borders and lifted surfaces. The exception is
+  **catalog elevation**: a grid of third-party brand tiles, where each tile is a separate
+  destination and the marks are supplied by other people. There, and only there, a tile may carry
+  a 1-2px, ≤8% black hairline lift, and a segmented control's active pill may carry the same. It
+  is a *seam*, not a glow — if it reads as a drop shadow at 100% zoom it is too big. Everything
+  else in the product app stays flat.
+- **Do not reach for an arbitrary `shadow-[…]` value elsewhere.** The scale is zeroed on purpose;
+  an arbitrary value is a circumvention, not an exemption. Widen this rule in this file first.
 - **Radius**: app 4/6/8px; docs 2/4/6px capped. Prefer the restrained end. Oversized radii are a
   smell.
 - **Icons** at 14/16/20/24px, Lucide outline. Never emoji.
@@ -701,6 +710,33 @@ runtime-managed ones; because adjacent inline spans concatenate with no space, t
 **Every empty state names its own cause.** "No records yet", "no column is visible", "nothing matches
 that filter" and "this schema will not parse" are four different problems with four different exits.
 One shared "No results" for all four tells the reader nothing they can act on.
+
+### The integrations catalog
+
+**This is the sanctioned card grid.** §1 bans card grids "without a content reason"; §6 lists the
+one place elevation is allowed. Both exemptions point here, and the reason is the same. Every other
+roster in this app lists objects *the operator authored* — agents, skills, routines — where the name
+is the identity and a list column aligns cleanly. The integrations catalog lists **other people's
+brands**, which an operator recognises by mark before name. A tile that leads with the logo is
+faster to scan than a row that leads with text, and the set is small and slow-growing, so the
+vertical cost cards pay at three hundred rows is never charged. Grid at `sm:2 / xl:3`.
+
+**One tile design for every entry.** The logo is the only place brand colour is allowed to land —
+the tile behind it is the same neutral surface at every tier, whether the mark is a vendored
+full-colour SVG, a monochrome glyph, or a fallback monogram. Tinting the tile to match the brand
+produces as many card designs as there are cards.
+
+**Coming-soon is a state, not a dimming.** An entry that is not available yet keeps its logo at full
+strength and says so in words and a badge. Fading the mark to signal unavailability makes the
+best-known brands the hardest ones to find, and communicates nothing to a reader who cannot compare
+it against an undimmed neighbour.
+
+**Connection state is a badge and is never implied.** `connected`, `connecting`, `error` and
+`disconnected` are four different claims and keep four tones — collapsing `error` into "Not
+connected" reports a fault as a choice. `disconnected` stays neutral rather than warning: an
+integration nobody has set up is not broken, and the warning tone carries an alert icon that would
+render a healthy instance as a wall of problems. A second badge such as "Update available" sits
+beside the connection badge, never in place of it.
 
 ### The agent roster and profile
 

--- a/apps/api/src/integrations/routes.ts
+++ b/apps/api/src/integrations/routes.ts
@@ -116,14 +116,24 @@ async function toCatalog(
             installed: false,
             status: "disconnected" as ConnectionStatus,
           };
-      const mark = await brandIcon(entry?.manifest.icon ?? listing?.icon);
+      const slug = entry?.manifest.icon ?? listing?.icon;
+      const mark = await brandIcon(slug);
       return {
         ...base,
+        // How much work connecting is, answered on the card rather than one click later. Absent for
+        // an entry with no manifest yet, where the honest answer is that nobody knows.
+        setupSteps: entry ? resolveAuthSteps(entry.manifest).length : undefined,
         title: listing?.title,
+        // An entry the registry has not opened yet is listed but not offered. Absent listing means
+        // an uncurated local install, which nobody is holding back.
+        availability: listing?.availability ?? "available",
         description: base.description ?? listing?.description,
         category: listing?.category,
         homepage: listing?.homepage,
         source: listing?.source,
+        // Forwarded so the client can prefer a vendored full-colour mark for brands whose colour is
+        // the identity; Simple Icons only carries a monochrome silhouette.
+        iconSlug: slug,
         iconPath: mark?.path,
         // The registry's colour is the fallback, not an override: it exists for brands the icon
         // set does not carry, so a resolved mark always keeps its own.
@@ -139,14 +149,17 @@ async function toDetail(
   personalConnected = false
 ) {
   const steps = resolveAuthSteps(entry.manifest);
-  const mark = await brandIcon(entry.manifest.icon ?? listing?.icon);
+  const slug = entry.manifest.icon ?? listing?.icon;
+  const mark = await brandIcon(slug);
   return {
     ...toSummary(entry),
     // The same brand identity the catalog row showed. Landing on a detail page that drops back to
     // a bare slug reads as a different product than the one that was clicked.
     title: listing?.title,
+    availability: listing?.availability ?? "available",
     category: listing?.category,
     homepage: listing?.homepage,
+    iconSlug: slug,
     iconPath: mark?.path,
     iconColor: mark?.hex ?? listing?.color,
     capabilities: entry.manifest.capabilities,
@@ -188,16 +201,19 @@ const IntegrationSummarySchema = {
   properties: {
     name: { type: "string" },
     title: { type: "string" },
+    availability: { type: "string", enum: ["available", "coming_soon"] },
     type: { type: "string" },
     description: { type: "string" },
     category: { type: "string" },
     homepage: { type: "string" },
+    iconSlug: { type: "string" },
     iconPath: { type: "string" },
     iconColor: { type: "string" },
     version: { type: "string" },
     maintainer: { type: "string" },
     source: { type: "string" },
     installed: { type: "boolean" },
+    setupSteps: { type: "number" },
     status: { type: "string", enum: ["connected", "disconnected"] },
     updateAvailable: { type: "boolean" },
   },

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -25,6 +25,7 @@ data loading, schema-driven resource UI, and browser rendering of Surface Artifa
 | `app/components/skills/` | Catalog, reach badge, capability/package/audience panels, marketplace browser. |
 | `app/components/resources/` | Stat strip, catalog table, schema summary for `/resources`. |
 | `app/components/routines/` | Catalog, row, canvas, run/dry-run, effects and bounds panels for `/routines`. |
+| `app/components/integrations/` | Brand-tile card grid, vendored colour logos, the `···` menu, and the `?view=` preview sheet for `/integrations`. The one sanctioned card grid — see DESIGN.md "The integrations catalog". |
 | `app/components/ui/` | Vendored shadcn primitives for this app only, plus `combobox.tsx` — hand-rolled, because `cmdk` forces its own input `id` and breaks `<label htmlFor>`. |
 | `app/lib/api.ts` | API client with cookies, CSRF header, optional bearer token, `ApiError`. |
 | `app/lib/schema.ts` | JSON-Schema field detection, list/detail/form metadata, value rendering, shared formatters. |

--- a/apps/web/app/components/integrations/brand-logo.tsx
+++ b/apps/web/app/components/integrations/brand-logo.tsx
@@ -1,0 +1,78 @@
+/*
+ * Full-colour brand marks, vendored.
+ *
+ * The API resolves a manifest `icon` slug against Simple Icons, which ships one *monochrome* path
+ * per brand and has dropped some marks entirely — Slack among them. That is fine for a brand whose
+ * logo is monochrome anyway (GitHub, Linear), but for one whose colour *is* the identity it renders
+ * as a generic silhouette. Those are authored here and take precedence; everything else falls
+ * through to the Simple Icons glyph in the brand's own hex.
+ *
+ * Vendored rather than fetched: an instance runs on the operator's own infrastructure, so a logo
+ * CDN would break offline installs and leak which integrations an instance browses.
+ */
+
+export type BrandLogo = {
+  /** Each mark keeps the viewBox it was authored in. */
+  readonly viewBox: string;
+  readonly paths: readonly { readonly fill: string; readonly d: string }[];
+};
+
+const SLACK: BrandLogo = {
+  viewBox: "0 0 127 127",
+  paths: [
+    {
+      fill: "#E01E5A",
+      d: "M27.2 80a13.2 13.2 0 0 1-13.2 13.2A13.2 13.2 0 0 1 .8 80a13.2 13.2 0 0 1 13.2-13.2h13.2Zm6.6 0a13.2 13.2 0 0 1 13.2-13.2A13.2 13.2 0 0 1 60.2 80v33a13.2 13.2 0 0 1-13.2 13.2A13.2 13.2 0 0 1 33.8 113Z",
+    },
+    {
+      fill: "#36C5F0",
+      d: "M47 27a13.2 13.2 0 0 1-13.2-13.2A13.2 13.2 0 0 1 47 .6a13.2 13.2 0 0 1 13.2 13.2V27Zm0 6.7a13.2 13.2 0 0 1 13.2 13.2A13.2 13.2 0 0 1 47 60.1H13.9A13.2 13.2 0 0 1 .7 46.9a13.2 13.2 0 0 1 13.2-13.2Z",
+    },
+    {
+      fill: "#2EB67D",
+      d: "M99.9 46.9a13.2 13.2 0 0 1 13.2-13.2 13.2 13.2 0 0 1 13.2 13.2 13.2 13.2 0 0 1-13.2 13.2H99.9Zm-6.6 0a13.2 13.2 0 0 1-13.2 13.2 13.2 13.2 0 0 1-13.2-13.2V13.8A13.2 13.2 0 0 1 80.1.6a13.2 13.2 0 0 1 13.2 13.2Z",
+    },
+    {
+      fill: "#ECB22E",
+      d: "M80.1 99.8a13.2 13.2 0 0 1 13.2 13.2 13.2 13.2 0 0 1-13.2 13.2A13.2 13.2 0 0 1 66.9 113V99.8Zm0-6.6a13.2 13.2 0 0 1-13.2-13.2 13.2 13.2 0 0 1 13.2-13.2h33.1a13.2 13.2 0 0 1 13.2 13.2 13.2 13.2 0 0 1-13.2 13.2Z",
+    },
+  ],
+};
+
+const GOOGLE: BrandLogo = {
+  viewBox: "0 0 48 48",
+  paths: [
+    {
+      fill: "#FFC107",
+      d: "M43.6 20.1H42V20H24v8h11.3A12 12 0 1 1 24 12c3.1 0 5.8 1.2 8 3l5.7-5.6A20 20 0 1 0 44 24c0-1.3-.1-2.6-.4-3.9Z",
+    },
+    {
+      fill: "#FF3D00",
+      d: "m6.3 14.7 6.6 4.8A12 12 0 0 1 24 12c3.1 0 5.8 1.2 8 3l5.7-5.6A20 20 0 0 0 6.3 14.7Z",
+    },
+    {
+      fill: "#4CAF50",
+      d: "M24 44c5.2 0 9.9-2 13.4-5.2l-6.2-5.2A12 12 0 0 1 12.7 28l-6.5 5A20 20 0 0 0 24 44Z",
+    },
+    {
+      fill: "#1976D2",
+      d: "M43.6 20.1H42V20H24v8h11.3a12 12 0 0 1-4.1 5.6l6.2 5.2C37 39.2 44 34 44 24c0-1.3-.1-2.6-.4-3.9Z",
+    },
+  ],
+};
+
+/* Keyed by the manifest `icon` slug the API forwards. Aliases cover the product names a manifest
+   may legitimately use for the same mark. */
+const LOGOS: Record<string, BrandLogo> = {
+  slack: SLACK,
+  google: GOOGLE,
+  googleworkspace: GOOGLE,
+  googledrive: GOOGLE,
+  gmail: GOOGLE,
+};
+
+/** A vendored full-colour mark for this slug, or null to fall back to the Simple Icons glyph. */
+export function brandLogo(slug: string | undefined | null): BrandLogo | null {
+  if (!slug) return null;
+  return LOGOS[slug.toLowerCase()] ?? null;
+}

--- a/apps/web/app/components/integrations/catalog-actions-menu.tsx
+++ b/apps/web/app/components/integrations/catalog-actions-menu.tsx
@@ -1,0 +1,173 @@
+import { Link } from "@remix-run/react";
+import { ArrowUpRight, BookOpen, MessageSquarePlus, MoreHorizontal, Sparkles } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { GITHUB_REPO_URL } from "~/lib/report-bug";
+import { cn } from "~/lib/utils";
+
+/*
+ * The catalog's overflow menu. Every item resolves to something this instance can actually do:
+ * asking for an integration is a chat draft, because a chat is how an agent is asked to build
+ * anything here — not a request form that files into a queue nobody owns.
+ */
+
+const DOCS = "https://tulipfarm.site/docs";
+
+/** Seeds the composer on the new-chat route, which strips the param once applied. */
+const REQUEST_DRAFT =
+  "I want to connect a tool that is not in the integrations catalog yet. " +
+  "Ask me which tool and what I need agents to do with it, then tell me whether you can build " +
+  "the integration and what you would need from me to do it.";
+
+type Item =
+  | { kind: "internal"; label: string; to: string; icon: typeof Sparkles }
+  | { kind: "external"; label: string; href: string; icon: typeof Sparkles }
+  | { kind: "separator" };
+
+const ITEMS: Item[] = [
+  {
+    kind: "internal",
+    label: "Request an integration",
+    to: `/?draft=${encodeURIComponent(REQUEST_DRAFT)}`,
+    icon: Sparkles,
+  },
+  { kind: "separator" },
+  {
+    kind: "external",
+    label: "How integrations work",
+    href: `${DOCS}/administration/how-integrations-work`,
+    icon: BookOpen,
+  },
+  {
+    kind: "external",
+    label: "Bundled integrations",
+    href: `${DOCS}/reference/bundled-integrations`,
+    icon: BookOpen,
+  },
+  { kind: "separator" },
+  {
+    kind: "external",
+    label: "Report a problem",
+    href: `${GITHUB_REPO_URL}/issues/new`,
+    icon: MessageSquarePlus,
+  },
+];
+
+const MENU_WIDTH = 240;
+const VIEWPORT_GUTTER = 8;
+
+/**
+ * Right-aligns the menu under its trigger, but never past the viewport edge — on a narrow phone
+ * the trigger sits far enough left that a purely right-aligned menu hangs off-screen and clips
+ * its own labels.
+ */
+function menuLeft(rect: DOMRect) {
+  const preferred = rect.right - MENU_WIDTH;
+  const max = window.innerWidth - MENU_WIDTH - VIEWPORT_GUTTER;
+  return Math.max(VIEWPORT_GUTTER, Math.min(preferred, max));
+}
+
+const ITEM_CLASS =
+  "flex w-full items-center gap-2.5 rounded-sm px-2 py-2 text-left text-sm text-foreground transition-colors hover:bg-secondary";
+
+/** Portalled so the page's own scroll container cannot clip it — mirrors `ChatActionsMenu`. */
+export function CatalogActionsMenu() {
+  const [open, setOpen] = useState(false);
+  const [rect, setRect] = useState<DOMRect | null>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (!triggerRef.current?.contains(target) && !menuRef.current?.contains(target)) {
+        setOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
+    };
+    const close = () => setOpen(false);
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    window.addEventListener("scroll", close, true);
+    window.addEventListener("resize", close);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+      window.removeEventListener("scroll", close, true);
+      window.removeEventListener("resize", close);
+    };
+  }, [open]);
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label="More integration actions"
+        onClick={() => {
+          if (!open && triggerRef.current) setRect(triggerRef.current.getBoundingClientRect());
+          setOpen((o) => !o);
+        }}
+        className={cn(
+          "inline-flex size-9 shrink-0 items-center justify-center rounded-md border border-input",
+          "text-muted-foreground transition-colors hover:bg-accent hover:text-foreground",
+          "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring",
+          open && "bg-accent text-foreground"
+        )}
+      >
+        <MoreHorizontal className="size-4" />
+      </button>
+
+      {open && rect
+        ? createPortal(
+            <div
+              ref={menuRef}
+              role="menu"
+              className="fixed z-50 rounded-md border border-border bg-card p-1 shadow-lg"
+              style={{ top: rect.bottom + 6, left: menuLeft(rect), width: MENU_WIDTH }}
+            >
+              {ITEMS.map((item, i) =>
+                item.kind === "separator" ? (
+                  <div key={`sep-${i}`} role="none" className="my-1 h-px bg-border" />
+                ) : item.kind === "internal" ? (
+                  <Link
+                    key={item.label}
+                    role="menuitem"
+                    to={item.to}
+                    onClick={() => setOpen(false)}
+                    className={ITEM_CLASS}
+                  >
+                    <item.icon aria-hidden className="size-4 text-muted-foreground" />
+                    {item.label}
+                  </Link>
+                ) : (
+                  <a
+                    key={item.label}
+                    role="menuitem"
+                    href={item.href}
+                    target="_blank"
+                    rel="noreferrer"
+                    onClick={() => setOpen(false)}
+                    className={ITEM_CLASS}
+                  >
+                    <item.icon aria-hidden className="size-4 text-muted-foreground" />
+                    <span className="flex-1">{item.label}</span>
+                    <ArrowUpRight aria-hidden className="size-3.5 text-muted-foreground" />
+                  </a>
+                )
+              )}
+            </div>,
+            document.body
+          )
+        : null}
+    </>
+  );
+}

--- a/apps/web/app/components/integrations/coming-soon-state.tsx
+++ b/apps/web/app/components/integrations/coming-soon-state.tsx
@@ -1,0 +1,29 @@
+import { Link } from "@remix-run/react";
+import { PageShell } from "~/components/page-shell";
+
+/**
+ * A catalog entry the registry lists but has not opened. It renders the page frame rather than an
+ * error, because nothing failed: the destination exists and is simply not ready to be connected.
+ */
+export function ComingSoonState({ name }: { name: string }) {
+  return (
+    <PageShell
+      crumbs={[{ label: "Integrations", to: "/integrations" }, { label: name }]}
+      title={name}
+      description="Coming soon."
+    >
+      <div className="flex max-w-prose flex-col gap-3 text-sm">
+        <p className="text-muted-foreground">
+          This integration is listed so you can see what is next. There is no setup to complete yet,
+          and no credentials to hand over.
+        </p>
+        <Link
+          to="/integrations"
+          className="w-fit rounded-sm font-medium text-primary transition-colors duration-150 hover:underline"
+        >
+          Back to integrations
+        </Link>
+      </div>
+    </PageShell>
+  );
+}

--- a/apps/web/app/components/integrations/integration-card.tsx
+++ b/apps/web/app/components/integrations/integration-card.tsx
@@ -1,0 +1,247 @@
+import { Link } from "@remix-run/react";
+import { ChevronRight } from "lucide-react";
+import { StatusBadge, type StatusTone } from "~/components/status-badge";
+import { Badge } from "~/components/ui/badge";
+import { Button } from "~/components/ui/button";
+import type { IntegrationSummary, McpConnectionStatus } from "~/lib/integrations";
+import { cn } from "~/lib/utils";
+import { IntegrationIcon } from "./integration-icon";
+
+// Grid rather than list: see DESIGN.md, "The integrations catalog".
+
+/** Uncurated entries carry no registry title, so the slug is the honest display name. */
+export function displayName(integration: IntegrationSummary): string {
+  return integration.title ?? integration.name;
+}
+
+/**
+ * Who publishes it, in the form an operator will recognise. The homepage host is the honest
+ * answer: `maintainer` is an author of the manifest, not the provider behind the brand.
+ */
+export function providerHost(integration: IntegrationSummary): string | undefined {
+  if (!integration.homepage) return undefined;
+  try {
+    return new URL(integration.homepage).host.replace(/^www\./, "");
+  } catch {
+    return undefined;
+  }
+}
+
+function Frame({ muted, children }: { muted?: boolean; children: React.ReactNode }) {
+  return (
+    <li
+      className={cn(
+        "relative flex flex-col overflow-hidden rounded-lg border border-border bg-card",
+        "transition-[border-color,box-shadow] duration-150",
+        "has-[:focus-visible]:outline-2 has-[:focus-visible]:outline-offset-2 has-[:focus-visible]:outline-ring",
+        muted
+          ? "bg-muted/20"
+          : "hover:border-foreground/20 hover:shadow-[0_1px_3px_rgb(0_0_0/0.06)]"
+      )}
+    >
+      {children}
+    </li>
+  );
+}
+
+function Head({ integration }: { integration: IntegrationSummary }) {
+  const name = displayName(integration);
+  const by = providerHost(integration);
+  // Falls back to the slug only when the title is not already it — repeating the heading one line
+  // below it says nothing, and an uncurated entry has nothing else to say.
+  const secondary = by ? `By ${by}` : name === integration.name ? undefined : integration.name;
+  return (
+    <div className="flex items-start gap-3">
+      <IntegrationIcon
+        label={name}
+        iconSlug={integration.iconSlug}
+        iconPath={integration.iconPath}
+        iconColor={integration.iconColor}
+        size="lg"
+      />
+      <div className="min-w-0 flex-1">
+        <h3 className="truncate text-[15px] font-semibold leading-tight text-foreground">{name}</h3>
+        {secondary ? (
+          <p className="mt-0.5 truncate text-[13px] leading-tight text-muted-foreground">
+            {secondary}
+          </p>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+/** A fact about the integration, sized to read as metadata rather than as content. */
+function Meta({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="inline-flex h-[18px] shrink-0 items-center rounded bg-muted px-1.5 text-[10px] font-semibold uppercase tracking-[0.04em] text-muted-foreground">
+      {children}
+    </span>
+  );
+}
+
+function Body({ integration }: { integration: IntegrationSummary }) {
+  const steps = integration.setupSteps;
+  return (
+    <div className="flex flex-1 flex-col gap-2.5 p-4">
+      {/* Connection state is stated once, in the footer, where it lines up across the grid. */}
+      <Head integration={integration} />
+      <p
+        className={cn(
+          "line-clamp-2 text-[13px] leading-[1.5]",
+          integration.description ? "text-muted-foreground" : "text-muted-foreground/70"
+        )}
+      >
+        {integration.description ?? "No description declared."}
+      </p>
+      <div className="mt-auto flex flex-wrap items-center gap-1.5 pt-0.5">
+        {integration.category ? <Meta>{integration.category}</Meta> : null}
+        {/* Only where connecting is on offer: a step count on a coming-soon entry describes work
+            nobody can start. */}
+        {integration.availability !== "coming_soon" && steps ? (
+          <Meta>
+            {steps} step{steps === 1 ? "" : "s"}
+          </Meta>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+/*
+ * Connection state, in the colour language the rest of the app already uses: green is working, red
+ * is broken, blue is mid-flight, grey is not started.
+ *
+ * `disconnected` stays grey deliberately. Amber carries a warning triangle, and an integration
+ * nobody has set up yet is not a fault to be warned about — it is the resting state of every entry
+ * in a fresh catalog. Colouring it would make a healthy instance look like a wall of problems, and
+ * spend the reader's attention on the one card that genuinely is one.
+ *
+ * The four states are kept apart rather than collapsed to connected/not: `error` and `connecting`
+ * both used to print "Not connected", which is a different claim from the one the runtime is
+ * making.
+ */
+export const CONNECTION: Record<McpConnectionStatus, { label: string; tone: StatusTone }> = {
+  connected: { label: "Connected", tone: "success" },
+  connecting: { label: "Connecting", tone: "info" },
+  error: { label: "Error", tone: "danger" },
+  disconnected: { label: "Not connected", tone: "neutral" },
+};
+
+/**
+ * The card footer, on a hairline so every tile's action lands on the same line whatever the
+ * description above it does.
+ */
+function Foot({ className, children }: { className?: string; children: React.ReactNode }) {
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-between gap-2 border-t border-border px-4 py-2.5 text-xs",
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+/**
+ * The card's one action, stretched over the whole tile so the pointer target is the card the user
+ * is already over. It stays an anchor to a real URL rather than a click handler, so open-in-new-tab,
+ * Back and a shared link all keep working — `?view=` is the panel's address, not local state.
+ */
+function PreviewLink({ integration, label }: { integration: IntegrationSummary; label: string }) {
+  return (
+    <Link
+      to={`?view=${encodeURIComponent(integration.name)}`}
+      preventScrollReset
+      aria-label={`${label} for ${displayName(integration)}`}
+      className={cn(
+        "flex items-center gap-1 rounded-sm font-medium text-foreground",
+        "transition-colors duration-150 hover:text-primary",
+        // The card carries the focus ring, because the stretched hit area is the card.
+        "focus-visible:outline-none",
+        "after:absolute after:inset-0 after:content-['']"
+      )}
+    >
+      {label}
+      {/* No leaves-here arrow: this opens a panel over the catalog, it does not navigate away. */}
+      <ChevronRight aria-hidden className="size-3.5" />
+    </Link>
+  );
+}
+
+export function IntegrationCard({
+  integration,
+  onUpdate,
+  updating,
+  isAdmin,
+}: {
+  integration: IntegrationSummary;
+  onUpdate: (name: string, source?: string) => void;
+  updating?: boolean;
+  isAdmin?: boolean;
+}) {
+  const name = displayName(integration);
+
+  // Listed so the roadmap is visible, closed because there is no setup flow to hand over yet. The
+  // preview still opens — a card that does nothing at all reads as broken rather than as pending —
+  // but it leads to the panel, never to the detail page that would offer a connection this
+  // deployment cannot honor.
+  if (integration.availability === "coming_soon") {
+    return (
+      <Frame muted>
+        <Body integration={integration} />
+        <Foot className="bg-muted/40">
+          <StatusBadge label="Coming soon" tone="info" />
+          <PreviewLink integration={integration} label="View details" />
+        </Foot>
+      </Frame>
+    );
+  }
+
+  // A curated entry that has not been cloned has no detail page to open — linking there would 404.
+  // It is a card about a repository, not about an integration this deployment has.
+  if (!integration.installed) {
+    return (
+      <Frame muted>
+        <Body integration={integration} />
+        <Foot className="bg-muted/40">
+          <StatusBadge label="Not installed" tone="neutral" />
+        </Foot>
+      </Frame>
+    );
+  }
+
+  return (
+    <Frame>
+      <Body integration={integration} />
+      {integration.errorMessage && (
+        <p className="px-4 pb-3 text-xs text-destructive">{integration.errorMessage}</p>
+      )}
+      <Foot className="bg-muted/40">
+        <span className="flex items-center gap-1.5">
+          <StatusBadge {...CONNECTION[integration.status]} />
+          {integration.updateAvailable && <Badge variant="primary">Update available</Badge>}
+        </span>
+        <span className="flex items-center gap-2">
+          {integration.updateAvailable && isAdmin && (
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={updating}
+              aria-label={`Update ${name}`}
+              // The card is a stretched link, so this button needs its own stacking context to
+              // stay clickable above it.
+              className="relative z-10"
+              onClick={() => onUpdate(integration.name, integration.source)}
+            >
+              {updating ? "Updating…" : "Update"}
+            </Button>
+          )}
+          <PreviewLink integration={integration} label="View details" />
+        </span>
+      </Foot>
+    </Frame>
+  );
+}

--- a/apps/web/app/components/integrations/integration-icon.test.tsx
+++ b/apps/web/app/components/integrations/integration-icon.test.tsx
@@ -45,33 +45,65 @@ describe("IntegrationIcon", () => {
     expect(container.firstElementChild).toHaveAttribute("aria-hidden");
   });
 
-  test("wears the brand's colour, corrected for each canvas", () => {
+  test("wears the brand's colour, corrected for the tile it sits on", () => {
     const { container } = render(
       <IntegrationIcon label="GitHub" iconPath="M0 0h24v24H0z" iconColor="181717" />
     );
     const tile = container.firstElementChild as HTMLElement;
-    // Both corrections are published so the `dark:` variant can switch between them without
-    // JavaScript — GitHub's near-black is unreadable on the dark canvas as authored.
-    expect(tile.style.getPropertyValue("--brand-light")).toBe("oklch(0.206 0.0016 17.3)");
-    expect(tile.style.getPropertyValue("--brand-dark")).toBe("oklch(0.720 0.0016 17.3)");
+    // One correction, not two: the tile is light in both themes, so the dark-canvas variant of the
+    // brand colour would only ever wash the mark out.
+    expect(tile.style.getPropertyValue("--brand")).toBe("oklch(0.206 0.0016 17.3)");
+    expect(container.querySelector("svg")?.getAttribute("class")).toContain("text-[var(--brand)]");
   });
 
-  test("colours the monogram too, so a brand without a mark is still that brand", () => {
-    // The whole reason the registry carries a colour: one grey tile among coloured logos reads as
-    // a failed image rather than as a brand that has no logo to show.
+  test("leaves a monogram neutral, because a two-letter word is not a logo", () => {
+    // A coloured monogram claims to be a brand mark. It is a placeholder, and reading as one is
+    // the honest outcome — the colour belongs to marks the brand actually authored.
     const { container } = render(<IntegrationIcon label="Slack" iconColor="4A154B" />);
-    const tile = container.firstElementChild as HTMLElement;
     expect(screen.getByText("SL")).toBeInTheDocument();
-    expect(tile.style.getPropertyValue("--brand-light")).toContain("oklch(");
-    expect(tile.className).toContain("text-[var(--brand)]");
+    expect(screen.getByText("SL").className).toContain("text-neutral-500");
+    expect(container.querySelector("svg")).toBeNull();
   });
 
-  test("falls back to the muted treatment when no colour is curated", () => {
+  test("needs no colour at all when none is curated", () => {
     // An integration installed from a URL has no registry entry, so inventing a colour for it
     // would be inventing a brand.
     const { container } = render(<IntegrationIcon label="Acme CRM" />);
     const tile = container.firstElementChild as HTMLElement;
-    expect(tile.style.getPropertyValue("--brand-light")).toBe("");
-    expect(tile.className).toContain("text-muted-foreground");
+    expect(tile.style.getPropertyValue("--brand")).toBe("");
+    expect(screen.getByText("AC")).toBeInTheDocument();
+  });
+
+  test("prefers the vendored full-colour mark over the monochrome glyph", () => {
+    // Slack is the case this exists for: it is absent from Simple Icons, so without the vendored
+    // mark the catalog shows an "SL" monogram where every other tile shows a logo.
+    const { container } = render(<IntegrationIcon label="Slack" iconSlug="slack" />);
+    const fills = [...container.querySelectorAll("path")].map((p) => p.getAttribute("fill"));
+    expect(fills).toEqual(["#E01E5A", "#36C5F0", "#2EB67D", "#ECB22E"]);
+    expect(screen.queryByText("SL")).not.toBeInTheDocument();
+  });
+
+  test("keeps the tile neutral behind a full-colour mark", () => {
+    // Tinting the tile with one of the brand's four colours would fight the other three, and
+    // tinting only *some* tiles is what makes a grid read as several card designs rather than one.
+    // So every tier gets the same tile, whatever mark ends up on it.
+    const tiles = [
+      render(<IntegrationIcon label="Slack" iconSlug="slack" iconColor="4A154B" />),
+      render(<IntegrationIcon label="GitHub" iconPath="M12 0z" iconColor="181717" />),
+      render(<IntegrationIcon label="Acme CRM" />),
+    ].map((r) => (r.container.firstElementChild as HTMLElement).className);
+    for (const tile of tiles) {
+      expect(tile).toContain("bg-white");
+      expect(tile).not.toContain("--brand)_12%");
+    }
+  });
+
+  test("still uses the monochrome glyph for a brand with no vendored mark", () => {
+    // GitHub's own logo is monochrome, so the Simple Icons path is the real mark, not a fallback.
+    const { container } = render(
+      <IntegrationIcon label="GitHub" iconSlug="github" iconPath="M12 0z" iconColor="181717" />
+    );
+    expect(container.querySelector("path")?.getAttribute("d")).toBe("M12 0z");
+    expect(container.querySelector("svg")?.getAttribute("class")).toContain("text-[var(--brand)]");
   });
 });

--- a/apps/web/app/components/integrations/integration-icon.tsx
+++ b/apps/web/app/components/integrations/integration-icon.tsx
@@ -1,16 +1,25 @@
 import type { CSSProperties } from "react";
 import { brandInk } from "~/lib/brand";
 import { cn } from "~/lib/utils";
+import { brandLogo } from "./brand-logo";
 
 /*
- * An integration's mark: the brand's Simple Icons glyph when it has one, a derived monogram
- * when it does not — both in the brand's own colour. The fallback is not an edge case.
+ * An integration's mark, in descending order of fidelity: the brand's own full-colour logo when one
+ * is vendored, the Simple Icons monochrome glyph in the brand's hex when it is not, and a derived
+ * monogram when the brand has neither. The fallbacks are not edge cases — an uncurated entry
+ * installed from git reaches the last one.
+ *
+ * Every mark sits on the same neutral tile, whichever tier it came from. Tinting the tile per brand
+ * was worse than it sounds: a grid then reads as five different card designs rather than one, and
+ * the brands that do have a vendored full-colour logo cannot be tinted at all without muddying
+ * colours the brand chose — so the tint was only ever applied to some tiles, which is exactly what
+ * made the row look unfinished. The colour lives in the mark; the tile stays out of its way.
  */
 
 const SIZE = {
   sm: { box: "size-5", mark: "size-3", text: "text-[0.5rem]" },
-  md: { box: "size-8", mark: "size-4", text: "text-[0.625rem]" },
-  lg: { box: "size-11", mark: "size-6", text: "text-sm" },
+  md: { box: "size-8", mark: "size-5", text: "text-[0.625rem]" },
+  lg: { box: "size-11", mark: "size-7", text: "text-sm" },
 } as const;
 
 export type IntegrationIconSize = keyof typeof SIZE;
@@ -24,12 +33,15 @@ export function monogram(label: string): string {
 
 export function IntegrationIcon({
   label,
+  iconSlug,
   iconPath,
   iconColor,
   size = "md",
   className,
 }: {
   label: string;
+  /** Manifest icon slug, used to look up a vendored full-colour mark. */
+  iconSlug?: string;
   /** Simple Icons path data from the API; absent when the brand has no mark. */
   iconPath?: string;
   iconColor?: string;
@@ -37,41 +49,39 @@ export function IntegrationIcon({
   className?: string;
 }) {
   const style = SIZE[size];
-  const ink = brandInk(iconColor);
+  const logo = brandLogo(iconSlug);
+  // The tile is always light, so the glyph always wants the light-background variant.
+  const ink = brandInk(iconColor)?.light;
+
   return (
     <span
       aria-hidden
       className={cn(
-        "flex shrink-0 items-center justify-center rounded-md border",
+        "flex shrink-0 items-center justify-center rounded-lg border border-black/[0.07] bg-white",
+        "shadow-[0_1px_2px_rgb(0_0_0/0.06)] dark:border-white/10 dark:bg-white/95",
         style.box,
-        ink
-          ? cn(
-              "[--brand:var(--brand-light)] dark:[--brand:var(--brand-dark)]",
-              "border-[color-mix(in_oklab,var(--brand)_25%,transparent)]",
-              "bg-[color-mix(in_oklab,var(--brand)_12%,transparent)]",
-              "text-[var(--brand)]"
-            )
-          : "border-border bg-muted text-muted-foreground",
         className
       )}
-      style={
-        ink
-          ? ({ "--brand-light": ink.light, "--brand-dark": ink.dark } as CSSProperties)
-          : undefined
-      }
+      style={ink ? ({ "--brand": ink } as CSSProperties) : undefined}
     >
-      {iconPath ? (
+      {logo ? (
+        <svg viewBox={logo.viewBox} aria-hidden="true" focusable="false" className={style.mark}>
+          {logo.paths.map((p) => (
+            <path key={p.d} fill={p.fill} d={p.d} />
+          ))}
+        </svg>
+      ) : iconPath ? (
         <svg
           viewBox="0 0 24 24"
           fill="currentColor"
           aria-hidden="true"
           focusable="false"
-          className={style.mark}
+          className={cn(style.mark, ink ? "text-[var(--brand)]" : "text-foreground/80")}
         >
           <path d={iconPath} />
         </svg>
       ) : (
-        <span className={cn("font-semibold", style.text)}>{monogram(label)}</span>
+        <span className={cn("font-semibold text-neutral-500", style.text)}>{monogram(label)}</span>
       )}
     </span>
   );

--- a/apps/web/app/components/integrations/integration-panel.tsx
+++ b/apps/web/app/components/integrations/integration-panel.tsx
@@ -1,0 +1,220 @@
+import { Link } from "@remix-run/react";
+import { ArrowUpRight, Check, Loader2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import { StatusBadge } from "~/components/status-badge";
+import { Badge } from "~/components/ui/badge";
+import { Sheet } from "~/components/ui/sheet";
+import { getIntegration, type IntegrationDetail } from "~/lib/integrations";
+import { cn } from "~/lib/utils";
+import { CONNECTION, displayName, providerHost } from "./integration-card";
+import { IntegrationIcon } from "./integration-icon";
+
+/*
+ * A preview of one integration, opened from its card without leaving the catalog.
+ *
+ * It reads, it does not act: connecting is a multi-step flow with credentials and approvals, and
+ * running that inside a dismissible sheet gives an operator a way to lose half-entered secrets to a
+ * stray backdrop click. Every write stays on the full page, which this always offers a route to.
+ */
+
+export function IntegrationPanel({ name, onClose }: { name?: string; onClose: () => void }) {
+  const [detail, setDetail] = useState<IntegrationDetail>();
+  const [error, setError] = useState<string>();
+
+  useEffect(() => {
+    if (!name) return;
+    let live = true;
+    setDetail(undefined);
+    setError(undefined);
+    getIntegration(name)
+      .then((d) => live && setDetail(d))
+      .catch((e) => live && setError(e instanceof Error ? e.message : "Could not load."));
+    return () => {
+      live = false;
+    };
+  }, [name]);
+
+  const title = detail ? displayName(detail) : (name ?? "");
+  const soon = detail?.availability === "coming_soon";
+
+  return (
+    <Sheet
+      open={Boolean(name)}
+      onClose={onClose}
+      title={`Integrations / ${title}`}
+      className="max-w-lg"
+      headerActions={
+        name && !soon ? (
+          <Link
+            to={`/integrations/${encodeURIComponent(name)}`}
+            aria-label={`Open the full ${title} page`}
+            className="rounded-sm p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          >
+            <ArrowUpRight className="size-4" aria-hidden />
+          </Link>
+        ) : null
+      }
+    >
+      {!name ? null : error ? (
+        <p className="text-sm text-destructive">{error}</p>
+      ) : !detail ? (
+        <p className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 aria-hidden className="size-4 animate-spin" />
+          Loading {title}…
+        </p>
+      ) : (
+        <Body detail={detail} />
+      )}
+    </Sheet>
+  );
+}
+
+function Body({ detail }: { detail: IntegrationDetail }) {
+  const name = displayName(detail);
+  const host = providerHost(detail);
+  const soon = detail.availability === "coming_soon";
+  const steps = detail.auth ?? [];
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-start gap-3">
+        <IntegrationIcon
+          label={name}
+          iconSlug={detail.iconSlug}
+          iconPath={detail.iconPath}
+          iconColor={detail.iconColor}
+          size="lg"
+        />
+        <div className="min-w-0 flex-1">
+          <h3 className="truncate text-base font-semibold text-foreground">{name}</h3>
+          {host ? <p className="truncate text-xs text-muted-foreground">By {host}</p> : null}
+        </div>
+        {soon ? (
+          <span className="shrink-0 text-xs text-muted-foreground">Coming soon</span>
+        ) : (
+          <Link
+            to={`/integrations/${encodeURIComponent(detail.name)}`}
+            className={cn(
+              "inline-flex shrink-0 items-center gap-1 rounded-md bg-primary px-3 py-2",
+              "text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90",
+              "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+            )}
+          >
+            {detail.status === "connected" ? "Manage" : "Set up"}
+            <ArrowUpRight aria-hidden className="size-3.5" />
+          </Link>
+        )}
+      </div>
+
+      <div className="flex flex-wrap gap-1.5">
+        {detail.category ? <Badge className="capitalize">{detail.category}</Badge> : null}
+        {!soon && steps.length > 0 ? (
+          <Badge>
+            {steps.length} step{steps.length === 1 ? "" : "s"}
+          </Badge>
+        ) : null}
+        {soon ? (
+          <StatusBadge label="Not available yet" tone="info" />
+        ) : (
+          <StatusBadge {...CONNECTION[detail.status]} />
+        )}
+      </div>
+
+      {detail.description ? (
+        <p className="text-sm leading-relaxed text-muted-foreground">{detail.description}</p>
+      ) : null}
+
+      {soon ? (
+        <Section title="Why it is listed">
+          <p className="text-sm leading-relaxed text-muted-foreground">
+            This one is on the roadmap, so the catalog names it rather than pretending it does not
+            exist. There is no setup to complete yet and no credentials to hand over.
+          </p>
+        </Section>
+      ) : null}
+
+      {detail.capabilities?.length ? (
+        <Section title="What agents can do">
+          <ul className="flex flex-col gap-2">
+            {detail.capabilities.map((c) => (
+              <li key={c} className="flex gap-2 text-sm text-muted-foreground">
+                <Check aria-hidden className="mt-0.5 size-3.5 shrink-0 text-primary" />
+                <span>{c}</span>
+              </li>
+            ))}
+          </ul>
+        </Section>
+      ) : null}
+
+      {detail.grants?.length ? (
+        <Section title="Access it hands over">
+          <ul className="flex flex-col gap-2">
+            {detail.grants.map((g) => (
+              <li key={g.label} className="rounded-md border border-border px-3 py-2.5">
+                <div className="flex items-baseline justify-between gap-2">
+                  <span className="min-w-0 truncate text-sm font-medium text-foreground">
+                    {g.label}
+                  </span>
+                  {g.access ? (
+                    <span className="shrink-0 text-xs text-muted-foreground">{g.access}</span>
+                  ) : null}
+                </div>
+                {g.description ? (
+                  <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                    {g.description}
+                  </p>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        </Section>
+      ) : null}
+
+      {!soon && steps.length > 0 ? (
+        <Section title="Setup">
+          <ol className="flex flex-col gap-2">
+            {steps.map((step, i) => (
+              <li
+                key={step.index}
+                className="flex items-start gap-3 rounded-md border border-border px-3 py-2.5"
+              >
+                <span className="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full bg-muted text-[0.625rem] font-medium text-muted-foreground tabular-nums">
+                  {i + 1}
+                </span>
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-baseline justify-between gap-2">
+                    <span className="min-w-0 truncate text-sm font-medium text-foreground">
+                      {step.title ?? step.kind}
+                    </span>
+                    <span
+                      className={cn(
+                        "shrink-0 text-[0.625rem] font-medium uppercase tracking-wide",
+                        step.satisfied ? "text-primary" : "text-muted-foreground"
+                      )}
+                    >
+                      {step.satisfied ? "Done" : "To do"}
+                    </span>
+                  </div>
+                  {step.description ? (
+                    <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                      {step.description}
+                    </p>
+                  ) : null}
+                </div>
+              </li>
+            ))}
+          </ol>
+        </Section>
+      ) : null}
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="flex flex-col gap-2.5 border-t border-border pt-5">
+      <h4 className="text-sm font-semibold text-foreground">{title}</h4>
+      {children}
+    </section>
+  );
+}

--- a/apps/web/app/components/ui/sheet.tsx
+++ b/apps/web/app/components/ui/sheet.tsx
@@ -8,12 +8,15 @@ export function Sheet({
   open,
   onClose,
   title,
+  headerActions,
   children,
   className,
 }: {
   open: boolean;
   onClose: () => void;
   title: string;
+  /** Extra controls seated left of Close, for a sheet that also opens somewhere fuller. */
+  headerActions?: React.ReactNode;
   children: React.ReactNode;
   className?: string;
 }) {
@@ -70,16 +73,19 @@ export function Sheet({
       )}
     >
       <div className="flex h-full flex-col">
-        <div className="flex shrink-0 items-center justify-between border-border border-b px-4 py-3">
-          <h2 className="text-sm font-medium text-foreground">{title}</h2>
-          <button
-            type="button"
-            aria-label="Close"
-            onClick={onClose}
-            className="cursor-pointer rounded-sm p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-          >
-            <X className="size-4" aria-hidden />
-          </button>
+        <div className="flex shrink-0 items-center justify-between gap-2 border-border border-b px-4 py-3">
+          <h2 className="min-w-0 truncate text-sm font-medium text-foreground">{title}</h2>
+          <div className="flex shrink-0 items-center gap-1">
+            {headerActions}
+            <button
+              type="button"
+              aria-label="Close"
+              onClick={onClose}
+              className="cursor-pointer rounded-sm p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            >
+              <X className="size-4" aria-hidden />
+            </button>
+          </div>
         </div>
         <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4 text-sm">{children}</div>
       </div>

--- a/apps/web/app/lib/integrations.ts
+++ b/apps/web/app/lib/integrations.ts
@@ -4,14 +4,21 @@ import { apiDelete, apiGet, apiWrite } from "./api";
 
 export type McpConnectionStatus = "connected" | "connecting" | "error" | "disconnected";
 
+/** Whether the curated registry has opened this entry for connection yet. */
+export type IntegrationAvailability = "available" | "coming_soon";
+
 export type IntegrationSummary = {
   name: string;
   /** Brand name from the curated registry; falls back to the slug when uncurated. */
   title?: string;
+  /** `coming_soon` is listed but not openable — there is no setup to hand an operator yet. */
+  availability?: IntegrationAvailability;
   type: string;
   description?: string;
   category?: string;
   homepage?: string;
+  /** Manifest icon slug, resolved server-side. Keys the vendored full-colour brand marks. */
+  iconSlug?: string;
   /** Simple Icons path data, resolved server-side. Absent when the brand has no mark. */
   iconPath?: string;
   /** Brand hex without `#`. Not canvas-safe as given — pass through `brandInk` before rendering. */
@@ -22,6 +29,8 @@ export type IntegrationSummary = {
   source?: string;
   /** False for a curated entry that has not been cloned into the soul repo yet. */
   installed: boolean;
+  /** How many setup steps connecting takes. Absent when nothing is installed to count. */
+  setupSteps?: number;
   status: McpConnectionStatus;
   errorMessage?: string;
   updateAvailable?: boolean;

--- a/apps/web/app/routes/_app.integrations.$name.tsx
+++ b/apps/web/app/routes/_app.integrations.$name.tsx
@@ -10,6 +10,7 @@ import {
 import { ArrowLeft, ExternalLink, MoreHorizontal, Trash2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { IntegrationAuthFlow, startHandoff } from "~/components/integrations/auth-flow";
+import { ComingSoonState } from "~/components/integrations/coming-soon-state";
 import { GitHubPersonalAccount } from "~/components/integrations/github-personal-account";
 import { IntegrationIcon } from "~/components/integrations/integration-icon";
 import { MarkdownView } from "~/components/markdown-view";
@@ -36,10 +37,23 @@ import { useIsAdmin } from "~/lib/use-session-user";
 
 export const meta: MetaFunction = () => [{ title: "Integration · tulipfarm" }];
 
+/**
+ * A registry entry that is listed but not opened yet. Thrown rather than rendered so the page
+ * never mounts a connect flow this deployment will not honor, however the URL was reached.
+ */
+class ComingSoonError extends Error {
+  constructor(readonly integrationName: string) {
+    super(`integration not available yet: ${integrationName}`);
+  }
+}
+
 export async function clientLoader({ params }: ClientLoaderFunctionArgs) {
   const name = params.name;
   if (!name) throw new ApiError(404, "missing integration name");
   const integration = await getIntegration(name);
+  if (integration.availability === "coming_soon") {
+    throw new ComingSoonError(integration.title ?? integration.name);
+  }
   let routesError: string | undefined;
   if (name === "slack" && integration.connected) {
     try {
@@ -339,6 +353,7 @@ export default function IntegrationDetailPage() {
           <div className="flex min-w-0 gap-3">
             <IntegrationIcon
               label={name}
+              iconSlug={integration.iconSlug}
               iconPath={integration.iconPath}
               iconColor={integration.iconColor}
               size="lg"
@@ -637,6 +652,9 @@ export default function IntegrationDetailPage() {
 
 export function ErrorBoundary() {
   const error = useRouteError();
+  if (error instanceof ComingSoonError) {
+    return <ComingSoonState name={error.integrationName} />;
+  }
   if (error instanceof ApiError && error.status === 404) {
     return <NotFoundState section="integrations" />;
   }

--- a/apps/web/app/routes/_app.integrations._index.tsx
+++ b/apps/web/app/routes/_app.integrations._index.tsx
@@ -1,18 +1,18 @@
 import {
-  Link,
   type MetaFunction,
   useLoaderData,
   useRevalidator,
   useRouteError,
+  useSearchParams,
 } from "@remix-run/react";
-import { ChevronRight, Search } from "lucide-react";
-import { type ReactNode, useId, useMemo, useState } from "react";
+import { Search } from "lucide-react";
+import { type ReactNode, useCallback, useId, useMemo, useState } from "react";
+import { CatalogActionsMenu } from "~/components/integrations/catalog-actions-menu";
 import { InstallFromSource } from "~/components/integrations/install-from-source";
-import { IntegrationIcon } from "~/components/integrations/integration-icon";
+import { displayName, IntegrationCard } from "~/components/integrations/integration-card";
+import { IntegrationPanel } from "~/components/integrations/integration-panel";
 import { ErrorState } from "~/components/states";
-import { StatusBadge } from "~/components/status-badge";
 import { Badge } from "~/components/ui/badge";
-import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { Panel, PanelEmpty } from "~/components/ui/panel";
 import { ApiError } from "~/lib/api";
@@ -20,7 +20,7 @@ import { type IntegrationSummary, listIntegrations, updateIntegration } from "~/
 import { useIsAdmin } from "~/lib/use-session-user";
 import { cn } from "~/lib/utils";
 
-/* Connection state is a row property; install is only for curated entries not yet cloned. */
+/* Connection state is a card property; install is only for curated entries not yet cloned. */
 
 export const meta: MetaFunction = () => [{ title: "Integrations · tulipfarm" }];
 
@@ -28,14 +28,22 @@ export async function clientLoader() {
   return { integrations: await listIntegrations() };
 }
 
-/** Uncurated entries carry no registry title, so the slug is the honest display name. */
-function displayName(integration: IntegrationSummary): string {
-  return integration.title ?? integration.name;
-}
-
 export default function IntegrationsIndex() {
   const { integrations } = useLoaderData<typeof clientLoader>();
   const revalidator = useRevalidator();
+  // The open preview lives in the URL, so Back closes it and a link to it can be shared.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const viewing = searchParams.get("view") ?? undefined;
+  const closePanel = useCallback(() => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.delete("view");
+        return next;
+      },
+      { replace: true, preventScrollReset: true }
+    );
+  }, [setSearchParams]);
   const [query, setQuery] = useState("");
   const [category, setCategory] = useState<string>();
   const searchId = useId();
@@ -74,37 +82,40 @@ export default function IntegrationsIndex() {
     });
   }, [integrations, query, category]);
 
-  // Connected first: it is the smaller group and the one an operator returns to check on. Within a
-  // group the server's alphabetical order stands, so rows do not move as connections change.
-  const connected = visible.filter((i) => i.status === "connected");
-  const rest = visible.filter((i) => i.status !== "connected");
+  // Three groups, in the order an operator needs them: what already works, what they can turn on
+  // today, and what is only announced. Within a group the server's alphabetical order stands, so
+  // cards do not move as connections change.
+  const soon = visible.filter((i) => i.availability === "coming_soon");
+  const ready = visible.filter((i) => i.availability !== "coming_soon");
+  const connected = ready.filter((i) => i.status === "connected");
+  const rest = ready.filter((i) => i.status !== "connected");
 
   return (
-    <div className="flex flex-col gap-4">
-      <div className="flex flex-col gap-3">
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-          <div className="relative flex-1">
-            <label className="sr-only" htmlFor={searchId}>
-              Search integrations
-            </label>
-            <Search
-              aria-hidden
-              className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
-            />
-            <Input
-              id={searchId}
-              type="search"
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              placeholder="Search integrations"
-              className="pl-8"
-            />
-          </div>
-          <InstallFromSource onInstalled={() => revalidator.revalidate()} />
+    <div className="flex flex-col gap-5">
+      {/* One toolbar, not three stacked rows. A search field stretched the full width of a page
+          holding five results announces itself as the main event; capped, it reads as the utility
+          it is and lets the catalog be what the eye lands on. */}
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+        <div className="relative w-full sm:w-64">
+          <label className="sr-only" htmlFor={searchId}>
+            Search integrations
+          </label>
+          <Search
+            aria-hidden
+            className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+          />
+          <Input
+            id={searchId}
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search integrations"
+            className="pl-8"
+          />
         </div>
 
         {categories.length > 0 && (
-          <div className="flex flex-wrap items-center gap-1">
+          <div className="flex flex-wrap items-center gap-0.5 rounded-lg bg-muted/60 p-0.5">
             <CategoryChip active={!category} onClick={() => setCategory(undefined)}>
               All
             </CategoryChip>
@@ -119,6 +130,11 @@ export default function IntegrationsIndex() {
             ))}
           </div>
         )}
+
+        <div className="ml-auto flex shrink-0 items-center gap-2">
+          <InstallFromSource onInstalled={() => revalidator.revalidate()} />
+          <CatalogActionsMenu />
+        </div>
       </div>
 
       {updateError && (
@@ -138,7 +154,7 @@ export default function IntegrationsIndex() {
       ) : (
         <>
           {connected.length > 0 && (
-            <Section
+            <Group
               title="Connected"
               items={connected}
               onUpdate={handleUpdate}
@@ -147,7 +163,7 @@ export default function IntegrationsIndex() {
             />
           )}
           {rest.length > 0 && (
-            <Section
+            <Group
               title={connected.length > 0 ? "Available" : "All integrations"}
               items={rest}
               onUpdate={handleUpdate}
@@ -155,8 +171,20 @@ export default function IntegrationsIndex() {
               isAdmin={isAdmin}
             />
           )}
+          {soon.length > 0 && (
+            <Group
+              title="Coming soon"
+              description="Listed so the roadmap is visible. There is nothing to connect yet."
+              items={soon}
+              onUpdate={handleUpdate}
+              updatingName={updatingName}
+              isAdmin={isAdmin}
+            />
+          )}
         </>
       )}
+
+      <IntegrationPanel name={viewing} onClose={closePanel} />
     </div>
   );
 }
@@ -176,10 +204,10 @@ function CategoryChip({
       onClick={onClick}
       aria-pressed={active}
       className={cn(
-        "rounded-sm border px-2 py-1 text-xs capitalize transition-colors",
+        "rounded-md px-2.5 py-1 text-xs font-medium capitalize transition-colors duration-150",
         active
-          ? "border-border bg-muted text-foreground"
-          : "border-transparent text-muted-foreground hover:bg-accent hover:text-foreground"
+          ? "bg-card text-foreground shadow-[0_1px_2px_rgb(0_0_0/0.08)] ring-1 ring-black/[0.06] dark:ring-white/10"
+          : "text-muted-foreground hover:text-foreground"
       )}
     >
       {children}
@@ -187,24 +215,40 @@ function CategoryChip({
   );
 }
 
-function Section({
+/**
+ * A named group of cards. Deliberately not a `Panel`: a bordered container around bordered cards
+ * frames the same content twice, so the heading names the group and the cards carry the only edge.
+ */
+function Group({
   title,
+  description,
   items,
   onUpdate,
   updatingName,
   isAdmin,
 }: {
   title: string;
+  description?: string;
   items: IntegrationSummary[];
   onUpdate: (name: string, source?: string) => void;
   updatingName?: string;
   isAdmin: boolean;
 }) {
+  const headingId = useId();
   return (
-    <Panel title={title} actions={<Badge>{items.length}</Badge>} flush>
-      <ul className="flex flex-col divide-y divide-border">
+    <section aria-labelledby={headingId} className="flex flex-col gap-3">
+      <div className="flex items-baseline gap-2">
+        <h2 id={headingId} className="text-sm font-semibold text-foreground">
+          {title}
+        </h2>
+        <Badge>{items.length}</Badge>
+        {description ? (
+          <p className="hidden text-xs text-muted-foreground sm:block">{description}</p>
+        ) : null}
+      </div>
+      <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
         {items.map((integration) => (
-          <IntegrationRow
+          <IntegrationCard
             key={integration.name}
             integration={integration}
             onUpdate={onUpdate}
@@ -213,100 +257,7 @@ function Section({
           />
         ))}
       </ul>
-    </Panel>
-  );
-}
-
-function RowBody({ integration }: { integration: IntegrationSummary }) {
-  const name = displayName(integration);
-  return (
-    <>
-      <IntegrationIcon
-        label={name}
-        iconPath={integration.iconPath}
-        iconColor={integration.iconColor}
-      />
-      <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-        <span className="flex items-center gap-2">
-          <span className="truncate font-medium text-foreground">{name}</span>
-          {integration.category && (
-            <Badge className="hidden capitalize sm:inline-flex">{integration.category}</Badge>
-          )}
-        </span>
-        {integration.description && (
-          <span className="line-clamp-1 text-xs text-muted-foreground">
-            {integration.description}
-          </span>
-        )}
-      </span>
-    </>
-  );
-}
-
-function IntegrationRow({
-  integration,
-  onUpdate,
-  updating,
-  isAdmin,
-}: {
-  integration: IntegrationSummary;
-  onUpdate: (name: string, source?: string) => void;
-  updating?: boolean;
-  isAdmin?: boolean;
-}) {
-  // A curated entry that has not been cloned has no detail page to open — linking there would 404.
-  // It is a row about a repository, not about an integration this deployment has.
-  if (!integration.installed) {
-    return (
-      <li className="flex items-center gap-3 px-4 py-3">
-        <RowBody integration={integration} />
-        <span className="shrink-0 text-xs text-muted-foreground">Not installed</span>
-      </li>
-    );
-  }
-
-  return (
-    <li className="flex flex-col">
-      {/* The row is the link. A catalog is scanned and clicked, so the target should be the row
-          the pointer is already over, not the few characters of its title. */}
-      <Link
-        to={`/integrations/${encodeURIComponent(integration.name)}`}
-        className="flex items-center gap-3 px-4 py-3 transition-colors hover:bg-accent"
-      >
-        <RowBody integration={integration} />
-        <span className="flex shrink-0 items-center gap-2">
-          {integration.updateAvailable && (
-            <span className="shrink-0 rounded-sm border border-primary px-1.5 py-0.5 text-xs uppercase tracking-[0.15em] text-primary">
-              update available
-            </span>
-          )}
-          {integration.updateAvailable && isAdmin && (
-            <Button
-              size="sm"
-              variant="outline"
-              disabled={updating}
-              aria-label={`Update ${displayName(integration)}`}
-              onClick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                onUpdate(integration.name, integration.source);
-              }}
-            >
-              {updating ? "Updating…" : "Update"}
-            </Button>
-          )}
-          {integration.status === "connected" ? (
-            <StatusBadge label="connected" tone="success" />
-          ) : (
-            <span className="text-xs text-muted-foreground">Set up</span>
-          )}
-          <ChevronRight aria-hidden className="size-4 text-muted-foreground" />
-        </span>
-      </Link>
-      {integration.errorMessage && (
-        <p className="px-4 pb-2 text-xs text-destructive">{integration.errorMessage}</p>
-      )}
-    </li>
+    </section>
   );
 }
 

--- a/apps/web/app/routes/integrations.catalog.test.tsx
+++ b/apps/web/app/routes/integrations.catalog.test.tsx
@@ -22,6 +22,7 @@ vi.mock("~/lib/use-session-user", () => ({
 vi.mock("~/lib/integrations", async (importOriginal) => ({
   ...(await importOriginal<typeof import("~/lib/integrations")>()),
   listIntegrations: vi.fn(),
+  getIntegration: vi.fn(),
   inspectIntegrationSource: vi.fn(),
   installIntegration: vi.fn(),
   updateIntegration: vi.fn(),
@@ -29,6 +30,7 @@ vi.mock("~/lib/integrations", async (importOriginal) => ({
 
 import type { IntegrationSummary } from "~/lib/integrations";
 import {
+  getIntegration,
   inspectIntegrationSource,
   installIntegration,
   updateIntegration,
@@ -46,7 +48,7 @@ function integration(over: Partial<IntegrationSummary> = {}): IntegrationSummary
   };
 }
 
-function renderCatalog(integrations: IntegrationSummary[]) {
+function renderCatalog(integrations: IntegrationSummary[], initialEntry = "/") {
   const Stub = createRemixStub([
     {
       path: "/",
@@ -55,13 +57,36 @@ function renderCatalog(integrations: IntegrationSummary[]) {
     },
     { path: "/integrations/:name", Component: () => <p>detail</p> },
   ]);
-  render(<Stub initialEntries={["/"]} />);
+  render(<Stub initialEntries={[initialEntry]} />);
 }
 
 test("shows the registry's brand name rather than the slug", async () => {
-  renderCatalog([integration({ name: "github", title: "GitHub" })]);
+  renderCatalog([integration({ name: "github", title: "GitHub", homepage: "https://github.com" })]);
   expect(await screen.findByText("GitHub")).toBeInTheDocument();
   expect(screen.queryByText("github")).not.toBeInTheDocument();
+});
+
+test("names the provider behind the brand, not the slug, when a homepage is curated", async () => {
+  renderCatalog([integration({ title: "GitHub", homepage: "https://www.github.com" })]);
+  expect(await screen.findByText("By github.com")).toBeInTheDocument();
+});
+
+test("lists a coming-soon entry without offering a way to connect it", async () => {
+  renderCatalog([
+    integration({ name: "github", title: "GitHub" }),
+    integration({ name: "jira", title: "Jira", availability: "coming_soon" }),
+  ]);
+
+  const headings = await screen.findAllByRole("heading", { level: 2 });
+  expect(headings.map((h) => h.textContent)).toEqual(["All integrations", "Coming soon"]);
+  const soon = headings[1].closest("section") as HTMLElement;
+  expect(within(soon).getByText("Jira")).toBeInTheDocument();
+  // The group heading and the card footer both say it: the section names it, the card states it.
+  expect(within(soon).getAllByText("Coming soon")).toHaveLength(2);
+  // It may preview — a card that does nothing reads as broken — but it must never link at the
+  // detail page, which is where a connection would be offered.
+  const preview = within(soon).getByRole("link", { name: /view details for jira/i });
+  expect(preview).toHaveAttribute("href", "/?view=jira");
 });
 
 test("falls back to the slug when nothing has curated a title", async () => {
@@ -90,12 +115,14 @@ test("titles the single group plainly when nothing is connected", async () => {
   expect(headings[0].textContent).toContain("All integrations");
 });
 
-test("an installed integration opens its detail page from anywhere in the row", async () => {
+test("an installed integration opens its preview panel from its card action", async () => {
   renderCatalog([integration({ name: "github", title: "GitHub", description: "Repos." })]);
-  const link = await screen.findByRole("link", { name: /GitHub/ });
-  expect(link).toHaveAttribute("href", "/integrations/github");
-  // The description is inside the link, not beside it: the whole row is the target.
-  expect(within(link).getByText("Repos.")).toBeInTheDocument();
+  const link = await screen.findByRole("link", { name: /view details for github/i });
+  // `?view=` and not a click handler: the preview has an address, so Back closes it and the link
+  // can be opened in a new tab or shared.
+  expect(link).toHaveAttribute("href", "/?view=github");
+  // One anchor per card, stretched over the tile — the description sits beside it, not inside it.
+  expect(screen.getByText("Repos.")).toBeInTheDocument();
 });
 
 test("a curated entry that is not installed yet is not a link to a detail page", async () => {
@@ -231,4 +258,83 @@ test("shows update available badge and update button on catalog row", async () =
 
   await user.click(updateButton);
   expect(updateIntegration).toHaveBeenCalledWith("linear", "acme/linear");
+});
+
+test("opens the preview panel straight from a ?view= URL, so the link is shareable", async () => {
+  vi.mocked(getIntegration).mockResolvedValue({
+    ...integration({ name: "github", title: "GitHub", homepage: "https://github.com" }),
+    grants: [{ label: "issues", access: "read and write", description: "Triage and comment." }],
+    capabilities: ["Review pull requests"],
+    manifest: {},
+    auth: [{ index: 0, kind: "fields", title: "Add a token", satisfied: false, producesEnv: true }],
+    connected: false,
+  });
+
+  renderCatalog([integration({ name: "github", title: "GitHub" })], "/?view=github");
+
+  const sheet = await screen.findByRole("dialog");
+  expect(within(sheet).getByText("Integrations / GitHub")).toBeInTheDocument();
+  // The panel previews; it never performs the write itself, so its action leaves for the page
+  // that does.
+  expect(within(sheet).getByRole("link", { name: /^set up/i })).toHaveAttribute(
+    "href",
+    "/integrations/github"
+  );
+  expect(within(sheet).getByText("Review pull requests")).toBeInTheDocument();
+  expect(within(sheet).getByText("issues")).toBeInTheDocument();
+  // The integration's own status, and separately the state of one setup step — a step is "to do",
+  // never "not connected", or the two read as the same fact reported twice.
+  expect(within(sheet).getByText("Not connected")).toBeInTheDocument();
+  expect(within(sheet).getByText("To do")).toBeInTheDocument();
+});
+
+test("the panel colours connection state, so a card and its panel agree", async () => {
+  vi.mocked(getIntegration).mockResolvedValue({
+    ...integration({ name: "github", title: "GitHub", status: "connected" }),
+    grants: [],
+    manifest: {},
+    auth: [],
+    connected: true,
+  });
+
+  renderCatalog(
+    [integration({ name: "github", title: "GitHub", status: "connected" })],
+    "/?view=github"
+  );
+
+  const sheet = await screen.findByRole("dialog");
+  // A green "Connected" on the card must not turn grey the moment the panel opens — same fact,
+  // same tone, or the colour stops meaning anything.
+  expect(within(sheet).getByText("Connected")).toHaveClass("text-status-success");
+});
+
+test("a coming-soon preview offers no way to connect", async () => {
+  vi.mocked(getIntegration).mockResolvedValue({
+    ...integration({ name: "jira", title: "Jira", availability: "coming_soon" }),
+    grants: [],
+    manifest: {},
+    auth: [],
+    connected: false,
+  });
+
+  renderCatalog(
+    [integration({ name: "jira", title: "Jira", availability: "coming_soon" })],
+    "/?view=jira"
+  );
+
+  const sheet = await screen.findByRole("dialog");
+  expect(within(sheet).queryByRole("link", { name: /set up|manage/i })).not.toBeInTheDocument();
+  // Not even the header shortcut: the detail page is where a connection would be offered.
+  expect(within(sheet).queryByRole("link", { name: /open the full/i })).not.toBeInTheDocument();
+});
+
+test("offers asking an agent for an integration the catalog does not carry", async () => {
+  const user = userEvent.setup();
+  renderCatalog([integration({ name: "github", title: "GitHub" })]);
+
+  await user.click(await screen.findByRole("button", { name: /more integration actions/i }));
+  // A chat draft, because chat is how an agent is asked to build anything here — not a request
+  // form that files into a queue nobody owns.
+  const request = screen.getByRole("menuitem", { name: /request an integration/i });
+  expect(request.getAttribute("href")).toMatch(/^\/\?draft=/);
 });

--- a/integrations/registry.yml
+++ b/integrations/registry.yml
@@ -8,6 +8,10 @@
 # installing it clones that repo. Operators can also install any repo by URL without it being
 # listed here; this file is curation, not an allowlist.
 #
+# `availability: coming_soon` means the manifest is in the image but the connect flow is not
+# something an operator should be handed yet. The catalog lists the entry so the roadmap is
+# visible, and refuses to open it, rather than offering a setup that ends in a dead end.
+#
 # Third-party integrations must be purely declarative. A manifest that runs code — `ts-code`
 # egress, a stdio MCP server, or an `ingress.handler` — is rejected at install
 # (packages/soul/src/integration-trust.ts).
@@ -17,10 +21,14 @@ version: 1
 integrations:
   - name: slack
     title: Slack
-    # No `icon`: Slack asked to be removed from Simple Icons, so there is no mark to name and the
-    # catalog falls back to a monogram. Do not point this at a lookalike slug.
-    # `color` is Slack's own aubergine, so the monogram still reads as Slack rather than as the one
-    # grey row in a catalog of coloured logos.
+    # `slack` is not a Simple Icons slug — Slack asked to be removed from that set, so the API's
+    # lookup misses and `iconPath` stays empty. It resolves instead against the vendored full-colour
+    # marks in apps/web/app/components/integrations/brand-logo.tsx, which carry Slack's official
+    # unmodified four-colour mark to identify a Slack integration, the use Slack's brand guidelines
+    # allow. Still do not point this at a *lookalike* Simple Icons slug.
+    # `color` remains Slack's aubergine, so a client without the vendored mark degrades to a
+    # monogram that still reads as Slack rather than as the one grey row in a coloured catalog.
+    icon: slack
     color: "4A154B"
     category: chat
     homepage: https://slack.com
@@ -34,6 +42,7 @@ integrations:
     description: Read and write repositories, issues, and pull requests.
 
   - name: jira
+    availability: coming_soon
     title: Jira
     icon: jira
     category: productivity
@@ -41,12 +50,14 @@ integrations:
     description: Search, create, estimate, prioritize, and transition Jira Cloud issues.
 
   - name: linear
+    availability: coming_soon
     title: Linear
     icon: linear
     category: productivity
     homepage: https://linear.app
     description: Read, create, update, and comment on issues with approval for changes.
   - name: google
+    availability: coming_soon
     title: Google Workspace
     icon: google
     category: productivity

--- a/packages/soul/src/index.ts
+++ b/packages/soul/src/index.ts
@@ -122,7 +122,7 @@ export {
 export { validateThirdPartyManifest } from "./integration-trust";
 export type { BundledIntegration } from "./integrations/bundled";
 export { bundledIntegrationsDir, loadBundledIntegrations } from "./integrations/bundled";
-export type { RegistryEntry } from "./integrations/registry";
+export type { RegistryAvailability, RegistryEntry } from "./integrations/registry";
 export { loadIntegrationRegistry } from "./integrations/registry";
 export {
   deleteLlmConfigFromSoulYaml,

--- a/packages/soul/src/integrations/registry.test.ts
+++ b/packages/soul/src/integrations/registry.test.ts
@@ -32,7 +32,28 @@ describe("loadIntegrationRegistry", () => {
       source: "acme/linear",
       description: undefined,
       homepage: undefined,
+      // An entry says nothing about availability, so it is open — curation closes a door, never
+      // the absence of curation.
+      availability: "available",
     });
+  });
+
+  it("keeps a curated entry closed when it is marked coming soon", async () => {
+    const dir = await withRegistry(
+      "version: 1\nintegrations:\n  - name: jira\n    availability: coming_soon\n"
+    );
+    expect((await loadIntegrationRegistry(logger, dir)).get("jira")?.availability).toBe(
+      "coming_soon"
+    );
+  });
+
+  it("treats an unreadable availability as open rather than guessing it is closed", async () => {
+    const dir = await withRegistry(
+      "version: 1\nintegrations:\n  - name: jira\n    availability: 7\n"
+    );
+    expect((await loadIntegrationRegistry(logger, dir)).get("jira")?.availability).toBe(
+      "available"
+    );
   });
 
   // The marketplace page is more useful bare than broken, so neither absence nor malformed YAML

--- a/packages/soul/src/integrations/registry.ts
+++ b/packages/soul/src/integrations/registry.ts
@@ -6,8 +6,13 @@ import { bundledIntegrationsDir } from "./bundled";
 
 /* Curated registry only decorates bundled integrations or points at third-party repos. */
 
+/** Whether an operator may connect this entry yet. Unset reads as `available`. */
+export type RegistryAvailability = "available" | "coming_soon";
+
 export interface RegistryEntry {
   name: string;
+  /** `coming_soon` keeps the entry listed but closed: no detail page, no connect flow. */
+  availability: RegistryAvailability;
   title?: string;
   description?: string;
   category?: string;
@@ -30,6 +35,11 @@ function asHex(value: unknown): string | undefined {
 
 function asString(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+/* An unreadable value must not silently open a flow the curator meant to keep closed. */
+function asAvailability(value: unknown): RegistryAvailability {
+  return value === "coming_soon" ? "coming_soon" : "available";
 }
 
 /** Missing or malformed registry is non-fatal; marketplace falls back to discovery. */
@@ -55,6 +65,7 @@ export async function loadIntegrationRegistry(
       if (!name || entries.has(name)) continue;
       entries.set(name, {
         name,
+        availability: asAvailability(record.availability),
         title: asString(record.title),
         description: asString(record.description),
         category: asString(record.category),


### PR DESCRIPTION
## Summary

<!-- What changed, and why. Link the driving issue if one exists. -->

## Test plan

<!-- Commands you ran, or manual steps / screenshots for UI changes. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (or the scoped `--filter` you actually ran)

## Checklist

- [ ] PR title follows Conventional Commits (`type(scope): subject`) — CI checks this
- [ ] Scoped to one logical change
- [ ] Tests added/updated for the behavior that changed
