### PR TITLE
fix(soul-doctor): reject repairs based on stale Soul content

### DIFF
--- a/apps/api/src/soul-doctor/compose.test.ts
+++ b/apps/api/src/soul-doctor/compose.test.ts
@@ -1,0 +1,133 @@
+import type { SoulWriteRequest, SoulWriter } from "@tulipfarm/soul";
+import { SoulWriteError } from "@tulipfarm/soul";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildSoulDoctor } from "./compose";
+
+const storage = vi.hoisted(() => ({
+  observe: vi.fn(async () => ({ state: "open", attempts: 0 })),
+  claim: vi.fn(async () => true),
+  settle: vi.fn(async () => undefined),
+  resolveUnseen: vi.fn(async () => 0),
+  listUnhealthyRuns: vi.fn(async () => []),
+  closeSupersededRuns: vi.fn(async () => undefined),
+}));
+
+const proposeSoulRepair = vi.hoisted(() => vi.fn());
+
+vi.mock("@tulipfarm/built-in-agents", () => ({ proposeSoulRepair }));
+vi.mock("@tulipfarm/storage", () => ({
+  closeSupersededRuns: storage.closeSupersededRuns,
+  listUnhealthyRuns: storage.listUnhealthyRuns,
+  SoulDoctorLedger: class {
+    observe = storage.observe;
+    claim = storage.claim;
+    settle = storage.settle;
+    resolveUnseen = storage.resolveUnseen;
+  },
+}));
+
+const brokenRoutine = {
+  apiVersion: "tulipfarm.ai/v1",
+  kind: "Routine",
+  metadata: {
+    id: "11111111-2222-4333-8444-555555555555",
+    slug: "quotes",
+    schemaVersion: 1,
+    authoredVersion: 1,
+    lifecycle: "published",
+  },
+  spec: {
+    owner: "platform",
+    start: "Start",
+    states: [{ type: "compute", name: "Start", input: { ok: true }, transition: "Nowhere" }],
+  },
+};
+
+const repairedRoutine = `apiVersion: tulipfarm.ai/v1
+kind: Routine
+metadata:
+  id: 11111111-2222-4333-8444-555555555555
+  slug: quotes
+  schemaVersion: 1
+  authoredVersion: 1
+  lifecycle: published
+spec:
+  owner: platform
+  start: Start
+  states:
+    - type: compute
+      name: Start
+      input:
+        ok: true
+      end: true
+`;
+
+describe("buildSoulDoctor", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects a repair when a user edits the Routine during the model call", async () => {
+    let currentBase = "base-commit";
+    let appliedContent: string | null = null;
+    const apply = vi.fn(async (request: SoulWriteRequest) => {
+      if (request.expectedBaseCommit !== undefined && request.expectedBaseCommit !== currentBase) {
+        throw new SoulWriteError("CONFLICT", "Soul write: base commit stale");
+      }
+      appliedContent = (request.changes[0] as { content: string }).content;
+      return {
+        commitSha: "repair-commit",
+        filesChanged: 1,
+        paths: ["routines/quotes/routine.yaml"],
+        pushed: true,
+        published: true,
+      };
+    });
+    const writer = {
+      readWithBase: vi.fn(async () => ({
+        content: "broken authored bytes",
+        baseCommit: currentBase,
+      })),
+      apply,
+    } as unknown as SoulWriter;
+    proposeSoulRepair.mockImplementationOnce(async () => {
+      currentBase = "user-edit-commit";
+      return { repairable: true, content: repairedRoutine, summary: "repair mapping" };
+    });
+    const upsertOpen = vi.fn(async () => undefined);
+
+    const doctor = buildSoulDoctor({
+      pool: {} as never,
+      businessId: "business-1",
+      soul: { routines: new Map([["quotes", { config: brokenRoutine }]]) },
+      writer,
+      actor: {
+        principalId: "system:soul-doctor",
+        email: "system@tulipfarm.local",
+        name: "Soul Doctor",
+      },
+      tasks: { upsertOpen } as never,
+      activity: { record: vi.fn(async () => undefined) } as never,
+      llm: {
+        isConfigured: true,
+        effortModel: vi.fn(() => ({})),
+      } as never,
+      headSha: async () => "published-commit",
+      activeCommitSha: async () => "published-commit",
+    });
+
+    const report = await doctor.sweep();
+
+    expect(report).toMatchObject({ found: 1, repaired: 0, escalated: 1 });
+    expect(apply).toHaveBeenCalledWith(
+      expect.objectContaining({ expectedBaseCommit: "base-commit" })
+    );
+    expect(appliedContent).toBeNull();
+    expect(upsertOpen).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: expect.stringContaining("base commit stale"),
+      }),
+      expect.any(Date)
+    );
+  });
+});

--- a/apps/api/src/soul-doctor/compose.ts
+++ b/apps/api/src/soul-doctor/compose.ts
@@ -119,6 +119,7 @@ export function buildSoulDoctor(deps: SoulDoctorDeps): { sweep(): Promise<SweepR
       return {
         path: `routines/${slug}/routine.yaml`,
         content: read.content,
+        baseCommit: read.baseCommit,
         facts: routineFacts(deps.soul.routines.get(slug)?.config ?? {}),
       };
     },
@@ -153,7 +154,11 @@ export function buildSoulDoctor(deps: SoulDoctorDeps): { sweep(): Promise<SweepR
       };
     },
 
-    async publish(finding: Finding, proposal: ProposedRepair): Promise<void> {
+    async publish(
+      finding: Finding,
+      proposal: ProposedRepair,
+      subject: RepairSubject
+    ): Promise<void> {
       const slug = routineSlug(finding);
       if (slug === null) throw new Error("soul doctor: a repair reached publish with no artifact");
       const result = await deps.writer.apply({
@@ -161,6 +166,7 @@ export function buildSoulDoctor(deps: SoulDoctorDeps): { sweep(): Promise<SweepR
         source: "api",
         actor: deps.actor,
         businessId,
+        expectedBaseCommit: subject.baseCommit,
         changes: [{ op: "put", target: { kind: "Routine", slug }, content: proposal.content }],
       });
       if (!result.published) {

--- a/apps/eval/src/l3/doctor.ts
+++ b/apps/eval/src/l3/doctor.ts
@@ -9,9 +9,11 @@
  * never that a vendor wrote good YAML.
  */
 
+import { execFileSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
+import { hermeticGitEnv } from "@tulipfarm/soul";
 import {
   type Finding,
   lintRoutineDocument,
@@ -68,9 +70,15 @@ export async function runDoctor(input: {
       if (finding.subject.kind !== "routine") return null;
       if (!soul.loader.routines.has(finding.subject.id)) return null;
       const path = `routines/${finding.subject.id}/routine.yaml`;
+      const baseCommit = execFileSync("git", ["rev-parse", "HEAD"], {
+        cwd: soul.path,
+        env: hermeticGitEnv(),
+        encoding: "utf8",
+      }).trim();
       return {
         path,
         content: await readFile(join(soul.path, path), "utf8"),
+        baseCommit,
         facts: [],
       };
     },

--- a/packages/soul-doctor/AGENTS.md
+++ b/packages/soul-doctor/AGENTS.md
@@ -34,6 +34,8 @@ be repaired automatically or must go to a person. Pure logic: no database, no mo
   key. Widening it needs a matching test, not a new branch.
 - Findings fingerprint on `{code, subject, digest, at}` so a republish retires the old one; Tasks
   dedupe on the subject alone so a republish does not open a second Task. Keep that asymmetry.
+- `RepairSubject` carries the Soul base commit read with its bytes; publication must use it as the
+  expected base so a model response cannot overwrite an interleaved user edit.
 - `doctor:` dedupe keys are refused from Agent-facing Tools (`apps/api/src/tasks/tools.ts`), so a
   Tool call cannot forge or resurrect the Doctor's own escalations.
 - Simulation is not the lint. `simulateRoutine` conflates a missing fixture with an unresolvable

--- a/packages/soul-doctor/src/sweep.test.ts
+++ b/packages/soul-doctor/src/sweep.test.ts
@@ -18,6 +18,7 @@ const SUBJECT: RepairSubject = {
   path: "soul/bundle",
   content: "states: []\n",
   facts: [],
+  baseCommit: "base-commit",
 };
 
 interface Harness {
@@ -25,6 +26,7 @@ interface Harness {
   events: SweepEvent[];
   escalations: { fingerprint: string; because: string }[];
   published: ProposedRepair[];
+  publishedBases: string[];
   settled: { fingerprint: string; state: string }[];
 }
 
@@ -41,6 +43,7 @@ function harness(
   const events: SweepEvent[] = [];
   const escalations: { fingerprint: string; because: string }[] = [];
   const published: ProposedRepair[] = [];
+  const publishedBases: string[] = [];
   const settled: { fingerprint: string; state: string }[] = [];
   const repair = {
     async locate() {
@@ -57,8 +60,9 @@ function harness(
             summary: "named the field the State publishes",
           };
     },
-    async publish(_finding: Finding, proposal: ProposedRepair) {
+    async publish(_finding: Finding, proposal: ProposedRepair, subject: RepairSubject) {
       published.push(proposal);
+      publishedBases.push(subject.baseCommit);
     },
   };
   const ports: SweepPorts = {
@@ -91,7 +95,7 @@ function harness(
       events.push(event);
     },
   };
-  return { ports, events, escalations, published, settled };
+  return { ports, events, escalations, published, publishedBases, settled };
 }
 
 describe("sweepSoul", () => {
@@ -100,6 +104,7 @@ describe("sweepSoul", () => {
     const report = await sweepSoul(h.ports);
     expect(report).toEqual({ found: 1, repaired: 1, escalated: 0, resolved: 3 });
     expect(h.published).toHaveLength(1);
+    expect(h.publishedBases).toEqual(["base-commit"]);
     expect(h.settled.at(-1)?.state).toBe("repaired");
     expect(h.events.map((event) => event.kind)).toEqual(["finding", "repaired"]);
   });

--- a/packages/soul-doctor/src/sweep.ts
+++ b/packages/soul-doctor/src/sweep.ts
@@ -10,6 +10,8 @@ export interface RepairSubject {
   /** Soul-repo path of the artifact the finding names. The gate holds the diff to exactly this. */
   readonly path: string;
   readonly content: string;
+  /** Soul revision read with the artifact, required to reject a stale repair at publication. */
+  readonly baseCommit: string;
   /** Facts the model may use instead of guessing — for a bad reference, the fields that exist. */
   readonly facts: readonly string[];
 }
@@ -49,7 +51,7 @@ export interface RepairPort {
   /** Asks for a repaired artifact and proves it lints. `null` when the model declined. */
   propose(finding: Finding, subject: RepairSubject): Promise<ProposedRepair | null>;
   /** Writes the repaired artifact through the Soul write gateway and republishes. */
-  publish(finding: Finding, repair: ProposedRepair): Promise<void>;
+  publish(finding: Finding, repair: ProposedRepair, subject: RepairSubject): Promise<void>;
 }
 
 export type SweepEvent =
@@ -132,7 +134,7 @@ async function treat(
     return "escalated";
   }
 
-  await repair.publish(finding, proposal);
+  await repair.publish(finding, proposal, subject);
   await ports.ledger.settle(finding.fingerprint, "repaired");
   await ports.report({ kind: "repaired", finding, summary: proposal.summary ?? "repaired" });
   return "repaired";


### PR DESCRIPTION
## Summary

<!-- What changed, and why. Link the driving issue if one exists. -->

## Test plan

<!-- Commands you ran, or manual steps / screenshots for UI changes. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (or the scoped `--filter` you actually ran)

## Checklist

- [ ] PR title follows Conventional Commits (`type(scope): subject`) — CI checks this
- [ ] Scoped to one logical change
- [ ] Tests added/updated for the behavior that changed
