### PR TITLE
feat(slack): react to acknowledge and supersede an in-flight reply

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1408,6 +1408,7 @@ async function boot() {
         }),
         runDeliveries: channelRunDeliveries,
         toolApprovals,
+        cancelRun: runCancel,
         surfaceStore: surfaceArtifactStore,
         surfaceActionStore,
         secrets: secretsService,

--- a/apps/api/src/internal/channel-routes.test.ts
+++ b/apps/api/src/internal/channel-routes.test.ts
@@ -77,6 +77,7 @@ describe("/api/v1/internal/channels", () => {
   let sessionCookie: string;
   let apiClientRepo: MemoryApiClientRepo;
   let runDeliveries: ChannelRunDeliveryStore;
+  let cancelled: { businessId: string; runId: string; reason: string }[];
   let surfaceStore: MemorySurfaceArtifactStore;
   let surfaceActionStore: MemorySurfaceActionStore;
 
@@ -123,6 +124,7 @@ describe("/api/v1/internal/channels", () => {
       waits: new DurableWaitManager(new WaitStore(transactions), new RunResumeGateway(runs)),
     });
     runDeliveries = new ChannelRunDeliveryStore(transactions, () => new Date().toISOString());
+    cancelled = [];
     surfaceStore = new MemorySurfaceArtifactStore();
     surfaceActionStore = new MemorySurfaceActionStore();
 
@@ -150,6 +152,12 @@ describe("/api/v1/internal/channels", () => {
         }),
         runDeliveries,
         toolApprovals,
+        cancelRun: {
+          cancel: async (input) => {
+            cancelled.push(input);
+            return true;
+          },
+        },
         surfaceStore,
         surfaceActionStore,
         bindLinkUrl: (token) => `http://localhost:4000/link-channel?token=${token}`,
@@ -378,6 +386,110 @@ describe("/api/v1/internal/channels", () => {
       expect(second.statusCode).toBe(200);
       expect(second.json()).toEqual({ runId: first.json().runId, outcome: "duplicate" });
       expect(store.turns).toHaveLength(1);
+    });
+
+    it("supersedes the Run still in flight when a second message lands in the same thread", async () => {
+      const first = await app.inject({
+        method: "POST",
+        url: "/api/v1/internal/channels/runs",
+        headers: asWorker(),
+        payload: runBody(),
+      });
+      const firstRunId = first.json().runId;
+
+      await app.inject({
+        method: "POST",
+        url: "/api/v1/internal/channels/runs",
+        headers: asWorker(),
+        payload: { ...runBody(), message: { ...runBody().message, text: "and the weather?" } },
+      });
+
+      expect(cancelled).toEqual([
+        {
+          businessId: DEPLOYMENT_BUSINESS_ID,
+          runId: firstRunId,
+          reason: "superseded by a newer message in the same thread",
+        },
+      ]);
+      expect((await runDeliveries.find(DEPLOYMENT_BUSINESS_ID, firstRunId))?.status).toBe(
+        "superseded"
+      );
+      // Both messages are on one Conversation, so the surviving Run still sees the first text.
+      expect(store.turns).toHaveLength(2);
+    });
+
+    it("does not supersede across threads", async () => {
+      await app.inject({
+        method: "POST",
+        url: "/api/v1/internal/channels/runs",
+        headers: asWorker(),
+        payload: runBody(),
+      });
+      await app.inject({
+        method: "POST",
+        url: "/api/v1/internal/channels/runs",
+        headers: asWorker(),
+        payload: {
+          ...runBody(),
+          message: { ...runBody().message, threadId: "1720000000.000200", text: "elsewhere" },
+        },
+      });
+
+      expect(cancelled).toEqual([]);
+    });
+
+    it("leaves a Run parked on an approval alone, so its buttons are not stranded", async () => {
+      const first = await app.inject({
+        method: "POST",
+        url: "/api/v1/internal/channels/runs",
+        headers: asWorker(),
+        payload: runBody(),
+      });
+      const decision = await toolApprovals.decide({
+        businessId: DEPLOYMENT_BUSINESS_ID,
+        runId: first.json().runId,
+        toolCallId: "call-1",
+        toolName: "record_delete",
+        args: { id: "record-1" },
+        requesterPrincipalId: "user:requester-1",
+        demand: {
+          demandedBy: "guardrail_rule",
+          guardrailRevision: "gr-1",
+          reason: "approval_required",
+          ruleId: "rule-1",
+        },
+      });
+      if (decision.status !== "pending") throw new Error("expected a pending approval");
+
+      await app.inject({
+        method: "POST",
+        url: "/api/v1/internal/channels/runs",
+        headers: asWorker(),
+        payload: { ...runBody(), message: { ...runBody().message, text: "second" } },
+      });
+
+      expect(cancelled).toEqual([]);
+      expect((await runDeliveries.find(DEPLOYMENT_BUSINESS_ID, first.json().runId))?.status).toBe(
+        "pending"
+      );
+    });
+
+    it("never cancels the Run a redelivered event is a replay of", async () => {
+      const body = runBody();
+      await app.inject({
+        method: "POST",
+        url: "/api/v1/internal/channels/runs",
+        headers: asWorker(),
+        payload: body,
+      });
+      await app.inject({
+        method: "POST",
+        url: "/api/v1/internal/channels/runs",
+        headers: asWorker(),
+        payload: body,
+      });
+
+      expect(cancelled).toEqual([]);
     });
 
     it("maps the same external thread to the same Conversation across messages", async () => {

--- a/apps/api/src/internal/channel-routes.ts
+++ b/apps/api/src/internal/channel-routes.ts
@@ -11,6 +11,7 @@ import type { ToolApprovalService } from "@tulipfarm/tool-host";
 import type { FastifyBaseLogger, FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { ErrorSchema } from "../auth/schemas";
 import type { ConversationRepo } from "../chat/conversations";
+import type { ChatRunCanceller } from "../chat/routes";
 import { durableTurnSubmitter } from "../chat/turn-submit";
 import type { ChatTurnPrincipal } from "../conversations/chat-turns";
 import type { ConversationStore } from "../conversations/service";
@@ -46,6 +47,11 @@ export interface ChannelInternalRouteDeps {
   readonly secrets?: ChannelCredentialSecretStore;
   /** Resolves an Agent label for `.../reply`'s `agentDisplayName`. */
   readonly soulLoader?: SoulLoader;
+  /**
+   * Stops the Run a newer message in the same thread has taken over. Omitted leaves every message
+   * answered separately — the pre-supersede behaviour — rather than failing the mint.
+   */
+  readonly cancelRun?: ChatRunCanceller;
   readonly newId?: () => string;
   /** Bind links must point at the web origin, not the API host. */
   readonly bindLinkUrl: (token: string) => string;
@@ -55,6 +61,8 @@ interface ChannelMessageBody {
   externalAppId: string;
   channelId: string;
   threadId?: string;
+  /** The provider message this Run answers, which is what a reaction must be applied to. */
+  sourceMessageTs?: string;
   text: string;
 }
 
@@ -129,6 +137,56 @@ export async function slackBlocksForReply(
       "slack surface render failed; replying with text and no action controls"
     );
     return { outcome: "render_failed" };
+  }
+}
+
+/**
+ * Retires the Run still answering an earlier message in this same thread, so two messages sent
+ * back-to-back produce one reply instead of two.
+ *
+ * This is safe to do without merging any text: `startTurn` writes the user Message durably before
+ * dispatch (`../chat/turn-submit.ts`), so cancelling the earlier Run leaves its message in the
+ * Conversation. The newer Turn therefore already sees it as history and answers both.
+ *
+ * Best-effort throughout. Nothing here may prevent the new Turn from being minted — the failure
+ * mode of doing nothing is the old double reply, which is strictly better than not answering.
+ */
+async function supersedeInFlightThreadRun(
+  deps: ChannelInternalRouteDeps,
+  input: {
+    businessId: string;
+    provider: string;
+    destination: string;
+    threadId: string;
+    excludeRunId?: string;
+  },
+  log: FastifyBaseLogger
+): Promise<void> {
+  if (deps.cancelRun === undefined) return;
+  try {
+    const inFlight = await deps.runDeliveries.findInFlightForThread(input);
+    if (inFlight === null) return;
+
+    // A Run parked on an approval has already posted Approve/Deny buttons into the thread.
+    // Cancelling it would strand that prompt on a decision nobody can act on, so this one case
+    // keeps both replies. Two answers beat a dead control.
+    const pendingApproval = await deps.toolApprovals
+      .pendingForRun(inFlight.runId)
+      .catch(() => null);
+    if (pendingApproval !== null) return;
+
+    // Retire the delivery first: it is the authority on whether the reply gets posted, and it is
+    // conditional on `pending`, so a poller that already claimed the row wins and we leave the
+    // Run alone. Cancelling a Run whose reply is already going out would waste the answer.
+    if (!(await deps.runDeliveries.markSuperseded(input.businessId, inFlight.runId))) return;
+
+    await deps.cancelRun.cancel({
+      businessId: input.businessId,
+      runId: inFlight.runId,
+      reason: "superseded by a newer message in the same thread",
+    });
+  } catch (err) {
+    log.warn({ err, ...input }, "channel run supersede failed; answering both messages");
   }
 }
 
@@ -356,6 +414,24 @@ export function registerChannelInternalRoutes(
         idempotencyKey: body.eventId,
         log: req.log as FastifyBaseLogger,
       });
+
+      // Resolve a redelivery of an event we already answered *before* superseding anything: a
+      // replay must never cancel the Run it is a replay of.
+      const replayed = await submitter.findSubmitted?.();
+      if (replayed) return reply.send({ runId: replayed.runId, outcome: "duplicate" });
+
+      // Then stop the earlier Run, before this one starts, so the two never execute side by side.
+      await supersedeInFlightThreadRun(
+        deps,
+        {
+          businessId,
+          provider: body.provider,
+          destination: body.message.channelId,
+          threadId: body.message.threadId ?? body.message.channelId,
+        },
+        req.log as FastifyBaseLogger
+      );
+
       const submission = await submitter.submit({
         conversationId: mapping.conversationId,
         content: body.message.text,
@@ -378,6 +454,9 @@ export function registerChannelInternalRoutes(
         provider: body.provider,
         destination: body.message.channelId,
         ...(body.message.threadId === undefined ? {} : { threadId: body.message.threadId }),
+        ...(body.message.sourceMessageTs === undefined
+          ? {}
+          : { sourceMessageTs: body.message.sourceMessageTs }),
         agentId: body.agentId,
         principalId: body.principal.id,
         idempotencyKey: body.eventId,

--- a/apps/api/src/internal/channel-schemas.ts
+++ b/apps/api/src/internal/channel-schemas.ts
@@ -74,6 +74,11 @@ export const ChannelRunCreateBodySchema = {
         externalAppId: { type: "string" },
         channelId: { type: "string" },
         threadId: { type: "string" },
+        sourceMessageTs: {
+          type: "string",
+          description:
+            "The provider id of the message that started this Run (Slack's `event.ts`). Distinct from `threadId`, which is the thread root — a reaction keyed off `threadId` lands on the wrong message for every in-thread reply.",
+        },
         text: { type: "string" },
       },
     },

--- a/apps/api/src/pg-migrations/index.ts
+++ b/apps/api/src/pg-migrations/index.ts
@@ -22,6 +22,7 @@ import {
   CHANNEL_DELIVERY_STORAGE_STATEMENTS,
   CHANNEL_INBOUND_STORAGE_STATEMENTS,
   CHANNEL_MENTIONED_THREAD_STORAGE_STATEMENTS,
+  CHANNEL_RUN_DELIVERY_ACKNOWLEDGE_STATEMENTS,
   CHANNEL_RUN_DELIVERY_APPROVAL_COLUMNS_STATEMENTS,
   CHANNEL_RUN_DELIVERY_STORAGE_STATEMENTS,
   CHILD_STORAGE_STATEMENTS,
@@ -2917,6 +2918,16 @@ export const PG_MIGRATIONS: PgMigration[] = [
       await q.query(
         "ALTER TABLE teams ADD COLUMN IF NOT EXISTS labels text[] NOT NULL DEFAULT '{}'"
       );
+    },
+  },
+  {
+    version: 96,
+    description: "channel_run_deliveries: emoji acknowledgement and superseded deliveries",
+    up: async (q) => {
+      if (!(await hasTableColumns(q, "channel_run_deliveries", ["business_id", "run_id"]))) {
+        return;
+      }
+      await applyStatements(CHANNEL_RUN_DELIVERY_ACKNOWLEDGE_STATEMENTS)(q);
     },
   },
 ];

--- a/apps/api/src/tools/contract-coverage.test.ts
+++ b/apps/api/src/tools/contract-coverage.test.ts
@@ -177,7 +177,7 @@ const EXPECTED_FAMILY_TOOL_NAMES = [
       "github_repository_list",
     ],
   },
-  { family: "slack", names: ["send_slack_message", "slack_channel_list"] },
+  { family: "slack", names: ["send_slack_message", "slack_channel_list", "slack_acknowledge"] },
   {
     family: "google",
     names: [

--- a/apps/api/src/tools/slack/tools.ts
+++ b/apps/api/src/tools/slack/tools.ts
@@ -54,6 +54,15 @@ function derivedId(...parts: readonly string[]): string {
 function mapDispatchError(error: ToolDispatchError): ToolCallResult {
   if (error.code === "invalid_output")
     return err("internal_error", "Slack returned an unexpected response shape");
+  if (error.detail?.startsWith("emoji_not_found") === true) {
+    const candidates = error.detail.slice("emoji_not_found".length).replace(/^:/, "");
+    return err(
+      "validation_error",
+      candidates.length === 0
+        ? "No emoji by that name in this workspace."
+        : `No emoji by that name in this workspace. Closest: ${candidates.split(",").join(", ")}.`
+    );
+  }
   if (error.detail === "channel_not_found") {
     return err("not_found", "No Slack channel by that name — check the bot has joined it.");
   }
@@ -146,8 +155,12 @@ function buildToolDef(
     authorization: {
       action: contract.action,
       resources: [SLACK_RESOURCE],
+      // `acknowledge` takes no channel: its target is the message that started the Run, which
+      // the adapter reads from the delivery row. There is no argument to scope the grant by.
       targets:
-        toolId === SLACK_TOOL_IDS.listChannels ? allSlackChannelsTarget : slackChannelTargets,
+        toolId === SLACK_TOOL_IDS.listChannels || toolId === SLACK_TOOL_IDS.acknowledge
+          ? allSlackChannelsTarget
+          : slackChannelTargets,
       dataClasses: contract.dataClasses,
       allowedDestinations: contract.allowedDestinations,
     },

--- a/apps/docs/content/docs/administration/connect-slack.mdx
+++ b/apps/docs/content/docs/administration/connect-slack.mdx
@@ -27,7 +27,8 @@ Slack account to a TulipFarm user.
     The manifest enables Socket Mode, a bot user, the Agent messaging experience, and these bot
     scopes: `chat:write`, `app_mentions:read`, `channels:read`, `channels:history`,
     `groups:read`, `groups:history`, `im:read`, `im:history`, `mpim:read`,
-    `mpim:history`, `users:read`, `users:read.email`, and `assistant:write`.
+    `mpim:history`, `users:read`, `users:read.email`, `assistant:write`,
+    `reactions:write`, and `emoji:read`.
   </Step>
   <Step>
     Confirm the manifest subscribes to `message.channels`, `message.im`, and

--- a/apps/eval/corpus/slack-acknowledges-instead-of-replying.json
+++ b/apps/eval/corpus/slack-acknowledges-instead-of-replying.json
@@ -1,0 +1,44 @@
+{
+  "id": "slack-acknowledges-instead-of-replying",
+  "tier": "l2",
+  "agent": "support",
+  "input": [
+    {
+      "role": "user",
+      "content": "thanks!"
+    }
+  ],
+  "platformTools": ["slack_acknowledge", "send_slack_message"],
+  "toolResults": [
+    {
+      "name": "slack_acknowledge",
+      "output": { "ok": true, "emoji": "thumbsup" }
+    }
+  ],
+  "script": [
+    {
+      "kind": "tool_calls",
+      "calls": [
+        {
+          "callId": "ack",
+          "name": "slack_acknowledge",
+          "arguments": { "emoji": "thumbsup" }
+        }
+      ]
+    },
+    { "kind": "text", "text": "Acknowledged with a reaction." }
+  ],
+  "expect": [
+    { "kind": "tool_called", "name": "slack_acknowledge" },
+    {
+      "kind": "tool_argument_equals",
+      "name": "slack_acknowledge",
+      "path": "emoji",
+      "value": "thumbsup"
+    },
+    { "kind": "tool_not_called", "name": "send_slack_message" },
+    { "kind": "tool_call_count", "count": 1 },
+    { "kind": "guardrail_allowed", "stage": "tool_call" },
+    { "kind": "loop_status", "status": "completed" }
+  ]
+}

--- a/apps/integration-worker/src/channels/delivery-poll-loop.test.ts
+++ b/apps/integration-worker/src/channels/delivery-poll-loop.test.ts
@@ -30,6 +30,16 @@ function row(
   };
 }
 
+/**
+ * The real claim echoes the row it moved out of `pending`, so a fake that rebuilds a bare row
+ * would silently drop the thread the reply belongs in.
+ */
+function claimStub() {
+  return vi.fn(async (_businessId: string, runId: string) =>
+    row({ runId, threadId: "1785000000.0001", status: "delivering" })
+  );
+}
+
 function persistedRun(overrides: Partial<PersistedRun> = {}): PersistedRun {
   return {
     id: "run-1",
@@ -68,6 +78,7 @@ describe("startDeliveryPollLoop", () => {
     const listPending = vi.fn().mockResolvedValue([row({ threadId: "1785000000.0001" })]);
     const runDeliveries = {
       listPending,
+      claim: claimStub(),
       markStatus: vi.fn(),
     } as unknown as ChannelRunDeliveryStore;
     const runs = {
@@ -96,6 +107,7 @@ describe("startDeliveryPollLoop", () => {
   it("delivers the reply and marks done when the Run succeeds", async () => {
     const runDeliveries = {
       listPending: vi.fn().mockResolvedValue([row({ threadId: "1785000000.0001" })]),
+      claim: claimStub(),
       markStatus: vi.fn().mockResolvedValue(undefined),
     } as unknown as ChannelRunDeliveryStore;
     const runs = {
@@ -131,6 +143,7 @@ describe("startDeliveryPollLoop", () => {
   it("prefers reply.agentDisplayName over the raw agentId when the reply endpoint returns it", async () => {
     const runDeliveries = {
       listPending: vi.fn().mockResolvedValue([row({ threadId: "1785000000.0001" })]),
+      claim: claimStub(),
       markStatus: vi.fn().mockResolvedValue(undefined),
     } as unknown as ChannelRunDeliveryStore;
     const runs = {
@@ -165,6 +178,7 @@ describe("startDeliveryPollLoop", () => {
   it("passes reply.blocks through to delivery when the reply endpoint returns them", async () => {
     const runDeliveries = {
       listPending: vi.fn().mockResolvedValue([row({ threadId: "1785000000.0001" })]),
+      claim: claimStub(),
       markStatus: vi.fn().mockResolvedValue(undefined),
     } as unknown as ChannelRunDeliveryStore;
     const runs = {
@@ -195,6 +209,7 @@ describe("startDeliveryPollLoop", () => {
   it("omits blocks from delivery when the reply endpoint doesn't return them", async () => {
     const runDeliveries = {
       listPending: vi.fn().mockResolvedValue([row({ threadId: "1785000000.0001" })]),
+      claim: claimStub(),
       markStatus: vi.fn().mockResolvedValue(undefined),
     } as unknown as ChannelRunDeliveryStore;
     const runs = {
@@ -225,6 +240,7 @@ describe("startDeliveryPollLoop", () => {
   it("marks failed and posts a failure message when the Run fails", async () => {
     const runDeliveries = {
       listPending: vi.fn().mockResolvedValue([row({ threadId: "1785000000.0001" })]),
+      claim: claimStub(),
       markStatus: vi.fn().mockResolvedValue(undefined),
     } as unknown as ChannelRunDeliveryStore;
     const runs = {
@@ -267,6 +283,7 @@ describe("startDeliveryPollLoop", () => {
   it("uses the reason-specific failure copy recovered from the reply route", async () => {
     const runDeliveries = {
       listPending: vi.fn().mockResolvedValue([row({ threadId: "1785000000.0001" })]),
+      claim: claimStub(),
       markStatus: vi.fn().mockResolvedValue(undefined),
     } as unknown as ChannelRunDeliveryStore;
     const runs = {
@@ -300,6 +317,7 @@ describe("startDeliveryPollLoop", () => {
   it("falls back to the generic failure message when recovering the reason errors", async () => {
     const runDeliveries = {
       listPending: vi.fn().mockResolvedValue([row({ threadId: "1785000000.0001" })]),
+      claim: claimStub(),
       markStatus: vi.fn().mockResolvedValue(undefined),
     } as unknown as ChannelRunDeliveryStore;
     const runs = {
@@ -331,10 +349,80 @@ describe("startDeliveryPollLoop", () => {
     expect(runDeliveries.markStatus).toHaveBeenCalledWith("business-1", "run-1", "failed");
   });
 
+  it("posts nothing when the Agent already answered by reacting", async () => {
+    const markStatus = vi.fn().mockResolvedValue(undefined);
+    const runDeliveries = {
+      listPending: vi
+        .fn()
+        .mockResolvedValue([row({ threadId: "1785000000.0001", acknowledgedEmoji: "thumbsup" })]),
+      claim: vi.fn(async (_businessId: string, runId: string) =>
+        row({
+          runId,
+          threadId: "1785000000.0001",
+          status: "delivering",
+          acknowledgedEmoji: "thumbsup",
+        })
+      ),
+      markStatus,
+    } as unknown as ChannelRunDeliveryStore;
+    const runs = {
+      find: vi.fn().mockResolvedValue(persistedRun({ status: "succeeded" })),
+    } as unknown as RunStore;
+    const deliver = vi.fn().mockResolvedValue(undefined);
+    const delivery = { setStatus: vi.fn(), deliver } as unknown as SlackDeliveryAdapter;
+    const internalApi = {
+      require: vi.fn().mockResolvedValue({ status: "succeeded", text: "Acknowledged." }),
+    } as unknown as InternalApiClient;
+
+    await runOneTick({
+      businessId: "business-1",
+      runDeliveries,
+      runs,
+      internalApi,
+      delivery,
+      credential: "xoxb-leased",
+      log: { warn: vi.fn() },
+    });
+
+    expect(deliver).not.toHaveBeenCalled();
+    expect(markStatus).toHaveBeenCalledWith("business-1", "run-1", "done");
+  });
+
+  it("posts nothing when a supersede took the row before the claim landed", async () => {
+    const markStatus = vi.fn().mockResolvedValue(undefined);
+    const runDeliveries = {
+      listPending: vi.fn().mockResolvedValue([row({ threadId: "1785000000.0001" })]),
+      claim: vi.fn().mockResolvedValue(null),
+      markStatus,
+    } as unknown as ChannelRunDeliveryStore;
+    const runs = {
+      find: vi.fn().mockResolvedValue(persistedRun({ status: "succeeded" })),
+    } as unknown as RunStore;
+    const deliver = vi.fn().mockResolvedValue(undefined);
+    const delivery = { setStatus: vi.fn(), deliver } as unknown as SlackDeliveryAdapter;
+    const internalApi = {
+      require: vi.fn().mockResolvedValue({ status: "succeeded", text: "The answer is 42." }),
+    } as unknown as InternalApiClient;
+
+    await runOneTick({
+      businessId: "business-1",
+      runDeliveries,
+      runs,
+      internalApi,
+      delivery,
+      credential: "xoxb-leased",
+      log: { warn: vi.fn() },
+    });
+
+    expect(deliver).not.toHaveBeenCalled();
+    expect(markStatus).not.toHaveBeenCalled();
+  });
+
   it("swallows a single row's failure so other pending rows still get polled", async () => {
     const rows = [row({ runId: "run-1" }), row({ runId: "run-2", threadId: "ts-2" })];
     const runDeliveries = {
       listPending: vi.fn().mockResolvedValue(rows),
+      claim: claimStub(),
       markStatus: vi.fn().mockResolvedValue(undefined),
     } as unknown as ChannelRunDeliveryStore;
     const find = vi.fn().mockImplementation((_businessId: string, runId: string) => {
@@ -367,6 +455,7 @@ describe("startDeliveryPollLoop", () => {
   it("posts the approval prompt for a still-running Run when an http port is supplied", async () => {
     const runDeliveries = {
       listPending: vi.fn().mockResolvedValue([row({ threadId: "1785000000.0001" })]),
+      claim: claimStub(),
       markStatus: vi.fn(),
       setApprovalPosted: vi.fn().mockResolvedValue(undefined),
     } as unknown as ChannelRunDeliveryStore;

--- a/apps/integration-worker/src/channels/delivery-poll-loop.ts
+++ b/apps/integration-worker/src/channels/delivery-poll-loop.ts
@@ -145,6 +145,14 @@ async function deliverReply(
     await markFailed(row, deps, reply.reason);
     return;
   }
+  // The Agent already answered by reacting to the message, so there is nothing to post. The
+  // recorded text is discarded rather than checked for emptiness: a Turn that produces no text at
+  // all fails as `empty_model_output` (`packages/turn-executor/src/driver.ts:420`), so an
+  // acknowledging Agent must still say something, and that something is not for the user.
+  if (row.acknowledgedEmoji !== undefined) {
+    await deps.runDeliveries.markStatus(deps.businessId, row.runId, "done");
+    return;
+  }
   const agentDisplayName =
     reply.agentDisplayName ?? deps.agentDisplayName?.(row.agentId) ?? row.agentId;
   try {
@@ -202,6 +210,7 @@ async function handleRow(
     const reply = await deps.internalApi
       .find<ReplyResponse>("GET", `/api/v1/internal/channels/runs/${row.runId}/reply`, [404])
       .catch(() => undefined);
+    if ((await deps.runDeliveries.claim(deps.businessId, row.runId)) === null) return;
     await markFailed(row, deps, reply?.reason);
     return;
   }
@@ -214,7 +223,13 @@ async function handleRow(
     await rotateStatus(row, deps);
     return;
   }
-  await deliverReply(row, reply, deps);
+  // Claim before posting: a newer message in the same thread may be superseding this Run right
+  // now, and only one of the two conditional writes on `pending` can win. Losing means the reply
+  // is deliberately dropped. The claimed row is used from here on because it is re-read inside the
+  // same statement — `row` came from a `listPending` that predates any acknowledgement.
+  const claimed = await deps.runDeliveries.claim(deps.businessId, row.runId);
+  if (claimed === null) return;
+  await deliverReply(claimed, reply, deps);
 }
 
 async function pollOnce(deps: DeliveryPollLoopDeps): Promise<void> {

--- a/apps/integration-worker/src/channels/run-starter.ts
+++ b/apps/integration-worker/src/channels/run-starter.ts
@@ -38,6 +38,9 @@ export function httpChannelRunStarter(
             externalAppId: input.message.externalAppId,
             channelId: input.message.channelId,
             ...(input.message.threadId === undefined ? {} : { threadId: input.message.threadId }),
+            ...(input.message.sourceMessageTs === undefined
+              ? {}
+              : { sourceMessageTs: input.message.sourceMessageTs }),
             text: input.message.text,
           },
         }

--- a/integrations/slack/manifest.yml
+++ b/integrations/slack/manifest.yml
@@ -49,6 +49,8 @@ auth:
             - users:read
             - users:read.email
             - assistant:write
+            - reactions:write
+            - emoji:read
       settings:
         event_subscriptions:
           bot_events:
@@ -129,4 +131,6 @@ auth:
       - users:read
       - users:read.email
       - assistant:write
+      - reactions:write
+      - emoji:read
 setup_guide_path: setup-guide.md

--- a/packages/integrations/src/channels/ports.ts
+++ b/packages/integrations/src/channels/ports.ts
@@ -29,6 +29,12 @@ export interface ChannelInboundEvent {
     externalAppId: string;
     channelId: string;
     threadId?: string;
+    /**
+     * The provider id of this very message, as opposed to `threadId`, which is the thread root.
+     * The two are equal only for a top-level message; anything that must act on the message the
+     * user actually sent — a reaction, most obviously — has to use this.
+     */
+    sourceMessageTs?: string;
     text: string;
     media: ChannelMediaReference[];
   };

--- a/packages/integrations/src/index.ts
+++ b/packages/integrations/src/index.ts
@@ -323,6 +323,9 @@ export type {
   SlackChannelKind,
   SlackDeliveryAdapterDeps,
   SlackDeliveryRequest,
+  SlackEmojiCacheOptions,
+  SlackEmojiDirectoryPort,
+  SlackEmojiResolution,
   SlackEventEnvelope,
   SlackFile,
   SlackKnowledgeApiPort,
@@ -344,6 +347,9 @@ export type {
 export {
   encodeMentionsInText,
   InMemorySlackKnowledgeCheckpointStore,
+  indexEmojiDirectory,
+  normalizeEmojiName,
+  resolveEmojiName,
   resolveMentionsInText,
   SLACK_ADAPTER_REF,
   SLACK_KNOWLEDGE_ACL_MAX_AGE_SECONDS,
@@ -356,6 +362,7 @@ export {
   SlackChannelAdapter,
   SlackDeliveryAdapter,
   SlackDeliveryError,
+  SlackEmojiDirectory,
   SlackToolAdapter,
   syncSlackKnowledge,
 } from "./slack";

--- a/packages/integrations/src/slack/adapter.test.ts
+++ b/packages/integrations/src/slack/adapter.test.ts
@@ -148,6 +148,7 @@ describe("SlackChannelAdapter", () => {
       externalAppId: "A-PRIMARY",
       channelId: "C-OPS",
       threadId: "1784999999.000001",
+      sourceMessageTs: "1785000000.000100",
       text: "status?",
       media: [
         {

--- a/packages/integrations/src/slack/adapter.ts
+++ b/packages/integrations/src/slack/adapter.ts
@@ -139,6 +139,7 @@ function normalizeSlackEvent(
       externalAppId: requiredString(envelope.api_app_id),
       channelId: requiredString(event.channel),
       threadId: optionalString(event.thread_ts) ?? messageId,
+      sourceMessageTs: messageId,
       text: typeof event.text === "string" ? event.text : "",
       media: normalizeFiles(event.files),
     },

--- a/packages/integrations/src/slack/contracts.test.ts
+++ b/packages/integrations/src/slack/contracts.test.ts
@@ -11,8 +11,18 @@ import {
 const byId = new Map(SLACK_TOOL_CONTRACTS.map((c) => [c.spec.toolId, c]));
 
 describe("SLACK_TOOL_CONTRACTS", () => {
-  it("publishes channel discovery and send Tools", () => {
-    expect([...byId.keys()]).toEqual([SLACK_TOOL_IDS.listChannels, SLACK_TOOL_IDS.sendMessage]);
+  it("publishes channel discovery, send, and acknowledge Tools", () => {
+    expect([...byId.keys()]).toEqual([
+      SLACK_TOOL_IDS.listChannels,
+      SLACK_TOOL_IDS.sendMessage,
+      SLACK_TOOL_IDS.acknowledge,
+    ]);
+  });
+
+  it("keeps acknowledge provider-idempotent, since a mutating Tool may not opt out", () => {
+    const acknowledge = byId.get(SLACK_TOOL_IDS.acknowledge);
+    expect(acknowledge?.spec.mutating).toBe(true);
+    expect(acknowledge?.spec.idempotency.strategy).toBe("provider");
   });
 
   it("loads into the Tool catalog as a published contract", () => {

--- a/packages/integrations/src/slack/contracts.ts
+++ b/packages/integrations/src/slack/contracts.ts
@@ -11,6 +11,7 @@ export const SLACK_ADAPTER_REF = "integration:slack";
 export const SLACK_TOOL_IDS = {
   listChannels: "slack.channel.list",
   sendMessage: "slack.message.send",
+  acknowledge: "slack.message.acknowledge",
 } as const;
 
 export type SlackToolId = (typeof SLACK_TOOL_IDS)[keyof typeof SLACK_TOOL_IDS];
@@ -22,6 +23,7 @@ export const SLACK_RECONCILIATION_OPERATIONS = {
 
 const LIST_CHANNELS_TOOL_VERSION = "1.0.0";
 const SEND_MESSAGE_TOOL_VERSION = "1.0.0";
+const ACKNOWLEDGE_TOOL_VERSION = "1.0.0";
 const SLACK_DESTINATION = "slack";
 const MESSAGE_DATA_CLASSES = ["source_content"];
 const CHANNEL_DIRECTORY_DATA_CLASSES = ["directory"];
@@ -78,6 +80,33 @@ const sendMessageOutputSchema = {
     channelId: { type: "string" },
     ts: { type: "string" },
     threadId: { type: "string" },
+  },
+} as const;
+
+const acknowledgeInputSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["emoji"],
+  properties: {
+    emoji: {
+      type: "string",
+      minLength: 1,
+      maxLength: 100,
+      description:
+        "Emoji short name without colons, e.g. 'thumbsup', 'eyes', 'white_check_mark'. Custom " +
+        "workspace emoji work too. An approximate name is matched against the workspace's own " +
+        "emoji, so a near miss still lands.",
+    },
+  },
+} as const;
+
+const acknowledgeOutputSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["ok", "emoji"],
+  properties: {
+    ok: { type: "boolean" },
+    emoji: { type: "string", description: "The emoji name actually applied, after matching." },
   },
 } as const;
 
@@ -147,7 +176,34 @@ const listChannels = publish(
   "slack-channel-list"
 );
 
-export const SLACK_TOOL_CONTRACTS: readonly ToolContractDefinition[] = [listChannels, sendMessage];
+const acknowledge = publish(
+  {
+    toolId: SLACK_TOOL_IDS.acknowledge,
+    toolVersion: ACKNOWLEDGE_TOOL_VERSION,
+    action: SLACK_TOOL_IDS.acknowledge,
+    inputSchema: acknowledgeInputSchema,
+    outputSchema: acknowledgeOutputSchema,
+    riskClass: "low",
+    mutating: true,
+    dataClasses: MESSAGE_DATA_CLASSES,
+    allowedDestinations: [SLACK_DESTINATION],
+    // Slack itself rejects a repeat with `already_reacted`, which the adapter treats as success,
+    // so a retry converges without a reconciliation lookup of our own.
+    idempotency: { strategy: "provider" },
+    timeout: { wallClockMs: 15_000 },
+    retry: { maxAttempts: 3, safeToRetry: true },
+    dryRun: false,
+    adapter: { kind: "integration", ref: SLACK_ADAPTER_REF },
+  },
+  "aaaaaaaa-0004-4000-8000-000000000003",
+  "slack-message-acknowledge"
+);
+
+export const SLACK_TOOL_CONTRACTS: readonly ToolContractDefinition[] = [
+  listChannels,
+  sendMessage,
+  acknowledge,
+];
 
 export const SLACK_TOOL_DECLARATIONS = [
   {
@@ -172,5 +228,16 @@ export const SLACK_TOOL_DECLARATIONS = [
       "into a real, clickable, notifying Slack mention before sending. Writing the name with no " +
       "'@' sends it as plain text and does not notify or tag anyone.",
     inputSchema: sendMessageInputSchema,
+  },
+  {
+    toolId: SLACK_TOOL_IDS.acknowledge,
+    toolVersion: ACKNOWLEDGE_TOOL_VERSION,
+    name: "slack_acknowledge",
+    description:
+      "React to the message you are answering with a single emoji instead of replying. Use this " +
+      "when a reply would add nothing — an acknowledgement, a thank-you, a 'got it', or a message " +
+      "that only confirms something you already did. Calling this ends your turn: do not also " +
+      "write a reply.",
+    inputSchema: acknowledgeInputSchema,
   },
 ] as const;

--- a/packages/integrations/src/slack/emoji.test.ts
+++ b/packages/integrations/src/slack/emoji.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import {
+  indexEmojiDirectory,
+  normalizeEmojiName,
+  resolveEmojiName,
+  SlackEmojiDirectory,
+  type SlackEmojiDirectoryPort,
+} from "./emoji";
+
+const DIRECTORY: Record<string, string> = {
+  thumbsup: "https://emoji.slack-edge.com/thumbsup.png",
+  white_check_mark: "https://emoji.slack-edge.com/check.png",
+  "party-parrot": "https://emoji.slack-edge.com/parrot.gif",
+  "+1": "alias:thumbsup",
+  tada: "https://emoji.slack-edge.com/tada.png",
+};
+
+describe("normalizeEmojiName", () => {
+  it("folds colons, case, and the separators the same emoji is written with", () => {
+    expect(normalizeEmojiName(":White_Check-Mark:")).toBe("whitecheckmark");
+    expect(normalizeEmojiName("party parrot")).toBe("partyparrot");
+  });
+});
+
+describe("indexEmojiDirectory", () => {
+  it("resolves an alias to the name Slack accepts", () => {
+    const index = indexEmojiDirectory(DIRECTORY);
+    expect(index.byNormalized.get("+1")).toBe("thumbsup");
+  });
+
+  it("does not let an alias displace the name it points at", () => {
+    const index = indexEmojiDirectory({ heart: "u.png", hearts: "alias:heart" });
+    expect(index.byNormalized.get("heart")).toBe("heart");
+  });
+});
+
+describe("resolveEmojiName", () => {
+  it("matches an exact name", () => {
+    expect(resolveEmojiName("tada", DIRECTORY)).toEqual({ outcome: "resolved", name: "tada" });
+  });
+
+  it("matches across separator spellings", () => {
+    expect(resolveEmojiName("thumbs_up", DIRECTORY)).toEqual({
+      outcome: "resolved",
+      name: "thumbsup",
+    });
+  });
+
+  it("matches a unique substring", () => {
+    expect(resolveEmojiName("parrot", DIRECTORY)).toEqual({
+      outcome: "resolved",
+      name: "party-parrot",
+    });
+  });
+
+  it("matches a near miss by edit distance", () => {
+    expect(resolveEmojiName("tadaa", DIRECTORY)).toEqual({ outcome: "resolved", name: "tada" });
+  });
+
+  it("reports unknown rather than guessing at a name nothing resembles", () => {
+    const result = resolveEmojiName("zzzzzzzzqqqq", DIRECTORY);
+    expect(result.outcome).toBe("unknown");
+  });
+
+  it("reports unknown for an empty request", () => {
+    expect(resolveEmojiName("::", DIRECTORY)).toEqual({ outcome: "unknown", candidates: [] });
+  });
+});
+
+function countingPort(directories: Record<string, string>[]): {
+  port: SlackEmojiDirectoryPort;
+  calls: () => number;
+} {
+  let calls = 0;
+  return {
+    port: {
+      async load() {
+        const value = directories[Math.min(calls, directories.length - 1)];
+        calls += 1;
+        return value;
+      },
+    },
+    calls: () => calls,
+  };
+}
+
+describe("SlackEmojiDirectory", () => {
+  it("loads once and serves later hits from cache", async () => {
+    const { port, calls } = countingPort([DIRECTORY]);
+    const directory = new SlackEmojiDirectory(port);
+
+    await directory.resolve("tada");
+    await directory.resolve("thumbsup");
+
+    expect(calls()).toBe(1);
+  });
+
+  it("refetches on a miss so an emoji added minutes ago still resolves", async () => {
+    const { port, calls } = countingPort([{ tada: "a.png" }, { tada: "a.png", newbie: "b.png" }]);
+    const directory = new SlackEmojiDirectory(port, { minRefreshIntervalMs: 0 });
+
+    expect(await directory.resolve("newbie")).toEqual({ outcome: "resolved", name: "newbie" });
+    expect(calls()).toBe(2);
+  });
+
+  it("does not refetch twice for misses inside the refresh floor", async () => {
+    let now = 1_000;
+    const { port, calls } = countingPort([{ tada: "a.png" }]);
+    const directory = new SlackEmojiDirectory(port, {
+      minRefreshIntervalMs: 60_000,
+      now: () => now,
+    });
+
+    await directory.resolve("zzzzzzzz");
+    now += 100;
+    await directory.resolve("qqqqqqqq");
+
+    expect(calls()).toBe(1);
+  });
+
+  it("reloads after the ttl expires", async () => {
+    let now = 0;
+    const { port, calls } = countingPort([DIRECTORY]);
+    const directory = new SlackEmojiDirectory(port, { ttlMs: 1_000, now: () => now });
+
+    await directory.resolve("tada");
+    now = 2_000;
+    await directory.resolve("tada");
+
+    expect(calls()).toBe(2);
+  });
+
+  it("degrades to an empty directory when the load fails", async () => {
+    const directory = new SlackEmojiDirectory({
+      async load() {
+        throw new Error("slack down");
+      },
+    });
+
+    expect(await directory.resolve("tada")).toEqual({ outcome: "unknown", candidates: [] });
+  });
+});

--- a/packages/integrations/src/slack/emoji.ts
+++ b/packages/integrations/src/slack/emoji.ts
@@ -1,0 +1,233 @@
+/**
+ * Resolves an emoji name an Agent asked for to one this workspace actually has.
+ *
+ * Custom emoji are per-workspace, so no model can know them in advance, and standard names are
+ * easy to get slightly wrong (`thumbs_up` for `thumbsup`, `check` for `white_check_mark`). Rather
+ * than spend a model turn on a discovery Tool, the requested name is matched against a cached
+ * directory through progressively looser tiers, and only a genuine miss is reported back — with
+ * candidates, so the model can correct itself in one retry instead of guessing again.
+ */
+
+/** Loads the workspace's emoji names. Implementations are expected to be network-backed. */
+export interface SlackEmojiDirectoryPort {
+  /**
+   * Every emoji name available to this workspace, custom and standard. Aliases are returned as
+   * `alias:target`; the resolver follows them.
+   */
+  load(): Promise<Readonly<Record<string, string>>>;
+}
+
+export type SlackEmojiResolution =
+  | { readonly outcome: "resolved"; readonly name: string }
+  | { readonly outcome: "unknown"; readonly candidates: readonly string[] };
+
+/** Alias chains are followed this far before being treated as a cycle and abandoned. */
+const MAX_ALIAS_HOPS = 5;
+
+/** Beyond this share of the name being wrong, a "closest match" is a guess, not a correction. */
+const MAX_FUZZY_DISTANCE_RATIO = 0.34;
+
+/** A fuzzy winner must beat the runner-up by this much, or the request is ambiguous. */
+const MIN_FUZZY_MARGIN = 1;
+
+const MAX_CANDIDATES = 8;
+
+/**
+ * Folds the spellings that mean the same emoji: case, the wrapping colons Slack shows in its UI,
+ * and the `-`/`_`/space the same emoji is written with in different places.
+ */
+export function normalizeEmojiName(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/^:+|:+$/g, "")
+    .replace(/[\s_-]+/g, "");
+}
+
+/** Levenshtein distance, bounded by `limit` so a large directory stays cheap to scan. */
+function editDistance(a: string, b: string, limit: number): number {
+  if (Math.abs(a.length - b.length) > limit) return limit + 1;
+  let previous = Array.from({ length: b.length + 1 }, (_, index) => index);
+  for (let i = 1; i <= a.length; i += 1) {
+    const current = [i];
+    let rowBest = i;
+    for (let j = 1; j <= b.length; j += 1) {
+      const substitution = previous[j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1);
+      const best = Math.min(current[j - 1] + 1, previous[j] + 1, substitution);
+      current.push(best);
+      if (best < rowBest) rowBest = best;
+    }
+    if (rowBest > limit) return limit + 1;
+    previous = current;
+  }
+  return previous[b.length];
+}
+
+interface DirectoryIndex {
+  /** Normalized name to the canonical name Slack expects in `reactions.add`. */
+  readonly byNormalized: ReadonlyMap<string, string>;
+}
+
+/** Follows `alias:target` to the name Slack will actually accept. */
+function resolveAlias(name: string, raw: Readonly<Record<string, string>>): string {
+  let current = name;
+  for (let hop = 0; hop < MAX_ALIAS_HOPS; hop += 1) {
+    const value = raw[current];
+    if (typeof value !== "string" || !value.startsWith("alias:")) return current;
+    const target = value.slice("alias:".length);
+    if (target.length === 0 || target === current) return current;
+    current = target;
+  }
+  return current;
+}
+
+export function indexEmojiDirectory(raw: Readonly<Record<string, string>>): DirectoryIndex {
+  const byNormalized = new Map<string, string>();
+  for (const name of Object.keys(raw)) {
+    const canonical = resolveAlias(name, raw);
+    const normalized = normalizeEmojiName(name);
+    if (normalized.length === 0) continue;
+    // First writer wins so an alias never displaces the name it points at.
+    if (!byNormalized.has(normalized)) byNormalized.set(normalized, canonical);
+  }
+  return { byNormalized };
+}
+
+/**
+ * Exact, then normalized, then unique substring, then bounded fuzzy — stopping at the first tier
+ * that produces a single unambiguous answer.
+ *
+ * A tie is deliberately reported as unknown rather than broken arbitrarily: reacting with the
+ * wrong emoji is worse than asking the model to name a real one.
+ */
+export function resolveEmojiName(
+  requested: string,
+  raw: Readonly<Record<string, string>>,
+  index: DirectoryIndex = indexEmojiDirectory(raw)
+): SlackEmojiResolution {
+  const normalized = normalizeEmojiName(requested);
+  if (normalized.length === 0) return { outcome: "unknown", candidates: [] };
+
+  const exact = index.byNormalized.get(normalizeEmojiName(requested));
+  if (exact !== undefined) return { outcome: "resolved", name: exact };
+
+  const substringHits: string[] = [];
+  for (const [candidate, canonical] of index.byNormalized) {
+    if (candidate.includes(normalized) || normalized.includes(candidate)) {
+      substringHits.push(canonical);
+      if (substringHits.length > MAX_CANDIDATES) break;
+    }
+  }
+  if (substringHits.length === 1) return { outcome: "resolved", name: substringHits[0] };
+
+  const limit = Math.max(1, Math.floor(normalized.length * MAX_FUZZY_DISTANCE_RATIO));
+  let best: { name: string; distance: number } | undefined;
+  let runnerUpDistance = Number.POSITIVE_INFINITY;
+  for (const [candidate, canonical] of index.byNormalized) {
+    const distance = editDistance(normalized, candidate, limit);
+    if (distance > limit) continue;
+    if (best === undefined || distance < best.distance) {
+      runnerUpDistance = best?.distance ?? runnerUpDistance;
+      best = { name: canonical, distance };
+    } else if (distance < runnerUpDistance) {
+      runnerUpDistance = distance;
+    }
+  }
+  if (best !== undefined && runnerUpDistance - best.distance >= MIN_FUZZY_MARGIN) {
+    return { outcome: "resolved", name: best.name };
+  }
+
+  const candidates = substringHits.slice(0, MAX_CANDIDATES);
+  if (candidates.length === 0 && best !== undefined) candidates.push(best.name);
+  return { outcome: "unknown", candidates };
+}
+
+export interface SlackEmojiCacheOptions {
+  /**
+   * How long a loaded directory is trusted without any prompting. Long by design: the directory is
+   * near-static and arrives in one response, so re-fetching it on a timer is pure waste. The
+   * staleness that matters — an emoji added minutes ago — is caught by the miss path instead.
+   */
+  readonly ttlMs?: number;
+  /** Floor between miss-triggered refetches, so unresolvable names cannot become an API flood. */
+  readonly minRefreshIntervalMs?: number;
+  readonly now?: () => number;
+}
+
+const DEFAULT_TTL_MS = 3 * 60 * 60 * 1000;
+const DEFAULT_MIN_REFRESH_INTERVAL_MS = 60 * 1000;
+
+/**
+ * A workspace emoji directory that is cached hard and refreshed on a miss rather than on a clock.
+ *
+ * A hit costs nothing after the first call. A miss — which is exactly the "someone just added this
+ * emoji" case — forces at most one refetch and retries, so the cache is self-healing without
+ * polling. A load failure degrades to an empty directory, and the caller is expected to fall back
+ * to sending the raw name and letting Slack judge it: a directory outage must not make reacting
+ * impossible.
+ */
+export class SlackEmojiDirectory {
+  private cached?: {
+    index: DirectoryIndex;
+    raw: Readonly<Record<string, string>>;
+    loadedAt: number;
+  };
+  private inFlight?: Promise<void>;
+  private lastLoadAttemptAt = Number.NEGATIVE_INFINITY;
+
+  private readonly ttlMs: number;
+  private readonly minRefreshIntervalMs: number;
+  private readonly now: () => number;
+
+  constructor(
+    private readonly port: SlackEmojiDirectoryPort,
+    options: SlackEmojiCacheOptions = {}
+  ) {
+    this.ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+    this.minRefreshIntervalMs = options.minRefreshIntervalMs ?? DEFAULT_MIN_REFRESH_INTERVAL_MS;
+    this.now = options.now ?? Date.now;
+  }
+
+  async resolve(requested: string): Promise<SlackEmojiResolution> {
+    await this.ensureLoaded();
+    const first = this.resolveAgainstCache(requested);
+    if (first.outcome === "resolved") return first;
+
+    // The one case worth a network call: a name nothing matches is what a newly added custom emoji
+    // looks like. Rate-limited, so a run of nonsense names cannot fan out into repeated calls.
+    if (!this.canRefresh()) return first;
+    await this.load();
+    return this.resolveAgainstCache(requested);
+  }
+
+  private resolveAgainstCache(requested: string): SlackEmojiResolution {
+    if (this.cached === undefined) return { outcome: "unknown", candidates: [] };
+    return resolveEmojiName(requested, this.cached.raw, this.cached.index);
+  }
+
+  private async ensureLoaded(): Promise<void> {
+    if (this.cached !== undefined && this.now() - this.cached.loadedAt < this.ttlMs) return;
+    await this.load();
+  }
+
+  private canRefresh(): boolean {
+    return this.now() - this.lastLoadAttemptAt >= this.minRefreshIntervalMs;
+  }
+
+  /** Concurrent callers share one request; a failure leaves the previous directory in place. */
+  private async load(): Promise<void> {
+    if (this.inFlight !== undefined) return this.inFlight;
+    this.lastLoadAttemptAt = this.now();
+    this.inFlight = (async () => {
+      try {
+        const raw = await this.port.load();
+        this.cached = { raw, index: indexEmojiDirectory(raw), loadedAt: this.now() };
+      } catch {
+        this.cached ??= { raw: {}, index: indexEmojiDirectory({}), loadedAt: this.now() };
+      } finally {
+        this.inFlight = undefined;
+      }
+    })();
+    return this.inFlight;
+  }
+}

--- a/packages/integrations/src/slack/index.ts
+++ b/packages/integrations/src/slack/index.ts
@@ -1,5 +1,6 @@
 export * from "./adapter";
 export * from "./contracts";
+export * from "./emoji";
 export * from "./knowledge";
 export * from "./mentions";
 export * from "./tool-adapter";

--- a/packages/integrations/src/slack/tool-adapter.test.ts
+++ b/packages/integrations/src/slack/tool-adapter.test.ts
@@ -244,6 +244,7 @@ describe("SlackToolAdapter thread replies", () => {
             updatedAt: "2026-01-01T00:00:00.000Z",
           };
         },
+        async markAcknowledged() {},
       },
     });
 
@@ -274,6 +275,7 @@ describe("SlackToolAdapter thread replies", () => {
             updatedAt: "2026-01-01T00:00:00.000Z",
           };
         },
+        async markAcknowledged() {},
       },
     });
 
@@ -290,11 +292,172 @@ describe("SlackToolAdapter thread replies", () => {
         async find() {
           return null;
         },
+        async markAcknowledged() {},
       },
     });
 
     await adapter.dispatch(sendRequest("C0123456789", "here you go"), CREDENTIAL);
 
     expect(threadTs(http.calls)).toBeUndefined();
+  });
+});
+
+function acknowledgeRequest(emoji: string): ToolAdapterRequest {
+  const intent: ToolIntent = {
+    intentId: "55555555-5555-4555-8555-555555555555",
+    businessId: "biz-1",
+    runId: "run-1",
+    stateId: "state-ack",
+    toolId: SLACK_TOOL_IDS.acknowledge,
+    toolVersion: "1.0.0",
+    action: SLACK_TOOL_IDS.acknowledge,
+    targetRefs: [],
+    arguments: { emoji },
+    credentialRef: "slack-bot-token",
+    idempotencyKey: "66666666-6666-4666-8666-666666666666",
+  };
+  return { intent, idempotencyKey: intent.idempotencyKey, attempt: 1 };
+}
+
+function acknowledgeDeps(options: {
+  readonly sourceMessageTs?: string;
+  readonly delivery?: "missing";
+  readonly reactionBody?: Record<string, unknown>;
+  readonly emojiOk?: boolean;
+}) {
+  const calls: IntegrationHttpRequest[] = [];
+  const acknowledged: { businessId: string; runId: string; emoji: string }[] = [];
+  const http = {
+    calls,
+    async send(request: IntegrationHttpRequest): Promise<IntegrationHttpResponse> {
+      calls.push(request);
+      if (request.path === "/emoji.list") {
+        return options.emojiOk === false
+          ? { status: 200, headers: {}, body: { ok: false, error: "missing_scope" } }
+          : {
+              status: 200,
+              headers: {},
+              body: { ok: true, emoji: { thumbsup: "a.png", "party-parrot": "b.gif" } },
+            };
+      }
+      if (request.path === "/reactions.add") {
+        return {
+          status: 200,
+          headers: {},
+          body: options.reactionBody ?? { ok: true },
+        };
+      }
+      throw new Error(`unexpected path: ${request.path}`);
+    },
+  };
+  const adapter = new SlackToolAdapter({
+    http,
+    channelRunDelivery: {
+      async find() {
+        if (options.delivery === "missing") return null;
+        return {
+          businessId: "biz-1",
+          runId: "run-1",
+          integrationId: "int-1",
+          routeId: "route-1",
+          provider: "slack",
+          destination: "C0123456789",
+          threadId: "1700000000.000001",
+          ...(options.sourceMessageTs === undefined
+            ? {}
+            : { sourceMessageTs: options.sourceMessageTs }),
+          agentId: "agent-1",
+          principalId: "principal-1",
+          idempotencyKey: "idem-1",
+          status: "pending" as const,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        };
+      },
+      async markAcknowledged(businessId: string, runId: string, emoji: string) {
+        acknowledged.push({ businessId, runId, emoji });
+      },
+    },
+  });
+  return { adapter, calls, acknowledged };
+}
+
+describe("SlackToolAdapter acknowledge", () => {
+  it("reacts to the message the Run started from, not the thread root", async () => {
+    const { adapter, calls, acknowledged } = acknowledgeDeps({
+      sourceMessageTs: "1700000000.000009",
+    });
+
+    const output = await adapter.dispatch(acknowledgeRequest("thumbsup"), CREDENTIAL);
+
+    const reaction = calls.find((call) => call.path === "/reactions.add");
+    expect(reaction?.body).toEqual({
+      channel: "C0123456789",
+      timestamp: "1700000000.000009",
+      name: "thumbsup",
+    });
+    expect(output).toEqual({ ok: true, emoji: "thumbsup" });
+    expect(acknowledged).toEqual([{ businessId: "biz-1", runId: "run-1", emoji: "thumbsup" }]);
+  });
+
+  it("corrects an approximate name against the workspace directory", async () => {
+    const { adapter, calls } = acknowledgeDeps({ sourceMessageTs: "1700000000.000009" });
+
+    await adapter.dispatch(acknowledgeRequest("thumbs_up"), CREDENTIAL);
+
+    const reaction = calls.find((call) => call.path === "/reactions.add");
+    expect((reaction?.body as Record<string, unknown> | undefined)?.name).toBe("thumbsup");
+  });
+
+  it("treats already_reacted as success so a retry converges", async () => {
+    const { adapter, acknowledged } = acknowledgeDeps({
+      sourceMessageTs: "1700000000.000009",
+      reactionBody: { ok: false, error: "already_reacted" },
+    });
+
+    await expect(adapter.dispatch(acknowledgeRequest("thumbsup"), CREDENTIAL)).resolves.toEqual({
+      ok: true,
+      emoji: "thumbsup",
+    });
+    expect(acknowledged).toHaveLength(1);
+  });
+
+  it("reports invalid_name as a non-retryable emoji_not_found", async () => {
+    const { adapter } = acknowledgeDeps({
+      sourceMessageTs: "1700000000.000009",
+      reactionBody: { ok: false, error: "invalid_name" },
+    });
+
+    await expect(adapter.dispatch(acknowledgeRequest("parrrot"), CREDENTIAL)).rejects.toMatchObject(
+      { name: "AdapterDispatchError", retryable: false }
+    );
+  });
+
+  it("still sends the raw name when the emoji directory is unreadable", async () => {
+    const { adapter, calls } = acknowledgeDeps({
+      sourceMessageTs: "1700000000.000009",
+      emojiOk: false,
+    });
+
+    await adapter.dispatch(acknowledgeRequest(":Tada:"), CREDENTIAL);
+
+    const reaction = calls.find((call) => call.path === "/reactions.add");
+    expect((reaction?.body as Record<string, unknown> | undefined)?.name).toBe("tada");
+  });
+
+  it("fails rather than guessing when the Run has no recorded delivery", async () => {
+    const { adapter } = acknowledgeDeps({ delivery: "missing" });
+
+    await expect(adapter.dispatch(acknowledgeRequest("thumbsup"), CREDENTIAL)).rejects.toThrow(
+      AdapterDispatchError
+    );
+  });
+
+  it("fails when the delivery predates source message capture", async () => {
+    const { adapter } = acknowledgeDeps({});
+
+    await expect(adapter.dispatch(acknowledgeRequest("thumbsup"), CREDENTIAL)).rejects.toThrow(
+      AdapterDispatchError
+    );
   });
 });

--- a/packages/integrations/src/slack/tool-adapter.ts
+++ b/packages/integrations/src/slack/tool-adapter.ts
@@ -8,6 +8,7 @@ import {
   PaginationBoundError,
 } from "../http";
 import { SLACK_TOOL_IDS } from "./contracts";
+import { normalizeEmojiName, SlackEmojiDirectory, type SlackEmojiDirectoryPort } from "./emoji";
 import { encodeMentionsInText, encodeRawIdsInText, type SlackUserLookupPort } from "./mentions";
 
 /**
@@ -20,7 +21,10 @@ export interface SlackToolAdapterDeps {
    * When the Run that's calling this Tool was itself started from a Slack thread, replies to the
    * same channel default to that thread instead of posting a new root message.
    */
-  readonly channelRunDelivery?: Pick<ChannelRunDeliveryStore, "find">;
+  readonly channelRunDelivery?: Pick<ChannelRunDeliveryStore, "find"> & {
+    /** Widened return: the adapter needs the write to have happened, not the row it produced. */
+    markAcknowledged(businessId: string, runId: string, emoji: string): Promise<unknown>;
+  };
 }
 
 interface SlackApiChannel {
@@ -66,6 +70,14 @@ function args(intent: ToolAdapterRequest["intent"]): { channel: string; text: st
   return { channel, text };
 }
 
+function acknowledgeArgs(intent: ToolAdapterRequest["intent"]): { emoji: string } {
+  const emoji = (intent.arguments as Record<string, unknown>).emoji;
+  if (typeof emoji !== "string" || emoji.length === 0) {
+    throw new AdapterDispatchError("before_dispatch", "invalid_arguments", false);
+  }
+  return { emoji };
+}
+
 function asRecord(body: unknown): Record<string, unknown> {
   return body !== null && typeof body === "object" && !Array.isArray(body)
     ? (body as Record<string, unknown>)
@@ -75,12 +87,15 @@ function asRecord(body: unknown): Record<string, unknown> {
 export class SlackToolAdapter implements ToolAdapter {
   readonly kind = "integration" as const;
 
+  private readonly emojiDirectories = new Map<string, SlackEmojiDirectory>();
+
   constructor(private readonly deps: SlackToolAdapterDeps) {}
 
   async dispatch(request: ToolAdapterRequest, credential?: string): Promise<unknown> {
     if (
       request.intent.toolId !== SLACK_TOOL_IDS.listChannels &&
-      request.intent.toolId !== SLACK_TOOL_IDS.sendMessage
+      request.intent.toolId !== SLACK_TOOL_IDS.sendMessage &&
+      request.intent.toolId !== SLACK_TOOL_IDS.acknowledge
     ) {
       throw new AdapterDispatchError("before_dispatch", "unsupported_tool", false);
     }
@@ -89,6 +104,9 @@ export class SlackToolAdapter implements ToolAdapter {
     }
     if (request.intent.toolId === SLACK_TOOL_IDS.listChannels) {
       return { channels: await this.listChannels(credential) };
+    }
+    if (request.intent.toolId === SLACK_TOOL_IDS.acknowledge) {
+      return this.acknowledge(request, credential);
     }
 
     const { channel, text } = args(request.intent);
@@ -129,6 +147,97 @@ export class SlackToolAdapter implements ToolAdapter {
       throw new AdapterDispatchError("after_dispatch", "invalid_response", false);
     }
     return { channelId, ts, threadId: ts };
+  }
+
+  /**
+   * Reacts to the very message this Run was started from, in place of a reply.
+   *
+   * The target is not an argument: an Agent that could name any message could react anywhere in
+   * the workspace, so the message is read from the delivery row that started the Run. A Run with
+   * no such row has nothing to react to and fails rather than guessing.
+   */
+  private async acknowledge(request: ToolAdapterRequest, credential: string): Promise<unknown> {
+    const store = this.deps.channelRunDelivery;
+    if (store === undefined) {
+      throw new AdapterDispatchError("before_dispatch", "acknowledge_unavailable", false);
+    }
+    const { emoji } = acknowledgeArgs(request.intent);
+    const delivery = await store
+      .find(request.intent.businessId, request.intent.runId)
+      .catch(() => null);
+    if (delivery === null || delivery.provider !== "slack") {
+      throw new AdapterDispatchError("before_dispatch", "acknowledge_target_unknown", false);
+    }
+    const timestamp = delivery.sourceMessageTs;
+    if (timestamp === undefined) {
+      throw new AdapterDispatchError("before_dispatch", "acknowledge_target_unknown", false);
+    }
+
+    const resolution = await this.emojiDirectory(credential).resolve(emoji);
+    // An unresolved name is still sent: the directory can be stale or unreadable, and Slack is the
+    // real authority on what it will accept. Its `invalid_name` carries the candidates back.
+    const name = resolution.outcome === "resolved" ? resolution.name : normalizeEmojiName(emoji);
+
+    const response = await this.deps.http.send(
+      {
+        method: "POST",
+        path: "/reactions.add",
+        body: { channel: delivery.destination, timestamp, name },
+      },
+      credential
+    );
+    const body = asRecord(response.body);
+    const failure = classifyHttpFailure(response, true);
+    const error = typeof body.error === "string" ? body.error : undefined;
+    // Slack refuses a repeat rather than duplicating it, which is exactly the convergence a
+    // provider-idempotent retry needs.
+    if (body.ok !== true && error !== "already_reacted") {
+      if (error === "invalid_name" || error === "no_reaction") {
+        const candidates =
+          resolution.outcome === "unknown" && resolution.candidates.length > 0
+            ? `:${resolution.candidates.join(",")}`
+            : "";
+        throw new AdapterDispatchError("before_dispatch", `emoji_not_found${candidates}`, false);
+      }
+      const code = error ?? failure?.code ?? "provider_error";
+      throw new AdapterDispatchError(
+        failure?.phase ?? "before_dispatch",
+        code,
+        error === undefined ? (failure?.retryable ?? false) : false
+      );
+    }
+
+    await store.markAcknowledged(request.intent.businessId, request.intent.runId, name);
+    return { ok: true, emoji: name };
+  }
+
+  /**
+   * One directory per credential: the cache is worth nothing if a new instance is built per call,
+   * and two workspaces must never share one.
+   */
+  private emojiDirectory(credential: string): SlackEmojiDirectory {
+    const existing = this.emojiDirectories.get(credential);
+    if (existing !== undefined) return existing;
+    const port: SlackEmojiDirectoryPort = {
+      load: async () => {
+        const response = await this.deps.http.send(
+          { method: "GET", path: "/emoji.list" },
+          credential
+        );
+        const body = asRecord(response.body);
+        if (body.ok !== true)
+          throw new AdapterDispatchError("before_dispatch", "emoji_list_failed", false);
+        const emoji = asRecord(body.emoji);
+        const names: Record<string, string> = {};
+        for (const [key, value] of Object.entries(emoji)) {
+          if (typeof value === "string") names[key] = value;
+        }
+        return names;
+      },
+    };
+    const directory = new SlackEmojiDirectory(port);
+    this.emojiDirectories.set(credential, directory);
+    return directory;
   }
 
   /**

--- a/packages/storage/src/integrations/channel-run-delivery-store.pg.test.ts
+++ b/packages/storage/src/integrations/channel-run-delivery-store.pg.test.ts
@@ -105,4 +105,76 @@ describe("ChannelRunDeliveryStore", () => {
       store.setApprovalPosted(BUSINESS_ID, "run-missing", "approval-1", "1720000000.000300")
     ).rejects.toThrow("channel_run_delivery_not_found");
   });
+
+  it("round-trips the source message ts a reaction has to target", async () => {
+    const created = await store.create({ ...delivery, sourceMessageTs: "1720000000.000900" });
+    expect(created.sourceMessageTs).toBe("1720000000.000900");
+    expect((await store.find(BUSINESS_ID, "run-1"))?.sourceMessageTs).toBe("1720000000.000900");
+  });
+
+  it("returns the newest pending row for a thread and can exclude the asking Run", async () => {
+    now = "2026-07-26T10:00:00.000Z";
+    await store.create(delivery);
+    now = "2026-07-26T10:00:01.000Z";
+    await store.create({ ...delivery, runId: "run-2" });
+
+    const query = {
+      businessId: BUSINESS_ID,
+      provider: "slack",
+      destination: "C-OPS",
+      threadId: "1720000000.000100",
+    };
+    expect((await store.findInFlightForThread(query))?.runId).toBe("run-2");
+    expect((await store.findInFlightForThread({ ...query, excludeRunId: "run-2" }))?.runId).toBe(
+      "run-1"
+    );
+  });
+
+  it("ignores rows that already left pending when looking for an in-flight Run", async () => {
+    await store.create(delivery);
+    await store.markStatus(BUSINESS_ID, "run-1", "done");
+
+    expect(
+      await store.findInFlightForThread({
+        businessId: BUSINESS_ID,
+        provider: "slack",
+        destination: "C-OPS",
+        threadId: "1720000000.000100",
+      })
+    ).toBeNull();
+  });
+
+  it("lets exactly one claimant move a row out of pending", async () => {
+    await store.create(delivery);
+
+    const first = await store.claim(BUSINESS_ID, "run-1");
+    expect(first?.status).toBe("delivering");
+    expect(await store.claim(BUSINESS_ID, "run-1")).toBeNull();
+  });
+
+  it("refuses to supersede a row a deliverer already claimed", async () => {
+    await store.create(delivery);
+    await store.claim(BUSINESS_ID, "run-1");
+
+    expect(await store.markSuperseded(BUSINESS_ID, "run-1")).toBe(false);
+  });
+
+  it("supersedes a still-pending row", async () => {
+    await store.create(delivery);
+
+    expect(await store.markSuperseded(BUSINESS_ID, "run-1")).toBe(true);
+    expect((await store.find(BUSINESS_ID, "run-1"))?.status).toBe("superseded");
+    expect(await store.claim(BUSINESS_ID, "run-1")).toBeNull();
+  });
+
+  it("records the emoji an Agent acknowledged with", async () => {
+    await store.create(delivery);
+
+    const updated = await store.markAcknowledged(BUSINESS_ID, "run-1", "thumbsup");
+    expect(updated.acknowledgedEmoji).toBe("thumbsup");
+
+    await expect(store.markAcknowledged(BUSINESS_ID, "run-missing", "thumbsup")).rejects.toThrow(
+      "channel_run_delivery_not_found"
+    );
+  });
 });

--- a/packages/storage/src/integrations/channel-run-delivery-store.ts
+++ b/packages/storage/src/integrations/channel-run-delivery-store.ts
@@ -1,6 +1,12 @@
 import type { TransactionPort } from "../ports";
 
-export type ChannelRunDeliveryStatus = "pending" | "done" | "failed";
+/**
+ * `pending` is unclaimed work — the Run may still be executing, or may have finished without a
+ * poll tick having picked it up yet. `delivering` is claimed: exactly one poller owns it and is
+ * posting. That claim is what makes superseding safe, because superseding is a conditional
+ * `pending` -> `superseded` write, so it and delivery can never both win the same row.
+ */
+export type ChannelRunDeliveryStatus = "pending" | "delivering" | "done" | "failed" | "superseded";
 
 export interface PersistedChannelRunDelivery {
   businessId: string;
@@ -13,6 +19,12 @@ export interface PersistedChannelRunDelivery {
   agentId: string;
   principalId: string;
   idempotencyKey: string;
+  /**
+   * The provider message that started this Run — Slack's `event.ts`. Distinct from `threadId`,
+   * which is the thread *root* (`thread_ts ?? ts`): reacting to `threadId` would land on the wrong
+   * message for every in-thread reply.
+   */
+  sourceMessageTs?: string;
 }
 
 export interface PersistedChannelRunDeliveryRecord extends PersistedChannelRunDelivery {
@@ -22,6 +34,8 @@ export interface PersistedChannelRunDeliveryRecord extends PersistedChannelRunDe
   approvalPostedId?: string;
   /** The Slack message ts of that posted approval prompt, for the best-effort status update. */
   approvalMessageTs?: string;
+  /** Set once the Agent acknowledged with a reaction instead of answering; suppresses the reply. */
+  acknowledgedEmoji?: string;
   createdAt: string;
   updatedAt: string;
 }
@@ -38,10 +52,14 @@ export const CHANNEL_RUN_DELIVERY_STORAGE_STATEMENTS: readonly string[] = [
     agent_id        text NOT NULL,
     principal_id    text NOT NULL,
     idempotency_key text NOT NULL,
-    status          text NOT NULL CHECK (status IN ('pending', 'done', 'failed')),
+    status          text NOT NULL CHECK (
+      status IN ('pending', 'delivering', 'done', 'failed', 'superseded')
+    ),
     slack_message_ts text,
     approval_posted_id text,
     approval_message_ts text,
+    source_message_ts text,
+    acknowledged_emoji text,
     created_at      timestamptz NOT NULL,
     updated_at      timestamptz NOT NULL,
     PRIMARY KEY (business_id, run_id)
@@ -49,12 +67,33 @@ export const CHANNEL_RUN_DELIVERY_STORAGE_STATEMENTS: readonly string[] = [
   `CREATE INDEX IF NOT EXISTS channel_run_deliveries_pending_idx
     ON channel_run_deliveries (business_id, status)
     WHERE status = 'pending'`,
+  `CREATE INDEX IF NOT EXISTS channel_run_deliveries_inflight_thread_idx
+    ON channel_run_deliveries (business_id, provider, destination, thread_id)
+    WHERE status = 'pending'`,
 ];
 
 /** Adds the Approve/Deny prompt correlation columns to a table created before they existed. */
 export const CHANNEL_RUN_DELIVERY_APPROVAL_COLUMNS_STATEMENTS: readonly string[] = [
   `ALTER TABLE channel_run_deliveries ADD COLUMN IF NOT EXISTS approval_posted_id text`,
   `ALTER TABLE channel_run_deliveries ADD COLUMN IF NOT EXISTS approval_message_ts text`,
+];
+
+/**
+ * Brings a table created before acknowledgement and superseding up to date: the reaction columns,
+ * the widened status domain, and the thread index a supersede lookup needs.
+ *
+ * `ADD CONSTRAINT` is not idempotent, so the check is dropped and re-added as a pair rather than
+ * guarded — re-running the pair is a no-op, re-running a bare `ADD` is an error.
+ */
+export const CHANNEL_RUN_DELIVERY_ACKNOWLEDGE_STATEMENTS: readonly string[] = [
+  `ALTER TABLE channel_run_deliveries ADD COLUMN IF NOT EXISTS source_message_ts text`,
+  `ALTER TABLE channel_run_deliveries ADD COLUMN IF NOT EXISTS acknowledged_emoji text`,
+  `ALTER TABLE channel_run_deliveries DROP CONSTRAINT IF EXISTS channel_run_deliveries_status_check`,
+  `ALTER TABLE channel_run_deliveries ADD CONSTRAINT channel_run_deliveries_status_check
+    CHECK (status IN ('pending', 'delivering', 'done', 'failed', 'superseded'))`,
+  `CREATE INDEX IF NOT EXISTS channel_run_deliveries_inflight_thread_idx
+    ON channel_run_deliveries (business_id, provider, destination, thread_id)
+    WHERE status = 'pending'`,
 ];
 
 interface RunDeliveryRow {
@@ -72,13 +111,15 @@ interface RunDeliveryRow {
   slack_message_ts: string | null;
   approval_posted_id: string | null;
   approval_message_ts: string | null;
+  source_message_ts: string | null;
+  acknowledged_emoji: string | null;
   created_at: Date | string;
   updated_at: Date | string;
 }
 
 const RUN_DELIVERY_COLUMNS = `business_id, run_id, integration_id, route_id, provider, destination,
   thread_id, agent_id, principal_id, idempotency_key, status, slack_message_ts, approval_posted_id,
-  approval_message_ts, created_at, updated_at`;
+  approval_message_ts, source_message_ts, acknowledged_emoji, created_at, updated_at`;
 
 function timestamp(value: Date | string): string {
   return value instanceof Date ? value.toISOString() : value;
@@ -100,6 +141,8 @@ function runDeliveryRecord(row: RunDeliveryRow): PersistedChannelRunDeliveryReco
     ...(row.slack_message_ts === null ? {} : { slackMessageTs: row.slack_message_ts }),
     ...(row.approval_posted_id === null ? {} : { approvalPostedId: row.approval_posted_id }),
     ...(row.approval_message_ts === null ? {} : { approvalMessageTs: row.approval_message_ts }),
+    ...(row.source_message_ts === null ? {} : { sourceMessageTs: row.source_message_ts }),
+    ...(row.acknowledged_emoji === null ? {} : { acknowledgedEmoji: row.acknowledged_emoji }),
     createdAt: timestamp(row.created_at),
     updatedAt: timestamp(row.updated_at),
   };
@@ -119,9 +162,10 @@ export class ChannelRunDeliveryStore {
         `INSERT INTO channel_run_deliveries (
            business_id, run_id, integration_id, route_id, provider, destination,
            thread_id, agent_id, principal_id, idempotency_key, status, slack_message_ts,
-           approval_posted_id, approval_message_ts, created_at, updated_at
+           approval_posted_id, approval_message_ts, source_message_ts, acknowledged_emoji,
+           created_at, updated_at
          ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, 'pending', NULL, NULL, NULL,
-           $11::timestamptz, $11::timestamptz)
+           $11, NULL, $12::timestamptz, $12::timestamptz)
          ON CONFLICT (business_id, run_id) DO UPDATE SET run_id = EXCLUDED.run_id
          RETURNING ${RUN_DELIVERY_COLUMNS}`,
         [
@@ -135,6 +179,7 @@ export class ChannelRunDeliveryStore {
           delivery.agentId,
           delivery.principalId,
           delivery.idempotencyKey,
+          delivery.sourceMessageTs ?? null,
           now,
         ]
       );
@@ -165,6 +210,111 @@ export class ChannelRunDeliveryStore {
         [businessId]
       );
       return result.rows.map(runDeliveryRecord);
+    });
+  }
+
+  /**
+   * The newest unclaimed delivery for a provider thread, excluding `runId` itself.
+   *
+   * Only `pending` rows are returned: a `delivering` row has already been claimed by a poller and
+   * is being posted, so it is past the point where superseding it could suppress anything.
+   */
+  async findInFlightForThread(input: {
+    businessId: string;
+    provider: string;
+    destination: string;
+    threadId: string;
+    excludeRunId?: string;
+  }): Promise<PersistedChannelRunDeliveryRecord | null> {
+    return this.transactions.withTransaction(async (transaction) => {
+      const result = await transaction.query<RunDeliveryRow>(
+        `SELECT ${RUN_DELIVERY_COLUMNS}
+           FROM channel_run_deliveries
+          WHERE business_id = $1
+            AND provider = $2
+            AND destination = $3
+            AND thread_id = $4
+            AND status = 'pending'
+            AND ($5::text IS NULL OR run_id <> $5)
+          ORDER BY created_at DESC
+          LIMIT 1`,
+        [
+          input.businessId,
+          input.provider,
+          input.destination,
+          input.threadId,
+          input.excludeRunId ?? null,
+        ]
+      );
+      const row = result.rows[0];
+      return row === undefined ? null : runDeliveryRecord(row);
+    });
+  }
+
+  /**
+   * Takes exclusive ownership of a delivery before it is posted (`pending` -> `delivering`).
+   *
+   * Returns `null` when the row was already claimed or superseded. Callers must post only on a
+   * non-null result: this claim is the sole reason a supersede and a delivery cannot both act on
+   * the same Run, and skipping it reintroduces the double reply as a narrow race rather than a
+   * reliable one.
+   */
+  async claim(
+    businessId: string,
+    runId: string
+  ): Promise<PersistedChannelRunDeliveryRecord | null> {
+    return this.transactions.withTransaction(async (transaction) => {
+      const result = await transaction.query<RunDeliveryRow>(
+        `UPDATE channel_run_deliveries
+            SET status = 'delivering',
+                updated_at = $3::timestamptz
+          WHERE business_id = $1 AND run_id = $2 AND status = 'pending'
+          RETURNING ${RUN_DELIVERY_COLUMNS}`,
+        [businessId, runId, this.now()]
+      );
+      const row = result.rows[0];
+      return row === undefined ? null : runDeliveryRecord(row);
+    });
+  }
+
+  /**
+   * Retires a delivery a newer message has taken over, so its reply is never posted.
+   *
+   * Conditional on `pending` for the same reason `claim` is, and reports whether it won so the
+   * caller knows whether cancelling the Run is still worthwhile.
+   */
+  async markSuperseded(businessId: string, runId: string): Promise<boolean> {
+    return this.transactions.withTransaction(async (transaction) => {
+      const result = await transaction.query<RunDeliveryRow>(
+        `UPDATE channel_run_deliveries
+            SET status = 'superseded',
+                updated_at = $3::timestamptz
+          WHERE business_id = $1 AND run_id = $2 AND status = 'pending'
+          RETURNING ${RUN_DELIVERY_COLUMNS}`,
+        [businessId, runId, this.now()]
+      );
+      return result.rows.length > 0;
+    });
+  }
+
+  /** Records the reaction an Agent answered with, which suppresses this Run's text reply. */
+  async markAcknowledged(
+    businessId: string,
+    runId: string,
+    emoji: string
+  ): Promise<PersistedChannelRunDeliveryRecord> {
+    return this.transactions.withTransaction(async (transaction) => {
+      const result = await transaction.query<RunDeliveryRow>(
+        `UPDATE channel_run_deliveries
+            SET acknowledged_emoji = $3,
+                updated_at = $4::timestamptz
+          WHERE business_id = $1 AND run_id = $2
+          RETURNING ${RUN_DELIVERY_COLUMNS}`,
+        [businessId, runId, emoji, this.now()]
+      );
+      const row = result.rows[0];
+      if (row === undefined) throw new Error("channel_run_delivery_not_found");
+      return runDeliveryRecord(row);
     });
   }
 

--- a/packages/storage/src/integrations/index.ts
+++ b/packages/storage/src/integrations/index.ts
@@ -31,6 +31,7 @@ export type {
   PersistedChannelRunDeliveryRecord,
 } from "./channel-run-delivery-store";
 export {
+  CHANNEL_RUN_DELIVERY_ACKNOWLEDGE_STATEMENTS,
   CHANNEL_RUN_DELIVERY_APPROVAL_COLUMNS_STATEMENTS,
   CHANNEL_RUN_DELIVERY_STORAGE_STATEMENTS,
   ChannelRunDeliveryStore,


### PR DESCRIPTION
- **Acknowledge instead of replying.** New `slack.message.acknowledge` Tool (`slack_acknowledge`) reacts to the message the Run started from and ends the turn; the delivery poll loop sees `acknowledged_emoji` and posts nothing. The reaction target is read from the Run's own delivery row, never from a Tool argument, so an Agent that can react cannot react anywhere else in the workspace. Emoji resolve against the workspace's own `emoji.list` — cached three hours, refetched once on a miss — through exact, substring and bounded fuzzy tiers, so custom emoji work and a near miss still lands.
- **No more double replies.** A second message in a thread whose earlier Run is still pending supersedes that Run before starting its own. Both messages already share one Conversation and the user Message is durable before dispatch, so the surviving Run answers both. Supersede and delivery contend for the same row through conditional writes (`pending`→`superseded` against `pending`→`delivering`), so exactly one wins. A Run parked on an approval is left alone — cancelling it would strand its Approve/Deny buttons.
- Adds `reactions:write` and `emoji:read` to both manifest scope lists and the connect-Slack docs; migration 96 adds `source_message_ts`, `acknowledged_emoji`, the widened status domain and the in-flight thread index.

## Test plan

- [x] `pnpm typecheck` — 40/40 workspaces
- [x] `@tulipfarm/integrations` — emoji resolver and cache (14), acknowledge dispatch (17), contracts (10)
- [x] `@tulipfarm/storage` — conditional claim/supersede semantics (13)
- [x] `@tulipfarm/integration-worker` — poll-loop suppression and lost claim (12)
- [x] `@tulipfarm/api` — supersede, cross-thread, approval-parked, replay (34)
- [x] `pnpm eval` — 49 passed, incl. new `slack-acknowledges-instead-of-replying`; verified it fails without the change (corpus refuses an unknown platform Tool)

⚠️ This edits `corpus/`, which moves `corpusHash` and retires every Baseline — a maintainer must re-promote before the gate compares again.