### PR TITLE
feat(resources): dedup Records via idempotency key, fuzzy match, and x-unique

### DIFF
--- a/apps/api/src/resources/reconcile.pg.test.ts
+++ b/apps/api/src/resources/reconcile.pg.test.ts
@@ -1,12 +1,17 @@
 import { randomUUID } from "node:crypto";
 import { EventEmitter } from "node:events";
 import type { PGlite } from "@electric-sql/pglite";
+import type { SoulResource } from "@tulipfarm/soul";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { makeMigratedPglite } from "../test/pglite";
 import { reconcileResourceTables, registerResourceReconcile } from "./reconcile";
 
-function soulOf(...types: string[]): { resources: Map<string, unknown> } {
-  return { resources: new Map(types.map((t) => [t, {}])) };
+function fakeResource(schema: Record<string, unknown> = {}): SoulResource {
+  return { name: "test", schema, hasHooks: false, hooksEnabled: false };
+}
+
+function soulOf(...types: string[]): { resources: Map<string, SoulResource> } {
+  return { resources: new Map(types.map((t) => [t, fakeResource()])) };
 }
 
 async function insertResource(db: PGlite, type: string): Promise<void> {
@@ -62,6 +67,15 @@ describe("reconcileResourceTables", () => {
     await insertResource(db, "ticket");
     expect(await count(db, "ticket")).toBe(1);
   });
+
+  it("materializes an x-unique index that rejects a duplicate on the named field", async () => {
+    const soul = {
+      resources: new Map([["ticket", fakeResource({ "x-unique": [["title"]] })]]),
+    };
+    await reconcileResourceTables(db, soul);
+    await insertResource(db, "ticket");
+    await expect(insertResource(db, "ticket")).rejects.toThrow(/unique/i);
+  });
 });
 
 describe("registerResourceReconcile", () => {
@@ -76,9 +90,9 @@ describe("registerResourceReconcile", () => {
   it("reloads soul and reconciles tables on soul.synced", async () => {
     const gitSync = new EventEmitter();
     const soul = {
-      resources: new Map<string, unknown>(),
+      resources: new Map<string, SoulResource>(),
       reload: vi.fn(async () => {
-        soul.resources.set("ticket", {});
+        soul.resources.set("ticket", fakeResource());
       }),
     };
     const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };

--- a/apps/api/src/resources/reconcile.ts
+++ b/apps/api/src/resources/reconcile.ts
@@ -1,10 +1,11 @@
 import type { EventEmitter } from "node:events";
-import type { Logger } from "@tulipfarm/soul";
+import { getUniqueKeySpecs } from "@tulipfarm/schema";
+import type { Logger, SoulResource } from "@tulipfarm/soul";
 import type { Queryable } from "../db";
-import { createHistoryTableSql, createResourceTableSql } from "./schema";
+import { createHistoryTableSql, createResourceTableSql, uniqueIndexSql } from "./schema";
 
 interface ResourceTypes {
-  resources: Map<string, unknown>;
+  resources: Map<string, SoulResource>;
 }
 interface ReloadableResourceTypes extends ResourceTypes {
   reload(): Promise<void>;
@@ -20,12 +21,22 @@ export async function reconcileResourceTables(
   soul: ResourceTypes,
   logger?: Pick<Logger, "warn">
 ): Promise<void> {
-  for (const type of soul.resources.keys()) {
+  for (const [type, resource] of soul.resources) {
     try {
       await q.query(createResourceTableSql(type));
       await q.query(createHistoryTableSql(type));
     } catch (err) {
       logger?.warn(`[resources] reconcile skipped type "${type}": ${msg(err)}`);
+      continue;
+    }
+    for (const fields of getUniqueKeySpecs(resource.schema)) {
+      try {
+        await q.query(uniqueIndexSql(type, fields));
+      } catch (err) {
+        logger?.warn(
+          `[resources] x-unique index skipped for "${type}" (${fields.join(", ")}): ${msg(err)}`
+        );
+      }
     }
   }
 }

--- a/apps/api/src/resources/repo.ts
+++ b/apps/api/src/resources/repo.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { ResourceUniqueViolationError } from "@tulipfarm/resources";
 import type { CounterFn } from "@tulipfarm/schema";
 import { type PaginatedResult, toPage, withTransaction } from "@tulipfarm/storage";
 import type { Queryable } from "../db";
@@ -65,6 +66,16 @@ export interface ResourceRepo {
   ): Promise<boolean>;
   /** Optional so in-memory test doubles need not implement it; absent means "no totals". */
   stats?(): Promise<ResourceStats>;
+  /**
+   * Fuzzy text match on one `data` field (Postgres `pg_trgm` similarity), for catching
+   * near-duplicates an exact filter or `idempotencyKey` would miss (paraphrase, spelling drift).
+   * Optional so in-memory test doubles need not implement it.
+   */
+  similar?(
+    field: string,
+    text: string,
+    opts?: { threshold?: number; limit?: number }
+  ): Promise<{ doc: ResourceDoc; score: number }[]>;
   readonly durableSideEffects?: true;
 }
 
@@ -94,15 +105,17 @@ export class PgResourceRepo implements ResourceRepo {
 
   async insert(doc: ResourceDoc, sideEffect?: ResourceSideEffect): Promise<void> {
     const { _id, version, createdAt, updatedAt, deletedAt, ...data } = doc;
-    await withTransaction(this.q, async (tx) => {
-      await tx.query(
-        `INSERT INTO ${this.table} (id, version, created_at, updated_at, deleted_at, data)
-         VALUES ($1, $2, $3, $4, $5, $6::jsonb)`,
-        [_id, version, createdAt, updatedAt, deletedAt ?? null, JSON.stringify(data)]
-      );
-      await this.appendHistory(tx, historyEntry(_id, "create", doc));
-      if (sideEffect) await writeResourceSideEffect(tx, randomUUID(), sideEffect);
-    });
+    await withUniqueTranslation(() =>
+      withTransaction(this.q, async (tx) => {
+        await tx.query(
+          `INSERT INTO ${this.table} (id, version, created_at, updated_at, deleted_at, data)
+           VALUES ($1, $2, $3, $4, $5, $6::jsonb)`,
+          [_id, version, createdAt, updatedAt, deletedAt ?? null, JSON.stringify(data)]
+        );
+        await this.appendHistory(tx, historyEntry(_id, "create", doc));
+        if (sideEffect) await writeResourceSideEffect(tx, randomUUID(), sideEffect);
+      })
+    );
   }
 
   async createIdempotently(
@@ -110,39 +123,41 @@ export class PgResourceRepo implements ResourceRepo {
     idempotencyKey: string,
     sideEffect: ResourceSideEffect
   ): Promise<{ readonly created: boolean; readonly doc: ResourceDoc }> {
-    return withTransaction(this.q, async (tx) => {
-      const claimed = await tx.query<{ resource_id: string }>(
-        `INSERT INTO resource_create_requests (resource_type, caller_id, idempotency_key, resource_id)
+    return withUniqueTranslation(() =>
+      withTransaction(this.q, async (tx) => {
+        const claimed = await tx.query<{ resource_id: string }>(
+          `INSERT INTO resource_create_requests (resource_type, caller_id, idempotency_key, resource_id)
          VALUES ($1, $2, $3, $4)
          ON CONFLICT (resource_type, caller_id, idempotency_key) DO NOTHING
          RETURNING resource_id`,
-        [this.type, sideEffect.actorId ?? "system", idempotencyKey, doc._id]
-      );
-      if (claimed.rows.length === 0) {
-        const existing = await tx.query(
-          `SELECT id, version, created_at, updated_at, deleted_at, data
+          [this.type, sideEffect.actorId ?? "system", idempotencyKey, doc._id]
+        );
+        if (claimed.rows.length === 0) {
+          const existing = await tx.query(
+            `SELECT id, version, created_at, updated_at, deleted_at, data
              FROM ${this.table}
             WHERE id = (
               SELECT resource_id FROM resource_create_requests
                WHERE resource_type = $1 AND caller_id = $2 AND idempotency_key = $3
             )`,
-          [this.type, sideEffect.actorId ?? "system", idempotencyKey]
-        );
-        const row = existing.rows[0];
-        if (!row) throw new Error("resource_idempotency_conflict_without_record");
-        return { created: false, doc: rowToResourceDoc(row) };
-      }
+            [this.type, sideEffect.actorId ?? "system", idempotencyKey]
+          );
+          const row = existing.rows[0];
+          if (!row) throw new Error("resource_idempotency_conflict_without_record");
+          return { created: false, doc: rowToResourceDoc(row) };
+        }
 
-      const { _id, version, createdAt, updatedAt, deletedAt, ...data } = doc;
-      await tx.query(
-        `INSERT INTO ${this.table} (id, version, created_at, updated_at, deleted_at, data)
+        const { _id, version, createdAt, updatedAt, deletedAt, ...data } = doc;
+        await tx.query(
+          `INSERT INTO ${this.table} (id, version, created_at, updated_at, deleted_at, data)
          VALUES ($1, $2, $3, $4, $5, $6::jsonb)`,
-        [_id, version, createdAt, updatedAt, deletedAt ?? null, JSON.stringify(data)]
-      );
-      await this.appendHistory(tx, historyEntry(_id, "create", doc));
-      await writeResourceSideEffect(tx, randomUUID(), sideEffect);
-      return { created: true, doc };
-    });
+          [_id, version, createdAt, updatedAt, deletedAt ?? null, JSON.stringify(data)]
+        );
+        await this.appendHistory(tx, historyEntry(_id, "create", doc));
+        await writeResourceSideEffect(tx, randomUUID(), sideEffect);
+        return { created: true, doc };
+      })
+    );
   }
 
   async findById(id: string): Promise<ResourceDoc | null> {
@@ -203,19 +218,43 @@ export class PgResourceRepo implements ResourceRepo {
   ): Promise<boolean> {
     if (!UUID_RE.test(id)) return false;
     const { _id, version, createdAt, updatedAt, deletedAt, ...data } = doc;
-    return withTransaction(this.q, async (tx) => {
-      const { rows } = await tx.query(
-        `UPDATE ${this.table}
-         SET version = $1, created_at = $2, updated_at = $3, deleted_at = $4, data = $5::jsonb
-         WHERE id = $6 AND version = $7
-         RETURNING id`,
-        [version, createdAt, updatedAt, deletedAt ?? null, JSON.stringify(data), id, expected]
-      );
-      if (rows.length !== 1) return false;
-      await this.appendHistory(tx, historyEntry(id, op, doc));
-      if (sideEffect) await writeResourceSideEffect(tx, randomUUID(), sideEffect);
-      return true;
-    });
+    return withUniqueTranslation(() =>
+      withTransaction(this.q, async (tx) => {
+        const { rows } = await tx.query(
+          `UPDATE ${this.table}
+           SET version = $1, created_at = $2, updated_at = $3, deleted_at = $4, data = $5::jsonb
+           WHERE id = $6 AND version = $7
+           RETURNING id`,
+          [version, createdAt, updatedAt, deletedAt ?? null, JSON.stringify(data), id, expected]
+        );
+        if (rows.length !== 1) return false;
+        await this.appendHistory(tx, historyEntry(id, op, doc));
+        if (sideEffect) await writeResourceSideEffect(tx, randomUUID(), sideEffect);
+        return true;
+      })
+    );
+  }
+
+  async similar(
+    field: string,
+    text: string,
+    opts?: { threshold?: number; limit?: number }
+  ): Promise<{ doc: ResourceDoc; score: number }[]> {
+    const threshold = opts?.threshold ?? 0.35;
+    const limit = opts?.limit ?? 10;
+    const { rows } = await this.q.query(
+      `SELECT id, version, created_at, updated_at, deleted_at, data,
+              similarity(data->>$1, $2) AS score
+         FROM ${this.table}
+        WHERE deleted_at IS NULL AND similarity(data->>$1, $2) >= $3
+        ORDER BY score DESC
+        LIMIT $4`,
+      [field, text, threshold, limit]
+    );
+    return rows.map((row) => ({
+      doc: rowToResourceDoc(row),
+      score: Number((row as { score: number | string }).score),
+    }));
   }
 
   async stats(): Promise<ResourceStats> {
@@ -281,4 +320,16 @@ export function toApiRecord(doc: ResourceDoc): Record<string, unknown> {
 
 function historyEntry(resourceId: string, operation: HistoryOp, snapshot: ResourceDoc) {
   return { _id: randomUUID(), resourceId, operation, snapshot, at: new Date() };
+}
+
+/** Runs `fn`, translating a Postgres unique_violation (23505) into `ResourceUniqueViolationError`. */
+async function withUniqueTranslation<T>(fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (err) {
+    if (err instanceof Error && (err as { code?: string }).code === "23505") {
+      throw new ResourceUniqueViolationError("duplicate value violates a unique constraint");
+    }
+    throw err;
+  }
 }

--- a/apps/api/src/resources/routes.ts
+++ b/apps/api/src/resources/routes.ts
@@ -204,6 +204,7 @@ export function registerResourceRoutes(
           400: ErrorSchema,
           403: ErrorSchema,
           404: ErrorSchema,
+          409: ErrorSchema,
           422: ValidationErrorSchema,
           401: ErrorSchema,
         },

--- a/apps/api/src/resources/schema.ts
+++ b/apps/api/src/resources/schema.ts
@@ -1,12 +1,23 @@
+import { createHash } from "node:crypto";
 import type { ResourceDoc } from "./repo";
 
-// Re-check type names before SQL interpolation and quote them; resources live in their own schema.
+// Re-check type and field names before SQL interpolation and quote them; resources live in their
+// own schema, and `x-unique` field names come from Soul-authored YAML, not a trusted constant.
 
 const TYPE_RE = /^[a-z][a-z0-9-]*$/;
+const FIELD_RE = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 
 export function assertValidType(type: string): void {
   if (!TYPE_RE.test(type)) {
     throw new Error(`invalid resource type name: ${JSON.stringify(type)}`);
+  }
+}
+
+export function assertValidFields(fields: readonly string[]): void {
+  for (const field of fields) {
+    if (!FIELD_RE.test(field)) {
+      throw new Error(`invalid unique field name: ${JSON.stringify(field)}`);
+    }
   }
 }
 
@@ -40,6 +51,24 @@ export function createHistoryTableSql(type: string): string {
     snapshot    jsonb NOT NULL,
     at          timestamptz NOT NULL
   )`;
+}
+
+/** Deterministic, length-safe index name; field names are not embedded (avoids ident limits). */
+function uniqueIndexName(type: string, fields: readonly string[]): string {
+  const hash = createHash("sha256").update(fields.join(" ")).digest("hex").slice(0, 12);
+  return `uniq_${type.replace(/-/g, "_")}_${hash}`;
+}
+
+/**
+ * Idempotent DDL enforcing one `x-unique` entry: a partial unique index over the named `data`
+ * fields, live rows only. A real constraint, unlike `idempotencyKey` — it holds across callers.
+ */
+export function uniqueIndexSql(type: string, fields: readonly string[]): string {
+  assertValidType(type);
+  assertValidFields(fields);
+  const name = uniqueIndexName(type, fields);
+  const expr = fields.map((f) => `(data->>'${f}')`).join(", ");
+  return `CREATE UNIQUE INDEX IF NOT EXISTS "${name}" ON ${tableName(type)} (${expr}) WHERE deleted_at IS NULL`;
 }
 
 /** Spread data first so row system columns remain authoritative. */

--- a/apps/api/src/resources/tools.ts
+++ b/apps/api/src/resources/tools.ts
@@ -109,6 +109,14 @@ const CREATE_SCHEMA = {
   properties: {
     type: { type: "string", minLength: 1, description: "Resource type name (e.g. 'ticket')." },
     data: { type: "object", additionalProperties: true, description: "Record fields." },
+    idempotencyKey: {
+      type: "string",
+      minLength: 1,
+      description:
+        "Stable dedupe key, e.g. a hash of the record's identifying fields. A repeat call with " +
+        "the same type + idempotencyKey returns the existing record instead of creating a " +
+        "duplicate. Use this for any record an Agent creates on a repeating schedule.",
+    },
   },
 } as const;
 
@@ -174,12 +182,39 @@ const SEARCH_SCHEMA = {
   },
 } as const;
 
+const SIMILAR_SCHEMA = {
+  type: "object",
+  required: ["type", "field", "text"],
+  additionalProperties: false,
+  properties: {
+    type: { type: "string", minLength: 1 },
+    field: {
+      type: "string",
+      minLength: 1,
+      description: "Data field to compare (e.g. 'quoteText').",
+    },
+    text: {
+      type: "string",
+      minLength: 1,
+      description: "Candidate text to check for near-duplicates against existing records.",
+    },
+    threshold: {
+      type: "number",
+      minimum: 0,
+      maximum: 1,
+      description: "Similarity cutoff, 0-1 (default 0.35). Lower catches more paraphrasing.",
+    },
+    limit: { type: "number", minimum: 1, maximum: 50 },
+  },
+} as const;
+
 const validateCreate = ajv.compile(CREATE_SCHEMA);
 const validateList = ajv.compile(LIST_SCHEMA);
 const validateGet = ajv.compile(GET_SCHEMA);
 const validateUpdate = ajv.compile(UPDATE_SCHEMA);
 const validateDelete = ajv.compile(DELETE_SCHEMA);
 const validateSearch = ajv.compile(SEARCH_SCHEMA);
+const validateSimilar = ajv.compile(SIMILAR_SCHEMA);
 
 const resourceCreate = defineApiTool<ResourceToolContext>({
   name: "record_create",
@@ -196,16 +231,26 @@ const resourceCreate = defineApiTool<ResourceToolContext>({
   },
   handler: async (args, ctx) => {
     if (!validateCreate(args)) return err("validation_error", firstError(validateCreate.errors));
-    const { type, data: rawData } = args as { type: string; data: Record<string, unknown> };
+    const {
+      type,
+      data: rawData,
+      idempotencyKey,
+    } = args as {
+      type: string;
+      data: Record<string, unknown>;
+      idempotencyKey?: string;
+    };
 
     const resourceDef = ctx.soulLoader.resources.get(type);
     if (!resourceDef) return err("not_found", `resource type not found: ${type}`);
 
     try {
       const created = await createRecord(
-        { type, resource: resourceDef, data: rawData },
+        { type, resource: resourceDef, data: rawData, idempotencyKey },
         resourceWritePorts(ctx)
       );
+      // No dedicated ToolErrorCode for 409: a unique-constraint violation is still "change your
+      // input and retry", so it maps onto validation_error like the 422 case beside it.
       if (!created.ok) return err("validation_error", created.err.body.error);
       if (!created.replayed) {
         await deliverImmediatelyWhenUndurable(
@@ -423,6 +468,52 @@ const resourceSearch = defineApiTool<ResourceToolContext>({
   },
 });
 
+const resourceFindSimilar = defineApiTool<ResourceToolContext>({
+  name: "record_find_similar",
+  description:
+    "Find records of a resource type whose given field is textually similar to the given text " +
+    "(fuzzy match, not exact). Call this before creating a record on a repeating or scheduled " +
+    "task to catch near-duplicates that differ only in spelling, phrasing, or word order — " +
+    "record_search only matches exact field values and will miss those.",
+  mutating: false,
+  tier: "system",
+  inputSchema: SIMILAR_SCHEMA,
+  authorization: {
+    // Deliberately same authority as record_list/record_search: all reveal records of one type.
+    action: "record.list",
+    resources: ["record"],
+    targets: recordTypeTargets,
+    dataClasses: ["business_record"],
+  },
+  handler: async (args, ctx) => {
+    if (!validateSimilar(args)) return err("validation_error", firstError(validateSimilar.errors));
+    const a = args as {
+      type: string;
+      field: string;
+      text: string;
+      threshold?: number;
+      limit?: number;
+    };
+
+    if (!ctx.soulLoader.resources.has(a.type))
+      return err("not_found", `resource type not found: ${a.type}`);
+
+    try {
+      const repo = ctx.repoFactory.forType(a.type);
+      if (!repo.similar) return err("internal_error", "similarity search not supported");
+      const matches = await repo.similar(a.field, a.text, {
+        threshold: a.threshold,
+        limit: a.limit,
+      });
+      return ok({
+        items: matches.map((m) => ({ ...toApiRecord(m.doc), similarity: m.score })),
+      });
+    } catch (e) {
+      return err("internal_error", reason(e));
+    }
+  },
+});
+
 export const RESOURCE_TOOLS: ApiToolDefinition<ResourceToolContext>[] = [
   resourceCreate,
   resourceList,
@@ -430,4 +521,5 @@ export const RESOURCE_TOOLS: ApiToolDefinition<ResourceToolContext>[] = [
   resourceUpdate,
   resourceDelete,
   resourceSearch,
+  resourceFindSimilar,
 ];

--- a/apps/api/src/tools/contract-coverage.test.ts
+++ b/apps/api/src/tools/contract-coverage.test.ts
@@ -78,6 +78,7 @@ const EXPECTED_FAMILY_TOOL_NAMES = [
     names: [
       "record_create",
       "record_delete",
+      "record_find_similar",
       "record_get",
       "record_list",
       "record_search",

--- a/packages/resources/src/index.ts
+++ b/packages/resources/src/index.ts
@@ -8,6 +8,7 @@ export {
   type ResourceDoc,
   type ResourceRepo,
   type ResourceRepoFactory,
+  ResourceUniqueViolationError,
   type ResourceWriteError,
   type ResourceWritePorts,
   type ResourceWriteResult,

--- a/packages/resources/src/service.ts
+++ b/packages/resources/src/service.ts
@@ -57,6 +57,9 @@ export interface ResourceBeforeHook {
 /** A hook adapter uses this only for a controlled hook rejection. */
 export class ResourceBeforeHookError extends Error {}
 
+/** A repo throws this when a write violates a schema-declared `x-unique` constraint. */
+export class ResourceUniqueViolationError extends Error {}
+
 export interface ResourceWritePorts {
   readonly catalog: ResourceCatalog;
   readonly repositories: ResourceRepoFactory;
@@ -89,7 +92,7 @@ type CreateRecordResult =
       replayed: boolean;
       repo: ResourceRepo;
     }
-  | { ok: false; err: ResourceWriteError<422> };
+  | { ok: false; err: ResourceWriteError<409 | 422> };
 
 export async function createRecord(
   input: {
@@ -113,12 +116,17 @@ export async function createRecord(
   };
   const repo = ports.repositories.forType(input.type);
   const sideEffect = resourceSideEffect("create", input.resource, input.type, doc, input.actorId);
-  if (input.idempotencyKey !== undefined && repo.createIdempotently) {
-    const outcome = await repo.createIdempotently(doc, input.idempotencyKey, sideEffect);
-    return { ok: true, doc: outcome.doc, sideEffect, replayed: !outcome.created, repo };
+  try {
+    if (input.idempotencyKey !== undefined && repo.createIdempotently) {
+      const outcome = await repo.createIdempotently(doc, input.idempotencyKey, sideEffect);
+      return { ok: true, doc: outcome.doc, sideEffect, replayed: !outcome.created, repo };
+    }
+    await repo.insert(doc, sideEffect);
+    return { ok: true, doc, sideEffect, replayed: false, repo };
+  } catch (err) {
+    if (err instanceof ResourceUniqueViolationError) return uniqueViolation(err);
+    throw err;
   }
-  await repo.insert(doc, sideEffect);
-  return { ok: true, doc, sideEffect, replayed: false, repo };
 }
 
 export async function updateRecord(
@@ -149,7 +157,13 @@ export async function updateRecord(
     ...prepared.data,
   };
   const sideEffect = resourceSideEffect("update", input.resource, input.type, doc, input.actorId);
-  const updated = await repo.replaceOne(input.id, existing.doc.version, doc, "update", sideEffect);
+  let updated: boolean;
+  try {
+    updated = await repo.replaceOne(input.id, existing.doc.version, doc, "update", sideEffect);
+  } catch (err) {
+    if (err instanceof ResourceUniqueViolationError) return uniqueViolation(err);
+    throw err;
+  }
   if (!updated) return conflict();
   return { ok: true, doc, sideEffect, replayed: false, repo };
 }
@@ -418,4 +432,11 @@ function validationError(error: TulipFarmValidationError): ResourceWriteError["b
 
 function conflict(): { ok: false; err: ResourceWriteError<409> } {
   return { ok: false, err: { code: 409, body: { error: "version conflict" } } };
+}
+
+function uniqueViolation(err: ResourceUniqueViolationError): {
+  ok: false;
+  err: ResourceWriteError<409>;
+} {
+  return { ok: false, err: { code: 409, body: { error: err.message } } };
 }

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -287,10 +287,11 @@ export {
 } from "./skill-tool-schemas";
 export type { FilesConfig, SoulConfig } from "./soul-config";
 export { FilesConfigSchema, SoulConfigSchema, validateSoulConfig } from "./soul-config";
-export type { CounterFn } from "./transforms";
+export type { CounterFn, UniqueKeySpec } from "./transforms";
 export {
   applyTransforms,
   COMPUTED_FN_KEYS,
+  getUniqueKeySpecs,
   NORMALIZER_KEYS,
   validateResourceSchema,
 } from "./transforms";

--- a/packages/schema/src/transforms/apply.test.ts
+++ b/packages/schema/src/transforms/apply.test.ts
@@ -176,6 +176,46 @@ describe("validateResourceSchema", () => {
     ).toThrow(TulipFarmValidationError);
   });
 
+  it("accepts x-unique naming declared fields, single and combined", () => {
+    expect(() =>
+      validateResourceSchema({
+        "x-unique": [["email"], ["firstName", "lastName"]],
+        properties: {
+          email: { type: "string" },
+          firstName: { type: "string" },
+          lastName: { type: "string" },
+        },
+      })
+    ).not.toThrow();
+  });
+
+  it("rejects x-unique naming an undeclared field", () => {
+    expect(() =>
+      validateResourceSchema({
+        "x-unique": [["ghost"]],
+        properties: { email: { type: "string" } },
+      })
+    ).toThrow(TulipFarmValidationError);
+  });
+
+  it("rejects an empty x-unique entry", () => {
+    expect(() =>
+      validateResourceSchema({
+        "x-unique": [[]],
+        properties: {},
+      })
+    ).toThrow(TulipFarmValidationError);
+  });
+
+  it("rejects x-unique that is not an array", () => {
+    expect(() =>
+      validateResourceSchema({
+        "x-unique": "email",
+        properties: { email: { type: "string" } },
+      })
+    ).toThrow(TulipFarmValidationError);
+  });
+
   it("error carries boundary=resource", () => {
     try {
       validateResourceSchema({

--- a/packages/schema/src/transforms/index.ts
+++ b/packages/schema/src/transforms/index.ts
@@ -2,4 +2,6 @@ export { applyTransforms } from "./apply";
 export type { CounterFn } from "./computed";
 export { COMPUTED_FN_KEYS, isComputedFnKey } from "./computed";
 export { isNormalizerKey, NORMALIZER_KEYS } from "./normalizers";
+export type { UniqueKeySpec } from "./unique";
+export { getUniqueKeySpecs } from "./unique";
 export { validateResourceSchema } from "./validate-schema";

--- a/packages/schema/src/transforms/unique.ts
+++ b/packages/schema/src/transforms/unique.ts
@@ -1,0 +1,11 @@
+/** One `x-unique` entry: a single column, or a combination that together must be unique. */
+export type UniqueKeySpec = readonly string[];
+
+export function getUniqueKeySpecs(schema: Record<string, unknown>): UniqueKeySpec[] {
+  const raw = schema["x-unique"];
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(
+    (spec): spec is string[] =>
+      Array.isArray(spec) && spec.length > 0 && spec.every((f) => typeof f === "string")
+  );
+}

--- a/packages/schema/src/transforms/validate-schema.ts
+++ b/packages/schema/src/transforms/validate-schema.ts
@@ -60,4 +60,34 @@ export function validateResourceSchema(schema: Record<string, unknown>): void {
       );
     }
   }
+
+  // Validate x-unique: an array of non-empty field-name arrays, each naming declared properties.
+  const uniqueRaw = schema["x-unique"];
+  if (uniqueRaw !== undefined) {
+    if (!Array.isArray(uniqueRaw)) {
+      throw new TulipFarmValidationError("resource", "/x-unique", "x-unique must be an array");
+    }
+    for (const [i, spec] of uniqueRaw.entries()) {
+      if (
+        !Array.isArray(spec) ||
+        spec.length === 0 ||
+        !spec.every((f) => typeof f === "string" && f.length > 0)
+      ) {
+        throw new TulipFarmValidationError(
+          "resource",
+          `/x-unique/${i}`,
+          "each x-unique entry must be a non-empty array of field names"
+        );
+      }
+      for (const field of spec) {
+        if (!(field in properties)) {
+          throw new TulipFarmValidationError(
+            "resource",
+            `/x-unique/${i}`,
+            `unknown field in x-unique: "${field}"`
+          );
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- Expose `idempotencyKey` support on `record_create` (existing capability, now reachable from Chat).
- Add `record_find_similar` tool: fuzzy/semantic near-duplicate check via Postgres `pg_trgm`.
- Add `x-unique` schema keyword: single or composite field uniqueness, enforced by a real Postgres partial unique index (materialized on `reconcileResourceTables`). A violating write returns `409`.

## Test plan
- [x] `pnpm --filter @tulipfarm/api test src/resources` — 114/114 pass, incl. new PGlite test proving a second insert against an `x-unique` field is rejected
- [x] `pnpm --filter @tulipfarm/resources test` — 3/3 pass
- [x] `pnpm --filter @tulipfarm/schema test` — 459/459 pass, incl. 4 new `x-unique` schema-load validation cases
- [x] `pnpm lint` / `pnpm typecheck` — clean (repo-wide)