### PR TITLE
perf(web): reuse settled catalog reads across staggered consumers

### DIFF
--- a/apps/web/app/lib/agents.ts
+++ b/apps/web/app/lib/agents.ts
@@ -1,4 +1,4 @@
-import { apiCommand, apiGet, shareInFlight } from "./api";
+import { apiCommand, apiGet, CATALOG_TTL_MS, shareInFlight } from "./api";
 
 /* Cookie-first read client for soul-backed Agents; non-2xx responses throw `ApiError`. */
 
@@ -63,7 +63,7 @@ export type AgentGovernance = {
 export const listAgents = shareInFlight(async (): Promise<AgentSummary[]> => {
   const body = await apiGet<{ agents: AgentSummary[] }>("/api/v1/agents");
   return body.agents;
-});
+}, CATALOG_TTL_MS);
 
 export async function getAgent(name: string): Promise<AgentDetail> {
   return apiGet<AgentDetail>(`/api/v1/agents/${encodeURIComponent(name)}`);

--- a/apps/web/app/lib/api.test.ts
+++ b/apps/web/app/lib/api.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
 import {
   ApiError,
+  CATALOG_TTL_MS,
   createRecord,
+  createResourceType,
   getRecord,
   getSession,
   listRecords,
@@ -25,6 +27,9 @@ beforeEach(() => {
   vi.unstubAllEnvs();
   // Baseline: no token, independent of any ambient apps/web/.env.local. Tests opt in explicitly.
   vi.stubEnv("VITE_API_TOKEN", "");
+  // The catalog readers hold a settled value across calls, so without this a test would be served
+  // the previous test's mock instead of its own.
+  listResourceTypes.invalidate();
 });
 
 afterEach(() => {
@@ -78,6 +83,56 @@ test("listResourceTypes unwraps the types array", async () => {
   const types = await listResourceTypes();
   expect(types).toHaveLength(1);
   expect(types[0].name).toBe("ticket");
+});
+
+// The sidebar's counts and the chat mention picker want the same catalogs but mount a few hundred
+// milliseconds apart, so sharing only the in-flight promise still fetched each list twice per load.
+test("serves a second caller from the settled catalog read instead of refetching", async () => {
+  const fetchFn = mockFetch(200, {
+    types: [{ name: "ticket", schema: "type: object", hasHooks: false }],
+  });
+  const first = await listResourceTypes();
+  const second = await listResourceTypes();
+  expect(fetchFn).toHaveBeenCalledTimes(1);
+  expect(second).toEqual(first);
+});
+
+test("refetches the catalog once the reuse window has passed", async () => {
+  vi.useFakeTimers({ toFake: ["Date"] });
+  try {
+    const fetchFn = mockFetch(200, { types: [] });
+    await listResourceTypes();
+    vi.setSystemTime(Date.now() + CATALOG_TTL_MS + 1);
+    await listResourceTypes();
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test("writing a resource type drops the cached catalog so the next read sees it", async () => {
+  mockFetch(200, { types: [] });
+  expect(await listResourceTypes()).toHaveLength(0);
+
+  mockFetch(201, { name: "ticket", schema: "type: object", hasHooks: false });
+  await createResourceType("ticket", "type: object");
+
+  const refetch = mockFetch(200, {
+    types: [{ name: "ticket", schema: "type: object", hasHooks: false }],
+  });
+  expect(await listResourceTypes()).toHaveLength(1);
+  expect(refetch).toHaveBeenCalledTimes(1);
+});
+
+test("does not cache a failed catalog read", async () => {
+  mockFetch(500, { error: "boom" });
+  await expect(listResourceTypes()).rejects.toBeInstanceOf(ApiError);
+
+  const retry = mockFetch(200, {
+    types: [{ name: "ticket", schema: "type: object", hasHooks: false }],
+  });
+  expect(await listResourceTypes()).toHaveLength(1);
+  expect(retry).toHaveBeenCalledTimes(1);
 });
 
 test("listRecords builds a query string with limit + includeDeleted, omitting an absent cursor", async () => {

--- a/apps/web/app/lib/api.ts
+++ b/apps/web/app/lib/api.ts
@@ -46,25 +46,57 @@ export type RecordPage = {
 };
 
 /**
- * Shares one in-flight read between callers that ask for the same list in the same tick.
- *
- * The chat composer's mention data and the transcript's mention catalog are independent hooks that
- * both want agents, skills and resource types, and both mount on the same render — so each list was
- * fetched twice on every chat open. Only the *in-flight* promise is shared: it is dropped as soon as
- * it settles, so the next caller still gets a fresh read and nothing is ever served stale.
+ * How long a settled catalog read stays reusable. Long enough to cover consumers that mount a few
+ * hundred milliseconds apart during one page load, short enough that a catalog changed by an agent
+ * in the background surfaces on the reader's next visit rather than on a later one.
  */
-export function shareInFlight<T>(load: () => Promise<T>): () => Promise<T> {
+export const CATALOG_TTL_MS = 5_000;
+
+/**
+ * Shares one read of a rarely-changing catalog between unrelated callers.
+ *
+ * Two things share a list here. Callers in the same tick share the in-flight promise: the composer's
+ * mention data and the transcript's mention catalog are independent hooks that both want agents,
+ * skills and resource types on the same render. Callers that arrive *after* it settles reuse the
+ * value for `ttlMs`, which in-flight sharing alone cannot do — the sidebar's counts and the chat
+ * mention picker mount about 150ms apart, so the first read had already resolved by the time the
+ * second asked and every catalog was fetched twice on each load.
+ *
+ * A rejection is never cached, and every write to a catalog calls `invalidate`, so the window can
+ * only ever serve a value the reader had no way to have changed.
+ */
+export function shareInFlight<T>(
+  load: () => Promise<T>,
+  ttlMs = 0
+): (() => Promise<T>) & { invalidate: () => void } {
   let inFlight: Promise<T> | null = null;
-  return () => {
+  let settled: { value: T; at: number } | null = null;
+
+  const read = () => {
     if (inFlight) return inFlight;
+    if (settled && ttlMs > 0 && Date.now() - settled.at < ttlMs) {
+      return Promise.resolve(settled.value);
+    }
     const started = load();
     inFlight = started;
-    const clear = () => {
-      if (inFlight === started) inFlight = null;
-    };
-    void started.then(clear, clear);
+    started.then(
+      (value) => {
+        if (inFlight === started) {
+          inFlight = null;
+          settled = { value, at: Date.now() };
+        }
+      },
+      () => {
+        if (inFlight === started) inFlight = null;
+      }
+    );
     return started;
   };
+
+  read.invalidate = () => {
+    settled = null;
+  };
+  return read;
 }
 
 export async function apiGet<T>(path: string): Promise<T> {
@@ -312,7 +344,12 @@ export async function createResourceType(
   name: string,
   schema: string
 ): Promise<ResourceTypeSummary> {
-  return apiWrite<ResourceTypeSummary>("POST", "/api/v1/resource-types", { name, schema });
+  const created = await apiWrite<ResourceTypeSummary>("POST", "/api/v1/resource-types", {
+    name,
+    schema,
+  });
+  listResourceTypes.invalidate();
+  return created;
 }
 
 // Replace a resource type's schema (full schema string, JSON or YAML). 404 if the type is gone.
@@ -320,23 +357,26 @@ export async function updateResourceType(
   name: string,
   schema: string
 ): Promise<ResourceTypeSummary> {
-  return apiWrite<ResourceTypeSummary>(
+  const updated = await apiWrite<ResourceTypeSummary>(
     "PUT",
     `/api/v1/resource-types/${encodeURIComponent(name)}`,
     { schema }
   );
+  listResourceTypes.invalidate();
+  return updated;
 }
 
 // Remove a resource type's definition from the soul. Non-destructive: the Postgres table (records)
 // is left intact. Returns 204 (void).
 export async function deleteResourceType(name: string): Promise<void> {
-  return apiDelete(`/api/v1/resource-types/${encodeURIComponent(name)}`);
+  await apiDelete(`/api/v1/resource-types/${encodeURIComponent(name)}`);
+  listResourceTypes.invalidate();
 }
 
 export const listResourceTypes = shareInFlight(async (): Promise<ResourceTypeSummary[]> => {
   const body = await apiGet<{ types: ResourceTypeSummary[] }>("/api/v1/resource-types");
   return body.types;
-});
+}, CATALOG_TTL_MS);
 
 /**
  * Catalog totals per resource type. The API omits any type the caller may not list, so a missing

--- a/apps/web/app/lib/skills.ts
+++ b/apps/web/app/lib/skills.ts
@@ -1,4 +1,4 @@
-import { apiDelete, apiGet, apiWrite, shareInFlight } from "./api";
+import { apiDelete, apiGet, apiWrite, CATALOG_TTL_MS, shareInFlight } from "./api";
 
 /* Skill installs publish executable commands only after server-side package/runtime gates pass. */
 
@@ -130,7 +130,7 @@ export type SkillAuditReport = {
 export const listSkills = shareInFlight(async (): Promise<SkillSummary[]> => {
   const body = await apiGet<{ skills: SkillSummary[] }>("/api/v1/skills");
   return body.skills;
-});
+}, CATALOG_TTL_MS);
 
 export async function getSkill(name: string): Promise<SkillDetail> {
   return apiGet<SkillDetail>(`/api/v1/skills/${encodeURIComponent(name)}`);
@@ -178,7 +178,9 @@ export async function installSkills(
     paths.length === skills.length
       ? { scanId, paths }
       : { scanId, names: skills.map((skill) => skill.name) };
-  return apiWrite<{ installed: string[] }>("POST", "/api/v1/skills/install", body);
+  const installed = await apiWrite<{ installed: string[] }>("POST", "/api/v1/skills/install", body);
+  listSkills.invalidate();
+  return installed;
 }
 
 export async function marketplaceSkills(): Promise<MarketplaceCatalog> {
@@ -186,5 +188,6 @@ export async function marketplaceSkills(): Promise<MarketplaceCatalog> {
 }
 
 export async function removeSkill(name: string): Promise<void> {
-  return apiDelete(`/api/v1/skills/${encodeURIComponent(name)}`);
+  await apiDelete(`/api/v1/skills/${encodeURIComponent(name)}`);
+  listSkills.invalidate();
 }


### PR DESCRIPTION
## Summary

<!-- What changed, and why. Link the driving issue if one exists. -->

## Test plan

<!-- Commands you ran, or manual steps / screenshots for UI changes. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (or the scoped `--filter` you actually ran)

## Checklist

- [ ] PR title follows Conventional Commits (`type(scope): subject`) — CI checks this
- [ ] Scoped to one logical change
- [ ] Tests added/updated for the behavior that changed
