### PR TITLE
feat(web,api): show Tools sent to the model in the debug drawer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,12 @@ pnpm install
 pnpm dev                    # api :4010, web :4000, worker :4020, integration-worker :4030
 ```
 
-Open `http://localhost:4000` and create an admin account at the `/setup` wizard.
+Open `http://localhost:4000` and log in with the dev admin `setup-dev.sh` seeds:
+
+```text
+email:    admin@tulipfarm.dev
+password: tulipfarm-dev
+```
 
 Run a single app with `pnpm dev:api`, `pnpm dev:web`, `pnpm dev:worker`, or
 `pnpm dev:integration-worker`. Start over from a clean slate with `pnpm reset:dev`.

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -507,6 +507,7 @@ export async function buildApp(opts: AppOptions = {}) {
             ? {}
             : { integrationRegistry: opts.integrationRegistry }),
           ...(opts.fileService === undefined ? {} : { files: opts.fileService }),
+          toolRegistry,
         },
         requireAuth
       );

--- a/apps/api/src/chat/conversation-routes.ts
+++ b/apps/api/src/chat/conversation-routes.ts
@@ -2,11 +2,12 @@ import { DEPLOYMENT_BUSINESS_ID } from "@tulipfarm/constants";
 import type { FileService } from "@tulipfarm/files";
 import { CHAT_TITLE_MAX_LENGTH, ConversationDetailSchema } from "@tulipfarm/schema";
 import type { SoulLoader } from "@tulipfarm/soul";
-import { resolveAgent } from "@tulipfarm/soul";
+import { getDefaultAssistant, resolveAgent } from "@tulipfarm/soul";
 import { parsePaginationQuery } from "@tulipfarm/storage";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { ErrorSchema } from "../auth/schemas";
 import type { UserDoc } from "../auth/users";
+import type { ToolRegistry } from "../broker/tool-adapter";
 import type { ConversationStore } from "../conversations/service";
 import {
   type IntegrationRegistryReader,
@@ -14,10 +15,17 @@ import {
   resolveSoulReminder,
   type SubjectAuthorityLayers,
 } from "../soul/reminder";
+import {
+  presentationContextFor,
+  surfaceCatalogFor,
+  surfaceCatalogRevisionFor,
+  surfaceRendererRegistry,
+} from "../surfaces/renderer-registry";
 import type { ConversationDoc, ConversationRepo } from "./conversations";
 import { type MessageRepo, referencedFileIds, withUnavailableFiles } from "./messages";
 import { MessageSchema } from "./schemas";
 import { assembleAgentSystemPrompt } from "./system-prompt";
+import { allowedToolNamesFor, toolAgentFor } from "./turn-helpers";
 
 type PreHandler = (req: FastifyRequest, reply: FastifyReply) => Promise<void>;
 
@@ -58,6 +66,8 @@ export interface ConversationRoutesDeps {
   customInstructions?: (userId: string) => Promise<string | undefined>;
   /** Fed to the reminder so the drawer shows the same `<available-integrations>` a Turn sends. */
   integrationRegistry?: IntegrationRegistryReader;
+  /** Lets `debug-context` list the same Tools a Turn would offer, narrowed the same way. */
+  toolRegistry?: ToolRegistry;
 }
 
 export function registerConversationRoutes(
@@ -75,6 +85,7 @@ export function registerConversationRoutes(
     memory,
     customInstructions,
     integrationRegistry,
+    toolRegistry,
   } = deps;
 
   app.get(
@@ -384,8 +395,20 @@ export function registerConversationRoutes(
                 systemPrompt: { type: "string" },
                 soulReminder: { type: "string" },
                 messages: { type: "array", items: MessageSchema },
+                tools: {
+                  type: "array",
+                  items: {
+                    type: "object",
+                    properties: {
+                      name: { type: "string" },
+                      description: { type: "string" },
+                      inputSchema: { type: "object", additionalProperties: true },
+                    },
+                    required: ["name", "description", "inputSchema"],
+                  },
+                },
               },
-              required: ["conversationId", "systemPrompt", "soulReminder", "messages"],
+              required: ["conversationId", "systemPrompt", "soulReminder", "messages", "tools"],
             },
             401: ErrorSchema,
             404: ErrorSchema,
@@ -413,11 +436,40 @@ export function registerConversationRoutes(
           now: new Date(),
         });
         const history = await messageRepo.listByConversation(id, 1000);
+        const platformAgent = getDefaultAssistant(agent.name);
+        const toolAgent = toolAgentFor(platformAgent, agent);
+        const presentationContext = presentationContextFor(
+          { channel: "web", surface: "chat" },
+          `conversation:${id}`
+        );
+        const surfaceComponents = [...(soulLoader?.surfaceComponents.values() ?? [])];
+        const toolContext = {
+          userId: user._id,
+          conversationId: id,
+          presentationContext,
+          surfaceCatalog: surfaceCatalogFor(presentationContext.target, surfaceComponents),
+          surfaceCatalogRevision: surfaceCatalogRevisionFor(
+            presentationContext.target,
+            surfaceComponents
+          ),
+          surfaceRendererManifest: surfaceRendererRegistry.manifestFor(presentationContext.target),
+          surfaceComponents,
+        };
+        const allowedNames = allowedToolNamesFor(toolRegistry, toolAgent, presentationContext);
+        const tools = (toolRegistry?.getAll() ?? [])
+          .filter((tool) => !allowedNames || allowedNames.has(tool.name))
+          .map((tool) => ({
+            name: tool.name,
+            description: tool.description,
+            inputSchema: tool.inputSchemaFor?.(toolContext) ?? tool.inputSchema,
+          }))
+          .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
         return reply.send({
           conversationId: id,
           systemPrompt,
           soulReminder,
           messages: history.items,
+          tools,
         });
       }
     );

--- a/apps/web/app/components/chat/chat-debug-drawer.test.tsx
+++ b/apps/web/app/components/chat/chat-debug-drawer.test.tsx
@@ -31,6 +31,13 @@ const DEBUG: DebugContext = {
       createdAt: "t1",
     },
   ],
+  tools: [
+    {
+      name: "search",
+      description: "TOOL_DESCRIPTION_MARKER",
+      inputSchema: { type: "object", properties: { q: { type: "string" } } },
+    },
+  ],
 };
 
 beforeEach(() => {

--- a/apps/web/app/components/chat/chat-debug-drawer.tsx
+++ b/apps/web/app/components/chat/chat-debug-drawer.tsx
@@ -2,7 +2,7 @@ import { Bug, Check, Copy, RefreshCw, X } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { CodeBlock, CollapsibleSection } from "~/components/chat/debug-code";
 import { copyText } from "~/lib/clipboard";
-import { type DebugContext, getDebugContext } from "~/lib/conversations";
+import { type DebugContext, type DebugTool, getDebugContext } from "~/lib/conversations";
 import { cn } from "~/lib/utils";
 
 /** A line that is nothing but one `<block>` or `</block>` tag, which is how prompt blocks open. */
@@ -65,6 +65,7 @@ function tokenCount(text: string): string {
 
 const TABS = [
   { id: "prompt", label: "Prompt" },
+  { id: "tools", label: "Tools" },
   { id: "json", label: "JSON" },
 ] as const;
 
@@ -91,6 +92,7 @@ function DebugDrawer({ conversationId }: { conversationId?: string }) {
   const [loading, setLoading] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
+  const [toolFilter, setToolFilter] = useState("");
   const panelRef = useRef<HTMLElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
 
@@ -161,7 +163,8 @@ function DebugDrawer({ conversationId }: { conversationId?: string }) {
   const promptText = data
     ? [data.systemPrompt, data.soulReminder].filter((part) => part.length > 0).join("\n")
     : "";
-  const copyPayload = tab === "prompt" ? promptText : json;
+  const toolsJson = data ? JSON.stringify(data.tools, null, 2) : "";
+  const copyPayload = tab === "prompt" ? promptText : tab === "tools" ? toolsJson : json;
 
   async function copy() {
     if (!(await copyText(copyPayload))) return;
@@ -255,6 +258,12 @@ function DebugDrawer({ conversationId }: { conversationId?: string }) {
               <p className="p-3 text-xs text-destructive">[error] {err}</p>
             ) : tab === "prompt" ? (
               <PromptView data={data} />
+            ) : tab === "tools" ? (
+              <ToolsView
+                tools={data?.tools ?? []}
+                filter={toolFilter}
+                onFilterChange={setToolFilter}
+              />
             ) : (
               <JsonView conversationId={data?.conversationId ?? ""} rows={rows} />
             )}
@@ -290,6 +299,53 @@ function PromptView({ data }: { data: DebugContext | null }) {
         <p className="px-2 py-1.5 text-[0.6875rem] text-muted-foreground">
           No Soul reminder for this reader.
         </p>
+      )}
+    </div>
+  );
+}
+
+/** Each Tool exactly as it was sent to the model this Turn: name, description, resolved schema. */
+function ToolsView({
+  tools,
+  filter,
+  onFilterChange,
+}: {
+  tools: readonly DebugTool[];
+  filter: string;
+  onFilterChange: (value: string) => void;
+}) {
+  const matched = tools.filter((t) => t.name.toLowerCase().includes(filter.trim().toLowerCase()));
+  return (
+    <div>
+      <div className="sticky top-0 z-10 border-b border-border bg-card px-2 py-1.5">
+        <input
+          type="text"
+          value={filter}
+          onChange={(e) => onFilterChange(e.target.value)}
+          placeholder="Filter tools by name…"
+          className="w-full rounded-sm border border-border bg-background px-2 py-1 text-[0.6875rem] outline-none focus:border-primary/60"
+        />
+      </div>
+      {matched.length === 0 ? (
+        <p className="px-2 py-1.5 text-[0.6875rem] text-muted-foreground">
+          {tools.length === 0
+            ? "No Tools available to this Agent for this channel."
+            : "No Tools match."}
+        </p>
+      ) : (
+        matched.map((t) => (
+          <CollapsibleSection
+            key={t.name}
+            title={t.name}
+            meta={tokenCount(JSON.stringify(t.inputSchema))}
+            defaultOpen={false}
+          >
+            <p className="px-2 pt-1.5 pb-1 text-[0.6875rem] text-muted-foreground">
+              {t.description}
+            </p>
+            <CodeBlock code={JSON.stringify(t.inputSchema, null, 2)} lang="json" />
+          </CollapsibleSection>
+        ))
       )}
     </div>
   );

--- a/apps/web/app/lib/conversations.ts
+++ b/apps/web/app/lib/conversations.ts
@@ -78,11 +78,18 @@ export async function getConversationMessages(id: string): Promise<ConversationM
   return body.messages;
 }
 
+export type DebugTool = {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+};
+
 export type DebugContext = {
   conversationId: string;
   systemPrompt: string;
   soulReminder: string;
   messages: ConversationMessage[];
+  tools: DebugTool[];
 };
 
 export function getDebugContext(id: string): Promise<DebugContext> {


### PR DESCRIPTION
## Summary
- Adds a Tools tab to the debug drawer, listing each Tool's name, description, and resolved input schema exactly as sent to the model for the Turn, narrowed the same way as the reader's own view.
- `debug-context` route now returns the narrowed `tools` list alongside the existing prompt/messages payload.
- Updates CONTRIBUTING.md's dev-login instructions to use the seeded dev admin credentials.

## Test plan
- [ ] Manual: open a chat, open debug drawer, verify Tools tab lists tools with filter working
- [ ] `pnpm --filter @tulipfarm/web test app/components/chat`