### PR TITLE
fix(web): single-source nav visibility and human-readable API errors

### DIFF
--- a/apps/web/app/components/app-sidebar.test.tsx
+++ b/apps/web/app/components/app-sidebar.test.tsx
@@ -202,13 +202,32 @@ test("hides denied destinations and the groups they empty", () => {
   const nav = screen.getByRole("navigation", { name: "Main" });
 
   expect(within(nav).getByRole("link", { name: "Activity" })).toBeInTheDocument();
-  expect(within(nav).getByRole("link", { name: "Teams" })).toBeInTheDocument();
   expect(within(nav).getByRole("link", { name: "Resources" })).toBeInTheDocument();
-  for (const label of ["Inbox", "Farm", "Knowledge"]) {
+  for (const label of ["Inbox", "Farm", "Knowledge", "Teams"]) {
     expect(within(nav).queryByRole("link", { name: label })).not.toBeInTheDocument();
   }
   expect(within(nav).queryByRole("heading", { name: "Build" })).toBeInTheDocument();
   expect(screen.queryByRole("link", { name: "Settings" })).not.toBeInTheDocument();
+});
+
+test("shows Teams once its path is granted, like any other visiblePaths-gated destination", () => {
+  const GrantedTeamsSidebarStub = createRemixStub([
+    {
+      path: "*",
+      Component: () => (
+        <AppSidebar
+          user={{
+            ...USER,
+            navigation: { visiblePaths: ["/resources", "/business/activities", "/teams"] },
+          }}
+        />
+      ),
+    },
+  ]);
+  render(<GrantedTeamsSidebarStub initialEntries={["/business/activities"]} />);
+  const nav = screen.getByRole("navigation", { name: "Main" });
+
+  expect(within(nav).getByRole("link", { name: "Teams" })).toBeInTheDocument();
 });
 
 test("replaces the app destinations with Settings navigation on a Settings-owned route", () => {

--- a/apps/web/app/lib/api.ts
+++ b/apps/web/app/lib/api.ts
@@ -9,12 +9,17 @@ export class ApiError extends Error {
   // JSON Pointer to the offending field on a 422 (`{path}` from the API), so forms can map a
   // validation failure back onto the input that caused it. Undefined for non-validation errors.
   readonly path?: string;
+  // The raw wire code from the API's `{ error }` body (e.g. "forbidden"), kept for logging only.
+  // Never render it directly — it is not user copy. `presentApiError` in `lib/present-api-error.ts`
+  // translates it; a call site with no translation falls back to generic copy, not this string.
+  readonly code?: string;
 
-  constructor(status: number, message: string, path?: string) {
+  constructor(status: number, message: string, path?: string, code?: string) {
     super(message);
     this.name = "ApiError";
     this.status = status;
     this.path = path;
+    this.code = code;
   }
 }
 
@@ -222,6 +227,7 @@ function readCookie(name: string): string | null {
 export async function readError(res: Response): Promise<ApiError> {
   let message = res.statusText || `request failed (${res.status})`;
   let path: string | undefined;
+  let code: string | undefined;
   try {
     const body = (await res.json()) as {
       error?: unknown;
@@ -229,7 +235,15 @@ export async function readError(res: Response): Promise<ApiError> {
       code?: unknown;
       path?: unknown;
     };
-    if (typeof body.error === "string") message = body.error;
+    // `error` is sometimes a genuinely descriptive message (a thrown service error's `.message`)
+    // and sometimes a bare wire code (route-gate's `{ error: "forbidden" }`). `message` keeps the
+    // existing fallback behaviour every call site already depends on; `code` mirrors the same raw
+    // value so a caller that recognizes it as a code (via `presentApiError`) can translate it
+    // instead of displaying it verbatim.
+    if (typeof body.error === "string") {
+      message = body.error;
+      code = body.error;
+    }
     if (
       typeof body.error === "object" &&
       body.error !== null &&
@@ -254,7 +268,7 @@ export async function readError(res: Response): Promise<ApiError> {
   } catch {
     // non-JSON body — keep the status-text fallback
   }
-  return new ApiError(res.status, message, path);
+  return new ApiError(res.status, message, path, code);
 }
 
 // `invited` is an account that exists but has no password yet: it holds an outstanding invite link

--- a/apps/web/app/lib/nav.test.ts
+++ b/apps/web/app/lib/nav.test.ts
@@ -61,7 +61,9 @@ test("a retired page still names its destination while it redirects", () => {
 });
 
 test("hides every denied destination and collapses its empty groups", () => {
-  expect(visibleSidebarGroups({ isDev: false, visiblePaths: ["/business/activities"] })).toEqual([
+  expect(
+    visibleSidebarGroups({ isDev: false, visiblePaths: ["/business/activities", "/teams"] })
+  ).toEqual([
     expect.objectContaining({
       heading: "Work",
       items: [
@@ -77,10 +79,18 @@ test("hides every denied destination and collapses its empty groups", () => {
 test("keeps Chat reachable for an account granted nothing", () => {
   const groups = visibleSidebarGroups({ isDev: false, visiblePaths: [] });
 
-  expect(groups.flatMap((group) => group.items).map((item) => item.to)).toEqual([
-    "/chats",
-    "/teams",
-  ]);
+  expect(groups.flatMap((group) => group.items).map((item) => item.to)).toEqual(["/chats"]);
+});
+
+/* Teams is server-sourced like everything else now — no more client-side `authenticated` guess. */
+test("shows Teams only when the server includes it in visiblePaths", () => {
+  const withTeams = visibleSidebarGroups({ isDev: false, visiblePaths: ["/teams"] });
+  const withoutTeams = visibleSidebarGroups({ isDev: false, visiblePaths: [] });
+
+  expect(withTeams.flatMap((group) => group.items.map((item) => item.to))).toContain("/teams");
+  expect(withoutTeams.flatMap((group) => group.items.map((item) => item.to))).not.toContain(
+    "/teams"
+  );
 });
 
 /*

--- a/apps/web/app/lib/nav.ts
+++ b/apps/web/app/lib/nav.ts
@@ -73,6 +73,8 @@ export const SIDEBAR_GROUPS: NavGroup[] = [
   {
     heading: "Work",
     items: [
+      // The sole item still bypassing visiblePaths — see the `always` field doc above. Every
+      // other destination, /teams included, sources its visibility from the server.
       { to: "/chats", label: "Chats", icon: MessageSquare, always: true },
       { to: "/inbox", label: "Inbox", icon: Inbox, badge: true },
       {
@@ -86,7 +88,6 @@ export const SIDEBAR_GROUPS: NavGroup[] = [
         to: "/teams",
         label: "Teams",
         icon: Users,
-        authenticated: true,
         description: "Browse the Teams and people that make up this business.",
       },
     ],

--- a/apps/web/app/lib/present-api-error.test.ts
+++ b/apps/web/app/lib/present-api-error.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "vitest";
+import { ApiError } from "./api";
+import { presentApiError } from "./present-api-error";
+
+test("maps a forbidden wire code to human copy naming the surface", () => {
+  const error = new ApiError(403, "forbidden", undefined, "forbidden");
+  expect(presentApiError(error, "The Team directory")).toBe(
+    "The Team directory isn't available to your account. Ask an administrator if you need access."
+  );
+});
+
+test("maps a denied wire code to human copy naming the surface", () => {
+  const error = new ApiError(403, "denied", undefined, "denied");
+  expect(presentApiError(error, "The Team directory")).toBe(
+    "The Team directory isn't available to your account. Ask an administrator if you need access."
+  );
+});
+
+test("maps an unauthorized wire code to human copy about signing in again", () => {
+  const error = new ApiError(401, "unauthorized", undefined, "unauthorized");
+  expect(presentApiError(error, "The Team directory")).toBe(
+    "The Team directory isn't available — sign in again to continue. Ask an administrator if you need access."
+  );
+});
+
+test("falls back to generic copy for an unrecognized code", () => {
+  const error = new ApiError(500, "internal server error", undefined, "internal server error");
+  expect(presentApiError(error, "The Team directory")).toBe(
+    "The Team directory could not be loaded. Ask an administrator if this continues."
+  );
+});
+
+test("falls back to generic copy for a non-ApiError", () => {
+  expect(presentApiError(new Error("network down"), "The Team directory")).toBe(
+    "The Team directory could not be loaded. Ask an administrator if this continues."
+  );
+});

--- a/apps/web/app/lib/present-api-error.ts
+++ b/apps/web/app/lib/present-api-error.ts
@@ -1,0 +1,26 @@
+import { ApiError } from "./api";
+
+/**
+ * The wire codes a route gate can send (`route-gate.ts`'s `{ error: "forbidden" }` and siblings).
+ * Anything else on `ApiError.code` — including a genuinely descriptive service message, a thrown
+ * error's own `.message` mirrored there by `readError` — is not a code this helper recognizes, so
+ * it falls through to the generic copy below rather than risk surfacing wire detail nobody chose
+ * as user-facing text.
+ */
+const KNOWN_WIRE_CODES: Record<string, string> = {
+  forbidden: "isn't available to your account",
+  denied: "isn't available to your account",
+  unauthorized: "isn't available — sign in again to continue",
+};
+
+/**
+ * Turns an API error into copy a person can read, for surfaces that would otherwise render a raw
+ * wire code (`forbidden`) straight from the response body. `context` names the surface that failed
+ * ("The Team directory"), so the result reads as a sentence naming what's unavailable and why.
+ */
+export function presentApiError(error: unknown, context: string): string {
+  const code = error instanceof ApiError ? error.code : undefined;
+  const known = code ? KNOWN_WIRE_CODES[code] : undefined;
+  if (known) return `${context} ${known}. Ask an administrator if you need access.`;
+  return `${context} could not be loaded. Ask an administrator if this continues.`;
+}

--- a/apps/web/app/routes/_app.business.access.teams.tsx
+++ b/apps/web/app/routes/_app.business.access.teams.tsx
@@ -16,7 +16,7 @@ import { Input } from "~/components/ui/input";
 import { Link } from "~/components/ui/link";
 import { Panel } from "~/components/ui/panel";
 import { Select } from "~/components/ui/select";
-import { ApiError } from "~/lib/api";
+import { presentApiError } from "~/lib/present-api-error";
 import { listTeams, type TeamDirectoryEntry } from "~/lib/teams";
 import { useIsAdmin } from "~/lib/use-session-user";
 import { cn } from "~/lib/utils";
@@ -289,8 +289,7 @@ function compareTeams(a: TeamDirectoryEntry, b: TeamDirectoryEntry, sort: TeamSo
 }
 
 function errorMessage(error: unknown): string {
-  if (error instanceof ApiError) return error.message;
-  return "Could not load the Team directory.";
+  return presentApiError(error, "The Team directory");
 }
 
 export function ErrorBoundary() {

--- a/apps/web/app/routes/business-access-teams.test.tsx
+++ b/apps/web/app/routes/business-access-teams.test.tsx
@@ -3,9 +3,10 @@ import { createRemixStub } from "@remix-run/testing";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, expect, test, vi } from "vitest";
+import { ApiError } from "~/lib/api";
 import type { TeamDirectoryEntry } from "~/lib/teams";
 import * as session from "~/lib/use-session-user";
-import TeamsDirectory from "./_app.business.access.teams";
+import TeamsDirectory, { ErrorBoundary } from "./_app.business.access.teams";
 
 vi.mock("@remix-run/react", async () => {
   const actual = await vi.importActual<typeof import("@remix-run/react")>("@remix-run/react");
@@ -152,4 +153,19 @@ test("shows useful empty and no-match states", async () => {
   await userEvent.type(screen.getByRole("searchbox", { name: "Search teams" }), "missing");
   expect(screen.getByText("No Teams found")).toBeInTheDocument();
   expect(screen.getByRole("button", { name: "Clear filters" })).toBeInTheDocument();
+});
+
+test("renders human copy, not the raw wire code, for a 403 on the Team directory", () => {
+  vi.mocked(remix.useRouteError).mockReturnValue(
+    new ApiError(403, "forbidden", undefined, "forbidden")
+  );
+
+  render(<ErrorBoundary />);
+
+  expect(screen.queryByText("forbidden")).not.toBeInTheDocument();
+  expect(
+    screen.getByText(
+      "The Team directory isn't available to your account. Ask an administrator if you need access."
+    )
+  ).toBeInTheDocument();
 });

--- a/packages/authz/src/navigation.ts
+++ b/packages/authz/src/navigation.ts
@@ -34,6 +34,12 @@ const USER_MANAGE: NavigationAuthorization = {
   fallback: "admin",
 };
 
+const TEAM_DIRECTORY_READ: NavigationAuthorization = {
+  action: "team.directory.read",
+  resourceType: "team",
+  fallback: "authenticated",
+};
+
 /** Server-owned visibility requirements for every static destination in the product shell. */
 export const NAVIGATION_REQUIREMENTS: readonly NavigationRequirement[] = [
   { path: "/farm", authorizations: [AUTHENTICATED_NAVIGATION] },
@@ -48,6 +54,7 @@ export const NAVIGATION_REQUIREMENTS: readonly NavigationRequirement[] = [
   // whether to show the Runs lane at all. Removing it would hide Runs from every session.
   { path: "/runs", authorizations: [OPERATIONS_READ] },
   { path: "/business/activities", authorizations: [AUTHENTICATED_NAVIGATION] },
+  { path: "/teams", authorizations: [TEAM_DIRECTORY_READ] },
   { path: "/operations", authorizations: [OPERATIONS_READ] },
   {
     path: "/business/cost",


### PR DESCRIPTION
## Summary
- Add `/teams` to `NAVIGATION_REQUIREMENTS` mirroring its actual route gate (`team.directory.read`, `authenticated` fallback), and drop the client-side `authenticated: true` guess so Teams flows through `visiblePaths` like every other nav item. `/chats` keeps its documented `always: true` exception.
- Add a `presentApiError(error, context)` helper and `ApiError.code` (the raw wire code, kept separate from the display `message`) so the Teams page renders human copy instead of the literal string `"forbidden"` on a 403. Wired into the Teams `ErrorBoundary` only; the remaining ~60 `ErrorBoundary` call sites are follow-up work.

Refs #729, #730. Neither issue is closed by this PR — the root cause of the `visiblePaths` collapse (authority-layer resolution vs. stale staging role data) is still unresolved and needs a live session payload the parent investigation deliberately did not gather. These are structural fixes only.

## Test plan
- [x] `presentApiError` unit tests: `forbidden`/`denied`/`unauthorized` codes and an unknown-code fallback
- [x] Teams `ErrorBoundary` test asserting human copy (not the raw code) renders for a 403
- [x] `nav.ts` tests updated/added asserting `/teams` visibility now follows `visiblePaths` (present when included, absent when not)
- [x] `packages/authz` navigation tests pass
- [x] `pnpm exec biome check --write` clean on all changed directories