### PR TITLE
fix(authz): stop secret.read navigation gate from diverging in enforcing mode

### DIFF
--- a/packages/authz/src/navigation.test.ts
+++ b/packages/authz/src/navigation.test.ts
@@ -1,5 +1,9 @@
 import { expect, test, vi } from "vitest";
-import { type NavigationAuthorization, sessionNavigationCapabilities } from "./navigation";
+import {
+  NAVIGATION_REQUIREMENTS,
+  type NavigationAuthorization,
+  sessionNavigationCapabilities,
+} from "./navigation";
 
 test("navigation capabilities omit every path whose authority is denied", async () => {
   const denied = new Set(["operations.read", "soul.git_config.read", "llm_config.read"]);
@@ -13,6 +17,20 @@ test("navigation capabilities omit every path whose authority is denied", async 
   );
   expect(capabilities.visiblePaths).toContain("/business/activities");
   expect(capabilities.visiblePaths).toContain("/files");
+});
+
+test("secret.read declares the same fallback everywhere it gates navigation (#754)", () => {
+  const secretReadFallbacks = NAVIGATION_REQUIREMENTS.flatMap((requirement) =>
+    requirement.authorizations.filter((authorization) => authorization.action === "secret.read")
+  ).map((authorization) => authorization.fallback);
+
+  expect(secretReadFallbacks.length).toBeGreaterThan(0);
+  // `secret.read` is enforced as admin-only everywhere else (apps/api/src/secrets/routes.ts); a
+  // looser "authenticated" fallback here diverges from the engine under enforcing mode and, in
+  // shadow mode or with no authorizer wired, would serve the permissive answer for real.
+  for (const fallback of secretReadFallbacks) {
+    expect(fallback).toBe("admin");
+  }
 });
 
 test("navigation capabilities evaluate each repeated authorization once", async () => {

--- a/packages/authz/src/navigation.ts
+++ b/packages/authz/src/navigation.ts
@@ -73,13 +73,13 @@ export const NAVIGATION_REQUIREMENTS: readonly NavigationRequirement[] = [
     path: "/business/models",
     authorizations: [
       { action: "llm_config.read", resourceType: "llm_config", fallback: "admin" },
-      { action: "secret.read", resourceType: "secret", fallback: "authenticated" },
+      { action: "secret.read", resourceType: "secret", fallback: "admin" },
     ],
   },
   {
     path: "/business/secrets",
     authorizations: [
-      { action: "secret.read", resourceType: "secret", fallback: "authenticated" },
+      { action: "secret.read", resourceType: "secret", fallback: "admin" },
       { action: "llm_config.read", resourceType: "llm_config", fallback: "admin" },
     ],
   },


### PR DESCRIPTION
## Summary

- `secret.read` is enforced admin-only everywhere it actually gates data (`apps/api/src/secrets/routes.ts` declares `fallback: "admin"`), but the navigation-visibility check for `/business/models` and `/business/secrets` declared `fallback: "authenticated"` for the same action — a mismatch that produced the recurring `authz.divergence` warning on the staging instance.
- `enforcing` mode already makes the engine's decision final: `apps/api/src/authz/route-gate.ts:205` returns `engineAllowed`, not `fallbackAllowed`, whenever `mode !== "shadow"`, and this is pinned by 8 passing assertions in `scripts/authz-lockout-safety.test.ts` plus the `route gate shadow mode` suite in `apps/api/src/authz/route-gate.test.ts`. So the mismatched fallback was not a live data-read bypass — but it would serve the permissive `"authenticated"` answer for real in `shadow` mode or whenever no authorizer is wired (`route-gate.ts:170-172`), and it kept firing the divergence warning on the sensitive action every session.
- Aligned both `secret.read` nav declarations in `packages/authz/src/navigation.ts` with `"admin"`, matching the real gate and every sibling admin-only nav entry (e.g. the neighboring `llm_config.read` declaration).

## Root cause (file:line evidence)

- `packages/authz/src/navigation.ts:76` and `:82` (before this change) declared `{ action: "secret.read", resourceType: "secret", fallback: "authenticated" }` for the `/business/models` and `/business/secrets` nav-visibility checks.
- `apps/api/src/secrets/routes.ts:79` declares the same action/resourceType with `fallback: "admin"` for the route that actually returns secret metadata — the two fallbacks for one action disagreed.
- `apps/api/src/identity/roles.ts` never grants `secret.read` to anyone but `admin`/`owner` (via their unrestricted wildcard grant), so `decideEffectivePermission` correctly abstains-to-deny for a regular member — matching the reported `engineAllowed: false`.
- `apps/api/src/authz/route-gate.ts:205` (`return mode === "shadow" ? fallbackAllowed : engineAllowed;`) already made the engine's `false` final under `enforcing`, which is why no secret data was ever actually exposed — the divergence log was real, but the observed decision was already correctly denying.

### Alternatives ruled out

1. **`enforcing` doesn't actually mean the engine decides.** Ruled out by `route-gate.ts:205` itself, and by the fact that `scripts/authz-lockout-safety.test.ts` (8 tests, all currently passing) and the `route gate shadow mode` describe block in `apps/api/src/authz/route-gate.test.ts` both assert `enforcing` returns the engine's answer even when it disagrees with the fallback.
2. **The engine's grant model is missing a rule the fallback implicitly had.** Ruled out because the real, currently-enforced route for this exact action (`secrets/routes.ts`) already uses `fallback: "admin"`, not `"authenticated"` — so the correct fix is aligning the nav check to the real policy, not widening the engine's grants to match a fallback that was itself wrong.

## Test plan

- [x] `pnpm --filter @tulipfarm/authz exec vitest run src/navigation.test.ts` — new test fails on the pre-fix fallback, passes after
- [x] `pnpm --filter @tulipfarm/authz exec vitest run` (239 tests)
- [x] `pnpm --filter @tulipfarm/api exec vitest run src/authz/route-gate.test.ts` (24 tests)
- [x] `pnpm exec vitest run scripts/authz-lockout-safety.test.ts` (8 tests)
- [x] `pnpm typecheck`

Closes #754