### PR TITLE
fix(api): stop hiding a completed reply that never got its completion row

### DIFF
--- a/apps/api/src/conversations/store.pg.test.ts
+++ b/apps/api/src/conversations/store.pg.test.ts
@@ -220,6 +220,38 @@ describe("PgConversationStore", () => {
     ]);
   });
 
+  it("surfaces a reply that was written but never completed (#662)", async () => {
+    // appendAssistantMessage and completeTurn are two separate writes; a crash in between (a
+    // guard timeout, a killed process) leaves exactly this: the reply row exists, but no
+    // turn_completions row was ever written for it. Existence-gating on that row would hide the
+    // reply from every reload forever even though the reader already watched it stream in.
+    await store.saveTurn(turn());
+    await store.appendMessage({
+      id: REPLY_ID,
+      businessId: DEPLOYMENT_BUSINESS_ID,
+      conversationId: CONVERSATION_ID,
+      turnId: TURN_ID,
+      role: "assistant",
+      content: textContent("revoke this key"),
+      attempt: 1,
+      createdAt: CREATED_AT,
+    });
+
+    const messages = await store.listMessages(DEPLOYMENT_BUSINESS_ID, CONVERSATION_ID);
+    expect(messages).toEqual([
+      {
+        id: REPLY_ID,
+        businessId: DEPLOYMENT_BUSINESS_ID,
+        conversationId: CONVERSATION_ID,
+        turnId: TURN_ID,
+        role: "assistant",
+        content: textContent("revoke this key"),
+        attempt: 1,
+        createdAt: CREATED_AT,
+      },
+    ]);
+  });
+
   it("round-trips assistant Message metadata without changing text content", async () => {
     await store.saveTurn(turn());
     await store.appendMessage({

--- a/apps/api/src/conversations/store.pg.ts
+++ b/apps/api/src/conversations/store.pg.ts
@@ -211,6 +211,14 @@ export class PgConversationStore implements ConversationStore {
     // Only Turn messages: rows predating migration 16 have a NULL turn_id. `content` stays raw
     // jsonb because a row may hold a bare string or parts; filtering to one shape here would
     // silently drop every Message carrying a File.
+    //
+    // `appendAssistantMessage` and `completeTurn` are two separate writes; a crash between them
+    // (a guard timeout, a killed process) leaves a real, already-shown reply with no completion
+    // row. Gating existence on that row would hide it from every reload forever — the reply is
+    // not "not yet decided", it is durable and simply never got its completion recorded. So an
+    // assistant Message also surfaces when its own Turn has no completion at or after its
+    // attempt and it is the latest attempt the Turn has: exactly the orphaned case, without
+    // resurrecting an earlier attempt's abandoned draft once a later attempt went on to complete.
     const { rows } = await this.q.query(
       `SELECT m.id, m.conversation_id, m.turn_id, m.role,
               m.content, m.metadata, m.attempt, m.created_at
@@ -219,9 +227,23 @@ export class PgConversationStore implements ConversationStore {
           AND m.turn_id IS NOT NULL
           AND (
             m.role = 'user'
-            OR (m.role = 'assistant' AND EXISTS (
-                 SELECT 1 FROM turn_completions c
-                  WHERE c.turn_id = m.turn_id AND c.message_id = m.id))
+            OR (m.role = 'assistant' AND (
+                 EXISTS (
+                   SELECT 1 FROM turn_completions c
+                    WHERE c.turn_id = m.turn_id AND c.message_id = m.id
+                 )
+                 OR (
+                   m.attempt IS NOT NULL
+                   AND NOT EXISTS (
+                     SELECT 1 FROM turn_completions c2
+                      WHERE c2.turn_id = m.turn_id AND c2.attempt >= m.attempt
+                   )
+                   AND m.attempt = (
+                     SELECT MAX(m2.attempt) FROM messages m2
+                      WHERE m2.turn_id = m.turn_id AND m2.role = 'assistant'
+                   )
+                 )
+               ))
           )
         ORDER BY m.created_at, m.id`,
       [conversationId]


### PR DESCRIPTION
## Summary
- `appendAssistantMessage` and `completeTurn` (`apps/api/src/internal/turn-host.ts`) are two separate, non-atomic writes called sequentially from `ConversationTurnCompleter.complete()`. A crash between them (guard timeout, killed process, a `needs_reconciliation` abort) leaves a real, already-streamed assistant Message row with no matching `turn_completions` row.
- `listMessages` (`apps/api/src/conversations/store.pg.ts`) required that `turn_completions` row to exist before it would surface an assistant Message, so an orphaned reply was durable in the database but permanently invisible on every reload — this is the confirmed half of #662 ("the agent's 'revoke this key' instruction... vanishes on refresh").
- Fix: `listMessages` now also surfaces an assistant Message when its own Turn has no completion row at or after its attempt and it is the Turn's latest attempt — exactly the orphaned case — without resurrecting an earlier attempt's abandoned draft once a retry went on to complete the Turn normally (covered by the existing "replays only the completed Message" test, still green).

This is a targeted, existence-gating fix at the read path rather than collapsing the write path into one cross-process transaction (the two writes are separate HTTP calls from the Worker to the API, so true atomicity would require merging two internal routes into one — larger blast radius across `packages/turn-executor`, `apps/worker`, and `apps/api` for the same observable fix).

**Not fixed here (flagged, out of scope for a persistence-layer fix):**
- The user-message-vanishing half of #662 is unconfirmed — no server-side delete path exists in the codebase, and a live repro wasn't run in this environment. Needs a live repro to determine if it's a client-side rendering artifact.
- `driver.ts`'s `needs_reconciliation` branch (`packages/turn-executor/src/driver.ts:231-239`) returns before `ConversationTurnCompleter.complete()` is ever called, so no message is written in that path at all — a Tool effect (e.g. an actual key revoke) can land with nothing recorded and no automatic retry. That's a Run-lifecycle gap, not a persistence-existence gap, and is worth a separate follow-up.
- No eval Case added: this change is a chat-history read-query fix, not Context assembly, the Tool loop, guardrails, or Run lifecycle/State/Run events — nothing in `apps/eval`'s harness-behavior table applies.

## Test plan
- [x] `pnpm exec biome check --write apps/api/src/conversations` (via `rtk proxy`)
- [x] `pnpm --filter @tulipfarm/api test src/conversations/store.pg.test.ts` — added test reproduces #662 (fails before the fix, passes after); existing retry/supersession test still passes unchanged.

Fixes #662