### PR TITLE
fix(knowledge): validate page id before querying knowledge_pages

### DIFF
--- a/apps/api/src/knowledge/repo.pg.test.ts
+++ b/apps/api/src/knowledge/repo.pg.test.ts
@@ -48,6 +48,27 @@ describe("PgKnowledgePageRepo", () => {
     expect(await repo.getById(randomUUID())).toBeNull();
   });
 
+  // A caller-supplied id that is not a UUID must read as absent, not raise the driver's
+  // `invalid input syntax for type uuid` — sentinels ("*", "default") and near-UUID hallucinations
+  // both hit this (issue #752).
+  it("answers null rather than raise for a non-UUID id", async () => {
+    for (const bad of [
+      "*",
+      "default",
+      "null",
+      "_",
+      "90ab7ba3-5608-4065-a835-b6d25fb4cba95", // 13 hex chars in the last group, not 12
+      "a1561eea-c9a9-457-98ed-09cab7605f0e", // 3 hex chars in the second group, not 4
+    ]) {
+      await expect(repo.getById(bad)).resolves.toBeNull();
+      await expect(repo.replaceOne(bad, 1, page())).resolves.toBe(false);
+      await expect(repo.softDelete(bad)).resolves.toBe(false);
+      await expect(repo.bumpAclRevision(bad)).resolves.toBe(false);
+      await expect(repo.moveSubtree(bad, null, "x")).resolves.toEqual([]);
+      await expect(repo.listSubtree(bad)).resolves.toEqual([]);
+    }
+  });
+
   it("upsertBySource is idempotent on (source, source_id) and bumps version", async () => {
     const first = page({ source: "resource", sourceId: "r1", title: "v1" });
     const a = await repo.upsertBySource(first);

--- a/packages/knowledge/src/repo.ts
+++ b/packages/knowledge/src/repo.ts
@@ -1,5 +1,6 @@
 import type { Queryable } from "@tulipfarm/storage";
 import { type PaginatedResult, toPage } from "@tulipfarm/storage";
+import { isKnowledgeId } from "./ids";
 import type {
   KnowledgePage,
   KnowledgeRevision,
@@ -173,6 +174,9 @@ export class PgKnowledgePageRepo implements KnowledgePageRepo {
   }
 
   async getById(id: string): Promise<KnowledgePage | null> {
+    // `id` is a `uuid` column, so a malformed id (a sentinel like "*", a hallucinated near-uuid)
+    // must read as absent rather than raise `invalid input syntax for type uuid`.
+    if (!isKnowledgeId(id)) return null;
     const { rows } = await this.q.query(`SELECT ${PAGE_COLS} FROM knowledge_pages WHERE id = $1`, [
       id,
     ]);
@@ -245,6 +249,7 @@ export class PgKnowledgePageRepo implements KnowledgePageRepo {
   }
 
   async replaceOne(id: string, expectedVersion: number, page: KnowledgePage): Promise<boolean> {
+    if (!isKnowledgeId(id)) return false;
     const { rows } = await this.q.query(
       `UPDATE knowledge_pages
        SET title=$1, content=$2, plain_text=$3, domain=$4, tags=$5::text[],
@@ -277,6 +282,7 @@ export class PgKnowledgePageRepo implements KnowledgePageRepo {
   }
 
   async softDelete(id: string): Promise<boolean> {
+    if (!isKnowledgeId(id)) return false;
     const { rows } = await this.q.query(
       `UPDATE knowledge_pages SET active=false, version=version+1, updated_at=now()
        WHERE id=$1 AND active=true RETURNING id`,
@@ -358,6 +364,7 @@ export class PgKnowledgePageRepo implements KnowledgePageRepo {
   }
 
   async bumpAclRevision(id: string): Promise<boolean> {
+    if (!isKnowledgeId(id)) return false;
     const { rows } = await this.q.query(
       `UPDATE knowledge_pages
           SET acl_revision = (COALESCE(NULLIF(acl_revision, '')::bigint, 0) + 1)::text
@@ -369,6 +376,7 @@ export class PgKnowledgePageRepo implements KnowledgePageRepo {
   }
 
   async moveSubtree(id: string, spaceId: string | null, path: string): Promise<readonly string[]> {
+    if (!isKnowledgeId(id)) return [];
     const { rows } = await this.q.query(
       `WITH origin AS (SELECT business_id, space_id, path FROM knowledge_pages WHERE id = $1)
        UPDATE knowledge_pages p
@@ -387,6 +395,7 @@ export class PgKnowledgePageRepo implements KnowledgePageRepo {
   }
 
   async listSubtree(id: string): Promise<readonly { id: string; path: string }[]> {
+    if (!isKnowledgeId(id)) return [];
     const { rows } = await this.q.query(
       `WITH origin AS (SELECT business_id, space_id, path FROM knowledge_pages WHERE id = $1)
        SELECT p.id, p.path FROM knowledge_pages p, origin


### PR DESCRIPTION
- `PgKnowledgePageRepo.getById` (packages/knowledge/src/repo.ts:175) passed a caller-supplied id straight to Postgres as a `uuid` parameter; a sentinel (`"*"`, `"default"`) or a hallucinated near-uuid made Postgres raise `invalid input syntax for type uuid` (leaking the full column list) instead of a clean not-found. The `get_page` Tool (packages/knowledge/src/precision-tools.ts:99) and `cite_sources` (packages/knowledge/src/tools.ts:192) both call `getActivePage` -> `getById` before the read gate runs, so an Agent hit the crash directly.
- Guard every single-id lookup in `PgKnowledgePageRepo` (`getById`, `replaceOne`, `softDelete`, `bumpAclRevision`, `moveSubtree`, `listSubtree`) with the existing `isKnowledgeId` check from `./ids`, matching the pattern `PgKnowledgeSpaceRepo` already uses. A malformed id now reads as absent, so `get_page`/`cite_sources` already return `err("not_found", NOT_FOUND_PAGE)` for it — no Tool-layer change needed.
- No separate bug passes a literal `"*"`/`"default"`: `packages/knowledge/src/tools.ts:34` and its test already document this as known model behaviour (placeholders for optional args); `get_page`'s `pageId` is required but ungated the same way, so the same class of Agent hallucination reaches it.

## Test plan
- [x] `apps/api/src/knowledge/repo.pg.test.ts` — added a case with the exact sentinel/near-uuid values from the issue; confirmed it fails with the reported `invalid input syntax for type uuid` error before the fix and passes after.
- [x] `pnpm --filter @tulipfarm/knowledge test` — 28 files / 317 tests passed.
- [x] `pnpm --filter @tulipfarm/api exec vitest run src/knowledge` — 61 files / 526 tests passed.
- [x] `pnpm typecheck` — passed.

Closes #752