### PR TITLE
fix(web): seed the composer from Companion cards through state, not the URL

### DIFF
--- a/apps/web/app/components/chat/chat-panel.tsx
+++ b/apps/web/app/components/chat/chat-panel.tsx
@@ -4,6 +4,7 @@ import { ConnectionStatus } from "~/components/shell/states";
 import { Link } from "~/components/ui/link";
 import type { ChatMessage, ChatModelSelector } from "~/lib/chat/types";
 import { useChatStream } from "~/lib/chat/use-chat-stream";
+import type { PendingChatDraft } from "~/lib/companion-context";
 import type { ConversationTurn } from "~/lib/conversations";
 import { errorAction } from "~/lib/error-actions";
 import type { Suggestion } from "~/lib/onboarding";
@@ -114,6 +115,7 @@ export function ChatPanel({
   initialTurn,
   onConversationChange,
   initialDraft,
+  pendingChatDraft,
   attachFileId,
 }: {
   agentId?: string;
@@ -127,8 +129,11 @@ export function ChatPanel({
   initialMessages?: ChatMessage[];
   initialTurn?: ConversationTurn | null;
   onConversationChange?: (conversationId: string | undefined) => void;
-  /** A prompt to draft into the composer once, seeded by the onboarding Companion. */
+  /** A prompt to draft into the composer once, seeded by a `?draft=` link. */
   initialDraft?: string;
+  /** A prompt to draft into the composer, seeded by the onboarding Companion's "chat" action.
+      Keyed by a nonce so re-clicking the same card still redrafts it. */
+  pendingChatDraft?: PendingChatDraft | null;
   /** An already-stored File to stage on the composer, handed over by the Files library. */
   attachFileId?: string | null;
 }) {
@@ -155,6 +160,13 @@ export function ChatPanel({
   });
   const busy = status === "submitted" || status === "streaming";
   const [revisionDraft, setRevisionDraft] = useState<{ key: string; text: string } | null>(null);
+  // Composer only re-seeds its draft on remount (see composer.tsx), so a Companion "chat" action
+  // rides the same key-forced-remount mechanism as a revision draft, keyed on its nonce rather
+  // than its text — otherwise re-clicking the same Task card would be a no-op.
+  useEffect(() => {
+    if (!pendingChatDraft) return;
+    setRevisionDraft({ key: `companion-${pendingChatDraft.id}`, text: pendingChatDraft.prompt });
+  }, [pendingChatDraft]);
   // Fetch the transcript's chunk as soon as the panel exists rather than when the first turn needs
   // it — off the critical path, but resident well before anyone has finished typing.
   useEffect(() => {

--- a/apps/web/app/components/onboarding/companion-panel.tsx
+++ b/apps/web/app/components/onboarding/companion-panel.tsx
@@ -1,7 +1,8 @@
-import { useNavigate } from "@remix-run/react";
+import { useLocation, useNavigate } from "@remix-run/react";
 import { useState } from "react";
 import { ArrowRight, Check, MessageCircle, X } from "~/components/icons";
 import { ApiError } from "~/lib/api";
+import { useCompanion } from "~/lib/companion-context";
 import { answerTask, completeTask, type Task, type TaskAction } from "~/lib/tasks";
 
 /** Inline form for an `answer`-action Task — answers land in the configured sink, no chat round-trip. */
@@ -76,6 +77,8 @@ function TaskRow({
   onClose: () => void;
 }) {
   const navigate = useNavigate();
+  const { pathname } = useLocation();
+  const { requestChatDraft } = useCompanion();
   const [busy, setBusy] = useState(false);
 
   async function acknowledge() {
@@ -118,7 +121,12 @@ function TaskRow({
                   if (action.kind === "link") {
                     navigate(action.href);
                   } else if (action.kind === "chat") {
-                    navigate(`/?draft=${encodeURIComponent(action.prompt)}`);
+                    // Prefill through shared state, not a `?draft=` URL: the Companion is mounted
+                    // globally and must also work from routes other than "/", and a raw
+                    // `history.replaceState` elsewhere desyncs the router if we round-trip through
+                    // the URL (see the loader's `draft` comment in _app._index.tsx).
+                    requestChatDraft(action.prompt);
+                    if (pathname !== "/") navigate("/");
                   }
                   onClose();
                 }}

--- a/apps/web/app/lib/companion-context.tsx
+++ b/apps/web/app/lib/companion-context.tsx
@@ -17,6 +17,10 @@ import { dismissTask, listTasks, type Task } from "~/lib/tasks";
 
 const POLL_INTERVAL_MS = 60_000;
 
+/** A Companion "chat"-action Task's prompt, seeded into the Chat composer. `id` is a monotonic
+    nonce, not the prompt text, so clicking the same card twice still triggers a fresh draft. */
+export type PendingChatDraft = { id: number; prompt: string };
+
 type CompanionContextValue = {
   tasks: Task[];
   loading: boolean;
@@ -24,6 +28,8 @@ type CompanionContextValue = {
   setOpen: (open: boolean) => void;
   refresh: () => Promise<void>;
   dismiss: (id: string) => Promise<void>;
+  pendingChatDraft: PendingChatDraft | null;
+  requestChatDraft: (prompt: string) => void;
 };
 
 const CompanionContext = createContext<CompanionContextValue | null>(null);
@@ -36,6 +42,12 @@ export function CompanionProvider({ children }: { children: ReactNode }) {
   const inFlight = useRef(false);
   const mounted = useRef(true);
   const lastPath = useRef<string | null>(null);
+  const [pendingChatDraft, setPendingChatDraft] = useState<PendingChatDraft | null>(null);
+  const draftNonce = useRef(0);
+  const requestChatDraft = useCallback((prompt: string) => {
+    draftNonce.current += 1;
+    setPendingChatDraft({ id: draftNonce.current, prompt });
+  }, []);
 
   const refresh = useCallback(async () => {
     if (inFlight.current) return;
@@ -100,7 +112,16 @@ export function CompanionProvider({ children }: { children: ReactNode }) {
     await dismissTask(id).catch(() => {});
   }, []);
 
-  const value: CompanionContextValue = { tasks, loading, open, setOpen, refresh, dismiss };
+  const value: CompanionContextValue = {
+    tasks,
+    loading,
+    open,
+    setOpen,
+    refresh,
+    dismiss,
+    pendingChatDraft,
+    requestChatDraft,
+  };
   return <CompanionContext.Provider value={value}>{children}</CompanionContext.Provider>;
 }
 
@@ -111,6 +132,8 @@ const INERT: CompanionContextValue = {
   setOpen: () => {},
   refresh: async () => {},
   dismiss: async () => {},
+  pendingChatDraft: null,
+  requestChatDraft: () => {},
 };
 
 export function useCompanion(): CompanionContextValue {

--- a/apps/web/app/routes/_app._index.companion-draft.test.tsx
+++ b/apps/web/app/routes/_app._index.companion-draft.test.tsx
@@ -1,0 +1,142 @@
+import * as remix from "@remix-run/react";
+import { createRemixStub } from "@remix-run/testing";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, expect, test, vi } from "vitest";
+import type { PMNode } from "~/components/chat/editor/serialize";
+import { OnboardingCompanion } from "~/components/onboarding/companion";
+import { CompanionProvider } from "~/lib/companion-context";
+import type { Task } from "~/lib/tasks";
+import ChatRoute from "~/routes/_app._index";
+
+/*
+ * Regression for #732: clicking a Companion "chat"-action Task while already on "/" used to
+ * `navigate("/?draft=...")`, then the route's own `history.replaceState` cleanup desynced the
+ * Remix router's tracked location from the address bar, silently dropping every navigation after
+ * it. The fix drafts the prompt through `CompanionProvider`'s shared state instead of the URL, so
+ * this exercises the full FAB → Task → composer path end to end rather than the route in isolation.
+ *
+ * ProseMirror's contenteditable can't be driven under jsdom (see composer-editor.test.tsx), so
+ * Tiptap is mocked the same way here: `useEditor` returns a fake whose `commands.setContent` is a
+ * spy, which is what `draftSuggestion` calls to seed the composer.
+ */
+let doc: PMNode;
+const setContent = vi.fn();
+const selectTextblockEnd = vi.fn();
+const insertContent = vi.fn();
+const viewFocus = vi.fn();
+
+const fakeEditor = {
+  isEmpty: false,
+  getJSON: () => doc,
+  isActive: () => false,
+  getAttributes: () => ({}),
+  commands: { clearContent: vi.fn(), setContent, selectTextblockEnd, insertContent },
+  view: { focus: viewFocus },
+  chain: () => ({ focus: () => ({ run: () => true }) }),
+};
+
+vi.mock("@tiptap/react", () => ({
+  useEditor: () => fakeEditor,
+  EditorContent: () => <div />,
+  useEditorState: ({ selector }: { selector: (ctx: { editor: typeof fakeEditor }) => unknown }) =>
+    selector({ editor: fakeEditor }),
+}));
+vi.mock("@tiptap/react/menus", () => ({ BubbleMenu: () => null }));
+vi.mock("@tiptap/starter-kit", () => ({ default: { configure: () => ({}) } }));
+vi.mock("@tiptap/extension-placeholder", () => ({ default: { configure: () => ({}) } }));
+vi.mock("@tiptap/extension-link", () => ({
+  default: {
+    extend: () => ({ configure: () => ({}) }),
+  },
+}));
+vi.mock("~/components/chat/editor/mentions", () => ({
+  buildMentionExtensions: () => [],
+  MENTION_PLUGIN_KEYS: [],
+}));
+vi.mock("~/components/chat/editor/use-mention-data", () => ({ useMentionData: () => () => [] }));
+
+vi.mock("@remix-run/react", async () => {
+  const actual = await vi.importActual<typeof import("@remix-run/react")>("@remix-run/react");
+  return { ...actual, useLoaderData: vi.fn() };
+});
+
+vi.mock("~/lib/onboarding", () => ({ listOnboardingSuggestions: vi.fn() }));
+vi.mock("~/lib/tasks", () => ({
+  listTasks: vi.fn(),
+  dismissTask: vi.fn(),
+  completeTask: vi.fn(),
+  answerTask: vi.fn(),
+}));
+
+import { listOnboardingSuggestions } from "~/lib/onboarding";
+import { listTasks } from "~/lib/tasks";
+
+Element.prototype.scrollIntoView = vi.fn();
+
+const CHAT_TASK: Task = {
+  id: "t1",
+  title: "Add your business description",
+  action: { kind: "chat", prompt: "Help me describe my business." },
+  blocking: false,
+  status: "open",
+  createdAt: "2026-01-01T00:00:00Z",
+};
+
+function App() {
+  return (
+    <CompanionProvider>
+      <OnboardingCompanion />
+      <ChatRoute />
+    </CompanionProvider>
+  );
+}
+
+const Stub = createRemixStub([{ path: "/", Component: App }]);
+
+beforeEach(() => {
+  doc = { type: "doc", content: [] };
+  setContent.mockClear();
+  selectTextblockEnd.mockClear();
+  viewFocus.mockClear();
+  vi.mocked(listOnboardingSuggestions).mockResolvedValue([]);
+  vi.mocked(listTasks).mockResolvedValue([CHAT_TASK]);
+  vi.mocked(remix.useLoaderData).mockReturnValue({ agentId: undefined, defaultModel: "auto" });
+});
+
+test("clicking a Companion 'Ask in chat' Task drafts its prompt into the composer", async () => {
+  const user = userEvent.setup();
+  render(<Stub initialEntries={["/"]} />);
+
+  await user.click(
+    await screen.findByRole("button", { name: "Onboarding companion, 1 suggestion" })
+  );
+  await user.click(await screen.findByRole("button", { name: "Ask in chat" }));
+
+  await waitFor(() => expect(setContent).toHaveBeenCalledWith("Help me describe my business."));
+});
+
+test("clicking the same Task card twice redrafts it both times, not just the first", async () => {
+  const user = userEvent.setup();
+  render(<Stub initialEntries={["/"]} />);
+
+  await user.click(
+    await screen.findByRole("button", { name: "Onboarding companion, 1 suggestion" })
+  );
+  await user.click(await screen.findByRole("button", { name: "Ask in chat" }));
+  await waitFor(() => expect(setContent).toHaveBeenCalledTimes(1));
+
+  setContent.mockClear();
+
+  // The panel closes itself on pick — reopen it to click the same card a second time. The Task
+  // itself is never removed: a "chat" action never calls onAnswered/dismiss.
+  await user.click(
+    await screen.findByRole("button", { name: "Onboarding companion, 1 suggestion" })
+  );
+  await user.click(await screen.findByRole("button", { name: "Ask in chat" }));
+
+  // Before the fix this second call never reached the editor: the composer's own `draftedRef`
+  // dedupes on identical prompt *text*, and the Companion had no nonce to key on instead.
+  await waitFor(() => expect(setContent).toHaveBeenCalledTimes(1));
+  expect(setContent).toHaveBeenCalledWith("Help me describe my business.");
+});

--- a/apps/web/app/routes/_app._index.tsx
+++ b/apps/web/app/routes/_app._index.tsx
@@ -64,7 +64,7 @@ export default function ChatRoute() {
   }, [draft, attach]);
   const { refresh, setActiveChatId, newChatNonce } = useConversations();
   const suggestions = useOnboardingSuggestions(newChatNonce);
-  const { tasks } = useCompanion();
+  const { tasks, pendingChatDraft } = useCompanion();
   const user = useSessionUser();
   // First turn of a fresh chat: refresh the Recent chats sidebar AND reflect the new conversation in
   // the URL so a reload restores it. We use `history.replaceState` rather than a router navigate so the
@@ -95,6 +95,7 @@ export default function ChatRoute() {
       greetingIndex={newChatNonce}
       onConversationChange={onConversationChange}
       initialDraft={draft}
+      pendingChatDraft={pendingChatDraft}
       attachFileId={attach}
     />
   );


### PR DESCRIPTION
## Summary
- Companion "chat"-action Tasks now prefill the composer through a shared `CompanionProvider` state (a monotonic nonce keyed draft) instead of a `navigate("/?draft=...")` + `history.replaceState` round-trip.
- The raw `replaceState` in `_app._index.tsx`'s cleanup effect never updates the Remix router's tracked `state.location`, so it silently desynced the router from the address bar and dropped every navigation after the first "Ask in chat" click on the same route — this removes that path's dependency on the URL entirely.
- `ChatPanel` reuses its existing revision-draft remount mechanism to reseed the composer, which also fixes re-clicking the same Task card (previously suppressed by `composer-editor.tsx`'s text-equality dedup).
- The `/?draft=` `<Link>`s in `_app.business.guardrails.tsx` and `_app.integrations.$name.tsx` are untouched — they navigate from a different route and still rely on the loader's `draft` param.

## Test plan
- [x] Added `apps/web/app/routes/_app._index.companion-draft.test.tsx`: renders the FAB + Chat route together, clicks "Ask in chat", and asserts the composer is drafted; confirmed it fails (times out) against the pre-fix code and passes after the fix.
- [x] `rtk proxy pnpm exec biome check --write apps/web/app`
- [x] `rtk proxy pnpm --filter @tulipfarm/web exec vitest run apps/web/app/routes/_app._index.companion-draft.test.tsx` (Node 24)

Closes #732