### PR TITLE
fix(api): retire slack-knowledge-sync pg-boss schedule left with no consumer

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -18,6 +18,8 @@ import { FileService, PgFileRepo } from "@tulipfarm/files";
 import { FetchEgressHttp, GuardedEgressHttp, PublicOriginsService } from "@tulipfarm/integrations";
 import {
   buildDefaultRegistry,
+  CONNECTOR_SYNC_QUEUE,
+  EMBEDDING_BACKFILL_QUEUE,
   enqueueIndex,
   KnowledgeOwnershipProjector,
   KnowledgeService,
@@ -222,6 +224,7 @@ import {
   CompositeLiveSourceAuthorization,
   SlackTenantLiveAuthorization,
 } from "./knowledge-sources/live-authorization";
+import { retireSlackKnowledgeSyncSchedule } from "./knowledge-sources/slack-sync-schedule";
 import { PgKnowledgeSourceStore } from "./knowledge-sources/source-store";
 import { registerLlmReload } from "./llm-reload";
 import { buildMemoryServices } from "./memory/composition";
@@ -229,12 +232,12 @@ import { parseObservabilityConfig } from "./observability/config";
 import { createEmbeddingUsageSink } from "./observability/embedding-usage";
 import { subscribeObservability } from "./observability/events";
 import { OtlpMetricsExporter } from "./observability/metrics";
-import { registerObsPruneSchedule } from "./observability/prune-schedule";
+import { OBS_PRUNE_QUEUE, registerObsPruneSchedule } from "./observability/prune-schedule";
 import { PgObsRepo } from "./observability/repo";
 import { PgResourceRepo } from "./observability/resource-repo";
 import { startProcessSamplers } from "./observability/samplers";
 import { ObservabilityService } from "./observability/service";
-import { registerSpendAlertSchedule } from "./observability/spend-alert";
+import { registerSpendAlertSchedule, SPEND_ALERT_QUEUE } from "./observability/spend-alert";
 import { createObservabilityTelemetryPort } from "./observability/telemetry-port";
 import { OtlpTracesExporter } from "./observability/traces";
 import { runPgMigrations } from "./pg-migrate";
@@ -271,8 +274,9 @@ import {
   resolveSoulCommitSigner,
   SYSTEM_SOUL_COMMIT_ACTOR,
 } from "./runtime/soul-writer";
+import { auditPersistedSchedules } from "./schedule/audit";
 import { ScheduleDispatcher } from "./schedule/dispatcher";
-import { registerScheduleDispatch } from "./schedule/register";
+import { registerScheduleDispatch, SCHEDULE_DISPATCH_QUEUE } from "./schedule/register";
 import { RoutineScheduleStateStore } from "./schedule/state-store";
 import { supersedeRoutineRuns } from "./schedule/supersede";
 import { bootstrapFromEnv } from "./setup/bootstrap";
@@ -289,12 +293,20 @@ import {
   provisionWorkerCredential,
 } from "./setup/worker-credential";
 import { agentForRunResolver, delegableToolNames } from "./soul/agents/registry";
-import { bundleRetentionMs, registerSoulBundlePruneSchedule } from "./soul/bundle-prune-schedule";
+import {
+  bundleRetentionMs,
+  registerSoulBundlePruneSchedule,
+  SOUL_BUNDLE_PRUNE_QUEUE,
+} from "./soul/bundle-prune-schedule";
 import { createGitHubSoulCredentialProvider } from "./soul/github-repo-credential";
 import { registerSoulPublicationRoutes } from "./soul/publication-routes";
 import { composeSkillTools } from "./soul/skills/compose";
 import { buildSoulDoctor } from "./soul-doctor/compose";
-import { kickSoulDoctor, registerSoulDoctorSchedule } from "./soul-doctor/schedule";
+import {
+  kickSoulDoctor,
+  registerSoulDoctorSchedule,
+  SOUL_DOCTOR_QUEUE,
+} from "./soul-doctor/schedule";
 import { registerSoulSync } from "./soul-sync";
 import { PgSurfaceActionStore } from "./surfaces/action-store";
 import { PgSurfaceArtifactStore } from "./surfaces/artifact-store";
@@ -1770,6 +1782,7 @@ async function boot() {
     // Every Soul commit publishes a bundle, so this table grows for the life of the deployment.
     await registerSoulBundlePruneSchedule(boss, bundleRetentionMs(process.env));
     await registerSpendAlertSchedule(boss, obsConfig.spendAlertUsd);
+    await retireSlackKnowledgeSyncSchedule(boss);
     await registerKnowledgeIndexing(boss, {
       service: knowledgeService,
       loadConversationText: async (conversationId) => {
@@ -1861,6 +1874,20 @@ async function boot() {
       service: knowledgeService,
       activity: activityService,
     });
+    await auditPersistedSchedules(
+      boss,
+      [
+        SCHEDULE_DISPATCH_QUEUE,
+        CURATOR_SWEEP_QUEUE,
+        SOUL_DOCTOR_QUEUE,
+        OBS_PRUNE_QUEUE,
+        SOUL_BUNDLE_PRUNE_QUEUE,
+        SPEND_ALERT_QUEUE,
+        CONNECTOR_SYNC_QUEUE,
+        EMBEDDING_BACKFILL_QUEUE,
+      ],
+      app.log
+    );
     app.listen({ port, host: "0.0.0.0" }, (err) => {
       if (err) {
         app.log.error(err);

--- a/apps/api/src/knowledge-sources/slack-registration.test.ts
+++ b/apps/api/src/knowledge-sources/slack-registration.test.ts
@@ -9,4 +9,12 @@ describe("Slack Knowledge registration", () => {
     expect(source).not.toContain("registerSlackKnowledgeSync");
     expect(source).not.toContain("SLACK_KNOWLEDGE_SYNC_QUEUE");
   });
+
+  it("retires any schedule a pre-#719 instance left behind for it", () => {
+    // registerSlackKnowledgeSync also called boss.schedule; removing the call without unscheduling
+    // leaves pg-boss enqueuing into a queue nothing consumes, forever (issue #750).
+    const source = readFileSync(join(__dirname, "..", "index.ts"), "utf8");
+
+    expect(source).toContain("retireSlackKnowledgeSyncSchedule");
+  });
 });

--- a/apps/api/src/knowledge-sources/slack-sync-schedule.test.ts
+++ b/apps/api/src/knowledge-sources/slack-sync-schedule.test.ts
@@ -7,9 +7,15 @@ import {
 } from "@tulipfarm/integrations";
 import type { SecretsService } from "@tulipfarm/secrets";
 import type { IntegrationStore, PersistedRoutingSnapshot } from "@tulipfarm/storage";
+import type { PgBoss } from "pg-boss";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { PgKnowledgeEmissionSink } from "./emission-sink";
-import { runSlackKnowledgeSync, SLACK_KNOWLEDGE_SYNC_CRON } from "./slack-sync-schedule";
+import {
+  retireSlackKnowledgeSyncSchedule,
+  runSlackKnowledgeSync,
+  SLACK_KNOWLEDGE_SYNC_CRON,
+  SLACK_KNOWLEDGE_SYNC_QUEUE,
+} from "./slack-sync-schedule";
 
 const { syncSlackKnowledge } = vi.hoisted(() => ({
   syncSlackKnowledge:
@@ -195,5 +201,25 @@ describe("Slack Knowledge ACL max age vs sync cadence", () => {
     expect(SLACK_KNOWLEDGE_ACL_MAX_AGE_SECONDS).toBeGreaterThanOrEqual(
       SLACK_KNOWLEDGE_SYNC_PERIOD_SECONDS * 2
     );
+  });
+});
+
+describe("retireSlackKnowledgeSyncSchedule", () => {
+  it("unschedules the queue so an upgraded instance stops enqueuing into it", async () => {
+    const unschedule = vi.fn(async () => {});
+    const boss = { unschedule } as unknown as PgBoss;
+
+    await retireSlackKnowledgeSyncSchedule(boss);
+
+    expect(unschedule).toHaveBeenCalledWith(SLACK_KNOWLEDGE_SYNC_QUEUE);
+  });
+
+  it("boots even when there is nothing to unschedule", async () => {
+    // A fresh instance, or one that never ran the automatic sync, has no persisted schedule for
+    // this queue; pg-boss is free to reject that, and boot must not fail over the cleanup.
+    const unschedule = vi.fn(async () => Promise.reject(new Error("no such schedule")));
+    const boss = { unschedule } as unknown as PgBoss;
+
+    await expect(retireSlackKnowledgeSyncSchedule(boss)).resolves.toBeUndefined();
   });
 });

--- a/apps/api/src/knowledge-sources/slack-sync-schedule.ts
+++ b/apps/api/src/knowledge-sources/slack-sync-schedule.ts
@@ -96,3 +96,13 @@ export async function registerSlackKnowledgeSync(
   );
   await boss.schedule(SLACK_KNOWLEDGE_SYNC_QUEUE, SLACK_KNOWLEDGE_SYNC_CRON);
 }
+
+/**
+ * Drops the `slack-knowledge-sync` schedule pg-boss persisted while `registerSlackKnowledgeSync`
+ * still ran. pg-boss schedules live in Postgres, independent of which code is deployed, so an
+ * instance upgraded from before automatic Slack history sync was retired keeps enqueuing into
+ * this queue forever — with no consumer left to drain it — unless the schedule itself is cleared.
+ */
+export async function retireSlackKnowledgeSyncSchedule(boss: PgBoss): Promise<void> {
+  await boss.unschedule(SLACK_KNOWLEDGE_SYNC_QUEUE).catch(() => {});
+}

--- a/apps/api/src/schedule/audit.test.ts
+++ b/apps/api/src/schedule/audit.test.ts
@@ -1,0 +1,45 @@
+import type { PgBoss } from "pg-boss";
+import { describe, expect, it, vi } from "vitest";
+import { auditPersistedSchedules } from "./audit";
+
+function fakeBoss(schedules: { name: string }[]) {
+  return { getSchedules: vi.fn(async () => schedules) } as unknown as PgBoss;
+}
+
+function fakeLog() {
+  return { error: vi.fn() };
+}
+
+describe("auditPersistedSchedules", () => {
+  it("logs nothing when every persisted schedule is still actively registered", async () => {
+    const boss = fakeBoss([{ name: "curator-sweep" }, { name: "obs-event-prune" }]);
+    const log = fakeLog();
+
+    await auditPersistedSchedules(boss, ["curator-sweep", "obs-event-prune"], log);
+
+    expect(log.error).not.toHaveBeenCalled();
+  });
+
+  it("logs loudly for a schedule no longer among the active queue names", async () => {
+    // This is exactly issue #750: registerSlackKnowledgeSync stopped running, but nothing
+    // unscheduled the queue it had persisted, so pg-boss kept enqueuing into it forever.
+    const boss = fakeBoss([{ name: "curator-sweep" }, { name: "slack-knowledge-sync" }]);
+    const log = fakeLog();
+
+    await auditPersistedSchedules(boss, ["curator-sweep"], log);
+
+    expect(log.error).toHaveBeenCalledTimes(1);
+    expect(log.error.mock.calls[0]?.[0]).toEqual({ queue: "slack-knowledge-sync" });
+    expect(log.error.mock.calls[0]?.[1]).toContain("slack-knowledge-sync");
+  });
+
+  it("does not block boot when the audit itself fails", async () => {
+    const boss = {
+      getSchedules: vi.fn(async () => Promise.reject(new Error("db unavailable"))),
+    } as unknown as PgBoss;
+    const log = fakeLog();
+
+    await expect(auditPersistedSchedules(boss, [], log)).resolves.toBeUndefined();
+    expect(log.error).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/schedule/audit.ts
+++ b/apps/api/src/schedule/audit.ts
@@ -1,0 +1,35 @@
+import type { PgBoss } from "pg-boss";
+
+/**
+ * pg-boss schedules live in Postgres, independent of which code is deployed: a queue whose
+ * `register*Schedule` call is removed keeps enqueuing forever unless something explicitly
+ * unschedules it (issue #750 — `slack-knowledge-sync` kept firing for a day after its consumer
+ * was retired, because nothing did). Call this once, after every schedule this boot intends to
+ * keep has been (re)registered, with the full list of those queue names: anything pg-boss still
+ * has scheduled outside that list is an orphan from a previous deploy, logged loudly so it does
+ * not silently pile up `created` jobs the way this one did.
+ */
+export async function auditPersistedSchedules(
+  boss: PgBoss,
+  activeQueueNames: readonly string[],
+  log: { error(obj: unknown, msg?: string): void }
+): Promise<void> {
+  const active = new Set(activeQueueNames);
+  let schedules: Awaited<ReturnType<PgBoss["getSchedules"]>>;
+  try {
+    schedules = await boss.getSchedules();
+  } catch (err) {
+    // A diagnostic must never block boot — surface it and move on.
+    log.error({ err }, "pg-boss schedule audit failed");
+    return;
+  }
+  for (const schedule of schedules) {
+    if (!active.has(schedule.name)) {
+      log.error(
+        { queue: schedule.name },
+        `pg-boss schedule "${schedule.name}" has no registered consumer this boot — jobs will ` +
+          `pile up in "created" forever. Call boss.unschedule("${schedule.name}") on boot to retire it.`
+      );
+    }
+  }
+}


### PR DESCRIPTION
- `registerSlackKnowledgeSync` (apps/api/src/knowledge-sources/slack-sync-schedule.ts:78-98) was the sole producer and consumer of the `slack-knowledge-sync` queue. PR #719 stopped calling it but never called `boss.unschedule()`, so pg-boss's Postgres-persisted cron kept enqueuing into a queue nothing consumes.
- Added `retireSlackKnowledgeSyncSchedule` (apps/api/src/knowledge-sources/slack-sync-schedule.ts) called from `apps/api/src/index.ts`, matching the existing retirement pattern used for `task-reconcile` and `obs-spend-alert`.
- Added `auditPersistedSchedules` (apps/api/src/schedule/audit.ts), called once at API boot, that error-logs any pg-boss schedule with no active consumer this boot — catches this bug class earlier.

## Test plan
- [x] `pnpm exec biome check --write apps/api/src`
- [x] `pnpm exec vitest run apps/api/src/knowledge-sources/slack-sync-schedule.test.ts apps/api/src/knowledge-sources/slack-registration.test.ts apps/api/src/schedule/audit.test.ts` — verified new tests fail before the fix, pass after
- [x] `pnpm --filter @tulipfarm/api test` — 327 files, 3722 tests, all passing
- [x] `pnpm typecheck` — 41/41 workspace tasks passing

Closes #750