### PR TITLE
feat(slack): add user-configured Knowledge tooling

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -179,7 +179,6 @@ import { PgApiClientRepo } from "./identity/api-clients";
 import { buildApiAuthorityLayerResolver } from "./identity/authority-layers";
 import { channelBindKeyResolver } from "./identity/channel-link";
 import { PgExternalIdentityRepo, PgExternalIdentityUnlinker } from "./identity/external-links";
-import { ExternalLinkKnowledgeIdentityMap } from "./identity/knowledge-identity-map";
 import { reconcileSoulRoles, registerSoulRoleReconcile } from "./identity/role-reconcile";
 import { syncDeploymentRoles } from "./identity/roles";
 import { IngressIdentityResolver } from "./ingress/identity";
@@ -210,14 +209,11 @@ import { knowledgeDenialSink as makeKnowledgeDenialSink } from "./knowledge/deni
 import { PageReadGate } from "./knowledge/page-access";
 import { ReaderDirectory } from "./knowledge/reader-directory";
 import { SubjectDirectory } from "./knowledge/subject-directory";
-import { PgSlackKnowledgeCheckpointStore } from "./knowledge-sources/checkpoint-store";
-import { PgKnowledgeEmissionSink } from "./knowledge-sources/emission-sink";
 import { PgKnowledgeIndexStore } from "./knowledge-sources/index-store";
 import {
   CompositeLiveSourceAuthorization,
   SlackTenantLiveAuthorization,
 } from "./knowledge-sources/live-authorization";
-import { registerSlackKnowledgeSync } from "./knowledge-sources/slack-sync-schedule";
 import { PgKnowledgeSourceStore } from "./knowledge-sources/source-store";
 import { registerLlmReload } from "./llm-reload";
 import { buildMemoryServices } from "./memory/composition";
@@ -1802,15 +1798,6 @@ async function boot() {
       service: knowledgeService,
       activity: activityService,
     });
-    await registerSlackKnowledgeSync(boss, {
-      integrations: integrationStore,
-      secrets: secretsService,
-      checkpoints: new PgSlackKnowledgeCheckpointStore(pool),
-      sink: new PgKnowledgeEmissionSink(knowledgeSourceStore, knowledgeIndexStore),
-      identity: new ExternalLinkKnowledgeIdentityMap(externalIdentityRepo),
-      activity: activityService,
-    });
-
     app.listen({ port, host: "0.0.0.0" }, (err) => {
       if (err) {
         app.log.error(err);

--- a/apps/api/src/integrations/routes.ts
+++ b/apps/api/src/integrations/routes.ts
@@ -164,6 +164,7 @@ async function toDetail(
     iconColor: mark?.hex ?? listing?.color,
     capabilities: entry.manifest.capabilities,
     grants: resolveGrants(entry.manifest),
+    knowledge: entry.manifest.knowledge,
     manifest: {
       // Derived from the resolved flow, not read from the manifest: a manifest that declares
       // `auth` has no `required_env`, and every consumer must see one shape.

--- a/apps/api/src/integrations/slack-auth-flow.test.ts
+++ b/apps/api/src/integrations/slack-auth-flow.test.ts
@@ -284,6 +284,17 @@ describe("slack declarative auth flow", () => {
     ]);
   });
 
+  it("advertises user-configured Knowledge setup without automatic indexing", async () => {
+    expect(await detail()).toMatchObject({
+      knowledge: {
+        mode: "user_configured",
+        automatic_indexing: false,
+        source_tools: ["slack_channel_list", "slack_message_history"],
+        write_tools: ["create_knowledge_page"],
+      },
+    });
+  });
+
   it("produces every value Slack channel routing reads", async () => {
     await submitFields();
     await installToWorkspace();

--- a/apps/api/src/knowledge-sources/README.md
+++ b/apps/api/src/knowledge-sources/README.md
@@ -3,8 +3,8 @@
 Concrete API adapters and schedules live here; provider-neutral sync logic lives in
 `@tulipfarm/integrations`.
 
-- Slack syncs per-channel through a concrete HTTP adapter, a durable checkpoint, and
-  `PgKnowledgeEmissionSink`.
+- Slack is not scheduled for automatic indexing. Users configure their own Soul-backed Routine
+  through the Integration setup surface and the bounded Slack read Tool.
 - Every provider emits `KnowledgeSourceEmission` plus chunks into `knowledge_source_*`; none writes
   OKF pages.
 - Missing, stale, or unreadable ACL data must emit `unverifiable` and remove indexed content.

--- a/apps/api/src/knowledge-sources/slack-registration.test.ts
+++ b/apps/api/src/knowledge-sources/slack-registration.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("Slack Knowledge registration", () => {
+  it("does not register automatic Slack history indexing", () => {
+    const source = readFileSync(join(__dirname, "..", "index.ts"), "utf8");
+
+    expect(source).not.toContain("registerSlackKnowledgeSync");
+    expect(source).not.toContain("SLACK_KNOWLEDGE_SYNC_QUEUE");
+  });
+});

--- a/apps/api/src/tools/contract-coverage.test.ts
+++ b/apps/api/src/tools/contract-coverage.test.ts
@@ -190,6 +190,7 @@ const EXPECTED_FAMILY_TOOL_NAMES = [
       "slack_file_info",
       "slack_file_upload",
       "slack_message_delete",
+      "slack_message_history",
       "slack_message_update",
       "slack_pin_manage",
       "slack_reaction_remove",

--- a/apps/api/src/tools/slack/tools.test.ts
+++ b/apps/api/src/tools/slack/tools.test.ts
@@ -288,6 +288,51 @@ describe("buildSlackTools", () => {
     ]);
   });
 
+  it("explains missing history scopes without indexing any messages", async () => {
+    const http = {
+      async send(request: IntegrationHttpRequest) {
+        if (request.path === "/conversations.info") {
+          return {
+            status: 200,
+            headers: {},
+            body: {
+              ok: true,
+              channel: {
+                id: "C1234567890",
+                name: "general",
+                is_member: true,
+                is_private: false,
+              },
+            },
+          };
+        }
+        if (request.path === "/conversations.history") {
+          return { status: 200, headers: {}, body: { ok: false, error: "missing_scope" } };
+        }
+        throw new Error(`unexpected request: ${request.path}`);
+      },
+    };
+    const tooling = buildSlackTooling({ secrets: fakeSecretsService(), http });
+    const tools = buildSlackTools(BUSINESS_ID, {
+      ...tooling,
+      effects: new MemoryEffectStore(),
+      threads: fakeThreads(),
+      mentionedThreads: fakeMentionedThreads(),
+    });
+    const tool = tools.find((candidate) => candidate.name === "slack_message_history");
+    if (tool === undefined) throw new Error("slack_message_history not registered");
+
+    const result = await tool.execute({ channel: "C1234567890" }, context());
+
+    expect(result).toEqual({
+      success: false,
+      error: {
+        code: "validation_error",
+        message: "Reconnect Slack and approve the channel history scopes before reading messages.",
+      },
+    });
+  });
+
   it("marks the sent thread as mentioned so a reply passes the ingress mention-gate", async () => {
     const tooling = buildSlackTooling({ secrets: fakeSecretsService(), http: fakeHttp("100.002") });
     const mentionedThreads = fakeMentionedThreads();

--- a/apps/api/src/tools/slack/tools.ts
+++ b/apps/api/src/tools/slack/tools.ts
@@ -70,6 +70,18 @@ function mapDispatchError(error: ToolDispatchError): ToolCallResult {
   if (error.detail === "channel_not_joined") {
     return err("not_found", "The Slack app has not joined that conversation.");
   }
+  if (error.detail === "restricted_channel") {
+    return err(
+      "validation_error",
+      "Slack Knowledge setup can read public channels only. Private channels and DMs are refused."
+    );
+  }
+  if (error.detail === "missing_scope") {
+    return err(
+      "validation_error",
+      "Reconnect Slack and approve the channel history scopes before reading messages."
+    );
+  }
   if (error.detail === "file_unavailable") {
     return err("not_found", "The File is unavailable to the person who started this Run.");
   }

--- a/apps/web/app/lib/integrations.ts
+++ b/apps/web/app/lib/integrations.ts
@@ -63,11 +63,20 @@ export type IntegrationGrant = {
   description?: string;
 };
 
+export type IntegrationKnowledgeSetup = {
+  mode: "user_configured";
+  automatic_indexing: false;
+  source_tools: string[];
+  write_tools: string[];
+};
+
 export type IntegrationDetail = IntegrationSummary & {
   /** Authored summary of what agents can do once connected. Not enforced — see `grants`. */
   capabilities?: string[];
   /** The authority connecting hands over. Derived from declared OAuth scopes where possible. */
   grants: IntegrationGrant[];
+  /** Explicit setup contract for user-authored Knowledge ingestion. */
+  knowledge?: IntegrationKnowledgeSetup;
   manifest: {
     required_env?: RequiredEnvVar[];
     egress?: { type?: string; entry?: Record<string, unknown> };

--- a/apps/web/app/routes/_app.integrations.$name.tsx
+++ b/apps/web/app/routes/_app.integrations.$name.tsx
@@ -97,6 +97,19 @@ function displayName(integration: IntegrationDetail): string {
   return integration.title ?? integration.name;
 }
 
+function knowledgeSetupDraft(integration: IntegrationDetail): string {
+  const sourceTools = integration.knowledge?.source_tools.join(", ") ?? "";
+  const writeTools = integration.knowledge?.write_tools.join(", ") ?? "";
+  return [
+    `Set up ${displayName(integration)} as a Knowledge source.`,
+    "Ask me which public channels, schedule, and summarization rules I want.",
+    "Do not read messages or create anything until I approve the plan.",
+    `Then create a durable Routine in the Soul using ${sourceTools} to read bounded pages and ${writeTools} to save reviewed content.`,
+    "Store the newest processed Slack timestamp and pass it as oldest on the next Run. Use nextCursor only to finish the current bounded scan.",
+    "Private channels and DMs must stay excluded.",
+  ].join(" ");
+}
+
 // Separators are decoration, and at narrow widths a wrapped line strands one at the end of the
 // row above. Below `sm` they are dropped and the gap widens instead, so the meta line still reads
 // as distinct items without the orphan.
@@ -504,6 +517,36 @@ export default function IntegrationDetailPage() {
                 : "What connecting asks the provider for. These are the provider's own terms. They should match what its consent screen shows you."}
             </p>
             <GrantList grants={integration.grants} />
+          </section>
+        )}
+
+        {integration.knowledge && (
+          <section className="flex flex-col gap-2">
+            <SectionHeading>Knowledge</SectionHeading>
+            <p className="max-w-prose text-sm text-foreground">
+              {isConnected
+                ? `${name} is authorized for user-configured Knowledge setup.`
+                : `Connect ${name} before setting it up as a Knowledge source.`}
+            </p>
+            <p className="max-w-prose text-xs text-muted-foreground">
+              Nothing is indexed automatically. The setup flow creates a Soul-backed Routine only
+              after you choose public channels, a schedule, and what should become Knowledge.
+              Private channels and DMs are refused.
+            </p>
+            {isConnected && (
+              <div className="flex flex-wrap gap-2">
+                <Button asChild size="sm">
+                  <Link to={`/?draft=${encodeURIComponent(knowledgeSetupDraft(integration))}`}>
+                    Set up in Chat
+                  </Link>
+                </Button>
+                {integration.setupGuide && (
+                  <Button size="sm" variant="outline" onClick={() => setGuideOpen(true)}>
+                    View setup guide
+                  </Button>
+                )}
+              </div>
+            )}
           </section>
         )}
 

--- a/apps/web/app/routes/integrations.detail.test.tsx
+++ b/apps/web/app/routes/integrations.detail.test.tsx
@@ -114,6 +114,34 @@ test("shows what agents can do when the manifest says so", async () => {
   expect(screen.getByText("Merge pull requests")).toBeInTheDocument();
 });
 
+test("offers connected Slack Knowledge setup without claiming automatic indexing", async () => {
+  renderDetail(
+    detail({
+      name: "slack",
+      title: "Slack",
+      connected: true,
+      status: "connected",
+      setupGuide: "# Slack setup",
+      knowledge: {
+        mode: "user_configured",
+        automatic_indexing: false,
+        source_tools: ["slack_channel_list", "slack_message_history"],
+        write_tools: ["create_knowledge_page"],
+      },
+    })
+  );
+
+  expect(await screen.findByRole("heading", { name: "Knowledge" })).toBeInTheDocument();
+  expect(screen.getByText(/nothing is indexed automatically/i)).toBeInTheDocument();
+  expect(screen.getByText(/private channels and DMs are refused/i)).toBeInTheDocument();
+  const link = screen.getByRole("link", { name: "Set up in Chat" });
+  expect(link).toHaveAttribute("href", expect.stringContaining("/?draft="));
+  expect(decodeURIComponent(link.getAttribute("href") ?? "")).toMatch(
+    /slack_message_history.*create_knowledge_page/i
+  );
+  expect(screen.getByRole("button", { name: "View setup guide" })).toBeInTheDocument();
+});
+
 test("shows connection state as a badge in the header", async () => {
   renderDetail(detail({ connected: true, status: "connected" }));
   expect(await screen.findByText("Connected")).toBeInTheDocument();

--- a/integrations/slack/manifest.yml
+++ b/integrations/slack/manifest.yml
@@ -9,6 +9,15 @@ capabilities:
   - Show a personalized TulipFarm Home tab
   - Post messages and replies into channels it has been added to
   - Read channel history to follow a conversation before replying
+  - Let users build their own Knowledge routine from selected public channels
+knowledge:
+  mode: user_configured
+  automatic_indexing: false
+  source_tools:
+    - slack_channel_list
+    - slack_message_history
+  write_tools:
+    - create_knowledge_page
 # No `grants`: the oauth2 step below declares the bot scopes, and those are resolved automatically.
 egress:
   type: none

--- a/integrations/slack/setup-guide.md
+++ b/integrations/slack/setup-guide.md
@@ -15,20 +15,46 @@ state identifies Slack and the setup step when the provider returns.
 4. Save the fields, then select **Authorize on Slack**. Approve the workspace install. TulipFarm
    receives the bot token and Team ID from Slack; you do not copy either value by hand.
 
+## Set up Slack as a Knowledge source
+
+Connecting Slack does not index any message. TulipFarm does not crawl channel history or start a
+background Slack indexer.
+
+After Slack is connected, select **Set up in Chat** on this Integration page. Chat will ask you to
+choose:
+
+1. The public channels to read. The bot must already be a member of each channel.
+2. The schedule for your Routine.
+3. What should become Knowledge, such as decisions, policies, or weekly summaries.
+
+Review the plan before approving it. The resulting Agent or Routine is stored in the Soul. It uses
+`slack_channel_list` to find joined channels, `slack_message_history` to read one bounded page, and
+`create_knowledge_page` to save reviewed content. The Routine must store the newest processed Slack
+timestamp and pass it as `oldest` on its next Run. `nextCursor` is only for finishing the current
+bounded scan.
+
+`slack_message_history` refuses private channels and DMs. This is deliberate: pages created by
+`create_knowledge_page` are shared across the business, so private Slack content must not be copied
+into them.
+
 If you'd rather build the app manually instead of importing a manifest: enable Socket Mode
 (Settings → Socket Mode) to mint the app-level token, turn on Agents & AI Apps
 (Features → Agents & AI Apps → enable Agent messaging), add Bot Token Scopes `chat:write`,
-`app_mentions:read`, `channels:read`, `channels:history`, `groups:read`, `groups:history`,
-`im:read`, `im:history`, `mpim:read`, `mpim:history`, `users:read`, `users:read.email`,
-`assistant:write` (Features → OAuth & Permissions), turn on Interactivity
-(Features → Interactivity & Shortcuts, no Request URL needed under Socket Mode), and turn on
-Event Subscriptions (Features → Event Subscriptions, no Request URL needed under Socket Mode)
-subscribed to `message.channels`, `message.groups`, `message.im`, `message.mpim`, and
-`app_mention`. Under **OAuth & Permissions → Redirect URLs**, add the exact callback shown under
+`commands`, `app_mentions:read`, `channels:read`, `channels:history`, `groups:read`,
+`groups:history`, `im:read`, `im:history`, `mpim:read`, `mpim:history`, `users:read`,
+`assistant:write`, `bookmarks:read`, `bookmarks:write`, `files:read`, `files:write`, `pins:read`,
+`pins:write`, `reactions:read`, `reactions:write`, and `emoji:read`
+(Features → OAuth & Permissions). Turn on Interactivity
+(Features → Interactivity & Shortcuts, no Request URL needed under Socket Mode), then turn on
+Event Subscriptions (Features → Event Subscriptions, no Request URL needed under Socket Mode).
+Subscribe to `message.channels`, `message.groups`, `message.im`, `message.mpim`, `app_mention`,
+`app_home_opened`, `assistant_thread_started`, `assistant_thread_context_changed`,
+`app_context_changed`, `reaction_added`, `reaction_removed`, `channel_created`, `channel_rename`,
+`channel_archive`, `channel_unarchive`, `member_joined_channel`, `member_left_channel`,
+`file_shared`, `file_deleted`, `team_join`, `user_change`, `user_profile_changed`, and
+`emoji_changed`. Under **OAuth & Permissions → Redirect URLs**, add the exact callback shown under
 TulipFarm's **Business → About → Public address**, then continue from step 2 above.
 
-If you already connected Slack before this app started using the Agents & AI Apps status
-indicator, `assistant:write` is a new scope, and if you connected before conversation indexing
-was added, `channels:read`, `groups:read`, `groups:history`, `im:read`, `mpim:read`, and
-`mpim:history` are new too: reinstall the app (Settings → Install App → Reinstall to Workspace)
-to re-approve permissions, then reconnect here with the same tokens.
+If you already connected Slack before these scopes were added, reinstall the app
+(Settings → Install App → Reinstall to Workspace) to re-approve permissions, then reconnect here
+with the same tokens.

--- a/packages/integrations/src/slack/contracts.test.ts
+++ b/packages/integrations/src/slack/contracts.test.ts
@@ -15,6 +15,7 @@ describe("SLACK_TOOL_CONTRACTS", () => {
     expect([...byId.keys()]).toEqual([
       SLACK_TOOL_IDS.listChannels,
       SLACK_TOOL_IDS.getConversation,
+      SLACK_TOOL_IDS.listMessages,
       SLACK_TOOL_IDS.sendMessage,
       SLACK_TOOL_IDS.updateMessage,
       SLACK_TOOL_IDS.deleteMessage,
@@ -107,6 +108,24 @@ describe("SLACK_TOOL_CONTRACTS", () => {
         })),
       })
     ).toBe(false);
+  });
+
+  it("keeps message history read-only, bounded, and explicit about not indexing", () => {
+    const history = byId.get(SLACK_TOOL_IDS.listMessages);
+    if (history === undefined) expect.unreachable("history contract missing");
+    expect(history.spec.mutating).toBe(false);
+    expect(history.spec.dataClasses).toEqual(["source_content"]);
+    expect(history.spec.retry?.safeToRetry).toBe(true);
+
+    const declaration = SLACK_TOOL_DECLARATIONS.find(
+      ({ toolId }) => toolId === SLACK_TOOL_IDS.listMessages
+    );
+    expect(declaration?.description).toMatch(/never writes to Knowledge/i);
+
+    const validateInput = ajv.compile(history.spec.inputSchema);
+    expect(validateInput({ channel: "general", limit: 200 })).toBe(true);
+    expect(validateInput({ channel: "general", limit: 201 })).toBe(false);
+    expect(validateInput({ channel: "general", threadTs: "not-a-timestamp" })).toBe(false);
   });
 
   it("declares a chat.delete compensation with a reconciliation lookup", () => {

--- a/packages/integrations/src/slack/contracts.ts
+++ b/packages/integrations/src/slack/contracts.ts
@@ -9,6 +9,7 @@ export const SLACK_ADAPTER_REF = "integration:slack";
 export const SLACK_TOOL_IDS = {
   listChannels: "slack.channel.list",
   getConversation: "slack.conversation.get",
+  listMessages: "slack.message.list",
   sendMessage: "slack.message.send",
   updateMessage: "slack.message.update",
   deleteMessage: "slack.message.delete",
@@ -84,6 +85,45 @@ const getConversationInput = {
     limit: { type: "integer", minimum: 1, maximum: 200, default: 100 },
   },
 } as const;
+
+const listMessagesInputSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["channel"],
+  properties: {
+    channel: {
+      type: "string",
+      minLength: 1,
+      maxLength: 80,
+      description:
+        "Public channel name (with or without a leading '#') or stable Slack channel ID. The bot " +
+        "must be a member.",
+    },
+    cursor: {
+      type: "string",
+      minLength: 1,
+      maxLength: 512,
+      description: "Slack cursor returned by the previous call.",
+    },
+    oldest: {
+      type: "string",
+      pattern: "^\\d+(?:\\.\\d+)?$",
+      description: "Optional Slack timestamp. Only messages after this timestamp are returned.",
+    },
+    threadTs: {
+      type: "string",
+      pattern: "^\\d+(?:\\.\\d+)?$",
+      description: "Optional parent message timestamp. When present, list that thread's replies.",
+    },
+    limit: {
+      type: "integer",
+      minimum: 1,
+      maximum: 200,
+      default: 100,
+    },
+  },
+} as const;
+
 const messageItem = {
   type: "object",
   additionalProperties: false,
@@ -113,6 +153,34 @@ const getConversationOutput = {
     },
     messages: { type: "array", maxItems: 200, items: messageItem },
     nextCursor: { type: "string" },
+  },
+} as const;
+
+const slackMessageSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["ts", "text"],
+  properties: {
+    ts: timestamp,
+    text: { type: "string", maxLength: 40_000 },
+    userId: { type: "string" },
+    threadTs: timestamp,
+    editedTs: timestamp,
+  },
+} as const;
+
+const listMessagesOutputSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["channelId", "messages"],
+  properties: {
+    channelId: { type: "string", minLength: 1 },
+    messages: {
+      type: "array",
+      maxItems: 200,
+      items: slackMessageSchema,
+    },
+    nextCursor: { type: "string", minLength: 1 },
   },
 } as const;
 
@@ -386,6 +454,13 @@ const getConversation = read(
   getConversationInput,
   getConversationOutput
 );
+const listMessages = read(
+  "aaaaaaaa-0004-4000-8000-000000000013",
+  "slack-message-list",
+  SLACK_TOOL_IDS.listMessages,
+  listMessagesInputSchema,
+  listMessagesOutputSchema
+);
 const sendMessage = mutation(
   "aaaaaaaa-0004-4000-8000-000000000001",
   "slack-message-send",
@@ -486,6 +561,7 @@ const lookupUser = read(
 export const SLACK_TOOL_CONTRACTS: readonly ToolContractDefinition[] = [
   listChannels,
   getConversation,
+  listMessages,
   sendMessage,
   updateMessage,
   deleteMessage,
@@ -504,6 +580,13 @@ const declarations = [
     getConversation,
     "slack_conversation_get",
     "Read up to 200 messages from one Slack conversation the bot has joined.",
+  ],
+  [
+    listMessages,
+    "slack_message_history",
+    "Read one bounded page from a joined public Slack channel, or one thread. This never writes to " +
+      "Knowledge or schedules another read. Use it only after the user selects the channel for " +
+      "their own ingestion Routine. Private channels and DMs are refused.",
   ],
   [
     sendMessage,

--- a/packages/integrations/src/slack/tool-adapter.test.ts
+++ b/packages/integrations/src/slack/tool-adapter.test.ts
@@ -79,6 +79,26 @@ function listRequest(): ToolAdapterRequest {
   return { intent, idempotencyKey: intent.idempotencyKey, attempt: 1 };
 }
 
+function historyRequest(
+  channel: string,
+  overrides: Record<string, unknown> = {}
+): ToolAdapterRequest {
+  const intent: ToolIntent = {
+    intentId: "55555555-5555-4555-8555-555555555555",
+    businessId: "biz-1",
+    runId: "run-1",
+    stateId: "state-history",
+    toolId: SLACK_TOOL_IDS.listMessages,
+    toolVersion: "1.0.0",
+    action: SLACK_TOOL_IDS.listMessages,
+    targetRefs: [],
+    arguments: { channel, ...overrides },
+    credentialRef: "slack-bot-token",
+    idempotencyKey: "66666666-6666-4666-8666-666666666666",
+  };
+  return { intent, idempotencyKey: intent.idempotencyKey, attempt: 1 };
+}
+
 describe("SlackToolAdapter channel discovery", () => {
   it("paginates and returns stable ids only for channels the bot has joined", async () => {
     const calls: IntegrationHttpRequest[] = [];
@@ -128,6 +148,159 @@ describe("SlackToolAdapter channel discovery", () => {
       limit: "100",
     });
     expect(calls[1]?.query?.cursor).toBe("page-2");
+  });
+
+  describe("SlackToolAdapter message history", () => {
+    it("returns one bounded public-channel page and its cursor without writing anywhere", async () => {
+      const calls: IntegrationHttpRequest[] = [];
+      const http = {
+        async send(request: IntegrationHttpRequest): Promise<IntegrationHttpResponse> {
+          calls.push(request);
+          if (request.path === "/conversations.info") {
+            return {
+              status: 200,
+              headers: {},
+              body: {
+                ok: true,
+                channel: {
+                  id: "C1234567890",
+                  name: "general",
+                  is_member: true,
+                  is_private: false,
+                },
+              },
+            };
+          }
+          if (request.path === "/conversations.history") {
+            return {
+              status: 200,
+              headers: {},
+              body: {
+                ok: true,
+                messages: [
+                  {
+                    ts: "1700000000.000100",
+                    text: "Ship it",
+                    user: "U123",
+                    edited: { ts: "1700000001.000100" },
+                  },
+                  { ts: "1700000002.000100", subtype: "message_deleted" },
+                ],
+                response_metadata: { next_cursor: "next-page" },
+              },
+            };
+          }
+          throw new Error(`unexpected path: ${request.path}`);
+        },
+      };
+      const adapter = new SlackToolAdapter({ http });
+
+      await expect(
+        adapter.dispatch(
+          historyRequest("C1234567890", { oldest: "1699999999.000000", limit: 25 }),
+          CREDENTIAL
+        )
+      ).resolves.toEqual({
+        channelId: "C1234567890",
+        messages: [
+          {
+            ts: "1700000000.000100",
+            text: "Ship it",
+            userId: "U123",
+            editedTs: "1700000001.000100",
+          },
+        ],
+        nextCursor: "next-page",
+      });
+      expect(calls.map(({ path }) => path)).toEqual([
+        "/conversations.info",
+        "/conversations.history",
+      ]);
+      expect(calls[1]?.query).toEqual({
+        channel: "C1234567890",
+        limit: "25",
+        oldest: "1699999999.000000",
+      });
+    });
+
+    it("refuses private channels before reading their messages", async () => {
+      const calls: IntegrationHttpRequest[] = [];
+      const http = {
+        async send(request: IntegrationHttpRequest): Promise<IntegrationHttpResponse> {
+          calls.push(request);
+          return {
+            status: 200,
+            headers: {},
+            body: {
+              ok: true,
+              channel: {
+                id: "G1234567890",
+                name: "leadership",
+                is_member: true,
+                is_private: true,
+              },
+            },
+          };
+        },
+      };
+      const adapter = new SlackToolAdapter({ http });
+
+      await expect(
+        adapter.dispatch(historyRequest("G1234567890"), CREDENTIAL)
+      ).rejects.toMatchObject({
+        code: "restricted_channel",
+      });
+      expect(calls.map(({ path }) => path)).toEqual(["/conversations.info"]);
+    });
+
+    it("reads a selected thread instead of channel history", async () => {
+      const calls: IntegrationHttpRequest[] = [];
+      const http = {
+        async send(request: IntegrationHttpRequest): Promise<IntegrationHttpResponse> {
+          calls.push(request);
+          if (request.path === "/conversations.info") {
+            return {
+              status: 200,
+              headers: {},
+              body: {
+                ok: true,
+                channel: {
+                  id: "C1234567890",
+                  name: "general",
+                  is_member: true,
+                  is_private: false,
+                },
+              },
+            };
+          }
+          return {
+            status: 200,
+            headers: {},
+            body: {
+              ok: true,
+              messages: [
+                { ts: "1700000001.000100", text: "Reply", thread_ts: "1700000000.000100" },
+              ],
+            },
+          };
+        },
+      };
+      const adapter = new SlackToolAdapter({ http });
+
+      await adapter.dispatch(
+        historyRequest("C1234567890", { threadTs: "1700000000.000100" }),
+        CREDENTIAL
+      );
+
+      expect(calls[1]).toMatchObject({
+        path: "/conversations.replies",
+        query: {
+          channel: "C1234567890",
+          limit: "100",
+          ts: "1700000000.000100",
+        },
+      });
+    });
   });
 
   it("fails instead of silently returning a truncated channel directory", async () => {

--- a/packages/integrations/src/slack/tool-adapter.ts
+++ b/packages/integrations/src/slack/tool-adapter.ts
@@ -136,8 +136,19 @@ interface SlackApiChannel {
   readonly is_member?: unknown;
   readonly is_im?: unknown;
   readonly is_mpim?: unknown;
+  readonly is_private?: unknown;
   readonly topic?: { readonly value?: unknown };
   readonly purpose?: { readonly value?: unknown };
+}
+
+interface SlackApiMessage {
+  readonly ts?: unknown;
+  readonly text?: unknown;
+  readonly user?: unknown;
+  readonly thread_ts?: unknown;
+  readonly edited?: unknown;
+  readonly subtype?: unknown;
+  readonly message?: unknown;
 }
 
 interface SlackApiUser {
@@ -273,6 +284,42 @@ function userView(value: unknown) {
   };
 }
 
+function messageHistoryArgs(intent: ToolAdapterRequest["intent"]): {
+  channel: string;
+  cursor?: string;
+  oldest?: string;
+  threadTs?: string;
+  limit: number;
+} {
+  const raw = intent.arguments as Record<string, unknown>;
+  const channel = raw.channel;
+  if (typeof channel !== "string" || channel.trim().length === 0) {
+    throw new AdapterDispatchError("before_dispatch", "invalid_arguments", false);
+  }
+  const optionalString = (name: "cursor" | "oldest" | "threadTs") => {
+    const value = raw[name];
+    if (value === undefined) return undefined;
+    if (typeof value !== "string" || value.length === 0) {
+      throw new AdapterDispatchError("before_dispatch", "invalid_arguments", false);
+    }
+    return value;
+  };
+  const limit = raw.limit ?? 100;
+  if (!Number.isInteger(limit) || Number(limit) < 1 || Number(limit) > 200) {
+    throw new AdapterDispatchError("before_dispatch", "invalid_arguments", false);
+  }
+  const cursor = optionalString("cursor");
+  const oldest = optionalString("oldest");
+  const threadTs = optionalString("threadTs");
+  return {
+    channel: channel.trim(),
+    limit: Number(limit),
+    ...(cursor === undefined ? {} : { cursor }),
+    ...(oldest === undefined ? {} : { oldest }),
+    ...(threadTs === undefined ? {} : { threadTs }),
+  };
+}
+
 async function sha256(bytes: Uint8Array): Promise<string> {
   const digest = await crypto.subtle.digest("SHA-256", Uint8Array.from(bytes).buffer);
   return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
@@ -293,6 +340,8 @@ export class SlackToolAdapter implements ToolAdapter, ToolReconciliationAdapter 
         return { channels: await this.listChannels(credential) };
       case SLACK_TOOL_IDS.getConversation:
         return this.getConversation(request, credential);
+      case SLACK_TOOL_IDS.listMessages:
+        return this.listMessages(request, credential);
       case SLACK_TOOL_IDS.sendMessage:
         return this.sendMessage(request, credential);
       case SLACK_TOOL_IDS.updateMessage:
@@ -1570,5 +1619,88 @@ export class SlackToolAdapter implements ToolAdapter, ToolReconciliationAdapter 
       if (cursor === undefined) break;
     }
     return { exact, firstName };
+  }
+
+  private async listMessages(
+    request: ToolAdapterRequest,
+    credential: string
+  ): Promise<{
+    channelId: string;
+    messages: {
+      ts: string;
+      text: string;
+      userId?: string;
+      threadTs?: string;
+      editedTs?: string;
+    }[];
+    nextCursor?: string;
+  }> {
+    const input = messageHistoryArgs(request.intent);
+    const channelId = await this.resolvePublicChannelId(input.channel, credential);
+    const page = await this.api(
+      credential,
+      input.threadTs === undefined ? "/conversations.history" : "/conversations.replies",
+      {
+        method: "GET",
+        query: {
+          channel: channelId,
+          limit: String(input.limit),
+          ...(input.cursor === undefined ? {} : { cursor: input.cursor }),
+          ...(input.threadTs === undefined
+            ? input.oldest === undefined
+              ? {}
+              : { oldest: input.oldest }
+            : { ts: input.threadTs }),
+        },
+      }
+    );
+
+    const rawMessages = Array.isArray(page.messages) ? (page.messages as SlackApiMessage[]) : [];
+    const messages = rawMessages.flatMap((raw) => {
+      if (raw.subtype === "message_deleted") return [];
+      const source =
+        raw.subtype === "message_changed" && record(raw.message).ts !== undefined
+          ? (record(raw.message) as SlackApiMessage)
+          : raw;
+      if (typeof source.ts !== "string" || typeof source.text !== "string") return [];
+      const edited = record(source.edited).ts;
+      return [
+        {
+          ts: source.ts,
+          text: source.text,
+          ...(typeof source.user === "string" ? { userId: source.user } : {}),
+          ...(typeof source.thread_ts === "string" ? { threadTs: source.thread_ts } : {}),
+          ...(typeof edited === "string" ? { editedTs: edited } : {}),
+        },
+      ];
+    });
+    return {
+      channelId,
+      messages,
+      ...(nextCursor(page) === undefined ? {} : { nextCursor: nextCursor(page) }),
+    };
+  }
+
+  private async resolvePublicChannelId(channel: string, credential: string): Promise<string> {
+    const channelId = isChannelId(channel)
+      ? channel
+      : await this.resolveChannelId(normalizeChannelName(channel), credential);
+    const info = await this.api(credential, "/conversations.info", {
+      method: "GET",
+      query: { channel: channelId },
+    });
+    const conversation = record(info.channel);
+    if (conversation.is_member !== true) {
+      throw new AdapterDispatchError("before_dispatch", "channel_not_joined", false);
+    }
+    if (
+      conversation.is_private === true ||
+      conversation.is_im === true ||
+      conversation.is_mpim === true ||
+      !channelId.startsWith("C")
+    ) {
+      throw new AdapterDispatchError("before_dispatch", "restricted_channel", false);
+    }
+    return channelId;
   }
 }

--- a/packages/knowledge/AGENTS.md
+++ b/packages/knowledge/AGENTS.md
@@ -72,5 +72,6 @@ propagation. This is the sole accountable owner for source ACL enforcement.
   model output. Extraction takes one chunk at a time for exactly that reason.
 - `@tulipfarm/llm` is not importable here, so both models arrive as ports
   (`GraphExtractionPort`, `GraphSummaryPort`, `GlobalAnswerPort`).- Nothing about a withheld source may reach candidates, citations, or audit payloads.
-- Slack syncs through the `knowledge_source_*` ports. Missing or stale captured ACL snapshots deny;
-  re-sync/deletion removes indexed chunks before content can reappear.
+- Connected-source content still denies on missing or stale ACL evidence. Slack is not
+  automatically indexed; user-configured Routines may write reviewed public-channel content as
+  Knowledge pages through the normal Tool and Page authorization paths.

--- a/packages/knowledge/src/tools.ts
+++ b/packages/knowledge/src/tools.ts
@@ -86,7 +86,7 @@ const queryKnowledge = defineApiTool<KnowledgeToolContext>({
   name: "query_knowledge",
   requiresAmbient: ["soul", "provider-credentials"],
   description:
-    "Search the shared knowledge base by meaning (vector) with a lexical fallback. Returns ranked OKF wiki pages and authorized indexed source snippets from every connected source — including synced Slack channel history and other connectors — each labelled with its origin. Use this (not a messaging tool) to answer questions about what was said in a Slack channel or any other connected source. Read OKF pages with `get_page` before answering; source snippets are already the retrievable excerpt. Pass `spaceId` to scope the search to a single space (wiki only).",
+    "Search the shared knowledge base by meaning (vector) with a lexical fallback. Returns ranked OKF wiki pages and authorized indexed source snippets from configured sources, each labelled with its origin. Read OKF pages with `get_page` before answering; source snippets are already the retrievable excerpt. Pass `spaceId` to scope the search to a single space (wiki only).",
   tier: "platform",
   mutating: false,
   inputSchema: QUERY_SCHEMA,

--- a/packages/schema/src/integration-manifest.test.ts
+++ b/packages/schema/src/integration-manifest.test.ts
@@ -44,6 +44,36 @@ describe("validateLegacyIntegrationManifest", () => {
     ).toMatchObject({ name: "github", egress: { type: "mcp" } });
   });
 
+  it("accepts only explicit user-configured Knowledge setup", () => {
+    expect(
+      validateLegacyIntegrationManifest({
+        name: "slack",
+        egress: { type: "none" },
+        knowledge: {
+          mode: "user_configured",
+          automatic_indexing: false,
+          source_tools: ["slack_message_history"],
+          write_tools: ["create_knowledge_page"],
+        },
+      })
+    ).toMatchObject({
+      knowledge: { mode: "user_configured", automatic_indexing: false },
+    });
+
+    expect(() =>
+      validateLegacyIntegrationManifest({
+        name: "slack",
+        egress: { type: "none" },
+        knowledge: {
+          mode: "user_configured",
+          automatic_indexing: true,
+          source_tools: ["slack_message_history"],
+          write_tools: ["create_knowledge_page"],
+        },
+      })
+    ).toThrow(TulipFarmValidationError);
+  });
+
   it("rejects a manifest without the required egress type", () => {
     expect(() =>
       validateLegacyIntegrationManifest({

--- a/packages/schema/src/integration-manifest.ts
+++ b/packages/schema/src/integration-manifest.ts
@@ -120,6 +120,22 @@ const IntegrationGrantSchema = Type.Object(
   { additionalProperties: true }
 );
 
+const IntegrationKnowledgeSetupSchema = Type.Object(
+  {
+    mode: Type.Literal("user_configured"),
+    automatic_indexing: Type.Literal(false),
+    source_tools: Type.Array(Type.String({ minLength: 1 }), {
+      minItems: 1,
+      uniqueItems: true,
+    }),
+    write_tools: Type.Array(Type.String({ minLength: 1 }), {
+      minItems: 1,
+      uniqueItems: true,
+    }),
+  },
+  { additionalProperties: false }
+);
+
 const AuthExchangeSchema = Type.Object(
   {
     url: Type.String({ minLength: 1 }),
@@ -355,6 +371,7 @@ export const LegacyIntegrationManifestSchema = Type.Object(
     icon: Type.Optional(Type.String()),
     capabilities: Type.Optional(Type.Array(Type.String())),
     grants: Type.Optional(Type.Array(IntegrationGrantSchema)),
+    knowledge: Type.Optional(IntegrationKnowledgeSetupSchema),
     egress: EgressSchema,
     ingress: Type.Optional(IngressSchema),
     auth: Type.Optional(Type.Array(AuthStepSchema)),

--- a/packages/soul/src/types.ts
+++ b/packages/soul/src/types.ts
@@ -274,6 +274,13 @@ export interface IntegrationGrant {
   description?: string;
 }
 
+export interface IntegrationKnowledgeSetup {
+  mode: "user_configured";
+  automatic_indexing: false;
+  source_tools: string[];
+  write_tools: string[];
+}
+
 export interface IntegrationManifest {
   name: string;
   version?: string;
@@ -285,6 +292,8 @@ export interface IntegrationManifest {
   capabilities?: string[];
   /** Authority handed to TulipFarm; derived from OAuth scopes unless the source is opaque. */
   grants?: IntegrationGrant[];
+  /** User-reachable setup contract. It advertises Tools but never starts ingestion itself. */
+  knowledge?: IntegrationKnowledgeSetup;
   egress: EgressConfig;
   ingress?: IngressConfig;
   /** Ordered connect flow; use `resolveAuthSteps()` to include legacy fields. */


### PR DESCRIPTION
## Summary

<!-- What changed, and why. Link the driving issue if one exists. -->

## Test plan

<!-- Commands you ran, or manual steps / screenshots for UI changes. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (or the scoped `--filter` you actually ran)

## Checklist

- [ ] PR title follows Conventional Commits (`type(scope): subject`) — CI checks this
- [ ] Scoped to one logical change
- [ ] Tests added/updated for the behavior that changed
