### PR TITLE
feat(agents): key every Agent record on its permanent id

### DIFF
--- a/apps/api/src/chat/conversation-entry.ts
+++ b/apps/api/src/chat/conversation-entry.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import type { EventEmitter } from "node:events";
 import type { LlmService } from "@tulipfarm/llm";
 import type { SoulLoader } from "@tulipfarm/soul";
-import { DEFAULT_ASSISTANT_NAME, getAgent } from "@tulipfarm/soul";
+import { DEFAULT_ASSISTANT_ID, getAgent } from "@tulipfarm/soul";
 import { DOMAIN_EVENTS } from "@tulipfarm/storage";
 import type { FastifyBaseLogger } from "fastify";
 import type { ConversationDoc, ConversationRepo } from "./conversations";
@@ -56,7 +56,7 @@ export async function resolveConversationEntry(
     return {
       conversation,
       isNew: true,
-      agentId: conversation.agentId ?? DEFAULT_ASSISTANT_NAME,
+      agentId: conversation.agentId ?? DEFAULT_ASSISTANT_ID,
     };
   }
 
@@ -68,15 +68,14 @@ export async function resolveConversationEntry(
   // Sticky `@mention` hand-off: a mid-conversation mention re-targets the Agent until a
   // different mention. Unknown names are ignored — the composer only offers real Agents,
   // so persisting one would leave a dangling reference.
-  const currentAgentId = found.agentId ?? DEFAULT_ASSISTANT_NAME;
-  const mentioned =
-    body.agentId && body.agentId !== currentAgentId
-      ? getAgent(soulLoader, body.agentId)
-      : undefined;
-  if (mentioned) {
-    found.agentId = mentioned.name;
+  const currentAgentId = found.agentId ?? DEFAULT_ASSISTANT_ID;
+  // This is the edge that turns a handle into an identity: `body.agentId` is whatever the composer
+  // put in the `@mention`, a name, and what is stored from here on is the Agent's permanent id.
+  const mentioned = body.agentId ? getAgent(soulLoader, body.agentId) : undefined;
+  if (mentioned && mentioned.id !== currentAgentId) {
+    found.agentId = mentioned.id;
     try {
-      await repo.setAgent(found._id, mentioned.name);
+      await repo.setAgent(found._id, mentioned.id);
     } catch (err) {
       // Non-fatal: the turn still runs as the mentioned Agent, it just does not stick to the
       // conversation. Failing the request would be a worse answer to a transient database error.
@@ -85,7 +84,7 @@ export async function resolveConversationEntry(
   }
 
   await repo.touch(found._id);
-  return { conversation: found, isNew: false, agentId: found.agentId ?? DEFAULT_ASSISTANT_NAME };
+  return { conversation: found, isNew: false, agentId: found.agentId ?? DEFAULT_ASSISTANT_ID };
 }
 
 async function openConversation(
@@ -94,7 +93,7 @@ async function openConversation(
 ): Promise<ConversationDoc> {
   const now = new Date();
   const requested = input.body.agentId;
-  const agentId = requested && getAgent(deps.soulLoader, requested) ? requested : undefined;
+  const agentId = requested ? getAgent(deps.soulLoader, requested)?.id : undefined;
   const conversation: ConversationDoc = {
     _id: randomUUID(),
     userId: input.userId,

--- a/apps/api/src/chat/conversation-routes.ts
+++ b/apps/api/src/chat/conversation-routes.ts
@@ -70,6 +70,21 @@ export interface ConversationRoutesDeps {
   toolRegistry?: ToolRegistry;
 }
 
+/**
+ * The Agent handle a client sees for a Conversation, from the permanent id it stores.
+ *
+ * A Conversation records the id, which survives a rename; the product shows and links Agents by
+ * name. An id that resolves to nothing — the Agent was deleted — reports no Agent rather than a
+ * dangling identifier the UI would try to open.
+ */
+function agentHandle(
+  soulLoader: SoulLoader | undefined,
+  agentId: string | undefined
+): string | null {
+  if (agentId === undefined) return null;
+  return resolveAgent(soulLoader, agentId)?.name ?? null;
+}
+
 export function registerConversationRoutes(
   app: FastifyInstance,
   deps: ConversationRoutesDeps,
@@ -139,7 +154,7 @@ export function registerConversationRoutes(
         conversations: convos.map((c) => ({
           id: c._id,
           title: c.title ?? null,
-          agentId: c.agentId ?? null,
+          agentId: agentHandle(soulLoader, c.agentId),
           starred: c.starred ?? false,
           createdAt: c.createdAt,
           updatedAt: c.updatedAt,
@@ -215,7 +230,7 @@ export function registerConversationRoutes(
       return reply.send({
         id: updated._id,
         title: updated.title ?? null,
-        agentId: updated.agentId ?? null,
+        agentId: agentHandle(soulLoader, updated.agentId),
         starred: updated.starred ?? false,
         createdAt: updated.createdAt,
         updatedAt: updated.updatedAt,
@@ -293,7 +308,7 @@ export function registerConversationRoutes(
       return reply.send({
         id: convo._id,
         userId: convo.userId ?? null,
-        agentId: convo.agentId ?? null,
+        agentId: agentHandle(soulLoader, convo.agentId),
         model: convo.model ?? null,
         title: convo.title ?? null,
         starred: convo.starred ?? false,
@@ -423,6 +438,9 @@ export function registerConversationRoutes(
           return reply.code(404).send({ error: "conversation not found" });
         }
         const agent = resolveAgent(soulLoader, convo.agentId);
+        // The Conversation names an Agent this Soul no longer has. Previewing the default
+        // assistant's prompt under that Agent's name would misreport what the turn would run as.
+        if (agent === undefined) return reply.code(404).send({ error: "agent not found" });
         const systemPrompt = assembleAgentSystemPrompt({ agent });
         const soulReminder = await resolveSoulReminder({
           ...(authorityLayers === undefined ? {} : { authorityLayers }),

--- a/apps/api/src/chat/durable-submission.pg.test.ts
+++ b/apps/api/src/chat/durable-submission.pg.test.ts
@@ -19,6 +19,7 @@ import {
   canonicalHash,
   INVOCATION_REQUEST_SCHEMAS,
 } from "@tulipfarm/schema";
+import { DEFAULT_ASSISTANT_ID } from "@tulipfarm/soul";
 import type { PaginatedResult } from "@tulipfarm/storage";
 import {
   ArtifactStore,
@@ -311,7 +312,8 @@ describe("durable chat submission over HTTP", () => {
     );
     expect(artifact.rows).toHaveLength(1);
     expect(artifact.rows[0]?.id).toBe(`${runId}:request`);
-    const resolvedBody = { ...BODY, agentId: "__tulipfarm_default__" };
+    // The request Artifact records the Agent's permanent id, not the name the composer sent.
+    const resolvedBody = { ...BODY, agentId: DEFAULT_ASSISTANT_ID };
     expect(artifact.rows[0]?.content).toEqual(resolvedBody);
     expect(artifact.rows[0]?.content_hash).toBe(canonicalHash(resolvedBody));
 

--- a/apps/api/src/chat/routes.ts
+++ b/apps/api/src/chat/routes.ts
@@ -3,7 +3,7 @@ import { type FileService, isAttachmentRefusal, resolveAttachments } from "@tuli
 import type { LlmService } from "@tulipfarm/llm";
 import type { DurableInvocationGateway } from "@tulipfarm/run-kernel";
 import type { SoulLoader } from "@tulipfarm/soul";
-import { DEFAULT_ASSISTANT_NAME } from "@tulipfarm/soul";
+import { DEFAULT_ASSISTANT_ID, resolveAgent } from "@tulipfarm/soul";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { ErrorSchema } from "../auth/schemas";
 import { chatConversationService } from "../conversations/chat-turns";
@@ -23,6 +23,22 @@ import { type ChatBody, ChatBodySchema, corsPassthrough } from "./turn-helpers";
 import { durableTurnSubmitter } from "./turn-submit";
 
 type PreHandler = (req: FastifyRequest, reply: FastifyReply) => Promise<void>;
+
+/**
+ * The Agent name a client should see, from the id the Conversation stores.
+ *
+ * Identity is the id and stays the id everywhere inside; the name is the handle, and it is the
+ * handle the composer echoes back to the participant. Normal chat runs on the default harness,
+ * which is not a user-selected Agent, so it announces none.
+ */
+function headerFor(name: string, value: string | undefined): Record<string, string> {
+  return value === undefined ? {} : { [name]: value };
+}
+
+function agentHandle(soulLoader: SoulLoader | undefined, agentId: string): string | undefined {
+  if (agentId === DEFAULT_ASSISTANT_ID) return undefined;
+  return resolveAgent(soulLoader, agentId)?.name;
+}
 
 /** 409 body for a replayed request: the Run that already answers it, so the client can reattach. */
 const DuplicateInvocationSchema = {
@@ -217,7 +233,7 @@ export function registerChatRoutes(
         "X-Turn-Id": claim.turnId,
         "X-Conversation-Id": entry.conversation._id,
         // Only user-selected Soul Agents are exposed; normal chat has no Agent identity.
-        ...(entry.agentId === DEFAULT_ASSISTANT_NAME ? {} : { "X-Agent-Id": entry.agentId }),
+        ...headerFor("X-Agent-Id", agentHandle(options.soulLoader, entry.agentId)),
         ...corsPassthrough(reply),
       });
       reply.hijack();
@@ -285,7 +301,7 @@ export function registerChatRoutes(
 
       // The Agent is the Conversation's, never the body's: a retry re-runs the question that was
       // asked, and letting the client re-target it here would be an edit wearing a retry's name.
-      const agentId = conversation.agentId ?? DEFAULT_ASSISTANT_NAME;
+      const agentId = conversation.agentId ?? DEFAULT_ASSISTANT_ID;
       const conversations = chatConversationService(
         { store: options.conversationStore, invocations: options.invocations },
         {
@@ -317,7 +333,7 @@ export function registerChatRoutes(
         "X-Run-Id": runId,
         "X-Turn-Id": turnId,
         "X-Conversation-Id": turn.conversationId,
-        ...(agentId === DEFAULT_ASSISTANT_NAME ? {} : { "X-Agent-Id": agentId }),
+        ...headerFor("X-Agent-Id", agentHandle(options.soulLoader, agentId)),
         ...corsPassthrough(reply),
       });
       reply.hijack();

--- a/apps/api/src/identity/agent-identifiers.ts
+++ b/apps/api/src/identity/agent-identifiers.ts
@@ -1,0 +1,176 @@
+import { DEFAULT_ASSISTANT_ID, DEFAULT_ASSISTANT_NAME, type Logger } from "@tulipfarm/soul";
+import type { Queryable } from "../db";
+import type { SoulAgents } from "./agent-principals";
+
+/**
+ * A column holding an Agent identifier. Every one of them recorded the Agent's Soul *name*, which
+ * the product lets a user change — so a rename silently detached the row from the Agent it names.
+ */
+interface AgentIdentifierColumn {
+  readonly table: string;
+  readonly column: string;
+}
+
+/**
+ * Every column that carries an Agent identifier, and nothing else. Each is re-keyed onto the
+ * Agent's permanent id by {@link reconcileAgentIdentifiers}.
+ *
+ * Tables are created lazily by their owning repository rather than all at once, so each is probed
+ * before it is written: a deployment that has never used a feature has no table for it.
+ */
+const AGENT_IDENTIFIER_COLUMNS: readonly AgentIdentifierColumn[] = [
+  { table: "audit_events", column: "agent_id" },
+  { table: "conversations", column: "agent_id" },
+  { table: "channel_delivery_attempts", column: "agent_id" },
+  { table: "channel_run_deliveries", column: "agent_id" },
+  { table: "integration_routes", column: "agent_id" },
+  { table: "obs_event", column: "agent_id" },
+  { table: "tasks", column: "origin_agent_id" },
+  { table: "file_generation_drafts", column: "authored_by_agent_id" },
+  { table: "asset_ownership_approvals", column: "agent_principal_id" },
+];
+
+/**
+ * The children of `asset_ownership`, which reference it by `(business_id, asset_type, asset_id)`
+ * with no `ON UPDATE CASCADE`. They must move to the new id after the parent row exists under it
+ * and before the old parent row goes, or the foreign key refuses the move.
+ */
+const AGENT_ASSET_CHILD_TABLES: readonly string[] = [
+  "asset_owners",
+  "asset_team_shares",
+  "asset_ownership_operations",
+];
+
+function msg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+async function hasColumn(q: Queryable, table: string, column: string): Promise<boolean> {
+  const present = await q.query(
+    `SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = $1 AND column_name = $2`,
+    [table, column]
+  );
+  return present.rows.length > 0;
+}
+
+/**
+ * The rename each Agent needs: its old name-shaped identifier, and the permanent id replacing it.
+ *
+ * The default assistant is included because chat runs on it and it is not a Soul artifact, so no
+ * publication would ever rename its rows. An Agent whose stored identifier already equals its id
+ * yields nothing — that is what makes a second pass a no-op.
+ */
+function renames(soul: SoulAgents): ReadonlyMap<string, string> {
+  const out = new Map<string, string>([[DEFAULT_ASSISTANT_NAME, DEFAULT_ASSISTANT_ID]]);
+  for (const agent of soul.agents.values()) {
+    if (agent.name !== agent.id) out.set(agent.name, agent.id);
+  }
+  out.delete(DEFAULT_ASSISTANT_ID);
+  return out;
+}
+
+/**
+ * Re-key one Agent's Team-ownership rows, parent before children before the old parent.
+ *
+ * A straight `UPDATE` of `asset_ownership.asset_id` cannot work: its children hold the old value
+ * and their foreign key has no `ON UPDATE CASCADE`, so the update is refused. Copying the parent
+ * first gives the children somewhere to point, and the old parent is only removed once nothing
+ * references it. `ON CONFLICT DO NOTHING` makes a second pass — or a half-finished first one —
+ * settle on the rows already there.
+ */
+async function moveAssetOwnership(
+  q: Queryable,
+  businessId: string,
+  name: string,
+  id: string
+): Promise<void> {
+  const stale = await q.query(
+    `SELECT 1 FROM asset_ownership
+      WHERE business_id = $1 AND asset_type = 'agent' AND asset_id = $2`,
+    [businessId, name]
+  );
+  if (stale.rows.length === 0) return;
+
+  await q.query(
+    `INSERT INTO asset_ownership (business_id, asset_type, asset_id, revision, created_at)
+     SELECT business_id, asset_type, $3, revision, created_at
+       FROM asset_ownership
+      WHERE business_id = $1 AND asset_type = 'agent' AND asset_id = $2
+     ON CONFLICT DO NOTHING`,
+    [businessId, name, id]
+  );
+
+  for (const table of AGENT_ASSET_CHILD_TABLES) {
+    if (!(await hasColumn(q, table, "asset_id"))) continue;
+    await q.query(
+      `UPDATE ${table} SET asset_id = $1
+        WHERE business_id = $2 AND asset_type = 'agent' AND asset_id = $3`,
+      [id, businessId, name]
+    );
+  }
+  await q.query(
+    `DELETE FROM asset_ownership
+      WHERE business_id = $1 AND asset_type = 'agent' AND asset_id = $2`,
+    [businessId, name]
+  );
+}
+
+/**
+ * Move every stored Agent identifier from the Agent's name onto its permanent id.
+ *
+ * This is the cut-over half of keying Agents on an id: the writers already record whatever the
+ * request carried, and the request now carries an id, so only rows written before that switch
+ * still name an Agent by name. Running it at boot rather than as a schema migration is deliberate
+ * — the mapping is `name -> agent.id`, which only the loaded Soul can supply.
+ *
+ * Idempotent and per-table isolated: a table that does not exist is skipped, and a table that
+ * fails is logged rather than thrown, so one unmigratable feature cannot stop the deployment from
+ * booting with the rest re-keyed.
+ */
+export async function reconcileAgentIdentifiers(
+  q: Queryable,
+  soul: SoulAgents,
+  businessId: string,
+  logger?: Pick<Logger, "warn">
+): Promise<void> {
+  const mapping = renames(soul);
+  if (mapping.size === 0) return;
+
+  // Not scoped by business: several of these tables carry no `business_id`, and a deployment holds
+  // exactly one business (`DEPLOYMENT_BUSINESS_ID`), so the identifier alone selects its rows.
+
+  for (const { table, column } of AGENT_IDENTIFIER_COLUMNS) {
+    if (!(await hasColumn(q, table, column))) continue;
+    for (const [name, id] of mapping) {
+      try {
+        await q.query(`UPDATE ${table} SET ${column} = $1 WHERE ${column} = $2`, [id, name]);
+      } catch (err) {
+        logger?.warn(`[agents] could not re-key ${table}.${column} for "${name}": ${msg(err)}`);
+      }
+    }
+  }
+
+  if (await hasColumn(q, "asset_ownership", "asset_id")) {
+    for (const [name, id] of mapping) {
+      try {
+        await moveAssetOwnership(q, businessId, name, id);
+      } catch (err) {
+        logger?.warn(`[agents] could not re-key ownership of agent "${name}": ${msg(err)}`);
+      }
+    }
+  }
+
+  // Last, because everything above still had to find its rows under the old identifier. Deleting
+  // the name-keyed Principal cascades its Role assignment away with it.
+  for (const [name] of mapping) {
+    try {
+      await q.query(
+        `DELETE FROM principals WHERE business_id = $1 AND id = $2 AND kind = 'agent'`,
+        [businessId, name]
+      );
+    } catch (err) {
+      logger?.warn(`[agents] could not reap the name-keyed principal "${name}": ${msg(err)}`);
+    }
+  }
+}

--- a/apps/api/src/identity/agent-principals.test.ts
+++ b/apps/api/src/identity/agent-principals.test.ts
@@ -1,7 +1,11 @@
-import { DEFAULT_ASSISTANT_NAME, type SoulAgent } from "@tulipfarm/soul";
+import { agentIdOf, DEFAULT_ASSISTANT_ID, type SoulAgent } from "@tulipfarm/soul";
 import { InMemoryPrincipalRepo, InMemoryRoleRepo } from "@tulipfarm/storage";
 import { describe, expect, it } from "vitest";
-import { ensureAgentPrincipal, reconcileAgentPrincipals } from "./agent-principals";
+import {
+  ensureAgentPrincipal,
+  reconcileAgentPrincipals,
+  removeAgentPrincipal,
+} from "./agent-principals";
 import { AGENT_ROLE_ID } from "./roles";
 
 const BUSINESS = "business-1";
@@ -12,84 +16,98 @@ function repos() {
 }
 
 function soulAgent(name: string): SoulAgent {
-  return { name, frontmatter: {}, body: "" } as SoulAgent;
+  return { id: agentIdOf(name, {}), name, frontmatter: {}, body: "" } as SoulAgent;
 }
+
+const SUPPORT = soulAgent("support");
+const RESEARCH = soulAgent("research");
 
 describe("ensureAgentPrincipal", () => {
   it("registers the Agent as an active principal holding the agent Role", async () => {
     const { principals, roles } = repos();
 
-    await ensureAgentPrincipal({ principals, roles }, BUSINESS, "support");
+    await ensureAgentPrincipal({ principals, roles }, BUSINESS, SUPPORT.id);
 
-    expect(await principals.get(BUSINESS, "support")).toEqual({
-      id: "support",
+    expect(await principals.get(BUSINESS, SUPPORT.id)).toEqual({
+      id: SUPPORT.id,
       businessId: BUSINESS,
       kind: "agent",
       status: "active",
     });
-    expect(await roles.listAssignments(BUSINESS, "support", NOW)).toEqual([
-      { principalId: "support", roleId: AGENT_ROLE_ID, businessId: BUSINESS },
+    expect(await roles.listAssignments(BUSINESS, SUPPORT.id, NOW)).toEqual([
+      { principalId: SUPPORT.id, roleId: AGENT_ROLE_ID, businessId: BUSINESS },
     ]);
   });
 
   it("is idempotent, so publication and the sweeps can all call it", async () => {
     const { principals, roles } = repos();
 
-    await ensureAgentPrincipal({ principals, roles }, BUSINESS, "support");
-    await ensureAgentPrincipal({ principals, roles }, BUSINESS, "support");
+    await ensureAgentPrincipal({ principals, roles }, BUSINESS, SUPPORT.id);
+    await ensureAgentPrincipal({ principals, roles }, BUSINESS, SUPPORT.id);
 
-    expect(await roles.listAssignments(BUSINESS, "support", NOW)).toHaveLength(1);
+    expect(await roles.listAssignments(BUSINESS, SUPPORT.id, NOW)).toHaveLength(1);
+  });
+});
+
+describe("removeAgentPrincipal", () => {
+  it("retires the deleted Agent's principal so its authority outlives nothing", async () => {
+    const { principals, roles } = repos();
+    await ensureAgentPrincipal({ principals, roles }, BUSINESS, SUPPORT.id);
+
+    await removeAgentPrincipal({ principals, roles }, BUSINESS, SUPPORT.id);
+
+    expect(await principals.get(BUSINESS, SUPPORT.id)).toBeUndefined();
   });
 });
 
 describe("reconcileAgentPrincipals", () => {
-  it("provisions every Soul Agent and the built-in default assistant", async () => {
+  it("provisions every Soul Agent by its permanent id, and the built-in default assistant", async () => {
     const { principals, roles } = repos();
     const soul = {
       agents: new Map([
-        ["support", soulAgent("support")],
-        ["research", soulAgent("research")],
+        ["support", SUPPORT],
+        ["research", RESEARCH],
       ]),
     };
 
     await reconcileAgentPrincipals({ principals, roles }, soul, BUSINESS);
 
-    expect((await principals.list(BUSINESS)).map((principal) => principal.id)).toEqual([
-      DEFAULT_ASSISTANT_NAME,
-      "research",
-      "support",
-    ]);
+    expect(new Set((await principals.list(BUSINESS)).map((principal) => principal.id))).toEqual(
+      new Set([DEFAULT_ASSISTANT_ID, RESEARCH.id, SUPPORT.id])
+    );
   });
 
   it("repairs an Agent that predates provisioning without touching the others", async () => {
     const { principals, roles } = repos();
-    await ensureAgentPrincipal({ principals, roles }, BUSINESS, "support");
+    await ensureAgentPrincipal({ principals, roles }, BUSINESS, SUPPORT.id);
     const soul = {
       agents: new Map([
-        ["support", soulAgent("support")],
-        ["research", soulAgent("research")],
+        ["support", SUPPORT],
+        ["research", RESEARCH],
       ]),
     };
 
     await reconcileAgentPrincipals({ principals, roles }, soul, BUSINESS);
 
-    expect(await roles.listAssignments(BUSINESS, "research", NOW)).toHaveLength(1);
-    expect(await roles.listAssignments(BUSINESS, "support", NOW)).toHaveLength(1);
+    expect(await roles.listAssignments(BUSINESS, RESEARCH.id, NOW)).toHaveLength(1);
+    expect(await roles.listAssignments(BUSINESS, SUPPORT.id, NOW)).toHaveLength(1);
   });
 
   it("keeps going when one Agent cannot be provisioned", async () => {
     const { principals, roles } = repos();
     const warnings: string[] = [];
+    const broken = soulAgent("broken");
     const failing = {
       put: async (record: Parameters<InMemoryPrincipalRepo["put"]>[0]) => {
-        if (record.id === "broken") throw new Error("principal rejected");
+        if (record.id === broken.id) throw new Error("principal rejected");
         await principals.put(record);
       },
+      delete: (businessId: string, id: string) => principals.delete(businessId, id),
     };
     const soul = {
       agents: new Map([
-        ["broken", soulAgent("broken")],
-        ["research", soulAgent("research")],
+        ["broken", broken],
+        ["research", RESEARCH],
       ]),
     };
 
@@ -97,8 +115,8 @@ describe("reconcileAgentPrincipals", () => {
       warn: (message: string) => warnings.push(message),
     });
 
-    expect(await principals.get(BUSINESS, "research")).toBeDefined();
+    expect(await principals.get(BUSINESS, RESEARCH.id)).toBeDefined();
     expect(warnings).toHaveLength(1);
-    expect(warnings[0]).toContain("broken");
+    expect(warnings[0]).toContain(broken.id);
   });
 });

--- a/apps/api/src/identity/agent-principals.ts
+++ b/apps/api/src/identity/agent-principals.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_ASSISTANT_NAME, type Logger, type SoulAgent } from "@tulipfarm/soul";
+import { DEFAULT_ASSISTANT_ID, type Logger, type SoulAgent } from "@tulipfarm/soul";
 import type { PrincipalRepo, RoleRepo } from "@tulipfarm/storage";
 import { AGENT_ROLE_ID } from "./roles";
 
@@ -7,7 +7,7 @@ export interface SoulAgents {
 }
 
 export interface AgentPrincipalRepos {
-  readonly principals: Pick<PrincipalRepo, "put">;
+  readonly principals: Pick<PrincipalRepo, "put" | "delete">;
   readonly roles: Pick<RoleRepo, "assign">;
 }
 
@@ -23,6 +23,9 @@ function msg(err: unknown): string {
  * every caller rather than denying something specific — so provisioning is not an enhancement to
  * an Agent, it is the difference between an Agent that works and one that cannot act at all.
  * Idempotent, so publication, the boot sweep and the post-sync sweep can all call it.
+ *
+ * `agentId` is the Agent's permanent id, never its name: a rename must not strand the Principal
+ * that carries the Agent's authority, nor mint a second one under the new name.
  */
 export async function ensureAgentPrincipal(
   repos: AgentPrincipalRepos,
@@ -34,11 +37,26 @@ export async function ensureAgentPrincipal(
 }
 
 /**
+ * Retire a deleted Agent's Principal, and with it — by the `role_assignments` cascade — its Role.
+ *
+ * Left behind, the pair is an authority with no Agent to exercise it. That is harmless only while
+ * every Agent holds the same Role and nothing routes a call to a deleted id, and it stops being
+ * harmless the moment Roles differ or an id is reachable again.
+ */
+export async function removeAgentPrincipal(
+  repos: AgentPrincipalRepos,
+  businessId: string,
+  agentId: string
+): Promise<void> {
+  await repos.principals.delete(businessId, agentId);
+}
+
+/**
  * Provision a Principal for every Agent a turn can route to.
  *
- * `DEFAULT_ASSISTANT_NAME` is included because normal chat runs on it and it is not a Soul
- * artifact, so no publication would ever create it. Failures are logged per Agent rather than
- * thrown: one unprovisionable Agent must not stop the rest from being repaired.
+ * `DEFAULT_ASSISTANT_ID` is included because normal chat runs on it and it is not a Soul artifact,
+ * so no publication would ever create it. Failures are logged per Agent rather than thrown: one
+ * unprovisionable Agent must not stop the rest from being repaired.
  */
 export async function reconcileAgentPrincipals(
   repos: AgentPrincipalRepos,
@@ -46,7 +64,8 @@ export async function reconcileAgentPrincipals(
   businessId: string,
   logger?: Pick<Logger, "warn">
 ): Promise<void> {
-  for (const agentId of [DEFAULT_ASSISTANT_NAME, ...soul.agents.keys()]) {
+  const ids = [DEFAULT_ASSISTANT_ID, ...[...soul.agents.values()].map((agent) => agent.id)];
+  for (const agentId of ids) {
     try {
       await ensureAgentPrincipal(repos, businessId, agentId);
     } catch (err) {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -177,7 +177,12 @@ import { registerGuardrailsReload } from "./guardrails/reload";
 import { createHookExecutor } from "./hooks/executor";
 import { PgRawPayloadVault } from "./hooks/raw-payload-vault";
 import { webhookSecretPort } from "./hooks/secret-port";
-import { ensureAgentPrincipal, reconcileAgentPrincipals } from "./identity/agent-principals";
+import { reconcileAgentIdentifiers } from "./identity/agent-identifiers";
+import {
+  ensureAgentPrincipal,
+  reconcileAgentPrincipals,
+  removeAgentPrincipal,
+} from "./identity/agent-principals";
 import { PgApiClientRepo } from "./identity/api-clients";
 import { buildApiAuthorityLayerResolver } from "./identity/authority-layers";
 import { channelBindKeyResolver } from "./identity/channel-link";
@@ -588,6 +593,10 @@ async function boot() {
       DEPLOYMENT_BUSINESS_ID,
       console
     );
+    // After the Principals exist under the new ids, never before: every row this moves is found by
+    // the Agent's old name, and the last thing it does is reap the name-keyed Principal the rows
+    // used to point at.
+    await reconcileAgentIdentifiers(pool, soulLoader, DEPLOYMENT_BUSINESS_ID, console);
     const rateLimiter = new PgRateLimiter(pool);
     const invocationValidator = new TypedOutputValidator(RUN_ARTIFACT_SCHEMAS);
     // Same root the Worker derives, so a blob-backed Run Artifact written by either process is
@@ -660,7 +669,8 @@ async function boot() {
     const feedbackRepo = new FeedbackRepo(pool);
     const surfaceArtifactStore = new PgSurfaceArtifactStore(pool);
     const surfaceActionStore = new PgSurfaceActionStore(pool);
-    const obsRepo = new PgObsRepo(pool);
+    // Given the Soul so spend rows can report Agent names; the events themselves store ids.
+    const obsRepo = new PgObsRepo(pool, soulLoader);
     const observabilityService = new ObservabilityService(obsRepo);
     // One reader for both the operational API and the `routine_run_*` Tools, so what an Agent
     // reports about a Run and what the Run inspector shows can never disagree.
@@ -1129,6 +1139,16 @@ async function boot() {
               );
             }
           ),
+        removePrincipal: (agentId) =>
+          removeAgentPrincipal(agentPrincipalRepos, DEPLOYMENT_BUSINESS_ID, agentId).catch(
+            (err) => {
+              app.log.error(
+                `[agents] could not retire principal for "${agentId}" — ${
+                  err instanceof Error ? err.message : String(err)
+                }`
+              );
+            }
+          ),
       },
       skillTools: { ...skillTools, hiddenSkillNames, teamAssets },
       github: githubTools,
@@ -1198,6 +1218,7 @@ async function boot() {
         // Tools that require one are filtered out here rather than refused at dispatch.
         agentTools: (agentName) => {
           const agent = resolveAgent(soulLoader, agentName);
+          if (agent === undefined) return [];
           const toolAgent = toolAgentFor(getDefaultAssistant(agent.name), agent);
           const allowed = allowedToolNamesFor(toolRegistry, toolAgent);
           return (toolRegistry?.getAll() ?? [])

--- a/apps/api/src/integrations/routes.test.ts
+++ b/apps/api/src/integrations/routes.test.ts
@@ -5,7 +5,7 @@ import type {
   SoulIntegration,
   SoulLoader,
 } from "@tulipfarm/soul";
-import { makeSoulWriterDouble } from "@tulipfarm/soul";
+import { agentIdOf, makeSoulWriterDouble } from "@tulipfarm/soul";
 import type { PaginatedResult } from "@tulipfarm/storage";
 import type { FastifyInstance } from "fastify";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -131,6 +131,8 @@ describe("integrations routes", () => {
   let reload: ReturnType<typeof vi.fn>;
   let soulIntegrations: Map<string, SoulIntegration>;
   let soulLoader: SoulLoader;
+  const AGENT_1_ID = agentIdOf("agent-1", {});
+  const AGENT_2_ID = agentIdOf("agent-2", {});
   let secretsService: FakeSecretsService;
   let bundledIntegrations: Map<string, BundledIntegration>;
   let integrationStore: FakeIntegrationStore;
@@ -167,8 +169,8 @@ describe("integrations routes", () => {
 
     soulIntegrations = new Map();
     const soulAgents = new Map([
-      ["agent-1", { name: "agent-1" }],
-      ["agent-2", { name: "agent-2" }],
+      ["agent-1", { id: AGENT_1_ID, name: "agent-1" }],
+      ["agent-2", { id: AGENT_2_ID, name: "agent-2" }],
     ]);
     soulLoader = {
       integrations: soulIntegrations,
@@ -693,8 +695,9 @@ describe("integrations routes", () => {
         externalTenantId: "T123",
         businessId: "biz-1",
       });
+      // The bind request names the Agent by its handle; the route stores its permanent id.
       expect(integrationStore.routes[0]).toMatchObject({
-        agentId: "agent-1",
+        agentId: AGENT_1_ID,
         businessId: "biz-1",
       });
     });
@@ -727,7 +730,7 @@ describe("integrations routes", () => {
       expect(integrationStore.apps).toHaveLength(1);
       expect(integrationStore.integrations).toHaveLength(1);
       expect(integrationStore.routes).toHaveLength(1);
-      expect(integrationStore.routes[0]).toMatchObject({ agentId: "agent-2" });
+      expect(integrationStore.routes[0]).toMatchObject({ agentId: AGENT_2_ID });
     });
   });
 });

--- a/apps/api/src/integrations/slack-binding.ts
+++ b/apps/api/src/integrations/slack-binding.ts
@@ -1,6 +1,6 @@
 import type { SecretsService } from "@tulipfarm/secrets";
 import type { SoulLoader } from "@tulipfarm/soul";
-import { DEFAULT_ASSISTANT_NAME } from "@tulipfarm/soul";
+import { DEFAULT_ASSISTANT_ID, getAgent } from "@tulipfarm/soul";
 import type { IntegrationStore } from "@tulipfarm/storage";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { ErrorSchema } from "../auth/schemas";
@@ -142,7 +142,7 @@ export async function ensureDefaultSlackRoute(deps: SlackBindDeps): Promise<void
     id: routeId,
     businessId: deps.businessId,
     integrationId,
-    agentId: DEFAULT_ASSISTANT_NAME,
+    agentId: DEFAULT_ASSISTANT_ID,
     channelId: null,
     threadId: null,
     eventTypes: ["message"],
@@ -197,7 +197,10 @@ export function registerSlackBindRoute(app: FastifyInstance, deps: SlackBindDeps
     },
     async (req, reply) => {
       const { agentId, channelId } = req.body as { agentId: string; channelId?: string };
-      if (!deps.soulLoader.agents.get(agentId)) {
+      // The request carries the Agent's handle; the route stores its permanent id, so a later
+      // rename cannot detach the binding from the Agent it names.
+      const agent = getAgent(deps.soulLoader, agentId);
+      if (agent === undefined) {
         return reply.code(400).send({ error: `agent not found: ${agentId}` });
       }
 
@@ -230,7 +233,7 @@ export function registerSlackBindRoute(app: FastifyInstance, deps: SlackBindDeps
         id: routeId,
         businessId: deps.businessId,
         integrationId,
-        agentId,
+        agentId: agent.id,
         channelId: channelId ?? null,
         threadId: null,
         eventTypes: ["message"],

--- a/apps/api/src/internal/delivery-host.ts
+++ b/apps/api/src/internal/delivery-host.ts
@@ -436,7 +436,7 @@ export class IngressDeliveryHost {
     const agentId = conversation?.agentId;
     if (agentId === undefined) return {};
     const autonomy = asChatAutonomy(
-      resolveAgent(this.options.soulLoader, agentId).frontmatter.autonomy
+      resolveAgent(this.options.soulLoader, agentId)?.frontmatter.autonomy
     );
     return { agentId, ...(autonomy === undefined ? {} : { autonomy }) };
   }

--- a/apps/api/src/internal/routes.ts
+++ b/apps/api/src/internal/routes.ts
@@ -21,6 +21,7 @@ const DENIAL_STATUS: Readonly<Record<TurnHost.TurnAuthorityDenial, number>> = {
   run_not_found: 404,
   run_not_running: 409,
   turn_not_found: 404,
+  agent_not_found: 404,
 };
 
 const DELIVERY_DENIAL_STATUS: Readonly<Record<DeliveryHost.DeliveryDenial, number>> = {

--- a/apps/api/src/internal/turn-context.ts
+++ b/apps/api/src/internal/turn-context.ts
@@ -195,6 +195,9 @@ export class ChatTurnContextResolver implements TurnContextResolver {
     const authority: ChatTurnAuthority = { ...turnAuthority, turn };
     const request = await readChatRequest(this.options.artifacts, authority, this.now());
     const agent = resolveAgent(this.options.soulLoader, request.agentId);
+    // The Turn names an Agent this Soul does not have. Assembling the default assistant's Context
+    // for it would run the turn as somebody else, so the Turn fails instead.
+    if (agent === undefined) throw new TurnAuthorityError("agent_not_found");
     const platformAgent = getDefaultAssistant(agent.name);
     const toolAgent = toolAgentFor(platformAgent, agent);
     const presentationContext = await presentationContextForAuthority(
@@ -382,7 +385,7 @@ export class ChatTurnContextResolver implements TurnContextResolver {
    */
   private async authorizeModelSelector(
     authority: ChatTurnAuthority,
-    agent: ReturnType<typeof resolveAgent>,
+    agent: NonNullable<ReturnType<typeof resolveAgent>>,
     request: ChatRequestPayload
   ): Promise<string> {
     const selector = resolveModelSelector(request);

--- a/apps/api/src/internal/turn-host.ts
+++ b/apps/api/src/internal/turn-host.ts
@@ -29,7 +29,11 @@ export interface HostedRunReader {
   } | null>;
 }
 
-export type TurnAuthorityDenial = "run_not_found" | "run_not_running" | "turn_not_found";
+export type TurnAuthorityDenial =
+  | "run_not_found"
+  | "run_not_running"
+  | "turn_not_found"
+  | "agent_not_found";
 
 export class TurnAuthorityError extends Error {
   readonly name = "TurnAuthorityError";

--- a/apps/api/src/observability/repo.ts
+++ b/apps/api/src/observability/repo.ts
@@ -1,4 +1,9 @@
-import { DEFAULT_ASSISTANT, DEFAULT_ASSISTANT_NAME } from "@tulipfarm/soul";
+import {
+  DEFAULT_ASSISTANT,
+  DEFAULT_ASSISTANT_ID,
+  resolveAgent,
+  type SoulLoader,
+} from "@tulipfarm/soul";
 import type { Queryable } from "../db";
 
 export type ObsEventType = "llm_call" | "tool_call" | "turn" | "job";
@@ -109,18 +114,24 @@ const numOrNull = (v: unknown): number | null => (v == null ? null : Number(v));
 const iso = (v: unknown): string => (v instanceof Date ? v.toISOString() : String(v));
 
 /**
- * Friendly label for a spend-by-agent row. The code-defined default assistant is stored under its
- * internal identity (`DEFAULT_ASSISTANT_NAME`), which must never leak to the dashboard; a call
- * with no agent attribution (a built-in/system task) reads as "System" rather than "(unknown)".
+ * Friendly label for a spend-by-agent row. Events store the Agent's permanent id, which is an
+ * opaque uuid and must never reach the dashboard; it is projected back to the Agent's name here,
+ * the same way Chat projects it. The code-defined default assistant is stored under
+ * `DEFAULT_ASSISTANT_ID`, and a call with no Agent attribution (a built-in or system task) reads
+ * as "System" rather than "(unknown)". An id the Soul no longer has keeps the id, because the
+ * spend it accounts for still happened and dropping the row would understate the total.
  */
-function agentLabel(agentId: string | null): string {
+function agentLabel(agentId: string | null, soulLoader: Pick<SoulLoader, "agents"> | undefined) {
   if (agentId == null) return "System";
-  if (agentId === DEFAULT_ASSISTANT_NAME) return DEFAULT_ASSISTANT.frontmatter.label as string;
-  return agentId;
+  if (agentId === DEFAULT_ASSISTANT_ID) return DEFAULT_ASSISTANT.frontmatter.label as string;
+  return resolveAgent(soulLoader as SoulLoader | undefined, agentId)?.name ?? agentId;
 }
 
 export class PgObsRepo implements ObsRepo {
-  constructor(private readonly q: Queryable) {}
+  constructor(
+    private readonly q: Queryable,
+    private readonly soulLoader?: Pick<SoulLoader, "agents">
+  ) {}
 
   async insert(row: ObsEventRow): Promise<void> {
     await this.q.query(
@@ -268,7 +279,10 @@ export class PgObsRepo implements ObsRepo {
       }),
       byAgent: byAgent.rows.map((r) => {
         const row = r as Record<string, unknown>;
-        return { agentId: agentLabel(row.agent as string | null), cost: num(row.cost) };
+        return {
+          agentId: agentLabel(row.agent as string | null, this.soulLoader),
+          cost: num(row.cost),
+        };
       }),
       byMember: byMember.rows.map((r) => {
         const row = r as Record<string, unknown>;

--- a/apps/api/src/soul/agents/registry.test.ts
+++ b/apps/api/src/soul/agents/registry.test.ts
@@ -1,5 +1,5 @@
 import type { SoulAgent, SoulLoader } from "@tulipfarm/soul";
-import { agentIdOf, DEFAULT_ASSISTANT_NAME } from "@tulipfarm/soul";
+import { agentIdOf, DEFAULT_ASSISTANT_ID, DEFAULT_ASSISTANT_NAME } from "@tulipfarm/soul";
 import { describe, expect, it } from "vitest";
 import { delegableToolNames, hostedAgentResolver } from "./registry";
 
@@ -51,11 +51,32 @@ describe("hostedAgentResolver", () => {
     });
   });
 
-  it("falls back to the default harness, which declares no ceiling", () => {
-    const resolved = hostedAgentResolver(loaderWith([])).resolve("missing");
+  it("resolves the default harness when a turn selected no Agent", () => {
+    const resolved = hostedAgentResolver(loaderWith([])).resolve(undefined);
 
     expect(resolved.name).toBe(DEFAULT_ASSISTANT_NAME);
+    expect(resolved.principalId).toBe(DEFAULT_ASSISTANT_ID);
     expect(resolved.autonomy).toBeUndefined();
+  });
+
+  it("reports a reference the Soul does not have, rather than substituting the default", () => {
+    const resolved = hostedAgentResolver(loaderWith([])).resolve("missing");
+
+    expect(resolved.unresolvedRef).toBe("missing");
+    expect(resolved.principalId).toBeUndefined();
+  });
+
+  it("carries the Agent's permanent id as the Principal the dispatcher authorizes by", () => {
+    const planner: SoulAgent = {
+      id: agentIdOf("planner", {}),
+      name: "planner",
+      frontmatter: {},
+      body: "",
+    };
+
+    expect(hostedAgentResolver(loaderWith([planner])).resolve("planner").principalId).toBe(
+      planner.id
+    );
   });
 });
 

--- a/apps/api/src/soul/agents/registry.ts
+++ b/apps/api/src/soul/agents/registry.ts
@@ -5,6 +5,7 @@ import {
 } from "@tulipfarm/run-kernel";
 import type { AgentCapabilityRestrictions } from "@tulipfarm/schema";
 import {
+  getAgent,
   getDefaultAssistant,
   resolveAgent,
   routineDefinitionReferences,
@@ -31,6 +32,9 @@ export function hostedAgentResolver(soulLoader: SoulLoader | undefined): AgentRe
   return {
     resolve(agentId?: string): HostedAgent {
       const agent = resolveAgent(soulLoader, agentId);
+      // Refused, not substituted: an `agentId` the Soul does not have must never run on the
+      // default assistant's authority. The dispatcher denies the call on this marker.
+      if (agent === undefined) return { name: agentId ?? "", unresolvedRef: agentId ?? "" };
       const allowlist = getDefaultAssistant(agent.name)?.toolAllowlist;
       const autonomy = asChatAutonomy(agent.frontmatter.autonomy);
       const capabilityRestrictions = agent.frontmatter.capabilityRestrictions as
@@ -38,6 +42,7 @@ export function hostedAgentResolver(soulLoader: SoulLoader | undefined): AgentRe
         | undefined;
       return {
         name: agent.name,
+        principalId: agent.id,
         ...(allowlist === undefined ? {} : { toolAllowlist: allowlist }),
         ...(autonomy === undefined ? {} : { autonomy }),
         ...(capabilityRestrictions === undefined ? {} : { capabilityRestrictions }),
@@ -139,7 +144,7 @@ export function delegableToolNames(
   const restrictions =
     agentId === undefined
       ? undefined
-      : (soulLoader?.agents.get(agentId)?.frontmatter.capabilityRestrictions as
+      : (getAgent(soulLoader, agentId)?.frontmatter.capabilityRestrictions as
           | AgentCapabilityRestrictions
           | undefined);
   if (restrictions === undefined) return undefined;

--- a/apps/api/src/soul/agents/tools.ts
+++ b/apps/api/src/soul/agents/tools.ts
@@ -43,6 +43,8 @@ export interface AgentToolContext {
    * degraded Agent to be repaired by the next sweep, never a failed create the model should retry.
    */
   ensurePrincipal?: (agentId: string) => Promise<void>;
+  /** Retires a deleted Agent's Principal and its Role assignment. */
+  removePrincipal?: (agentId: string) => Promise<void>;
 }
 
 function ownershipOf(frontmatter: Record<string, unknown>) {
@@ -230,7 +232,7 @@ const agentCreate = defineApiTool<AgentToolContext>({
       try {
         await ctx.teamAssets.require(
           "agent",
-          plan.agent.name,
+          plan.agent.id,
           principal,
           "edit",
           ownershipOf(plan.agent.frontmatter)
@@ -255,8 +257,8 @@ const agentCreate = defineApiTool<AgentToolContext>({
       () => err("validation_error", "agent already exists")
     );
     if (!failure && created) {
-      if (ctx.teamAssets) await ctx.teamAssets.ensure("agent", target, ownershipOf(frontmatter));
-      await ctx.ensurePrincipal?.(target);
+      if (ctx.teamAssets) await ctx.teamAssets.ensure("agent", id, ownershipOf(frontmatter));
+      await ctx.ensurePrincipal?.(id);
     }
     return failure ?? ok({ name: target, created, changed: true, frontmatter, body });
   },
@@ -320,7 +322,7 @@ const agentUpdate = defineApiTool<AgentToolContext>({
       try {
         await ctx.teamAssets.require(
           "agent",
-          name,
+          existing.id,
           principal,
           "edit",
           ownershipOf(existing.frontmatter)
@@ -385,7 +387,7 @@ const agentGet = defineApiTool<AgentToolContext>({
       try {
         await ctx.teamAssets.require(
           "agent",
-          name,
+          agent.id,
           principal,
           "view",
           ownershipOf(agent.frontmatter)
@@ -435,7 +437,7 @@ const agentList = defineApiTool<AgentToolContext>({
                   agent,
                   access: await ctx.teamAssets?.access(
                     "agent",
-                    agent.name,
+                    agent.id,
                     principal,
                     ownershipOf(agent.frontmatter)
                   ),
@@ -487,7 +489,8 @@ const agentDelete = defineApiTool<AgentToolContext>({
       ownershipOperationId?: string;
     };
 
-    if (!ctx.soulLoader.agents.has(name)) return err("not_found", `agent not found: ${name}`);
+    const existing = ctx.soulLoader.agents.get(name);
+    if (!existing) return err("not_found", `agent not found: ${name}`);
     if (ctx.teamAssets) {
       if (!ownershipOperationId) {
         return err("write_denied", "Agent deletion requires unanimous owner Approval");
@@ -495,7 +498,7 @@ const agentDelete = defineApiTool<AgentToolContext>({
       try {
         await ctx.teamAssets.consumeLifecycleApproval(
           "agent",
-          name,
+          existing.id,
           "delete",
           ownershipOperationId
         );
@@ -519,7 +522,10 @@ const agentDelete = defineApiTool<AgentToolContext>({
       return err("internal_error", reason(e));
     }
 
-    await ctx.teamAssets?.remove("agent", name);
+    await ctx.teamAssets?.remove("agent", existing.id);
+    // Reaped with the Agent, not left behind: an orphaned Principal is an authority nothing owns,
+    // and the id would carry that authority into whatever is later created under it.
+    await ctx.removePrincipal?.(existing.id);
     return ok({ name, deleted: true });
   },
 });

--- a/apps/api/src/team-assets/catalog-provider.ts
+++ b/apps/api/src/team-assets/catalog-provider.ts
@@ -5,12 +5,13 @@ import type {
   KnowledgeSpaceRepo,
 } from "@tulipfarm/knowledge";
 import type { TeamAssetType } from "@tulipfarm/schema";
-import type {
-  BundledSkill,
-  RoutineCatalog,
-  SoulAgent,
-  SoulLoader,
-  SoulSkill,
+import {
+  type BundledSkill,
+  type RoutineCatalog,
+  resolveAgentRef,
+  type SoulAgent,
+  type SoulLoader,
+  type SoulSkill,
 } from "@tulipfarm/soul";
 import type { PgKnowledgeSourceStore } from "../knowledge-sources/source-store";
 import {
@@ -54,7 +55,10 @@ function put(out: Map<string, TeamAssetCatalogMetadata>, metadata: TeamAssetCata
 function agentMetadata(agent: SoulAgent): TeamAssetCatalogMetadata {
   return {
     assetType: "agent",
-    id: agent.name,
+    // The ownership row keys on the Agent's permanent id, so the catalogue entry must too, or a
+    // renamed Agent's assets stop matching the rows that describe them. `href` keeps the name,
+    // which is what the product's URLs carry.
+    id: agent.id,
     label: text(agent.frontmatter.label) ?? agent.name,
     description: text(agent.frontmatter.description) ?? null,
     href: `/agents/${encodeURIComponent(agent.name)}`,
@@ -117,7 +121,7 @@ export class TeamAssetCatalogProvider implements TeamAssetCatalogMetadataProvide
     const out = new Map<string, TeamAssetCatalogMetadata>();
 
     for (const id of ids.get("agent") ?? []) {
-      const agent = this.deps.soul.agents.get(id);
+      const agent = resolveAgentRef(this.deps.soul.agents, id);
       if (agent) put(out, agentMetadata(agent));
     }
     for (const id of ids.get("skill") ?? []) {

--- a/packages/soul/src/agents/registry.test.ts
+++ b/packages/soul/src/agents/registry.test.ts
@@ -23,10 +23,16 @@ describe("agent registry", () => {
     );
   });
 
-  it("resolves a selected Soul agent, otherwise falls back to normal chat", () => {
+  it("resolves a selected Soul agent by name or by id", () => {
     const loader = makeSoulLoader([PLANNER]);
     expect(resolveAgent(loader, "sprint-planner")).toBe(PLANNER);
-    expect(resolveAgent(loader, "missing-agent")).toBe(DEFAULT_ASSISTANT);
+    expect(resolveAgent(loader, PLANNER.id)).toBe(PLANNER);
+  });
+
+  it("refuses a reference the Soul does not have rather than substituting the default", () => {
+    const loader = makeSoulLoader([PLANNER]);
+    expect(resolveAgent(loader, "missing-agent")).toBeUndefined();
+    expect(resolveAgent(undefined, "missing-agent")).toBeUndefined();
   });
 
   it("lists and retrieves only user-created Soul agents", () => {

--- a/packages/soul/src/agents/registry.ts
+++ b/packages/soul/src/agents/registry.ts
@@ -1,6 +1,7 @@
 import type { SoulLoader } from "../published-loader";
 import type { SoulAgent } from "../types";
-import { DEFAULT_ASSISTANT } from "./platform-agents";
+import { resolveAgentRef } from "./agent-id";
+import { DEFAULT_ASSISTANT, DEFAULT_ASSISTANT_ID } from "./platform-agents";
 
 /**
  * User-created Agent registry. Normal chat uses the unlisted default harness when no Soul Agent
@@ -9,14 +10,30 @@ import { DEFAULT_ASSISTANT } from "./platform-agents";
 
 export {
   DEFAULT_ASSISTANT,
+  DEFAULT_ASSISTANT_ID,
   DEFAULT_ASSISTANT_NAME,
   getDefaultAssistant,
   type PlatformAgent,
 } from "./platform-agents";
 
-/** Resolve a named Soul Agent, falling back to the normal-chat harness. */
-export function resolveAgent(soulLoader: SoulLoader | undefined, agentId?: string): SoulAgent {
-  return (agentId ? soulLoader?.agents.get(agentId) : undefined) ?? DEFAULT_ASSISTANT;
+/**
+ * Resolve the Agent a reference names, by id or by Soul name.
+ *
+ * Naming nothing is the request that selected no Agent, which is normal chat on the default
+ * harness. Naming something the Soul does not have is different in kind and answers `undefined`:
+ * every Agent used to hold the same wide Role, so falling back was harmless, but a caller-supplied
+ * reference that resolves to nothing must never borrow the default assistant's authority once
+ * Roles differ per Agent. Callers must refuse, not substitute.
+ */
+export function resolveAgent(
+  soulLoader: SoulLoader | undefined,
+  agentId?: string
+): SoulAgent | undefined {
+  if (!agentId) return DEFAULT_ASSISTANT;
+  if (agentId === DEFAULT_ASSISTANT_ID || agentId === DEFAULT_ASSISTANT.name) {
+    return DEFAULT_ASSISTANT;
+  }
+  return soulLoader === undefined ? undefined : resolveAgentRef(soulLoader.agents, agentId);
 }
 
 /** The registry view contains only user-created Soul Agents. */
@@ -24,7 +41,12 @@ export function listAgents(soulLoader: SoulLoader | undefined): SoulAgent[] {
   return soulLoader ? Array.from(soulLoader.agents.values()) : [];
 }
 
-/** Look up one user-created Soul Agent for the detail view. */
-export function getAgent(soulLoader: SoulLoader | undefined, name: string): SoulAgent | undefined {
-  return soulLoader?.agents.get(name);
+/**
+ * Look up one user-created Soul Agent for the detail view, by id or by Soul name.
+ *
+ * The name is still what URLs and `@mentions` carry, so both must resolve; this is the edge that
+ * turns either into the Agent whose permanent id everything downstream then uses.
+ */
+export function getAgent(soulLoader: SoulLoader | undefined, ref: string): SoulAgent | undefined {
+  return soulLoader === undefined ? undefined : resolveAgentRef(soulLoader.agents, ref);
 }

--- a/packages/storage/src/auth/principal-repo.ts
+++ b/packages/storage/src/auth/principal-repo.ts
@@ -20,6 +20,12 @@ export interface PrincipalRepo {
   put(record: PrincipalRecord): Promise<void>;
   /** Lists registered principals so non-human ids are discoverable for grants. */
   list(businessId: string): Promise<readonly PrincipalRecord[]>;
+  /**
+   * Removes a Principal and, by cascade, its Role assignments. For a subject that no longer
+   * exists: a deleted Agent whose id could otherwise be re-created under different ownership and
+   * inherit the authority the old one held.
+   */
+  delete(businessId: string, id: string): Promise<void>;
 }
 
 /**
@@ -45,6 +51,10 @@ export class InMemoryPrincipalRepo implements PrincipalRepo {
     return [...this.records.values()]
       .filter((record) => record.businessId === businessId)
       .sort((left, right) => left.id.localeCompare(right.id));
+  }
+
+  async delete(businessId: string, id: string): Promise<void> {
+    this.records.delete(this.key(businessId, id));
   }
 }
 
@@ -107,6 +117,15 @@ export class PgPrincipalRepo implements PrincipalRepo {
         [businessId]
       );
       return result.rows.map(principalFromRow);
+    });
+  }
+
+  async delete(businessId: string, id: string): Promise<void> {
+    await this.transactions.withTransaction(async (transaction) => {
+      await transaction.query(`DELETE FROM principals WHERE business_id = $1 AND id = $2`, [
+        businessId,
+        id,
+      ]);
     });
   }
 }

--- a/packages/tool-host/src/dispatcher.test.ts
+++ b/packages/tool-host/src/dispatcher.test.ts
@@ -1105,7 +1105,7 @@ describe("authorization gate", () => {
         agentId: "agent-1",
       }) as unknown as ArtifactService,
       gate: new LiveToolGate(),
-      agents: { resolve: () => ({ name: "agent-1" }) },
+      agents: { resolve: () => ({ name: "agent-1", principalId: "agent-1-id" }) },
       authorityLayers: {
         resolvePrincipalLayer: async (name) => ({ name, grants: ALLOW }),
         resolveAgentLayer: async () => ({ name: "agent", grants: [] }),
@@ -1122,8 +1122,9 @@ describe("authorization gate", () => {
     expect(execute).not.toHaveBeenCalled();
   });
 
-  // An unknown `agentId` falls back to a real Agent, so reading the request would authorize the
-  // fallback's call under a name that names no Principal — an empty layer, and a blanket denial.
+  // Reading the requested `agentId` would authorize the resolved Agent's call under something that
+  // may name no Principal at all — an empty layer, and a blanket denial. The Principal id is also
+  // not the name: only the id keys the `principals` row a layer is built from.
   it("resolves the Agent layer for the Agent that was resolved, not the one requested", async () => {
     const resolved: (string | undefined)[] = [];
     const execute = vi.fn(async () => ok({}));
@@ -1133,7 +1134,7 @@ describe("authorization gate", () => {
       registry,
       artifacts: fakeArtifacts({ agentId: "ghost" }) as unknown as ArtifactService,
       gate: new LiveToolGate(),
-      agents: { resolve: () => ({ name: "fallback" }) },
+      agents: { resolve: () => ({ name: "fallback", principalId: "fallback-id" }) },
       authorityLayers: {
         resolvePrincipalLayer: async (name) => ({ name, grants: ALLOW }),
         resolveAgentLayer: async (_businessId, agentId): Promise<AuthorityLayer> => {
@@ -1150,7 +1151,34 @@ describe("authorization gate", () => {
     });
 
     expect(result).toMatchObject({ status: "succeeded" });
-    expect(resolved).toEqual(["fallback"]);
+    expect(resolved).toEqual(["fallback-id"]);
+  });
+
+  // Roles differ per Agent, so a reference that resolves to nothing must not borrow the default
+  // assistant's authority. The resolver reports it as an Agent, and the call is refused.
+  it("denies a call whose Agent reference resolved to nothing", async () => {
+    const execute = vi.fn(async () => ok({}));
+    const registry = new InMemoryToolCatalog();
+    registry.register(gatedTool(execute));
+    const dispatcher = new RegistryToolDispatcher({
+      registry,
+      artifacts: fakeArtifacts({ agentId: "ghost" }) as unknown as ArtifactService,
+      gate: new LiveToolGate(),
+      agents: { resolve: () => ({ name: "ghost", unresolvedRef: "ghost" }) },
+      authorityLayers: {
+        resolvePrincipalLayer: async (name) => ({ name, grants: ALLOW }),
+        resolveAgentLayer: async (): Promise<AuthorityLayer> => ({ name: "agent", grants: ALLOW }),
+      },
+    });
+
+    const result = await dispatcher.dispatch(AUTHORITY, {
+      callId: "c1",
+      name: "echo",
+      arguments: { text: "hi" },
+    });
+
+    expect(result).toMatchObject({ status: "denied" });
+    expect(execute).not.toHaveBeenCalled();
   });
 
   // The stand-in for "this process composed no resolver" is not an Agent anyone configured, so it

--- a/packages/tool-host/src/dispatcher.ts
+++ b/packages/tool-host/src/dispatcher.ts
@@ -51,16 +51,16 @@ import type { ParkableToolDef, RequestContext, ToolHostLogger } from "./types";
 const DEFAULT_AGENT: HostedAgent = { name: "assistant" };
 
 /**
- * The Principal whose authority layer bounds this call — the Agent that was actually resolved,
- * never the one the request asked for. An unrecognised `agentId` falls back to a real Agent while
- * the requested name stays unknown, so reading the request would authorize one identity under
- * another's name and resolve an empty layer for it.
+ * The Principal whose authority layer bounds this call — the resolved Agent's permanent id, never
+ * its name. The name is a handle a user may change; the Principal, its Role assignment and its
+ * ownership rows all key on the id, so authorizing by name would resolve an empty layer for every
+ * Agent that has ever been renamed.
  *
  * `DEFAULT_AGENT` is the stand-in for "this process composed no resolver", not an Agent anyone
- * configured, so it names no Principal and contributes no layer.
+ * configured, so it carries no id and contributes no layer.
  */
 function agentPrincipalIdOf(agent: HostedAgent): string | undefined {
-  return agent === DEFAULT_AGENT ? undefined : agent.name;
+  return agent.principalId;
 }
 
 /** Executes one Tool call: allowlist, schema, gate, and context all come from the recorded Run. */
@@ -315,6 +315,12 @@ export class RegistryToolDispatcher implements TurnToolDispatcher {
       request === undefined
         ? (authority.agent ?? DEFAULT_AGENT)
         : (this.options.agents?.resolve(request.agentId) ?? authority.agent ?? DEFAULT_AGENT);
+    // A named Agent that resolves to nothing is refused rather than run as somebody else. It
+    // reaches here as an Agent, not as absence, because absence means "no resolver was composed"
+    // and would leave the call on this process's own unrestricted default.
+    if (agent.unresolvedRef !== undefined) {
+      return { status: "denied", reason: `agent "${agent.unresolvedRef}" is not configured` };
+    }
     // The routed Agent's configured autonomy is an authority ceiling, so the turn runs at the more
     // restrictive of it and whatever this request asked for. Reading `request.autonomy` alone made
     // the ceiling shown on the Agent advisory: any caller that supplied a permissive per-turn value

--- a/packages/tool-host/src/ports.ts
+++ b/packages/tool-host/src/ports.ts
@@ -42,6 +42,19 @@ export interface ChannelDeliveryReader {
 /** The Agent a turn runs as, reduced to what Tool visibility and the gate actually read. */
 export interface HostedAgent {
   readonly name: string;
+  /**
+   * The Agent's permanent id, which is also its Principal id. Absent only for a stand-in this
+   * process invented rather than resolved, which names no Principal and contributes no layer.
+   */
+  readonly principalId?: string;
+  /**
+   * Set when a request named an Agent that resolves to nothing.
+   *
+   * Carried as an Agent rather than as absence because absence already means "this process was
+   * composed without a resolver", which is the *wider* authority — the durable runtime takes it as
+   * licence to run on its own default. An unknown name must narrow, so it is carried and refused.
+   */
+  readonly unresolvedRef?: string;
   readonly toolAllowlist?: readonly string[];
   /**
    * The Agent's own configured autonomy, which bounds every turn it runs. Absent means the Agent


### PR DESCRIPTION
- Keys the Agent Principal, its Role assignment, the `asset_ownership` rows (and their child tables) and the nine columns carrying an Agent identifier on the permanent id minted in #726; the Soul name stays the human-facing handle, resolved to an id at the edge and projected back to a name for Chat and the spend dashboard.
- Adds a boot sweep (`identity/agent-identifiers.ts`) that moves rows written before the cut-over and reaps the name-keyed Principal last; it is idempotent, probes each lazily-created table, and logs per-table failures rather than blocking boot. It runs after `reconcileAgentPrincipals`, never before.
- Fails closed on an unresolved `agentId` instead of falling back to the default assistant, and reaps the Principal and Role assignment on `agent_delete`.

Operator note: audit, obs and task surfaces that showed an Agent's Soul name now show its id, except the spend-by-agent breakdown, which is projected back to the name.

## Test plan

- [x] `pnpm typecheck` (41/41)
- [x] `pnpm --filter @tulipfarm/api test` (plus targeted re-runs of `src/observability`, `src/integrations/slack`, `src/identity`)
- [x] `pnpm --filter @tulipfarm/worker test`
- [x] `pnpm --filter @tulipfarm/soul test`, `@tulipfarm/tool-host`, `@tulipfarm/storage`
- [ ] Boot an existing deployment and confirm the sweep re-keys its rows once and no-ops on the next start