### PR TITLE
fix(surface): surface provenance in Form field pickers

### DIFF
--- a/packages/integrations/src/github/contracts.ts
+++ b/packages/integrations/src/github/contracts.ts
@@ -156,7 +156,12 @@ export const GITHUB_REPOSITORY_LIST_DECLARATION = {
     "first when the user names no repository, or names one you're not sure is installed. This " +
     "reports only which repositories the workspace's GitHub App can see — it does not mean " +
     "you personally can act on them. Every other GitHub Tool also requires the calling person " +
-    "to have connected their own GitHub account, separately from that App installation.",
+    "to have connected their own GitHub account, separately from that App installation. Each " +
+    "result carries the `account` it was installed under; when you build a repository picker " +
+    "(e.g. a Form field) from this output, set the field's `description` to name that account " +
+    '(for example "Using the GitHub connection for account: <account>") so the person choosing ' +
+    "knows whose repositories they're looking at, especially if more than one installation or " +
+    "account is in play.",
   inputSchema: {
     type: "object",
     additionalProperties: false,

--- a/packages/surface-web/src/blocks/input.tsx
+++ b/packages/surface-web/src/blocks/input.tsx
@@ -306,6 +306,7 @@ export function SurfaceForm({
           const input = String(field.input);
           const label = String(field.label);
           const required = field.required === true;
+          const description = typeof field.description === "string" ? field.description : undefined;
           const options = Array.isArray(field.options)
             ? field.options.filter((option): option is string => typeof option === "string")
             : [];
@@ -323,6 +324,7 @@ export function SurfaceForm({
                 <span>
                   {label}
                   {required ? <small data-surface-required>required</small> : null}
+                  {description ? <small data-surface-field-description>{description}</small> : null}
                 </span>
               </label>
             );
@@ -334,6 +336,7 @@ export function SurfaceForm({
                 <legend data-surface-field-label>
                   {label}
                   {required ? <small data-surface-required>required</small> : null}
+                  {description ? <small data-surface-field-description>{description}</small> : null}
                 </legend>
                 {options.map((option) => (
                   <label key={option} htmlFor={`${fieldId}-${option}`} data-surface-radio>
@@ -358,6 +361,7 @@ export function SurfaceForm({
                 <span data-surface-field-label>
                   {label}
                   {required ? <small data-surface-required>required</small> : null}
+                  {description ? <small data-surface-field-description>{description}</small> : null}
                 </span>
                 <select
                   id={fieldId}
@@ -439,6 +443,7 @@ export function SurfaceForm({
               <span data-surface-field-label>
                 {label}
                 {required ? <small data-surface-required>required</small> : null}
+                {description ? <small data-surface-field-description>{description}</small> : null}
               </span>
               {control}
             </label>

--- a/packages/surface-web/src/styles.css
+++ b/packages/surface-web/src/styles.css
@@ -808,6 +808,17 @@ ol[data-surface-list] li::before {
   opacity: 0.75;
 }
 
+/* Provenance/context for a field, e.g. which connected account a picker's options came from.
+   Own line under the label so it reads as an explanation, not a badge like `required`. */
+[data-surface-field-description] {
+  display: block;
+  margin-left: 0;
+  color: var(--muted-foreground);
+  font-size: 0.6875rem;
+  font-weight: 400;
+  line-height: 1.4;
+}
+
 [data-surface-field] input,
 [data-surface-field] textarea,
 [data-surface-field] select {

--- a/packages/surface/src/catalog.ts
+++ b/packages/surface/src/catalog.ts
@@ -233,6 +233,9 @@ const definitions = [
           ]),
           required: Type.Optional(Type.Boolean()),
           options: Type.Optional(Type.Array(Type.String({ maxLength: 200 }), { maxItems: 100 })),
+          // Provenance/context for the field, e.g. which connected account a picker's options
+          // came from. Rendered under the label, before the control.
+          description: Type.Optional(Type.String({ maxLength: 300 })),
         }),
         { minItems: 1, maxItems: 50 }
       ),


### PR DESCRIPTION
## Summary
- The GitHub repo picker rendered a bare list of `owner/repo` options with no framing of which installed GitHub account they came from — `github_repository_list` already returns an `account` per repo, but it was dropped when a Form field's options were built.
- Add an optional `description` (helper text) to `Form.fields` in the Surface catalog (`packages/surface/src/catalog.ts`), render it under the field label in every input variant (`packages/surface-web/src/blocks/input.tsx`, styled in `styles.css`).
- Update `github_repository_list`'s tool description (`packages/integrations/src/github/contracts.ts`) to instruct the agent to populate that description with the installing account (e.g. "Using the GitHub connection for account: X") when it builds a repo picker.

This does not change the installation-scoping architecture (one GitHub App installation per business is correct and unchanged) — it's a UX/provenance fix so the picker names whose repos are being listed.

Fixes #659

## Test plan
- [x] `pnpm exec biome check --write` on changed dirs — clean
- [x] `pnpm --filter @tulipfarm/surface typecheck` / `test` — pass
- [x] `pnpm --filter @tulipfarm/surface-web typecheck` — pass
- [x] `pnpm --filter @tulipfarm/integrations typecheck` — pass