### PR TITLE
fix(deploy): allow worker blob writes without exposing secrets

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { EventEmitter } from "node:events";
+import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import {
   createSubagentSpawning,
@@ -558,7 +559,10 @@ async function boot() {
     // Same root the Worker derives, so a blob-backed Run Artifact written by either process is
     // readable by the other. Without it `publishFile` fails with `artifact_blob_unavailable`,
     // which is how a sandboxed Skill command dies before its container ever starts.
-    const blobs = createBlobPort(join(resolveDataDir() ?? process.cwd(), "blobs"));
+    const dataDir = resolveDataDir();
+    // Compose mounts only this subdirectory writable in the worker, after API readiness.
+    if (dataDir !== undefined) await mkdir(join(dataDir, "blobs"), { recursive: true });
+    const blobs = createBlobPort(join(dataDir ?? process.cwd(), "blobs"));
     /** Every Artifact reader is the same service over a different transaction scope. */
     const artifactsOver = (transactions: ConstructorParameters<typeof ArtifactStore>[0]) =>
       new ArtifactService(new ArtifactStore(transactions), invocationValidator, blobs);

--- a/apps/api/src/setup/compose-storage.test.ts
+++ b/apps/api/src/setup/compose-storage.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+const root = resolve(__dirname, "../../../..");
+
+describe("Compose filesystem storage", () => {
+  it("lets the worker write existing blobs without writing bootstrap secrets or Soul", () => {
+    const compose = parse(readFileSync(resolve(root, "docker-compose.yml"), "utf8"));
+    expect(compose.services.app.volumes).toContain("tulipfarm-data:/data");
+    expect(compose.services.worker.volumes).toContain("tulipfarm-data:/data:ro");
+    expect(compose.services.worker.volumes).toContainEqual({
+      type: "volume",
+      source: "tulipfarm-data",
+      target: "/data/blobs",
+      volume: { subpath: "blobs", nocopy: true },
+    });
+    expect(JSON.stringify(compose.services.worker.volumes)).not.toContain("tulipfarm-soul");
+  });
+
+  it("prepares the blob subdirectory before the API becomes ready", () => {
+    const source = readFileSync(resolve(root, "apps/api/src/index.ts"), "utf8");
+    const preparation = source.indexOf('await mkdir(join(dataDir, "blobs"), { recursive: true })');
+    expect(preparation).toBeGreaterThan(-1);
+    expect(preparation).toBeLessThan(source.indexOf("app.listen("));
+  });
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -171,9 +171,14 @@ services:
       S3_ACCESS_KEY_ID: ${S3_ACCESS_KEY_ID:-}
       S3_SECRET_ACCESS_KEY: ${S3_SECRET_ACCESS_KEY:-}
     volumes:
-      # Read-only: `app` owns everything on this volume. The worker only reads back the two
-      # values it was given.
+      # Credentials stay read-only. Only blobs are writable; keep the existing data location.
       - tulipfarm-data:/data:ro
+      - type: volume
+        source: tulipfarm-data
+        target: /data/blobs
+        volume:
+          subpath: blobs
+          nocopy: true
     # No published port: the probes are for the orchestrator, not for users.
     healthcheck:
       test:


### PR DESCRIPTION
## Summary

<!-- What changed, and why. Link the driving issue if one exists. -->

## Test plan

<!-- Commands you ran, or manual steps / screenshots for UI changes. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (or the scoped `--filter` you actually ran)

## Checklist

- [ ] PR title follows Conventional Commits (`type(scope): subject`) — CI checks this
- [ ] Scoped to one logical change
- [ ] Tests added/updated for the behavior that changed
