### PR TITLE
fix(agent-runtime): break the tool loop on repeated identical calls

### DIFF
--- a/apps/eval/corpus/support-breaks-a-looping-identical-tool-call.json
+++ b/apps/eval/corpus/support-breaks-a-looping-identical-tool-call.json
@@ -1,0 +1,43 @@
+{
+  "id": "support-breaks-a-looping-identical-tool-call",
+  "tier": "l2",
+  "agent": "support",
+  "input": [{ "role": "user", "content": "What's the tax rate for Nevada?" }],
+  "tools": [
+    {
+      "name": "lookup_tax_rate",
+      "description": "Look up the sales tax rate for a US state by its two-letter code.",
+      "inputSchema": {
+        "type": "object",
+        "properties": { "state": { "type": "string" } },
+        "required": ["state"]
+      }
+    }
+  ],
+  "toolResults": [
+    { "name": "lookup_tax_rate", "output": { "state": "NV", "ratePercent": "6.85%" } }
+  ],
+  "script": [
+    {
+      "kind": "tool_calls",
+      "calls": [{ "callId": "c1", "name": "lookup_tax_rate", "arguments": { "state": "NV" } }]
+    },
+    {
+      "kind": "tool_calls",
+      "calls": [{ "callId": "c2", "name": "lookup_tax_rate", "arguments": { "state": "NV" } }]
+    },
+    {
+      "kind": "tool_calls",
+      "calls": [{ "callId": "c3", "name": "lookup_tax_rate", "arguments": { "state": "NV" } }]
+    },
+    {
+      "kind": "tool_calls",
+      "calls": [{ "callId": "c4", "name": "lookup_tax_rate", "arguments": { "state": "NV" } }]
+    }
+  ],
+  "expect": [
+    { "kind": "tool_called", "name": "lookup_tax_rate" },
+    { "kind": "tool_call_count", "count": 3 },
+    { "kind": "loop_status", "status": "failed" }
+  ]
+}

--- a/apps/worker/src/routine/agent-port.test.ts
+++ b/apps/worker/src/routine/agent-port.test.ts
@@ -506,14 +506,15 @@ describe("BundleRoutineAgentPort", () => {
       callCount += 1;
       // Two calls per iteration, so the 12-call ceiling is reached after 6 iterations — well under
       // the 12-iteration ceiling — proving this failure is attributed to the Tool-call limit and
-      // not merely to running out of iterations.
+      // not merely to running out of iterations. Arguments vary by iteration so the repeated-call
+      // guard never trips first and the ceiling is what actually ends the Turn.
       return {
         requestId: `req-${callCount}`,
         output: {
           kind: "tool_calls",
           calls: [
-            { callId: `call-${callCount}-a`, name: "lookup", arguments: {} },
-            { callId: `call-${callCount}-b`, name: "lookup", arguments: {} },
+            { callId: `call-${callCount}-a`, name: "lookup", arguments: { iteration: callCount } },
+            { callId: `call-${callCount}-b`, name: "lookup", arguments: { iteration: callCount } },
           ],
         },
         usage: { inputTokens: 10, outputTokens: 4 },
@@ -540,6 +541,50 @@ describe("BundleRoutineAgentPort", () => {
     expect(appended.at(-1)).toMatchObject({
       eventType: "turn.finished",
       payload: { status: "failed", messageId: null, reason: "tool_call_limit" },
+    });
+  });
+
+  it("surfaces a looping model repeating one Tool call as its own failure (#749)", async () => {
+    const tools: ExposedTool[] = [
+      {
+        name: "lookup",
+        description: "Looks something up.",
+        inputSchema: { type: "object", properties: {}, additionalProperties: false },
+      },
+    ];
+    let callCount = 0;
+    invoke = vi.fn<ModelPort["invoke"]>(async () => {
+      callCount += 1;
+      return {
+        requestId: `req-${callCount}`,
+        output: {
+          kind: "tool_calls",
+          calls: [{ callId: `call-${callCount}`, name: "lookup", arguments: {} }],
+        },
+        usage: { inputTokens: 10, outputTokens: 4 },
+      } as ModelInvocationResult;
+    });
+
+    const result = await port({
+      tools: {
+        dispatch: async (call) => ({
+          status: "succeeded",
+          callId: call.callId,
+          output: "ok",
+        }),
+      },
+      catalog: async () => tools,
+      toolCallCeiling: { maxIterations: 12, maxToolCalls: 12 },
+    }).execute(request());
+
+    expect(result).toEqual({
+      kind: "failed",
+      reason: "repeated_tool_calls",
+      retryable: false,
+    });
+    expect(appended.at(-1)).toMatchObject({
+      eventType: "turn.finished",
+      payload: { status: "failed", messageId: null, reason: "repeated_tool_calls" },
     });
   });
 
@@ -586,6 +631,7 @@ describe("isRetryableAgentFailure", () => {
       "model_not_found",
       "iteration_limit",
       "tool_call_limit",
+      "repeated_tool_calls",
       "repair_budget_exhausted",
       "budget_exhausted",
       "empty_model_output",

--- a/packages/agent-runtime/src/loop/contract.ts
+++ b/packages/agent-runtime/src/loop/contract.ts
@@ -195,6 +195,7 @@ export interface AgentLoopBudgetPort {
 export type AgentLoopFailureReason =
   | "iteration_limit"
   | "tool_call_limit"
+  | "repeated_tool_calls"
   | "repair_budget_exhausted"
   | "budget_exhausted"
   | "input_request_failed"

--- a/packages/agent-runtime/src/loop/loop.test.ts
+++ b/packages/agent-runtime/src/loop/loop.test.ts
@@ -2313,6 +2313,83 @@ describe("AgentLoop repeated Tool calls inside one Turn", () => {
   });
 });
 
+describe("AgentLoop breaking on a looping model", () => {
+  const listCall = (callId: string, args: unknown) =>
+    toolCallResult([{ callId, name: "github.issue.comment", arguments: args }]);
+
+  /** Every Tool result in the final prompt, in the order the model reads them. */
+  const results = (prompt: readonly ModelMessage[]) =>
+    prompt
+      .filter((message) => message.role === "tool")
+      .map((message) => JSON.parse(contentText(message.content)) as Record<string, unknown>);
+
+  it("ends the Turn as repeated_tool_calls instead of burning the whole tool-call budget (#749)", async () => {
+    // Regression for staging's `IndexSlackKnowledge`: raising `maxToolCalls` (#745) did not stop a
+    // model that proposes the exact same call, unchanged, every iteration. Before this fix, nothing
+    // in the loop broke on that pattern — it just re-dispatched forever and eventually reported
+    // `tool_call_limit`, however high the ceiling was raised.
+    const model = promptRecordingModel(
+      listCall("call-1", { body: "same" }),
+      listCall("call-2", { body: "same" }),
+      listCall("call-3", { body: "same" }),
+      listCall("call-4", { body: "same" })
+    );
+    const tools = dispatcher(
+      { status: "succeeded", callId: "call-1", output: { ok: true } },
+      { status: "succeeded", callId: "call-2", output: { ok: true } },
+      { status: "succeeded", callId: "call-3", output: { ok: true } }
+    );
+
+    const outcome = await loop({ model, tools }).run(
+      input({ limits: { maxIterations: 20, maxToolCalls: 20, maxRepairAttempts: 2 } })
+    );
+
+    expect(outcome).toMatchObject({ status: "failed", reason: "repeated_tool_calls" });
+    // Broken well short of the (generous) ceiling: the model was stopped for looping, not for
+    // spending its whole budget.
+    expect(tools.calls).toHaveLength(3);
+    expect(model.prompts).toHaveLength(4);
+
+    // The model saw a plain warning before the loop gave up on it.
+    const warned = model.prompts[3]?.at(-1);
+    expect(warned).toMatchObject({ role: "user" });
+    const warning = JSON.parse(contentText((warned as ModelMessage).content)) as {
+      warning: string;
+      detail: string;
+    };
+    expect(warning.warning).toBe("repeated_tool_calls");
+    expect(warning.detail).toContain("3 times in a row");
+  });
+
+  it("does not trip the loop guard when the arguments actually change", async () => {
+    const model = promptRecordingModel(
+      listCall("call-1", { body: "one" }),
+      listCall("call-2", { body: "two" }),
+      listCall("call-3", { body: "three" }),
+      listCall("call-4", { body: "four" }),
+      textResult("done")
+    );
+    const tools = dispatcher(
+      { status: "succeeded", callId: "call-1", output: { ok: true } },
+      { status: "succeeded", callId: "call-2", output: { ok: true } },
+      { status: "succeeded", callId: "call-3", output: { ok: true } },
+      { status: "succeeded", callId: "call-4", output: { ok: true } }
+    );
+
+    const outcome = await loop({ model, tools }).run(
+      input({ limits: { maxIterations: 20, maxToolCalls: 20, maxRepairAttempts: 2 } })
+    );
+
+    expect(outcome).toMatchObject({ status: "completed" });
+    expect(tools.calls).toHaveLength(4);
+    for (const prompt of model.prompts) {
+      for (const result of results(prompt)) {
+        expect(result.repeatedCall).toBeUndefined();
+      }
+    }
+  });
+});
+
 describe("AgentLoop park-time answers and cancellation accounting", () => {
   const readTools = [
     { name: "github.issue.search", inputSchema: { type: "object" }, mutating: false },

--- a/packages/agent-runtime/src/loop/loop.ts
+++ b/packages/agent-runtime/src/loop/loop.ts
@@ -31,8 +31,10 @@ import { askFor, distilledPayload, latestAsk } from "./distill";
 import { extractSkillName, narrowToolsToSkill, SKILL_TOOL } from "./narrowing";
 import { capToolResult, MAX_TOOL_RESULT_CHARS } from "./oversize";
 import {
+  batchSignature,
   callSignature,
   elideRepeatedSkillText,
+  repeatedBatchWarning,
   repeatedCall,
   servedFromCache,
   shortCircuitedRepeat,
@@ -73,6 +75,16 @@ const REPEATED_REJECTION_LIMIT = 2;
  * stays silent until the ceiling is close, so an ordinarily-sized Turn never sees it.
  */
 const BUDGET_WARNING_THRESHOLD = 3;
+
+/**
+ * How many times in a row the model may propose the exact same batch of Tool calls — same names,
+ * same arguments, nothing else in between — before the loop stops treating the repeat as a retry
+ * it can still learn from. Raising `maxToolCalls` cannot fix a model that is looping rather than
+ * running out of room, and it left a genuine loop free to burn the whole (now enormous) budget
+ * before failing; this catches it in a handful of iterations instead. One more identical batch
+ * past this count ends the Turn — see the warning appended at the threshold.
+ */
+const CONSECUTIVE_REPEAT_WARNING = 3;
 
 export class AgentLoop {
   constructor(private readonly deps: AgentLoopDependencies) {}
@@ -116,6 +128,11 @@ export class AgentLoop {
     // How often each Tool has already answered this exact question this attempt. Not checkpointed,
     // for the same reason: a resume replays the transcript, so the repetition stays visible there.
     const repeatCounts = new Map<string, number>();
+    // The signature of the last iteration's whole proposed batch, and how many times running it
+    // has repeated exactly. Not checkpointed, for the same reason as `repeatCounts`: a resumed
+    // attempt rebuilds it from the calls it can see rather than trusting a stale count.
+    let lastCallBatchSignature: string | undefined;
+    let consecutiveIdenticalBatches = 0;
     // The first successful result for each signature a `cacheable` Tool has answered this attempt,
     // keyed the same way as `repeatCounts`. Not checkpointed: a resume replays the transcript, so
     // a resumed Turn rebuilds this the same way a fresh one does, from the calls it can see.
@@ -960,11 +977,51 @@ export class AgentLoop {
       // operator never set.
 
       if (result.output.kind === "tool_calls") {
-        const outcome = await dispatchCalls(
-          normalizeCalls(result.output.calls, counters.iterations),
-          false
-        );
+        const calls = normalizeCalls(result.output.calls, counters.iterations);
+        const signature = batchSignature(calls);
+        if (signature !== undefined && signature === lastCallBatchSignature) {
+          consecutiveIdenticalBatches += 1;
+        } else {
+          lastCallBatchSignature = signature;
+          consecutiveIdenticalBatches = signature === undefined ? 0 : 1;
+        }
+
+        // Past the warning, the model has already been told once and repeated anyway: dispatching
+        // again would only spend more of the (now enormous) `maxToolCalls` budget on a loop that
+        // is not going to run out on its own. Ending here, before this batch dispatches, is what
+        // keeps the failure cheap instead of exhausting the whole ceiling first.
+        if (consecutiveIdenticalBatches > CONSECUTIVE_REPEAT_WARNING) {
+          this.deps.log?.warn(
+            {
+              event: "agent_loop.repeated_tool_calls",
+              runId: input.runId,
+              stateId: input.stateId,
+              iteration: counters.iterations,
+              occurrences: consecutiveIdenticalBatches,
+            },
+            "model repeated the same Tool call batch past the warning; ending the Turn"
+          );
+          return finish({ status: "failed", reason: "repeated_tool_calls", ...counters }, "failed");
+        }
+
+        const outcome = await dispatchCalls(calls, false);
         if (outcome !== undefined) return outcome;
+
+        // One warning, on the batch that trips the threshold, before the loop stops trusting the
+        // repeat — the same shape as the empty-completion and schema-repair nudges below, so the
+        // model gets to see it and change course on the very next call.
+        if (consecutiveIdenticalBatches === CONSECUTIVE_REPEAT_WARNING) {
+          messages.push({
+            role: "user",
+            content: textContent(
+              JSON.stringify({
+                warning: "repeated_tool_calls",
+                detail: repeatedBatchWarning(consecutiveIdenticalBatches),
+              })
+            ),
+          });
+          await checkpoint();
+        }
         continue;
       }
 

--- a/packages/agent-runtime/src/loop/repeat.ts
+++ b/packages/agent-runtime/src/loop/repeat.ts
@@ -99,6 +99,39 @@ export function servedFromCache(count: number): { readonly count: number; readon
   };
 }
 
+/**
+ * A stable identity for one iteration's whole batch of proposed calls, order-independent so a
+ * provider that reorders an otherwise-identical batch still matches.
+ *
+ * `undefined` whenever any call's own signature could not be computed, so an unsignable batch is
+ * never mistaken for a repeat of itself — see `callSignature`.
+ */
+export function batchSignature(
+  calls: readonly { readonly name: string; readonly arguments: unknown }[]
+): string | undefined {
+  const signatures: string[] = [];
+  for (const call of calls) {
+    const signature = callSignature(call.name, call.arguments);
+    if (signature === undefined) return undefined;
+    signatures.push(signature);
+  }
+  return signatures.sort().join("");
+}
+
+/**
+ * What the model is told after proposing the exact same batch of calls several times running, one
+ * iteration before the loop gives up on it as a retry the model can steer out of.
+ */
+export function repeatedBatchWarning(count: number): string {
+  return (
+    `You have proposed this exact same set of Tool calls ${count} times in a row in this Turn, ` +
+    "with no different arguments and no other call in between. If the answer you already have is " +
+    "enough, stop calling Tools and use it. If you are stuck, change the arguments, try a " +
+    "different Tool, or explain the obstacle in your reply — repeating this call again will end " +
+    "the Turn."
+  );
+}
+
 /** What a repeated `skill` load carries instead of the text it already sent. */
 const REPEATED_SKILL_NOTE =
   "Already sent earlier in this Turn and omitted here, because a Skill cannot change mid-Turn. " +


### PR DESCRIPTION
## Summary
- The bounded Tool loop only ever *annotated* a repeated identical Tool call (`repeatCounts` in `packages/agent-runtime/src/loop/loop.ts`, `repeatedCall()` in `repeat.ts`) — it never broke the loop, so a model stuck proposing the same call kept looping until it burned the whole `maxToolCalls` budget.
- After 3 consecutive identical Tool-call batches (name + normalized arguments), the loop now warns the model once, and fails the Turn on the 4th with a new, distinct `repeated_tool_calls` reason instead of continuing to spend budget.
- Adds a Corpus Case asserting the new behavior.

## Root cause
`packages/agent-runtime/src/loop/loop.ts` tracked repeats only for successful dispatches, and only ever attached a `repeatedCall()` note (`packages/agent-runtime/src/loop/repeat.ts:52`) — it never had any path that broke the loop on repetition, no matter how many times a call repeated. A failed/denied dispatch got zero repeat tracking at all.

PR #745 raised `maxIterations`/`maxToolCalls` to 1,000,000 (`apps/worker/src/routine/agent-port.ts:163,166`, confirmed present, no production override of `toolCallCeiling`), which removed the low ceiling the loop used to hit but did not add any guard against a looping model — so a model stuck repeating the same call now runs up to a million times before failing, still surfacing as `tool_call_limit` (`routine:agent_tool_call_limit` per `apps/worker/src/routine/executor.ts`'s generic `routine:agent_<reason>` evidence-ref).

Two alternatives ruled out:
- **Ceiling still too low in production** — ruled out: verified `MAX_ITERATIONS`/`MAX_TOOL_CALLS` are 1,000,000 in `apps/worker/src/routine/agent-port.ts` and there is no production override of `toolCallCeiling`.
- **A separate, mislabeled budget key** — ruled out: `tool_call_limit` is raised only from the two `counters.toolCalls`/`available` vs `input.limits.maxToolCalls` checks in `loop.ts`, a distinct code path from the separate `budget_exhausted` / `ITERATION_BUDGET_KEY` check.

## Eval corpus
Adds `apps/eval/corpus/support-breaks-a-looping-identical-tool-call.json`, asserting `tool_called`, `tool_call_count: 3` (proving an early break rather than the ceiling), and `loop_status: "failed"`.

**Editing `corpus/` moves `corpusHash`, which retires every Baseline** — a maintainer needs to re-promote against the new Corpus before the gate compares anything again.

## Test plan
- [x] `pnpm exec biome check --write packages/agent-runtime apps/eval` — clean
- [x] `pnpm --filter @tulipfarm/agent-runtime typecheck` — passes
- [x] `pnpm exec vitest run packages/agent-runtime/src/loop/loop.test.ts` — 96 tests pass; new test confirmed to fail before the fix (temporarily disabled the guard) and pass after
- [x] `pnpm eval` (scripted tier) — 52/52 Cases pass, including the new one, corpusHash `7ee400459d8582cd`
- [x] `pnpm typecheck` — 41/41 workspaces pass

Closes #749