### PR TITLE
fix: Slack agent silently failing on LLM rate limits

### DIFF
--- a/apps/api/src/conversations/service.ts
+++ b/apps/api/src/conversations/service.ts
@@ -1,5 +1,6 @@
 /** SPEC §10/§18: persist the Turn before dispatch; stream resumes from its durable cursor. */
 
+import type { ModelFailureDiagnostic } from "@tulipfarm/agent-runtime";
 import {
   type ConversationTurn,
   contentText,
@@ -36,6 +37,9 @@ export interface TurnCompletion {
   /** Last Run event sequence this attempt wrote; readers resume strictly after it. */
   readonly cursor: number;
   readonly createdAt: Date;
+  /** Bounded, participant-safe failure evidence; absent for a succeeded completion. */
+  readonly reason?: string;
+  readonly modelFailure?: ModelFailureDiagnostic;
 }
 
 export interface PersistedTurn {

--- a/apps/api/src/conversations/store.pg.test.ts
+++ b/apps/api/src/conversations/store.pg.test.ts
@@ -170,6 +170,26 @@ describe("PgConversationStore", () => {
     await expect(store.findCompletion(DEPLOYMENT_BUSINESS_ID, TURN_ID, 2)).resolves.toBeUndefined();
   });
 
+  it("round-trips a failed completion's reason and model diagnostic through jsonb", async () => {
+    await store.saveTurn(turn());
+    const completion = {
+      businessId: DEPLOYMENT_BUSINESS_ID,
+      turnId: TURN_ID,
+      attempt: 1,
+      status: "failed" as const,
+      messageId: null,
+      cursor: 4,
+      createdAt: CREATED_AT,
+      reason: "model_rate_limited",
+      modelFailure: { requestId: "req-1", modelId: "gpt-x" },
+    };
+    await store.completeTurn({ completion });
+
+    await expect(store.findCompletion(DEPLOYMENT_BUSINESS_ID, TURN_ID, 1)).resolves.toEqual(
+      completion
+    );
+  });
+
   it("replays only the assistant Message that completed the Turn", async () => {
     await store.saveTurn(turn());
     // What a Worker killed after writing its reply leaves behind.

--- a/apps/api/src/conversations/store.pg.ts
+++ b/apps/api/src/conversations/store.pg.ts
@@ -1,3 +1,4 @@
+import type { ModelFailureDiagnostic } from "@tulipfarm/agent-runtime";
 import { DEPLOYMENT_BUSINESS_ID } from "@tulipfarm/constants";
 import { normalizeMessageContent } from "@tulipfarm/schema";
 import { findLatestConversationTurn, recordCuratorWork } from "@tulipfarm/storage";
@@ -56,6 +57,8 @@ interface CompletionRow {
   message_id: string | null;
   cursor: string | number;
   created_at: Date;
+  reason: string | null;
+  model_failure: unknown | null;
 }
 
 const TURN_COLUMNS = `id, conversation_id, idempotency_key, request_message_id, status, attempt,
@@ -130,6 +133,10 @@ function toCompletion(row: CompletionRow): TurnCompletion {
     messageId: row.message_id,
     cursor: Number(row.cursor),
     createdAt: row.created_at,
+    ...(row.reason === null ? {} : { reason: row.reason }),
+    ...(row.model_failure === null
+      ? {}
+      : { modelFailure: row.model_failure as ModelFailureDiagnostic }),
   };
 }
 
@@ -258,7 +265,7 @@ export class PgConversationStore implements ConversationStore {
   ): Promise<TurnCompletion | undefined> {
     assertDeploymentBusiness(businessId);
     const { rows } = await this.q.query(
-      `SELECT turn_id, attempt, status, message_id, cursor, created_at
+      `SELECT turn_id, attempt, status, message_id, cursor, created_at, reason, model_failure
          FROM turn_completions WHERE turn_id = $1 AND attempt = $2`,
       [turnId, attempt]
     );
@@ -272,8 +279,10 @@ export class PgConversationStore implements ConversationStore {
     return withTransaction(this.q, async (tx) => {
       // must leave the recorded answer — and the Message it names — exactly as it stands.
       const inserted = await tx.query(
-        `INSERT INTO turn_completions (turn_id, attempt, status, message_id, cursor, created_at)
-         VALUES ($1, $2, $3, $4, $5, $6)
+        `INSERT INTO turn_completions (
+           turn_id, attempt, status, message_id, cursor, created_at, reason, model_failure
+         )
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb)
          ON CONFLICT (turn_id, attempt) DO NOTHING
          RETURNING turn_id`,
         [
@@ -283,6 +292,10 @@ export class PgConversationStore implements ConversationStore {
           input.completion.messageId,
           input.completion.cursor,
           input.completion.createdAt,
+          input.completion.reason ?? null,
+          input.completion.modelFailure === undefined
+            ? null
+            : JSON.stringify(input.completion.modelFailure),
         ]
       );
       const completionInserted = inserted.rows.length > 0;

--- a/apps/api/src/internal/channel-routes.test.ts
+++ b/apps/api/src/internal/channel-routes.test.ts
@@ -693,6 +693,41 @@ describe("/api/v1/internal/channels", () => {
       });
       expect(res.statusCode).toBe(404);
     });
+
+    it("returns the recorded failure reason for a failed attempt", async () => {
+      store.turns.push({
+        id: "turn-1",
+        businessId: DEPLOYMENT_BUSINESS_ID,
+        conversationId: "conversation-1",
+        idempotencyKey: "key-1",
+        requestMessageId: "message-1",
+        status: "failed",
+        attempt: 1,
+        runId: "run-1",
+        cursor: 0,
+        supersededRunIds: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+      store.completions.push({
+        businessId: DEPLOYMENT_BUSINESS_ID,
+        turnId: "turn-1",
+        attempt: 1,
+        status: "failed",
+        messageId: null,
+        cursor: 0,
+        createdAt: new Date(),
+        reason: "model_rate_limited",
+      });
+
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/internal/channels/runs/run-1/reply",
+        headers: asWorker(),
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ status: "failed", reason: "model_rate_limited" });
+    });
   });
 
   describe("GET /runs/:runId/pending-approval", () => {

--- a/apps/api/src/internal/channel-routes.ts
+++ b/apps/api/src/internal/channel-routes.ts
@@ -421,7 +421,10 @@ export function registerChannelInternalRoutes(
       );
       if (completion === undefined) return reply.send({ status: "pending" });
       if (completion.status !== "succeeded" || completion.messageId === null) {
-        return reply.send({ status: "failed" });
+        return reply.send({
+          status: "failed",
+          ...(completion.reason === undefined ? {} : { reason: completion.reason }),
+        });
       }
 
       const messages = await deps.store.listMessages(businessId, turn.conversationId);

--- a/apps/api/src/internal/channel-schemas.ts
+++ b/apps/api/src/internal/channel-schemas.ts
@@ -102,6 +102,7 @@ export const ChannelRunReplyResponseSchema = {
     text: { type: "string" },
     agentDisplayName: { type: "string" },
     blocks: { type: "array", items: { type: "object", additionalProperties: true } },
+    reason: { type: "string" },
   },
 } as const;
 

--- a/apps/api/src/internal/routes.test.ts
+++ b/apps/api/src/internal/routes.test.ts
@@ -428,6 +428,38 @@ describe("/api/v1/internal/turns", () => {
     expect(store.turns[0]).toMatchObject({ businessId: BUSINESS_ID, status: "succeeded" });
   });
 
+  it("records and replays a failure reason and model diagnostic for a failed attempt", async () => {
+    const completed = await app.inject({
+      method: "POST",
+      url: `/api/v1/internal/turns/${RUN_ID}/completion`,
+      headers: asWorker(),
+      payload: {
+        attempt: 1,
+        status: "failed",
+        cursor: 3,
+        messageId: null,
+        reason: "model_rate_limited",
+        modelFailure: { requestId: "req-1", modelId: "gpt-x" },
+      },
+    });
+    expect(completed.statusCode).toBe(200);
+
+    const recorded = await app.inject({
+      method: "GET",
+      url: `/api/v1/internal/turns/${RUN_ID}/completion?attempt=1`,
+      headers: asWorker(),
+    });
+    expect(recorded.json()).toEqual({
+      turnId: TURN_ID,
+      attempt: 1,
+      status: "failed",
+      messageId: null,
+      cursor: 3,
+      reason: "model_rate_limited",
+      modelFailure: { requestId: "req-1", modelId: "gpt-x" },
+    });
+  });
+
   it("hands the Worker the Agent's capability restrictions with the Run's authority", async () => {
     hostedAgent = {
       name: "reporter",

--- a/apps/api/src/internal/routes.ts
+++ b/apps/api/src/internal/routes.ts
@@ -1,4 +1,5 @@
 import { Readable } from "node:stream";
+import type { ModelFailureDiagnostic } from "@tulipfarm/agent-runtime";
 import { DEPLOYMENT_BUSINESS_ID } from "@tulipfarm/constants";
 import type { ParticipantToolCall } from "@tulipfarm/schema";
 import type { FastifyBaseLogger, FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
@@ -444,6 +445,8 @@ export function registerInternalTurnRoutes(
         status: completion.status,
         messageId: completion.messageId,
         cursor: completion.cursor,
+        ...(completion.reason === undefined ? {} : { reason: completion.reason }),
+        ...(completion.modelFailure === undefined ? {} : { modelFailure: completion.modelFailure }),
       });
     }
   );
@@ -514,6 +517,8 @@ export function registerInternalTurnRoutes(
         cursor: number;
         messageId?: string | null;
         surfaces?: { artifactId: string; revision: number }[];
+        reason?: string;
+        modelFailure?: ModelFailureDiagnostic;
       };
       const recorded = await guard(reply, async () => {
         await deps.host.completeTurn({
@@ -524,6 +529,8 @@ export function registerInternalTurnRoutes(
           cursor: body.cursor,
           messageId: body.messageId ?? null,
           surfaces: body.surfaces ?? [],
+          ...(body.reason === undefined ? {} : { reason: body.reason }),
+          ...(body.modelFailure === undefined ? {} : { modelFailure: body.modelFailure }),
         });
         return true;
       });

--- a/apps/api/src/internal/schemas.ts
+++ b/apps/api/src/internal/schemas.ts
@@ -316,6 +316,17 @@ export const InternalTurnCompletionQuerySchema = {
   properties: { attempt: { type: "integer", minimum: 1 } },
 } as const;
 
+/** Bounded, participant-safe evidence for a failed model call; provider error bodies never cross this seam. */
+const MODEL_FAILURE_SCHEMA = {
+  type: "object",
+  required: ["requestId"],
+  additionalProperties: false,
+  properties: {
+    requestId: { type: "string" },
+    modelId: { type: "string" },
+  },
+} as const;
+
 export const InternalTurnCompletionResponseSchema = {
   type: "object",
   required: ["turnId", "attempt", "status", "messageId", "cursor"],
@@ -325,6 +336,8 @@ export const InternalTurnCompletionResponseSchema = {
     status: { type: "string", enum: ["succeeded", "failed"] },
     messageId: { type: ["string", "null"] },
     cursor: { type: "integer" },
+    reason: { type: "string" },
+    modelFailure: MODEL_FAILURE_SCHEMA,
   },
 } as const;
 
@@ -372,6 +385,9 @@ export const InternalTurnCompletionRecordBodySchema = {
     cursor: { type: "integer", minimum: 0 },
     messageId: { type: ["string", "null"] },
     surfaces: { type: "array", items: SURFACE_LINK_SCHEMA },
+    // Bounded `AgentLoopFailureReason` (or a handful of driver-level reasons); never raw provider text.
+    reason: { type: "string" },
+    modelFailure: MODEL_FAILURE_SCHEMA,
   },
 } as const;
 

--- a/apps/api/src/internal/turn-host.ts
+++ b/apps/api/src/internal/turn-host.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import type { ModelRequirementsPolicy } from "@tulipfarm/agent-runtime";
+import type { ModelFailureDiagnostic, ModelRequirementsPolicy } from "@tulipfarm/agent-runtime";
 import { readTurnAttachment, type TurnAttachmentStore } from "@tulipfarm/files";
 import { type InvocationPrincipal, SUBAGENT_RUN_SOURCE } from "@tulipfarm/run-kernel";
 import { type MessageContent, type ParticipantToolCall, textContent } from "@tulipfarm/schema";
@@ -435,6 +435,8 @@ export class InternalTurnHost {
     cursor: number;
     messageId: string | null;
     surfaces?: readonly { artifactId: string; revision: number }[];
+    reason?: string;
+    modelFailure?: ModelFailureDiagnostic;
   }): Promise<void> {
     const { turn, subject } = await this.turnAuthority(input.businessId, input.runId);
     const now = this.now();
@@ -464,6 +466,8 @@ export class InternalTurnHost {
         messageId: input.messageId,
         cursor: input.cursor,
         createdAt: now,
+        ...(input.reason === undefined ? {} : { reason: input.reason }),
+        ...(input.modelFailure === undefined ? {} : { modelFailure: input.modelFailure }),
       },
       ...(current
         ? {

--- a/apps/api/src/pg-migrate.test.ts
+++ b/apps/api/src/pg-migrate.test.ts
@@ -67,6 +67,25 @@ async function seedChannelBindTokensAlterTarget(db: PGlite): Promise<void> {
   )`);
 }
 
+/**
+ * The `conversation_turns` (v16) and `turn_completions` (v17) tables that v84 later alters.
+ * Fixtures whose floor is above v17 must stand both in.
+ */
+async function seedTurnCompletionsAlterTarget(db: PGlite): Promise<void> {
+  await db.query(`CREATE TABLE IF NOT EXISTS conversation_turns (
+    id uuid PRIMARY KEY
+  )`);
+  await db.query(`CREATE TABLE IF NOT EXISTS turn_completions (
+    turn_id    uuid NOT NULL REFERENCES conversation_turns(id),
+    attempt    integer NOT NULL CHECK (attempt >= 0),
+    status     text NOT NULL,
+    message_id uuid,
+    cursor     bigint NOT NULL DEFAULT 0,
+    created_at timestamptz NOT NULL,
+    PRIMARY KEY (turn_id, attempt)
+  )`);
+}
+
 describe("the migration ledger is append-only", () => {
   it("assigns every migration a distinct version", () => {
     const seen = new Map<number, string[]>();
@@ -403,6 +422,7 @@ describe("runPgMigrations", () => {
       await seedRunsFkTarget(db);
       await seedApprovalsAlterTarget(db);
       await seedChannelBindTokensAlterTarget(db);
+      await seedTurnCompletionsAlterTarget(db);
       await db.query(`INSERT INTO soul_execution_bundles (
         digest, business_id, changeset_id, commit_sha, bundle, signature
       ) VALUES (
@@ -476,6 +496,7 @@ describe("runPgMigrations", () => {
       await seedRunsFkTarget(db);
       await seedApprovalsAlterTarget(db);
       await seedChannelBindTokensAlterTarget(db);
+      await seedTurnCompletionsAlterTarget(db);
       await db.query(`INSERT INTO runs (id, bundle)
         VALUES ('00000000-0000-4000-8000-000000000001', '{"routineId":"chat"}'::jsonb)`);
       await db.query(`CREATE TABLE schema_version (
@@ -549,6 +570,7 @@ describe("runPgMigrations", () => {
       await seedRunsFkTarget(db);
       await seedApprovalsAlterTarget(db);
       await seedChannelBindTokensAlterTarget(db);
+      await seedTurnCompletionsAlterTarget(db);
 
       await runPgMigrations(db, undefined, () => {});
 
@@ -575,6 +597,7 @@ describe("runPgMigrations", () => {
       await seedRunsFkTarget(db);
       await seedApprovalsAlterTarget(db);
       await seedChannelBindTokensAlterTarget(db);
+      await seedTurnCompletionsAlterTarget(db);
 
       await expect(runPgMigrations(db, undefined, () => {})).resolves.not.toThrow();
     });
@@ -813,6 +836,7 @@ describe("runPgMigrations concurrency and atomicity", () => {
       await seedRunsFkTarget(db);
       await seedApprovalsAlterTarget(db);
       await seedChannelBindTokensAlterTarget(db);
+      await seedTurnCompletionsAlterTarget(db);
 
       await runPgMigrations(db, undefined, NOOP_LOG);
 

--- a/apps/api/src/pg-migrations/index.ts
+++ b/apps/api/src/pg-migrations/index.ts
@@ -2270,4 +2270,12 @@ export const PG_MIGRATIONS: PgMigration[] = [
       await q.query("ALTER TABLE channel_bind_tokens ADD COLUMN IF NOT EXISTS thread_id text");
     },
   },
+  {
+    version: 84,
+    description: "turn_completions: bounded failure reason and participant-safe model diagnostic",
+    up: async (q) => {
+      await q.query("ALTER TABLE turn_completions ADD COLUMN IF NOT EXISTS reason text");
+      await q.query("ALTER TABLE turn_completions ADD COLUMN IF NOT EXISTS model_failure jsonb");
+    },
+  },
 ];

--- a/apps/integration-worker/src/channels/delivery-poll-loop.test.ts
+++ b/apps/integration-worker/src/channels/delivery-poll-loop.test.ts
@@ -232,7 +232,10 @@ describe("startDeliveryPollLoop", () => {
     } as unknown as RunStore;
     const deliver = vi.fn().mockResolvedValue(undefined);
     const delivery = { setStatus: vi.fn(), deliver } as unknown as SlackDeliveryAdapter;
-    const internalApi = { require: vi.fn() } as unknown as InternalApiClient;
+    const internalApi = {
+      require: vi.fn(),
+      find: vi.fn().mockResolvedValue(undefined),
+    } as unknown as InternalApiClient;
 
     await runOneTick({
       businessId: "business-1",
@@ -245,10 +248,86 @@ describe("startDeliveryPollLoop", () => {
     });
 
     expect(deliver).toHaveBeenCalledWith(
-      expect.objectContaining({ destination: "C1", threadId: "1785000000.0001" }),
+      expect.objectContaining({
+        destination: "C1",
+        threadId: "1785000000.0001",
+        text: "Something went wrong answering this — please try again.",
+      }),
       "xoxb-leased"
     );
+    expect(internalApi.find).toHaveBeenCalledWith(
+      "GET",
+      "/api/v1/internal/channels/runs/run-1/reply",
+      [404]
+    );
     expect(internalApi.require).not.toHaveBeenCalled();
+    expect(runDeliveries.markStatus).toHaveBeenCalledWith("business-1", "run-1", "failed");
+  });
+
+  it("uses the reason-specific failure copy recovered from the reply route", async () => {
+    const runDeliveries = {
+      listPending: vi.fn().mockResolvedValue([row({ threadId: "1785000000.0001" })]),
+      markStatus: vi.fn().mockResolvedValue(undefined),
+    } as unknown as ChannelRunDeliveryStore;
+    const runs = {
+      find: vi.fn().mockResolvedValue(persistedRun({ status: "failed" })),
+    } as unknown as RunStore;
+    const deliver = vi.fn().mockResolvedValue(undefined);
+    const delivery = { setStatus: vi.fn(), deliver } as unknown as SlackDeliveryAdapter;
+    const internalApi = {
+      require: vi.fn(),
+      find: vi.fn().mockResolvedValue({ status: "failed", reason: "model_rate_limited" }),
+    } as unknown as InternalApiClient;
+
+    await runOneTick({
+      businessId: "business-1",
+      runDeliveries,
+      runs,
+      internalApi,
+      delivery,
+      credential: "xoxb-leased",
+      log: { warn: vi.fn() },
+    });
+
+    expect(deliver).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "The model provider is rate-limiting us right now. I retried automatically but it's still throttled — please try again shortly.",
+      }),
+      "xoxb-leased"
+    );
+  });
+
+  it("falls back to the generic failure message when recovering the reason errors", async () => {
+    const runDeliveries = {
+      listPending: vi.fn().mockResolvedValue([row({ threadId: "1785000000.0001" })]),
+      markStatus: vi.fn().mockResolvedValue(undefined),
+    } as unknown as ChannelRunDeliveryStore;
+    const runs = {
+      find: vi.fn().mockResolvedValue(persistedRun({ status: "cancelled" })),
+    } as unknown as RunStore;
+    const deliver = vi.fn().mockResolvedValue(undefined);
+    const delivery = { setStatus: vi.fn(), deliver } as unknown as SlackDeliveryAdapter;
+    const internalApi = {
+      require: vi.fn(),
+      find: vi.fn().mockRejectedValue(new Error("internal api unreachable")),
+    } as unknown as InternalApiClient;
+
+    await runOneTick({
+      businessId: "business-1",
+      runDeliveries,
+      runs,
+      internalApi,
+      delivery,
+      credential: "xoxb-leased",
+      log: { warn: vi.fn() },
+    });
+
+    expect(deliver).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "Something went wrong answering this — please try again.",
+      }),
+      "xoxb-leased"
+    );
     expect(runDeliveries.markStatus).toHaveBeenCalledWith("business-1", "run-1", "failed");
   });
 

--- a/apps/integration-worker/src/channels/delivery-poll-loop.ts
+++ b/apps/integration-worker/src/channels/delivery-poll-loop.ts
@@ -16,13 +16,50 @@ const TERMINAL_RUN_STATUSES: ReadonlySet<PersistedRunStatus> = new Set([
   "cancelled",
 ]);
 
-const FAILURE_MESSAGE = "Something went wrong answering this — please try again.";
+const GENERIC_FAILURE_MESSAGE = "Something went wrong answering this — please try again.";
+
+/** Sanitized, participant-safe copy per `AgentLoopFailureReason` (`packages/agent-runtime/src/loop/contract.ts`) plus driver-level reasons. Never echoes raw provider error text. */
+const FAILURE_MESSAGE_BY_REASON: Readonly<Record<string, string>> = {
+  model_rate_limited:
+    "The model provider is rate-limiting us right now. I retried automatically but it's still throttled — please try again shortly.",
+  model_provider_unavailable:
+    "The model provider looks to be down or unreachable right now. I retried automatically — please try again shortly.",
+  model_error:
+    "The model provider returned an error while answering. I retried automatically but it kept failing — please try again.",
+  model_billing_inactive:
+    "The configured model provider's billing is inactive, so I can't answer right now. This needs an operator to check the provider account.",
+  model_authentication_failed:
+    "The configured model provider rejected our credentials, so I can't answer right now. This needs an operator to check the provider API key.",
+  model_not_configured:
+    "No model is configured for this, so I can't answer right now. This needs an operator to set one up.",
+  model_not_found:
+    "The configured model couldn't be found by the provider, so I can't answer right now. This needs an operator to check the model configuration.",
+  iteration_limit:
+    "This took more steps than I'm allowed to run in one turn, so I stopped before finishing.",
+  tool_call_limit:
+    "This needed more tool calls than I'm allowed to make in one turn, so I stopped before finishing.",
+  budget_exhausted: "This turn used up its allotted budget before finishing.",
+  repair_budget_exhausted:
+    "I kept producing output that didn't fit what was needed, and ran out of attempts to fix it.",
+  input_request_failed: "I couldn't record the question I needed to ask — please try again.",
+  handoff_unavailable: "The agent this needed to hand off to isn't available right now.",
+  effect_after_report: "I ran into an internal ordering error while finishing this turn.",
+  empty_model_output: "The model provider returned nothing for this turn — please try again.",
+  needs_reconciliation: "This got stuck mid-run and needs to be retried — please try again.",
+  turn_execution_failed: "Something went wrong while running this turn — please try again.",
+};
+
+function failureMessageFor(reason?: string): string {
+  if (reason === undefined) return GENERIC_FAILURE_MESSAGE;
+  return FAILURE_MESSAGE_BY_REASON[reason] ?? GENERIC_FAILURE_MESSAGE;
+}
 
 interface ReplyResponse {
   status: "succeeded" | "failed" | "pending";
   text?: string;
   agentDisplayName?: string;
   blocks?: readonly Record<string, unknown>[];
+  reason?: string;
 }
 
 export interface DeliveryPollLoopDeps {
@@ -73,7 +110,8 @@ async function rotateStatus(
 
 async function markFailed(
   row: PersistedChannelRunDeliveryRecord,
-  deps: DeliveryPollLoopDeps
+  deps: DeliveryPollLoopDeps,
+  reason?: string
 ): Promise<void> {
   try {
     await deps.delivery.deliver(
@@ -86,7 +124,7 @@ async function markFailed(
         destination: row.destination,
         agentId: row.agentId,
         principalId: row.principalId,
-        text: FAILURE_MESSAGE,
+        text: failureMessageFor(reason),
         agentDisplayName: deps.agentDisplayName?.(row.agentId) ?? row.agentId,
         ...(row.threadId === undefined ? {} : { threadId: row.threadId }),
       },
@@ -104,7 +142,7 @@ async function deliverReply(
   deps: DeliveryPollLoopDeps
 ): Promise<void> {
   if (reply.status !== "succeeded") {
-    await markFailed(row, deps);
+    await markFailed(row, deps, reply.reason);
     return;
   }
   const agentDisplayName =
@@ -159,7 +197,12 @@ async function handleRow(
   }
 
   if (run.status !== "succeeded") {
-    await markFailed(row, deps);
+    // Best-effort: a completed attempt may have recorded a reason even though the Run itself
+    // ended failed/cancelled; a Run that never completed a Turn attempt has none to read.
+    const reply = await deps.internalApi
+      .find<ReplyResponse>("GET", `/api/v1/internal/channels/runs/${row.runId}/reply`, [404])
+      .catch(() => undefined);
+    await markFailed(row, deps, reply?.reason);
     return;
   }
 

--- a/apps/worker/src/internal/turn-host.test.ts
+++ b/apps/worker/src/internal/turn-host.test.ts
@@ -117,4 +117,44 @@ describe("HttpTurnHost", () => {
       messageId: "message-1",
     });
   });
+
+  it("forwards the failure reason and model diagnostic on a failed completion", async () => {
+    const bodies: string[] = [];
+    const { turns } = host((_url, init) => {
+      bodies.push(typeof init?.body === "string" ? init.body : "");
+      return json({});
+    });
+
+    await turns.completeTurn({
+      ...REF,
+      status: "failed",
+      cursor: 7,
+      messageId: null,
+      reason: "model_rate_limited",
+      modelFailure: { requestId: "req-1", modelId: "gpt-x" },
+    });
+
+    expect(JSON.parse(bodies[0] as string)).toEqual({
+      attempt: 2,
+      status: "failed",
+      cursor: 7,
+      messageId: null,
+      reason: "model_rate_limited",
+      modelFailure: { requestId: "req-1", modelId: "gpt-x" },
+    });
+  });
+
+  it("omits reason and modelFailure from the completion body when absent", async () => {
+    const bodies: string[] = [];
+    const { turns } = host((_url, init) => {
+      bodies.push(typeof init?.body === "string" ? init.body : "");
+      return json({});
+    });
+
+    await turns.completeTurn({ ...REF, status: "failed", cursor: 7, messageId: null });
+
+    const body = JSON.parse(bodies[0] as string);
+    expect(body).not.toHaveProperty("reason");
+    expect(body).not.toHaveProperty("modelFailure");
+  });
 });

--- a/apps/worker/src/internal/turn-host.ts
+++ b/apps/worker/src/internal/turn-host.ts
@@ -1,5 +1,6 @@
 import type {
   ExposedTool,
+  ModelFailureDiagnostic,
   ToolDispatchPort,
   ToolDispatchRequest,
   ToolDispatchResult,
@@ -242,6 +243,8 @@ export class HttpTurnHost
       cursor: number;
       messageId: string | null;
       surfaces?: readonly { artifactId: string; revision: number }[];
+      reason?: string;
+      modelFailure?: ModelFailureDiagnostic;
     }
   ): Promise<void> {
     await this.client.require("POST", turnPath(input.runId, "/completion"), {
@@ -250,6 +253,8 @@ export class HttpTurnHost
       cursor: input.cursor,
       messageId: input.messageId,
       ...(input.surfaces?.length ? { surfaces: input.surfaces } : {}),
+      ...(input.reason === undefined ? {} : { reason: input.reason }),
+      ...(input.modelFailure === undefined ? {} : { modelFailure: input.modelFailure }),
     });
   }
 }

--- a/apps/worker/src/model.test.ts
+++ b/apps/worker/src/model.test.ts
@@ -1263,7 +1263,7 @@ describe("LlmModelPort — a call the provider gate refused", () => {
       }),
     });
 
-  /** Not retryable, so the call fails once and opens the breaker at a known count. */
+  /** Rate-limited: retried in-process a bounded number of times before the breaker counts it. */
   const rateLimited = (): APICallError =>
     new APICallError({
       message: "http 429",
@@ -1329,7 +1329,10 @@ describe("LlmModelPort — a call the provider gate refused", () => {
     await expect(port().invoke(request())).resolves.toBeDefined();
     await expect(port().invoke(request())).resolves.toBeDefined();
 
-    expect(sonnet.doStreamCalls).toHaveLength(1);
+    // First invoke retries the rate-limited primary in-process (bounded) before the breaker
+    // counts one failure and the chain advances; the second invoke finds the breaker already
+    // open and never calls the primary again.
+    expect(sonnet.doStreamCalls).toHaveLength(3);
     expect(terra.doStreamCalls).toHaveLength(2);
   });
 

--- a/packages/llm/src/fallback.test.ts
+++ b/packages/llm/src/fallback.test.ts
@@ -92,6 +92,57 @@ describe("FallbackModel.doGenerate", () => {
     await expect(fallback.doGenerate(opts)).rejects.toBe(abort);
     expect(m2.doGenerate).not.toHaveBeenCalled();
   });
+
+  it("retries a rate-limited link in place instead of advancing to fallback", async () => {
+    vi.useFakeTimers();
+    try {
+      const result = {
+        text: "recovered",
+        finishReason: "stop",
+        usage: {},
+        rawCall: { rawPrompt: null, rawSettings: {} },
+      };
+      const doGenerate = vi
+        .fn()
+        .mockRejectedValueOnce(apiError(429, true))
+        .mockResolvedValueOnce(result);
+      const m1 = makeModel({ doGenerate });
+      const m2 = makeModel();
+      const fallback = new FallbackModel([m1, m2]);
+
+      const promise = fallback.doGenerate(opts);
+      await vi.runAllTimersAsync();
+      await expect(promise).resolves.toBe(result);
+      expect(doGenerate).toHaveBeenCalledTimes(2);
+      expect(m2.doGenerate).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("advances to fallback once rate-limit retries are exhausted", async () => {
+    vi.useFakeTimers();
+    try {
+      const result = {
+        text: "fallback",
+        finishReason: "stop",
+        usage: {},
+        rawCall: { rawPrompt: null, rawSettings: {} },
+      };
+      const doGenerate = vi.fn().mockRejectedValue(apiError(429, true));
+      const m1 = makeModel({ doGenerate });
+      const m2 = makeModel({ doGenerate: vi.fn().mockResolvedValue(result) });
+      const fallback = new FallbackModel([m1, m2]);
+
+      const promise = fallback.doGenerate(opts);
+      await vi.runAllTimersAsync();
+      await expect(promise).resolves.toBe(result);
+      // 1 initial attempt + 2 retries against the same link, then advance.
+      expect(doGenerate).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("FallbackModel.doStream", () => {

--- a/packages/llm/src/fallback.ts
+++ b/packages/llm/src/fallback.ts
@@ -42,6 +42,38 @@ export interface FallbackCallGate {
 
 const noopLogger: FallbackLogger = { warn() {} };
 
+/**
+ * Bounds retries against the *same* link for a rate-limited call, before it counts as a breaker
+ * failure and the chain advances. A 1-strike breaker (see `apps/worker/src/model-gate.ts`) turns a
+ * single 429 into a full 30s shutout of a provider that is otherwise healthy; a short backoff here
+ * gives a transient throttle a chance to clear without burning the link's one strike.
+ */
+const RATE_LIMIT_MAX_RETRIES = 2;
+const RATE_LIMIT_BASE_DELAY_MS = 1_000;
+const RATE_LIMIT_MAX_DELAY_MS = 8_000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Seconds or an HTTP-date, per RFC 9110 §10.2.3; only the seconds form is common in practice. */
+function retryAfterMs(err: unknown): number | undefined {
+  if (!APICallError.isInstance(err)) return undefined;
+  const header = err.responseHeaders?.["retry-after"];
+  if (header === undefined) return undefined;
+  const seconds = Number(header);
+  if (Number.isFinite(seconds)) return Math.max(0, seconds * 1_000);
+  const dateMs = Date.parse(header);
+  return Number.isNaN(dateMs) ? undefined : Math.max(0, dateMs - Date.now());
+}
+
+function rateLimitBackoffMs(err: unknown, attempt: number): number {
+  const fromHeader = retryAfterMs(err);
+  if (fromHeader !== undefined) return Math.min(fromHeader, RATE_LIMIT_MAX_DELAY_MS);
+  const exponential = RATE_LIMIT_BASE_DELAY_MS * 2 ** attempt;
+  return Math.min(exponential, RATE_LIMIT_MAX_DELAY_MS) + Math.random() * 250;
+}
+
 function isAbortError(err: unknown): boolean {
   return err instanceof Error && err.name === "AbortError";
 }
@@ -141,7 +173,7 @@ export class FallbackModel implements LanguageModelV4 {
         if ((lease !== undefined || this.gate === undefined) && this.attempted !== undefined) {
           this.attempted.modelId = model.modelId;
         }
-        const generated = await model.doGenerate(options);
+        const generated = await this.callWithRateLimitRetry(model, () => model.doGenerate(options));
         lease?.succeeded();
         this.commit(model);
         return generated;
@@ -158,6 +190,35 @@ export class FallbackModel implements LanguageModelV4 {
     throw lastError;
   }
 
+  /**
+   * Retries a rate-limited call against the same link before it is treated as a link failure.
+   * Any other error, or exhausting the retry budget, is rethrown unchanged for the caller's
+   * existing failure handling (breaker strike + advance to the next link).
+   */
+  private async callWithRateLimitRetry<T>(
+    model: LanguageModelV4,
+    call: () => PromiseLike<T>
+  ): Promise<T> {
+    for (let attempt = 0; ; attempt++) {
+      try {
+        return await call();
+      } catch (err) {
+        if (isHardFailure(err)) throw err;
+        if (
+          classifyProviderError(err) !== "model_rate_limited" ||
+          attempt >= RATE_LIMIT_MAX_RETRIES
+        ) {
+          throw err;
+        }
+        const delayMs = rateLimitBackoffMs(err, attempt);
+        this.logger.warn(
+          `[llm] rate limited, retrying provider=${model.provider} model=${model.modelId} attempt=${attempt + 1}/${RATE_LIMIT_MAX_RETRIES} delayMs=${Math.round(delayMs)}`
+        );
+        await sleep(delayMs);
+      }
+    }
+  }
+
   async doStream(options: LanguageModelV4CallOptions) {
     let lastError: unknown;
     for (const [index, model] of this.models.entries()) {
@@ -168,7 +229,7 @@ export class FallbackModel implements LanguageModelV4 {
         if ((lease !== undefined || this.gate === undefined) && this.attempted !== undefined) {
           this.attempted.modelId = model.modelId;
         }
-        result = await model.doStream(options);
+        result = await this.callWithRateLimitRetry(model, () => model.doStream(options));
       } catch (err) {
         if (isHardFailure(err)) {
           lease?.release();

--- a/packages/turn-executor/src/conversation-turn.ts
+++ b/packages/turn-executor/src/conversation-turn.ts
@@ -44,6 +44,9 @@ export interface TurnCompletionStore {
       messageId: string | null;
       conversationId?: string;
       surfaces?: readonly TurnSurfaceLink[];
+      /** Bounded, participant-safe failure evidence; absent for a succeeded completion. */
+      reason?: string;
+      modelFailure?: ModelFailureDiagnostic;
     }
   ): Promise<void>;
 }
@@ -135,6 +138,10 @@ export class ConversationTurnCompleter {
         status: "failed",
         cursor: input.cursor,
         messageId: null,
+        reason: input.outcome.reason,
+        ...(input.outcome.modelFailure === undefined
+          ? {}
+          : { modelFailure: input.outcome.modelFailure }),
       });
       return {
         status: "failed",


### PR DESCRIPTION
## Summary
- Retry a rate-limited LLM call (up to 2x, header-driven/exponential backoff) before advancing fallback, instead of immediately tripping the local circuit breaker on a single transient 429.
- Thread the real Turn failure reason (bounded, participant-safe — no raw provider text) end-to-end from the agent loop through turn-executor, worker, API (`turn_completions` migration 84), and the Slack reply route, replacing the single generic "Something went wrong" message with per-reason copy in the delivery poll loop.

Root cause: staging's LLM chain has exactly one provider per tier (Azure Foundry, no fallback), and the local breaker opened on the first 429 with no retry, so a single rate-limited call fully exhausted the Turn with no visible cause in Slack.

## Test plan
- [x] `pnpm --filter @tulipfarm/llm test fallback` — 30/30, including 2 new retry-behavior tests
- [x] `pnpm --filter @tulipfarm/api test src/conversations src/internal` — 235/235
- [x] `pnpm --filter @tulipfarm/worker test src/internal/turn-host` — 10/10
- [x] `pnpm --filter @tulipfarm/integration-worker test src/channels/delivery-poll-loop` — 10/10
- [x] `pnpm --filter @tulipfarm/api typecheck`, `@tulipfarm/worker typecheck`, `@tulipfarm/integration-worker typecheck`, `@tulipfarm/turn-executor typecheck` — all clean
- [x] `pnpm exec biome check` on all touched files — clean