### PR TITLE
fix(storage): stop leaking FileHandles from FileSystemBlobPort.get

### DIFF
--- a/packages/storage/src/ports/filesystem-blob.ts
+++ b/packages/storage/src/ports/filesystem-blob.ts
@@ -1,5 +1,4 @@
 import { createHash, randomUUID } from "node:crypto";
-import type { FileHandle } from "node:fs/promises";
 import { link, mkdir, open, stat, unlink } from "node:fs/promises";
 import { join } from "node:path";
 import type { BlobBody, BlobMetadata, BlobPort, BlobRange, BlobRef } from "./blob";
@@ -55,10 +54,12 @@ export class FileSystemBlobPort implements BlobPort {
   async get(ref: BlobRef, range?: BlobRange): Promise<AsyncIterable<Uint8Array>> {
     const path = this.resolve(ref);
     assertValidRange(range);
-    // Opening before returning means an absent object rejects the call, rather than failing
-    // partway through a stream the caller has already started consuming.
-    const handle = await open(path, "r");
-    return readChunks(handle, range, range === undefined ? ref.hash : undefined);
+    // stat, not open, so an absent object rejects the call itself without holding a FileHandle
+    // open across the async boundary to first iteration — a caller that requests a stream and
+    // never consumes it (or abandons it mid-stream) must not leak an open fd. The FileHandle
+    // itself opens lazily, inside readChunks, only once iteration actually starts.
+    await stat(path);
+    return readChunks(path, range, range === undefined ? ref.hash : undefined);
   }
 
   async head(ref: BlobRef): Promise<BlobMetadata | null> {
@@ -125,11 +126,12 @@ async function* chunksOf(body: BlobBody): AsyncIterable<Uint8Array> {
 }
 
 async function* readChunks(
-  handle: FileHandle,
+  path: string,
   range: BlobRange | undefined,
   verifyAgainst: string | undefined
 ): AsyncIterable<Uint8Array> {
   const hasher = verifyAgainst === undefined ? undefined : createHash("sha256");
+  const handle = await open(path, "r");
   try {
     const stream = handle.createReadStream({
       autoClose: false,


### PR DESCRIPTION
## Summary
- `get()` opened the FileHandle eagerly and handed it to an unstarted async generator; a caller that never fully consumed the returned stream left the fd open until GC finalized it, which Node now throws `ERR_INVALID_STATE` for instead of warning.
- The handle now opens lazily inside `readChunks` on first iteration; an eager `stat()` before that preserves existing behavior where an absent object rejects the `get()` call itself.
- Root cause of `Test packages` failures on PR #719 and #720 (`packages/files/src/service.test.ts`), unrelated to either PR's own diff.

## Test plan
- [x] `rtk proxy pnpm --filter @tulipfarm/storage exec vitest run src/ports` — 132 passed, 16 skipped
- [x] `rtk proxy pnpm --filter @tulipfarm/files exec vitest run` — 269 passed, no unhandled FileHandle errors