### PR TITLE
fix(knowledge): retain draft warnings until saves succeed

### DIFF
--- a/apps/web/app/components/knowledge/page-form.test.tsx
+++ b/apps/web/app/components/knowledge/page-form.test.tsx
@@ -36,6 +36,16 @@ function mount(props: Partial<React.ComponentProps<typeof PageForm>> = {}) {
   return { onSubmit };
 }
 
+function deferred() {
+  let resolve!: () => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
 describe("PageForm", () => {
   it("reports a rejected path against the path field, not only at the top", async () => {
     mount({ fieldErrors: { path: "path is already taken" } });
@@ -68,15 +78,47 @@ describe("PageForm", () => {
     expect(dispatchUnload()).toBe(true);
   });
 
-  it("stops warning once the work has been handed to the server", async () => {
+  it("keeps warning while a save is pending and stops after it succeeds", async () => {
     const user = userEvent.setup();
-    mount({ onSubmit: vi.fn() });
+    const save = deferred();
+    mount({ onSubmit: vi.fn(() => save.promise) });
 
     await user.type(screen.getByLabelText(/path/i), "notes/one");
     await user.type(screen.getByLabelText("body"), "saved");
     await user.click(screen.getByRole("button", { name: /create/i }));
+    expect(dispatchUnload()).toBe(true);
 
+    save.resolve();
     await waitFor(() => expect(dispatchUnload()).toBe(false));
+  });
+
+  it("keeps warning after a save fails", async () => {
+    const user = userEvent.setup();
+    const save = deferred();
+    mount({ onSubmit: vi.fn(() => save.promise) });
+
+    await user.type(screen.getByLabelText(/path/i), "notes/one");
+    await user.type(screen.getByLabelText("body"), "draft");
+    await user.click(screen.getByRole("button", { name: /create/i }));
+    save.reject(new Error("save failed"));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("save failed");
+    await waitFor(() => expect(dispatchUnload()).toBe(true));
+  });
+
+  it("keeps warning when the draft changes during a successful save", async () => {
+    const user = userEvent.setup();
+    const save = deferred();
+    mount({ onSubmit: vi.fn(() => save.promise) });
+
+    await user.type(screen.getByLabelText(/path/i), "notes/one");
+    await user.type(screen.getByLabelText("body"), "first");
+    await user.click(screen.getByRole("button", { name: /create/i }));
+    await user.type(screen.getByLabelText("body"), " second");
+    save.resolve();
+
+    await waitFor(() => expect(screen.getByLabelText("body")).toHaveValue("first second"));
+    expect(dispatchUnload()).toBe(true);
   });
 
   it("offers a way back before an in-SPA navigation discards unsaved work", async () => {
@@ -113,7 +155,11 @@ describe("PageForm", () => {
     await user.type(screen.getByLabelText("body"), "hello");
     await user.click(screen.getByRole("button", { name: /create/i }));
 
-    expect(onSubmit).toHaveBeenCalledWith("notes/one", expect.stringContaining("hello"));
+    expect(onSubmit).toHaveBeenCalledWith(
+      "notes/one",
+      expect.stringContaining("hello"),
+      expect.any(Function)
+    );
   });
 });
 

--- a/apps/web/app/components/knowledge/page-form.tsx
+++ b/apps/web/app/components/knowledge/page-form.tsx
@@ -19,7 +19,7 @@ export type PageFormProps = {
   lockPath?: boolean;
   initialContent?: string;
   initialTab?: Tab;
-  onSubmit: (path: string, content: string) => void | Promise<void>;
+  onSubmit: (path: string, content: string, confirmSaved: () => boolean) => void | Promise<void>;
   submitting: boolean;
   formError?: string | null;
   /** Server rejections keyed by the field that caused them, so each lands where it can be fixed. */
@@ -51,6 +51,8 @@ export function PageForm({
   const pathLocked = mode === "edit" || !!lockPath;
   const mentionExtensions = useWikiMentionExtensions(spaceId);
   const [dirty, setDirty] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const draftRevision = useRef(0);
   // A ref, not state: the unload listener must read the current value without being re-registered
   // on every keystroke.
   const dirtyRef = useRef(false);
@@ -70,11 +72,17 @@ export function PageForm({
   // `beforeunload` only covers leaving the document. Most navigation here is in-SPA, where the
   // browser never fires it, so the same work would vanish on a stray sidebar click.
   const blocker = useBlocker(({ currentLocation, nextLocation }) => {
-    return dirty && currentLocation.pathname !== nextLocation.pathname;
+    return dirtyRef.current && currentLocation.pathname !== nextLocation.pathname;
   });
 
-  function setField<K extends keyof OkfFields>(key: K, value: OkfFields[K]) {
+  function markDirty() {
+    draftRevision.current += 1;
+    dirtyRef.current = true;
     setDirty(true);
+  }
+
+  function setField<K extends keyof OkfFields>(key: K, value: OkfFields[K]) {
+    markDirty();
     setFields((prev) => ({ ...prev, [key]: value }));
   }
 
@@ -85,18 +93,28 @@ export function PageForm({
     setTab(next);
   }
 
-  function handleSubmit(e: FormEvent) {
+  async function handleSubmit(e: FormEvent) {
     e.preventDefault();
+    setSubmitError(null);
     const content =
       tab === "raw" ? raw : serializeOkf({ ...fields, tags: mergeTags(fields.tags, fields.body) });
-    // Cleared on hand-off, not on success: a failed save leaves the work in the editor, where the
-    // author can retry it, and re-marks the form dirty the moment they touch it again.
-    setDirty(false);
-    onSubmit(path.trim(), content);
+    const submittedRevision = draftRevision.current;
+    const confirmSaved = () => {
+      if (draftRevision.current !== submittedRevision) return false;
+      dirtyRef.current = false;
+      setDirty(false);
+      return true;
+    };
+    try {
+      await onSubmit(path.trim(), content, confirmSaved);
+      confirmSaved();
+    } catch (error) {
+      setSubmitError(error instanceof Error ? error.message : "The page could not be saved.");
+    }
   }
 
   return (
-    <form onSubmit={handleSubmit} className="flex flex-col gap-4" noValidate>
+    <form onSubmit={(event) => void handleSubmit(event)} className="flex flex-col gap-4" noValidate>
       {blocker.state === "blocked" ? (
         <div
           role="alertdialog"
@@ -120,9 +138,12 @@ export function PageForm({
           </div>
         </div>
       ) : null}
-      {formError ? (
-        <p className="rounded-sm border border-destructive/40 bg-destructive/5 px-3 py-2 text-destructive">
-          error: {formError}
+      {formError || submitError ? (
+        <p
+          role="alert"
+          className="rounded-sm border border-destructive/40 bg-destructive/5 px-3 py-2 text-destructive"
+        >
+          error: {formError || submitError}
         </p>
       ) : null}
 
@@ -136,7 +157,7 @@ export function PageForm({
           className={fieldClass(!!fieldErrors?.path)}
           value={path}
           onChange={(e) => {
-            setDirty(true);
+            markDirty();
             setPath(e.target.value);
           }}
           placeholder="tables/orders"
@@ -250,7 +271,7 @@ export function PageForm({
             className={`${fieldClass(!!fieldErrors?.content)} min-h-96 font-mono`}
             value={raw}
             onChange={(e) => {
-              setDirty(true);
+              markDirty();
               setRaw(e.target.value);
             }}
             required

--- a/apps/web/app/routes/_app.knowledge.pages.$pageId.edit.tsx
+++ b/apps/web/app/routes/_app.knowledge.pages.$pageId.edit.tsx
@@ -35,20 +35,23 @@ export default function PageEdit() {
   const spaceHome = `/knowledge/spaces/${encodeURIComponent(space.id)}`;
   const pagePath = pageHref(doc.id, path);
 
-  async function onSubmit(_path: string, content: string) {
+  async function onSubmit(_path: string, content: string, confirmSaved: () => boolean) {
     setSubmitting(true);
     setFormError(null);
     setFieldErrors({});
     try {
       // The path is fixed on edit (read-only field); re-post to the same path to replace content.
       await writePage(space.id, path, content);
+      const shouldNavigate = confirmSaved();
       window.dispatchEvent(new Event("okf:space-changed")); // refresh the persistent tree
-      navigate(pagePath);
+      if (shouldNavigate) navigate(pagePath);
+      else setSubmitting(false);
     } catch (err) {
       const mapped = pageFormErrors(err);
       setFormError(mapped.formError);
       setFieldErrors(mapped.fieldErrors);
       setSubmitting(false);
+      throw err;
     }
   }
 

--- a/apps/web/app/routes/_app.knowledge.spaces.$id.pages.new.tsx
+++ b/apps/web/app/routes/_app.knowledge.spaces.$id.pages.new.tsx
@@ -53,14 +53,17 @@ export default function PageNew() {
 
   const detailPath = `/knowledge/spaces/${encodeURIComponent(space.id)}`;
 
-  async function onSubmit(path: string, content: string) {
+  async function onSubmit(path: string, content: string, confirmSaved: () => boolean) {
     setSubmitting(true);
     setFormError(null);
     setFieldErrors({});
     try {
       const result = await writePage(space.id, path, content);
+      const shouldNavigate = confirmSaved();
       window.dispatchEvent(new Event("okf:space-changed")); // refresh the tree
-      if ("override" in result) {
+      if (!shouldNavigate) {
+        setSubmitting(false);
+      } else if ("override" in result) {
         navigate(detailPath);
       } else {
         navigate(pageHref(result.id, path)); // canonical uuid URL of the new page
@@ -70,6 +73,7 @@ export default function PageNew() {
       setFormError(mapped.formError);
       setFieldErrors(mapped.fieldErrors);
       setSubmitting(false);
+      throw err;
     }
   }
 


### PR DESCRIPTION
## Summary

<!-- What changed, and why. Link the driving issue if one exists. -->

## Test plan

<!-- Commands you ran, or manual steps / screenshots for UI changes. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (or the scoped `--filter` you actually ran)

## Checklist

- [ ] PR title follows Conventional Commits (`type(scope): subject`) — CI checks this
- [ ] Scoped to one logical change
- [ ] Tests added/updated for the behavior that changed
