### PR TITLE
feat(skills): give Resource Forge archetypes and a schema spec

### DIFF
--- a/skills/forge/resource-forge/SKILL.md
+++ b/skills/forge/resource-forge/SKILL.md
@@ -11,6 +11,7 @@ tools:
     create_resource_hooks,
     resource_hooks_get,
     resource_hooks_delete,
+    skill,
     validate_artifact,
     present,
     request_input,
@@ -23,6 +24,116 @@ Skill reports its outcome directly.
 
 {{FORGE_EXECUTION_CONTRACT}}
 
+## Start from an archetype, never from a blank page
+
+Asking "what fields would you like?" is the worst outcome this Skill can produce. The user asked for
+a leave tracker precisely because they do not want to design one, and the type they get should not
+depend on which model happened to serve them. So: **read the reference for their use case before you
+ask them anything about fields**, then propose a concrete, complete type and invite edits.
+
+Route from the request to one file, and read only that one. Call `skill` with
+`name: "resource-forge"` and the `file` below. Each file carries the field sets, the shape decisions,
+the hooks worth offering, the limits to state up front, and the few questions actually worth asking.
+**One read is enough** — nothing changes while you work.
+
+| The request is about | `file:` |
+| --- | --- |
+| Issue tracking, sprints, backlogs, projects, bugs, "a Jira/Linear/Trello alternative" | `references/ticket-management.md` |
+| Helpdesk, support inbox, service desk, customer-facing tickets, SLAs | `references/customer-support.md` |
+| Employee directory, org chart, leave and time off, hiring, onboarding, IT assets | `references/hr-and-people.md` |
+| Invoicing, billing, expenses, reimbursements, purchase orders, vendors | `references/finance.md` |
+| CRM, sales pipeline, leads, campaigns, content calendar, events | `references/marketing-and-sales.md` |
+| Incidents, on-call, postmortems, service catalog, deploy logs | `references/engineering-ops.md` |
+| A `customer` or an `employee` — the types the others link to | `references/core-types.md` |
+
+Two more reads, each with its own trigger:
+
+- `references/core-types.md` — whenever your bundle links to `customer` or `employee` and the
+  instance does not have them yet.
+- `references/schema-spec.md` — before Step 4, whenever you will write any `x-*` keyword. It is the
+  exact accepted shape of every one of them, and a wrong shape is rejected only after the user has
+  approved. The summary in Step 4 below covers the common cases; the spec covers all of them.
+
+If the request matches no row, design it from the rules below — and still propose fields first
+rather than asking the user to invent them.
+
+## Data Shape
+
+Decide, per piece of data, whether it becomes its own Resource type (**normalize**) or lives inside
+the parent (**embed**). This choice is expensive to reverse — existing Records must be migrated — so
+make it before Step 4, not after.
+
+### The runtime constraints that decide it
+
+Each Resource type is one PostgreSQL table whose business fields all live in a single `data` JSONB
+column. Four consequences drive every rule below:
+
+- **There are no joins.** Search filters one type at a time, by exact containment on `data`. A
+  question spanning two types costs one read per type, in the caller.
+- **`x-links` is checked, not cascaded.** The target must exist at write time. Deleting the target
+  later orphans the link; nothing cleans it up.
+- **Nothing refreshes a copied field.** Transforms (`x-computed`) read only the Record's own
+  fields. A hook can read another type, but it fires on *this* type's writes — a change to the
+  source never propagates back.
+- **A link must be a single string id.** An array of ids is not validated at all.
+
+### The rule
+
+Give it its own Resource type when **any** of these is true:
+
+- It has its own identity people refer to (a Customer, an Invoice, an Employee).
+- It has its own lifecycle — created, updated or deleted independently of the parent.
+- Users need to list, search or report on it on its own.
+- The same instance is referenced by more than one parent.
+
+Embed it in the parent (`object`, or `array` of `object`) when **all** of these hold:
+
+- It has no meaning apart from its parent.
+- It is never queried on its own.
+- It is created and deleted with the parent.
+
+```text
+customer            -> own type    (own identity, listed, referenced by many)
+  billing address   -> embed       (object; no identity, dies with customer)
+order
+  customerId        -> x-links     (customer outlives the order)
+  lineItems         -> embed       (array of object; meaningless alone)
+```
+
+### Copying a field across types
+
+Copying a value from a linked Record onto this one is correct **only** when you want the value as it
+was at that moment, not as it is now. Name it so the snapshot is obvious, and write it in a `before`
+hook (Step 8) — no transform can read another type.
+
+```text
+priceAtOrder, addressAtShipping, rateAtBooking   -> correct: point-in-time facts
+customerName copied onto ticket                  -> wrong: goes stale on rename
+```
+
+Never copy a field only to display it. The UI resolves a link to the target's label already, so a
+copied name buys nothing and can disagree with the source.
+
+### Many-to-many, and links that carry data
+
+Never model a many-to-many as an array of ids — link validation skips arrays, so the ids are
+unchecked. Create a third Resource type holding one `x-links` field per side. Do the same when the
+relationship itself has fields.
+
+```text
+project <-> person, with a role   ->  project-membership
+                                        projectId  x-links: { target: "project" }
+                                        personId   x-links: { target: "person" }
+                                        role       enum
+```
+
+### Two things normalizing does not give you
+
+- **Uniqueness** comes from `x-unique` on the owning type, not from splitting a type out. Add it
+  when duplicates would be a real problem.
+- **Referential cleanup** does not exist. If an orphaned link would break the business, guard the
+  parent's deletion in a `before` hook on the target type.
+
 ## Create Flow
 
 ### Step 0 — Overlap check
@@ -32,6 +143,12 @@ similar name, matching purpose), surface it and ask whether to **use it**, **edi
 or **create a new one alongside it**. Only continue when the user wants a new type. This prevents
 accidental duplicates.
 
+Then read the reference file for the request (routing table above) and take its bundle. Most
+requests are a bundle, not one type — "ticket management" means `project`, `issue` and `cycle`, not
+an `issue` alone. Name the whole bundle, separate the core types from the optional ones, and confirm
+the set before building any of it. Build them one at a time in the order the file gives: a link
+cannot point at a type that does not exist yet.
+
 ### Step 1 — Identity
 
 Establish: the singular kebab-case **name** (e.g. `support-ticket`), a one-sentence
@@ -40,38 +157,61 @@ you genuinely cannot determine.
 
 ### Step 2 — Fields
 
+**Propose, do not interview.** Present the archetype's fields as a concrete list the user can react
+to, call out anything you deliberately left out (personal data, salary, retention-bound fields), and
+ask one question: what to add, drop or rename. Ask about a field individually only when the
+reference file says to — the leave-type list, the real department names, points versus hours.
+
 For each field collect: name (camelCase), type (string/number/boolean/date/enum/array/object/
 reference), required-or-optional, and a short description. Declare only the business fields.
-Suggest sensible fields for the archetype. For a ticketing system, suggest a `status` field (e.g.
-`todo`, `in-progress`, `review`, `done`) and an `assignee`/`assigneeId` reference.
 
 Do not declare system fields — the platform auto-manages `id` (UUID primary key), `createdAt`,
 `updatedAt`, and `version` on every Record; declaring them just creates empty duplicate fields.
 A human/display identifier (e.g. `TICK-123`) is a separate business field produced by
 `x-id-strategy` (RES-V1-001), not the system id.
 
-### Step 3 — Relationships (`x-links`)
+### Step 3 — Shape and relationships (`x-links`)
 
-Ask whether this Resource type references existing types. Encode each as `x-links`: the referencing
-field points at the target type's Record by `_id`. Links are validated on write (the target must
-exist) and orphaned (not cascaded) on delete.
+Walk the fields from Step 2 against [Data Shape](#data-shape) and settle each one: embedded value,
+embedded `object`/`array`, or a link to another type. State the split in one sentence when you
+preview (Step 6) — the user rarely knows the trade and always cares about the result.
+
+Encode every relationship as `x-links`: the referencing field points at the target type's Record by
+`_id`. Links are validated on write (the target must exist) and orphaned (not cascaded) on delete.
 
 Use exactly `x-links: { target: "customer" }` on the referencing field, where `customer` is the
 existing Resource type name. `target` must be a non-empty string; never leave it blank or use an
-object.
+object. A link field holds one id — for many-to-many, create the join type from
+[Data Shape](#data-shape) instead.
 
 ### Step 4 — Generate Schema
 
-Construct a JSON Schema 2020-12 object:
+Construct a JSON Schema 2020-12 object — the **record schema only**. The platform wraps it in the
+Soul envelope; never write `apiVersion`, `kind`, `metadata` or `spec` yourself, and never set
+`domain` (it is admin-only, so a type created from Chat lands in `resources/<name>/schema.yml`).
 
 - `$schema: "https://json-schema.org/draft/2020-12/schema"`, `type: object` at the root.
-- All fields under `properties`; required ones in `required`.
-- `x-links` for relationships; declarative transforms (`x-id-strategy`, `x-computed`,
-  `x-normalize`) where useful.
+- All fields under `properties`, camelCase; required ones in `required`.
+- Never declare `id`, `createdAt`, `updatedAt` or `version` — the platform manages them.
+
+The `x-*` vocabulary below is **closed**: the validator rejects a wrong shape, and a *misspelled*
+keyword is silently ignored instead, so copy the spelling exactly. Full detail, including every
+allowed value, is in `references/schema-spec.md`.
+
+| Keyword | Level | Shape |
+| --- | --- | --- |
+| `x-links` | property | `{ target: "customer" }` — non-empty string naming an existing type |
+| `x-normalize` | property | array of `trim`, `lowercase`, `uppercase`, `slugify`, `phone-e164`, `email-normalize` |
+| `x-unique` | root | **array of arrays**: `[[workEmail]]`, `[[projectId, key]]` — never `[workEmail]` |
+| `x-computed` | root | `{ field, from: [...], fn }`, `fn` ∈ `sha256`, `uuid`, `sequence`; `from` reads this Record only |
+| `x-id-strategy` | root | `{ prefix: "TICK-", sequence: true, field: key }` — counter is per type, not per parent |
+| `x-readOnly` / `x-immutable` | property | booleans; pair `x-readOnly` with `x-id-strategy` and with any hook-computed total |
 
 ### Step 5 — Validate (optional)
 
-If `validate_artifact` is available, validate the Schema and fix any errors before presenting.
+If `validate_artifact` is available, validate the Schema and fix any errors before presenting. It
+runs the same checks the write does, so an error caught here is one the user would otherwise hit
+*after* approving.
 
 ### Step 6 — Preview & approve
 
@@ -93,6 +233,10 @@ hooks, explain why in one sentence, then present the choice. Common triggers tha
 
 - A field references another Resource type and writes need to validate a value on the target (not
   just existence — `x-links` handles existence). Example: checking the target's balance or status.
+- A point-in-time snapshot must be copied from a linked Record (see [Data Shape](#data-shape)).
+  `ctx.resources.get` + `ctx.patch` in the `before` hook is the only way to do it, and the copy is
+  never refreshed afterwards — so only snapshot what should stay frozen.
+- Deleting this Record would orphan links pointing at it, and that would break the business.
 - Status transitions need to be guarded (e.g. only `pending` → `approved` or `rejected`).
 - A computed field depends on data from another Resource type (cross-Resource join at write time).
 - A date range needs business-day calculation or overlap detection.

--- a/skills/forge/resource-forge/references/core-types.md
+++ b/skills/forge/resource-forge/references/core-types.md
@@ -1,0 +1,62 @@
+# Core Types
+
+Two types that other archetypes link to. Build them first in any bundle that names them, because a
+link cannot point at a type that does not exist yet.
+
+Always call `list_resource_types` before creating either — an instance that has been used for a
+while usually has one already, possibly under a different name (`client`, `account`, `staff`,
+`person`). Reuse it rather than creating a second one.
+
+## `customer`
+
+The company or account other records point at.
+
+| Field | Type | Req | Notes |
+| --- | --- | --- | --- |
+| `name` | string | yes | Display name |
+| `domain` | string | no | Primary email/web domain |
+| `tier` | enum | no | `free`, `pro`, `enterprise` |
+| `status` | enum | yes | `prospect`, `active`, `churned` |
+| `ownerId` | reference | no | `x-links` → `employee` |
+| `billingAddress` | object | no | `line1`, `line2`, `city`, `region`, `postalCode`, `country` |
+| `annualValue` | number | no | Recurring revenue |
+| `startedOn` | date | no | |
+
+**Shape** — `billingAddress` is embedded: no identity of its own, never listed alone, dies with the
+customer.
+
+`x-unique: [[domain]]` only when one domain genuinely means one customer. For an agency or a group
+with many subsidiaries on a shared domain it makes every second create fail, so ask before adding
+it.
+
+## `employee`
+
+The people directory. Assignees, owners, approvers and managers across every other archetype are
+links to this type.
+
+| Field | Type | Req | Notes |
+| --- | --- | --- | --- |
+| `fullName` | string | yes | |
+| `workEmail` | string | yes | |
+| `jobTitle` | string | no | |
+| `department` | enum | no | Ask for the real list; a wrong enum is a schema edit later |
+| `managerId` | reference | no | `x-links` → `employee` — self-link, gives the org chart |
+| `startDate` | date | yes | |
+| `endDate` | date | no | |
+| `employmentType` | enum | yes | `full-time`, `part-time`, `contractor`, `intern` |
+| `location` | string | no | |
+| `status` | enum | yes | `active`, `on-leave`, `departed` |
+| `emergencyContact` | object | no | `name`, `relationship`, `phone` |
+
+**Shape** — `x-unique: [[workEmail]]`. `emergencyContact` is embedded. `managerId` pointing at the
+same type is what makes the org chart work; there is no separate hierarchy type.
+
+**Left out on purpose.** Home address, salary, bank details, date of birth and national ID are not
+in the default set. Offer them as an explicit addition and say what changes: anyone who can read
+the type can read every field on it, so putting salary here means the directory and the payroll
+data share one permission. A separate type for the sensitive fields, linked by `employeeId`, is
+usually what the user actually wants.
+
+**Departures.** `status: departed` with an `endDate` keeps history intact. Deleting the record
+orphans every link pointing at it — past leave requests, closed issues, old invoices — because link
+targets are checked on write and never cascaded on delete.

--- a/skills/forge/resource-forge/references/customer-support.md
+++ b/skills/forge/resource-forge/references/customer-support.md
@@ -1,0 +1,79 @@
+# Customer Support
+
+Inbound requests from people outside the company. Build this when the user asks for a helpdesk, a
+support inbox, a service desk, ticketing for customers, or names a support product they want to
+replace.
+
+For internal engineering work — bugs, features, sprints — use `ticket-management.md`. The two are
+different shapes. A support ticket faces a customer and closes; an issue is internal work with an
+estimate and a cycle. Users who want both should get both, linked by an `issueId` field on the
+ticket, not one merged type.
+
+## The bundle
+
+| | Type | |
+| --- | --- | --- |
+| Core | `support-ticket` | The request, from raised to resolved |
+| Core | `customer` | From `core-types.md` — who raised it |
+| Optional | `employee` | From `core-types.md` — needed for assignees |
+
+Build order: `customer` and `employee` → `support-ticket`.
+
+## `support-ticket`
+
+| Field | Type | Req | Notes |
+| --- | --- | --- | --- |
+| `key` | string | no | `x-id-strategy` → `TICK-1`; `x-readOnly` |
+| `subject` | string | yes | |
+| `description` | string | yes | |
+| `status` | enum | yes | `new`, `open`, `pending`, `resolved`, `closed` |
+| `priority` | enum | yes | `low`, `normal`, `high`, `urgent` |
+| `channel` | enum | no | `email`, `chat`, `phone`, `portal` |
+| `category` | enum | no | Ask for their real list — billing, bug, how-to, feature |
+| `customerId` | reference | no | `x-links` → `customer` |
+| `requesterName` | string | no | The person, when they are not a linked record |
+| `requesterEmail` | string | no | |
+| `assigneeId` | reference | no | `x-links` → `employee` |
+| `dueAt` | date | no | The SLA deadline — see below |
+| `firstRespondedAt` | date | no | |
+| `resolvedAt` | date | no | |
+| `tags` | array | no | Strings |
+
+**Shape** — `customerId` is optional on purpose. Support requests arrive from people who are not yet
+customers, and a required link would reject them. Keep `requesterEmail` for that case.
+
+`pending` means waiting on the customer. It is the status people forget to ask for and then miss,
+because it is what stops the clock on a response target.
+
+## SLAs
+
+`dueAt` is a stored date, not a live rule. Nothing recalculates it when priority changes unless a
+hook does.
+
+The workable version is a `before` hook that sets `dueAt` from `priority` and the creation time —
+four hours for urgent, one business day for high, and so on. Offer it, and be explicit that it is
+computed once at write time. A user who expects escalation, business-hours calendars or pause-on-
+pending is describing a Routine that runs on a schedule, not a field on this type; say so rather
+than building a field that will quietly be wrong.
+
+## Hooks worth offering
+
+- Set `resolvedAt` when `status` becomes `resolved`, and clear it if the ticket is reopened.
+- Set `firstRespondedAt` once, on the first transition out of `new`.
+- Block a transition from `closed` back to `new` — reopening should go to `open`.
+
+## Limits worth saying out loud
+
+- **Email does not arrive on its own.** This type stores tickets; it does not read a mailbox.
+  Populating it from an inbox is an Integration and a Routine, not part of the Resource type.
+- **Statuses are fixed in the schema**, the same for every ticket, and changing them later is a
+  schema edit.
+- **Counting open tickets per customer is a filtered query, not a field.** Do not store
+  `openTicketCount` on `customer`; nothing would keep it correct.
+- **Records display as a sortable table with a text filter, not a queue view with live counts.**
+
+## Questions worth asking, and nothing else
+
+1. What categories do their tickets actually fall into?
+2. Do they want response deadlines — and if so, do they accept "computed once at creation"?
+3. Are requesters always existing customers, or do strangers write in too?

--- a/skills/forge/resource-forge/references/engineering-ops.md
+++ b/skills/forge/resource-forge/references/engineering-ops.md
@@ -1,0 +1,90 @@
+# Engineering Ops
+
+Services, incidents and releases. Build this when the user asks for incident management, on-call
+records, postmortems, a service catalog, or a deploy log.
+
+For issue and sprint tracking use `ticket-management.md`.
+
+## The bundle
+
+| They say | Build |
+| --- | --- |
+| incident management, on-call, postmortems, outage log | `incident` + `service` |
+| service catalog, ownership registry, who owns what | `service` alone |
+| deploy log, release tracking, change log | `deployment` + `service` |
+
+Build `service` first — the other two link to it.
+
+## `service`
+
+| Field | Type | Req | Notes |
+| --- | --- | --- | --- |
+| `name` | string | yes | |
+| `description` | string | no | |
+| `repoUrl` | string | no | |
+| `tier` | enum | yes | `tier-1`, `tier-2`, `tier-3` |
+| `ownerId` | reference | no | `x-links` → `employee` |
+| `ownerTeam` | string | no | Team name, when teams are not their own type |
+| `oncallContact` | string | no | Rotation name or channel |
+| `runbookUrl` | string | no | |
+| `status` | enum | yes | `active`, `deprecated`, `retired` |
+
+**Shape** — `x-unique: [[name]]`.
+
+## `incident`
+
+| Field | Type | Req | Notes |
+| --- | --- | --- | --- |
+| `key` | string | no | `x-id-strategy` → `INC-1`; `x-readOnly` |
+| `title` | string | yes | |
+| `severity` | enum | yes | `sev1`, `sev2`, `sev3`, `sev4` |
+| `status` | enum | yes | `investigating`, `identified`, `monitoring`, `resolved`, `postmortem-done` |
+| `serviceId` | reference | no | `x-links` → `service` |
+| `commanderId` | reference | no | `x-links` → `employee` |
+| `detectedAt` | date | no | |
+| `startedAt` | date | yes | |
+| `resolvedAt` | date | no | |
+| `customerImpact` | string | no | |
+| `rootCause` | string | no | |
+| `timeline` | array | no | Objects: `at`, `note`, `authorId` |
+| `actionItems` | array | no | Objects: `description`, `ownerId`, `dueDate`, `done` |
+
+**Shape** — `timeline` is embedded: entries have no meaning outside the incident and are never
+listed alone.
+
+**The fork worth raising.** `actionItems` embedded is right if they are a postmortem checklist
+nobody tracks elsewhere. If the user wants follow-up work on the same board as everything else, the
+action items should be `issue` records linking back with an `incidentId` field instead. Ask —
+converting later means migrating every incident.
+
+**One incident, one service** as written. A `serviceIds` array would not be validated at all, so
+multi-service incidents need either a join type or the honest answer that `serviceId` names the
+primary one. Say which you chose.
+
+**Hooks worth offering** — compute `durationMinutes` from `startedAt` and `resolvedAt`, and set
+`resolvedAt` on the transition into `resolved`.
+
+## `deployment`
+
+| Field | Type | Req | Notes |
+| --- | --- | --- | --- |
+| `serviceId` | reference | yes | `x-links` → `service` |
+| `version` | string | yes | |
+| `commitSha` | string | no | |
+| `environment` | enum | yes | `dev`, `staging`, `production` |
+| `status` | enum | yes | `pending`, `succeeded`, `failed`, `rolled-back` |
+| `deployedById` | reference | no | `x-links` → `employee` |
+| `deployedAt` | date | yes | |
+| `rolledBackAt` | date | no | |
+| `notes` | string | no | |
+
+**Shape** — a rollback is a status on the original record, not a second deployment, unless the user
+wants the rollback itself timed and attributed. Ask which.
+
+## Limits worth saying out loud
+
+- **Nothing writes these records for you.** A deploy log is populated by a Routine calling this type
+  from CI, or by hand. The Resource type is the store, not the collector.
+- **"Deploys this week" and "incidents per service" are filtered queries, not stored counts.** Do
+  not add `incidentCount` to `service`.
+- **Deleting a service orphans its incidents and deployments.** Use `status: retired`.

--- a/skills/forge/resource-forge/references/finance.md
+++ b/skills/forge/resource-forge/references/finance.md
@@ -1,0 +1,138 @@
+# Finance
+
+Invoicing, expenses and procurement. This file has the clearest examples of point-in-time snapshots
+in the whole archetype set — a finance record must show what was true when it was issued, not what
+is true now.
+
+| They say | Build |
+| --- | --- |
+| invoicing, billing, accounts receivable, what customers owe | `invoice` + `customer` |
+| expenses, reimbursements, expense claims | `expense-claim` + `employee` |
+| procurement, purchase orders, purchasing, spend approval | `purchase-order` + `vendor` |
+| vendor management, suppliers, contracts | `vendor` alone |
+
+Build `customer`, `employee` (both in `core-types.md`) or `vendor` before the type that links to it.
+
+## The snapshot rule, stated once
+
+Copying a value from a linked record onto a finance record is correct **only** when the value must
+stay frozen. Nothing refreshes a copy — no cascade, no back-propagation — which is exactly what a
+finance record wants.
+
+```text
+billingAddressAtIssue on invoice   -> the address it was issued to, even after the customer moves
+unitPrice inside lineItems         -> what was charged, not today's price
+vendorNameAtOrder on purchase-order -> the paper trail, even after the vendor is renamed
+```
+
+Write each of these in a `before` hook with `ctx.resources.get` and `ctx.patch`; no transform can
+read another type. Name every one so the freeze is obvious in the field name itself, and say it to
+the user — it is usually the thing they had not thought of.
+
+The mirror of the rule: never copy a field just to display it. The UI already resolves a link to
+the target's name.
+
+## `vendor`
+
+| Field | Type | Req | Notes |
+| --- | --- | --- | --- |
+| `name` | string | yes | |
+| `category` | enum | no | `software`, `hardware`, `services`, `facilities`, `other` |
+| `contactName` | string | no | |
+| `contactEmail` | string | no | |
+| `paymentTerms` | enum | no | `net-15`, `net-30`, `net-60`, `prepaid` |
+| `currency` | string | no | ISO code |
+| `contractStartsOn` | date | no | |
+| `contractEndsOn` | date | no | |
+| `status` | enum | yes | `active`, `pending-approval`, `terminated` |
+| `ownerId` | reference | no | `x-links` → `employee` |
+| `notes` | string | no | |
+
+**Shape** — `x-unique: [[name]]`.
+
+## `invoice`
+
+| Field | Type | Req | Notes |
+| --- | --- | --- | --- |
+| `invoiceNumber` | string | no | `x-id-strategy` → `INV-1`; `x-readOnly` |
+| `customerId` | reference | yes | `x-links` → `customer` |
+| `issueDate` | date | yes | |
+| `dueDate` | date | yes | |
+| `status` | enum | yes | `draft`, `sent`, `paid`, `overdue`, `void` |
+| `currency` | string | yes | ISO code |
+| `lineItems` | array | yes | Objects: `description`, `quantity`, `unitPrice`, `amount` |
+| `subtotal` | number | yes | Computed — see below |
+| `taxAmount` | number | no | |
+| `total` | number | yes | Computed |
+| `paidAt` | date | no | |
+| `billingAddressAtIssue` | object | no | Snapshot |
+| `notes` | string | no | |
+
+**Shape** — `lineItems` embedded: a line has no meaning outside its invoice and is never listed
+alone.
+
+**Hook worth offering** — compute `subtotal` and `total` from `lineItems` and mark both
+`x-readOnly`, so the stored totals cannot disagree with the lines that produced them.
+
+**Money.** Store amounts in one currency per invoice, in the currency's own units. If they trade in
+several currencies and want a combined total, that needs a rate — which is a snapshot too
+(`rateAtIssue`), not a live lookup. Raise it; do not silently sum across currencies.
+
+**`overdue` is not automatic.** Nothing moves an invoice from `sent` to `overdue` when the date
+passes. That is a scheduled Routine. Offer the status, and say what has to exist for it to mean
+anything.
+
+**Never delete a paid invoice.** `void` is the status that exists for corrections; deletion removes
+the record from the accounting history.
+
+## `expense-claim`
+
+| Field | Type | Req | Notes |
+| --- | --- | --- | --- |
+| `employeeId` | reference | yes | `x-links` → `employee` |
+| `description` | string | yes | |
+| `category` | enum | yes | `travel`, `meals`, `equipment`, `software`, `other` |
+| `amount` | number | yes | |
+| `currency` | string | yes | ISO code |
+| `incurredOn` | date | yes | |
+| `submittedAt` | date | no | |
+| `status` | enum | yes | `draft`, `submitted`, `approved`, `rejected`, `reimbursed` |
+| `approverId` | reference | no | `x-links` → `employee` |
+| `receiptUrl` | string | no | |
+| `decisionNote` | string | no | |
+| `reimbursedAt` | date | no | |
+
+**Hooks worth offering** — block self-approval (`approverId` equal to `employeeId`), guard the
+status transitions, and reject an `incurredOn` in the future.
+
+An approval threshold — anything over a limit needs a second approver — is a real request and needs
+either a second approver field or a routing Routine. Ask before assuming one approver is enough.
+
+## `purchase-order`
+
+| Field | Type | Req | Notes |
+| --- | --- | --- | --- |
+| `poNumber` | string | no | `x-id-strategy` → `PO-1`; `x-readOnly` |
+| `vendorId` | reference | yes | `x-links` → `vendor` |
+| `requestedById` | reference | yes | `x-links` → `employee` |
+| `approvedById` | reference | no | `x-links` → `employee` |
+| `status` | enum | yes | `draft`, `pending-approval`, `approved`, `ordered`, `received`, `cancelled` |
+| `currency` | string | yes | ISO code |
+| `lineItems` | array | yes | Objects: `description`, `quantity`, `unitPrice`, `amount` |
+| `total` | number | yes | Computed from `lineItems` |
+| `orderedOn` | date | no | |
+| `expectedOn` | date | no | |
+| `receivedOn` | date | no | |
+| `vendorNameAtOrder` | string | no | Snapshot |
+
+**Shape** — an approved purchase order should not be editable. Mark `total`, `lineItems` and
+`vendorId` `x-immutable` once approved, or guard the edit in a `before` hook; an approval that can
+be changed afterwards approves nothing.
+
+## Limits worth saying out loud
+
+- **"Total outstanding" and "spend this quarter" are filtered queries, not stored fields.** Do not
+  add `totalBilled` to `customer` or `totalSpend` to `vendor`; nothing keeps them correct.
+- **Statuses do not advance on their own.** `overdue`, reminders and escalations all need a Routine.
+- **Deleting a customer or vendor orphans every invoice or order pointing at it.** Use the
+  `churned` / `terminated` status instead.

--- a/skills/forge/resource-forge/references/hr-and-people.md
+++ b/skills/forge/resource-forge/references/hr-and-people.md
@@ -1,0 +1,133 @@
+# HR & People Ops
+
+Everything built around the people directory. Build `employee` from `core-types.md` first —
+every type here links to it.
+
+Match the request to the smallest set that answers it. "Leave management" does not need
+`job-application`, and offering all five at once buries the thing they asked for.
+
+| They say | Build |
+| --- | --- |
+| employee directory, org chart, staff list, HR system | `employee` alone |
+| leave management, time off, PTO, holiday tracker, absence | `leave-request` + `employee` |
+| hiring, applicant tracking, recruiting, candidate pipeline | `job-application` + `employee` |
+| onboarding, new-hire checklist, first-week setup | `onboarding-task` + `employee` |
+| IT assets, equipment, laptop tracking, inventory | `asset-assignment` + `employee` |
+
+`employee` itself lives in `core-types.md`, including what is deliberately left out of it and why
+salary and identity documents belong in a separate linked type.
+
+## `leave-request`
+
+Time off, from request to approval. The archetype with the strongest case for hooks in this file.
+
+| Field | Type | Req | Notes |
+| --- | --- | --- | --- |
+| `employeeId` | reference | yes | `x-links` → `employee` |
+| `leaveType` | enum | yes | `annual`, `sick`, `unpaid`, `parental`, `bereavement` |
+| `startDate` | date | yes | |
+| `endDate` | date | yes | |
+| `dayCount` | number | no | Computed in a hook — see below |
+| `halfDay` | boolean | no | |
+| `reason` | string | no | Optional on purpose; sick leave should not require one |
+| `status` | enum | yes | `draft`, `submitted`, `approved`, `rejected`, `cancelled` |
+| `approverId` | reference | no | `x-links` → `employee` |
+| `decidedAt` | date | no | |
+| `decisionNote` | string | no | |
+
+**Hooks worth offering** — say which of these they want before writing any:
+
+- Compute `dayCount` from the dates, and mark it `x-readOnly` so the stored number cannot disagree
+  with the range. Business-day counting is possible; public holidays are not, unless the holidays
+  themselves are a Resource type the hook can read.
+- Reject `endDate` earlier than `startDate`.
+- Guard the transitions: only `submitted` → `approved` or `rejected`, and only `draft` →
+  `submitted`.
+- Block self-approval — `approverId` equal to `employeeId`.
+- Overlap detection against the same employee's approved leave. A hook can read other records to do
+  it, so say it costs a lookup on every write.
+
+**Balances are a separate decision.** "How many days do I have left?" is not a field on this type.
+It is either a `leave-balance` type per employee per year that a hook decrements, or a filtered sum
+computed when someone asks. Ask which; do not add an `remainingDays` field to `employee`, because
+nothing would keep it correct.
+
+## `job-application`
+
+| Field | Type | Req | Notes |
+| --- | --- | --- | --- |
+| `candidateName` | string | yes | |
+| `email` | string | yes | |
+| `phone` | string | no | |
+| `roleTitle` | string | yes | |
+| `stage` | enum | yes | `applied`, `screening`, `interviewing`, `offer`, `hired`, `rejected` |
+| `source` | enum | no | `referral`, `job-board`, `outbound`, `careers-page` |
+| `appliedAt` | date | yes | |
+| `recruiterId` | reference | no | `x-links` → `employee` |
+| `referredById` | reference | no | `x-links` → `employee` |
+| `resumeUrl` | string | no | |
+| `interviewRounds` | array | no | Objects: `name`, `interviewerId`, `scheduledAt`, `outcome`, `notes` |
+| `rejectionReason` | string | no | |
+
+**Shape** — `interviewRounds` is embedded: a round belongs to this application and nothing else, and
+is never listed on its own. If the user wants interviewers to see "my upcoming interviews" as a
+list, that is the case for splitting rounds into their own type — ask rather than assuming.
+
+**Say this once, do not decide it.** Candidate records are personal data about people who do not
+work there, and most jurisdictions put a retention limit on them. Mention that deletion or
+anonymisation after a period is usually required, and leave the policy to the user.
+
+If they want a hired candidate to become an `employee`, that is a copy at conversion time, not a
+link — the two records have different lifecycles and different readers.
+
+## `onboarding-task`
+
+| Field | Type | Req | Notes |
+| --- | --- | --- | --- |
+| `employeeId` | reference | yes | `x-links` → `employee` |
+| `task` | string | yes | |
+| `category` | enum | no | `it`, `payroll`, `compliance`, `training`, `social` |
+| `ownerId` | reference | no | `x-links` → `employee` |
+| `dueDate` | date | no | |
+| `status` | enum | yes | `pending`, `in-progress`, `done`, `blocked` |
+| `completedAt` | date | no | |
+
+**Shape** — one record per task, not an array on `employee`. Different people own different tasks,
+each has its own due date, and IT wants to see every pending IT task across all new hires — none of
+which works if they are buried in an array on the person.
+
+A reusable checklist template is a separate idea. Generating the tasks for each new hire is a
+Routine, not a field here.
+
+## `asset-assignment`
+
+| Field | Type | Req | Notes |
+| --- | --- | --- | --- |
+| `assetTag` | string | yes | |
+| `assetType` | enum | yes | `laptop`, `monitor`, `phone`, `badge`, `other` |
+| `model` | string | no | |
+| `serialNumber` | string | no | |
+| `assignedToId` | reference | no | `x-links` → `employee`; empty means in stock |
+| `assignedAt` | date | no | |
+| `returnedAt` | date | no | |
+| `condition` | enum | no | `new`, `good`, `worn`, `damaged` |
+| `purchaseDate` | date | no | |
+| `purchaseCost` | number | no | |
+| `notes` | string | no | |
+
+**Shape** — `x-unique: [[assetTag]]`.
+
+**The fork worth raising.** This models the asset together with its *current* holder, so
+reassigning a laptop overwrites who had it before. That is fine for "who has what right now" and
+wrong for "who had this laptop when it was damaged". The alternative is two types — `asset` and
+`asset-assignment` linking to it — which keeps the history and costs an extra lookup everywhere.
+Ask, because converting later means migrating every record.
+
+## Limits worth saying out loud
+
+- **Statuses and enums are fixed in the schema.** Their real department list and leave types should
+  be collected now, not guessed.
+- **Anyone who can read a type reads every field on it.** That is why sensitive fields belong in a
+  separate linked type rather than on `employee`.
+- **Deleting an employee orphans every link pointing at them** — past leave, old applications,
+  assigned assets. Use `status: departed`.

--- a/skills/forge/resource-forge/references/marketing-and-sales.md
+++ b/skills/forge/resource-forge/references/marketing-and-sales.md
@@ -1,0 +1,116 @@
+# Marketing & Sales
+
+Pipeline, campaigns and content. Build `customer` and `employee` from `core-types.md` first where
+the chosen types link to them.
+
+| They say | Build |
+| --- | --- |
+| CRM, sales pipeline, lead tracking, prospects | `lead` + `customer` |
+| marketing, campaign tracking, channel spend | `campaign` + `lead` |
+| content calendar, editorial planning, blog pipeline | `content-piece` |
+| events, webinars, conferences | `event` |
+
+"A CRM" is the ambiguous one. Ask whether they are tracking people they hope to sell to (`lead`),
+companies they already sell to (`customer`), or both with a conversion between them — which is the
+usual answer.
+
+## `lead`
+
+A prospect, before they become a customer.
+
+| Field | Type | Req | Notes |
+| --- | --- | --- | --- |
+| `fullName` | string | yes | |
+| `email` | string | yes | |
+| `company` | string | no | |
+| `jobTitle` | string | no | |
+| `source` | enum | no | `website`, `event`, `referral`, `outbound`, `campaign` |
+| `campaignId` | reference | no | `x-links` → `campaign` |
+| `stage` | enum | yes | `new`, `contacted`, `qualified`, `unqualified`, `converted` |
+| `score` | number | no | |
+| `ownerId` | reference | no | `x-links` → `employee` |
+| `convertedCustomerId` | reference | no | `x-links` → `customer`; set on conversion |
+| `lastContactedAt` | date | no | |
+| `notes` | string | no | |
+
+**Shape** — `lead` and `customer` stay separate types. A lead has a qualification lifecycle a
+customer does not, and merging them fills the customer list with people who never bought anything.
+`convertedCustomerId` is the bridge, and conversion copies what should carry over rather than
+moving the record.
+
+`x-unique: [[email]]` only if they genuinely never re-engage an old lead. Most teams do, so leave it
+off unless they ask.
+
+**Activity history** — calls, emails, meetings — is not an embedded array. Each has its own author
+and date and gets listed across leads ("my calls this week"), so it is a `lead-activity` type
+linking back with a `leadId`. Offer it only if they ask for activity tracking; it doubles the build.
+
+## `campaign`
+
+| Field | Type | Req | Notes |
+| --- | --- | --- | --- |
+| `name` | string | yes | |
+| `channel` | enum | yes | `email`, `paid-search`, `paid-social`, `organic`, `events`, `partner` |
+| `status` | enum | yes | `planned`, `active`, `paused`, `completed` |
+| `startDate` | date | yes | |
+| `endDate` | date | no | |
+| `budget` | number | no | |
+| `spend` | number | no | Entered, not computed |
+| `currency` | string | no | ISO code |
+| `goal` | string | no | |
+| `ownerId` | reference | no | `x-links` → `employee` |
+
+**Shape** — lead counts, conversion rates and cost-per-lead are **not** fields here. Each is a
+filtered count of `lead` records by `campaignId`, and storing it on the campaign gives a number that
+silently goes stale the moment a lead is added. Say this when the user asks for them, and say where
+the real number comes from.
+
+## `content-piece`
+
+| Field | Type | Req | Notes |
+| --- | --- | --- | --- |
+| `title` | string | yes | |
+| `contentType` | enum | yes | `blog`, `case-study`, `video`, `whitepaper`, `social`, `newsletter` |
+| `status` | enum | yes | `idea`, `drafting`, `in-review`, `scheduled`, `published`, `archived` |
+| `authorId` | reference | no | `x-links` → `employee` |
+| `campaignId` | reference | no | `x-links` → `campaign` |
+| `channel` | string | no | |
+| `dueDate` | date | no | |
+| `publishDate` | date | no | |
+| `url` | string | no | |
+| `tags` | array | no | Strings |
+
+**Shape** — `tags` is an embedded array of strings, not links. Same reason as labels elsewhere: no
+lifecycle of their own, and an array of references is not validated.
+
+**Nothing publishes on its own.** `scheduled` with a `publishDate` records intent. Actually posting
+is an Integration and a Routine.
+
+## `event`
+
+| Field | Type | Req | Notes |
+| --- | --- | --- | --- |
+| `name` | string | yes | |
+| `eventType` | enum | yes | `webinar`, `conference`, `meetup`, `workshop`, `trade-show` |
+| `status` | enum | yes | `planned`, `open`, `running`, `completed`, `cancelled` |
+| `startsAt` | date | yes | |
+| `endsAt` | date | no | |
+| `location` | string | no | Venue, or a URL when virtual |
+| `campaignId` | reference | no | `x-links` → `campaign` |
+| `ownerId` | reference | no | `x-links` → `employee` |
+| `budget` | number | no | |
+| `capacity` | number | no | |
+| `sessions` | array | no | Objects: `title`, `speaker`, `startsAt`, `durationMinutes` |
+
+**Shape** — `sessions` embedded; they exist only within the event.
+
+**Attendees are not an embedded array.** They are people with their own follow-up, so they belong
+either as `lead` records carrying this event's `campaignId`, or as a dedicated registration type if
+the user needs check-in tracking and a capacity count. Ask which; the second is a real extra build.
+
+## Limits worth saying out loud
+
+- **Every rollup is a query, not a field.** Leads per campaign, revenue per channel, published posts
+  this month — none of these should be stored, because nothing would keep them correct.
+- **Enums are fixed in the schema.** Collect their real channel and content-type lists now.
+- **Deleting a campaign orphans the leads and content pointing at it.** Use `status: completed`.

--- a/skills/forge/resource-forge/references/schema-spec.md
+++ b/skills/forge/resource-forge/references/schema-spec.md
@@ -1,0 +1,161 @@
+# Record Schema Spec
+
+The exact shape `create_resource_type` and `resource_type_update` accept, and the closed `x-*`
+vocabulary the validator enforces. Read this before Step 4 if you are writing anything beyond plain
+fields — every `x-*` keyword below is rejected outright when its value is the wrong shape, and the
+error arrives after the user has already approved.
+
+## What you pass, and where it lands
+
+You pass **only the record schema** — a JSON Schema object serialized as YAML. The platform wraps it
+in the Soul envelope; you never write the envelope yourself, and you never set `apiVersion`, `kind`,
+`metadata` or `spec`.
+
+```text
+soul/resources/<slug>/
+├── resource.yaml   canonical envelope; written for a Resource type that has a domain
+├── schema.yml      legacy bare schema; written for a domainless type — the common case
+└── hooks.ts        companion, written by create_resource_hooks
+```
+
+`domain` is admin-only. `create_resource_type` and `resource_type_update` cannot set, change or
+clear it, so a type you create from Chat lands in `schema.yml`. That is expected, not a fallback.
+
+## The schema you write
+
+Validated as **JSON Schema 2020-12** (Ajv 2020, non-strict), then against the closed `x-*`
+vocabulary below.
+
+```yaml
+$schema: https://json-schema.org/draft/2020-12/schema
+type: object            # must be exactly "object"
+properties:
+  title:
+    type: string
+    description: Short summary of the request
+  status:
+    type: string
+    enum: [todo, in-progress, done]
+  customerId:
+    type: string
+    x-links: { target: customer }
+required: [title, status]
+```
+
+`type: object` and `properties` are mandatory. `required` is optional and its entries must be
+unique. Unknown top-level keys are allowed — the schema is open — so a typo in an `x-*` keyword is
+silently ignored rather than rejected. Spell them exactly as written below.
+
+Never declare `id`, `createdAt`, `updatedAt` or `version`. The platform manages them on every
+Record, and declaring them creates empty duplicate fields.
+
+## The closed `x-*` vocabulary
+
+These five are validated. Getting the shape wrong fails the write.
+
+### `x-links` — property level
+
+```yaml
+customerId:
+  type: string
+  x-links: { target: customer }
+```
+
+`target` must be a non-empty string naming an existing Resource type. Not an object, not an array,
+not blank. The value stored in the field is the target Record's `_id`.
+
+Checked on write — the target must exist. **Not cascaded on delete**: deleting the target leaves the
+link pointing at nothing, and nothing cleans it up.
+
+Only a **string** value is checked. A field holding an array of ids passes validation untouched, so
+an array of references is unvalidated in practice — use a join Resource type instead.
+
+### `x-normalize` — property level
+
+```yaml
+email:
+  type: string
+  x-normalize: [trim, lowercase]
+```
+
+An array, applied in order, to string values only. The six allowed keys are the whole set:
+
+| Key | Effect |
+| --- | --- |
+| `trim` | strips surrounding whitespace |
+| `lowercase` | lowercases |
+| `uppercase` | uppercases |
+| `slugify` | kebab-case slug |
+| `phone-e164` | strips non-digits, prefixes `+1` — US-shaped, so do not use it for other regions |
+| `email-normalize` | trim plus lowercase |
+
+Any other key is a validation error.
+
+### `x-unique` — root level
+
+**An array of arrays.** Each inner array is one uniqueness constraint over the named fields, and
+every field it names must be declared in `properties`.
+
+```yaml
+x-unique: [[workEmail]]              # one single-field constraint
+x-unique: [[projectId, key]]         # one composite constraint
+x-unique: [[workEmail], [employeeNumber]]   # two separate constraints
+```
+
+```yaml
+x-unique: [workEmail]                # WRONG — entries must be arrays
+x-unique: workEmail                  # WRONG — not an array
+```
+
+Becomes a partial unique index over live rows, so soft-deleted Records do not block a re-create.
+This is the only real duplicate guard, and it holds only within one Resource type.
+
+### `x-computed` — root level
+
+```yaml
+x-computed:
+  - field: fingerprint
+    from: [title, customerId]
+    fn: sha256
+```
+
+One object or an array of them. `fn` must be `sha256`, `uuid` or `sequence`; anything else is a
+validation error. `from` names fields on **this same Record** — a computed field cannot read another
+Resource type. Cross-type values need a `before` hook.
+
+### `x-id-strategy` — root level
+
+```yaml
+x-id-strategy: { prefix: "TICK-", sequence: true, field: key }
+```
+
+Produces `TICK-1`, `TICK-2` into `field` (default `id`) on create. Only runs when
+`sequence: true`. The counter is **per Resource type**, not per parent — several projects sharing
+one `issue` type get one global sequence.
+
+This is the human-facing identifier, entirely separate from the system `id` UUID.
+
+## Property flags
+
+Booleans on a property. Not part of the closed vocabulary, so a typo here fails silently — check the
+spelling, including the capital letters.
+
+| Flag | Effect |
+| --- | --- |
+| `x-readOnly: true` | stripped from user input; for fields only the platform or a hook sets |
+| `x-immutable: true` | keeps its existing value on update once set; for fields that must not change after creation |
+
+Pair `x-readOnly` with `x-id-strategy` and with any total a hook computes, so the stored value
+cannot disagree with what produced it.
+
+## Hooks
+
+`x-hooks-enabled: false` at root turns hooks off without deleting `hooks.ts`. Omitted means enabled.
+The hook source itself is written by `create_resource_hooks`, never inside the schema.
+
+## Before you write
+
+- Field names are camelCase; the Resource type name is singular kebab-case.
+- Every `x-links` target must already exist — build linked types first.
+- Call `validate_artifact` if it is available. It runs the same checks, so a failure there is a
+  failure the user would otherwise have seen after approving.

--- a/skills/forge/resource-forge/references/ticket-management.md
+++ b/skills/forge/resource-forge/references/ticket-management.md
@@ -1,0 +1,170 @@
+# Ticket Management
+
+Issue tracking for internal work. Build this when the user asks for a tracker, an issue tracker,
+project management, a backlog, sprints, or names a product they want a replacement for.
+
+For customer-facing tickets — someone outside the company raised it and expects a reply — use
+`customer-support.md` instead. The two are different shapes and both may be wanted.
+
+## What the user is asking for
+
+The product they name tells you what they expect. Ask which way they lean if it is not obvious;
+the answer changes the fields, not just the wording.
+
+| They say | They usually want | Lean towards |
+| --- | --- | --- |
+| "a Jira alternative" | Projects, workflows, epics, story points, structured process | `project` + `issue` + `cycle`, `estimate` in points, `parentIssueId` used for epics |
+| "a Linear alternative" | Speed, cycles, a tight opinionated set of states, little config | `project` + `issue` + `cycle`, fewer statuses, no `issue-relation` at first |
+| "a Trello/kanban board" | Cards moving through columns, no estimates | `project` + `issue` only, statuses named as their columns; read the display limit below |
+| "a backlog" / "a to-do list for the team" | One flat list, no ceremony | `issue` alone, `projectId` optional |
+| "a bug tracker" | Defect intake, no sprints | `issue` with `issueType` fixed to `bug`, plus `stepsToReproduce` and `environment` |
+
+Do not build all five types because they said "Jira". Propose the core three, name the other two as
+optional, and let them decide.
+
+## The bundle
+
+| | Type | |
+| --- | --- | --- |
+| Core | `project` | Container, and the source of the issue key prefix |
+| Core | `issue` | The unit of work |
+| Core | `cycle` | Sprint or iteration — drop it if they do not run sprints |
+| Optional | `issue-comment` | Threaded discussion on an issue |
+| Optional | `issue-relation` | blocks / duplicates / relates-to |
+
+Build order: `employee` (from `core-types.md`) → `project` → `cycle` → `issue` → the optional two.
+`issue` links to all three of the others, so it cannot be created first.
+
+## `project`
+
+| Field | Type | Req | Notes |
+| --- | --- | --- | --- |
+| `name` | string | yes | |
+| `key` | string | yes | Short uppercase prefix, e.g. `ENG` |
+| `description` | string | no | |
+| `status` | enum | yes | `planned`, `active`, `paused`, `completed`, `cancelled` |
+| `leadId` | reference | no | `x-links` → `employee` |
+| `startDate` | date | no | |
+| `targetDate` | date | no | |
+
+**Shape** — `x-unique: [[key]]`. Every issue carries the prefix, so two projects sharing a key make
+their issues indistinguishable.
+
+## `issue`
+
+Bugs, features, tasks and chores are **one type**, separated by `issueType`. Splitting them into
+separate Resource types fragments every board and every query, and there are no joins to put them
+back together.
+
+| Field | Type | Req | Notes |
+| --- | --- | --- | --- |
+| `key` | string | no | `x-id-strategy` → `ENG-1`; `x-readOnly` |
+| `title` | string | yes | |
+| `description` | string | no | |
+| `issueType` | enum | yes | `bug`, `feature`, `task`, `chore` |
+| `status` | enum | yes | `backlog`, `todo`, `in-progress`, `in-review`, `done`, `cancelled` |
+| `priority` | enum | yes | `none`, `low`, `medium`, `high`, `urgent` |
+| `projectId` | reference | yes | `x-links` → `project` |
+| `assigneeId` | reference | no | `x-links` → `employee` |
+| `reporterId` | reference | no | `x-links` → `employee` |
+| `parentIssueId` | reference | no | `x-links` → `issue` — sub-issues and epics |
+| `cycleId` | reference | no | `x-links` → `cycle` |
+| `estimate` | number | no | Points or hours — ask which, and say so in the description |
+| `labels` | array | no | Strings |
+| `dueDate` | date | no | |
+| `completedAt` | date | no | |
+
+For a bug-only tracker add `stepsToReproduce` (string), `environment` (enum) and `severity` (enum)
+as optional fields on this same type. Only create a separate `bug-report` type if the user runs a
+genuinely separate intake process with different people and a different lifecycle.
+
+### The key prefix is what makes it feel real
+
+`x-id-strategy: { prefix: "ENG-", sequence: true, field: "key" }` produces `ENG-1`, `ENG-2`. Offer
+it every time — a tracker whose items have no short handle is a spreadsheet. Take the prefix from
+the project key and mark `key` as `x-readOnly` so nobody edits it.
+
+The counter is per Resource type, not per project. With several projects in one `issue` type the
+numbers are global: `ENG-1`, `ENG-2`, `ENG-3` regardless of which project each belongs to. Say this
+before building it. A user who insists on per-project numbering needs one issue type per project,
+which costs them the shared backlog — usually not worth it.
+
+### Labels are strings, not links
+
+`labels` is an embedded array of **strings**. Labels have no lifecycle of their own, and an array of
+ids is not validated at all, so an array of references would silently accept nonsense. If labels
+later need owners, colours or descriptions, they become their own type plus a join type — never an
+array of references.
+
+### Epics are the same type
+
+`parentIssueId` is a self-link, so an epic is an issue with children and a sub-task is an issue with
+a parent. There is no separate epic type. Two levels is what this supports comfortably; deeper
+nesting works but nothing displays the tree.
+
+## `cycle`
+
+| Field | Type | Req | Notes |
+| --- | --- | --- | --- |
+| `name` | string | yes | e.g. `Cycle 14` |
+| `projectId` | reference | no | `x-links` → `project`; omit for one shared cadence |
+| `startDate` | date | yes | |
+| `endDate` | date | yes | |
+| `status` | enum | yes | `planned`, `active`, `completed` |
+| `goal` | string | no | |
+| `committedPoints` | number | no | Scope at start — see below |
+
+**Shape** — `committedPoints` is a deliberate point-in-time snapshot, written once when the cycle
+starts and never recomputed. Scope creep is the difference between it and the live sum of the
+cycle's issues. Put that in the field description so nobody "fixes" it into a computed total later.
+
+## `issue-comment`
+
+| Field | Type | Req | Notes |
+| --- | --- | --- | --- |
+| `issueId` | reference | yes | `x-links` → `issue` |
+| `authorId` | reference | yes | `x-links` → `employee` |
+| `body` | string | yes | |
+| `postedAt` | date | yes | |
+| `editedAt` | date | no | |
+
+**Shape** — its own type, deliberately **not** an embedded array on `issue`. Embedding rewrites the
+whole issue record on every comment and bumps its version, so two people commenting at the same time
+collide on the concurrency check. Comments are also edited and deleted on their own.
+
+## `issue-relation`
+
+| Field | Type | Req | Notes |
+| --- | --- | --- | --- |
+| `fromIssueId` | reference | yes | `x-links` → `issue` |
+| `toIssueId` | reference | yes | `x-links` → `issue` |
+| `relationType` | enum | yes | `blocks`, `duplicates`, `relates-to` |
+
+**Shape** — the join-type pattern: many-to-many, and the relationship carries a field of its own, so
+it cannot be an array on either side. Skip it unless the user asked for dependency tracking; most
+small teams never use it.
+
+## Limits worth saying out loud before you build
+
+Say these while proposing, not after the user finds them.
+
+- **Statuses are fixed in the schema.** `status` is an enum on the type, so changing the workflow
+  means editing the Resource type, not dragging columns in a settings screen. Get the list right at
+  build time and ask whether they want `in-review` and `cancelled` before assuming.
+- **The same statuses apply to every project.** Per-project workflows are not reachable.
+- **Records display as a sortable table with a text filter, not a drag-and-drop board.** If the
+  user pictured cards in columns, they should hear this before the type exists, not after.
+- **Counting issues per cycle or project is a filtered query, not a stored number.** Do not add
+  `issueCount` to `project` or `cycle`; nothing would keep it correct.
+- **Deleting a project or cycle orphans the issues pointing at it.** Link targets are checked when
+  the issue is written and never cascaded on delete. Prefer `status: cancelled` over deletion, or
+  guard it in a `before` hook on `project`.
+
+## Questions worth asking, and nothing else
+
+The archetype answers everything else. Ask only:
+
+1. Points or hours for `estimate`?
+2. Do they run sprints — build `cycle` or not?
+3. What prefix for the issue keys?
+4. Any status in their real workflow that is missing from the list?


### PR DESCRIPTION
## Summary

- Resource Forge had no field-level guidance, so the type a user got for "a leave tracker" varied by model, and the common failure was asking them to invent fields from nothing. Adds eight use-case reference files (23 archetypes) the Skill routes to, each with field sets, shape decisions, hooks worth offering, limits to state up front, and a short list of questions actually worth asking.
- Adds a `Data Shape` section deriving normalize-vs-embed from the runtime's real constraints — one JSONB table per type, no joins, links checked but never cascaded, nothing refreshes a copied field.
- Documents the record schema spec from the validators: the closed `x-*` vocabulary, the envelope boundary, and `x-unique`'s array-of-arrays shape.

## Notes

- `skill` added to the Skill's `tools` list. Without it the reference files are unreachable, since reading them goes through `skill` with `file:`.
- The routing table lives in `SKILL.md`, not a reference file, so routing costs no read and a run opens one file (~90 lines) rather than all eight.
- Competitor product names appear only as user vocabulary ("when the user says 'a Jira alternative', they mean…"), never as design attribution.
- Stated limits were verified against the code, not assumed: records render as a sortable table rather than a board (`apps/web/app/routes/_app.resources.$type._index.tsx:119`), and the `x-id-strategy` counter is per Resource type rather than per parent (`packages/schema/src/transforms/apply.ts:20`).

## Test plan

- [x] `pnpm --filter @tulipfarm/soul test src/skills` — 164 pass, including the bundled-Skill invariants and the canonical `x-links` example assertion
- [x] Docs-only diff outside `SKILL.md`; no runtime code touched