### PR TITLE
feat(agents): mint a permanent id for every Agent

### DIFF
--- a/apps/api/src/chat/system-prompt.test.ts
+++ b/apps/api/src/chat/system-prompt.test.ts
@@ -1,9 +1,11 @@
 import { assembleSystemPrompt } from "@tulipfarm/agent-runtime";
 import type { SoulAgent } from "@tulipfarm/soul";
+import { agentIdOf } from "@tulipfarm/soul";
 import { describe, expect, it } from "vitest";
 import { assembleAgentSystemPrompt } from "./system-prompt";
 
 const agent: SoulAgent = {
+  id: agentIdOf("test-agent", {}),
   name: "test-agent",
   frontmatter: { domain: "testing" },
   body: "You are a test agent.",

--- a/apps/api/src/chat/turn-helpers.test.ts
+++ b/apps/api/src/chat/turn-helpers.test.ts
@@ -1,3 +1,4 @@
+import { agentIdOf } from "@tulipfarm/soul";
 import type { ToolDef } from "@tulipfarm/tool-host";
 import { describe, expect, it } from "vitest";
 import { ToolRegistry } from "../broker/tool-adapter";
@@ -60,6 +61,7 @@ describe("allowedToolNamesFor / availableToolsFor excluded param", () => {
     registry.register(stubTool("record_delete", true));
 
     const available = availableToolsFor(registry, {
+      id: agentIdOf("reporter", {}),
       name: "reporter",
       frontmatter: {},
       body: "",

--- a/apps/api/src/internal/delivery-host.test.ts
+++ b/apps/api/src/internal/delivery-host.test.ts
@@ -13,6 +13,7 @@ import {
   textContent,
 } from "@tulipfarm/schema";
 import type { SoulAgent, SoulIntegration, SoulLoader } from "@tulipfarm/soul";
+import { agentIdOf } from "@tulipfarm/soul";
 import {
   DOMAIN_EVENTS,
   type IntegrationEventPayload,
@@ -396,7 +397,15 @@ describe("IngressDeliveryHost.attachChat", () => {
   // its Agent was configured with. The routed Agent now supplies both fields.
   it("carries the routed Agent's own autonomy into the derived chat request", async () => {
     const agents = new Map<string, SoulAgent>([
-      ["mutator", { name: "mutator", frontmatter: { autonomy: "approval-required" }, body: "" }],
+      [
+        "mutator",
+        {
+          id: agentIdOf("mutator", {}),
+          name: "mutator",
+          frontmatter: { autonomy: "approval-required" },
+          body: "",
+        },
+      ],
     ]);
     const { host, threads, conversations, artifacts } = await harness({ agents });
     conversations.push({

--- a/apps/api/src/internal/slack-home-projection.test.ts
+++ b/apps/api/src/internal/slack-home-projection.test.ts
@@ -1,3 +1,4 @@
+import { agentIdOf } from "@tulipfarm/soul";
 import { describe, expect, it, vi } from "vitest";
 import { SlackHomeProjectionService } from "./slack-home-projection";
 
@@ -73,6 +74,7 @@ describe("SlackHomeProjectionService", () => {
         list: () =>
           Array.from({ length: 7 }, (_, index) => ({
             name: `agent-${index}`,
+            id: agentIdOf(`agent-${index}`, {}),
             frontmatter: { label: `Agent ${index}` },
             body: "",
           })),

--- a/apps/api/src/platform/tools.test.ts
+++ b/apps/api/src/platform/tools.test.ts
@@ -10,6 +10,7 @@ import type {
   SoulSkill,
   SoulWriter,
 } from "@tulipfarm/soul";
+import { agentIdOf } from "@tulipfarm/soul";
 import { describe, expect, it, vi } from "vitest";
 import { delegateToAgentTool } from "./delegate-tool";
 import {
@@ -40,6 +41,7 @@ function makeBundledSkill(name: string, directory = `/bundled/core/${name}`): Bu
 function makeAgent(name: string, displayName?: string): SoulAgent {
   return {
     name,
+    id: agentIdOf(name, {}),
     frontmatter: displayName ? { name: displayName } : {},
     body: `# ${displayName ?? name}`,
   };

--- a/apps/api/src/soul/agents/name-conflict.test.ts
+++ b/apps/api/src/soul/agents/name-conflict.test.ts
@@ -1,4 +1,5 @@
 import type { GitSyncService, SoulAgent, SoulLoader, SoulWriter } from "@tulipfarm/soul";
+import { agentIdOf } from "@tulipfarm/soul";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AGENT_TOOLS, type AgentToolContext } from "./tools";
 
@@ -46,6 +47,7 @@ describe("agent_create refuses a duplicate Agent name in the Tool execution path
   // absent-slug precondition never fires and the duplicate lands silently.
   it("refuses a frontmatter label that duplicates an existing Agent, even when the slug is free", async () => {
     const existing: SoulAgent = {
+      id: agentIdOf("qa-20260819-0102-fullstaging-authtest", {}),
       name: "qa-20260819-0102-fullstaging-authtest",
       frontmatter: { label: EXISTING_LABEL },
       body: "original",
@@ -74,7 +76,14 @@ describe("agent_create refuses a duplicate Agent name in the Tool execution path
         body: "triage",
         frontmatter: { label: "Support Triage" },
       },
-      ctx([{ name: "support-triage", frontmatter: { label: "Support Triage" }, body: "old" }])
+      ctx([
+        {
+          id: agentIdOf("support-triage", {}),
+          name: "support-triage",
+          frontmatter: { label: "Support Triage" },
+          body: "old",
+        },
+      ])
     );
 
     expect(result).toMatchObject({ success: false, error: { code: "validation_error" } });
@@ -85,6 +94,7 @@ describe("agent_create refuses a duplicate Agent name in the Tool execution path
   // Without one the answer has nowhere to land, so every later Turn re-derives the same card.
   it("terminates on 'leave the existing Agent unchanged' without writing", async () => {
     const existing: SoulAgent = {
+      id: agentIdOf("support-triage", {}),
       name: "support-triage",
       frontmatter: { label: "Support Triage" },
       body: "old",
@@ -110,6 +120,7 @@ describe("agent_create refuses a duplicate Agent name in the Tool execution path
   // #463: and so must "update the existing one", in one call, with no second question.
   it("terminates on 'update the existing Agent' with a single write", async () => {
     const existing: SoulAgent = {
+      id: agentIdOf("support-triage", {}),
       name: "support-triage",
       frontmatter: { label: "Support Triage" },
       body: "old",
@@ -137,8 +148,18 @@ describe("agent_create refuses a duplicate Agent name in the Tool execution path
   // A decided call must never re-enter the undecided branch: answering the question once ends it.
   it("never re-refuses a call that already carries a decision", async () => {
     const agents: SoulAgent[] = [
-      { name: "support-triage", frontmatter: { label: "Support Triage" }, body: "old" },
-      { name: "other", frontmatter: { label: "Support Triage" }, body: "other" },
+      {
+        id: agentIdOf("support-triage", {}),
+        name: "support-triage",
+        frontmatter: { label: "Support Triage" },
+        body: "old",
+      },
+      {
+        id: agentIdOf("other", {}),
+        name: "other",
+        frontmatter: { label: "Support Triage" },
+        body: "other",
+      },
     ];
     for (const onExisting of ["keep", "update"] as const) {
       const first = await createTool.handler(
@@ -157,7 +178,14 @@ describe("agent_create refuses a duplicate Agent name in the Tool execution path
   it("still creates when nothing collides", async () => {
     const result = await createTool.handler(
       { name: "brand-new", body: "b", frontmatter: { label: "Brand New" } },
-      ctx([{ name: "support-triage", frontmatter: { label: "Support Triage" }, body: "old" }])
+      ctx([
+        {
+          id: agentIdOf("support-triage", {}),
+          name: "support-triage",
+          frontmatter: { label: "Support Triage" },
+          body: "old",
+        },
+      ])
     );
     expect(result).toMatchObject({ success: true, data: { name: "brand-new", created: true } });
     expect(soulWriter.apply).toHaveBeenCalledOnce();

--- a/apps/api/src/soul/agents/registry.test.ts
+++ b/apps/api/src/soul/agents/registry.test.ts
@@ -1,5 +1,5 @@
 import type { SoulAgent, SoulLoader } from "@tulipfarm/soul";
-import { DEFAULT_ASSISTANT_NAME } from "@tulipfarm/soul";
+import { agentIdOf, DEFAULT_ASSISTANT_NAME } from "@tulipfarm/soul";
 import { describe, expect, it } from "vitest";
 import { delegableToolNames, hostedAgentResolver } from "./registry";
 
@@ -10,7 +10,12 @@ function loaderWith(agents: readonly SoulAgent[]): SoulLoader {
 describe("hostedAgentResolver", () => {
   it("carries the Agent's authored autonomy so the dispatcher can bound the turn by it", () => {
     const loader = loaderWith([
-      { name: "mutator", frontmatter: { autonomy: "approval-required" }, body: "" },
+      {
+        id: agentIdOf("mutator", {}),
+        name: "mutator",
+        frontmatter: { autonomy: "approval-required" },
+        body: "",
+      },
     ]);
 
     expect(hostedAgentResolver(loader).resolve("mutator")).toMatchObject({
@@ -21,8 +26,8 @@ describe("hostedAgentResolver", () => {
 
   it("states no autonomy for an Agent that declares none, or declares nonsense", () => {
     const loader = loaderWith([
-      { name: "plain", frontmatter: {}, body: "" },
-      { name: "bogus", frontmatter: { autonomy: "banana" }, body: "" },
+      { id: agentIdOf("plain", {}), name: "plain", frontmatter: {}, body: "" },
+      { id: agentIdOf("bogus", {}), name: "bogus", frontmatter: { autonomy: "banana" }, body: "" },
     ]);
     const resolver = hostedAgentResolver(loader);
 
@@ -33,6 +38,7 @@ describe("hostedAgentResolver", () => {
   it("carries authored capability restrictions to the dispatcher", () => {
     const loader = loaderWith([
       {
+        id: agentIdOf("cleanup", {}),
         name: "cleanup",
         frontmatter: { capabilityRestrictions: { records: { actions: { deny: ["delete"] } } } },
         body: "",
@@ -62,7 +68,9 @@ describe("delegableToolNames", () => {
   ];
 
   it("leaves the delegation root untouched for an Agent with no restrictions", () => {
-    const loader = loaderWith([{ name: "plain", frontmatter: {}, body: "" }]);
+    const loader = loaderWith([
+      { id: agentIdOf("plain", {}), name: "plain", frontmatter: {}, body: "" },
+    ]);
 
     expect(delegableToolNames(loader, "plain", catalog)).toBeUndefined();
     expect(delegableToolNames(loader, undefined, catalog)).toBeUndefined();
@@ -71,6 +79,7 @@ describe("delegableToolNames", () => {
   it("narrows the delegation root to what a restricted Agent itself holds", () => {
     const loader = loaderWith([
       {
+        id: agentIdOf("reporter", {}),
         name: "reporter",
         frontmatter: { capabilityRestrictions: { tools: { allowMutating: false } } },
         body: "",

--- a/apps/api/src/soul/agents/routes.test.ts
+++ b/apps/api/src/soul/agents/routes.test.ts
@@ -1,5 +1,5 @@
 import type { GitSyncService, SoulAgent, SoulLoader } from "@tulipfarm/soul";
-import { makeSoulWriterDouble } from "@tulipfarm/soul";
+import { agentIdOf, makeSoulWriterDouble } from "@tulipfarm/soul";
 import type { PaginatedResult } from "@tulipfarm/storage";
 import type { FastifyInstance } from "fastify";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -72,6 +72,7 @@ function makeSoulLoader(agents: SoulAgent[]) {
 }
 
 const PLANNER: SoulAgent = {
+  id: agentIdOf("sprint-planner", {}),
   name: "sprint-planner",
   frontmatter: {
     label: "Sprint Planner",
@@ -164,7 +165,12 @@ describe("agents routes", () => {
     });
 
     it("omits capabilityRestrictions entirely for an agent that declares none", async () => {
-      const bare: SoulAgent = { name: "bare", frontmatter: {}, body: "x" };
+      const bare: SoulAgent = {
+        id: agentIdOf("bare", {}),
+        name: "bare",
+        frontmatter: {},
+        body: "x",
+      };
       const solo = await buildApp({
         sessionStore: store,
         userRepo,

--- a/apps/api/src/soul/agents/tools.test.ts
+++ b/apps/api/src/soul/agents/tools.test.ts
@@ -1,6 +1,6 @@
 import type { AgentCapabilityRestrictions } from "@tulipfarm/schema";
 import type { GitSyncService, SoulAgent, SoulLoader, SoulWriter } from "@tulipfarm/soul";
-import { SoulWriteError, type SoulWriteErrorCode } from "@tulipfarm/soul";
+import { agentIdOf, SoulWriteError, type SoulWriteErrorCode } from "@tulipfarm/soul";
 import { agentCapabilityDenial } from "@tulipfarm/tool-host";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { parse } from "yaml";
@@ -114,7 +114,9 @@ describe("agent_create", () => {
           {
             op: "put",
             target: { kind: "Agent", slug: "task-planner", definitionMode: "legacy" },
-            content: "You plan tasks.",
+            // The minted id makes every AGENT.md carry a frontmatter block, even one the caller
+            // authored no frontmatter for.
+            content: expect.stringMatching(/^---\nid: [0-9a-f-]{36}\n---\nYou plan tasks\.$/),
           },
         ],
         preconditions: [{ kind: "Agent", slug: "task-planner", state: "absent" }],
@@ -234,6 +236,7 @@ describe("agent_create", () => {
 
 describe("agent_update", () => {
   const existingAgent: SoulAgent = {
+    id: agentIdOf("task-planner", {}),
     name: "task-planner",
     frontmatter: { domain: "engineering" },
     body: "Old body.",
@@ -320,6 +323,7 @@ describe("agent_update", () => {
     // validates every write (legacy AGENT.md included), so a body-only update no longer bypasses
     // it: the tool forwards the merged content and lets a VALIDATION_FAILED surface as one.
     const legacy: SoulAgent = {
+      id: agentIdOf("task-planner", {}),
       name: "task-planner",
       frontmatter: { custom: "kept-as-is", autonomy: "legacy-bad" },
       body: "Old body.",
@@ -345,7 +349,14 @@ describe("agent_update", () => {
 
 describe("agent_get", () => {
   it("returns agent frontmatter and body", async () => {
-    const ctx = makeCtx([{ name: "reviewer", frontmatter: { domain: "eng" }, body: "Review." }]);
+    const ctx = makeCtx([
+      {
+        id: agentIdOf("reviewer", {}),
+        name: "reviewer",
+        frontmatter: { domain: "eng" },
+        body: "Review.",
+      },
+    ]);
     const res = await getTool.handler({ name: "reviewer" }, ctx);
     expect(res).toEqual({
       success: true,
@@ -377,8 +388,13 @@ describe("agent_list", () => {
 
   it("returns agents with name and frontmatter", async () => {
     const ctx = makeCtx([
-      { name: "planner", frontmatter: { domain: "tasks" }, body: "Plan." },
-      { name: "reviewer", frontmatter: {}, body: "Review." },
+      {
+        id: agentIdOf("planner", {}),
+        name: "planner",
+        frontmatter: { domain: "tasks" },
+        body: "Plan.",
+      },
+      { id: agentIdOf("reviewer", {}), name: "reviewer", frontmatter: {}, body: "Review." },
     ]);
     const res = await listTool.handler({}, ctx);
     expect(res.success).toBe(true);
@@ -397,7 +413,9 @@ describe("agent_delete", () => {
   });
 
   it("deletes the agent artifact through the write gateway", async () => {
-    const ctx = makeCtx([{ name: "task-planner", frontmatter: {}, body: "body" }]);
+    const ctx = makeCtx([
+      { id: agentIdOf("task-planner", {}), name: "task-planner", frontmatter: {}, body: "body" },
+    ]);
     const res = await deleteTool.handler({ name: "task-planner" }, ctx);
 
     expect(res).toEqual({ success: true, data: { name: "task-planner", deleted: true } });
@@ -418,7 +436,9 @@ describe("agent_delete", () => {
   });
 
   it("maps a gateway PRECONDITION_FAILED to not_found", async () => {
-    const ctx = makeCtx([{ name: "task-planner", frontmatter: {}, body: "body" }]);
+    const ctx = makeCtx([
+      { id: agentIdOf("task-planner", {}), name: "task-planner", frontmatter: {}, body: "body" },
+    ]);
     rejectApplyWith(ctx.soulWriter, "PRECONDITION_FAILED", 'Agent "task-planner" does not exist');
     const res = await deleteTool.handler({ name: "task-planner" }, ctx);
     expect(res).toMatchObject({ success: false, error: { code: "not_found" } });
@@ -537,6 +557,7 @@ describe("capability restrictions authored from chat", () => {
   it("keeps the restriction when an edit rewrites the frontmatter", async () => {
     const ctx = makeCtx([
       {
+        id: agentIdOf("reporter", {}),
         name: "reporter",
         frontmatter: { capabilityRestrictions: READ_ONLY_REPORTER },
         body: "body",
@@ -553,5 +574,106 @@ describe("capability restrictions authored from chat", () => {
 
     expect(res).toMatchObject({ success: true });
     expect(writtenFrontmatter(ctx.soulWriter).capabilityRestrictions).toEqual(READ_ONLY_REPORTER);
+  });
+});
+
+// ── the Agent's permanent id ──────────────────────────────────────────────────
+
+/**
+ * The id has to be written by the Tool, not by the model: it is what the Agent's Principal and its
+ * ownership rows key on, so a model that could set it could point one Agent's authority at another.
+ */
+describe("agent id", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+  it("mints one on create", async () => {
+    const ctx = makeCtx();
+    const res = await createTool.handler({ name: "task-planner", body: "b" }, ctx);
+
+    expect(res).toMatchObject({ success: true });
+    expect(writtenFrontmatter(ctx.soulWriter).id).toMatch(UUID);
+  });
+
+  it("mints a different one for each Agent", async () => {
+    const first = makeCtx();
+    await createTool.handler({ name: "one", body: "b" }, first);
+    const second = makeCtx();
+    await createTool.handler({ name: "two", body: "b" }, second);
+
+    expect(writtenFrontmatter(first.soulWriter).id).not.toBe(
+      writtenFrontmatter(second.soulWriter).id
+    );
+  });
+
+  it("never takes the id from create arguments", async () => {
+    const ctx = makeCtx();
+    const res = await createTool.handler(
+      {
+        name: "task-planner",
+        body: "b",
+        frontmatter: { id: "11111111-2222-3333-4444-555555555555" },
+      },
+      ctx
+    );
+
+    expect(res).toMatchObject({ success: true });
+    expect(writtenFrontmatter(ctx.soulWriter).id).not.toBe("11111111-2222-3333-4444-555555555555");
+  });
+
+  it("never takes the id from update arguments", async () => {
+    const existing = agentIdOf("task-planner", {});
+    const ctx = makeCtx([{ id: existing, name: "task-planner", frontmatter: {}, body: "old" }]);
+    const res = await updateTool.handler(
+      { name: "task-planner", frontmatter: { id: "11111111-2222-3333-4444-555555555555" } },
+      ctx
+    );
+
+    expect(res).toMatchObject({ success: true });
+    expect(writtenFrontmatter(ctx.soulWriter).id).toBe(existing);
+  });
+
+  it("carries the authored id through an update that rewrites the frontmatter", async () => {
+    const authored = "11111111-2222-3333-4444-555555555555";
+    const ctx = makeCtx([
+      { id: authored, name: "task-planner", frontmatter: { id: authored }, body: "old" },
+    ]);
+    const res = await updateTool.handler(
+      { name: "task-planner", frontmatter: { domain: "qa" } },
+      ctx
+    );
+
+    expect(res).toMatchObject({ success: true });
+    expect(writtenFrontmatter(ctx.soulWriter)).toEqual({ id: authored, domain: "qa" });
+  });
+
+  it("backfills the derived id for an Agent that predates the field", async () => {
+    const derived = agentIdOf("task-planner", {});
+    const ctx = makeCtx([{ id: derived, name: "task-planner", frontmatter: {}, body: "old" }]);
+    await updateTool.handler({ name: "task-planner", body: "new" }, ctx);
+
+    expect(writtenFrontmatter(ctx.soulWriter).id).toBe(derived);
+  });
+
+  it("keeps the existing Agent's id when onExisting=update replaces it", async () => {
+    const authored = "11111111-2222-3333-4444-555555555555";
+    const ctx = makeCtx([
+      {
+        id: authored,
+        name: "task-planner",
+        frontmatter: { id: authored, label: "Task Planner" },
+        body: "old",
+      },
+    ]);
+    const res = await createTool.handler(
+      { name: "task-planner", body: "new", onExisting: "update" },
+      ctx
+    );
+
+    expect(res).toMatchObject({ success: true, data: { created: false } });
+    expect(writtenFrontmatter(ctx.soulWriter).id).toBe(authored);
   });
 });

--- a/apps/api/src/soul/agents/tools.ts
+++ b/apps/api/src/soul/agents/tools.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { DEPLOYMENT_BUSINESS_ID } from "@tulipfarm/constants";
 import { ajv, TulipFarmValidationError, validateAgentFrontmatter } from "@tulipfarm/schema";
 import {
@@ -101,6 +102,16 @@ function agentTargets(args: unknown) {
 
 // Write-time meta-schema gate (VAL-V1-010). Returns a validation_error
 // result on invalid frontmatter, or null when it passes.
+/**
+ * Caller-supplied frontmatter with `id` removed. The field is owned by `putAgent`, and a model that
+ * sent one would otherwise be told its value failed a pattern it was never meant to author.
+ */
+function withoutId(frontmatter: Record<string, unknown>): Record<string, unknown> {
+  if (!("id" in frontmatter)) return frontmatter;
+  const { id: _discarded, ...rest } = frontmatter;
+  return rest;
+}
+
 function frontmatterError(frontmatter: Record<string, unknown>): ToolCallResult | null {
   try {
     validateAgentFrontmatter(frontmatter);
@@ -113,18 +124,26 @@ function frontmatterError(frontmatter: Record<string, unknown>): ToolCallResult 
   }
 }
 
-/** The one `AGENT.md` write both agent Tools take: the failing result, or `null` once committed. */
+/**
+ * The one `AGENT.md` write both agent Tools take: the failing result, or `null` once committed.
+ *
+ * `id` is written here rather than by either caller, so there is exactly one place the Agent's
+ * permanent identity can be set. It overwrites whatever the frontmatter carries: an id that came
+ * from Tool arguments would let a model re-point an Agent at another Agent's Principal and
+ * ownership rows by editing a field.
+ */
 async function putAgent(
   ctx: AgentToolContext,
   verb: "add" | "update",
   name: string,
+  id: string,
   frontmatter: Record<string, unknown>,
   body: string,
   onPrecondition: () => ToolCallResult
 ): Promise<ToolCallResult | null> {
   const actor = ctx.requestContext?.actor ?? SYSTEM_SOUL_COMMIT_ACTOR;
   try {
-    await ctx.soulWriter.apply(agentWriteRequest(verb, name, frontmatter, body, actor));
+    await ctx.soulWriter.apply(agentWriteRequest(verb, name, { ...frontmatter, id }, body, actor));
     // Same-Turn tools (e.g. routine_forge) read ctx.soulLoader.agents synchronously right after
     // this call; without a reload here they'd validate against the pre-write snapshot and reject
     // an agentRef this Turn just created.
@@ -184,7 +203,7 @@ const agentCreate = defineApiTool<AgentToolContext>({
     const {
       name,
       body,
-      frontmatter = {},
+      frontmatter: authored = {},
       onExisting,
     } = args as {
       name: string;
@@ -192,6 +211,7 @@ const agentCreate = defineApiTool<AgentToolContext>({
       frontmatter?: Record<string, unknown>;
       onExisting?: AgentExistingDecision;
     };
+    const frontmatter = withoutId(authored);
 
     if (!NAME_RE.test(name)) return err("validation_error", "invalid agent name");
 
@@ -222,8 +242,17 @@ const agentCreate = defineApiTool<AgentToolContext>({
 
     const created = plan.outcome === "create";
     const target = created ? name : plan.agent.name;
-    const failure = await putAgent(ctx, created ? "add" : "update", target, frontmatter, body, () =>
-      err("validation_error", "agent already exists")
+    // A replace keeps the existing Agent's id: its Principal, ownership rows and history all point
+    // at it, and a fresh id would orphan every one of them while the Agent still looks the same.
+    const id = created ? randomUUID() : plan.agent.id;
+    const failure = await putAgent(
+      ctx,
+      created ? "add" : "update",
+      target,
+      id,
+      frontmatter,
+      body,
+      () => err("validation_error", "agent already exists")
     );
     if (!failure && created) {
       if (ctx.teamAssets) await ctx.teamAssets.ensure("agent", target, ownershipOf(frontmatter));
@@ -270,11 +299,16 @@ const agentUpdate = defineApiTool<AgentToolContext>({
   requiresApproval: false,
   handler: async (args, ctx) => {
     if (!validateUpdate(args)) return err("validation_error", firstError(validateUpdate.errors));
-    const { name, body, frontmatter } = args as {
+    const {
+      name,
+      body,
+      frontmatter: authored,
+    } = args as {
       name: string;
       body?: string;
       frontmatter?: Record<string, unknown>;
     };
+    const frontmatter = authored === undefined ? undefined : withoutId(authored);
     if (body === undefined && frontmatter === undefined)
       return err("validation_error", "at least one of body or frontmatter must be provided");
 
@@ -304,7 +338,10 @@ const agentUpdate = defineApiTool<AgentToolContext>({
     const newBody = body ?? existing.body;
     const newFm = frontmatter ?? existing.frontmatter;
 
-    const failure = await putAgent(ctx, "update", name, newFm, newBody, () =>
+    // `existing.id` is the authored id, or the derived one for an Agent that predates the field.
+    // Writing the derived value here is the backfill: it pins the id at what every stored reference
+    // already holds, so this Agent's next rename no longer moves its identity.
+    const failure = await putAgent(ctx, "update", name, existing.id, newFm, newBody, () =>
       err("not_found", `agent not found: ${name}`)
     );
     return failure ?? ok({ name, frontmatter: newFm, body: newBody });

--- a/packages/schema/src/agent.ts
+++ b/packages/schema/src/agent.ts
@@ -73,8 +73,20 @@ const AgentCapabilityRestrictionsSchema = Type.Object(
   { additionalProperties: false }
 );
 
+/** UUID shape, matching what `randomUUID` mints and what `deriveDefinitionId` formats. */
+const AGENT_ID_PATTERN = "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$";
+
 export const AgentFrontmatterSchema = Type.Object(
   {
+    /**
+     * The Agent's permanent identity, minted on create and never rewritten. Optional because every
+     * Agent authored before this field existed has none, and the whole Soul tree is re-validated on
+     * every publication — requiring it would quarantine those Agents rather than migrate them. The
+     * loader supplies a derived id in its place; the next write persists it.
+     *
+     * Never taken from caller input: the writing Tools strip it and set it themselves.
+     */
+    id: Type.Optional(Type.String({ pattern: AGENT_ID_PATTERN })),
     label: Type.Optional(Type.String({ minLength: 1 })),
     domain: Type.Optional(Type.String({ minLength: 1 })),
     description: Type.Optional(Type.String({ minLength: 1 })),

--- a/packages/soul/src/agents/agent-id.test.ts
+++ b/packages/soul/src/agents/agent-id.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import type { SoulAgent } from "../types";
+import { agentIdOf, resolveAgentRef } from "./agent-id";
+
+function agent(name: string, frontmatter: Record<string, unknown> = {}): SoulAgent {
+  return { id: agentIdOf(name, frontmatter), name, frontmatter, body: "" };
+}
+
+describe("agentIdOf", () => {
+  it("takes the authored id when the frontmatter carries one", () => {
+    const authored = "11111111-2222-3333-4444-555555555555";
+    expect(agentIdOf("support-triage", { id: authored })).toBe(authored);
+  });
+
+  it("survives a rename once the id is authored", () => {
+    const frontmatter = { id: "11111111-2222-3333-4444-555555555555" };
+    expect(agentIdOf("support-triage", frontmatter)).toBe(agentIdOf("renamed", frontmatter));
+  });
+
+  it("derives a stable id for an Agent authored before the field existed", () => {
+    expect(agentIdOf("support-triage", {})).toBe(agentIdOf("support-triage", {}));
+    expect(agentIdOf("support-triage", {})).not.toBe(agentIdOf("other", {}));
+  });
+
+  it("ignores an id that is not a usable string", () => {
+    const derived = agentIdOf("support-triage", {});
+    for (const id of [42, "", null, undefined, {}]) {
+      expect(agentIdOf("support-triage", { id })).toBe(derived);
+    }
+  });
+});
+
+describe("resolveAgentRef", () => {
+  const support = agent("support-triage", { id: "11111111-2222-3333-4444-555555555555" });
+  const agents = new Map([[support.name, support]]);
+
+  it("resolves by id", () => {
+    expect(resolveAgentRef(agents, support.id)).toBe(support);
+  });
+
+  it("resolves by Soul slug, so references made before the id still work", () => {
+    expect(resolveAgentRef(agents, "support-triage")).toBe(support);
+  });
+
+  it("answers nothing for a reference naming neither", () => {
+    expect(resolveAgentRef(agents, "ghost")).toBeUndefined();
+  });
+
+  it("prefers the id when a different Agent has since taken the name", () => {
+    // `support-triage` was renamed to `triage`, and a new Agent took the freed name. A stored
+    // reference to the original must still reach it rather than the impostor holding its old name.
+    const renamed: SoulAgent = { ...support, name: "triage" };
+    const impostor = agent("support-triage", { id: "99999999-8888-7777-6666-555555555555" });
+    const both = new Map([
+      [impostor.name, impostor],
+      [renamed.name, renamed],
+    ]);
+    expect(resolveAgentRef(both, renamed.id)).toBe(renamed);
+  });
+});

--- a/packages/soul/src/agents/agent-id.ts
+++ b/packages/soul/src/agents/agent-id.ts
@@ -1,0 +1,33 @@
+import { deriveDefinitionId } from "../converters/shared";
+import type { SoulAgent } from "../types";
+
+/**
+ * An Agent's permanent id.
+ *
+ * `frontmatter.id` is the authored value, minted once by `agent_create` and carried forward by
+ * every later write. An Agent authored before that field existed has none, so the id is derived
+ * from the name instead — which is exactly what every Agent identifier in the database already is,
+ * so the fallback changes nothing while it lasts. The next write to that Agent persists the derived
+ * value into its frontmatter, and from then on the id no longer follows the name.
+ */
+export function agentIdOf(name: string, frontmatter: Record<string, unknown>): string {
+  const authored = frontmatter.id;
+  return typeof authored === "string" && authored.length > 0
+    ? authored
+    : deriveDefinitionId("Agent", name);
+}
+
+/**
+ * The Agent an external reference names, by id or by Soul slug.
+ *
+ * Both are accepted because the two identifiers coexist for as long as any stored reference
+ * predates the id: URLs, @-mentions and delegation all still carry the name. The id is tried first
+ * so a name that has since been taken by a *different* Agent cannot shadow the one actually meant.
+ */
+export function resolveAgentRef(
+  agents: ReadonlyMap<string, SoulAgent>,
+  ref: string
+): SoulAgent | undefined {
+  for (const agent of agents.values()) if (agent.id === ref) return agent;
+  return agents.get(ref);
+}

--- a/packages/soul/src/agents/platform-agents.ts
+++ b/packages/soul/src/agents/platform-agents.ts
@@ -1,3 +1,4 @@
+import { deriveDefinitionId } from "../converters/shared";
 import type { SoulAgent } from "../types";
 
 export const FORGE_SKILL_NAMES = [
@@ -71,7 +72,15 @@ Asked for a Resource type, Agent, Skill, Routine, Surface component, or first-ti
 - \`create_resource_type\` and \`agent_create\` commit immediately; do not ask for approval to edit those.
 - Never modify or remove an existing artifact unless the user asks for that change.`;
 
+/**
+ * Fixed, not minted: the default assistant is code-defined and exists on every deployment, so its
+ * identity must be the same everywhere. It is derived from the name like any pre-id Agent, but that
+ * name is a constant nothing can rename, so the derivation is stable rather than fragile here.
+ */
+export const DEFAULT_ASSISTANT_ID = deriveDefinitionId("Agent", DEFAULT_ASSISTANT_NAME);
+
 export const DEFAULT_ASSISTANT: PlatformAgent = {
+  id: DEFAULT_ASSISTANT_ID,
   name: DEFAULT_ASSISTANT_NAME,
   frontmatter: {
     label: "TulipFarm Assistant",

--- a/packages/soul/src/agents/registry.test.ts
+++ b/packages/soul/src/agents/registry.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { SoulLoader } from "../published-loader";
 import type { SoulAgent } from "../types";
+import { agentIdOf } from "./agent-id";
 import { DEFAULT_ASSISTANT, getAgent, listAgents, resolveAgent } from "./registry";
 
 function makeSoulLoader(agents: SoulAgent[] = []): SoulLoader {
@@ -8,6 +9,7 @@ function makeSoulLoader(agents: SoulAgent[] = []): SoulLoader {
 }
 
 const PLANNER: SoulAgent = {
+  id: agentIdOf("sprint-planner", {}),
   name: "sprint-planner",
   frontmatter: { label: "Sprint Planner", domain: "engineering" },
   body: "# Role\nYou plan sprints.",

--- a/packages/soul/src/catalogue.test.ts
+++ b/packages/soul/src/catalogue.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { agentIdOf } from "./agents/agent-id";
 import { buildSoulCatalogue } from "./catalogue";
 import type { RegistryEntry } from "./integrations/registry";
 import type { SoulLoader } from "./published-loader";
@@ -16,6 +17,7 @@ const skill = (name: string, frontmatter: Record<string, unknown> = {}): SoulSki
   body: "",
 });
 const agent = (name: string, description?: string): SoulAgent => ({
+  id: agentIdOf(name, {}),
   name,
   frontmatter: description ? { description } : {},
   body: "",

--- a/packages/soul/src/converters/agent.test.ts
+++ b/packages/soul/src/converters/agent.test.ts
@@ -1,5 +1,6 @@
 import { DEFINITION_REGISTRATIONS, SchemaRegistry } from "@tulipfarm/schema";
 import { describe, expect, it } from "vitest";
+import { agentIdOf } from "../agents/agent-id";
 import type { SoulAgent } from "../types";
 import { convertLegacyAgent } from "./agent";
 
@@ -13,6 +14,7 @@ function agentYaml(result: ReturnType<typeof convertLegacyAgent>): string {
 
 describe("convertLegacyAgent", () => {
   const validLegacy: SoulAgent = {
+    id: agentIdOf("Support Bot", {}),
     name: "Support Bot",
     frontmatter: {
       owner: "team-support",

--- a/packages/soul/src/converters/legacy-definitions.test.ts
+++ b/packages/soul/src/converters/legacy-definitions.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { agentIdOf } from "../agents/agent-id";
 import type { SoulAgent } from "../types";
 import { convertLegacyDefinitions } from "./legacy-definitions";
 
@@ -6,6 +7,7 @@ describe("convertLegacyDefinitions (batch)", () => {
   it("aggregates files and warnings across agents", () => {
     const agents: SoulAgent[] = [
       {
+        id: agentIdOf("Support Bot", {}),
         name: "Support Bot",
         frontmatter: {
           owner: "team-support",

--- a/packages/soul/src/index.ts
+++ b/packages/soul/src/index.ts
@@ -7,12 +7,14 @@ export type {
   PublishedAgentVersion,
 } from "./agent-publication";
 export { AgentPublicationError, publishAgentVersion } from "./agent-publication";
+export { agentIdOf, resolveAgentRef } from "./agents/agent-id";
 export { agentWriteRequest, serializeAgent } from "./agents/agent-write";
 export type { AgentExistingDecision, AgentNamePlan } from "./agents/name-conflict";
 export { AGENT_EXISTING_DECISIONS, resolveAgentName } from "./agents/name-conflict";
 export type { PlatformAgent } from "./agents/platform-agents";
 export {
   DEFAULT_ASSISTANT,
+  DEFAULT_ASSISTANT_ID,
   DEFAULT_ASSISTANT_NAME,
   FORGE_SKILL_NAMES,
   getDefaultAssistant,

--- a/packages/soul/src/published-loader.ts
+++ b/packages/soul/src/published-loader.ts
@@ -21,6 +21,7 @@ import {
   validateSoulSurfaceComponent,
 } from "@tulipfarm/surface";
 import { parse as parseYaml } from "yaml";
+import { agentIdOf } from "./agents/agent-id";
 import { readFrontmatterArtifact, resolveDefinition } from "./definition-reader";
 import { validateAuthSteps, validateIngressContextEnv } from "./integration-auth";
 import { readContainedFile } from "./safe-fs";
@@ -216,7 +217,7 @@ export class SoulLoader {
           name,
           definition
         );
-        map.set(name, { name, frontmatter, body });
+        map.set(name, { id: agentIdOf(name, frontmatter), name, frontmatter, body });
       } catch (err) {
         throw artifactLoadError("agent", name, err);
       }

--- a/packages/soul/src/types.ts
+++ b/packages/soul/src/types.ts
@@ -1,6 +1,12 @@
 import type { RoleDefinition } from "@tulipfarm/schema";
 
 export interface SoulAgent {
+  /**
+   * The Agent's permanent identity. It outlives the name, which the product lets a user change.
+   * Anything that must still point at this Agent after a rename — its Principal, its ownership
+   * rows — keys on this. Use `agentIdOf` to derive it; never read `frontmatter.id` directly.
+   */
+  id: string;
   name: string;
   frontmatter: Record<string, unknown>;
   body: string;


### PR DESCRIPTION
## Summary

- An Agent is identified by its name, which the product lets a user change, and `deriveDefinitionId` is a SHA-256 of that name. Rename an Agent and its Principal, its ownership rows and its authority are all orphaned — deny-all again, for that Agent.
- `SoulAgent.id` becomes the identity: taken from `AGENT.md` frontmatter when it carries one, derived from the name otherwise. The derived value is what every stored Agent identifier already is, so the fallback changes nothing while it lasts, and the next write persists it.
- `putAgent` is the only place the id is set — minted on create, carried forward on update. Caller-supplied values are stripped before validation and overwritten before the write, because a model that could author an id could point one Agent's authority at another Agent's Principal.

Nothing reads the id yet. Re-keying the Principal, `asset_ownership` and the nine columns that carry an Agent identifier is the follow-up.

The frontmatter field is optional on purpose: the whole Soul tree is re-validated on every publication, so a required field would quarantine every Agent authored before it existed rather than migrate them.

## Test plan

- [x] `pnpm lint` (41 tasks)
- [x] `pnpm typecheck` (41 tasks)
- [x] `pnpm --filter @tulipfarm/api test` — 3713 tests / 326 files
- [x] `pnpm --filter @tulipfarm/soul test` — 754 tests / 54 files
- [x] `pnpm --filter @tulipfarm/schema test` — 472 tests / 32 files
- [x] `pnpm --filter @tulipfarm/worker test` — 518 tests / 47 files
- [x] `pnpm eval` — 50 passed, 0 failed