### PR TITLE
chore(release): v0.18.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.18.5](https://github.com/TulipFarm/tulipfarm/compare/v0.18.4...v0.18.5) (2026-09-02)
+
+### Performance Improvements
+
+* **web:** split heavy chunks and prefetch routes to cut first load ([#673](https://github.com/TulipFarm/tulipfarm/issues/673)) ([4cbf2e3](https://github.com/TulipFarm/tulipfarm/commit/4cbf2e3aa32285104dd276817db3f596783b0fd1))
+
 ## [0.18.4](https://github.com/TulipFarm/tulipfarm/compare/v0.18.3...v0.18.4) (2026-09-02)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tulipfarm",
   "private": true,
-  "version": "0.18.4",
+  "version": "0.18.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/TulipFarm/tulipfarm.git"


### PR DESCRIPTION
## Summary

- prepare TulipFarm v0.18.5
- update the package version and generated changelog
- publish the verified GHCR image and GitHub Release automatically after merge

## Test plan

- [ ] Required PR checks pass
- [ ] Version and changelog are approved
