### PR TITLE
fix(authz): provision an Agent Principal for every Agent

### DIFF
--- a/apps/api/src/admin/runtime.test.ts
+++ b/apps/api/src/admin/runtime.test.ts
@@ -241,7 +241,7 @@ describe("runtime operational API", () => {
     expect(await api.getRun(grant, "missing")).toBeNull();
 
     const roles = await api.getRoles(grant);
-    expect(roles.items.map((role) => role.id)).toEqual(["owner", "admin", "member"]);
+    expect(roles.items.map((role) => role.id)).toEqual(["owner", "admin", "agent", "member"]);
     expect(roles.revision).toMatch(/^[a-f0-9]{64}$/);
     // Secret actions are absent from the member allow-list rather than spelled as an explicit
     // deny, because a deny would veto any exact secret grants configured on top of member.

--- a/apps/api/src/identity/agent-principals.test.ts
+++ b/apps/api/src/identity/agent-principals.test.ts
@@ -1,0 +1,104 @@
+import { DEFAULT_ASSISTANT_NAME, type SoulAgent } from "@tulipfarm/soul";
+import { InMemoryPrincipalRepo, InMemoryRoleRepo } from "@tulipfarm/storage";
+import { describe, expect, it } from "vitest";
+import { ensureAgentPrincipal, reconcileAgentPrincipals } from "./agent-principals";
+import { AGENT_ROLE_ID } from "./roles";
+
+const BUSINESS = "business-1";
+const NOW = new Date("2026-09-07T00:00:00.000Z");
+
+function repos() {
+  return { principals: new InMemoryPrincipalRepo(), roles: new InMemoryRoleRepo() };
+}
+
+function soulAgent(name: string): SoulAgent {
+  return { name, frontmatter: {}, body: "" } as SoulAgent;
+}
+
+describe("ensureAgentPrincipal", () => {
+  it("registers the Agent as an active principal holding the agent Role", async () => {
+    const { principals, roles } = repos();
+
+    await ensureAgentPrincipal({ principals, roles }, BUSINESS, "support");
+
+    expect(await principals.get(BUSINESS, "support")).toEqual({
+      id: "support",
+      businessId: BUSINESS,
+      kind: "agent",
+      status: "active",
+    });
+    expect(await roles.listAssignments(BUSINESS, "support", NOW)).toEqual([
+      { principalId: "support", roleId: AGENT_ROLE_ID, businessId: BUSINESS },
+    ]);
+  });
+
+  it("is idempotent, so publication and the sweeps can all call it", async () => {
+    const { principals, roles } = repos();
+
+    await ensureAgentPrincipal({ principals, roles }, BUSINESS, "support");
+    await ensureAgentPrincipal({ principals, roles }, BUSINESS, "support");
+
+    expect(await roles.listAssignments(BUSINESS, "support", NOW)).toHaveLength(1);
+  });
+});
+
+describe("reconcileAgentPrincipals", () => {
+  it("provisions every Soul Agent and the built-in default assistant", async () => {
+    const { principals, roles } = repos();
+    const soul = {
+      agents: new Map([
+        ["support", soulAgent("support")],
+        ["research", soulAgent("research")],
+      ]),
+    };
+
+    await reconcileAgentPrincipals({ principals, roles }, soul, BUSINESS);
+
+    expect((await principals.list(BUSINESS)).map((principal) => principal.id)).toEqual([
+      DEFAULT_ASSISTANT_NAME,
+      "research",
+      "support",
+    ]);
+  });
+
+  it("repairs an Agent that predates provisioning without touching the others", async () => {
+    const { principals, roles } = repos();
+    await ensureAgentPrincipal({ principals, roles }, BUSINESS, "support");
+    const soul = {
+      agents: new Map([
+        ["support", soulAgent("support")],
+        ["research", soulAgent("research")],
+      ]),
+    };
+
+    await reconcileAgentPrincipals({ principals, roles }, soul, BUSINESS);
+
+    expect(await roles.listAssignments(BUSINESS, "research", NOW)).toHaveLength(1);
+    expect(await roles.listAssignments(BUSINESS, "support", NOW)).toHaveLength(1);
+  });
+
+  it("keeps going when one Agent cannot be provisioned", async () => {
+    const { principals, roles } = repos();
+    const warnings: string[] = [];
+    const failing = {
+      put: async (record: Parameters<InMemoryPrincipalRepo["put"]>[0]) => {
+        if (record.id === "broken") throw new Error("principal rejected");
+        await principals.put(record);
+      },
+    };
+    const soul = {
+      agents: new Map([
+        ["broken", soulAgent("broken")],
+        ["research", soulAgent("research")],
+      ]),
+    };
+
+    await reconcileAgentPrincipals({ principals: failing, roles }, soul, BUSINESS, {
+      warn: (message: string) => warnings.push(message),
+    });
+
+    expect(await principals.get(BUSINESS, "research")).toBeDefined();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("broken");
+  });
+});

--- a/apps/api/src/identity/agent-principals.ts
+++ b/apps/api/src/identity/agent-principals.ts
@@ -1,0 +1,56 @@
+import { DEFAULT_ASSISTANT_NAME, type Logger, type SoulAgent } from "@tulipfarm/soul";
+import type { PrincipalRepo, RoleRepo } from "@tulipfarm/storage";
+import { AGENT_ROLE_ID } from "./roles";
+
+export interface SoulAgents {
+  agents: Map<string, SoulAgent>;
+}
+
+export interface AgentPrincipalRepos {
+  readonly principals: Pick<PrincipalRepo, "put">;
+  readonly roles: Pick<RoleRepo, "assign">;
+}
+
+function msg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Register one Agent as a Principal holding the `agent` Role.
+ *
+ * The Tool gate resolves an Agent authority layer for every call and intersects it with the
+ * caller's. An Agent with no Principal resolves to an empty layer, which denies every Tool for
+ * every caller rather than denying something specific — so provisioning is not an enhancement to
+ * an Agent, it is the difference between an Agent that works and one that cannot act at all.
+ * Idempotent, so publication, the boot sweep and the post-sync sweep can all call it.
+ */
+export async function ensureAgentPrincipal(
+  repos: AgentPrincipalRepos,
+  businessId: string,
+  agentId: string
+): Promise<void> {
+  await repos.principals.put({ id: agentId, businessId, kind: "agent", status: "active" });
+  await repos.roles.assign({ principalId: agentId, roleId: AGENT_ROLE_ID, businessId });
+}
+
+/**
+ * Provision a Principal for every Agent a turn can route to.
+ *
+ * `DEFAULT_ASSISTANT_NAME` is included because normal chat runs on it and it is not a Soul
+ * artifact, so no publication would ever create it. Failures are logged per Agent rather than
+ * thrown: one unprovisionable Agent must not stop the rest from being repaired.
+ */
+export async function reconcileAgentPrincipals(
+  repos: AgentPrincipalRepos,
+  soul: SoulAgents,
+  businessId: string,
+  logger?: Pick<Logger, "warn">
+): Promise<void> {
+  for (const agentId of [DEFAULT_ASSISTANT_NAME, ...soul.agents.keys()]) {
+    try {
+      await ensureAgentPrincipal(repos, businessId, agentId);
+    } catch (err) {
+      logger?.warn(`[agents] could not provision principal for "${agentId}": ${msg(err)}`);
+    }
+  }
+}

--- a/apps/api/src/identity/role-reconcile.test.ts
+++ b/apps/api/src/identity/role-reconcile.test.ts
@@ -216,6 +216,7 @@ describe("registerSoulRoleReconcile", () => {
 
     const soul = {
       roles: new Map<string, SoulRole>(),
+      agents: new Map(),
       reload: async () => {
         const id = ++pass;
         trace.push(`start:${id}`);

--- a/apps/api/src/identity/role-reconcile.ts
+++ b/apps/api/src/identity/role-reconcile.ts
@@ -6,16 +6,27 @@ import {
   type SoulRole,
 } from "@tulipfarm/soul";
 import type { RoleRepo } from "@tulipfarm/storage";
+import {
+  type AgentPrincipalRepos,
+  reconcileAgentPrincipals,
+  type SoulAgents,
+} from "./agent-principals";
+import { AGENT_ROLE_ID } from "./roles";
 
 interface SoulRoles {
   roles: Map<string, SoulRole>;
 }
-interface ReloadableSoulRoles extends SoulRoles {
+interface ReloadableSoulRoles extends SoulRoles, SoulAgents {
   reload(): Promise<void>;
 }
 
 /** Bootstrap-owned Role ids must never be deleted or overwritten by Soul-authored Roles. */
-export const RESERVED_ROLE_IDS: ReadonlySet<string> = new Set(["owner", "admin", "member"]);
+export const RESERVED_ROLE_IDS: ReadonlySet<string> = new Set([
+  "owner",
+  "admin",
+  "member",
+  AGENT_ROLE_ID,
+]);
 
 function msg(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
@@ -74,14 +85,19 @@ export async function reconcileSoulRoles(
 }
 
 /**
- * On soul.synced, reload from disk and reconcile Roles; failures are logged so sync keeps running.
+ * On soul.synced, reload from disk and reconcile Roles, then the Agent Principals a sync may have
+ * introduced; failures are logged so sync keeps running.
+ *
+ * Both sweeps share this one handler because both read the loader that `soul.reload()` mutates —
+ * a second listener with a reload of its own would make each pass observe a half-settled Soul.
  */
 export function registerSoulRoleReconcile(
   gitSync: EventEmitter,
   soul: ReloadableSoulRoles,
   roles: RoleRepo,
   businessId: string,
-  logger: Logger
+  logger: Logger,
+  agentPrincipals?: AgentPrincipalRepos
 ): void {
   // Serialized, because `soul.reload()` mutates shared loader state that the reconcile then reads.
   // Two overlapping syncs can interleave into a resurrection: the newer one reaps a role that Soul
@@ -95,6 +111,9 @@ export function registerSoulRoleReconcile(
         await soul.reload();
         await reconcileSoulRoles(roles, soul, businessId, logger);
         logger.info("[roles] soul roles reconciled after soul.synced");
+        if (agentPrincipals) {
+          await reconcileAgentPrincipals(agentPrincipals, soul, businessId, logger);
+        }
       } catch (err) {
         logger.error(`[roles] reconcile after soul.synced failed — ${msg(err)}`);
       }

--- a/apps/api/src/identity/roles.ts
+++ b/apps/api/src/identity/roles.ts
@@ -315,6 +315,9 @@ export const OWNER_SCOPED_SURFACES: readonly {
  * Unrestricted authority, spelled for both request shapes: a grant with no domain covers only
  * domainless requests, so the pair is what "anything" actually means to `grantMatches`.
  */
+/** The Role every Agent Principal holds. Bootstrap-owned, so Soul may never redefine it. */
+export const AGENT_ROLE_ID = "agent";
+
 const UNRESTRICTED_GRANTS: readonly AccessGrant[] = [
   { action: "*", resourceType: "*", effect: "allow" },
   { action: "*", resourceType: "*", domain: "*", effect: "allow" },
@@ -340,6 +343,20 @@ export const DEPLOYMENT_ROLES: readonly Role[] = [
     id: "admin",
     businessId: DEPLOYMENT_BUSINESS_ID,
     assignableTo: ["user"],
+    parentRoleIds: [],
+    grants: [...UNRESTRICTED_GRANTS],
+  },
+  /**
+   * Every Agent's own Principal holds this. Authority is the intersection of the delegating
+   * caller's layer, this one, and the Tool allowlist (ADR authorization-design D9), so this layer
+   * is a ceiling and it starts fully open — narrowing it here would silently subtract from what
+   * the person driving the turn may already do. An Agent that must be bounded declares that in
+   * its own configuration; nothing is granted here that the caller does not already hold.
+   */
+  {
+    id: AGENT_ROLE_ID,
+    businessId: DEPLOYMENT_BUSINESS_ID,
+    assignableTo: ["agent"],
     parentRoleIds: [],
     grants: [...UNRESTRICTED_GRANTS],
   },
@@ -375,6 +392,7 @@ const ROLE_NAMES: Readonly<Record<string, string>> = {
   owner: "Owner",
   admin: "Administrator",
   member: "Member",
+  [AGENT_ROLE_ID]: "Agent",
 };
 
 function grantLabel(grant: AccessGrant): string {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -177,6 +177,7 @@ import { registerGuardrailsReload } from "./guardrails/reload";
 import { createHookExecutor } from "./hooks/executor";
 import { PgRawPayloadVault } from "./hooks/raw-payload-vault";
 import { webhookSecretPort } from "./hooks/secret-port";
+import { ensureAgentPrincipal, reconcileAgentPrincipals } from "./identity/agent-principals";
 import { PgApiClientRepo } from "./identity/api-clients";
 import { buildApiAuthorityLayerResolver } from "./identity/authority-layers";
 import { channelBindKeyResolver } from "./identity/channel-link";
@@ -570,6 +571,19 @@ async function boot() {
     // reaped). Reserved bootstrap ids are never touched. See identity/role-reconcile.ts.
     await reconcileSoulRoles(
       new PgRoleRepo(transactionPort(pool)),
+      soulLoader,
+      DEPLOYMENT_BUSINESS_ID,
+      console
+    );
+    // Must run before the first Tool call, not merely on publication: an Agent authored before
+    // this sweep existed has no Principal, and an Agent with no Principal contributes an empty
+    // authority layer, which denies every Tool for every caller.
+    const agentPrincipalRepos = {
+      principals: new PgPrincipalRepo(transactionPort(pool)),
+      roles: new PgRoleRepo(transactionPort(pool)),
+    };
+    await reconcileAgentPrincipals(
+      agentPrincipalRepos,
       soulLoader,
       DEPLOYMENT_BUSINESS_ID,
       console
@@ -1100,7 +1114,22 @@ async function boot() {
         events: domainEventEmitter,
       },
       resourceTypes: { gitSync, soulWriter, soulLoader, reconcile: reconcileResources },
-      agentTools: { gitSync, soulWriter, soulLoader, teamAssets },
+      agentTools: {
+        gitSync,
+        soulWriter,
+        soulLoader,
+        teamAssets,
+        ensurePrincipal: (agentId) =>
+          ensureAgentPrincipal(agentPrincipalRepos, DEPLOYMENT_BUSINESS_ID, agentId).catch(
+            (err) => {
+              app.log.error(
+                `[agents] could not provision principal for "${agentId}" — ${
+                  err instanceof Error ? err.message : String(err)
+                }`
+              );
+            }
+          ),
+      },
       skillTools: { ...skillTools, hiddenSkillNames, teamAssets },
       github: githubTools,
       slack: slackTools,
@@ -1679,7 +1708,8 @@ async function boot() {
       soulLoader,
       new PgRoleRepo(transactionPort(pool)),
       DEPLOYMENT_BUSINESS_ID,
-      app.log
+      app.log,
+      agentPrincipalRepos
     );
     logEnvironmentStatus(app.log);
     // Before the wizard, and independent of it: a deployment that never opens the wizard still

--- a/apps/api/src/pg-migrations/index.ts
+++ b/apps/api/src/pg-migrations/index.ts
@@ -63,6 +63,7 @@ import {
 } from "@tulipfarm/tool-broker";
 import { APPROVAL_EVIDENCE_STORAGE_STATEMENTS } from "@tulipfarm/tool-host";
 import type { Queryable } from "../db";
+import { AGENT_ROLE_ID } from "../identity/roles";
 import { resourceSideEffectMigration } from "../resources/outbox";
 
 export interface PgMigration {
@@ -808,7 +809,8 @@ async function seedBootstrapRole(
     readonly resourceType: string;
     readonly domain?: string;
     readonly effect: "allow" | "deny";
-  }>
+  }>,
+  assignableTo: readonly string[] = ["user"]
 ): Promise<void> {
   await q.query(
     `INSERT INTO roles (business_id, id, assignable_to)
@@ -816,7 +818,7 @@ async function seedBootstrapRole(
      ON CONFLICT (business_id, id) DO UPDATE SET
        assignable_to = EXCLUDED.assignable_to,
        updated_at = now()`,
-    [DEPLOYMENT_BUSINESS_ID, roleId, ["user"]]
+    [DEPLOYMENT_BUSINESS_ID, roleId, assignableTo]
   );
   for (const [index, grant] of grants.entries()) {
     await q.query(
@@ -879,6 +881,18 @@ async function seedAuthorizationBootstrap(q: Queryable): Promise<void> {
     { action: "*", resourceType: "*", domain: "*", effect: "allow" },
   ]);
   await seedBootstrapRole(q, "member", []);
+  // The Agent authority layer is an intersection member, so an Agent whose Role is missing can do
+  // nothing at all rather than merely less. Seeded here as well as synced on boot so a database
+  // built by the migrations alone is already able to authorize a Tool call.
+  await seedBootstrapRole(
+    q,
+    AGENT_ROLE_ID,
+    [
+      { action: "*", resourceType: "*", effect: "allow" },
+      { action: "*", resourceType: "*", domain: "*", effect: "allow" },
+    ],
+    ["agent"]
+  );
   await q.query(
     `INSERT INTO principal_groups (business_id, id)
      VALUES ($1, 'owners')

--- a/apps/api/src/soul/agents/tools.ts
+++ b/apps/api/src/soul/agents/tools.ts
@@ -35,6 +35,13 @@ export interface AgentToolContext {
   /** Which Agent is executing this Turn. Absent outside an Agent Turn. */
   agentId?: string;
   teamAssets?: TeamAssetService;
+  /**
+   * Registers the new Agent as a Principal. The boot and post-sync sweeps would reach it
+   * eventually, but "eventually" here means every Tool call the Agent makes until then is denied.
+   * Must not throw: the Agent is already written by the time it runs, so a failure here is a
+   * degraded Agent to be repaired by the next sweep, never a failed create the model should retry.
+   */
+  ensurePrincipal?: (agentId: string) => Promise<void>;
 }
 
 function ownershipOf(frontmatter: Record<string, unknown>) {
@@ -218,8 +225,9 @@ const agentCreate = defineApiTool<AgentToolContext>({
     const failure = await putAgent(ctx, created ? "add" : "update", target, frontmatter, body, () =>
       err("validation_error", "agent already exists")
     );
-    if (!failure && created && ctx.teamAssets) {
-      await ctx.teamAssets.ensure("agent", target, ownershipOf(frontmatter));
+    if (!failure && created) {
+      if (ctx.teamAssets) await ctx.teamAssets.ensure("agent", target, ownershipOf(frontmatter));
+      await ctx.ensurePrincipal?.(target);
     }
     return failure ?? ok({ name: target, created, changed: true, frontmatter, body });
   },

--- a/apps/api/src/soul/roles/authoring.ts
+++ b/apps/api/src/soul/roles/authoring.ts
@@ -20,6 +20,7 @@ import {
 } from "@tulipfarm/soul";
 import { stringify as stringifyYaml } from "yaml";
 import type { CapabilityCatalog } from "../../authz/capabilities";
+import { RESERVED_ROLE_IDS } from "../../identity/role-reconcile";
 import { SYSTEM_SOUL_COMMIT_ACTOR } from "../../runtime/soul-writer";
 
 const definitionRegistry = new SchemaRegistry(DEFINITION_REGISTRATIONS);
@@ -48,13 +49,13 @@ export class LevelError extends Error {
 }
 
 /**
- * Slugs a level may not take. `owner`, `admin` and `member` are the bootstrap Roles:
- * `reconcileSoulRoles` refuses to project a Soul Role that collides with one, so a level authored
- * under those names would be written to git, reported as created, and then never take effect — the
- * worst of both outcomes. Refusing up front means the failure is a message the author reads rather
- * than silence they have to notice.
+ * Slugs a level may not take: the bootstrap Roles. `reconcileSoulRoles` refuses to project a Soul
+ * Role that collides with one, so a level authored under those names would be written to git,
+ * reported as created, and then never take effect — the worst of both outcomes. Refusing up front
+ * means the failure is a message the author reads rather than silence they have to notice. Taken
+ * from the reconcile's own set so the two can never disagree about what is reserved.
  */
-const RESERVED_SLUGS: ReadonlySet<string> = new Set(["owner", "admin", "member"]);
+const RESERVED_SLUGS: ReadonlySet<string> = RESERVED_ROLE_IDS;
 
 export function slugifyLevelName(name: string): string {
   return name

--- a/packages/tool-host/src/dispatcher.test.ts
+++ b/packages/tool-host/src/dispatcher.test.ts
@@ -1105,6 +1105,7 @@ describe("authorization gate", () => {
         agentId: "agent-1",
       }) as unknown as ArtifactService,
       gate: new LiveToolGate(),
+      agents: { resolve: () => ({ name: "agent-1" }) },
       authorityLayers: {
         resolvePrincipalLayer: async (name) => ({ name, grants: ALLOW }),
         resolveAgentLayer: async () => ({ name: "agent", grants: [] }),
@@ -1119,6 +1120,67 @@ describe("authorization gate", () => {
 
     expect(result).toMatchObject({ status: "denied" });
     expect(execute).not.toHaveBeenCalled();
+  });
+
+  // An unknown `agentId` falls back to a real Agent, so reading the request would authorize the
+  // fallback's call under a name that names no Principal — an empty layer, and a blanket denial.
+  it("resolves the Agent layer for the Agent that was resolved, not the one requested", async () => {
+    const resolved: (string | undefined)[] = [];
+    const execute = vi.fn(async () => ok({}));
+    const registry = new InMemoryToolCatalog();
+    registry.register(gatedTool(execute));
+    const dispatcher = new RegistryToolDispatcher({
+      registry,
+      artifacts: fakeArtifacts({ agentId: "ghost" }) as unknown as ArtifactService,
+      gate: new LiveToolGate(),
+      agents: { resolve: () => ({ name: "fallback" }) },
+      authorityLayers: {
+        resolvePrincipalLayer: async (name) => ({ name, grants: ALLOW }),
+        resolveAgentLayer: async (_businessId, agentId): Promise<AuthorityLayer> => {
+          resolved.push(agentId);
+          return { name: "agent", grants: ALLOW };
+        },
+      },
+    });
+
+    const result = await dispatcher.dispatch(AUTHORITY, {
+      callId: "c1",
+      name: "echo",
+      arguments: { text: "hi" },
+    });
+
+    expect(result).toMatchObject({ status: "succeeded" });
+    expect(resolved).toEqual(["fallback"]);
+  });
+
+  // The stand-in for "this process composed no resolver" is not an Agent anyone configured, so it
+  // names no Principal; resolving a layer for it would deny every Tool in such a process.
+  it("resolves no Agent layer when the host composed no Agent at all", async () => {
+    const resolved: (string | undefined)[] = [];
+    const execute = vi.fn(async () => ok({}));
+    const registry = new InMemoryToolCatalog();
+    registry.register(gatedTool(execute));
+    const dispatcher = new RegistryToolDispatcher({
+      registry,
+      artifacts: fakeArtifacts() as unknown as ArtifactService,
+      gate: new LiveToolGate(),
+      authorityLayers: {
+        resolvePrincipalLayer: async (name) => ({ name, grants: ALLOW }),
+        resolveAgentLayer: async (_businessId, agentId): Promise<AuthorityLayer> => {
+          resolved.push(agentId);
+          return { name: "agent", grants: [] };
+        },
+      },
+    });
+
+    const result = await dispatcher.dispatch(AUTHORITY, {
+      callId: "c1",
+      name: "echo",
+      arguments: { text: "hi" },
+    });
+
+    expect(result).toMatchObject({ status: "succeeded" });
+    expect(resolved).toEqual([]);
   });
 
   it("refuses a subject kind the authority model does not know", async () => {

--- a/packages/tool-host/src/dispatcher.ts
+++ b/packages/tool-host/src/dispatcher.ts
@@ -50,6 +50,19 @@ import type { ParkableToolDef, RequestContext, ToolHostLogger } from "./types";
  */
 const DEFAULT_AGENT: HostedAgent = { name: "assistant" };
 
+/**
+ * The Principal whose authority layer bounds this call — the Agent that was actually resolved,
+ * never the one the request asked for. An unrecognised `agentId` falls back to a real Agent while
+ * the requested name stays unknown, so reading the request would authorize one identity under
+ * another's name and resolve an empty layer for it.
+ *
+ * `DEFAULT_AGENT` is the stand-in for "this process composed no resolver", not an Agent anyone
+ * configured, so it names no Principal and contributes no layer.
+ */
+function agentPrincipalIdOf(agent: HostedAgent): string | undefined {
+  return agent === DEFAULT_AGENT ? undefined : agent.name;
+}
+
 /** Executes one Tool call: allowlist, schema, gate, and context all come from the recorded Run. */
 
 export interface RegistryToolDispatcherOptions {
@@ -385,7 +398,7 @@ export class RegistryToolDispatcher implements TurnToolDispatcher {
     const verdict = await this.authorize(
       authority,
       agent.name,
-      request?.agentId ?? authority.agent?.name,
+      agentPrincipalIdOf(agent),
       definition,
       availableTools,
       call,

--- a/scripts/authz-lockout-safety.test.ts
+++ b/scripts/authz-lockout-safety.test.ts
@@ -171,6 +171,7 @@ describe("a deployment cannot lock itself out of its own authorization", () => {
 
     expect((await roles.listRoles(BUSINESS)).map((role) => role.id).sort()).toEqual([
       "admin",
+      "agent",
       "member",
       "owner",
     ]);
@@ -186,6 +187,7 @@ describe("a deployment cannot lock itself out of its own authorization", () => {
     const remaining = (await roles.listRoles(BUSINESS)).map((role) => role.id).sort();
     expect(remaining, "the reap took a bootstrap Role with it").toEqual([
       "admin",
+      "agent",
       "member",
       "owner",
     ]);


### PR DESCRIPTION
## Summary

- Every Tool call was denied for every Agent on every Surface. PR #692 added the Agent's own Principal as a third authority layer, but nothing ever created a Principal of kind `agent` — authority is an intersection (ADR `authorization-design` D9), so that layer resolved to `{ grants: [] }` and denied everything.
- Adds a bootstrap `agent` Role (deliberately wide — layer 3 is a ceiling; the caller layer and the Tool allowlist still bind) and provisions an Agent Principal plus its Role assignment on migration, on boot, on `soul.synced`, and at `agent_create`. A deployment that upgrades heals itself; no manual rows.
- The dispatcher now takes the Principal id from the *resolved* Agent rather than from `request.agentId`, so the gate can never authorize one identity while naming another.

## Test plan

- [x] `pnpm lint` (41 tasks)
- [x] `pnpm typecheck` (41 tasks)
- [x] `pnpm --filter @tulipfarm/api test` — 3706 tests / 326 files
- [x] `pnpm --filter @tulipfarm/worker test` — 518 tests / 47 files
- [x] `pnpm --filter @tulipfarm/tool-host test` — 149 tests / 9 files
- [x] `scripts/authz-lockout-safety.test.ts` — 8 tests