### PR TITLE
fix(tools): replay durable Tool output after restart

### DIFF
--- a/apps/api/src/pg-migrate.test.ts
+++ b/apps/api/src/pg-migrate.test.ts
@@ -1521,6 +1521,28 @@ describe("runPgMigrations concurrency and atomicity", () => {
     });
   });
 
+  describe("migration 99", () => {
+    it("marks existing confirmed effects as having no stored output evidence", async () => {
+      const effectId = "11111111-1111-4111-8111-111111111111";
+      await db.query("CREATE TABLE effect_records (effect_id uuid PRIMARY KEY)");
+      await db.query("INSERT INTO effect_records (effect_id) VALUES ($1)", [effectId]);
+      await db.query(`CREATE TABLE schema_version (
+        id boolean PRIMARY KEY DEFAULT true,
+        version integer NOT NULL,
+        CONSTRAINT schema_version_single_row CHECK (id)
+      )`);
+      await db.query("INSERT INTO schema_version (id, version) VALUES (true, 98)");
+
+      await runPgMigrations(db, undefined, NOOP_LOG);
+
+      const effects = await db.query<{
+        output: unknown;
+        output_stored: boolean;
+      }>("SELECT output, output_stored FROM effect_records WHERE effect_id = $1", [effectId]);
+      expect(effects.rows).toEqual([{ output: null, output_stored: false }]);
+    });
+  });
+
   describe("migration 50", () => {
     it("drops the single-admin index and revokes owner authority when admin is demoted", async () => {
       const adminId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";

--- a/apps/api/src/pg-migrations/index.ts
+++ b/apps/api/src/pg-migrations/index.ts
@@ -3188,7 +3188,7 @@ export const PG_MIGRATIONS: PgMigration[] = [
     },
   },
   {
-    version: 99,
+    version: 106,
     description: "effect ledger: persist immutable confirmed Tool outputs",
     up: async (q) => {
       const present = await q.query<{ present: boolean }>(

--- a/apps/api/src/pg-migrations/index.ts
+++ b/apps/api/src/pg-migrations/index.ts
@@ -3190,6 +3190,11 @@ export const PG_MIGRATIONS: PgMigration[] = [
   {
     version: 99,
     description: "effect ledger: persist immutable confirmed Tool outputs",
-    up: applyStatements(EFFECT_OUTPUT_STORAGE_STATEMENTS),
+    up: async (q) => {
+      const present = await q.query<{ present: boolean }>(
+        "SELECT to_regclass('effect_records') IS NOT NULL AS present"
+      );
+      if (present.rows[0]?.present) await applyStatements(EFFECT_OUTPUT_STORAGE_STATEMENTS)(q);
+    },
   },
 ];

--- a/apps/api/src/pg-migrations/index.ts
+++ b/apps/api/src/pg-migrations/index.ts
@@ -57,7 +57,10 @@ import {
   TEAM_STORAGE_STATEMENTS,
   WAIT_STORAGE_STATEMENTS,
 } from "@tulipfarm/storage";
-import { EFFECT_STORAGE_STATEMENTS } from "@tulipfarm/tool-broker";
+import {
+  EFFECT_OUTPUT_STORAGE_STATEMENTS,
+  EFFECT_STORAGE_STATEMENTS,
+} from "@tulipfarm/tool-broker";
 import { APPROVAL_EVIDENCE_STORAGE_STATEMENTS } from "@tulipfarm/tool-host";
 import type { Queryable } from "../db";
 import { resourceSideEffectMigration } from "../resources/outbox";
@@ -3183,5 +3186,10 @@ export const PG_MIGRATIONS: PgMigration[] = [
         "ALTER TABLE routine_schedule_state ADD PRIMARY KEY (business_id, routine_slug, trigger_id)"
       );
     },
+  },
+  {
+    version: 99,
+    description: "effect ledger: persist immutable confirmed Tool outputs",
+    up: applyStatements(EFFECT_OUTPUT_STORAGE_STATEMENTS),
   },
 ];

--- a/apps/api/src/tools/declarative/tools.test.ts
+++ b/apps/api/src/tools/declarative/tools.test.ts
@@ -203,7 +203,7 @@ describe("buildDeclarativeTools", () => {
     const second = await tool?.execute({ body: { q: "x" } }, CTX);
 
     expect(first).toMatchObject({ success: true });
-    expect(second).toMatchObject({ success: true, data: { replayed: true } });
+    expect(second).toEqual(first);
     expect(http.sent).toHaveLength(1);
   });
 

--- a/apps/api/src/tools/declarative/tools.ts
+++ b/apps/api/src/tools/declarative/tools.ts
@@ -20,6 +20,7 @@ import { isPersonalCredentialStep, resolveAuthSteps } from "@tulipfarm/soul";
 import {
   CredentialDispatcher,
   EffectDispatcher,
+  type EffectRecord,
   type EffectStore,
   intentDigest,
   normalizeToolIntent,
@@ -111,12 +112,14 @@ function mapDispatchError(error: ToolDispatchError, slug: string): ToolCallResul
   }
 }
 
-/** Rediscovered ledger effects cannot replay provider output; only settled state is stored. */
-function replayed(state: string): ToolCallResult {
-  if (state === "confirmed") {
-    return ok({ replayed: true, note: "This call already completed; not repeated." });
+/** Rediscovered confirmed effects return the first immutable provider result. */
+function replayed(effect: EffectRecord): ToolCallResult {
+  if (effect.state === "confirmed") {
+    return effect.outputStored
+      ? ok(effect.output)
+      : err("internal_error", "confirmed_effect_output_unavailable");
   }
-  return err("internal_error", `effect_${state}`);
+  return err("internal_error", `effect_${effect.state}`);
 }
 
 function declarationSlug(slug: string): string {
@@ -422,7 +425,7 @@ function buildToolDef(
         guardrailRevision: ctx.guardrailRevision ?? "none",
         createdAt: new Date().toISOString(),
       });
-      if (reserved.outcome === "duplicate") return replayed(reserved.effect.state);
+      if (reserved.outcome === "duplicate") return replayed(reserved.effect);
 
       try {
         return ok(

--- a/apps/api/src/tools/github/tools.test.ts
+++ b/apps/api/src/tools/github/tools.test.ts
@@ -469,9 +469,7 @@ describe("buildGitHubTools", () => {
 
     expect(first.success).toBe(true);
     expect(second.success).toBe(true);
-    if (second.success) {
-      expect(second.data).toMatchObject({ replayed: true });
-    }
+    expect(second).toEqual(first);
     expect(issueGets).toBe(1);
   });
 

--- a/apps/api/src/tools/github/tools.ts
+++ b/apps/api/src/tools/github/tools.ts
@@ -9,6 +9,7 @@ import {
 import type { MutationGuard } from "@tulipfarm/observability";
 import {
   EffectDispatcher,
+  type EffectRecord,
   type EffectStore,
   intentDigest,
   normalizeToolIntent,
@@ -104,17 +105,19 @@ function mapDispatchError(error: ToolDispatchError, toolId: GitHubToolId): ToolC
   return err("internal_error", error.detail ? `${error.code}:${error.detail}` : error.message);
 }
 
-/** Replayed effect: `confirmed` is success without repeating; no response body is retained. */
-function replayed(state: string): ToolCallResult {
-  switch (state) {
+/** Replayed effect: `confirmed` returns the first immutable provider result. */
+function replayed(effect: EffectRecord): ToolCallResult {
+  switch (effect.state) {
     case "confirmed":
-      return ok({ replayed: true, note: "This action already completed; not repeated." });
+      return effect.outputStored
+        ? ok(effect.output)
+        : err("internal_error", "confirmed_effect_output_unavailable");
     case "denied":
       return err("internal_error", "effect_denied");
     case "failed":
       return err("internal_error", "effect_failed");
     default:
-      return err("internal_error", `effect_${state}`);
+      return err("internal_error", `effect_${effect.state}`);
   }
 }
 
@@ -247,7 +250,7 @@ function buildToolDef(
         createdAt: new Date().toISOString(),
       });
 
-      if (reserved.outcome === "duplicate") return replayed(reserved.effect.state);
+      if (reserved.outcome === "duplicate") return replayed(reserved.effect);
 
       const dispatcher = new EffectDispatcher({
         store: tooling.effects,

--- a/apps/api/src/tools/google/tools.test.ts
+++ b/apps/api/src/tools/google/tools.test.ts
@@ -201,7 +201,7 @@ describe("buildGoogleTools", () => {
 
     expect(first.success).toBe(true);
     expect(second.success).toBe(true);
-    if (second.success) expect(second.data).toMatchObject({ replayed: true });
+    expect(second).toEqual(first);
     expect(posts).toBe(1);
   });
 

--- a/apps/api/src/tools/google/tools.ts
+++ b/apps/api/src/tools/google/tools.ts
@@ -3,6 +3,7 @@ import { GOOGLE_TOOL_CONTRACTS, GOOGLE_TOOL_IDS, type GoogleToolId } from "@tuli
 import type { MutationGuard } from "@tulipfarm/observability";
 import {
   EffectDispatcher,
+  type EffectRecord,
   type EffectStore,
   intentDigest,
   normalizeToolIntent,
@@ -150,17 +151,19 @@ function mapDispatchError(error: ToolDispatchError): ToolCallResult {
   return err("internal_error", error.detail ? `${error.code}:${error.detail}` : error.message);
 }
 
-/** Replayed effect: settled state only, no retained Google response body. */
-function replayed(state: string): ToolCallResult {
-  switch (state) {
+/** Replayed effect: `confirmed` returns the first immutable Google result. */
+function replayed(effect: EffectRecord): ToolCallResult {
+  switch (effect.state) {
     case "confirmed":
-      return ok({ replayed: true, note: "This action already completed; not repeated." });
+      return effect.outputStored
+        ? ok(effect.output)
+        : err("internal_error", "confirmed_effect_output_unavailable");
     case "denied":
       return err("internal_error", "effect_denied");
     case "failed":
       return err("internal_error", "effect_failed");
     default:
-      return err("internal_error", `effect_${state}`);
+      return err("internal_error", `effect_${effect.state}`);
   }
 }
 
@@ -239,7 +242,7 @@ function buildToolDef(
         createdAt: new Date().toISOString(),
       });
 
-      if (reserved.outcome === "duplicate") return replayed(reserved.effect.state);
+      if (reserved.outcome === "duplicate") return replayed(reserved.effect);
 
       const dispatcher = new EffectDispatcher({
         store: tooling.effects,

--- a/apps/api/src/tools/slack/tools.test.ts
+++ b/apps/api/src/tools/slack/tools.test.ts
@@ -407,9 +407,7 @@ describe("buildSlackTools", () => {
 
     expect(first.success).toBe(true);
     expect(second.success).toBe(true);
-    if (second.success) {
-      expect(second.data).toMatchObject({ replayed: true });
-    }
+    expect(second).toEqual(first);
     expect(posts).toBe(1);
   });
 

--- a/apps/api/src/tools/slack/tools.ts
+++ b/apps/api/src/tools/slack/tools.ts
@@ -9,6 +9,7 @@ import type { MutationGuard } from "@tulipfarm/observability";
 import type { ChannelMentionedThreadStore } from "@tulipfarm/storage";
 import {
   EffectDispatcher,
+  type EffectRecord,
   type EffectStore,
   intentDigest,
   normalizeToolIntent,
@@ -89,17 +90,19 @@ function mapDispatchError(error: ToolDispatchError): ToolCallResult {
   return err("internal_error", error.detail ? `${error.code}:${error.detail}` : error.message);
 }
 
-/** Replayed effect: settled state only, no retained Slack response body. */
-function replayed(state: string): ToolCallResult {
-  switch (state) {
+/** Replayed effect: `confirmed` returns the first immutable Slack result. */
+function replayed(effect: EffectRecord): ToolCallResult {
+  switch (effect.state) {
     case "confirmed":
-      return ok({ replayed: true, note: "This message already sent; not repeated." });
+      return effect.outputStored
+        ? ok(effect.output)
+        : err("internal_error", "confirmed_effect_output_unavailable");
     case "denied":
       return err("internal_error", "effect_denied");
     case "failed":
       return err("internal_error", "effect_failed");
     default:
-      return err("internal_error", `effect_${state}`);
+      return err("internal_error", `effect_${effect.state}`);
   }
 }
 
@@ -233,7 +236,7 @@ function buildToolDef(
         createdAt: new Date().toISOString(),
       });
 
-      if (reserved.outcome === "duplicate") return replayed(reserved.effect.state);
+      if (reserved.outcome === "duplicate") return replayed(reserved.effect);
 
       const dispatcher = new EffectDispatcher({
         store: tooling.effects,

--- a/apps/worker/AGENTS.md
+++ b/apps/worker/AGENTS.md
@@ -58,7 +58,8 @@ reconciliation, turn execution, delivery classification, projections, and outbox
   delete, a withdrawal or a revoke has nothing to act on, so all three are re-asked once it does.
 - Integration Runs classify delivery, then hand real turns to the same chat executor as web chat.
 - Routine execution reads only the Run's exact signed bundle and immutable request Artifact.
-- Routine replay safety depends on persisting successors first and durable occurrence keys.
+- Routine replay safety depends on durable occurrence keys and immutable Tool outputs; a confirmed
+  legacy effect with no stored output parks instead of inventing data for following States.
 - Wait ids derive from `(runId, occurrence key)`; `event` waits are refused as `unsupported_wait`.
 - Routine `tool` States are the only Routine Tool authority: authorize, reserve, then dispatch.
 - A Routine Tool intent carries the objects the pinned ToolContract's `spec.targets` declares, so a

--- a/apps/worker/src/config.ts
+++ b/apps/worker/src/config.ts
@@ -4,10 +4,10 @@ import { DEPLOYMENT_BUSINESS_ID } from "@tulipfarm/constants";
 /**
  * Refuse to boot below the schema floor the worker's work requires.
  *
- * 86, not 81: the hosted `file_create` Tool now writes Chat drafts and generation idempotency
- * fields added by migration 86. A worker below that floor could claim a Run and fail mid-Tool.
+ * 99: Routine Tool replay reads immutable confirmed outputs added by migration 99. A worker below
+ * that floor could claim a replayed State and lose the Tool result needed by following States.
  */
-export const REQUIRED_SCHEMA_VERSION = 90;
+export const REQUIRED_SCHEMA_VERSION = 99;
 
 export interface WorkerConfig {
   readonly databaseUrl: string;

--- a/apps/worker/src/routine/action-port.test.ts
+++ b/apps/worker/src/routine/action-port.test.ts
@@ -33,21 +33,15 @@ describe("DispatchRoutineActionPort", () => {
     });
   });
 
-  /**
-   * A confirmed-effect replay reports `succeeded` but returns `{replayed:true}` instead of what the
-   * Tool answered, because the ledger records that a call happened and not its result. An `action`
-   * State publishes its output to later States, so taking that marker as data would feed the rest
-   * of the Routine a value the Tool never produced.
-   */
-  it("parks rather than publishing a replay marker as if it were the Tool's answer", async () => {
+  it("publishes the immutable stored output when the Tool effect is replayed", async () => {
     const { port } = portReturning({
       status: "succeeded",
       replayed: true,
-      output: { replayed: true, note: "This action already completed; it was not repeated." },
+      output: { id: "rec_1" },
     });
     await expect(port.execute(request)).resolves.toEqual({
-      kind: "unavailable",
-      reason: "replayed_without_output",
+      kind: "succeeded",
+      output: { id: "rec_1" },
     });
   });
 

--- a/apps/worker/src/routine/action-port.ts
+++ b/apps/worker/src/routine/action-port.ts
@@ -55,13 +55,6 @@ export class DispatchRoutineActionPort implements RoutineActionPort {
 
     switch (result.status) {
       case "succeeded":
-        // A confirmed-effect replay reports success but hands back a marker, because the ledger
-        // records that the call happened and not what it answered. An `action` State publishes its
-        // output to later States, so accepting that marker would quietly feed them the wrong data.
-        // Parking is the honest answer: the effect stands, and reconciliation decides the rest.
-        if (result.replayed === true) {
-          return { kind: "unavailable", reason: "replayed_without_output" };
-        }
         return { kind: "succeeded", output: result.output };
       case "denied":
         return { kind: "failed", reason: `denied_${result.reason}` };

--- a/apps/worker/src/routine/adapters.test.ts
+++ b/apps/worker/src/routine/adapters.test.ts
@@ -122,6 +122,8 @@ function readIssueEffect(): EffectRecord {
     intentDigest: "digest-1",
     guardrailRevision: "guardrail-rev-1",
     state: "authorized",
+    outputStored: false,
+    output: null,
     createdAt: "2026-08-06T00:00:00.000Z",
     updatedAt: "2026-08-06T00:00:00.000Z",
     intent: {

--- a/apps/worker/src/routine/tool-port.test.ts
+++ b/apps/worker/src/routine/tool-port.test.ts
@@ -1,10 +1,14 @@
+import { PGlite } from "@electric-sql/pglite";
 import type { AuthorityLayer } from "@tulipfarm/authz";
 import type { ToolDispatchPlan } from "@tulipfarm/run-kernel";
 import type { GuardrailDefinition, ToolContractDefinition } from "@tulipfarm/schema";
 import type { BundleDefinition, RuntimeBundle } from "@tulipfarm/soul";
+import type { TransactionPort } from "@tulipfarm/storage";
 import {
   AdapterDispatchError,
+  EFFECT_STORAGE_STATEMENTS,
   MemoryEffectStore,
+  PgEffectStore,
   type ToolAdapter,
   type ToolAdapterRequest,
 } from "@tulipfarm/tool-broker";
@@ -141,7 +145,10 @@ function port(): BrokerRoutineToolPort {
 
 describe("BrokerRoutineToolPort", () => {
   it("authorizes against the Run's pinned policy, reserves the effect, then dispatches", async () => {
-    expect(await port().execute(request())).toEqual({ kind: "succeeded", output: null });
+    expect(await port().execute(request())).toEqual({
+      kind: "succeeded",
+      output: { commentId: 12 },
+    });
 
     const effect = await effects.get(BUSINESS_ID, PLAN.effectId);
     expect(effect?.state).toBe("confirmed");
@@ -162,7 +169,10 @@ describe("BrokerRoutineToolPort", () => {
     });
 
     const input = request();
-    expect(await dynamic.execute(input)).toEqual({ kind: "succeeded", output: null });
+    expect(await dynamic.execute(input)).toEqual({
+      kind: "succeeded",
+      output: { commentId: 12 },
+    });
     expect(adaptersFor).toHaveBeenCalledWith(input);
     expect(dispatch).toHaveBeenCalledOnce();
   });
@@ -191,14 +201,17 @@ describe("BrokerRoutineToolPort", () => {
   it("authorizes from the bundle's own ToolContract alone, even with no external authority layers", async () => {
     expect(await port().execute(request({ authorityLayers: [] }))).toEqual({
       kind: "succeeded",
-      output: null,
+      output: { commentId: 12 },
     });
   });
 
   // Contracts that declare no target keep the coarser Tool-granular decision; that is the one
   // legitimate empty target list, and it is not the same as a target we could not work out.
   it("decides at Tool granularity when the contract declares no target of its own", async () => {
-    expect(await port().execute(request())).toEqual({ kind: "succeeded", output: null });
+    expect(await port().execute(request())).toEqual({
+      kind: "succeeded",
+      output: { commentId: 12 },
+    });
 
     const dispatched = dispatch.mock.calls[0]?.[0];
     expect(dispatched?.intent.arguments).not.toEqual({});
@@ -261,8 +274,108 @@ describe("BrokerRoutineToolPort", () => {
     const subject = port();
     await subject.execute(request());
 
-    expect(await subject.execute(request())).toEqual({ kind: "succeeded", output: null });
+    expect(await subject.execute(request())).toEqual({
+      kind: "succeeded",
+      output: { commentId: 12 },
+    });
     expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("replays the exact stored output after a database-backed port restart", async () => {
+    const database = new PGlite();
+    try {
+      for (const statement of EFFECT_STORAGE_STATEMENTS) await database.query(statement);
+      const transactions: TransactionPort = {
+        withTransaction: (operation) => database.transaction(operation),
+      };
+      const first = new BrokerRoutineToolPort({
+        effects: new PgEffectStore(transactions),
+        adapters,
+      });
+
+      await expect(first.execute(request())).resolves.toEqual({
+        kind: "succeeded",
+        output: { commentId: 12 },
+      });
+      const restarted = new BrokerRoutineToolPort({
+        effects: new PgEffectStore(transactions),
+        adapters,
+      });
+      await expect(restarted.execute(request())).resolves.toEqual({
+        kind: "succeeded",
+        output: { commentId: 12 },
+      });
+      expect(dispatch).toHaveBeenCalledTimes(1);
+    } finally {
+      await database.close();
+    }
+  });
+
+  it("replays an explicit null output after a database-backed port restart", async () => {
+    const database = new PGlite();
+    try {
+      for (const statement of EFFECT_STORAGE_STATEMENTS) await database.query(statement);
+      const transactions: TransactionPort = {
+        withTransaction: (operation) => database.transaction(operation),
+      };
+      dispatch.mockResolvedValue(null);
+      const nullRequest = request({
+        bundle: bundle([
+          {
+            kind: "ToolContract",
+            document: contract({ outputSchema: { type: "null" } }),
+          },
+          { kind: "Guardrail", document: guardrail([ALLOW_COMMENT]) },
+        ]),
+      });
+
+      await expect(
+        new BrokerRoutineToolPort({
+          effects: new PgEffectStore(transactions),
+          adapters,
+        }).execute(nullRequest)
+      ).resolves.toEqual({ kind: "succeeded", output: null });
+      await expect(
+        new BrokerRoutineToolPort({
+          effects: new PgEffectStore(transactions),
+          adapters,
+        }).execute(nullRequest)
+      ).resolves.toEqual({ kind: "succeeded", output: null });
+      expect(dispatch).toHaveBeenCalledTimes(1);
+    } finally {
+      await database.close();
+    }
+  });
+
+  it("parks a confirmed legacy effect when no output evidence exists", async () => {
+    const database = new PGlite();
+    try {
+      for (const statement of EFFECT_STORAGE_STATEMENTS) await database.query(statement);
+      const transactions: TransactionPort = {
+        withTransaction: (operation) => database.transaction(operation),
+      };
+      await new BrokerRoutineToolPort({
+        effects: new PgEffectStore(transactions),
+        adapters,
+      }).execute(request());
+      await database.query(
+        "UPDATE effect_records SET output_stored = false, output = NULL WHERE effect_id = $1",
+        [PLAN.effectId]
+      );
+
+      await expect(
+        new BrokerRoutineToolPort({
+          effects: new PgEffectStore(transactions),
+          adapters,
+        }).execute(request())
+      ).resolves.toEqual({
+        kind: "unavailable",
+        reason: "confirmed_effect_output_unavailable",
+      });
+      expect(dispatch).toHaveBeenCalledTimes(1);
+    } finally {
+      await database.close();
+    }
   });
 
   it("parks an ambiguous effect, which only reconciliation may resolve", async () => {
@@ -373,7 +486,10 @@ describe("BrokerRoutineToolPort contract-declared targets", () => {
   }
 
   it("carries the object the arguments name into the intent the gate and ledger see", async () => {
-    expect(await port().execute(targetedRequest())).toEqual({ kind: "succeeded", output: null });
+    expect(await port().execute(targetedRequest())).toEqual({
+      kind: "succeeded",
+      output: { commentId: 12 },
+    });
 
     const expected = [{ type: "github.issue", id: "tulip/farm#42" }];
     expect(dispatch.mock.calls[0]?.[0].intent.targetRefs).toEqual(expected);
@@ -383,7 +499,10 @@ describe("BrokerRoutineToolPort contract-declared targets", () => {
   it("lets a grant scoped to exactly that object authorize the call", async () => {
     const scoped = targetedRequest({ authorityLayers: operatorLayer("tulip/farm#42") });
 
-    expect(await port().execute(scoped)).toEqual({ kind: "succeeded", output: null });
+    expect(await port().execute(scoped)).toEqual({
+      kind: "succeeded",
+      output: { commentId: 12 },
+    });
   });
 
   it("refuses the same call under a grant scoped to a different object", async () => {

--- a/apps/worker/src/routine/tool-port.ts
+++ b/apps/worker/src/routine/tool-port.ts
@@ -13,6 +13,7 @@ import {
   type CredentialDispatcher,
   deriveContractTargets,
   EffectDispatcher,
+  type EffectRecord,
   type EffectStore,
   type ToolAdapter,
   ToolBroker,
@@ -28,13 +29,7 @@ import { GITHUB_INSTALLATION_SECRET_REF, githubInstallationSecretRef } from "./g
 /** Routine Tool authority: pinned bundle only; authorize, reserve, then dispatch fail-closed. */
 
 export type RoutineToolOutcome =
-  /**
-   * Dispatched and confirmed, or recognized as an effect this Run already confirmed.
-   *
-   * `output` is `null` for a `tool` State: the Broker settles a ToolContract as a durable *effect*
-   * in the ledger, and a replayed Run reads back only that the effect was confirmed, never what the
-   * provider returned. A State that needs the provider's data uses an `action` State instead.
-   */
+  /** Dispatched and confirmed, or replayed with the first immutable provider result. */
   | { readonly kind: "succeeded"; readonly output: unknown }
   /**
    * A definitive negative the authored `onError` path may claim, named by its reason code.
@@ -136,16 +131,18 @@ function targetsOf(catalog: ToolCatalog, request: RoutineToolRequest): readonly 
 }
 
 /** Replay durable effects; only reconciliation may resolve `ambiguous`. */
-function replayed(state: string): RoutineToolOutcome {
-  switch (state) {
+function replayed(effect: EffectRecord): RoutineToolOutcome {
+  switch (effect.state) {
     case "confirmed":
-      return { kind: "succeeded", output: null };
+      return effect.outputStored
+        ? { kind: "succeeded", output: effect.output }
+        : { kind: "unavailable", reason: "confirmed_effect_output_unavailable" };
     case "denied":
       return { kind: "failed", reason: "effect_denied" };
     case "failed":
       return { kind: "failed", reason: "effect_failed" };
     default:
-      return { kind: "unavailable", reason: `effect_${state}` };
+      return { kind: "unavailable", reason: `effect_${effect.state}` };
   }
 }
 
@@ -217,7 +214,7 @@ export class BrokerRoutineToolPort implements RoutineToolPort {
       guardrailRevision: request.bundle.digest,
       createdAt: this.now().toISOString(),
     });
-    if (reserved.outcome === "duplicate") return replayed(reserved.effect.state);
+    if (reserved.outcome === "duplicate") return replayed(reserved.effect);
 
     const adapters = new Map(this.options.adapters);
     for (const [ref, adapter] of this.options.adaptersFor?.(request) ?? []) {
@@ -235,8 +232,8 @@ export class BrokerRoutineToolPort implements RoutineToolPort {
       now: () => this.now().toISOString(),
     });
     try {
-      await dispatcher.dispatch(request.businessId, request.plan.effectId);
-      return { kind: "succeeded", output: null };
+      const output = await dispatcher.dispatch(request.businessId, request.plan.effectId);
+      return { kind: "succeeded", output };
     } catch (error) {
       if (!(error instanceof ToolDispatchError)) throw error;
       // Provider write may have landed; park `ambiguous` for reconciliation, never retry here.

--- a/apps/worker/vitest.config.ts
+++ b/apps/worker/vitest.config.ts
@@ -6,5 +6,8 @@ export default defineConfig({
     // vitest fails. Only the TypeScript sources are the suite.
     include: ["src/**/*.test.ts", "test/**/*.test.ts"],
     exclude: ["dist/**"],
+    // PGlite (real WASM Postgres) boot time spikes under CI's parallel test-file load; the
+    // default 5000ms trips intermittently even though the same tests run in ~2s locally.
+    testTimeout: 15000,
   },
 });

--- a/packages/tool-broker/AGENTS.md
+++ b/packages/tool-broker/AGENTS.md
@@ -27,6 +27,8 @@ credential dispatch, sandbox adaptation, and reconciliation.
 - `EffectDispatcher` consults the mutation kill switch before recording an attempt, so a denied
   mutation leaves no attempt in the ledger. A dispatcher constructed without `mutationGuard` is
   outside the emergency stop; `scripts/mutation-kill-switch.test.ts` fails the build on one.
+- A confirmed effect stores its first output immutably. `outputStored` distinguishes JSON `null`
+  from legacy rows with no replay evidence; a caller must fail closed when that flag is false.
 - A kill switch scope is only meaningful if the dispatch site fills the matching `MutationContext`
   field. Adding a scope kind means supplying its identity in `mutationIdentity` first, never after.
 - `deriveContractTargets` refuses; it never returns `[]` for a target it failed to derive. An empty

--- a/packages/tool-broker/src/effects/dispatch.test.ts
+++ b/packages/tool-broker/src/effects/dispatch.test.ts
@@ -97,7 +97,11 @@ describe("EffectDispatcher", () => {
     const result = await dispatcher(adapter).dispatch(BUSINESS_ID, EFFECT_ID);
 
     expect(result).toEqual({ providerId: "external-42" });
-    expect(await store.get(BUSINESS_ID, EFFECT_ID)).toMatchObject({ state: "confirmed" });
+    expect(await store.get(BUSINESS_ID, EFFECT_ID)).toMatchObject({
+      state: "confirmed",
+      outputStored: true,
+      output: { providerId: "external-42" },
+    });
   });
 
   it("retries a classified pre-dispatch failure with the same stable key and backoff", async () => {

--- a/packages/tool-broker/src/effects/dispatch.ts
+++ b/packages/tool-broker/src/effects/dispatch.ts
@@ -215,6 +215,7 @@ export class EffectDispatcher {
           attemptState: "confirmed",
           effectState: "confirmed",
           outputDigest: canonicalHash(output),
+          output: { value: output },
           finishedAt: this.now(),
         });
         return output;

--- a/packages/tool-broker/src/effects/model.ts
+++ b/packages/tool-broker/src/effects/model.ts
@@ -26,6 +26,8 @@ export interface EffectRecord {
   readonly approvalId?: string;
   readonly state: EffectState;
   readonly parentEffectId?: string;
+  readonly outputStored: boolean;
+  readonly output: unknown;
   readonly createdAt: string;
   readonly updatedAt: string;
 }
@@ -72,6 +74,8 @@ export interface FinishEffectAttemptInput {
   readonly effectState: EffectState;
   readonly providerRequestId?: string;
   readonly outputDigest?: string;
+  /** Wrapped so an explicit `undefined`/`null` result differs from no saved output. */
+  readonly output?: { readonly value: unknown };
   readonly errorCode?: string;
   readonly finishedAt: string;
 }

--- a/packages/tool-broker/src/effects/store.test.ts
+++ b/packages/tool-broker/src/effects/store.test.ts
@@ -56,6 +56,46 @@ describe("MemoryEffectStore", () => {
     });
   });
 
+  it("keeps a confirmed output immutable after settlement", async () => {
+    const store = new MemoryEffectStore();
+    await store.reserve(input());
+    const attempt = await store.beginAttempt(BUSINESS_ID, EFFECT_ID, "2026-07-25T00:00:01.000Z");
+    const output = { providerId: "external-42", nested: { status: "created" } };
+
+    await store.finishAttempt({
+      businessId: BUSINESS_ID,
+      effectId: EFFECT_ID,
+      attempt: attempt.attempt,
+      attemptState: "confirmed",
+      effectState: "confirmed",
+      output: { value: output },
+      finishedAt: "2026-07-25T00:00:02.000Z",
+    });
+    output.nested.status = "changed";
+
+    const stored = await store.get(BUSINESS_ID, EFFECT_ID);
+    expect(stored).toMatchObject({
+      outputStored: true,
+      output: { providerId: "external-42", nested: { status: "created" } },
+    });
+    expect(Object.isFrozen(stored?.output)).toBe(true);
+    await expect(
+      store.finishAttempt({
+        businessId: BUSINESS_ID,
+        effectId: EFFECT_ID,
+        attempt: attempt.attempt,
+        attemptState: "confirmed",
+        effectState: "confirmed",
+        output: { value: { providerId: "replacement" } },
+        finishedAt: "2026-07-25T00:00:03.000Z",
+      })
+    ).rejects.toThrow(new EffectLedgerError("attempt_not_found", String(attempt.attempt)));
+    expect((await store.get(BUSINESS_ID, EFFECT_ID))?.output).toEqual({
+      providerId: "external-42",
+      nested: { status: "created" },
+    });
+  });
+
   it("deduplicates concurrent matching keys into one durable intent", async () => {
     const store = new MemoryEffectStore();
     const ledger = new EffectLedger(store);
@@ -108,5 +148,128 @@ describe("PgEffectStore", () => {
     await expect(
       ledger.reserve(input({ effectId: crypto.randomUUID(), intentDigest: "c".repeat(64) }))
     ).rejects.toThrow(EffectLedgerError);
+  });
+
+  it("reloads the exact confirmed output after a store restart", async () => {
+    await store.reserve(input());
+    const attempt = await store.beginAttempt(BUSINESS_ID, EFFECT_ID, "2026-07-25T00:00:01.000Z");
+    await store.finishAttempt({
+      businessId: BUSINESS_ID,
+      effectId: EFFECT_ID,
+      attempt: attempt.attempt,
+      attemptState: "confirmed",
+      effectState: "confirmed",
+      output: { value: { providerId: "external-42", labels: ["triaged"] } },
+      finishedAt: "2026-07-25T00:00:02.000Z",
+    });
+
+    const restarted = new PgEffectStore({
+      withTransaction: (operation) => database.transaction(operation),
+    });
+    const replay = await restarted.reserve(input());
+
+    expect(replay).toMatchObject({
+      outcome: "duplicate",
+      effect: {
+        state: "confirmed",
+        outputStored: true,
+        output: { providerId: "external-42", labels: ["triaged"] },
+      },
+    });
+    await expect(
+      restarted.finishAttempt({
+        businessId: BUSINESS_ID,
+        effectId: EFFECT_ID,
+        attempt: attempt.attempt,
+        attemptState: "confirmed",
+        effectState: "confirmed",
+        output: { value: { providerId: "replacement" } },
+        finishedAt: "2026-07-25T00:00:03.000Z",
+      })
+    ).rejects.toThrow(new EffectLedgerError("attempt_not_found", String(attempt.attempt)));
+    expect((await restarted.get(BUSINESS_ID, EFFECT_ID))?.output).toEqual({
+      providerId: "external-42",
+      labels: ["triaged"],
+    });
+  });
+
+  it("distinguishes explicit null or void output from missing legacy output", async () => {
+    await store.reserve(input());
+    const attempt = await store.beginAttempt(BUSINESS_ID, EFFECT_ID, "2026-07-25T00:00:01.000Z");
+    await store.finishAttempt({
+      businessId: BUSINESS_ID,
+      effectId: EFFECT_ID,
+      attempt: attempt.attempt,
+      attemptState: "confirmed",
+      effectState: "confirmed",
+      output: { value: null },
+      finishedAt: "2026-07-25T00:00:02.000Z",
+    });
+
+    expect(await store.get(BUSINESS_ID, EFFECT_ID)).toMatchObject({
+      state: "confirmed",
+      outputStored: true,
+      output: null,
+    });
+
+    const voidEffect = input({
+      effectId: "33333333-3333-4333-8333-333333333333",
+      stateId: "void-label",
+      logicalEffectOrdinal: 2,
+      idempotencyKey: "effect-key-void",
+      intent: {
+        ...input().intent,
+        intentId: "intent-void",
+        stateId: "void-label",
+        idempotencyKey: "effect-key-void",
+      },
+    });
+    await store.reserve(voidEffect);
+    const voidAttempt = await store.beginAttempt(
+      BUSINESS_ID,
+      voidEffect.effectId,
+      "2026-07-25T00:00:03.000Z"
+    );
+    await store.finishAttempt({
+      businessId: BUSINESS_ID,
+      effectId: voidEffect.effectId,
+      attempt: voidAttempt.attempt,
+      attemptState: "confirmed",
+      effectState: "confirmed",
+      output: { value: undefined },
+      finishedAt: "2026-07-25T00:00:04.000Z",
+    });
+    expect(await store.get(BUSINESS_ID, voidEffect.effectId)).toMatchObject({
+      state: "confirmed",
+      outputStored: true,
+      output: null,
+    });
+
+    const legacy = input({
+      effectId: "44444444-4444-4444-8444-444444444444",
+      stateId: "legacy-label",
+      logicalEffectOrdinal: 3,
+      idempotencyKey: "effect-key-legacy",
+      intent: {
+        ...input().intent,
+        intentId: "intent-legacy",
+        stateId: "legacy-label",
+        idempotencyKey: "effect-key-legacy",
+      },
+    });
+    await store.reserve(legacy);
+    await store.transition({
+      businessId: BUSINESS_ID,
+      effectId: legacy.effectId,
+      expectedStates: ["authorized"],
+      state: "confirmed",
+      updatedAt: "2026-07-25T00:00:03.000Z",
+    });
+
+    expect(await store.get(BUSINESS_ID, legacy.effectId)).toMatchObject({
+      state: "confirmed",
+      outputStored: false,
+      output: null,
+    });
   });
 });

--- a/packages/tool-broker/src/effects/store.ts
+++ b/packages/tool-broker/src/effects/store.ts
@@ -39,6 +39,8 @@ export const EFFECT_STORAGE_STATEMENTS: readonly string[] = [
       'failed', 'ambiguous', 'compensating', 'compensated', 'reconciliation_required'
     )),
     parent_effect_id       uuid,
+    output                 jsonb,
+    output_stored          boolean NOT NULL DEFAULT false,
     created_at             timestamptz NOT NULL,
     updated_at             timestamptz NOT NULL,
     PRIMARY KEY (business_id, effect_id),
@@ -69,6 +71,11 @@ export const EFFECT_STORAGE_STATEMENTS: readonly string[] = [
   )`,
 ];
 
+export const EFFECT_OUTPUT_STORAGE_STATEMENTS: readonly string[] = [
+  "ALTER TABLE effect_records ADD COLUMN IF NOT EXISTS output jsonb",
+  "ALTER TABLE effect_records ADD COLUMN IF NOT EXISTS output_stored boolean NOT NULL DEFAULT false",
+];
+
 export interface EffectStore {
   reserve(input: ReserveEffectInput): Promise<ReserveEffectResult>;
   reserveCompensation(
@@ -90,11 +97,30 @@ function freezeIntent(intent: ToolIntent): ToolIntent {
   });
 }
 
+function cloneOutput(output: unknown): unknown {
+  if (Array.isArray(output)) {
+    return Object.freeze(output.map((value) => cloneOutput(value)));
+  }
+  if (output !== null && typeof output === "object") {
+    return Object.freeze(
+      Object.fromEntries(
+        Object.entries(output as Record<string, unknown>).map(([key, value]) => [
+          key,
+          cloneOutput(value),
+        ])
+      )
+    );
+  }
+  return output;
+}
+
 function effect(input: ReserveEffectInput): EffectRecord {
   return Object.freeze({
     ...input,
     intent: freezeIntent(input.intent),
     state: "authorized",
+    outputStored: false,
+    output: null,
     updatedAt: input.createdAt,
   });
 }
@@ -194,7 +220,9 @@ export class MemoryEffectStore implements EffectStore {
     const key = this.key(input.businessId, record.idempotencyKey);
     const attempts = this.attempts.get(key) ?? [];
     const index = attempts.findIndex((attempt) => attempt.attempt === input.attempt);
-    if (index < 0) throw new EffectLedgerError("attempt_not_found", String(input.attempt));
+    if (index < 0 || attempts[index]?.state !== "dispatched") {
+      throw new EffectLedgerError("attempt_not_found", String(input.attempt));
+    }
     const completed = Object.freeze({
       ...attempts[index],
       state: input.attemptState,
@@ -210,6 +238,9 @@ export class MemoryEffectStore implements EffectStore {
     const updated = Object.freeze({
       ...record,
       state: input.effectState,
+      ...(input.output === undefined
+        ? {}
+        : { outputStored: true, output: cloneOutput(input.output.value) }),
       updatedAt: input.finishedAt,
     });
     this.records.set(key, updated);
@@ -236,6 +267,8 @@ interface EffectRow {
   approval_id: string | null;
   state: EffectRecord["state"];
   parent_effect_id: string | null;
+  output_stored: boolean;
+  output: unknown;
   created_at: string | Date;
   updated_at: string | Date;
 }
@@ -270,6 +303,8 @@ function fromRow(row: EffectRow): EffectRecord {
     approvalId: row.approval_id ?? undefined,
     state: row.state,
     parentEffectId: row.parent_effect_id ?? undefined,
+    outputStored: row.output_stored,
+    output: cloneOutput(row.output),
     createdAt: iso(row.created_at),
     updatedAt: iso(row.updated_at),
   });
@@ -519,9 +554,20 @@ export class PgEffectStore implements EffectStore {
         throw new EffectLedgerError("attempt_not_found", String(input.attempt));
       }
       await transaction.query(
-        `UPDATE effect_records SET state = $3, updated_at = $4
+        `UPDATE effect_records
+            SET state = $3,
+                updated_at = $4,
+                output_stored = output_stored OR $5,
+                output = CASE WHEN $5 THEN $6::jsonb ELSE output END
           WHERE business_id = $1 AND effect_id = $2`,
-        [input.businessId, input.effectId, input.effectState, input.finishedAt]
+        [
+          input.businessId,
+          input.effectId,
+          input.effectState,
+          input.finishedAt,
+          input.output !== undefined,
+          input.output === undefined ? null : (JSON.stringify(input.output.value) ?? null),
+        ]
       );
       const updated = await this.findById(transaction, input.businessId, input.effectId);
       if (updated === undefined) throw new EffectLedgerError("effect_not_found", input.effectId);

--- a/packages/tool-broker/src/index.ts
+++ b/packages/tool-broker/src/index.ts
@@ -73,6 +73,7 @@ export type {
 export {
   AdapterDispatchError,
   CompensationError,
+  EFFECT_OUTPUT_STORAGE_STATEMENTS,
   EFFECT_STORAGE_STATEMENTS,
   EffectCompensator,
   EffectDispatcher,

--- a/packages/tool-host/AGENTS.md
+++ b/packages/tool-host/AGENTS.md
@@ -63,6 +63,8 @@ Individual Tool families (`packages/kv`, `apps/api/src/tools/**`), the model-fac
 - **A park settles its effect `confirmed` and is never retried.** The effect committed and the
   resume wait is registered; only the answer is outstanding. Anything else lets reconciliation
   read a merely-waiting Turn as a lost write.
+- **A confirmed replay returns the immutable first Tool output.** A legacy confirmation without
+  `outputStored` fails closed; never replace missing evidence with a replay marker or empty value.
 - No dependency on `@tulipfarm/agent-runtime` — it depends on this package's consumers' shape, not
   the reverse. Narrow structural types instead.
 - A Tool with call-level classification is validated first; the derived action, mutation state,

--- a/packages/tool-host/src/authority.ts
+++ b/packages/tool-host/src/authority.ts
@@ -83,9 +83,8 @@ export type HostedToolResult =
       readonly status: "succeeded";
       readonly output: unknown;
       /**
-       * The effect had already confirmed, so `output` is a marker rather than what the Tool
-       * returned — the ledger records that a call happened, not what it answered. Chat can say
-       * so in words; a caller that feeds the output to a later step must not treat it as data.
+       * The effect had already confirmed, so `output` is its immutable first result and the Tool
+       * was not run again.
        */
       readonly replayed?: true;
     }

--- a/packages/tool-host/src/dispatcher.test.ts
+++ b/packages/tool-host/src/dispatcher.test.ts
@@ -6,6 +6,8 @@ import {
   CompositeToolEntitlement,
   MemoryEffectStore,
   NOT_APPLICABLE,
+  type ReserveEffectInput,
+  type ReserveEffectResult,
 } from "@tulipfarm/tool-broker";
 import { describe, expect, it, vi } from "vitest";
 import type { TurnAuthority } from "./authority";
@@ -1332,10 +1334,25 @@ describe("effect ledger", () => {
     ) as ToolDef;
   }
 
-  function ledgerDispatcher(tool: ToolDef, executeTimeoutMs?: number) {
+  class LegacyOutputEffectStore extends MemoryEffectStore {
+    override async reserve(input: ReserveEffectInput): Promise<ReserveEffectResult> {
+      const reserved = await super.reserve(input);
+      return reserved.outcome === "duplicate"
+        ? {
+            ...reserved,
+            effect: Object.freeze({ ...reserved.effect, outputStored: false, output: null }),
+          }
+        : reserved;
+    }
+  }
+
+  function ledgerDispatcher(
+    tool: ToolDef,
+    executeTimeoutMs?: number,
+    effects = new MemoryEffectStore()
+  ) {
     const registry = new InMemoryToolCatalog();
     registry.register(tool);
-    const effects = new MemoryEffectStore();
     return {
       effects,
       dispatcher: new RegistryToolDispatcher({
@@ -1365,13 +1382,47 @@ describe("effect ledger", () => {
     const execute = vi.fn(async () => ok({ done: true }));
     const { dispatcher, effects } = ledgerDispatcher(ledgeredTool(execute));
 
-    await dispatcher.dispatch(AUTHORITY, CALL);
+    const first = await dispatcher.dispatch(AUTHORITY, CALL);
     const second = await dispatcher.dispatch(AUTHORITY, CALL);
 
     expect(execute).toHaveBeenCalledTimes(1);
-    expect(second).toMatchObject({ status: "succeeded" });
-    expect(second).toMatchObject({ output: { replayed: true } });
+    expect(first).toMatchObject({ status: "succeeded", output: { done: true } });
+    expect(second).toEqual({ status: "succeeded", replayed: true, output: { done: true } });
     expect(await effects.list(BUSINESS_ID)).toHaveLength(1);
+  });
+
+  it("replays an explicit null output without repeating the call", async () => {
+    const execute = vi.fn(async () => ok(null));
+    const { dispatcher } = ledgerDispatcher(ledgeredTool(execute));
+
+    expect(await dispatcher.dispatch(AUTHORITY, CALL)).toMatchObject({
+      status: "succeeded",
+      output: null,
+    });
+    expect(await dispatcher.dispatch(AUTHORITY, CALL)).toEqual({
+      status: "succeeded",
+      replayed: true,
+      output: null,
+    });
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed when a confirmed legacy effect has no stored output", async () => {
+    const execute = vi.fn(async () => ok({ done: true }));
+    const { dispatcher } = ledgerDispatcher(
+      ledgeredTool(execute),
+      undefined,
+      new LegacyOutputEffectStore()
+    );
+
+    await dispatcher.dispatch(AUTHORITY, CALL);
+    const replay = await dispatcher.dispatch(AUTHORITY, CALL);
+
+    expect(replay).toEqual({
+      status: "failed",
+      reason: 'tool "echo" already completed, but its output is unavailable',
+    });
+    expect(execute).toHaveBeenCalledTimes(1);
   });
 
   it("refuses the same call id carrying different arguments without running it", async () => {

--- a/packages/tool-host/src/dispatcher.ts
+++ b/packages/tool-host/src/dispatcher.ts
@@ -524,7 +524,9 @@ export class RegistryToolDispatcher implements TurnToolDispatcher {
           ? {}
           : { destination: definition.definition.effectiveDestination }),
       });
-      if (reserved.outcome === "duplicate") return replayedEffect(call.name, reserved.state);
+      if (reserved.outcome === "duplicate") {
+        return replayedEffect(call.name, reserved.state, reserved.outputStored, reserved.output);
+      }
       if (reserved.outcome === "conflict") {
         return {
           status: "failed",
@@ -554,14 +556,25 @@ export class RegistryToolDispatcher implements TurnToolDispatcher {
   }
 }
 
-/** Confirmed ledger replays report success; unsettled states fail without repeating the call. */
-function replayedEffect(toolName: string, state: string): HostedToolResult {
+/** Confirmed ledger replays return the first immutable output; unsettled states fail closed. */
+function replayedEffect(
+  toolName: string,
+  state: string,
+  outputStored: boolean,
+  output: unknown
+): HostedToolResult {
   switch (state) {
     case "confirmed":
+      if (!outputStored) {
+        return {
+          status: "failed",
+          reason: `tool "${toolName}" already completed, but its output is unavailable`,
+        };
+      }
       return {
         status: "succeeded",
         replayed: true,
-        output: { replayed: true, note: "This action already completed; it was not repeated." },
+        output,
       };
     case "failed":
       return { status: "failed", reason: `tool "${toolName}" already ran and failed` };

--- a/packages/tool-host/src/effect-ledger.ts
+++ b/packages/tool-host/src/effect-ledger.ts
@@ -48,7 +48,12 @@ export type ReserveOutcome =
   /** Fresh reservation; the caller must execute and then report a terminal state. */
   | { readonly outcome: "reserved"; readonly effectId: string }
   /** This exact call already ran. `state` is what the earlier attempt settled on. */
-  | { readonly outcome: "duplicate"; readonly state: string }
+  | {
+      readonly outcome: "duplicate";
+      readonly state: string;
+      readonly outputStored: boolean;
+      readonly output: unknown;
+    }
   /** Same call id with different authorized arguments: refuse as an idempotency conflict. */
   | { readonly outcome: "conflict" };
 
@@ -93,7 +98,12 @@ export class ChatEffectLedger {
         createdAt: new Date().toISOString(),
       });
       return reserved.outcome === "duplicate"
-        ? { outcome: "duplicate", state: reserved.effect.state }
+        ? {
+            outcome: "duplicate",
+            state: reserved.effect.state,
+            outputStored: reserved.effect.outputStored,
+            output: reserved.effect.output,
+          }
         : { outcome: "reserved", effectId: reserved.effect.effectId };
     } catch (error) {
       if (error instanceof EffectLedgerError && error.code === "idempotency_digest_mismatch") {
@@ -113,7 +123,11 @@ export class ChatEffectLedger {
     businessId: string,
     effectId: string,
     attempt: number,
-    outcome: { readonly state: "confirmed" | "failed" | "ambiguous"; readonly errorCode?: string }
+    outcome: {
+      readonly state: "confirmed" | "failed" | "ambiguous";
+      readonly errorCode?: string;
+      readonly output?: { readonly value: unknown };
+    }
   ): Promise<void> {
     await this.store.finishAttempt({
       businessId,
@@ -122,6 +136,7 @@ export class ChatEffectLedger {
       attemptState: outcome.state,
       effectState: outcome.state,
       finishedAt: new Date().toISOString(),
+      ...(outcome.output === undefined ? {} : { output: outcome.output }),
       ...(outcome.errorCode === undefined ? {} : { errorCode: outcome.errorCode }),
     });
   }

--- a/packages/tool-host/src/execution.ts
+++ b/packages/tool-host/src/execution.ts
@@ -77,11 +77,16 @@ async function wait(delayMs: number): Promise<void> {
  */
 export async function runToolAttempts(input: ToolAttemptInput): Promise<HostedToolResult> {
   const { businessId, tool, call, ledger, reservation } = input;
-  const settle = async (state: "confirmed" | "failed" | "ambiguous", errorCode?: string) => {
+  const settle = async (
+    state: "confirmed" | "failed" | "ambiguous",
+    errorCode?: string,
+    output?: { readonly value: unknown }
+  ) => {
     if (!ledger || !reservation) return;
     await ledger.finishAttempt(businessId, reservation.effectId, reservation.attempt, {
       state,
       ...(errorCode === undefined ? {} : { errorCode }),
+      ...(output === undefined ? {} : { output }),
     });
   };
 
@@ -102,7 +107,7 @@ export async function runToolAttempts(input: ToolAttemptInput): Promise<HostedTo
       return { status: "failed", reason: `tool "${call.name}" raised an internal error` };
     }
     if (result.success) {
-      await settle("confirmed");
+      await settle("confirmed", undefined, { value: result.data });
       return { status: "succeeded", output: result.data };
     }
     if (isParked(result)) {


### PR DESCRIPTION
## Summary

<!-- What changed, and why. Link the driving issue if one exists. -->

## Test plan

<!-- Commands you ran, or manual steps / screenshots for UI changes. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (or the scoped `--filter` you actually ran)

## Checklist

- [ ] PR title follows Conventional Commits (`type(scope): subject`) — CI checks this
- [ ] Scoped to one logical change
- [ ] Tests added/updated for the behavior that changed
