### PR TITLE
perf(api,web): return group members and roles in one list read

### DIFF
--- a/apps/api/src/authz/routes.test.ts
+++ b/apps/api/src/authz/routes.test.ts
@@ -464,6 +464,66 @@ describe("authz admin routes", () => {
       expect(await groups.getGroup(BUSINESS, "ops")).toBeUndefined();
     });
 
+    it("returns every group's members and held Roles from one list read", async () => {
+      // The Access screens render N teams; a list that omitted members forced N detail reads.
+      for (const id of ["ops", "finance"]) {
+        await app.inject({
+          method: "POST",
+          url: "/api/v1/authz/groups",
+          ...write(adminSid),
+          payload: { id },
+        });
+      }
+      await app.inject({
+        method: "POST",
+        url: "/api/v1/authz/groups/ops/members",
+        ...write(adminSid),
+        payload: { principalId: "p-user" },
+      });
+      await app.inject({
+        method: "POST",
+        url: "/api/v1/authz/groups/ops/roles",
+        ...write(adminSid),
+        payload: { roleId: "support" },
+      });
+      await app.inject({
+        method: "POST",
+        url: "/api/v1/authz/groups/finance/members",
+        ...write(adminSid),
+        payload: { principalId: "p-two" },
+      });
+
+      // Expired links are seeded through the repo because the route rejects a past expiry.
+      await groups.addMember({
+        businessId: BUSINESS,
+        groupId: "finance",
+        principalId: "p-gone",
+        expiresAt: new Date("2000-01-01T00:00:00.000Z"),
+      });
+      await groups.assignRole({
+        businessId: BUSINESS,
+        groupId: "finance",
+        roleId: "support",
+        expiresAt: new Date("2000-01-01T00:00:00.000Z"),
+      });
+
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/authz/groups",
+        cookies: { [SESSION_COOKIE]: adminSid },
+      });
+      expect(res.statusCode).toBe(200);
+
+      const byId = new Map(res.json().groups.map((g: { id: string }) => [g.id, g] as const)) as Map<
+        string,
+        { members: { principalId: string }[]; roles: { roleId: string }[] }
+      >;
+      expect(byId.get("ops")?.members.map((m) => m.principalId)).toEqual(["p-user"]);
+      expect(byId.get("ops")?.roles.map((r) => r.roleId)).toEqual(["support"]);
+      expect(byId.get("finance")?.members.map((m) => m.principalId)).toEqual(["p-two"]);
+      expect(byId.get("finance")?.roles).toEqual([]);
+    });
+
     it("re-stating a group answers 200 and records the expiry it overwrote", async () => {
       // Full upsert without `expiresAt` clears expiry; report 200, not created.
       const created = await app.inject({

--- a/apps/api/src/authz/routes.ts
+++ b/apps/api/src/authz/routes.ts
@@ -148,7 +148,8 @@ export function registerAuthzRoutes(
     {
       preHandler: gate(authz("authz.group.read")),
       schema: {
-        description: "List every principal group.",
+        description:
+          "List every principal group, each with its unexpired members and the Roles it holds.",
         tags: ["authz"],
         security: AUTHZ_SECURITY,
         response: {
@@ -159,7 +160,7 @@ export function registerAuthzRoutes(
         },
       },
     },
-    async () => ({ groups: await service.listGroups() })
+    async () => ({ groups: await service.listGroupDetails() })
   );
 
   app.get(

--- a/apps/api/src/authz/schemas.ts
+++ b/apps/api/src/authz/schemas.ts
@@ -228,7 +228,7 @@ export const GroupListResponseSchema = {
   type: "object",
   additionalProperties: false,
   required: ["groups"],
-  properties: { groups: { type: "array", items: GroupViewSchema } },
+  properties: { groups: { type: "array", items: GroupDetailSchema } },
 } as const;
 
 export const GroupIdParamsSchema = {

--- a/apps/api/src/authz/service.ts
+++ b/apps/api/src/authz/service.ts
@@ -142,6 +142,43 @@ export class AuthzAdminService {
     return groups.map((group) => ({ id: group.id, expiresAt: iso(group.expiresAt) }));
   }
 
+  /**
+   * Every group with its unexpired members and held Roles, in a fixed number of reads.
+   *
+   * The access screens need all of it at once, and asking per group cost one `getGroup` — three
+   * reads — per team, over its own HTTP request. This collects the same rows business-wide and
+   * groups them in memory instead.
+   */
+  async listGroupDetails(): Promise<readonly GroupDetailView[]> {
+    const now = this.now();
+    const [groups, members, roles] = await Promise.all([
+      this.deps.groups.listGroups(this.deps.businessId),
+      this.deps.groups.listAllMembers(this.deps.businessId, now),
+      this.deps.groups.listAllGroupRoles(this.deps.businessId, now),
+    ]);
+
+    const membersByGroup = new Map<string, GroupDetailView["members"][number][]>();
+    for (const member of members) {
+      const bucket = membersByGroup.get(member.groupId) ?? [];
+      bucket.push({ principalId: member.principalId, expiresAt: iso(member.expiresAt) });
+      membersByGroup.set(member.groupId, bucket);
+    }
+
+    const rolesByGroup = new Map<string, GroupDetailView["roles"][number][]>();
+    for (const held of roles) {
+      const bucket = rolesByGroup.get(held.groupId) ?? [];
+      bucket.push({ roleId: held.roleId, expiresAt: iso(held.expiresAt) });
+      rolesByGroup.set(held.groupId, bucket);
+    }
+
+    return groups.map((group) => ({
+      id: group.id,
+      expiresAt: iso(group.expiresAt),
+      members: membersByGroup.get(group.id) ?? [],
+      roles: rolesByGroup.get(group.id) ?? [],
+    }));
+  }
+
   /** Includes non-human principals that have no users-list source. */
   async listPrincipals(): Promise<readonly PrincipalView[]> {
     const principals = await this.deps.principals.list(this.deps.businessId);

--- a/apps/web/app/lib/authz.ts
+++ b/apps/web/app/lib/authz.ts
@@ -184,8 +184,8 @@ export function listRoleAssignees(roleId: string): Promise<{ assignees: RoleAssi
   );
 }
 
-export function listGroups(): Promise<{ groups: AuthzGroup[] }> {
-  return apiGet<{ groups: AuthzGroup[] }>("/api/v1/authz/groups");
+export function listGroups(): Promise<{ groups: AuthzGroupDetail[] }> {
+  return apiGet<{ groups: AuthzGroupDetail[] }>("/api/v1/authz/groups");
 }
 
 export function getGroup(groupId: string): Promise<AuthzGroupDetail> {

--- a/apps/web/app/routes/_app.business.access._index.tsx
+++ b/apps/web/app/routes/_app.business.access._index.tsx
@@ -36,7 +36,6 @@ import {
   type AuthzRole,
   type EffectiveGrants,
   getEffectiveGrants,
-  getGroup,
   listCapabilities,
   listGroups,
   listRoleAssignees,
@@ -56,7 +55,7 @@ export type SelectedAccess =
 export async function clientLoader({ request }: ClientLoaderFunctionArgs) {
   const selectedId = new URL(request.url).searchParams.get("person")?.trim() ?? "";
 
-  const [users, { roles }, { groups }, catalog] = await Promise.all([
+  const [users, { roles }, { groups: teams }, catalog] = await Promise.all([
     listUsers(),
     listRoles(),
     listGroups(),
@@ -65,14 +64,13 @@ export async function clientLoader({ request }: ClientLoaderFunctionArgs) {
     // simply is not offered, rather than the whole page failing.
     listCapabilities().catch(() => null),
   ]);
-  const [assignments, teams, selectedAccess] = await Promise.all([
+  const [assignments, selectedAccess] = await Promise.all([
     Promise.all(
       roles.map(async (role) => ({
         roleId: role.id,
         assignees: (await listRoleAssignees(role.id)).assignees,
       }))
     ),
-    Promise.all(groups.map((group) => getGroup(group.id))),
     loadSelected(selectedId),
   ]);
 

--- a/apps/web/app/routes/_app.business.access.teams.tsx
+++ b/apps/web/app/routes/_app.business.access.teams.tsx
@@ -18,7 +18,6 @@ import {
   type AuthzGroupDetail,
   type AuthzRole,
   createGroup,
-  getGroup,
   listCapabilities,
   listGroups,
   listRoles,
@@ -31,13 +30,12 @@ type TeamFilter = "all" | "no-access" | "empty";
 type TeamSort = "name-asc" | "name-desc" | "members-desc" | "members-asc";
 
 export async function clientLoader() {
-  const [{ groups }, { roles }, users, catalog] = await Promise.all([
+  const [{ groups: teams }, { roles }, users, catalog] = await Promise.all([
     listGroups(),
     listRoles(),
     listUsers(),
     listCapabilities().catch(() => null),
   ]);
-  const teams = await Promise.all(groups.map((group) => getGroup(group.id)));
   return { teams, roles, users, catalog };
 }
 

--- a/packages/storage/src/auth/group-repo.ts
+++ b/packages/storage/src/auth/group-repo.ts
@@ -45,6 +45,13 @@ export interface GroupRepo {
   ): Promise<GroupMembershipRecord[]>;
   /** Every unexpired member of a group. */
   listMembers(businessId: string, groupId: string, now: Date): Promise<GroupMembershipRecord[]>;
+  /**
+   * Every unexpired membership in the business, for callers that need all groups at once.
+   *
+   * Listing groups with their members otherwise costs one `listMembers` per group, which the
+   * access screens paid over HTTP — one request per team on every load.
+   */
+  listAllMembers(businessId: string, now: Date): Promise<GroupMembershipRecord[]>;
   /** Grants a Role to a group; members inherit it. */
   assignRole(record: GroupRoleAssignmentRecord): Promise<void>;
   /** Removes one Role from a group; a no-op when it does not hold it. */
@@ -55,6 +62,8 @@ export interface GroupRepo {
     groupId: string,
     now: Date
   ): Promise<GroupRoleAssignmentRecord[]>;
+  /** Every unexpired group-held Role in the business; the `listAllMembers` counterpart. */
+  listAllGroupRoles(businessId: string, now: Date): Promise<GroupRoleAssignmentRecord[]>;
 }
 
 export class InMemoryGroupRepo implements GroupRepo {
@@ -138,6 +147,14 @@ export class InMemoryGroupRepo implements GroupRepo {
     );
   }
 
+  async listAllMembers(businessId: string, now: Date): Promise<GroupMembershipRecord[]> {
+    return this.memberships.filter(
+      (membership) =>
+        membership.businessId === businessId &&
+        (!membership.expiresAt || membership.expiresAt > now)
+    );
+  }
+
   async assignRole(record: GroupRoleAssignmentRecord): Promise<void> {
     await this.revokeRole(record.businessId, record.groupId, record.roleId);
     this.groupRoles.push(Object.freeze({ ...record }));
@@ -162,6 +179,12 @@ export class InMemoryGroupRepo implements GroupRepo {
         held.businessId === businessId &&
         held.groupId === groupId &&
         (!held.expiresAt || held.expiresAt > now)
+    );
+  }
+
+  async listAllGroupRoles(businessId: string, now: Date): Promise<GroupRoleAssignmentRecord[]> {
+    return this.groupRoles.filter(
+      (held) => held.businessId === businessId && (!held.expiresAt || held.expiresAt > now)
     );
   }
 }
@@ -326,6 +349,20 @@ export class PgGroupRepo implements GroupRepo {
     });
   }
 
+  async listAllMembers(businessId: string, now: Date): Promise<GroupMembershipRecord[]> {
+    return this.transactions.withTransaction(async (transaction) => {
+      const result = await transaction.query<MembershipRow>(
+        `SELECT business_id, principal_id, group_id, expires_at
+           FROM principal_group_members
+          WHERE business_id = $1
+            AND (expires_at IS NULL OR expires_at > $2)
+          ORDER BY group_id, principal_id`,
+        [businessId, now]
+      );
+      return result.rows.map(membershipFromRow);
+    });
+  }
+
   async assignRole(record: GroupRoleAssignmentRecord): Promise<void> {
     await this.transactions.withTransaction(async (transaction) => {
       await transaction.query(
@@ -363,6 +400,20 @@ export class PgGroupRepo implements GroupRepo {
             AND (expires_at IS NULL OR expires_at > $3)
           ORDER BY role_id`,
         [businessId, groupId, now]
+      );
+      return result.rows.map(groupRoleFromRow);
+    });
+  }
+
+  async listAllGroupRoles(businessId: string, now: Date): Promise<GroupRoleAssignmentRecord[]> {
+    return this.transactions.withTransaction(async (transaction) => {
+      const result = await transaction.query<GroupRoleRow>(
+        `SELECT business_id, group_id, role_id, expires_at
+           FROM group_role_assignments
+          WHERE business_id = $1
+            AND (expires_at IS NULL OR expires_at > $2)
+          ORDER BY group_id, role_id`,
+        [businessId, now]
       );
       return result.rows.map(groupRoleFromRow);
     });


### PR DESCRIPTION
## Summary

<!-- What changed, and why. Link the driving issue if one exists. -->

## Test plan

<!-- Commands you ran, or manual steps / screenshots for UI changes. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (or the scoped `--filter` you actually ran)

## Checklist

- [ ] PR title follows Conventional Commits (`type(scope): subject`) — CI checks this
- [ ] Scoped to one logical change
- [ ] Tests added/updated for the behavior that changed
