### PR TITLE
fix(web): anchor the sidebar collapse toggle in the sidebar in both states

### DIFF
--- a/apps/web/app/components/app-sidebar.test.tsx
+++ b/apps/web/app/components/app-sidebar.test.tsx
@@ -703,16 +703,43 @@ test("keeps / for the page when the reader is already typing", async () => {
 });
 
 /* Two controls claiming the same job is one control too many. */
-test("shows one collapse control at a time, moving it out of the sidebar when it narrows", async () => {
+test("shows one collapse control at a time, anchored in the sidebar in both states", async () => {
   const user = userEvent.setup();
   render(<ShellStub initialEntries={["/agents"]} />);
+  const aside = screen.getByRole("complementary", { name: "Application navigation" });
 
   expect(screen.getAllByRole("button", { name: "Collapse sidebar" })).toHaveLength(1);
   expect(screen.queryByRole("button", { name: "Expand sidebar" })).not.toBeInTheDocument();
+  expect(within(aside).getByRole("button", { name: "Collapse sidebar" })).toBeInTheDocument();
 
   await user.click(screen.getByRole("button", { name: "Collapse sidebar" }));
   expect(screen.getAllByRole("button", { name: "Expand sidebar" })).toHaveLength(1);
   expect(screen.queryByRole("button", { name: "Collapse sidebar" })).not.toBeInTheDocument();
+  expect(within(aside).getByRole("button", { name: "Expand sidebar" })).toBeInTheDocument();
+});
+
+/*
+ * The expanded and collapsed toggle used to be two separate <button> elements gated by
+ * `collapsed`, one inside the sidebar header and one in the content header. Swapping between them
+ * changed React's reconciliation identity, so focus dropped to the document body on every toggle.
+ * One button, driven by `collapsed`, keeps its identity across the swap.
+ */
+test("keeps focus on the toggle after it collapses and expands the sidebar", async () => {
+  const user = userEvent.setup();
+  render(<ShellStub initialEntries={["/agents"]} />);
+
+  const collapseButton = screen.getByRole("button", { name: "Collapse sidebar" });
+  collapseButton.focus();
+  expect(collapseButton).toHaveFocus();
+
+  await user.click(collapseButton);
+  const expandButton = screen.getByRole("button", { name: "Expand sidebar" });
+  expect(expandButton).toBe(collapseButton);
+  expect(document.activeElement).toBe(expandButton);
+
+  await user.click(expandButton);
+  expect(document.activeElement).toBe(expandButton);
+  expect(screen.getByRole("button", { name: "Collapse sidebar" })).toBe(expandButton);
 });
 
 /*

--- a/apps/web/app/components/app-sidebar.tsx
+++ b/apps/web/app/components/app-sidebar.tsx
@@ -190,19 +190,23 @@ function SidebarHeader({
         <>
           <SidebarCommand visibility={visibility} collapsed={false} compact />
           <NewChatButton collapsed={false} compact onNavigate={onNavigate} />
-          <Tooltip content="Collapse sidebar">
-            <button
-              type="button"
-              aria-label="Collapse sidebar"
-              aria-expanded
-              onClick={onToggleCollapsed}
-              className="hidden size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-sidebar-accent hover:text-foreground lg:flex"
-            >
-              <PanelLeftClose className="size-4" aria-hidden />
-            </button>
-          </Tooltip>
         </>
       )}
+      <Tooltip content={collapsed ? "Expand sidebar" : "Collapse sidebar"}>
+        <button
+          type="button"
+          aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+          aria-expanded={!collapsed}
+          onClick={onToggleCollapsed}
+          className="hidden size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-sidebar-accent hover:text-foreground lg:flex"
+        >
+          {collapsed ? (
+            <PanelLeftOpen className="size-4" aria-hidden />
+          ) : (
+            <PanelLeftClose className="size-4" aria-hidden />
+          )}
+        </button>
+      </Tooltip>
     </div>
   );
 }
@@ -848,7 +852,6 @@ export function AppShell({ children, user }: { children: ReactNode; user?: Sessi
     () => document.documentElement.dataset.sidebar === "collapsed"
   );
   const { pathname } = useLocation();
-  const settingsMode = isSettingsPath(pathname);
   const openerRef = useRef<HTMLButtonElement>(null);
   const { activeChatTitle, activeChatId } = useConversations();
   const isConversation = pathname === "/" || pathname.startsWith("/chat/");
@@ -910,25 +913,6 @@ export function AppShell({ children, user }: { children: ReactNode; user?: Sessi
           >
             <Menu className="size-5" aria-hidden />
           </button>
-          {/* Expanded, the collapse control lives in the sidebar's own header, next to the thing
-           * it resizes. Collapsed, that header has room for the mark alone, so the way back out
-           * moves here — one control, never two claiming the same job. */}
-          {collapsed && !settingsMode ? (
-            <>
-              <Tooltip content="Expand sidebar">
-                <button
-                  type="button"
-                  aria-label="Expand sidebar"
-                  aria-expanded={false}
-                  onClick={toggleCollapsed}
-                  className="hidden size-9 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground lg:flex"
-                >
-                  <PanelLeftOpen className="size-4" aria-hidden />
-                </button>
-              </Tooltip>
-              <Separator orientation="vertical" className="mx-1 hidden h-5 lg:block" />
-            </>
-          ) : null}
           <PageTitle pathname={pathname} pageTitle={pageTitle} titleSlot={chatTitleSlot} />
           <div className="ml-auto flex shrink-0 items-center gap-1 pl-2">
             {/* Page actions land left of the shell's own controls, so the reader meets what this


### PR DESCRIPTION
## Summary
- Two separate `<button>` elements rendered the sidebar collapse toggle under different DOM parents, gated by the same `collapsed` boolean; swapping between them changed React's reconciliation identity and dropped focus on every toggle.
- `SidebarHeader` now renders one toggle button whose icon and label are driven by `collapsed`, and the duplicate toggle in `AppShell`'s content header is removed.

## Test plan
- [x] `rtk proxy pnpm exec biome check --write apps/web/app/components`
- [x] `rtk proxy pnpm --filter @tulipfarm/web exec vitest run apps/web/app/components/app-sidebar.test.tsx` (Node 24) — 46 passed, including new tests asserting the toggle is present in both states inside the sidebar element, and that focus survives a toggle

Closes #733