### PR TITLE
fix(agent-runtime): make agent aware of marketplace integrations

### DIFF
--- a/apps/api/src/app-options.ts
+++ b/apps/api/src/app-options.ts
@@ -76,7 +76,7 @@ import type { RoutineDetailDeps } from "./routines/detail-routes";
 import type { RunEventRouteDeps } from "./runs/events";
 import type { RunReplayDeps } from "./runs/replay";
 import type { SetupAdminCreator } from "./setup/first-admin";
-import type { SubjectAuthorityLayers } from "./soul/reminder";
+import type { IntegrationRegistryReader, SubjectAuthorityLayers } from "./soul/reminder";
 import type { SurfaceActionStore } from "./surfaces/action-store";
 import type { SurfaceArtifactStore } from "./surfaces/artifact-store";
 import type { SystemRoutesDeps } from "./system/routes";
@@ -85,6 +85,12 @@ import type { TriggerInvokeDeps } from "./triggers/routes";
 export interface AppOptions {
   /** Backs the read-only Memory panel on `/settings/profile`. */
   readonly memoryDocuments?: MemoryDocumentRepo;
+  /**
+   * The marketplace catalog for the Soul reminder's `<available-integrations>` block, so an Agent
+   * can tell a connected Integration apart from one that merely exists but is not set up yet.
+   * Absent leaves that block naming only what this Soul has already connected.
+   */
+  readonly integrationRegistry?: IntegrationRegistryReader;
   sessionStore?: SessionStore;
   userRepo?: UserRepo;
   userAdminRepo?: UserAdminRepo;

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -503,6 +503,9 @@ export async function buildApp(opts: AppOptions = {}) {
                 customInstructions: (userId: string) =>
                   readCustomInstructions(kvForInstructions, userId),
               }),
+          ...(opts.integrationRegistry === undefined
+            ? {}
+            : { integrationRegistry: opts.integrationRegistry }),
           ...(opts.fileService === undefined ? {} : { files: opts.fileService }),
         },
         requireAuth

--- a/apps/api/src/chat/conversation-routes.ts
+++ b/apps/api/src/chat/conversation-routes.ts
@@ -9,6 +9,7 @@ import { ErrorSchema } from "../auth/schemas";
 import type { UserDoc } from "../auth/users";
 import type { ConversationStore } from "../conversations/service";
 import {
+  type IntegrationRegistryReader,
   type MemoryDocumentReader,
   resolveSoulReminder,
   type SubjectAuthorityLayers,
@@ -55,6 +56,8 @@ export interface ConversationRoutesDeps {
   /** Fed to the reminder so the drawer shows the same personal blocks the Turn sends. */
   memory?: MemoryDocumentReader;
   customInstructions?: (userId: string) => Promise<string | undefined>;
+  /** Fed to the reminder so the drawer shows the same `<available-integrations>` a Turn sends. */
+  integrationRegistry?: IntegrationRegistryReader;
 }
 
 export function registerConversationRoutes(
@@ -71,6 +74,7 @@ export function registerConversationRoutes(
     authorityLayers,
     memory,
     customInstructions,
+    integrationRegistry,
   } = deps;
 
   app.get(
@@ -402,6 +406,7 @@ export function registerConversationRoutes(
           ...(soulLoader === undefined ? {} : { soulLoader }),
           ...(memory === undefined ? {} : { memory }),
           ...(customInstructions === undefined ? {} : { customInstructions }),
+          ...(integrationRegistry === undefined ? {} : { integrationRegistry }),
           businessId: DEPLOYMENT_BUSINESS_ID,
           subjectId: user._id,
           subjectKind: "user",

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -62,6 +62,7 @@ import {
   loadBundledIntegrations,
   loadBundledSkills,
   loadDisabledBundledSkills,
+  loadIntegrationRegistry,
   PgBundleStore,
   resolveAgent,
   resolveAuthSteps,
@@ -991,6 +992,9 @@ async function boot() {
           // about what is on file for this person.
           memory: memoryDocuments,
           customInstructions: (userId: string) => readCustomInstructions(kvService, userId),
+          // Same marketplace catalog the Integrations page reads, so the reminder never claims a
+          // catalogued Integration does not exist.
+          integrationRegistry: { load: () => loadIntegrationRegistry(app.log) },
         }),
         files: fileService,
         tools: buildDelegatedToolDispatch({
@@ -1155,6 +1159,9 @@ async function boot() {
       surfaceArtifactStore,
       surfaceActionStore,
       memoryDocuments,
+      // Same marketplace catalog the Integrations page reads, so the chat drawer's reminder
+      // preview never claims a catalogued Integration does not exist.
+      integrationRegistry: { load: () => loadIntegrationRegistry(app.log) },
       kvService,
       taskStore: taskRepo,
       fileService,

--- a/apps/api/src/internal/turn-context.ts
+++ b/apps/api/src/internal/turn-context.ts
@@ -34,6 +34,7 @@ import { assembleAgentSystemPrompt } from "../chat/system-prompt";
 import { availableToolsFor, toolAgentFor } from "../chat/turn-helpers";
 import type { ConversationStore, PersistedMessage } from "../conversations/service";
 import {
+  type IntegrationRegistryReader,
   type MemoryDocumentReader,
   resolveSoulReminder,
   type SubjectAuthorityLayers,
@@ -122,7 +123,7 @@ export async function readChatRequest(
   return artifact.content as ChatRequestPayload;
 }
 
-export type { SubjectAuthorityLayers } from "../soul/reminder";
+export type { IntegrationRegistryReader, SubjectAuthorityLayers } from "../soul/reminder";
 export interface ChatTurnContextResolverOptions {
   readonly artifacts: ArtifactService;
   readonly store: ConversationStore;
@@ -161,6 +162,14 @@ export interface ChatTurnContextResolverOptions {
    */
   readonly memory?: MemoryDocumentReader;
   readonly customInstructions?: (userId: string) => Promise<string | undefined>;
+  /**
+   * The marketplace catalog for the reminder's `<available-integrations>` block.
+   *
+   * Absent leaves that block naming only what this Soul has already connected, exactly as before
+   * this existed — an Agent still learns of the rest only by being told, or by a Tool this package
+   * does not have.
+   */
+  readonly integrationRegistry?: IntegrationRegistryReader;
   readonly telemetry?: TelemetryPort;
   /**
    * Reads the Files this Turn attached, so their authorization can be checked again here.
@@ -326,6 +335,9 @@ export class ChatTurnContextResolver implements TurnContextResolver {
       ...(this.options.customInstructions === undefined
         ? {}
         : { customInstructions: this.options.customInstructions }),
+      ...(this.options.integrationRegistry === undefined
+        ? {}
+        : { integrationRegistry: this.options.integrationRegistry }),
       ...(agentRestrictions === undefined ? {} : { agentRestrictions }),
       pinned,
       businessId: authority.businessId,

--- a/apps/api/src/soul/reminder.ts
+++ b/apps/api/src/soul/reminder.ts
@@ -9,7 +9,7 @@ import {
 } from "@tulipfarm/agent-runtime";
 import type { AuthorityLayer } from "@tulipfarm/authz";
 import type { AgentCapabilityRestrictions } from "@tulipfarm/schema";
-import { buildSoulCatalogue, type SoulLoader } from "@tulipfarm/soul";
+import { buildSoulCatalogue, type RegistryEntry, type SoulLoader } from "@tulipfarm/soul";
 import { type AuthorityPrincipal, agentCanUseSkill, principalKindOf } from "@tulipfarm/tool-host";
 
 /**
@@ -27,6 +27,16 @@ export interface MemoryDocumentReader {
   render(businessId: string, userId: string): Promise<string>;
 }
 
+/**
+ * The marketplace catalog read the reminder needs; `loadIntegrationRegistry` satisfies it.
+ *
+ * Every business reads the same registry, so this takes no arguments — unlike `MemoryDocumentReader`,
+ * which is scoped per subject.
+ */
+export interface IntegrationRegistryReader {
+  load(): Promise<ReadonlyMap<string, RegistryEntry>>;
+}
+
 export interface SoulReminderInput {
   readonly authorityLayers?: SubjectAuthorityLayers;
   readonly soulLoader?: SoulLoader;
@@ -34,6 +44,8 @@ export interface SoulReminderInput {
   readonly memory?: MemoryDocumentReader;
   /** Absent leaves `<custom-instructions>` empty rather than failing the Turn. */
   readonly customInstructions?: (userId: string) => Promise<string | undefined>;
+  /** Absent leaves `<available-integrations>` naming only what this Soul has connected. */
+  readonly integrationRegistry?: IntegrationRegistryReader;
   readonly businessId: string;
   readonly subjectId: string;
   readonly subjectKind: string;
@@ -123,7 +135,8 @@ export async function resolveSoulReminder(input: SoulReminderInput): Promise<str
     kind,
   });
   const business = businessFrom(input.soulLoader);
-  const loaded = buildSoulCatalogue(input.soulLoader);
+  const registry = await input.integrationRegistry?.load().catch(() => undefined);
+  const loaded = buildSoulCatalogue(input.soulLoader, registry);
   const catalogue = {
     ...loaded,
     skills: loaded.skills.filter((entry) => agentCanUseSkill(input.agentRestrictions, entry.name)),

--- a/packages/agent-runtime/src/context/assemble.ts
+++ b/packages/agent-runtime/src/context/assemble.ts
@@ -44,6 +44,10 @@ Never invent a URL, id, or file path. Use only ones the user gave you or a Tool 
 
 State a business fact, Record value, or system state only if you read it from a Tool result or from context you were given. Otherwise say you do not know, then go find out. Never present a report about work you have not finished. Never estimate how long work will take.
 
+## Integrations
+
+Check <available-integrations> before telling someone a third party has no integration. If it lists as connected, use its Tools. If it lists as available or coming soon, say so and point them at the Integrations page - never invent a raw API key or credential workaround for something already catalogued there.
+
 ## Approvals
 
 Never bypass an approval; request it and wait. If the user denies an action, do not retry that call - work out why and change approach. An approval covers that one action, that once; it does not extend to later, to similar actions, or to wider scope.

--- a/packages/agent-runtime/src/context/index.ts
+++ b/packages/agent-runtime/src/context/index.ts
@@ -25,6 +25,7 @@ export type {
   SoulBusinessDetails,
   SoulReminderCatalogue,
   SoulReminderEntry,
+  SoulReminderIntegrationEntry,
   SoulReminderPersonal,
   SoulReminderPinned,
 } from "./soul-reminder";

--- a/packages/agent-runtime/src/context/soul-reminder.test.ts
+++ b/packages/agent-runtime/src/context/soul-reminder.test.ts
@@ -262,6 +262,43 @@ describe("renderSoulReminder", () => {
   });
 });
 
+describe("renderSoulReminder — integrations", () => {
+  // #663: an Agent that only ever saw connected Integrations told a user a catalogued-but-
+  // unconnected Integration had no native support, then invented a raw API-key path. The status
+  // label is what lets it tell "connected" apart from "exists, but not set up yet".
+  it("renders a connected Integration exactly as before — bare name and description", () => {
+    const out = renderSoulReminder(
+      catalogue({
+        integrations: [{ name: "slack", description: "Team chat", status: "connected" }],
+      })
+    );
+
+    expect(out).toContain("<available-integrations>\nslack: Team chat\n</available-integrations>");
+  });
+
+  it("labels an available-but-unconnected Integration and points at the Integrations page", () => {
+    const out = renderSoulReminder(
+      catalogue({
+        integrations: [{ name: "github", description: "Code hosting", status: "available" }],
+      })
+    );
+
+    expect(out).toContain(
+      "github: not connected — set up from the Integrations page — Code hosting"
+    );
+  });
+
+  it("labels a coming-soon Integration as not yet available", () => {
+    const out = renderSoulReminder(
+      catalogue({
+        integrations: [{ name: "linear", description: "Issue tracking", status: "coming_soon" }],
+      })
+    );
+
+    expect(out).toContain("linear: coming soon, not yet available to connect — Issue tracking");
+  });
+});
+
 describe("renderSoulReminder — the business", () => {
   it("labels each field and omits only the ones that are unset", () => {
     const out = renderSoulReminder(

--- a/packages/agent-runtime/src/context/soul-reminder.ts
+++ b/packages/agent-runtime/src/context/soul-reminder.ts
@@ -19,6 +19,19 @@ export interface SoulReminderEntry {
   readonly description: string;
 }
 
+/**
+ * An Integration as the reminder names it, plus whether this business has it connected yet.
+ *
+ * Distinct from `SoulReminderEntry` because an Integration is the one artifact kind the catalogue
+ * names before it exists here: `available` and `coming_soon` describe the marketplace, not
+ * anything in this Soul. Without `status` the reminder cannot tell an Agent "not connected, go set
+ * it up" apart from "connected, use it" — which is exactly the gap that let an Agent claim no
+ * integration existed and invent a raw API-key path instead.
+ */
+export interface SoulReminderIntegrationEntry extends SoulReminderEntry {
+  readonly status: "connected" | "available" | "coming_soon";
+}
+
 /** Who the business is, as `soul.yaml` states it. Every field is optional and often unset. */
 export interface SoulBusinessDetails {
   readonly name?: string;
@@ -33,7 +46,7 @@ export interface SoulReminderCatalogue {
   readonly skills: readonly SoulReminderEntry[];
   readonly resourceTypes: readonly SoulReminderEntry[];
   readonly routines: readonly SoulReminderEntry[];
-  readonly integrations: readonly SoulReminderEntry[];
+  readonly integrations: readonly SoulReminderIntegrationEntry[];
 }
 
 /**
@@ -243,6 +256,9 @@ export function filterSoulCatalogue(
   return {
     ...EMPTY_CATALOGUE,
     ...filtered,
+    // `filtered` is widened to the common `SoulReminderEntry` shape for the loop above; the
+    // filter never touches `status`, so the narrower type is safe to restore here.
+    integrations: filtered.integrations as readonly SoulReminderIntegrationEntry[],
     ...(business === undefined ? {} : { business }),
   };
 }
@@ -375,6 +391,44 @@ function renderSection(tag: string, entries: readonly SoulReminderEntry[]): stri
   return `<${tag}>\n${body}\n</${tag}>`;
 }
 
+/** How `renderIntegrationsSection` labels a status other than `connected`, which needs no label. */
+const INTEGRATION_STATUS_LABEL: Record<
+  Exclude<SoulReminderIntegrationEntry["status"], "connected">,
+  string
+> = {
+  available: "not connected — set up from the Integrations page",
+  coming_soon: "coming soon, not yet available to connect",
+};
+
+/**
+ * Renders `<available-integrations>`, one line per Integration, connected or not.
+ *
+ * This is the one section carrying `status` alongside a name and description, so an Agent can
+ * tell "connected, call its Tools" apart from "listed but not connected" without a Tool round
+ * trip — the gap that let an Agent claim a catalogued Integration had no native support and
+ * invent a raw API-key path instead. Naming a `coming_soon` entry as such stops the same wrong
+ * guess in the other direction, where an Agent could point someone at a "Set up" flow that is
+ * not actually open yet.
+ */
+function renderIntegrationsSection(entries: readonly SoulReminderIntegrationEntry[]): string {
+  const body =
+    entries.length === 0
+      ? EMPTY_SECTION
+      : entries
+          .map((entry) => {
+            const name = line(entry.name);
+            const description = line(entry.description);
+            const label =
+              entry.status === "connected" ? undefined : INTEGRATION_STATUS_LABEL[entry.status];
+            const detail = [label, description]
+              .filter((part) => (part ?? "").length > 0)
+              .join(" — ");
+            return detail.length === 0 ? name : `${name}: ${detail}`;
+          })
+          .join("\n");
+  return `<available-integrations>\n${body}\n</available-integrations>`;
+}
+
 /**
  * Renders what the participant pointed at, or `""` when they pointed at nothing.
  *
@@ -420,7 +474,9 @@ export function renderSoulReminder(
   pinned: SoulReminderPinned = {}
 ): string {
   const soul = SOUL_REMINDER_SECTIONS.map((section) =>
-    renderSection(section.tag, catalogue[section.key] ?? [])
+    section.key === "integrations"
+      ? renderIntegrationsSection(catalogue.integrations ?? [])
+      : renderSection(section.tag, catalogue[section.key] ?? [])
   ).join("\n");
   const blocks = [
     renderBusiness(catalogue.business),

--- a/packages/soul/src/catalogue.test.ts
+++ b/packages/soul/src/catalogue.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from "vitest";
 import { buildSoulCatalogue } from "./catalogue";
+import type { RegistryEntry } from "./integrations/registry";
 import type { SoulLoader } from "./published-loader";
 import type { SoulAgent, SoulIntegration, SoulResource, SoulRoutine, SoulSkill } from "./types";
+
+const registryEntry = (
+  name: string,
+  availability: RegistryEntry["availability"],
+  description?: string
+): RegistryEntry => ({ name, availability, description });
 
 const skill = (name: string, frontmatter: Record<string, unknown> = {}): SoulSkill => ({
   name,
@@ -121,5 +128,38 @@ describe("buildSoulCatalogue", () => {
     expect(cat.resourceTypes).toEqual([]);
     expect(cat.routines).toEqual([]);
     expect(cat.integrations).toEqual([]);
+  });
+
+  it("marks a connected Integration's status without a registry", () => {
+    const cat = buildSoulCatalogue(fakeLoader({ integrations: [integration("slack", "Chat")] }));
+    expect(cat.integrations).toEqual([{ name: "slack", description: "Chat", status: "connected" }]);
+  });
+
+  // This is the fix for #663: an Agent that only ever saw connected Integrations claimed a
+  // catalogued-but-unconnected one had no native support at all, and invented a raw API-key path.
+  describe("with a marketplace registry", () => {
+    it("lists a marketplace entry the Soul has not connected, labelled by its availability", () => {
+      const cat = buildSoulCatalogue(
+        fakeLoader({}),
+        new Map([
+          ["linear", registryEntry("linear", "coming_soon", "Issue tracking")],
+          ["github", registryEntry("github", "available", "Code hosting")],
+        ])
+      );
+      expect(cat.integrations).toEqual([
+        { name: "github", description: "Code hosting", status: "available" },
+        { name: "linear", description: "Issue tracking", status: "coming_soon" },
+      ]);
+    });
+
+    it("prefers the connected entry over the registry's copy of the same name", () => {
+      const cat = buildSoulCatalogue(
+        fakeLoader({ integrations: [integration("github", "Connected description")] }),
+        new Map([["github", registryEntry("github", "available", "Marketplace description")]])
+      );
+      expect(cat.integrations).toEqual([
+        { name: "github", description: "Connected description", status: "connected" },
+      ]);
+    });
   });
 });

--- a/packages/soul/src/catalogue.ts
+++ b/packages/soul/src/catalogue.ts
@@ -1,4 +1,5 @@
 import { listAgents } from "./agents/registry";
+import type { RegistryEntry } from "./integrations/registry";
 import type { SoulLoader } from "./published-loader";
 
 /** L1 projection for one Soul artifact. */
@@ -7,13 +8,24 @@ export interface SoulCatalogueEntry {
   description: string;
 }
 
+/**
+ * Where an Integration stands relative to this business's Soul: already connected, listed in the
+ * marketplace and installable, or listed but not yet open for installs.
+ */
+export type IntegrationCatalogueStatus = "connected" | "available" | "coming_soon";
+
+/** A catalogued Integration also carries whether it is connected here yet. */
+export interface IntegrationCatalogueEntry extends SoulCatalogueEntry {
+  status: IntegrationCatalogueStatus;
+}
+
 /** L1 Soul catalog. Reached through `agent_list` / `skill_list` / `list_resource_types`. */
 export interface SoulCatalogue {
   agents: SoulCatalogueEntry[];
   skills: SoulCatalogueEntry[];
   resourceTypes: SoulCatalogueEntry[];
   routines: SoulCatalogueEntry[];
-  integrations: SoulCatalogueEntry[];
+  integrations: IntegrationCatalogueEntry[];
 }
 
 /** Read a record field as a string, or "" when absent / non-string. */
@@ -30,8 +42,16 @@ function byName(a: SoulCatalogueEntry, b: SoulCatalogueEntry): number {
   return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
 }
 
-/** Projects all Soul artifact types to the L1 catalog. */
-export function buildSoulCatalogue(soulLoader: SoulLoader | undefined): SoulCatalogue {
+/** Projects all Soul artifact types to the L1 catalog.
+ *
+ * `registry` is the marketplace catalogue (`integrations/registry.yml`, via
+ * `loadIntegrationRegistry`) — every business sees the same one, so it defaults to empty rather
+ * than requiring every caller that does not care about it to pass one.
+ */
+export function buildSoulCatalogue(
+  soulLoader: SoulLoader | undefined,
+  registry: ReadonlyMap<string, RegistryEntry> = new Map()
+): SoulCatalogue {
   const agents = listAgents(soulLoader)
     .map((a) => ({ name: a.name, description: asDesc(a.frontmatter.description) }))
     .sort(byName);
@@ -54,13 +74,28 @@ export function buildSoulCatalogue(soulLoader: SoulLoader | undefined): SoulCata
     }))
     .sort(byName);
 
-  const integrations = values(soulLoader?.integrations)
+  const connectedIntegrations = values(soulLoader?.integrations)
     .filter((i) => i.manifest !== undefined)
     .map((i) => ({
       name: i.slug,
       description: asDesc(i.manifest?.description),
-    }))
-    .sort(byName);
+      status: "connected" as const,
+    }));
+  const connectedNames = new Set(connectedIntegrations.map((i) => i.name));
+
+  /*
+   * A registry entry already connected is represented once, as `connected` — the marketplace copy
+   * would otherwise tell the Agent to go set up something it can already use.
+   */
+  const marketplaceIntegrations = Array.from(registry.values())
+    .filter((entry) => !connectedNames.has(entry.name))
+    .map((entry) => ({
+      name: entry.name,
+      description: asDesc(entry.description),
+      status: entry.availability,
+    }));
+
+  const integrations = [...connectedIntegrations, ...marketplaceIntegrations].sort(byName);
 
   return { agents, skills, resourceTypes, routines, integrations };
 }

--- a/packages/soul/src/index.ts
+++ b/packages/soul/src/index.ts
@@ -51,7 +51,12 @@ export {
 export type { BundleRetentionInput } from "./bundle-store.pg";
 export { PgBundleStore, SOUL_BUNDLE_STORAGE_STATEMENTS } from "./bundle-store.pg";
 export { bundleTriggerDefinitions, findBundleTrigger } from "./bundle-triggers";
-export type { SoulCatalogue, SoulCatalogueEntry } from "./catalogue";
+export type {
+  IntegrationCatalogueEntry,
+  IntegrationCatalogueStatus,
+  SoulCatalogue,
+  SoulCatalogueEntry,
+} from "./catalogue";
 export { buildSoulCatalogue } from "./catalogue";
 export type {
   SoulChangeset,


### PR DESCRIPTION
## Summary
- `buildSoulCatalogue` (packages/soul) now merges the marketplace registry (`integrations/registry.yml`) alongside connected Integrations, tagging each `connected` / `available` / `coming_soon`.
- The Soul reminder (`packages/agent-runtime`) renders that status in `<available-integrations>`, and a new "## Integrations" platform instruction tells the Agent to check it before claiming a gap exists — and to point users at the Integrations page instead of inventing a raw API-key workaround.
- Wired through both the live Turn context resolver and `/chats/:id/debug-context` so they stay identical, per that route's existing invariant.

Fixes #663. Note: the issue's literal premise (Linear has a "Set up" button) was stale — `integrations/registry.yml` marks Linear `coming_soon` — but the real defect (no marketplace visibility at all) is what this fixes.

## Eval Corpus note
No Corpus Case added. The scripted harness's `assembleSystemPrompt` never calls `resolveSoulReminder`/`renderSoulReminder`, so `<available-integrations>` is not reachable by any `prompt_contains`/`prompt_omits` Expectation today — a Case here couldn't ground itself. Covered instead by unit tests in `packages/soul` and `packages/agent-runtime`. No `corpus/` files touched, so `corpusHash` is unchanged and no Baseline needs re-promotion.

## Test plan
- [x] `pnpm --filter @tulipfarm/soul exec vitest run src/catalogue.test.ts` — 7 passed
- [x] `pnpm --filter @tulipfarm/agent-runtime exec vitest run src/context/soul-reminder.test.ts src/context/assemble.test.ts` — 48 passed
- [x] `pnpm --filter @tulipfarm/api exec vitest run src/chat/conversation-routes.test.ts src/internal/turn-context.test.ts src/app.test.ts` — 42 passed
- [x] `pnpm --filter @tulipfarm/soul typecheck`, `pnpm --filter @tulipfarm/agent-runtime typecheck`, `pnpm --filter @tulipfarm/api typecheck` — clean
- [x] Full scripted eval Corpus run — 45 passed, 0 failed, 0 errored
- [x] `pnpm exec biome check --write` on all changed files — no issues