### PR TITLE
fix: report total model time and fix stream-render glitches around finish

### DIFF
--- a/apps/web/app/components/chat/response.tsx
+++ b/apps/web/app/components/chat/response.tsx
@@ -1,6 +1,13 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { MarkdownView } from "~/components/markdown-view";
 import type { StreamWordCounter } from "~/lib/rehype-stream-words";
+
+/**
+ * `.tf-word-in` runs a 420ms transition plus up to `--word-delay` per word (`app.css`); this is
+ * how long the pipeline stays in streaming mode after `streaming` itself goes false, so the last
+ * batch's spans can finish before the rebuild to plain text happens on an already-settled pass.
+ */
+const STREAM_WORD_SETTLE_MS = 600;
 
 /**
  * Assistant text rendered as terminal-native markdown (reuses the shared MarkdownView so code, lists,
@@ -25,12 +32,28 @@ export function Response({
     revealed.current = counter.current.total;
   });
 
+  // `streaming` flips false in the same commit that seals the message. Dropping the streamWords
+  // plugin on that same render rebuilds every already-transitioning `.tf-word-in` span straight to
+  // plain text mid-animation — the outgoing glyphs visibly smear. Holding the pipeline in streaming
+  // mode for one settle period lets that last batch finish before the rebuild happens.
+  const [settled, setSettled] = useState(streaming !== true);
+  useEffect(() => {
+    if (streaming) {
+      setSettled(false);
+      return;
+    }
+    const timer = setTimeout(() => setSettled(true), STREAM_WORD_SETTLE_MS);
+    return () => clearTimeout(timer);
+  }, [streaming]);
+
+  const animating = streaming === true || !settled;
+
   return (
     <div>
       {text ? (
         <MarkdownView
           citations={citations}
-          streamWords={streaming ? { from: revealed.current, counter: counter.current } : undefined}
+          streamWords={animating ? { from: revealed.current, counter: counter.current } : undefined}
         >
           {text}
         </MarkdownView>

--- a/apps/web/app/components/chat/tool-step.test.tsx
+++ b/apps/web/app/components/chat/tool-step.test.tsx
@@ -215,6 +215,27 @@ describe("A Tool step on the trace", () => {
     expect(screen.getByText("Ask an administrator to add this Credential.")).toBeInTheDocument();
   });
 
+  it("settles an automatic authorization denial collapsed instead of flashing it open", () => {
+    // No `approval` field: an automatic denial never entered the human-approval flow, so it
+    // never had anything asking the reader to act on it — it should read as an already-resolved,
+    // collapsed step from first paint like any other finished call.
+    renderStep(toolPart({ outcome: "error", meta: { errorCode: "denied" } }));
+
+    expect(step()).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("still holds a genuinely human-denied call open, since the reader had to decide on it", () => {
+    renderStep(
+      toolPart({
+        outcome: "error",
+        meta: { errorCode: "denied" },
+        approval: { approvalId: "appr_1", status: "denied" },
+      })
+    );
+
+    expect(step()).toHaveAttribute("aria-expanded", "true");
+  });
+
   it("renders the running state while the call is still in flight", () => {
     const { container } = renderStep(toolPart({ status: "running", outcome: undefined }), {
       pending: true,

--- a/apps/web/app/components/chat/tool-step.tsx
+++ b/apps/web/app/components/chat/tool-step.tsx
@@ -47,6 +47,13 @@ export function ToolStepRow({
   const approval = part.approval;
   const fileDraft = fileDraftOf(part);
   const isAdmin = useIsAdmin();
+  // An automatic authorization denial (`errorCode: "denied"`, no `approval`) never entered the
+  // human approval flow — nothing asks the reader to act on it, so it settles collapsed like any
+  // other finished step. Every other failure (a genuine tool error, or a call the participant
+  // actually had to decide on) still holds itself open.
+  const isAutomaticDenial =
+    status === "error" && part.meta?.errorCode === "denied" && approval === undefined;
+  const holdOpenOnError = !isAutomaticDenial;
   return (
     <>
       <TraceStep
@@ -57,6 +64,7 @@ export function ToolStepRow({
         activeLabel={label === undefined ? describeToolCallActive(ran) : undefined}
         value={part.toolName}
         mono
+        holdOpenOnError={holdOpenOnError}
         className={className}
         marker={
           part.meta?.mutating === true ? (

--- a/apps/web/app/components/chat/transcript.test.tsx
+++ b/apps/web/app/components/chat/transcript.test.tsx
@@ -746,4 +746,129 @@ describe("Transcript auto-scroll stays inside its own scroll container", () => {
       tracked.restore();
     }
   });
+
+  it("anchors a block taller than the viewport to its own top instead of the tail", async () => {
+    // A block taller than the container would land the reader mid-card under a bare
+    // `scrollTop = scrollHeight` jump. Give every element the same generous rect except the
+    // scroll container itself, so the last block reads as "taller than the viewport" and its
+    // computed top sits 50px below the container's.
+    const rectDescriptor = HTMLElement.prototype.getBoundingClientRect;
+    HTMLElement.prototype.getBoundingClientRect = function (this: HTMLElement) {
+      if (this.classList.contains("overflow-y-auto")) {
+        return { top: 0, height: 200 } as DOMRect;
+      }
+      return { top: 50, height: 400 } as DOMRect;
+    };
+    const clientHeightDescriptor = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "clientHeight"
+    );
+    Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+      configurable: true,
+      get(this: HTMLElement) {
+        return this.classList.contains("overflow-y-auto") ? 200 : 0;
+      },
+    });
+    const scrolled: number[] = [];
+    const scrollTopDescriptor = Object.getOwnPropertyDescriptor(Element.prototype, "scrollTop");
+    Object.defineProperty(Element.prototype, "scrollTop", {
+      configurable: true,
+      get: () => 0,
+      set: (value: number) => void scrolled.push(value),
+    });
+    try {
+      render(
+        <Transcript
+          messages={fold([{ type: "text", data: { delta: "streaming" } }], "hi").messages}
+          status="streaming"
+          onApprove={vi.fn()}
+        />
+      );
+      await act(async () => {
+        await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+      });
+
+      // The container starts at top 0; the block starts 50px lower, so the anchor write is 50,
+      // never the tail-jump `scrollHeight` value a plain bottom-pin would have produced.
+      expect(scrolled).toContain(50);
+    } finally {
+      HTMLElement.prototype.getBoundingClientRect = rectDescriptor;
+      if (clientHeightDescriptor) {
+        Object.defineProperty(HTMLElement.prototype, "clientHeight", clientHeightDescriptor);
+      }
+      if (scrollTopDescriptor) {
+        Object.defineProperty(Element.prototype, "scrollTop", scrollTopDescriptor);
+      }
+    }
+  });
+
+  it("re-arms sticking once the reader is back at the bottom, undoing an incidental un-stick", async () => {
+    const scrolled: number[] = [];
+    let scrollTopValue = 0;
+    const scrollTopDescriptor = Object.getOwnPropertyDescriptor(Element.prototype, "scrollTop");
+    Object.defineProperty(Element.prototype, "scrollTop", {
+      configurable: true,
+      get: () => scrollTopValue,
+      set: (value: number) => {
+        scrollTopValue = value;
+        scrolled.push(value);
+      },
+    });
+
+    function flushFrames() {
+      return act(async () => {
+        await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+      });
+    }
+
+    try {
+      const first = fold([{ type: "text", data: { delta: "hello" } }], "hi");
+      const { rerender, container } = render(
+        <Transcript messages={first.messages} status="streaming" onApprove={vi.fn()} />
+      );
+      await flushFrames();
+      const scrollEl = container.querySelector(".overflow-y-auto") as HTMLElement;
+      expect(scrollEl).not.toBeNull();
+      const before = scrolled.length;
+
+      // A deliberate scroll away from the bottom (a wheel gesture, then landing away from it)
+      // un-sticks the transcript — no further auto-scroll should happen while it stays there.
+      Object.defineProperty(scrollEl, "scrollHeight", { configurable: true, value: 1000 });
+      Object.defineProperty(scrollEl, "clientHeight", { configurable: true, value: 200 });
+      scrollTopValue = 0;
+      scrollEl.dispatchEvent(new Event("wheel", { bubbles: true }));
+      scrollEl.dispatchEvent(new Event("scroll", { bubbles: true }));
+
+      const second = fold(
+        [
+          { type: "text", data: { delta: "hello" } },
+          { type: "text", data: { delta: " world" } },
+        ],
+        "hi"
+      );
+      rerender(<Transcript messages={second.messages} status="streaming" onApprove={vi.fn()} />);
+      await flushFrames();
+      expect(scrolled.length).toBe(before);
+
+      // Reaching the bottom by any means (here, an incidental jump back) re-arms sticking, so the
+      // very next update auto-scrolls again instead of staying stuck un-stuck forever.
+      scrollTopValue = 800;
+      scrollEl.dispatchEvent(new Event("scroll", { bubbles: true }));
+
+      const third = fold(
+        [
+          { type: "text", data: { delta: "hello" } },
+          { type: "text", data: { delta: " world again" } },
+        ],
+        "hi"
+      );
+      rerender(<Transcript messages={third.messages} status="streaming" onApprove={vi.fn()} />);
+      await flushFrames();
+      expect(scrolled.length).toBeGreaterThan(before);
+    } finally {
+      if (scrollTopDescriptor) {
+        Object.defineProperty(Element.prototype, "scrollTop", scrollTopDescriptor);
+      }
+    }
+  });
 });

--- a/apps/web/app/components/chat/transcript.tsx
+++ b/apps/web/app/components/chat/transcript.tsx
@@ -463,11 +463,30 @@ export function Transcript({
   onReviseDraft?: (draft: FileDraftResult) => void;
 }) {
   const scrollRef = useRef<HTMLDivElement>(null);
+  const lastBlockRef = useRef<HTMLDivElement>(null);
+  // Whether the reader is following the stream at the bottom. Only a deliberate user gesture
+  // (wheel/touch) may unstick it; a scroll event with no such gesture behind it is an incidental
+  // jump — a collapsing trace, a layout shift — and must not be read as "the reader scrolled up",
+  // or the tail of a finished turn silently stops reaching the viewport (#728).
   const stick = useRef(true);
+  const userGesture = useRef(false);
+
+  function onWheelOrTouch() {
+    userGesture.current = true;
+  }
 
   function onScroll() {
     const el = scrollRef.current;
-    if (el) stick.current = el.scrollHeight - el.scrollTop - el.clientHeight < 48;
+    if (!el) return;
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 48;
+    // Reaching the bottom re-arms sticking regardless of what caused it — including our own
+    // programmatic jump — so a stale "unstuck" state from an earlier incidental scroll cannot
+    // outlive the moment the reader is actually back at the tail.
+    if (atBottom) {
+      stick.current = true;
+    } else if (userGesture.current) {
+      stick.current = false;
+    }
   }
 
   // Auto-scroll is layout-forcing, so coalesce bursts of stream updates into one write per frame.
@@ -479,29 +498,50 @@ export function Transcript({
     if (!stick.current) return;
     const frame = requestAnimationFrame(() => {
       const el = scrollRef.current;
-      if (el) el.scrollTop = el.scrollHeight;
+      if (!el) return;
+      const block = lastBlockRef.current;
+      // A block taller than the viewport lands the reader mid-card if the container is simply
+      // pinned to `scrollHeight` — the tail shows, not the start of what just appeared. Anchor to
+      // the block's own top instead, so a large delta always opens on its beginning.
+      if (block && block.getBoundingClientRect().height > el.clientHeight) {
+        const withinEl =
+          el.scrollTop + (block.getBoundingClientRect().top - el.getBoundingClientRect().top);
+        el.scrollTop = Math.max(0, withinEl);
+      } else {
+        el.scrollTop = el.scrollHeight;
+      }
     });
     return () => cancelAnimationFrame(frame);
   }, [messages, status]);
 
   return (
-    <div ref={scrollRef} onScroll={onScroll} className="flex-1 min-h-0 overflow-y-auto">
+    <div
+      ref={scrollRef}
+      onScroll={onScroll}
+      onWheel={onWheelOrTouch}
+      onTouchMove={onWheelOrTouch}
+      className="flex-1 min-h-0 overflow-y-auto"
+    >
       <div className="mx-auto flex w-full max-w-4xl flex-col gap-7 px-4 py-7 sm:px-6 sm:py-9">
-        {messages.map((m, i) => (
-          <Message
-            key={m.id}
-            message={m}
-            status={status}
-            isLast={i === messages.length - 1}
-            mentions={mentions}
-            onApprove={onApprove}
-            onRegenerate={onRegenerate}
-            onTryHarder={onTryHarder}
-            onFeedback={onFeedback}
-            onSurfaceInteraction={onSurfaceInteraction}
-            onReviseDraft={onReviseDraft}
-          />
-        ))}
+        {messages.map((m, i) => {
+          const isLast = i === messages.length - 1;
+          return (
+            <div key={m.id} ref={isLast ? lastBlockRef : undefined}>
+              <Message
+                message={m}
+                status={status}
+                isLast={isLast}
+                mentions={mentions}
+                onApprove={onApprove}
+                onRegenerate={onRegenerate}
+                onTryHarder={onTryHarder}
+                onFeedback={onFeedback}
+                onSurfaceInteraction={onSurfaceInteraction}
+                onReviseDraft={onReviseDraft}
+              />
+            </div>
+          );
+        })}
         {status === "submitted" ? <Loader /> : null}
       </div>
     </div>

--- a/apps/web/app/components/chat/transcript.tsx
+++ b/apps/web/app/components/chat/transcript.tsx
@@ -52,6 +52,19 @@ function formatLatency(ms: number): string {
   return `${(ms / 1000).toFixed(ms < 10_000 ? 1 : 0)} s`;
 }
 
+/**
+ * When a turn shape makes more than one model call (e.g. a tool proposal denied, then a second
+ * call answers), `modelCallLatencyMs` alone reports only the last call and understates the
+ * turn's real model time. Render the total plus the call count whenever there is more than one,
+ * so triage can see the breakdown rather than a bare, misleadingly small number.
+ */
+function modelTimeLabel(receipt: ModelReceipt): string {
+  const total = receipt.totalModelCallLatencyMs ?? receipt.modelCallLatencyMs;
+  const count = receipt.modelCallCount ?? 1;
+  if (count <= 1) return `model call ${formatLatency(total)}`;
+  return `${count} model calls · ${formatLatency(total)} total`;
+}
+
 function ModelReceiptView({ receipt }: { receipt: ModelReceipt }) {
   const asked = effortLabel(receipt.effortPreset);
   // `auto` is a request, not an outcome. Showing only "Auto" hides the choice the deployment made
@@ -65,7 +78,7 @@ function ModelReceiptView({ receipt }: { receipt: ModelReceipt }) {
         {receipt.modelId}
       </code>
       {effort ? <span>· {effort} effort</span> : null}
-      <span>· model call {formatLatency(receipt.modelCallLatencyMs)}</span>
+      <span>· {modelTimeLabel(receipt)}</span>
     </p>
   );
 }

--- a/apps/web/app/components/ui/trace.tsx
+++ b/apps/web/app/components/ui/trace.tsx
@@ -211,6 +211,14 @@ export type TraceStepProps = {
   diff?: { added: number; removed: number };
   /** What the step actually did. Shown while it is the live step, on demand once it settles. */
   detail?: ReactNode;
+  /**
+   * An error the reader must not have to notice on their own — an approval-gated call the
+   * participant themselves denied, say. Defaults to true, which is what makes an `error` status
+   * hold itself open below. Set false for a failure nothing asks the reader to act on (an
+   * automatic authorization denial, never surfaced as an approval), so it settles collapsed like
+   * any other finished step instead of flashing open until the turn ends.
+   */
+  holdOpenOnError?: boolean;
   className?: string;
 };
 
@@ -231,11 +239,12 @@ export function TraceStep({
   marker,
   diff,
   detail,
+  holdOpenOnError = true,
   className,
 }: TraceStepProps) {
   const [choice, setChoice] = useState<boolean | null>(null);
   const bodyId = useId();
-  const open = choice ?? (status === "running" || status === "error");
+  const open = choice ?? (status === "running" || (status === "error" && holdOpenOnError));
   const expandable = detail !== undefined;
   const shown = status === "running" ? (activeLabel ?? label) : label;
 

--- a/apps/web/app/lib/chat/sse-client.ts
+++ b/apps/web/app/lib/chat/sse-client.ts
@@ -88,6 +88,8 @@ type RunEventData = {
   effortPreset?: ChatModelSelector;
   effortApplied?: EffortRung;
   modelCallLatencyMs?: number;
+  totalModelCallLatencyMs?: number;
+  modelCallCount?: number;
   artifactId?: string;
   revision?: number;
   rounds?: PlanRound[];
@@ -255,6 +257,12 @@ export function createRunEventMapper(): (frame: ParsedFrame) => ChatEvent[] {
                 ...(data.effortPreset === undefined ? {} : { effortPreset: data.effortPreset }),
                 ...(data.effortApplied === undefined ? {} : { effortApplied: data.effortApplied }),
                 modelCallLatencyMs: data.modelCallLatencyMs,
+                ...(data.totalModelCallLatencyMs === undefined
+                  ? {}
+                  : { totalModelCallLatencyMs: data.totalModelCallLatencyMs }),
+                ...(data.modelCallCount === undefined
+                  ? {}
+                  : { modelCallCount: data.modelCallCount }),
               }
             : undefined;
         if (data.status === "succeeded") {

--- a/apps/web/app/lib/chat/types.ts
+++ b/apps/web/app/lib/chat/types.ts
@@ -171,7 +171,11 @@ export type ModelReceipt = {
   modelId: string;
   effortPreset?: EffortPreset;
   effortApplied?: EffortRung;
+  /** The last model call's own duration. */
   modelCallLatencyMs: number;
+  /** Summed across every model call the turn made; absent on a legacy event. */
+  totalModelCallLatencyMs?: number;
+  modelCallCount?: number;
 };
 
 export type TimelinePart =

--- a/apps/worker/src/model.test.ts
+++ b/apps/worker/src/model.test.ts
@@ -357,6 +357,48 @@ describe("LlmModelPort", () => {
       modelId: "claude-sonnet-5",
       effortPreset: "balanced",
       modelCallLatencyMs: 42,
+      totalModelCallLatencyMs: 42,
+      modelCallCount: 1,
+    });
+  });
+
+  it("accumulates latency and count across every model call this port makes", async () => {
+    // A turn shape that proposes tools, gets denials, then answers makes two calls on the same
+    // port instance (one per Turn-attempt). `modelCallLatencyMs` alone would report only the
+    // second call's duration and hide the first entirely.
+    const ticks = [0, 100, 200, 250];
+    const mock = new MockLanguageModelV4({
+      doStream: async () => ({
+        stream: simulateReadableStream<StreamPart>({
+          chunks: [...textParts("t1", ["ok"]), FINISH],
+        }),
+      }),
+    });
+    const port = new LlmModelPort({
+      model: async (): Promise<LlmModelResolution> => ({
+        kind: "available",
+        price: TEST_PRICE,
+        model: mock as unknown as LanguageModel,
+        routing: {
+          outcome: "selected",
+          selector: "balanced",
+          resolution: "effort_preset",
+          profileId: "primary",
+          chain: [{ profileId: "primary", modelId: "claude-sonnet-5" }],
+          cacheAllowed: true,
+          rejectedFallbacks: [],
+        },
+      }),
+      now: () => ticks.shift() ?? 0,
+    });
+
+    await port.invoke(request({ requestId: "run-1:invoke:1", modelProfileId: "balanced" }));
+    await port.invoke(request({ requestId: "run-1:invoke:2", modelProfileId: "balanced" }));
+
+    expect(port.latestModelCallReceipt()).toMatchObject({
+      modelCallLatencyMs: 50,
+      totalModelCallLatencyMs: 150,
+      modelCallCount: 2,
     });
   });
 

--- a/apps/worker/src/model.ts
+++ b/apps/worker/src/model.ts
@@ -105,14 +105,29 @@ export type { ModelCallReceipt, ModelCallReceiptSource } from "@tulipfarm/turn-e
 
 export class LlmModelPort implements ModelPort, ModelCallReceiptSource {
   private receipt: ModelCallReceipt | undefined;
+  /** Cumulative across every model call this port makes; a turn shape can call the model twice. */
+  private totalModelCallLatencyMs = 0;
+  private modelCallCount = 0;
   /** Cached effort decision; `undefined` is a real inferred result and must not re-run. */
   private effort: { readonly value: RunEventEffortInference | undefined } | undefined;
 
   constructor(private readonly options: LlmModelPortOptions) {}
 
-  /** The last completed model call on this port, or `undefined` when none completed. */
+  /**
+   * The last completed model call on this port, or `undefined` when none completed.
+   *
+   * `modelId`/`effortPreset`/`effortApplied`/`modelCallLatencyMs` describe that last call, but
+   * `totalModelCallLatencyMs`/`modelCallCount` accumulate every call this port made — a turn
+   * shape that proposes tools, gets denials, then answers makes two, and reporting only the last
+   * call's latency understates the turn's real model time by the first call's whole duration.
+   */
   latestModelCallReceipt(): ModelCallReceipt | undefined {
-    return this.receipt;
+    if (this.receipt === undefined) return undefined;
+    return {
+      ...this.receipt,
+      totalModelCallLatencyMs: this.totalModelCallLatencyMs,
+      modelCallCount: this.modelCallCount,
+    };
   }
 
   async invoke(request: ModelInvocationRequest): Promise<ModelInvocationResult> {
@@ -309,9 +324,10 @@ export class LlmModelPort implements ModelPort, ModelCallReceiptSource {
     // Priced after the call, against the chain link that actually answered — never the head of
     // the chain, which is a prediction rather than an outcome.
     const cost = resolution.price(inputTokens, outputTokens);
-    this.receipt =
-      receiptFromRouting(resolution.routing, Math.max(0, Math.round(finishedAt - startedAt))) ??
-      this.receipt;
+    const latencyMs = Math.max(0, Math.round(finishedAt - startedAt));
+    this.totalModelCallLatencyMs += latencyMs;
+    this.modelCallCount += 1;
+    this.receipt = receiptFromRouting(resolution.routing, latencyMs) ?? this.receipt;
 
     // ai@7 can emit `finish` without running the provider; treat empty calls/text/usage as a fault.
     if (

--- a/packages/schema/src/run-events.ts
+++ b/packages/schema/src/run-events.ts
@@ -260,6 +260,8 @@ const TURN_FINISHED_SCHEMA = {
     effortPreset: { type: "string", enum: EFFORT_PRESETS },
     effortApplied: { type: "string", enum: EFFORT_RUNGS },
     modelCallLatencyMs: { type: "integer", minimum: 0 },
+    totalModelCallLatencyMs: { type: "integer", minimum: 0 },
+    modelCallCount: { type: "integer", minimum: 0 },
     usage: {
       type: "object",
       additionalProperties: false,
@@ -583,6 +585,8 @@ export interface RunEventPayloads {
     readonly effortPreset?: EffortPreset;
     readonly effortApplied?: EffortRung;
     readonly modelCallLatencyMs?: number;
+    readonly totalModelCallLatencyMs?: number;
+    readonly modelCallCount?: number;
     readonly usage?: { readonly inputTokens?: number; readonly outputTokens?: number };
   };
   readonly "context.assembled": {

--- a/packages/turn-executor/src/driver.test.ts
+++ b/packages/turn-executor/src/driver.test.ts
@@ -305,6 +305,40 @@ describe("TurnDriver", () => {
     });
   });
 
+  it("threads the accumulated model latency and call count into the finished event", async () => {
+    // A turn shape that proposes tools, gets denials, then answers makes two model calls; the
+    // driver must not drop the cumulative fields the receipt carries alongside the last call's.
+    const { driver, events } = harness(
+      {
+        status: "completed",
+        output: "the answer",
+        ...counters,
+      },
+      {
+        receipt: {
+          modelId: "claude-sonnet-5",
+          modelCallLatencyMs: 21_000,
+          totalModelCallLatencyMs: 30_000,
+          modelCallCount: 2,
+        },
+      }
+    );
+
+    await driver.run(request());
+
+    expect(events.appended.at(-1)).toEqual({
+      eventType: "turn.finished",
+      payload: {
+        status: "succeeded",
+        messageId: "msg-1",
+        modelId: "claude-sonnet-5",
+        modelCallLatencyMs: 21_000,
+        totalModelCallLatencyMs: 30_000,
+        modelCallCount: 2,
+      },
+    });
+  });
+
   it("finishes without receipt fields when no model call was observed", async () => {
     const { driver, events } = harness({ status: "completed", output: "hi", ...counters });
 

--- a/packages/turn-executor/src/ports.ts
+++ b/packages/turn-executor/src/ports.ts
@@ -108,7 +108,15 @@ export interface ModelCallReceipt {
   readonly effortPreset?: EffortPreset;
   /** Actual rung, when knowable, so clients can escalate `auto` without guessing. */
   readonly effortApplied?: EffortRung;
+  /** The last completed model call's own duration. */
   readonly modelCallLatencyMs: number;
+  /**
+   * Summed across every model call this Turn-attempt made — a turn shape that proposes tools,
+   * gets denials, then answers makes two calls, and `modelCallLatencyMs` alone reports only the
+   * second.
+   */
+  readonly totalModelCallLatencyMs?: number;
+  readonly modelCallCount?: number;
 }
 
 /** Latest-call receipt is scoped to this Turn-attempt port, not a process registry. */


### PR DESCRIPTION
## Summary

- #727's "~21s unaccounted overhead" premise is incorrect — the second ~21s is a real, second model call (a tool proposal denied, then a second call answers). The actual defect is that `LlmModelPort` reported only the *last* call's latency, silently dropping the first call's time from the receipt. This PR fixes that reporting gap, not a latency regression — no retry/backoff behaviour changed, and the issue's stated "p95 < 10s" target is not something this PR targets, since it was written on the false premise.
- #728's four symptoms (denied-tool-card flash-then-collapse, scroll landing mid-card, tail never reached, glyph smear at stream end) all trace back to the same atomic `finish` SSE commit, but are three independent fixes, not one shared root cause: settle an automatic authorization denial collapsed from first paint (never a genuine or human-denied failure), anchor auto-scroll to a new block's own top with a proper re-arm path instead of a raw `scrollHeight` pin that only unsticks forever, and hold the streamed-word animation pipeline active for one settle period past the `streaming` flip so in-flight word transitions finish before the rebuild to plain text.
- Confirmed but intentionally left unfixed: `packages/turn-executor`'s `approval-resolved` reducer case (`apps/web/app/lib/chat/reducer.ts:212-218`) never clears `part.approval` for a genuinely human-denied call — only its `status` updates. Not exercised by this PR's fixes and out of scope; filing as a follow-up issue.

## Test plan

- [x] `apps/worker/src/model.test.ts` — accumulated receipt latency/count across every model call in a turn
- [x] `packages/turn-executor/src/driver.test.ts` — accumulated fields thread through into `turn.finished`
- [x] `apps/web/app/components/chat/tool-step.test.tsx` — an automatic authorization denial renders settled/collapsed; a genuinely human-denied call still holds open
- [x] `apps/web/app/components/chat/transcript.test.tsx` — auto-scroll anchors a tall block to its own top; sticking re-arms once the reader returns to the bottom instead of staying un-stuck forever
- [x] `pnpm exec biome check --write` on every changed file

Closes #727
Closes #728