### PR TITLE
chore(release): v0.18.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.18.14](https://github.com/TulipFarm/tulipfarm/compare/v0.18.13...v0.18.14) (2026-09-07)
+
+### Features
+
+* **agents:** key every Agent record on its permanent id ([#737](https://github.com/TulipFarm/tulipfarm/issues/737)) ([0d69cac](https://github.com/TulipFarm/tulipfarm/commit/0d69cac42ae8adffb50e576142d59a71ffb9f666)), references [#726](https://github.com/TulipFarm/tulipfarm/issues/726)
+
 ## [0.18.13](https://github.com/TulipFarm/tulipfarm/compare/v0.18.12...v0.18.13) (2026-09-07)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tulipfarm",
   "private": true,
-  "version": "0.18.13",
+  "version": "0.18.14",
   "repository": {
     "type": "git",
     "url": "https://github.com/TulipFarm/tulipfarm.git"


### PR DESCRIPTION
## Summary

- prepare TulipFarm v0.18.14
- update the package version and generated changelog
- publish the verified GHCR image and GitHub Release automatically after merge

## Test plan

- [ ] Required PR checks pass
- [ ] Version and changelog are approved
