### PR TITLE
fix(google): include tables when reading Docs content

### DIFF
--- a/packages/integrations/src/google/tool-adapter.test.ts
+++ b/packages/integrations/src/google/tool-adapter.test.ts
@@ -1,0 +1,120 @@
+import type { ToolAdapterRequest, ToolIntent } from "@tulipfarm/tool-broker";
+import { describe, expect, it } from "vitest";
+import type { IntegrationHttpPort, IntegrationHttpRequest } from "../http";
+import { GOOGLE_TOOL_IDS } from "./contracts";
+import { GoogleToolAdapter } from "./tool-adapter";
+
+const CREDENTIAL = "google-token";
+
+function docsReadRequest(): ToolAdapterRequest {
+  const intent: ToolIntent = {
+    intentId: "11111111-1111-4111-8111-111111111111",
+    businessId: "biz-1",
+    runId: "run-1",
+    stateId: "state-1",
+    toolId: GOOGLE_TOOL_IDS.docsRead,
+    toolVersion: "1.0.0",
+    action: GOOGLE_TOOL_IDS.docsRead,
+    targetRefs: [],
+    arguments: { documentId: "doc-1" },
+    credentialRef: "google-token",
+    idempotencyKey: "22222222-2222-4222-8222-222222222222",
+  };
+  return { intent, idempotencyKey: intent.idempotencyKey, attempt: 1 };
+}
+
+function adapter(document: unknown): GoogleToolAdapter {
+  const http: IntegrationHttpPort = {
+    async send(request: IntegrationHttpRequest, credential: string) {
+      expect(request).toMatchObject({ method: "GET", path: "/documents/doc-1" });
+      expect(credential).toBe(CREDENTIAL);
+      return { status: 200, headers: {}, body: document };
+    },
+  };
+  return new GoogleToolAdapter({ http: () => http });
+}
+
+function paragraph(text: string) {
+  return { paragraph: { elements: [{ textRun: { content: text } }] } };
+}
+
+describe("GoogleToolAdapter Docs reading", () => {
+  it("extracts a table-only document with nested table content", async () => {
+    const document = {
+      documentId: "doc-1",
+      title: "Table",
+      body: {
+        content: [
+          {
+            table: {
+              tableRows: [
+                {
+                  tableCells: [
+                    { content: [paragraph("Name\n")] },
+                    { content: [paragraph("Details\n")] },
+                  ],
+                },
+                {
+                  tableCells: [
+                    { content: [paragraph("TulipFarm\n")] },
+                    {
+                      content: [
+                        {
+                          table: {
+                            tableRows: [
+                              {
+                                tableCells: [
+                                  { content: [paragraph("Self-hosted\n")] },
+                                  { content: [paragraph("Agent control panel\n")] },
+                                ],
+                              },
+                            ],
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+      },
+    };
+
+    await expect(adapter(document).dispatch(docsReadRequest(), CREDENTIAL)).resolves.toEqual({
+      documentId: "doc-1",
+      title: "Table",
+      body: "Name\tDetails\nTulipFarm\tSelf-hosted\tAgent control panel\n",
+    });
+  });
+
+  it("keeps readable boundaries across paragraphs, tables, and table-of-contents content", async () => {
+    const document = {
+      documentId: "doc-1",
+      title: "Mixed",
+      body: {
+        content: [
+          paragraph("Intro\n"),
+          {
+            table: {
+              tableRows: [
+                {
+                  tableCells: [{ content: [paragraph("A\n")] }, { content: [paragraph("B\n")] }],
+                },
+              ],
+            },
+          },
+          { tableOfContents: { content: [paragraph("Contents entry\n")] } },
+          paragraph("After\n"),
+        ],
+      },
+    };
+
+    await expect(adapter(document).dispatch(docsReadRequest(), CREDENTIAL)).resolves.toEqual({
+      documentId: "doc-1",
+      title: "Mixed",
+      body: "Intro\nA\tB\nContents entry\nAfter\n",
+    });
+  });
+});

--- a/packages/integrations/src/google/tool-adapter.ts
+++ b/packages/integrations/src/google/tool-adapter.ts
@@ -122,20 +122,49 @@ function driveQuery(query: string): string {
   return `fullText contains '${escaped}' or name contains '${escaped}'`;
 }
 
-/** Flattens a Docs `body.content` tree into its text runs. */
-function extractDocumentText(document: Record<string, unknown>): string {
-  const body = asRecord(document.body);
-  const content = Array.isArray(body.content) ? body.content : [];
+function extractParagraphText(paragraph: Record<string, unknown>): string {
+  let text = "";
+  for (const element of asArray(paragraph.elements)) {
+    const textRun = asRecord(asRecord(element).textRun);
+    if (typeof textRun.content === "string") text += textRun.content;
+  }
+  return text;
+}
+
+function extractTableText(table: Record<string, unknown>): string {
+  const rows = asArray(table.tableRows).map((row) =>
+    asArray(asRecord(row).tableCells)
+      .map((cell) => extractStructuralText(asArray(asRecord(cell).content)).trimEnd())
+      .join("\t")
+  );
+  return rows.length === 0 ? "" : `${rows.join("\n")}\n`;
+}
+
+function extractStructuralText(content: readonly unknown[]): string {
   let text = "";
   for (const element of content) {
-    const paragraph = asRecord(asRecord(element).paragraph);
-    const elements = Array.isArray(paragraph.elements) ? paragraph.elements : [];
-    for (const run of elements) {
-      const textRun = asRecord(asRecord(run).textRun);
-      if (typeof textRun.content === "string") text += textRun.content;
+    const structuralElement = asRecord(element);
+    const paragraph = asRecord(structuralElement.paragraph);
+    if (Object.keys(paragraph).length > 0) {
+      text += extractParagraphText(paragraph);
+      continue;
+    }
+    const table = asRecord(structuralElement.table);
+    if (Object.keys(table).length > 0) {
+      text += extractTableText(table);
+      continue;
+    }
+    const tableOfContents = asRecord(structuralElement.tableOfContents);
+    if (Object.keys(tableOfContents).length > 0) {
+      text += extractStructuralText(asArray(tableOfContents.content));
     }
   }
   return text;
+}
+
+/** Flattens Docs structural elements, including tables nested inside table cells. */
+function extractDocumentText(document: Record<string, unknown>): string {
+  return extractStructuralText(asArray(asRecord(document.body).content));
 }
 
 export class GoogleToolAdapter implements ToolAdapter {


### PR DESCRIPTION
## Summary

<!-- What changed, and why. Link the driving issue if one exists. -->

## Test plan

<!-- Commands you ran, or manual steps / screenshots for UI changes. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (or the scoped `--filter` you actually ran)

## Checklist

- [ ] PR title follows Conventional Commits (`type(scope): subject`) — CI checks this
- [ ] Scoped to one logical change
- [ ] Tests added/updated for the behavior that changed
