### PR TITLE
fix(deploy): cap docker logs, journald, and README update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,11 @@ for every knob (TLS, `POSTGRES_PASSWORD`, `PUBLIC_URL`).
 
 **Updating**: releases publish `ghcr.io/tulipfarm/tulipfarm:v<version>` (+ `:latest` for
 stable). Updates are always **manual** (no auto-update by design) — re-run the install
-command, or `docker compose pull && docker compose up -d`. Database migrations run
-automatically on boot; there are **no down-migrations**, so back up before updating. See
-the [update guide](https://tulipfarm.site/docs/self-hosting/updating) for the full procedure and
+command, or `docker compose pull && docker compose up -d && docker image prune -f`. The
+trailing prune reclaims the image the update replaced; skipping it leaves an orphaned
+~1.8 GB on disk every time. Database migrations run automatically on boot; there are **no
+down-migrations**, so back up before updating. See the
+[update guide](https://tulipfarm.site/docs/self-hosting/updating) for the full procedure and
 every deployment target.
 
 **Uninstall permanently** (deletes the database, soul, secrets, backups, volumes, and

--- a/apps/docs/content/docs/self-hosting/install.mdx
+++ b/apps/docs/content/docs/self-hosting/install.mdx
@@ -19,6 +19,11 @@ One command. About five minutes, most of it waiting for the image to download.
 A machine with **Docker** or **Podman**. On Linux the installer installs Podman for you if neither
 is present. On macOS and Windows, install Docker Desktop or Podman yourself first.
 
+Leave real headroom on the disk holding `/var/lib/docker`. The app image alone is around
+1.8 GB, and every update briefly needs both the old and new image on disk before the old one
+is pruned, plus room for container logs and the Postgres data volume. 29 GB is tight for that;
+prefer 40 GB or more on anything you intend to keep updating.
+
 <Steps>
 
 <Step>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,6 +122,13 @@ services:
       # Generated bootstrap secrets and backups. Losing this volume loses the encryption
       # key for every stored secret — back it up.
       - tulipfarm-data:/data
+    # The default json-file driver has no size cap, so an instance nobody watches can fill its
+    # disk on logs alone. Bounded here so every deployment gets a ceiling with no extra setup.
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     healthcheck:
       test:
         [
@@ -179,6 +186,11 @@ services:
         volume:
           subpath: blobs
           nocopy: true
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     # No published port: the probes are for the orchestrator, not for users.
     healthcheck:
       test:
@@ -220,6 +232,11 @@ services:
       # Read-only: `app` owns everything on this volume. This process only reads back the
       # credential it was given.
       - tulipfarm-data:/data:ro
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     # No published port: the probes are for the orchestrator, not for users.
     healthcheck:
       test:
@@ -261,6 +278,11 @@ services:
       # Read-only: `app` owns everything on this volume. Only the two secrets are read back.
       - tulipfarm-data:/data:ro
       - tulipfarm-bucket:/var/lib/garage
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     # No published port: bytes reach a browser through the API, which is where authorization for
     # a File is decided. A bucket reachable from outside would be a way around that.
     healthcheck:
@@ -303,6 +325,11 @@ services:
       POSTGRES_DB: tulipfarm
     volumes:
       - tulipfarm-postgres:/var/lib/postgresql/data
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "tulipfarm", "-d", "tulipfarm"]
       interval: 10s

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -473,6 +473,19 @@ prune_orphaned_images() {
     || warn "could not prune orphaned images — reclaim them later with '${ENGINE} image prune -f'"
 }
 
+# journald has no size cap by default, and an instance with nobody watching disk usage can let
+# /var/log/journal grow unbounded. Best-effort and non-fatal: a host with no systemd (or one
+# already managing this itself) just skips it.
+configure_journald_limit() {
+  [ "$OS" = linux ] || return 0
+  command -v systemctl >/dev/null 2>&1 || return 0
+  $SUDO mkdir -p /etc/systemd/journald.conf.d 2>/dev/null || return 0
+  printf '[Journal]\nSystemMaxUse=200M\n' | $SUDO tee /etc/systemd/journald.conf.d/tulipfarm.conf >/dev/null 2>&1 \
+    || { warn "could not cap journald log size"; return 0; }
+  $SUDO systemctl restart systemd-journald >/dev/null 2>&1 \
+    || warn "wrote journald cap but could not restart systemd-journald — it takes effect on next boot"
+}
+
 wait_health() {
   log "Waiting for TulipFarm to become healthy…"
   local _
@@ -500,6 +513,7 @@ main() {
   detect_sudo
   resolve_project_name
   ensure_engine
+  configure_journald_limit
   $SUDO mkdir -p "$INSTALL_DIR"
   fetch_file docker-compose.yml "${INSTALL_DIR}/docker-compose.yml"
   fetch_file .env.example "${INSTALL_DIR}/.env.example" || true


### PR DESCRIPTION
- Root cause: `scripts/install.sh:470-474` and `deploy/deploy.txt:777` already pruned dangling images after a healthy update (#634, merged Aug 30), but `README.md:119` documented the raw `docker compose pull && docker compose up -d` for a hand-run Compose update with no prune — the command an operator following the top-level README would actually copy.
- Neither compose service in `docker-compose.yml` bounded its `json-file` log driver, so container logs could also grow unbounded; and nothing in the repo capped journald.
- Bound each service's logs to `max-size: 10m` / `max-file: 3` in `docker-compose.yml`, cap journald at `SystemMaxUse=200M` in `scripts/install.sh` (best-effort, Linux/systemd only), add the missing `&& docker image prune -f` to README's update command, and note in `install.mdx` that 29 GB is tight for a ~1.8 GB image plus rollback headroom.

## Test plan
- [x] `docker compose config --quiet` and `docker compose -f docker-compose.yml -f docker-compose.dev.yml config --quiet`
- [x] `bash -n scripts/install.sh` (and the other CI-checked shell scripts)
- [x] `pnpm exec vitest run scripts/docs-fitness.test.ts` (and the rest of the `docs:test` suite) — one pre-existing, unrelated failure in `docs-tool-catalog.test.ts` (stale generated tool catalog page, not touched by this change)
- [x] `pnpm typecheck`

Closes #751