### PR TITLE
fix(web): clarify secrets 403 and hide dead-end Credential link

### DIFF
--- a/apps/web/app/components/chat/plan-trace.test.tsx
+++ b/apps/web/app/components/chat/plan-trace.test.tsx
@@ -1,9 +1,15 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { LOADER_LABELS } from "~/components/ui/loading-state";
 import type { TimelinePart } from "~/lib/chat/types";
 import { PlanTrace } from "./plan-trace";
 import type { PlannedRound } from "./timeline-groups";
+
+vi.mock("~/lib/use-session-user", async () => {
+  const actual =
+    await vi.importActual<typeof import("~/lib/use-session-user")>("~/lib/use-session-user");
+  return { ...actual, useIsAdmin: vi.fn(() => true) };
+});
 
 type ToolPart = Extract<TimelinePart, { kind: "tool" }>;
 

--- a/apps/web/app/components/chat/tool-step.test.tsx
+++ b/apps/web/app/components/chat/tool-step.test.tsx
@@ -1,8 +1,17 @@
+import { createRemixStub } from "@remix-run/testing";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { TimelinePart } from "~/lib/chat/types";
+import * as useSessionUser from "~/lib/use-session-user";
 import { ToolTrace } from "./tool-trace";
+
+vi.mock("~/lib/use-session-user", async () => {
+  const actual =
+    await vi.importActual<typeof import("~/lib/use-session-user")>("~/lib/use-session-user");
+  return { ...actual, useIsAdmin: vi.fn(() => true) };
+});
+const useIsAdmin = vi.mocked(useSessionUser.useIsAdmin);
 
 type ToolPart = Extract<TimelinePart, { kind: "tool" }>;
 
@@ -18,21 +27,36 @@ function toolPart(overrides: Partial<ToolPart> = {}): ToolPart {
   };
 }
 
-/** One call still draws as a run of one, so this is the step's contract, not the run's. */
+/**
+ * One call still draws as a run of one, so this is the step's contract, not the run's.
+ *
+ * Routed through a stub router (rather than a bare `render`) because a step can render a `<Link>`
+ * to the secrets page, which requires router context.
+ */
 function renderStep(part: ToolPart, options?: { pending?: boolean }) {
-  return render(
-    <ToolTrace
-      parts={[part]}
-      pending={options?.pending === true}
-      foldable={false}
-      onApprove={vi.fn()}
-    />
-  );
+  const Stub = createRemixStub([
+    {
+      path: "/",
+      Component: () => (
+        <ToolTrace
+          parts={[part]}
+          pending={options?.pending === true}
+          foldable={false}
+          onApprove={vi.fn()}
+        />
+      ),
+    },
+  ]);
+  return render(<Stub />);
 }
 
 const step = () => screen.getByRole("button", { name: /github_issue_comment/i });
 
 describe("A Tool step on the trace", () => {
+  beforeEach(() => {
+    useIsAdmin.mockReturnValue(true);
+  });
+
   it("summarises the call in words instead of printing the tool name alone", () => {
     renderStep(
       toolPart({
@@ -120,6 +144,34 @@ describe("A Tool step on the trace", () => {
 
     await userEvent.click(step());
     expect(screen.getByText("Input")).toBeInTheDocument();
+  });
+
+  it("offers a member the required Credential link when they are an admin", () => {
+    useIsAdmin.mockReturnValue(true);
+    renderStep(
+      toolPart({
+        outcome: "error",
+        meta: { errorCode: "missing_credential", connectUrl: "/business/secrets?required=FOO" },
+      })
+    );
+
+    expect(screen.getByRole("link", { name: "Add the required Credential →" })).toHaveAttribute(
+      "href",
+      "/business/secrets?required=FOO"
+    );
+  });
+
+  it("tells a non-admin to ask an administrator instead of linking to the admin-only page", () => {
+    useIsAdmin.mockReturnValue(false);
+    renderStep(
+      toolPart({
+        outcome: "error",
+        meta: { errorCode: "missing_credential", connectUrl: "/business/secrets?required=FOO" },
+      })
+    );
+
+    expect(screen.queryByRole("link", { name: /Add the required Credential/i })).toBeNull();
+    expect(screen.getByText("Ask an administrator to add this Credential.")).toBeInTheDocument();
   });
 
   it("renders the running state while the call is still in flight", () => {

--- a/apps/web/app/components/chat/tool-step.tsx
+++ b/apps/web/app/components/chat/tool-step.tsx
@@ -2,6 +2,7 @@ import { Link } from "@remix-run/react";
 import { PenLine } from "lucide-react";
 import { TraceStep } from "~/components/ui/trace";
 import type { TimelinePart } from "~/lib/chat/types";
+import { useIsAdmin } from "~/lib/use-session-user";
 import { ApprovalCard } from "./approval-card";
 import { SubagentPanel, traceOf } from "./subagent-panel";
 import { ToolInspector, toolHasDetails } from "./tool-inspector";
@@ -41,6 +42,7 @@ export function ToolStepRow({
   const ran = summarizeToolCall(part);
   const status = part.status === "running" ? "running" : outcomeOf(part);
   const approval = part.approval;
+  const isAdmin = useIsAdmin();
   return (
     <>
       <TraceStep
@@ -60,7 +62,7 @@ export function ToolStepRow({
             />
           ) : undefined
         }
-        detail={detailOf(part, status, label === undefined ? undefined : ran)}
+        detail={detailOf(part, status, isAdmin, label === undefined ? undefined : ran)}
       />
       {/*
        * The one thing a step may not hide behind its own disclosure. Everything else in a trace is
@@ -88,7 +90,12 @@ export function ToolStepRow({
  * `ran` is passed only when the row's label came from somewhere other than the call, in which case
  * the call's own summary leads the disclosure.
  */
-function detailOf(part: ToolPart, status: "running" | "done" | "error", ran?: string) {
+function detailOf(
+  part: ToolPart,
+  status: "running" | "done" | "error",
+  isAdmin: boolean,
+  ran?: string
+) {
   const code = status === "error" ? part.meta?.errorCode : undefined;
   const hint = status === "done" ? describeToolResult(part) : undefined;
   const duration = formatDuration(part.meta?.durationMs);
@@ -125,11 +132,11 @@ function detailOf(part: ToolPart, status: "running" | "done" | "error", ran?: st
           )}
         </span>
       )}
-      {connectUrl === undefined ? null : (
+      {connectUrl === undefined ? null : isSecretsUrl(connectUrl) && !isAdmin ? (
+        <p className="text-muted-foreground">Ask an administrator to add this Credential.</p>
+      ) : (
         <Link to={connectUrl} className="block text-primary hover:underline">
-          {connectUrl.startsWith("/business/secrets")
-            ? "Add the required Credential →"
-            : "Connect your account →"}
+          {isSecretsUrl(connectUrl) ? "Add the required Credential →" : "Connect your account →"}
         </Link>
       )}
       {/*
@@ -145,4 +152,8 @@ function detailOf(part: ToolPart, status: "running" | "done" | "error", ran?: st
 
 function outcomeOf(part: ToolPart): "done" | "error" {
   return part.outcome === "error" ? "error" : "done";
+}
+
+function isSecretsUrl(connectUrl: string): boolean {
+  return connectUrl.startsWith("/business/secrets");
 }

--- a/apps/web/app/components/chat/tool-trace.test.tsx
+++ b/apps/web/app/components/chat/tool-trace.test.tsx
@@ -6,6 +6,12 @@ import { ToolTrace } from "~/components/chat/tool-trace";
 import { LOADER_LABELS } from "~/components/ui/loading-state";
 import type { TimelinePart } from "~/lib/chat/types";
 
+vi.mock("~/lib/use-session-user", async () => {
+  const actual =
+    await vi.importActual<typeof import("~/lib/use-session-user")>("~/lib/use-session-user");
+  return { ...actual, useIsAdmin: vi.fn(() => true) };
+});
+
 type ToolPart = Extract<TimelinePart, { kind: "tool" }>;
 
 function call(overrides: Partial<ToolPart> & { toolCallId: string; toolName: string }): ToolPart {

--- a/apps/web/app/components/chat/transcript.test.tsx
+++ b/apps/web/app/components/chat/transcript.test.tsx
@@ -5,6 +5,12 @@ import { Transcript } from "~/components/chat/transcript";
 import { appendUserMessage, chatReducer, initialChatState } from "~/lib/chat/reducer";
 import type { ChatEvent, ChatState, ChatTurnOptions } from "~/lib/chat/types";
 
+vi.mock("~/lib/use-session-user", async () => {
+  const actual =
+    await vi.importActual<typeof import("~/lib/use-session-user")>("~/lib/use-session-user");
+  return { ...actual, useIsAdmin: vi.fn(() => true) };
+});
+
 // jsdom has no layout engine; the transcript's auto-scroll calls scrollIntoView.
 beforeEach(() => {
   Element.prototype.scrollIntoView = vi.fn();

--- a/apps/web/app/routes/_app.business.secrets.tsx
+++ b/apps/web/app/routes/_app.business.secrets.tsx
@@ -2,6 +2,7 @@ import { useLoaderData, useRevalidator, useRouteError, useSearchParams } from "@
 import { ChevronRight, Trash2 } from "lucide-react";
 import { type FormEvent, useMemo, useState } from "react";
 import { FormStatus } from "~/components/form-status";
+import { PageShell } from "~/components/page-shell";
 import { ErrorState } from "~/components/states";
 import { Badge } from "~/components/ui/badge";
 import { Button } from "~/components/ui/button";
@@ -343,5 +344,20 @@ export function ErrorBoundary() {
   const error = useRouteError();
   const status = error instanceof ApiError ? error.status : undefined;
   const message = error instanceof Error ? error.message : undefined;
+
+  if (status === 403) {
+    return (
+      <PageShell title="Credentials">
+        <div className="flex flex-col gap-2 text-sm">
+          <p className="text-destructive">error: 403 forbidden</p>
+          <p className="text-muted-foreground">
+            Only a workspace administrator can view or change stored Credentials. Ask an admin to
+            add or update one for you.
+          </p>
+        </div>
+      </PageShell>
+    );
+  }
+
   return <ErrorState section="business" status={status} message={message} />;
 }


### PR DESCRIPTION
## Summary
- Route-local `ErrorBoundary` in `_app.business.secrets.tsx` now shows a specific "admin-only, ask a workspace administrator" message on a 403, instead of the generic "could not complete this request" text.
- `tool-step.tsx`'s chat trace only renders the clickable "Add the required Credential →" link to `/business/secrets` when the current user `isAdmin`; a non-admin sees plain text ("Ask an administrator to add this Credential.") instead of a dead-end link.
- Admin-only gating for secrets is unchanged/intentional — no authz changes.

## Test plan
- [x] `pnpm exec biome check --write apps/web/app/components/chat apps/web/app/routes/_app.business.secrets.tsx`
- [x] `pnpm --filter @tulipfarm/web test app/components/chat` (266 passed, includes new admin/non-admin Credential-link tests)
- [x] `pnpm --filter @tulipfarm/web typecheck`

Fixes #661