### PR TITLE
fix(api): grant members platform.skill.load and .run

### DIFF
--- a/apps/api/src/identity/roles.test.ts
+++ b/apps/api/src/identity/roles.test.ts
@@ -126,6 +126,26 @@ describe("describeDeploymentRoles", () => {
     expect(decision.allowed).toBe(false);
   });
 
+  /** #651: the `skill` Tool's load/run modes fell through to default-deny for every member. */
+  it("lets a member load and run Skills, not just list them", () => {
+    const memberRole = DEPLOYMENT_ROLES.find((role) => role.id === "member");
+    if (!memberRole) throw new Error("member role missing from the deployment catalog");
+    const layers = [{ name: "member", grants: memberRole.grants }];
+
+    expect(
+      decideEffectivePermission(layers, {
+        action: "platform.skill.load",
+        resourceType: "soul.skill",
+      }).allowed
+    ).toBe(true);
+    expect(
+      decideEffectivePermission(layers, {
+        action: "platform.skill.run",
+        resourceType: "soul.skill",
+      }).allowed
+    ).toBe(true);
+  });
+
   it("keeps member record access for resource types with no domain", () => {
     const memberRole = DEPLOYMENT_ROLES.find((role) => role.id === "member");
     if (!memberRole) throw new Error("member role missing from the deployment catalog");

--- a/apps/api/src/identity/roles.ts
+++ b/apps/api/src/identity/roles.ts
@@ -219,11 +219,14 @@ export const MEMBER_ALLOWED_SURFACES: readonly {
     ],
     enforcedIn: "soul/resource-types/routes.ts; soul/resource-types/tools.ts",
   },
-  /** Read-only Skill listing so Agents can load guidance; authoring stays a Team-level grant. */
+  /**
+   * Listing, loading and running Skills so Agents can follow guidance; authoring stays a
+   * Team-level grant.
+   */
   {
     type: "soul.skill",
-    actions: ["soul.skill.list"],
-    enforcedIn: "soul/skills/tools.ts",
+    actions: ["soul.skill.list", "platform.skill.load", "platform.skill.run"],
+    enforcedIn: "soul/skills/tools.ts; platform/tools.ts",
   },
   { type: "surface", actions: ["*"], enforcedIn: "surfaces/routes.ts" },
   { type: "platform.surface", actions: ["*"], enforcedIn: "surfaces/tools.ts" },


### PR DESCRIPTION
## Summary
- `MEMBER_ALLOWED_SURFACES` only granted `soul.skill.list` on the `soul.skill` type, so the `skill` Tool's `load`/`run` modes (`platform.skill.load` / `platform.skill.run`) fell through to default-deny for every member — the adjacent comment already stated the intent was read-only Skill loading for members, and `platform.skill.load` is non-mutating.
- Added `platform.skill.load` and `platform.skill.run` to that catalog entry, matching the existing `soul.skill.list` pattern.
- Left `soul.resource_type.create` untouched: it's deliberately listed in `ADMIN_ONLY_SURFACES` with an explicit "requires an explicit Team-level grant" comment, matching the same pattern already used for `soul.skill.create/update/delete`. It is not an omission.

Fixes #651

## Test plan
- [x] Added `apps/api/src/identity/roles.test.ts` — "lets a member load and run Skills, not just list them"; confirmed it fails on the pre-fix `roles.ts` and passes after.
- [x] `pnpm exec vitest run src/identity/roles.test.ts src/identity/role-catalog-fitness.test.ts` — 19 passed.
- [x] `pnpm exec biome check --write apps/api/src/identity` — clean.