### PR TITLE
fix(chat): keep failed Surface choices retryable

### DIFF
--- a/apps/web/app/components/chat/parts.test.tsx
+++ b/apps/web/app/components/chat/parts.test.tsx
@@ -1,5 +1,5 @@
 import { createRemixStub } from "@remix-run/testing";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createSurfaceArtifact } from "@tulipfarm/surface";
 import { surfaceActionKey } from "@tulipfarm/surface/client";
@@ -25,6 +25,14 @@ const NARRATION_PARTS: { name: string; part: TimelinePart }[] = [
     part: { kind: "guardrail", stage: "output", reason: "policy", message: "Refunds are capped" },
   },
 ];
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
 
 /** Sources link in-app, so these parts need a router around them. */
 function renderPart(part: TimelinePart) {
@@ -189,6 +197,171 @@ test("Choices render as a decision card and lock after selection", async () => {
   expect(screen.getByRole("button", { name: "Keep investigating" })).toBeDisabled();
 });
 
+test("Choices stay retryable when an interaction fails", async () => {
+  const user = userEvent.setup();
+  const action = { event: "incident.choose" };
+  const artifact = createSurfaceArtifact({
+    id: "decision",
+    component: { name: "Choices", version: "1.0" },
+    props: {
+      question: "Which action should we take?",
+      choices: [
+        { label: "Roll back", value: "rollback" },
+        { label: "Keep investigating", value: "investigate" },
+      ],
+      action,
+    },
+    target: { channel: "web", surface: "chat" },
+    audience: ["user:1"],
+    classification: "internal",
+  });
+  const onInteraction = vi.fn().mockRejectedValue(new Error("busy"));
+
+  render(
+    <MessagePartView
+      part={{
+        kind: "surface",
+        artifactId: artifact.id,
+        revision: artifact.revision,
+        artifact,
+        actionHandles: {
+          [surfaceActionKey({ ...action, payload: { value: "rollback" } })]: "rollback-handle",
+          [surfaceActionKey({ ...action, payload: { value: "investigate" } })]:
+            "investigate-handle",
+        },
+      }}
+      onApprove={() => undefined}
+      onSurfaceInteraction={onInteraction}
+    />
+  );
+
+  await user.click(screen.getByRole("button", { name: "Roll back" }));
+  expect(await screen.findByRole("alert")).toHaveTextContent("busy");
+  await waitFor(() => expect(screen.getByRole("button", { name: "Roll back" })).toBeEnabled());
+  expect(screen.getByRole("button", { name: "Keep investigating" })).toBeEnabled();
+});
+
+test("Choices show a pending state before they report acceptance", async () => {
+  const user = userEvent.setup();
+  const pending = deferred();
+  const action = { event: "incident.choose" };
+  const artifact = createSurfaceArtifact({
+    id: "decision",
+    component: { name: "Choices", version: "1.0" },
+    props: {
+      question: "Which action should we take?",
+      choices: [{ label: "Roll back", value: "rollback" }],
+      action,
+    },
+    target: { channel: "web", surface: "chat" },
+    audience: ["user:1"],
+    classification: "internal",
+  });
+
+  render(
+    <MessagePartView
+      part={{
+        kind: "surface",
+        artifactId: artifact.id,
+        revision: artifact.revision,
+        artifact,
+        actionHandles: {
+          [surfaceActionKey({ ...action, payload: { value: "rollback" } })]: "rollback-handle",
+        },
+      }}
+      onApprove={() => undefined}
+      onSurfaceInteraction={() => pending.promise}
+    />
+  );
+
+  await user.click(screen.getByRole("button", { name: "Roll back" }));
+  expect(screen.getByRole("button", { name: "Roll back, submitting" })).toBeDisabled();
+  expect(screen.queryByRole("button", { name: "Roll back, selected" })).toBeNull();
+
+  pending.resolve();
+  expect(await screen.findByRole("button", { name: "Roll back, selected" })).toBeDisabled();
+});
+
+test("MultiChoice stays retryable when an interaction fails", async () => {
+  const user = userEvent.setup();
+  const action = { event: "incident.assign" };
+  const artifact = createSurfaceArtifact({
+    id: "assign",
+    component: { name: "MultiChoice", version: "1.0" },
+    props: {
+      question: "Who should investigate?",
+      choices: [
+        { label: "Operations", value: "operations" },
+        { label: "Support", value: "support" },
+      ],
+      action,
+    },
+    target: { channel: "web", surface: "chat" },
+    audience: ["user:1"],
+    classification: "internal",
+  });
+  const onInteraction = vi.fn().mockRejectedValue(new Error("network failed"));
+
+  render(
+    <MessagePartView
+      part={{
+        kind: "surface",
+        artifactId: artifact.id,
+        revision: artifact.revision,
+        artifact,
+        actionHandles: { [surfaceActionKey(action)]: "assign-handle" },
+      }}
+      onApprove={() => undefined}
+      onSurfaceInteraction={onInteraction}
+    />
+  );
+
+  await user.click(screen.getByRole("checkbox", { name: "Operations" }));
+  await user.click(screen.getByRole("button", { name: "Submit" }));
+
+  expect(await screen.findByRole("alert")).toHaveTextContent("network failed");
+  await waitFor(() => expect(screen.getByRole("button", { name: "Submit" })).toBeEnabled());
+  expect(screen.getByRole("checkbox", { name: "Operations" })).toBeChecked();
+});
+
+test("MultiChoice reports submitting before it reports success", async () => {
+  const user = userEvent.setup();
+  const pending = deferred();
+  const action = { event: "incident.assign" };
+  const artifact = createSurfaceArtifact({
+    id: "assign",
+    component: { name: "MultiChoice", version: "1.0" },
+    props: {
+      question: "Who should investigate?",
+      choices: [{ label: "Operations", value: "operations" }],
+      action,
+    },
+    target: { channel: "web", surface: "chat" },
+    audience: ["user:1"],
+    classification: "internal",
+  });
+
+  render(
+    <MessagePartView
+      part={{
+        kind: "surface",
+        artifactId: artifact.id,
+        revision: artifact.revision,
+        artifact,
+        actionHandles: { [surfaceActionKey(action)]: "assign-handle" },
+      }}
+      onApprove={() => undefined}
+      onSurfaceInteraction={() => pending.promise}
+    />
+  );
+
+  await user.click(screen.getByRole("checkbox", { name: "Operations" }));
+  await user.click(screen.getByRole("button", { name: "Submit" }));
+  expect(screen.getByRole("button", { name: "Submitting…" })).toBeDisabled();
+
+  pending.resolve();
+  expect(await screen.findByRole("button", { name: "Submitted" })).toBeDisabled();
+});
 function recommendationArtifact(recommend?: string) {
   return createSurfaceArtifact({
     id: "restock",

--- a/apps/web/app/lib/chat/use-chat-stream.test.tsx
+++ b/apps/web/app/lib/chat/use-chat-stream.test.tsx
@@ -1,0 +1,114 @@
+import { createRemixStub } from "@remix-run/testing";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { beforeEach, expect, test, vi } from "vitest";
+import {
+  postChat,
+  postSurfaceInteraction,
+  resumeRun,
+  sendApprovalDecision,
+  stopChatRun,
+} from "~/lib/chat/sse-client";
+import { useChatStream } from "./use-chat-stream";
+
+vi.mock("~/lib/chat/sse-client", () => ({
+  postChat: vi.fn(),
+  postChatRetry: vi.fn(),
+  postSurfaceInteraction: vi.fn(),
+  resumeRun: vi.fn(),
+  sendApprovalDecision: vi.fn(),
+  stopChatRun: vi.fn(),
+}));
+
+const mockPostChat = vi.mocked(postChat);
+const mockPostSurfaceInteraction = vi.mocked(postSurfaceInteraction);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPostChat.mockResolvedValue(undefined);
+  mockPostSurfaceInteraction.mockResolvedValue(undefined);
+  vi.mocked(resumeRun).mockResolvedValue(undefined);
+  vi.mocked(sendApprovalDecision).mockResolvedValue(undefined);
+  vi.mocked(stopChatRun).mockResolvedValue(undefined);
+});
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function Harness() {
+  const chat = useChatStream();
+  const [outcome, setOutcome] = useState("idle");
+
+  async function interact() {
+    try {
+      await chat.sendSurfaceInteraction("choice-handle", { value: "approve" });
+      setOutcome("resolved");
+    } catch {
+      setOutcome("rejected");
+    }
+  }
+
+  return (
+    <>
+      <p>{chat.status}</p>
+      <p>{chat.error ?? ""}</p>
+      <p data-testid="outcome">{outcome}</p>
+      <button type="button" onClick={() => void chat.send("start")}>
+        Start
+      </button>
+      <button type="button" onClick={() => void interact()}>
+        Choose
+      </button>
+    </>
+  );
+}
+
+function renderHarness() {
+  const Stub = createRemixStub([{ path: "/", Component: Harness }]);
+  return render(<Stub initialEntries={["/"]} />);
+}
+
+test("a Surface interaction Promise stays pending until the follow-up send completes", async () => {
+  const user = userEvent.setup();
+  const stream = deferred();
+  mockPostChat.mockReturnValue(stream.promise);
+  renderHarness();
+
+  await user.click(screen.getByRole("button", { name: "Choose" }));
+  await waitFor(() => expect(mockPostChat).toHaveBeenCalledTimes(1));
+  expect(screen.getByTestId("outcome")).toHaveTextContent("idle");
+
+  stream.resolve();
+  await waitFor(() => expect(screen.getByTestId("outcome")).toHaveTextContent("resolved"));
+});
+
+test("a failed Surface interaction rejects after exposing the Chat error", async () => {
+  const user = userEvent.setup();
+  mockPostSurfaceInteraction.mockRejectedValue(new Error("interaction failed"));
+  renderHarness();
+
+  await user.click(screen.getByRole("button", { name: "Choose" }));
+
+  await waitFor(() => expect(screen.getByTestId("outcome")).toHaveTextContent("rejected"));
+  expect(screen.getByText("interaction failed")).toBeInTheDocument();
+  expect(mockPostChat).not.toHaveBeenCalled();
+});
+
+test("a Surface interaction rejects while Chat is busy", async () => {
+  const user = userEvent.setup();
+  mockPostChat.mockReturnValue(new Promise<void>(() => {}));
+  renderHarness();
+
+  await user.click(screen.getByRole("button", { name: "Start" }));
+  await screen.findByText("submitted");
+  await user.click(screen.getByRole("button", { name: "Choose" }));
+
+  await waitFor(() => expect(screen.getByTestId("outcome")).toHaveTextContent("rejected"));
+  expect(mockPostSurfaceInteraction).not.toHaveBeenCalled();
+});

--- a/apps/web/app/lib/chat/use-chat-stream.ts
+++ b/apps/web/app/lib/chat/use-chat-stream.ts
@@ -394,17 +394,21 @@ export function useChatStream(opts?: UseChatStreamOptions) {
   }, []);
 
   const sendSurfaceInteraction = useCallback(
-    (handle: string, input: Readonly<Record<string, unknown>>) => {
-      if (isChatBusy(stateRef.current.status)) return;
+    async (handle: string, input: Readonly<Record<string, unknown>>) => {
+      if (isChatBusy(stateRef.current.status)) {
+        throw new Error("Wait for the current response before choosing an option.");
+      }
       dispatch({ type: "surface-submit" });
-      void postSurfaceInteraction(handle, { ...input })
-        .then(() => send(surfaceInteractionAnswer(input), lastOptsRef.current))
-        .catch((error) => {
-          dispatch({
-            type: "error",
-            data: { message: error instanceof Error ? error.message : "interaction failed" },
-          });
+      try {
+        await postSurfaceInteraction(handle, { ...input });
+        await send(surfaceInteractionAnswer(input), lastOptsRef.current);
+      } catch (error) {
+        dispatch({
+          type: "error",
+          data: { message: error instanceof Error ? error.message : "interaction failed" },
         });
+        throw error;
+      }
     },
     [send]
   );

--- a/packages/surface-web/src/blocks/input.tsx
+++ b/packages/surface-web/src/blocks/input.tsx
@@ -3,7 +3,12 @@
 import type { SurfaceAction, SurfaceArtifact } from "@tulipfarm/surface/client";
 import type { ChangeEvent, FormEvent, ReactElement } from "react";
 import { useId, useState } from "react";
-import { ActionButton, inlineMarkup, type SurfaceWebProps } from "../primitives";
+import {
+  ActionButton,
+  inlineMarkup,
+  interactionErrorMessage,
+  type SurfaceWebProps,
+} from "../primitives";
 
 type Choice = {
   label: string;
@@ -78,16 +83,36 @@ export function SurfaceChoices({
   const [leadIndex, setLeadIndex] = useState(recommendedIndex);
   const [open, setOpen] = useState(false);
   const [selected, setSelected] = useState<string>();
+  const [pending, setPending] = useState<string>();
+  const [error, setError] = useState<string>();
   const questionId = `surface-${artifact.id}-question`;
 
   const choose = (choice: Choice) => ({
     ...action,
     payload: { ...action.payload, value: choice.value },
   });
+  const submitChoice = async (
+    choice: Choice,
+    handle: string,
+    input: Readonly<Record<string, unknown>>
+  ) => {
+    setPending(choice.value);
+    setError(undefined);
+    try {
+      await onInteraction?.(handle, input);
+      setSelected(choice.value);
+    } catch (error) {
+      setSelected(undefined);
+      setError(interactionErrorMessage(error));
+    } finally {
+      setPending(undefined);
+    }
+  };
 
   const question = (
     <header data-surface-choices-header>
       <h3 id={questionId}>{inlineMarkup(String(props.question))}</h3>
+      {error ? <p role="alert">{error}</p> : null}
     </header>
   );
 
@@ -102,16 +127,10 @@ export function SurfaceChoices({
               key={choice.value}
               label={choice.label}
               action={choose(choice)}
-              disabled={selected !== undefined}
+              disabled={selected !== undefined || pending !== undefined}
               selected={selected === choice.value}
-              onInteraction={async (handle, input) => {
-                setSelected(choice.value);
-                try {
-                  await onInteraction?.(handle, input);
-                } catch {
-                  setSelected(undefined);
-                }
-              }}
+              busy={pending === choice.value}
+              onInteraction={(handle, input) => submitChoice(choice, handle, input)}
               actionHandleFor={actionHandleFor}
             />
           ))}
@@ -121,7 +140,7 @@ export function SurfaceChoices({
   }
 
   const alternatives = choices.filter((_, index) => index !== leadIndex);
-  const decided = selected !== undefined;
+  const locked = selected !== undefined || pending !== undefined;
 
   return (
     <section data-surface-choices data-surface-recommend aria-labelledby={questionId}>
@@ -148,7 +167,7 @@ export function SurfaceChoices({
                 <button
                   key={choice.value}
                   type="button"
-                  disabled={decided}
+                  disabled={locked}
                   data-surface-choices-alternative
                   onClick={() => {
                     setLeadIndex(choices.indexOf(choice));
@@ -179,26 +198,20 @@ export function SurfaceChoices({
               data-surface-button
               data-variant="secondary"
               aria-expanded={open}
-              disabled={decided}
+              disabled={locked}
               onClick={() => setOpen((current) => !current)}
             >
               <span>Alternatives</span>
             </button>
           )}
           <ActionButton
-            label={decided ? "Accepted" : lead.label}
+            label={selected !== undefined ? "Accepted" : lead.label}
             action={choose(lead)}
-            disabled={decided}
-            state={decided ? "accepted" : undefined}
+            disabled={locked}
+            busy={pending === lead.value}
+            state={selected !== undefined ? "accepted" : undefined}
             primary
-            onInteraction={async (handle, input) => {
-              setSelected(lead.value);
-              try {
-                await onInteraction?.(handle, input);
-              } catch {
-                setSelected(undefined);
-              }
-            }}
+            onInteraction={(handle, input) => submitChoice(lead, handle, input)}
             actionHandleFor={actionHandleFor}
           />
         </span>
@@ -219,7 +232,8 @@ export function SurfaceMultiChoice({
   readonly actionHandleFor?: SurfaceWebProps["actionHandleFor"];
 }) {
   const [selected, setSelected] = useState<readonly string[]>([]);
-  const [submitted, setSubmitted] = useState(false);
+  const [submission, setSubmission] = useState<"idle" | "submitting" | "submitted">("idle");
+  const [error, setError] = useState<string>();
   const choices = props.choices as Array<{ label: string; value: string }>;
   const action = props.action as SurfaceAction;
   const handle = actionHandleFor?.(action);
@@ -229,13 +243,23 @@ export function SurfaceMultiChoice({
       previous.includes(value) ? previous.filter((item) => item !== value) : [...previous, value]
     );
   };
-  const submit = () => {
-    setSubmitted(true);
-    if (handle) void onInteraction?.(handle, { ...action.payload, values: selected });
+  const submit = async () => {
+    if (!handle) return;
+    setSubmission("submitting");
+    setError(undefined);
+    try {
+      await onInteraction?.(handle, { ...action.payload, values: selected });
+      setSubmission("submitted");
+    } catch (error) {
+      setSubmission("idle");
+      setError(interactionErrorMessage(error));
+    }
   };
+  const locked = submission !== "idle";
 
   return (
     <section data-surface-multi-choice aria-labelledby={questionId}>
+      {error ? <p role="alert">{error}</p> : null}
       <header data-surface-choices-header>
         <span data-surface-eyebrow>Select any</span>
         <h3 id={questionId}>{String(props.question)}</h3>
@@ -245,7 +269,7 @@ export function SurfaceMultiChoice({
           <label key={choice.value} data-surface-checkbox>
             <input
               type="checkbox"
-              disabled={submitted}
+              disabled={locked}
               checked={selected.includes(choice.value)}
               onChange={() => toggle(choice.value)}
             />
@@ -256,12 +280,19 @@ export function SurfaceMultiChoice({
       <footer data-surface-form-footer>
         <button
           type="button"
-          disabled={submitted || !handle || selected.length === 0}
+          disabled={locked || !handle || selected.length === 0}
+          aria-busy={submission === "submitting" || undefined}
           data-surface-button
           data-variant="primary"
-          onClick={submit}
+          onClick={() => void submit()}
         >
-          <span>Submit</span>
+          <span>
+            {submission === "submitting"
+              ? "Submitting…"
+              : submission === "submitted"
+                ? "Submitted"
+                : "Submit"}
+          </span>
         </button>
       </footer>
     </section>
@@ -279,12 +310,18 @@ export function SurfaceForm({
 }) {
   const formId = useId();
   const [values, setValues] = useState<Record<string, unknown>>({});
+  const [error, setError] = useState<string>();
   const fields = props.fields as Array<Record<string, unknown>>;
   const action = props.action as SurfaceAction;
   const handle = actionHandleFor?.(action);
   const submit = (event: FormEvent) => {
     event.preventDefault();
-    if (handle) void onInteraction?.(handle, values);
+    if (handle) {
+      setError(undefined);
+      void Promise.resolve()
+        .then(() => onInteraction?.(handle, values))
+        .catch((error) => setError(interactionErrorMessage(error)));
+    }
   };
   const update = (name: string, value: unknown) => {
     setValues((previous) => ({ ...previous, [name]: value }));
@@ -292,6 +329,7 @@ export function SurfaceForm({
 
   return (
     <form data-surface-form onSubmit={submit}>
+      {error ? <p role="alert">{error}</p> : null}
       {/*
         No eyebrow and no field count. A form with inputs and a submit button already says it is an
         ask, and a count of its own fields is a number no reader acts on.

--- a/packages/surface-web/src/code-view.tsx
+++ b/packages/surface-web/src/code-view.tsx
@@ -15,7 +15,7 @@ import {
   type SurfaceSandboxRenderMessage,
 } from "@tulipfarm/surface/client";
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { SurfaceWebProps } from "./primitives";
+import { interactionErrorMessage, type SurfaceWebProps } from "./primitives";
 
 export interface SurfaceCodeViewProps extends SurfaceWebProps {
   /** The compiled module produced at authoring time. Never authored source. */
@@ -35,6 +35,7 @@ export function SurfaceCodeView({
   const [height, setHeight] = useState(SURFACE_SANDBOX_MIN_HEIGHT);
   const [failed, setFailed] = useState(false);
   const [ready, setReady] = useState(false);
+  const [interactionError, setInteractionError] = useState<string>();
 
   const props = artifact.props as Readonly<Record<string, unknown>>;
 
@@ -75,10 +76,15 @@ export function SurfaceCodeView({
       const handle = actionHandleFor?.(emitted.action);
       if (!handle) return;
       const input = emitted.input;
-      void onInteraction?.(
-        handle,
-        (typeof input === "object" && input !== null ? input : {}) as Record<string, unknown>
-      );
+      setInteractionError(undefined);
+      void Promise.resolve()
+        .then(() =>
+          onInteraction?.(
+            handle,
+            (typeof input === "object" && input !== null ? input : {}) as Record<string, unknown>
+          )
+        )
+        .catch((error) => setInteractionError(interactionErrorMessage(error)));
     }
     window.addEventListener("message", onMessage);
     return () => window.removeEventListener("message", onMessage);
@@ -103,14 +109,17 @@ export function SurfaceCodeView({
   }
 
   return (
-    <iframe
-      data-surface-code-view
-      ref={frame}
-      sandbox={SURFACE_SANDBOX_ATTRIBUTE}
-      src={SURFACE_SANDBOX_FRAME_SRC}
-      title={artifact.component.name}
-      height={height}
-      style={{ width: "100%", height, border: "0", display: "block" }}
-    />
+    <>
+      <iframe
+        data-surface-code-view
+        ref={frame}
+        sandbox={SURFACE_SANDBOX_ATTRIBUTE}
+        src={SURFACE_SANDBOX_FRAME_SRC}
+        title={artifact.component.name}
+        height={height}
+        style={{ width: "100%", height, border: "0", display: "block" }}
+      />
+      {interactionError ? <p role="alert">{interactionError}</p> : null}
+    </>
   );
 }

--- a/packages/surface-web/src/primitives.tsx
+++ b/packages/surface-web/src/primitives.tsx
@@ -5,7 +5,7 @@ import type {
   SurfaceAction,
   SurfaceArtifact,
 } from "@tulipfarm/surface/client";
-import type { ReactNode } from "react";
+import { type ReactNode, useId, useState } from "react";
 
 export interface SurfaceWebProps {
   readonly artifact: SurfaceArtifact;
@@ -122,6 +122,10 @@ export function SurfaceAlert({
   );
 }
 
+export function interactionErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "The action could not be completed. Try again.";
+}
+
 export function ActionButton(props: {
   readonly label: string;
   readonly action: SurfaceAction;
@@ -131,30 +135,57 @@ export function ActionButton(props: {
   readonly selected?: boolean;
   readonly primary?: boolean;
   readonly submit?: boolean;
+  readonly busy?: boolean;
   /** Reports that this action already ran, so the button can say so instead of inviting a repeat. */
   readonly state?: "accepted";
 }) {
+  const [error, setError] = useState<string>();
+  const errorId = useId();
   const handle = props.actionHandleFor?.(props.action);
   return (
-    <button
-      type={props.submit ? "submit" : "button"}
-      disabled={props.disabled || props.action.disabled || !handle}
-      aria-label={props.selected ? `${props.label}, selected` : undefined}
-      aria-pressed={props.selected}
-      data-surface-action={handle}
-      data-surface-button
-      data-variant={props.primary ? "primary" : "secondary"}
-      data-state={props.state}
-      onClick={
-        props.submit
-          ? undefined
-          : () => {
-              if (handle) void props.onInteraction?.(handle, props.action.payload ?? {});
-            }
-      }
-    >
-      <span>{props.label}</span>
-      {props.selected ? <span data-surface-button-state>selected</span> : null}
-    </button>
+    <>
+      <button
+        type={props.submit ? "submit" : "button"}
+        disabled={props.disabled || props.action.disabled || !handle}
+        aria-label={
+          props.selected
+            ? `${props.label}, selected`
+            : props.busy
+              ? `${props.label}, submitting`
+              : undefined
+        }
+        aria-pressed={props.selected}
+        aria-busy={props.busy || undefined}
+        aria-describedby={error ? errorId : undefined}
+        data-surface-action={handle}
+        data-surface-button
+        data-variant={props.primary ? "primary" : "secondary"}
+        data-state={props.busy ? "submitting" : props.state}
+        onClick={
+          props.submit
+            ? undefined
+            : () => {
+                if (handle) {
+                  setError(undefined);
+                  void Promise.resolve()
+                    .then(() => props.onInteraction?.(handle, props.action.payload ?? {}))
+                    .catch((error) => setError(interactionErrorMessage(error)));
+                }
+              }
+        }
+      >
+        <span>{props.label}</span>
+        {props.busy ? (
+          <span data-surface-button-state>submitting</span>
+        ) : props.selected ? (
+          <span data-surface-button-state>selected</span>
+        ) : null}
+      </button>
+      {error ? (
+        <span id={errorId} role="alert">
+          {error}
+        </span>
+      ) : null}
+    </>
   );
 }


### PR DESCRIPTION
## Summary

<!-- What changed, and why. Link the driving issue if one exists. -->

## Test plan

<!-- Commands you ran, or manual steps / screenshots for UI changes. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (or the scoped `--filter` you actually ran)

## Checklist

- [ ] PR title follows Conventional Commits (`type(scope): subject`) — CI checks this
- [ ] Scoped to one logical change
- [ ] Tests added/updated for the behavior that changed
