### PR TITLE
fix(routines): make a triggered Run's outcome readable to an Agent

### DIFF
--- a/apps/api/src/admin/run-reader.ts
+++ b/apps/api/src/admin/run-reader.ts
@@ -21,7 +21,7 @@ interface ObsCostReader {
 export interface RunReader {
   list(
     businessId: string,
-    options: { cursor?: string; limit: number }
+    options: { cursor?: string; limit: number; routineId?: string }
   ): Promise<{ items: readonly RunReadModel[]; nextCursor: string | null }>;
   get(businessId: string, runId: string): Promise<RunReadModel | null>;
   /**
@@ -104,6 +104,7 @@ export function createRunReader(
         businessId,
         limit: options.limit,
         ...(options.cursor === undefined ? {} : { cursor: options.cursor }),
+        ...(options.routineId === undefined ? {} : { routineId: options.routineId }),
       });
       return {
         items: page.items.map((run) => runReadModel(run, [], [], NO_COSTS)),

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -618,6 +618,9 @@ async function boot() {
     const surfaceActionStore = new PgSurfaceActionStore(pool);
     const obsRepo = new PgObsRepo(pool);
     const observabilityService = new ObservabilityService(obsRepo);
+    // One reader for both the operational API and the `routine_run_*` Tools, so what an Agent
+    // reports about a Run and what the Run inspector shows can never disagree.
+    const runReader = createRunReader(runStore, budgetStore, obsRepo);
     // Built after observability so embedding spend lands in the same table as every other call.
     const embeddingService = new EmbeddingService({
       usage: createEmbeddingUsageSink(observabilityService, () => obsConfig.pricingOverrides),
@@ -1076,6 +1079,7 @@ async function boot() {
           ...sandboxRuntimeImage,
         }),
         routineCatalog,
+        runs: runReader,
         teamAssets,
         delegateToAgent: agentDelegation.delegate,
         spawnSubagent: subagentSpawning.spawn,
@@ -1441,7 +1445,7 @@ async function boot() {
         approvals: approvalsRepo,
         ownershipApprovals: teamAssets,
         toolApprovals,
-        runs: createRunReader(runStore, budgetStore, obsRepo),
+        runs: runReader,
         healthProbes: [
           postgresProbe(pool),
           queueProbe(boss),

--- a/apps/api/src/platform/routine-run-tools.test.ts
+++ b/apps/api/src/platform/routine-run-tools.test.ts
@@ -1,0 +1,120 @@
+import { DEPLOYMENT_BUSINESS_ID } from "@tulipfarm/constants";
+import type { RoutineCatalog } from "@tulipfarm/soul";
+import { describe, expect, it } from "vitest";
+import type { RunReader } from "../admin/run-reader";
+import type { RunReadModel } from "../admin/types";
+import { routineRunGetTool, routineRunListTool } from "./routine-run-tools";
+import type { PlatformToolContext } from "./tools";
+
+const ROUTINE_ID = "00000000-0000-4000-8000-000000000101";
+
+function runModel(overrides: Partial<RunReadModel> = {}): RunReadModel {
+  return {
+    id: "cd7a9f0b-d9f0-45c0-ba32-14d978373eea",
+    routineId: ROUTINE_ID,
+    routineVersion: "5",
+    status: "failed",
+    version: 3,
+    createdAt: "2026-09-05T15:16:22.160Z",
+    startedAt: "2026-09-05T15:16:28.843Z",
+    finishedAt: "2026-09-05T15:16:28.882Z",
+    states: [
+      {
+        key: "LoadQuoteHistory",
+        status: "failed",
+        attempts: 1,
+        errorEvidenceRef: "routine:input_not_evaluable:PostEngineeringQuote",
+      },
+    ],
+    effects: [],
+    waits: [],
+    guardrailDecisions: [],
+    lineage: [],
+    costs: { amountUsd: 0, modelTokens: 0 },
+    ...overrides,
+  };
+}
+
+function ctx(reader: Partial<RunReader>, catalogId: string | null = ROUTINE_ID) {
+  return {
+    soulWriter: {},
+    runs: reader as RunReader,
+    routineCatalog: {
+      list: async () => [],
+      get: async (slug: string) =>
+        catalogId === null ? undefined : { id: catalogId, slug, triggers: [] },
+    } as unknown as RoutineCatalog,
+  } as unknown as PlatformToolContext;
+}
+
+describe("routineRunGetTool", () => {
+  it("explains the evidence ref and names the State that stopped the Run", async () => {
+    const res = await routineRunGetTool.handler(
+      { runId: runModel().id },
+      ctx({ get: async () => runModel() })
+    );
+    expect(res.success).toBe(true);
+    if (!res.success) throw new Error("expected success");
+    const data = res.data as Record<string, unknown>;
+    expect(data.status).toBe("failed");
+    const error = data.error as Record<string, string>;
+    expect(error.state).toBe("LoadQuoteHistory");
+    expect(error.explanation).toContain("does not exist at run time");
+    expect(error.explanation).toContain("PostEngineeringQuote");
+  });
+
+  it("spells out that needs_reconciliation will never finish on its own", async () => {
+    const res = await routineRunGetTool.handler(
+      { runId: runModel().id },
+      ctx({ get: async () => runModel({ status: "needs_reconciliation", finishedAt: null }) })
+    );
+    if (!res.success) throw new Error("expected success");
+    expect((res.data as Record<string, string>).statusMeaning).toContain("needs an operator");
+  });
+
+  it("returns not_found for a run id this business does not own", async () => {
+    const res = await routineRunGetTool.handler(
+      { runId: "missing" },
+      ctx({ get: async () => null })
+    );
+    expect(res).toMatchObject({ success: false, error: { code: "not_found" } });
+  });
+
+  it("reports the Run reader being unavailable rather than an empty answer", async () => {
+    const res = await routineRunGetTool.handler({ runId: "x" }, {
+      soulWriter: {},
+    } as unknown as PlatformToolContext);
+    expect(res).toMatchObject({ success: false, error: { code: "internal_error" } });
+  });
+});
+
+describe("routineRunListTool", () => {
+  it("filters by the Routine id the catalogue resolves the slug to", async () => {
+    let seen: string | undefined;
+    const res = await routineRunListTool.handler(
+      { name: "engineering-motivation-quotes", limit: 3 },
+      ctx({
+        list: async (businessId, options) => {
+          expect(businessId).toBe(DEPLOYMENT_BUSINESS_ID);
+          expect(options.limit).toBe(3);
+          seen = options.routineId;
+          return { items: [runModel()], nextCursor: null };
+        },
+        get: async () => runModel(),
+      })
+    );
+    expect(seen).toBe(ROUTINE_ID);
+    if (!res.success) throw new Error("expected success");
+    const data = res.data as { runs: Record<string, unknown>[] };
+    expect(data.runs).toHaveLength(1);
+    expect(data.runs[0]?.status).toBe("failed");
+  });
+
+  it("returns not_found when the Routine slug is unknown", async () => {
+    const res = await routineRunListTool.handler(
+      { name: "nope" },
+      ctx({ list: async () => ({ items: [], nextCursor: null }) }, null)
+    );
+    expect(res).toMatchObject({ success: false, error: { code: "not_found" } });
+  });
+});

--- a/apps/api/src/platform/routine-run-tools.ts
+++ b/apps/api/src/platform/routine-run-tools.ts
@@ -1,0 +1,215 @@
+import { DEPLOYMENT_BUSINESS_ID } from "@tulipfarm/constants";
+import { ajv } from "@tulipfarm/schema";
+import { defineApiTool } from "@tulipfarm/tool-host";
+import type { RunReadModel, RunStateReadModel } from "../admin/types";
+import { firstError, SOUL_ROUTINE_TARGET, soulTarget } from "./tool-args";
+import { err, ok } from "./tool-result";
+import type { PlatformToolContext } from "./tools";
+
+/**
+ * Prose for a Run status an Agent has to explain to a person. `needs_reconciliation` in
+ * particular reads as a healthy word and is not one: it means the Run stopped where no retry can
+ * move it, and someone has to look.
+ */
+const RUN_STATUS_MEANING: Record<string, string> = {
+  queued: "Accepted, not yet picked up by a Worker.",
+  running: "Executing now.",
+  waiting: "Parked on a wait, an approval, or a child Run.",
+  succeeded: "Finished. Every State completed.",
+  failed: "Finished unsuccessfully. See `states[].error`.",
+  cancelled: "Stopped on request before it finished.",
+  paused: "Held by an operator; resumable.",
+  needs_reconciliation:
+    "Stopped in a state no retry can clear — usually an authoring bug or a missing dependency. " +
+    "It will never finish on its own and needs an operator.",
+};
+
+/**
+ * Turns an `error_evidence_ref` into something worth reading. The refs are `routine:<code>` or
+ * `routine:<code>:<state>`, and the codes are the executor's own vocabulary, so an Agent handed
+ * the bare ref reports a token rather than a cause.
+ */
+const EVIDENCE_MEANING: Record<string, string> = {
+  input_not_evaluable:
+    "One of this State's input mappings referenced something that does not exist at run time — " +
+    "typically `${states.<Name>.output.<field>}` naming a field the previous State never " +
+    "published. Read the Routine with `routine_get` and compare the mapping to what the earlier " +
+    "State actually returns.",
+  missing_state: "The Routine transitions to a State name that its own definition does not define.",
+  unsupported_state: "This deployment hosts no executor for that State type.",
+  state_cannot_progress: "The State was reached in a status it cannot be run from.",
+  missing_action_name: "An `action` State does not name the runtime Tool to call.",
+};
+
+function explainEvidence(ref: string | undefined): string | null {
+  if (ref === undefined) return null;
+  const [, code, state] = ref.split(":");
+  const meaning = code === undefined ? undefined : EVIDENCE_MEANING[code];
+  const at = state === undefined ? "" : ` (at State \`${state}\`)`;
+  return meaning === undefined ? `${ref}${at}` : `${meaning}${at}`;
+}
+
+const UNSETTLED = new Set(["queued", "running", "waiting", "paused"]);
+
+/** The State that explains the Run: the one carrying evidence, else the one still unsettled. */
+function culprit(states: readonly RunStateReadModel[]): RunStateReadModel | undefined {
+  return (
+    states.find((state) => state.errorEvidenceRef !== undefined) ??
+    states.find((state) => UNSETTLED.has(state.status))
+  );
+}
+
+function runSummary(run: RunReadModel) {
+  const failing = culprit(run.states);
+  return {
+    runId: run.id,
+    routineId: run.routineId,
+    routineVersion: run.routineVersion,
+    status: run.status,
+    statusMeaning: RUN_STATUS_MEANING[run.status] ?? null,
+    createdAt: run.createdAt,
+    startedAt: run.startedAt,
+    finishedAt: run.finishedAt,
+    states: run.states.map((state) => ({
+      name: state.key,
+      status: state.status,
+      attempts: state.attempts,
+      error: explainEvidence(state.errorEvidenceRef),
+    })),
+    error:
+      failing?.errorEvidenceRef === undefined
+        ? null
+        : {
+            state: failing.key,
+            evidenceRef: failing.errorEvidenceRef,
+            explanation: explainEvidence(failing.errorEvidenceRef),
+          },
+    costs: run.costs,
+  };
+}
+
+const ROUTINE_RUN_GET_SCHEMA: Record<string, unknown> = {
+  type: "object",
+  additionalProperties: false,
+  required: ["runId"],
+  properties: {
+    runId: {
+      type: "string",
+      minLength: 1,
+      description: "Run id, exactly as `trigger_routine` returned it.",
+    },
+  },
+};
+const validateRoutineRunGet = ajv.compile(ROUTINE_RUN_GET_SCHEMA);
+
+export const routineRunGetTool = defineApiTool<PlatformToolContext>({
+  name: "routine_run_get",
+  description:
+    "Read the status of one Routine Run by its run id — the id `trigger_routine` returns. Answers " +
+    "whether it is still running, succeeded, failed, or stopped needing an operator, and names " +
+    "the State it stopped on with a readable explanation of the error. Use this whenever someone " +
+    "asks what happened to a Run, and poll it after `trigger_routine` rather than assuming a " +
+    "triggered Run did its work.",
+  mutating: false,
+  tier: "platform",
+  inputSchema: ROUTINE_RUN_GET_SCHEMA,
+  authorization: {
+    action: "platform.routine.read",
+    resources: ["soul.routine"],
+    targets: () => [],
+    dataClasses: ["operational"],
+  },
+  requiresApproval: false,
+  handler: async (args, ctx) => {
+    if (!validateRoutineRunGet(args))
+      return err("validation_error", firstError(validateRoutineRunGet.errors));
+    const { runId } = args as { runId: string };
+    if (ctx.runs === undefined)
+      return err("internal_error", "The Run reader is unavailable, so no Run can be read.");
+
+    let run: RunReadModel | null;
+    try {
+      run = await ctx.runs.get(DEPLOYMENT_BUSINESS_ID, runId);
+    } catch (e) {
+      return err("internal_error", e instanceof Error ? e.message : String(e));
+    }
+    if (run === null) return err("not_found", `No Run with id ${runId}.`);
+    return ok(runSummary(run));
+  },
+});
+
+const ROUTINE_RUN_LIST_SCHEMA: Record<string, unknown> = {
+  type: "object",
+  additionalProperties: false,
+  required: ["name"],
+  properties: {
+    name: {
+      type: "string",
+      minLength: 1,
+      description: "Routine slug, as `routine_picker` lists it.",
+    },
+    limit: {
+      type: "integer",
+      minimum: 1,
+      maximum: 20,
+      description: "How many of the most recent Runs to return. Defaults to 5.",
+    },
+  },
+};
+const validateRoutineRunList = ajv.compile(ROUTINE_RUN_LIST_SCHEMA);
+
+export const routineRunListTool = defineApiTool<PlatformToolContext>({
+  name: "routine_run_list",
+  description:
+    "List the most recent Runs of one Routine, newest first, with the same status and error " +
+    "detail as `routine_run_get`. Use it when someone asks whether a Routine is working and no " +
+    "run id is to hand — including right after a scheduled window, to see whether the schedule " +
+    "actually fired.",
+  mutating: false,
+  tier: "platform",
+  inputSchema: ROUTINE_RUN_LIST_SCHEMA,
+  authorization: {
+    action: "platform.routine.read",
+    resources: ["soul.routine"],
+    targets: (args) => soulTarget(SOUL_ROUTINE_TARGET, args, "name"),
+    dataClasses: ["operational"],
+  },
+  requiresApproval: false,
+  handler: async (args, ctx) => {
+    if (!validateRoutineRunList(args))
+      return err("validation_error", firstError(validateRoutineRunList.errors));
+    const { name, limit } = args as { name: string; limit?: number };
+    if (ctx.runs === undefined)
+      return err("internal_error", "The Run reader is unavailable, so no Run can be read.");
+    if (ctx.routineCatalog === undefined)
+      return err(
+        "internal_error",
+        "The Routines surface is unavailable, so no Routine can be read."
+      );
+
+    // Runs pin the Routine's id, not its slug, so the catalog is the only way from the name a
+    // person uses to the key the Run carries.
+    const detail = await ctx.routineCatalog.get(name);
+    if (detail === undefined) return err("not_found", `routine not found: ${name}`);
+
+    let page: { items: readonly RunReadModel[] };
+    try {
+      page = await ctx.runs.list(DEPLOYMENT_BUSINESS_ID, {
+        limit: limit ?? 5,
+        routineId: detail.id,
+      });
+    } catch (e) {
+      return err("internal_error", e instanceof Error ? e.message : String(e));
+    }
+
+    // The list page carries no States, so each Run is re-read for the detail that makes the
+    // answer worth giving. `limit` is capped at 20 precisely to bound this.
+    const runs = await Promise.all(
+      page.items.map(async (item) => {
+        const full = await ctx.runs?.get(DEPLOYMENT_BUSINESS_ID, item.id);
+        return runSummary(full ?? item);
+      })
+    );
+    return ok({ routine: name, runs });
+  },
+});

--- a/apps/api/src/platform/tools.test.ts
+++ b/apps/api/src/platform/tools.test.ts
@@ -1020,6 +1020,8 @@ describe("PLATFORM_TOOLS registry", () => {
       "routine_forge",
       "routine_picker",
       "routine_get",
+      "routine_run_get",
+      "routine_run_list",
       "routine_delete",
       "guardrail_forge",
       "soul_repo_push",

--- a/apps/api/src/platform/tools.ts
+++ b/apps/api/src/platform/tools.ts
@@ -47,6 +47,7 @@ import {
   type ToolCallResult,
 } from "@tulipfarm/tool-host";
 import { stringify as stringifyYaml } from "yaml";
+import type { RunReader } from "../admin/run-reader";
 import { SYSTEM_SOUL_COMMIT_ACTOR } from "../runtime/soul-writer";
 import type { TeamAssetService } from "../team-assets/service";
 import { declaredStringList } from "../tools/network/compose";
@@ -54,6 +55,7 @@ import { mapSoulWriteError, soulCommitError } from "../tools/soul-faults";
 import { delegateToAgentTool } from "./delegate-tool";
 import { guardrailForgeTool } from "./guardrail-tool";
 import { validateRoutineForgeDefinitions } from "./routine-forge-validation";
+import { routineRunGetTool, routineRunListTool } from "./routine-run-tools";
 import { spawnSubagentTool } from "./spawn-tool";
 import { firstError, SOUL_ROUTINE_TARGET, SOUL_SKILL_TARGET, soulTarget } from "./tool-args";
 import { err, ok } from "./tool-result";
@@ -108,6 +110,12 @@ export interface PlatformToolContext {
    * use rather than a restatement of what the write path was asked to do.
    */
   routineCatalog?: RoutineCatalog;
+  /**
+   * Reads Runs for `routine_run_get` and `routine_run_list`. `trigger_routine` hands back a run
+   * id, and without this an Agent holds an id it cannot resolve — so a Routine that stopped on its
+   * first State reads to the user exactly like one that worked.
+   */
+  runs?: RunReader;
   /**
    * Re-reads `guardrails.yaml` into the live {@link GuardrailsService}. Every Turn's Context
    * carries the in-process policy, not the published bundle, so without this a committed
@@ -1010,6 +1018,8 @@ export const PLATFORM_TOOLS: ParkableApiToolDefinition<PlatformToolContext>[] = 
   routineForgeTool,
   routinePickerTool,
   routineGetTool,
+  routineRunGetTool,
+  routineRunListTool,
   routineDeleteTool,
   guardrailForgeTool,
   soulRepoPushTool,

--- a/apps/api/src/tools/contract-coverage.test.ts
+++ b/apps/api/src/tools/contract-coverage.test.ts
@@ -145,6 +145,8 @@ const EXPECTED_FAMILY_TOOL_NAMES = [
       "routine_forge",
       "routine_get",
       "routine_picker",
+      "routine_run_get",
+      "routine_run_list",
       "skill",
       "soul_repo_push",
       "spawn_subagent",

--- a/apps/worker/src/routine/executor.test.ts
+++ b/apps/worker/src/routine/executor.test.ts
@@ -365,7 +365,7 @@ describe("createRoutineExecutor", () => {
     expect(harness.states.has("Missed")).toBe(false);
   });
 
-  it("parks a compute State whose mapping cannot resolve, without settling it", async () => {
+  it("fails a compute State whose mapping cannot resolve, without settling it", async () => {
     const harness = new StateHarness([state("Start")]);
     const execute = executor(
       definition([
@@ -379,12 +379,42 @@ describe("createRoutineExecutor", () => {
       harness
     );
 
-    await expect(execute(run())).resolves.toEqual({ status: "needs_reconciliation" });
+    await expect(execute(run())).resolves.toEqual({
+      status: "failed",
+      errorEvidenceRef: "routine:input_not_evaluable:Start",
+    });
     expect(harness.states.get("Start")).toMatchObject({
-      status: "needs_reconciliation",
-      errorEvidenceRef: "routine:input_not_evaluable",
+      status: "failed",
+      errorEvidenceRef: "routine:input_not_evaluable:Start",
     });
     expect(harness.transitions).not.toContain("Start:running->succeeded");
+  });
+
+  it("fails the Run naming the successor whose mapping cannot resolve", async () => {
+    const harness = new StateHarness([state("Start")]);
+    const execute = executor(
+      definition([
+        { type: "compute", name: "Start", input: { ok: true }, transition: "Next" },
+        {
+          type: "compute",
+          name: "Next",
+          input: { derived: "${ states.Start.output.absent }" },
+          end: true,
+        },
+      ] as unknown as routine.RoutineState[]),
+      harness
+    );
+
+    // The successor's input is resolved while its predecessor is still settling, so the failure
+    // arrives on the `Start` row and would otherwise be reported against the wrong State.
+    await expect(execute(run())).resolves.toEqual({
+      status: "failed",
+      errorEvidenceRef: "routine:input_not_evaluable:Next",
+    });
+    expect(harness.states.get("Start")).toMatchObject({
+      status: "failed",
+      errorEvidenceRef: "routine:input_not_evaluable:Next",
+    });
   });
 });
 
@@ -2041,7 +2071,7 @@ describe("createRoutineExecutor — emit States", () => {
     expect(harness.states.get("Start")?.errorEvidenceRef).toBe("routine:unsupported_state");
   });
 
-  it("parks rather than announcing when the payload cannot be resolved", async () => {
+  it("fails rather than announcing when the payload cannot be resolved", async () => {
     const harness = new StateHarness([state("Start")]);
     const emissions = new EmitHarness();
 
@@ -2051,7 +2081,10 @@ describe("createRoutineExecutor — emit States", () => {
         harness,
         emissions.port
       )(run())
-    ).resolves.toEqual({ status: "needs_reconciliation" });
+    ).resolves.toEqual({
+      status: "failed",
+      errorEvidenceRef: "routine:input_not_evaluable:Start",
+    });
     expect(emissions.announced).toHaveLength(0);
   });
 });

--- a/apps/worker/src/routine/executor.ts
+++ b/apps/worker/src/routine/executor.ts
@@ -349,6 +349,18 @@ class RoutineExecution {
         if (!isRefusal(error) && !(error instanceof RoutineInputResolutionError)) throw error;
         // Settled States cannot be parked; claimed States record the refusal on their own row.
         if (row.status === "succeeded") return "needs_reconciliation";
+        // An input mapping that does not evaluate is an authoring bug in the Routine, not a
+        // transient fault: the same Context will resolve the same way on every replay, so parking
+        // for reconciliation leaves a Run that can never finish and reads as still in flight. It
+        // fails, and the evidence names the State whose mapping broke — which is not always the
+        // State being settled, because a successor's input is resolved as its predecessor
+        // completes.
+        if (error instanceof RoutineInputResolutionError) {
+          const evidenceRef = `routine:${error.code}:${error.state}`;
+          await this.transition(key, "running", "failed", evidenceRef);
+          this.lastFailureEvidenceRef = evidenceRef;
+          return "failed";
+        }
         await this.park(key, `routine:${error.code}`);
         return "needs_reconciliation";
       }


### PR DESCRIPTION
## Summary

- An unresolvable input mapping parked the Run at `needs_reconciliation` with `finished_at = NULL` and zero Run events. Nothing requeues that status, so the Run read exactly like one still in flight — a Routine that never sent its Slack message reported as working.
- Adds `routine_run_get` and `routine_run_list` so an Agent can resolve the run id `trigger_routine` hands back, with prose for the status and for the `error_evidence_ref`.
- The executor now **fails** on `RoutineInputResolutionError` instead of parking. The same Context resolves the same way on every replay, so parking left a Run that could never finish; and the evidence ref now names the State whose mapping broke, which is not the State being settled — a successor's input is resolved as its predecessor completes.

Found on staging: `engineering-motivation-quotes` maps `${states.LoadQuoteHistory.output.records}`, but `record_list` publishes `{ items, nextCursor }`.

## Test plan

- [x] `apps/worker/src/routine` — 174 passed
- [x] `apps/api/src/platform src/admin` — 206 passed
- [x] `pnpm typecheck` clean for both workspaces
- [ ] Note: `scripts/control-plane-size.test.ts` fails on `main` already (65649 lines vs 53616 ceiling); this diff takes it to 65879. Pre-existing, verified by stashing.