### PR TITLE
fix(api): stop rekeying append-only audit_events at boot

### DIFF
--- a/apps/api/src/identity/agent-identifiers.test.ts
+++ b/apps/api/src/identity/agent-identifiers.test.ts
@@ -1,0 +1,75 @@
+import { agentIdOf, DEFAULT_ASSISTANT_NAME, type SoulAgent } from "@tulipfarm/soul";
+import { describe, expect, it, vi } from "vitest";
+import type { Queryable } from "../db";
+import { reconcileAgentIdentifiers } from "./agent-identifiers";
+import type { SoulAgents } from "./agent-principals";
+
+const BUSINESS = "business-1";
+
+function soulAgent(name: string): SoulAgent {
+  return { id: agentIdOf(name, {}), name, frontmatter: {}, body: "" } as SoulAgent;
+}
+
+const SUPPORT = soulAgent("support");
+
+function soul(agents: readonly SoulAgent[]): SoulAgents {
+  return { agents: new Map(agents.map((agent) => [agent.name, agent])) };
+}
+
+/**
+ * Reports every column probed with `hasColumn` as present, so `reconcileAgentIdentifiers` walks
+ * its full column list. Records every SQL statement issued; a stub can force a table to fail so
+ * the failure-handling path is exercised too.
+ */
+function fakeQueryable(options: { failTable?: string } = {}): { q: Queryable; sql: string[] } {
+  const sql: string[] = [];
+  const q: Queryable = {
+    query: vi.fn(async (text: string) => {
+      sql.push(text);
+      if (text.includes("information_schema.columns")) {
+        return { rows: [{}] };
+      }
+      if (options.failTable && text.includes(`UPDATE ${options.failTable} `)) {
+        throw new Error(`permission denied for table ${options.failTable}`);
+      }
+      return { rows: [] };
+    }),
+  } as unknown as Queryable;
+  return { q, sql };
+}
+
+describe("reconcileAgentIdentifiers", () => {
+  it("never issues an UPDATE against audit_events", async () => {
+    const { q, sql } = fakeQueryable();
+
+    await reconcileAgentIdentifiers(q, soul([SUPPORT]), BUSINESS);
+
+    expect(sql.some((statement) => statement.includes("audit_events"))).toBe(false);
+  });
+
+  it("still re-keys other identifier columns, including the default assistant", async () => {
+    const { q, sql } = fakeQueryable();
+
+    await reconcileAgentIdentifiers(q, soul([SUPPORT]), BUSINESS);
+
+    expect(sql.some((statement) => statement.startsWith("UPDATE conversations "))).toBe(true);
+    const conversationsUpdates = (q.query as ReturnType<typeof vi.fn>).mock.calls.filter(
+      ([statement]) => (statement as string).startsWith("UPDATE conversations ")
+    );
+    const renamedIdentifiers = conversationsUpdates.map(([, params]) => (params as unknown[])[1]);
+    expect(renamedIdentifiers).toEqual(expect.arrayContaining([DEFAULT_ASSISTANT_NAME, "support"]));
+  });
+
+  it("surfaces a rejected rekey through the logger's error level, not warn, and does not throw", async () => {
+    const { q } = fakeQueryable({ failTable: "conversations" });
+    const logger = { error: vi.fn() };
+
+    await expect(
+      reconcileAgentIdentifiers(q, soul([SUPPORT]), BUSINESS, logger)
+    ).resolves.toBeUndefined();
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('could not re-key conversations.agent_id for "support"')
+    );
+  });
+});

--- a/apps/api/src/identity/agent-identifiers.ts
+++ b/apps/api/src/identity/agent-identifiers.ts
@@ -17,9 +17,13 @@ interface AgentIdentifierColumn {
  *
  * Tables are created lazily by their owning repository rather than all at once, so each is probed
  * before it is written: a deployment that has never used a feature has no table for it.
+ *
+ * `audit_events.agent_id` is deliberately absent: that table is append-only and hash-chained, and
+ * the database grant refuses any `UPDATE` on it, in-place rekey or otherwise. A row written before
+ * an Agent's id cutover keeps recording whatever identifier was true at the time, which is what an
+ * immutable audit trail is for; it is never rewritten to match a later rename.
  */
 const AGENT_IDENTIFIER_COLUMNS: readonly AgentIdentifierColumn[] = [
-  { table: "audit_events", column: "agent_id" },
   { table: "conversations", column: "agent_id" },
   { table: "channel_delivery_attempts", column: "agent_id" },
   { table: "channel_run_deliveries", column: "agent_id" },
@@ -126,13 +130,16 @@ async function moveAssetOwnership(
  *
  * Idempotent and per-table isolated: a table that does not exist is skipped, and a table that
  * fails is logged rather than thrown, so one unmigratable feature cannot stop the deployment from
- * booting with the rest re-keyed.
+ * booting with the rest re-keyed. A per-table failure is logged at `error`, not `warn` — the
+ * durable app log only retains `error`/`fatal` records (`@tulipfarm/observability`), and a rejected
+ * rekey is exactly the kind of partial state an operator needs to be able to find later, not a
+ * transient notice that is fine to lose.
  */
 export async function reconcileAgentIdentifiers(
   q: Queryable,
   soul: SoulAgents,
   businessId: string,
-  logger?: Pick<Logger, "warn">
+  logger?: Pick<Logger, "error">
 ): Promise<void> {
   const mapping = renames(soul);
   if (mapping.size === 0) return;
@@ -146,7 +153,7 @@ export async function reconcileAgentIdentifiers(
       try {
         await q.query(`UPDATE ${table} SET ${column} = $1 WHERE ${column} = $2`, [id, name]);
       } catch (err) {
-        logger?.warn(`[agents] could not re-key ${table}.${column} for "${name}": ${msg(err)}`);
+        logger?.error(`[agents] could not re-key ${table}.${column} for "${name}": ${msg(err)}`);
       }
     }
   }
@@ -156,7 +163,7 @@ export async function reconcileAgentIdentifiers(
       try {
         await moveAssetOwnership(q, businessId, name, id);
       } catch (err) {
-        logger?.warn(`[agents] could not re-key ownership of agent "${name}": ${msg(err)}`);
+        logger?.error(`[agents] could not re-key ownership of agent "${name}": ${msg(err)}`);
       }
     }
   }
@@ -170,7 +177,7 @@ export async function reconcileAgentIdentifiers(
         [businessId, name]
       );
     } catch (err) {
-      logger?.warn(`[agents] could not reap the name-keyed principal "${name}": ${msg(err)}`);
+      logger?.error(`[agents] could not reap the name-keyed principal "${name}": ${msg(err)}`);
     }
   }
 }


### PR DESCRIPTION
## Summary
- The Agent-identity boot sweep (`reconcileAgentIdentifiers`) issued `UPDATE audit_events SET agent_id = $1 WHERE agent_id = $2` for every renamed Agent; Postgres always refuses this because `audit_events` is append-only and hash-chained, so `audit_events` is dropped from the rekeyed-column list — audit history stays immutable and each row keeps whichever identifier was true when it was written.
- The rejection was only ever logged at `warn`, a level the app's durable log spine (`packages/observability/src/logs.ts`) never persists — only `error`/`fatal` records are retained — so it never reached the app log, only the Postgres server log. Per-table rekey failures in this sweep now log at `error`.
- Added `apps/api/src/identity/agent-identifiers.test.ts`, which fails against the old code (asserts no `audit_events` UPDATE is ever issued, and that a rejected rekey surfaces via `logger.error`, not `.warn`) and passes after the fix.

## Root cause
`apps/api/src/identity/agent-identifiers.ts` `AGENT_IDENTIFIER_COLUMNS` included `{ table: "audit_events", column: "agent_id" }`. `reconcileAgentIdentifiers` (called once, at API boot, from `apps/api/src/index.ts:599`) loops that list and runs `UPDATE ${table} SET ${column} = $1 WHERE ${column} = $2` for every Agent whose Soul name differs from its permanent id (introduced in #737, "key every Agent record on its permanent id"). Postgres's `permission denied for table audit_events` matches this statement exactly. The `catch` around the query called `logger?.warn(...)`, and the only caller passes `console` — but `warn`-level output is never captured by the durable `log_event` app-log spine, which only retains `error`/`fatal` (see the comment at `packages/observability/src/logs.ts:4-6`), so the denial was visible only in the Postgres log.

Not applicable: this boot-time reconciliation sweep is never reached during an Agent Turn, so no `apps/eval` Corpus Case is needed for this change.

## Test plan
- [x] `pnpm exec biome check --write apps/api/src/identity` — no issues
- [x] `pnpm --filter @tulipfarm/api exec vitest run src/identity/agent-identifiers.test.ts` — fails on old code (2/3), passes after the fix (3/3)
- [x] `pnpm --filter @tulipfarm/api exec vitest run src/identity` — 161/161 passed
- [x] `pnpm --filter @tulipfarm/api exec vitest run src/db-roles.test.ts` — 15/15 passed (confirms `audit_events` append-only grant behavior is unaffected)
- [x] `pnpm --filter @tulipfarm/api typecheck` — clean

Closes #753