### PR TITLE
fix(resources): preserve generated Record IDs on updates

### DIFF
--- a/packages/resources/AGENTS.md
+++ b/packages/resources/AGENTS.md
@@ -19,3 +19,4 @@ Deep domain module for Record write policy and mutation orchestration.
 - Depend on repository, catalog, clock, and hook ports; never import `apps/*`, Fastify, or sandbox.
 - Dynamic Record-table SQL remains in the API adapter after resource-type validation.
 - Side effects travel with the mutation port so persistence can enqueue them atomically.
+- A schema-generated human ID is create-only; replace and patch preserve the existing value.

--- a/packages/resources/src/service.test.ts
+++ b/packages/resources/src/service.test.ts
@@ -1,5 +1,5 @@
 import type { ResourceSideEffect } from "@tulipfarm/storage";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   createRecord,
   type ResourceDoc,
@@ -119,6 +119,77 @@ describe("Record write service", () => {
       err: { code: 422, body: { path: "/name", error: "name must not be empty" } },
     });
     expect(tickets.effects).toHaveLength(0);
+  });
+
+  it("keeps the generated default human ID stable on replace updates", async () => {
+    const tickets = new MemoryRepo();
+    tickets.records.set("ticket-1", {
+      _id: "ticket-1",
+      version: 1,
+      createdAt: new Date("2025-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2025-01-01T00:00:00.000Z"),
+      id: "TICK-7",
+      title: "old",
+    });
+    const counter = vi.fn(async () => 8);
+
+    const result = await updateRecord(
+      {
+        type: "ticket",
+        resource: {
+          schema: {
+            type: "object",
+            "x-id-strategy": { prefix: "TICK-", sequence: true },
+            properties: {
+              id: { type: "string" },
+              title: { type: "string", "x-normalize": ["trim"] },
+            },
+          },
+        },
+        id: "ticket-1",
+        expectedVersion: 1,
+        data: { id: "TICK-999", title: "  new  " },
+        mode: "replace",
+      },
+      { ...ports({ ticket: tickets }), counter }
+    );
+
+    expect(result).toMatchObject({ ok: true, doc: { id: "TICK-7", title: "new" } });
+    expect(counter).not.toHaveBeenCalled();
+  });
+
+  it("keeps a generated custom-field human ID stable on patch updates", async () => {
+    const tickets = new MemoryRepo();
+    tickets.records.set("ticket-1", {
+      _id: "ticket-1",
+      version: 1,
+      createdAt: new Date("2025-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2025-01-01T00:00:00.000Z"),
+      ref: "REF-12",
+      title: "old",
+    });
+    const counter = vi.fn(async () => 13);
+
+    const result = await updateRecord(
+      {
+        type: "ticket",
+        resource: {
+          schema: {
+            type: "object",
+            "x-id-strategy": { field: "ref", prefix: "REF-", sequence: true },
+            properties: { ref: { type: "string" }, title: { type: "string" } },
+          },
+        },
+        id: "ticket-1",
+        expectedVersion: 1,
+        data: { ref: "REF-999", title: "new" },
+        mode: "patch",
+      },
+      { ...ports({ ticket: tickets }), counter }
+    );
+
+    expect(result).toMatchObject({ ok: true, doc: { ref: "REF-12", title: "new" } });
+    expect(counter).not.toHaveBeenCalled();
   });
 
   it("refuses a link to a missing Record before any mutation is enqueued", async () => {

--- a/packages/resources/src/service.ts
+++ b/packages/resources/src/service.ts
@@ -213,7 +213,10 @@ async function prepareData(
   let data = stripReadOnly(resource.schema, stripSystemFields(raw));
   if (existing) data = stripImmutable(resource.schema, existing, data);
   try {
-    data = await applyTransforms(type, resource.schema, data, { counter: ports.counter });
+    data = await applyTransforms(type, resource.schema, data, {
+      counter: ports.counter,
+      ...(existing === undefined ? {} : { existingRecord: existing }),
+    });
   } catch (error) {
     if (error instanceof TulipFarmValidationError) {
       return { ok: false, err: { code: 422, body: validationError(error) } };

--- a/packages/schema/AGENTS.md
+++ b/packages/schema/AGENTS.md
@@ -50,6 +50,7 @@ Run event/request vocabularies, canonical hashes, Secret references, and resourc
 - Skill `requiredSecrets` names references only; `allowedDomains` accepts exact hosts, never URLs or wildcards.
 - Invocation gateways must compile `INVOCATION_REQUEST_SCHEMAS` and deny unregistered refs.
 - `applyTransforms` order is `x-id-strategy` -> `x-normalize` -> `x-computed`; normalizer and
-  computed keys are closed sets and must be added beside their implementation maps.
+  computed keys are closed sets and must be added beside their implementation maps. An
+  `x-id-strategy` value is generated only for create; updates preserve the existing target field.
 - Call `validateResourceSchema()` when loading resource schemas; AJV `strict: false` will not reject
   unknown `x-*` keys or functions for you.

--- a/packages/schema/src/transforms/apply.ts
+++ b/packages/schema/src/transforms/apply.ts
@@ -16,6 +16,7 @@ interface ComputedSpec {
 
 interface TransformOpts {
   counter?: CounterFn;
+  existingRecord?: Record<string, unknown>;
 }
 
 async function applyIdStrategy(
@@ -27,6 +28,14 @@ async function applyIdStrategy(
   const idStrategy = schema["x-id-strategy"] as IdStrategy | undefined;
   if (!idStrategy?.sequence) return;
   const targetField = idStrategy.field ?? "id";
+  if (opts?.existingRecord !== undefined) {
+    if (Object.hasOwn(opts.existingRecord, targetField)) {
+      out[targetField] = opts.existingRecord[targetField];
+    } else {
+      delete out[targetField];
+    }
+    return;
+  }
   if (!opts?.counter) {
     throw new TulipFarmValidationError(
       "resource",


### PR DESCRIPTION
## Summary

<!-- What changed, and why. Link the driving issue if one exists. -->

## Test plan

<!-- Commands you ran, or manual steps / screenshots for UI changes. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (or the scoped `--filter` you actually ran)

## Checklist

- [ ] PR title follows Conventional Commits (`type(scope): subject`) — CI checks this
- [ ] Scoped to one logical change
- [ ] Tests added/updated for the behavior that changed
