### PR TITLE
fix(web): allow blob: object URLs in the production CSP

### DIFF
--- a/apps/web/scripts/csp-header.test.ts
+++ b/apps/web/scripts/csp-header.test.ts
@@ -19,6 +19,11 @@ describe("CSP header generation", () => {
     expect(header).not.toMatch(/script-src[^;]*'unsafe-inline'/);
     // The Surface code-view frame is same-origin; without this the sandbox would never load.
     expect(header).toContain("frame-src 'self'");
+    // The file preview holds fetched File bytes as an object URL, so blob: must be allowed
+    // alongside self on each directive that touches it.
+    expect(header).toMatch(/img-src[^;]*\bblob:/);
+    expect(header).toMatch(/connect-src[^;]*\bblob:/);
+    expect(header).toMatch(/frame-src[^;]*\bblob:/);
   });
 
   it("fails when the final HTML has no inline scripts", () => {

--- a/apps/web/scripts/csp-header.ts
+++ b/apps/web/scripts/csp-header.ts
@@ -20,11 +20,15 @@ export function cspHeaderForHtml(html: string): string {
   const scriptSrc = ["'self'", "'unsafe-eval'", ...hashes].join(" ");
   return (
     `default-src 'self'; script-src ${scriptSrc}; style-src 'self' 'unsafe-inline'; ` +
-    "img-src 'self' data:; font-src 'self' data:; connect-src 'self'; " +
+    // blob: on img-src/connect-src/frame-src: the file preview fetches File bytes itself (the
+    // content route needs the session, which an <img>/<iframe> src can't carry) and holds them as
+    // an object URL instead. That URL is same-origin, opaque and readable only by this page, so
+    // allowing it does not widen what default-src 'self' is guarding against.
+    "img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' blob:; " +
     // Stated rather than inherited from default-src: the sandbox frame that runs authored code is
     // served from this origin, and a reader deleting a `default-src` fallback should not silently
     // take the frame with it.
-    "frame-src 'self'; frame-ancestors 'none'"
+    "frame-src 'self' blob:; frame-ancestors 'none'"
   );
 }
 


### PR DESCRIPTION
## Summary

- Closes #734. The file preview fetches File bytes itself and holds them as a `blob:` object URL — the content route needs the session cookie, which an `<img>`/`<iframe>` `src` can't carry — but the production CSP's `img-src`/`connect-src`/`frame-src` allowed only `'self'` and `data:`, so the browser refused to paint the object URL.
- The same gap broke the PDF branch of the same preview component (`<iframe src={blobUrl}>`), by the identical mechanism.
- A `blob:` URL is same-origin, opaque, unguessable, and readable only by the page that minted it, so allowing it does not meaningfully widen the policy `default-src 'self'` enforces — it cannot be used to reach a third party.

## Test plan

- [x] `rtk proxy pnpm exec vitest run apps/web/scripts/csp-header.test.ts` — new assertions for `blob:` on `img-src`/`connect-src`/`frame-src` fail before the fix and pass after
- [x] `rtk proxy pnpm exec biome check --write apps/web/scripts`
- [x] `pnpm --filter @tulipfarm/web typecheck`