### PR TITLE
fix: raise chat and routine agent tool-call ceilings

### DIFF
--- a/apps/worker/src/routine/agent-port.test.ts
+++ b/apps/worker/src/routine/agent-port.test.ts
@@ -529,6 +529,7 @@ describe("BundleRoutineAgentPort", () => {
         }),
       },
       catalog: async () => tools,
+      toolCallCeiling: { maxIterations: 12, maxToolCalls: 12 },
     }).execute(request());
 
     expect(result).toEqual({

--- a/apps/worker/src/routine/agent-port.ts
+++ b/apps/worker/src/routine/agent-port.ts
@@ -151,11 +151,14 @@ export function isRetryableAgentFailure(reason: string): boolean {
  * A State that can call Tools needs room to call one and then answer with what it returned; at 1
  * the model could only ever describe the call it wanted. Matches the Chat Turn ceiling, so the
  * same Agent behaves the same in a Routine as in a conversation.
+ *
+ * Effectively unbounded, matching `MAX_TOOL_STEPS` in `@tulipfarm/memory` — kept finite because it
+ * crosses the internal checkpoint API's `type: "integer"` schema.
  */
-const MAX_ITERATIONS = 12;
+const MAX_ITERATIONS = 1_000_000;
 
 /** Tool calls one State may make. Same ceiling as the iteration budget, as in Chat. */
-const MAX_TOOL_CALLS = 12;
+const MAX_TOOL_CALLS = 1_000_000;
 
 const SYSTEM_SOURCE_ID = "system";
 const REQUEST_SOURCE_ID = "request";

--- a/apps/worker/src/routine/agent-port.ts
+++ b/apps/worker/src/routine/agent-port.ts
@@ -108,6 +108,11 @@ export interface BundleRoutineAgentPortOptions {
   /** Where a guard that timed out or threw is reported; it is skipped, never allowed to stall. */
   readonly log: { warn(obj: unknown, msg?: string): void };
   readonly now?: () => Date;
+  /**
+   * Overrides `MAX_ITERATIONS`/`MAX_TOOL_CALLS` for a test that needs to actually reach the
+   * ceiling. Absent in production, where the real (effectively unbounded) ceiling applies.
+   */
+  readonly toolCallCeiling?: { readonly maxIterations: number; readonly maxToolCalls: number };
 }
 
 /** A settled routing decision: the chain to invoke, in order, and the evidence that chose it. */
@@ -553,11 +558,15 @@ export class BundleRoutineAgentPort implements RoutineAgentPort {
   }
 
   private limits(plan: AgentInvocationPlan, toolCount: number): AgentLoopLimits {
-    return {
+    const ceiling = this.options.toolCallCeiling ?? {
       maxIterations: MAX_ITERATIONS,
+      maxToolCalls: MAX_TOOL_CALLS,
+    };
+    return {
+      maxIterations: ceiling.maxIterations,
       // Zero when the State is offered nothing, so a deployment with no Tool host keeps the exact
       // single-call shape this port had before.
-      maxToolCalls: toolCount === 0 ? 0 : MAX_TOOL_CALLS,
+      maxToolCalls: toolCount === 0 ? 0 : ceiling.maxToolCalls,
       maxRepairAttempts: plan.maxRepairAttempts ?? 0,
     };
   }

--- a/packages/memory/src/limits.ts
+++ b/packages/memory/src/limits.ts
@@ -1,5 +1,9 @@
-/** Max sequential LLM steps in one chat turn's tool loop (TOOLS spec: max_tool_calls). */
-export const MAX_TOOL_STEPS = 25;
+/**
+ * Max sequential LLM steps in one chat turn's tool loop (TOOLS spec: max_tool_calls).
+ * Effectively unbounded — long research/agentic work should not hit a step ceiling. Kept finite
+ * (not `Infinity`) because it crosses the internal checkpoint API's `type: "integer"` schema.
+ */
+export const MAX_TOOL_STEPS = 1_000_000;
 
 /** Conversation compaction starts when coarse history estimate exceeds the model-safe budget. */
 export const MAX_HISTORY_TOKENS = 120_000;


### PR DESCRIPTION
## Summary
- Raise `MAX_TOOL_STEPS` (chat, `packages/memory/src/limits.ts`) and `MAX_ITERATIONS`/`MAX_TOOL_CALLS` (routine agent, `apps/worker/src/routine/agent-port.ts`) from 25/12 to 1,000,000 — long-running research/agentic work was hitting the ceiling mid-task.
- Kept finite (not `Infinity`) since these values cross the internal checkpoint API's `type: "integer"` schema (`apps/api/src/internal/schemas.ts`), which rejects non-finite numbers.

Fixes #736 

## Test plan
- [ ] `pnpm --filter @tulipfarm/memory typecheck`
- [ ] `pnpm --filter @tulipfarm/worker typecheck`