### PR TITLE
fix(observability): log worker State failures and queue lifecycle

### DIFF
--- a/apps/worker/src/job-consumers.test.ts
+++ b/apps/worker/src/job-consumers.test.ts
@@ -109,6 +109,86 @@ describe("startJobConsumers", () => {
     expect(order).toEqual(["gather", "curator"]);
   });
 
+  it("logs what obs-prune actually deleted from each spine", async () => {
+    const query = vi.fn(async () => ({ rows: [{ id: "expired" }] }));
+    const database = { query } as Queryable;
+    const now = new Date("2026-08-01T12:00:00.000Z");
+    const info = vi.fn();
+    const boss = {
+      start: vi.fn(async () => {}),
+      createQueue: vi.fn(async () => {}),
+      work: vi.fn(
+        async (_name: string, _handler: (jobs: unknown[]) => Promise<void>) => "worker-id"
+      ),
+    };
+
+    await startJobConsumers({
+      databaseUrl: "postgres://database/tulipfarm",
+      database,
+      now: () => now,
+      boss: boss as unknown as PgBoss,
+      log: { error: vi.fn(), info },
+    });
+
+    const handler = boss.work.mock.calls.find(([queue]) => queue === OBS_PRUNE_QUEUE)?.[1];
+    await handler?.([{ data: { retentionMs: 60_000 } }]);
+
+    expect(info).toHaveBeenCalledWith(
+      expect.stringContaining("obs-prune deleted obs_event=1 log_event=1 resource_sample=1")
+    );
+  });
+
+  it("logs and rethrows when a queue handler throws", async () => {
+    const query = vi.fn(async () => {
+      throw new Error("connection reset");
+    });
+    const database = { query } as Queryable;
+    const error = vi.fn();
+    const boss = {
+      start: vi.fn(async () => {}),
+      createQueue: vi.fn(async () => {}),
+      work: vi.fn(
+        async (_name: string, _handler: (jobs: unknown[]) => Promise<void>) => "worker-id"
+      ),
+    };
+
+    await startJobConsumers({
+      databaseUrl: "postgres://database/tulipfarm",
+      database,
+      boss: boss as unknown as PgBoss,
+      log: { error, info: vi.fn() },
+    });
+
+    const handler = boss.work.mock.calls.find(([queue]) => queue === OBS_PRUNE_QUEUE)?.[1];
+    await expect(handler?.([{ data: {} }])).rejects.toThrow("connection reset");
+    expect(error).toHaveBeenCalledWith(
+      expect.stringContaining(`queue handler threw queue=${OBS_PRUNE_QUEUE}`)
+    );
+  });
+
+  it("logs each queue subscription once it is registered", async () => {
+    const info = vi.fn();
+    const boss = {
+      start: vi.fn(async () => {}),
+      createQueue: vi.fn(async () => {}),
+      work: vi.fn(async () => "worker-id"),
+      send: vi.fn(async () => "job-id"),
+    };
+
+    await startJobConsumers({
+      databaseUrl: "postgres://database/tulipfarm",
+      database: { query: vi.fn(async () => ({ rows: [] })) } as Queryable,
+      boss: boss as unknown as PgBoss,
+      businessId: "business-1",
+      taskStore: { upsertOpen: vi.fn(), closeByDedupeKey: vi.fn() } as never,
+      taskSignals: { gather: vi.fn(async () => ({}) as never) } as never,
+      log: { error: vi.fn(), info },
+    });
+
+    expect(info).toHaveBeenCalledWith(`queue subscribed queue=${OBS_PRUNE_QUEUE}`);
+    expect(info).toHaveBeenCalledWith(`queue subscribed queue=${CURATOR_SWEEP_QUEUE}`);
+  });
+
   it("registers no sweep queue, and no boot kick, without task deps", async () => {
     const boss = {
       start: vi.fn(async () => {}),

--- a/apps/worker/src/job-consumers.ts
+++ b/apps/worker/src/job-consumers.ts
@@ -85,6 +85,22 @@ interface SoulBundlePruneJob {
 }
 
 /**
+ * Reports what nothing else in a handler would: that a queue is live, and — if the handler
+ * throws — that it did. pg-boss records a failed job in its own tables, but nothing carried that
+ * fact to the operator log spine, so a queue that stopped draining looked identical to one that
+ * was never subscribed at all.
+ */
+function logSubscribed(log: JobConsumerOptions["log"], queue: string): void {
+  log?.info?.(`queue subscribed queue=${queue}`);
+}
+
+function logHandlerThrew(log: JobConsumerOptions["log"], queue: string, error: unknown): void {
+  log?.error(
+    `queue handler threw queue=${queue} — ${error instanceof Error ? error.message : String(error)}`
+  );
+}
+
+/**
  * Attach to the pg-boss schema the API already migrated, then register every Worker-owned
  * consumer. `migrate: false` is load-bearing: this process never creates or changes a schema.
  */
@@ -98,48 +114,74 @@ export async function startJobConsumers(options: JobConsumerOptions): Promise<Pg
   const resourcePruner = new PgResourceSamplePruner(options.database);
   await boss.createQueue(OBS_PRUNE_QUEUE);
   await boss.work<ObservabilityPruneJob>(OBS_PRUNE_QUEUE, async (jobs) => {
-    const configured = jobs[0]?.data.retentionMs;
-    const retentionMs =
-      typeof configured === "number" && configured > 0 ? configured : OBS_RETENTION_MS;
-    const cutoff = new Date(now().getTime() - retentionMs);
-    await pruner.deleteOlderThan(cutoff);
-    // Same window, same sweep: both spines are raw telemetry under one retention policy. Failing
-    // the job on a missing log_event would also strand obs_event, so the delete runs after it.
-    await logPruner.deleteOlderThan(cutoff);
-    // Samples get their own, shorter window. They arrive on a clock rather than on events, so the
-    // 90-day policy above would keep two orders of magnitude more rows than the 24h chart can show.
-    // The job override deliberately does not apply — it configures the event window, not this one.
-    await resourcePruner.deleteOlderThan(new Date(now().getTime() - RESOURCE_RETENTION_MS));
+    try {
+      const configured = jobs[0]?.data.retentionMs;
+      const retentionMs =
+        typeof configured === "number" && configured > 0 ? configured : OBS_RETENTION_MS;
+      const cutoff = new Date(now().getTime() - retentionMs);
+      const deletedObsEvents = await pruner.deleteOlderThan(cutoff);
+      // Same window, same sweep: both spines are raw telemetry under one retention policy. Failing
+      // the job on a missing log_event would also strand obs_event, so the delete runs after it.
+      const deletedLogEvents = await logPruner.deleteOlderThan(cutoff);
+      // Samples get their own, shorter window. They arrive on a clock rather than on events, so the
+      // 90-day policy above would keep two orders of magnitude more rows than the 24h chart can
+      // show. The job override deliberately does not apply — it configures the event window, not
+      // this one.
+      const deletedSamples = await resourcePruner.deleteOlderThan(
+        new Date(now().getTime() - RESOURCE_RETENTION_MS)
+      );
+      // Reported every pass, zero-delete included, the same convention as bundle retention below —
+      // an operator otherwise cannot tell a queue that swept nothing from one that never ran.
+      options.log?.info?.(
+        `obs-prune deleted obs_event=${deletedObsEvents} log_event=${deletedLogEvents} resource_sample=${deletedSamples}`
+      );
+    } catch (error) {
+      logHandlerThrew(options.log, OBS_PRUNE_QUEUE, error);
+      throw error;
+    }
   });
+  logSubscribed(options.log, OBS_PRUNE_QUEUE);
 
   await boss.createQueue(SPEND_ALERT_QUEUE);
   await boss.work<SpendAlertJob>(SPEND_ALERT_QUEUE, async (jobs) => {
-    const thresholdUsd = jobs[0]?.data.thresholdUsd;
-    // No threshold means the operator set none. There is no default budget to fall back to.
-    if (typeof thresholdUsd !== "number" || thresholdUsd <= 0) return;
-    const window = await readSpendWindow(options.database, thresholdUsd, now());
-    if (!breached(window)) return;
-    options.log?.error(spendAlertMessage(window));
+    try {
+      const thresholdUsd = jobs[0]?.data.thresholdUsd;
+      // No threshold means the operator set none. There is no default budget to fall back to.
+      if (typeof thresholdUsd !== "number" || thresholdUsd <= 0) return;
+      const window = await readSpendWindow(options.database, thresholdUsd, now());
+      if (!breached(window)) return;
+      options.log?.error(spendAlertMessage(window));
+    } catch (error) {
+      logHandlerThrew(options.log, SPEND_ALERT_QUEUE, error);
+      throw error;
+    }
   });
+  logSubscribed(options.log, SPEND_ALERT_QUEUE);
 
   if (options.businessId !== undefined && options.bundles) {
     const businessId = options.businessId;
     const bundles = options.bundles;
     await boss.createQueue(SOUL_BUNDLE_PRUNE_QUEUE);
     await boss.work<SoulBundlePruneJob>(SOUL_BUNDLE_PRUNE_QUEUE, async (jobs) => {
-      const configured = jobs[0]?.data.retentionMs;
-      const retentionMs =
-        typeof configured === "number" && configured > 0 ? configured : SOUL_BUNDLE_RETENTION_MS;
-      const result = await pruneUnreferencedBundles({
-        store: bundles,
-        businessId,
-        now: now(),
-        retentionMs,
-      });
-      // The pass is bounded, so a large backlog drains across scheduled runs. Reporting every
-      // pass — including the zero-delete ones — is how an operator sees that it is keeping up.
-      options.log?.info?.(bundleRetentionMessage(businessId, result));
+      try {
+        const configured = jobs[0]?.data.retentionMs;
+        const retentionMs =
+          typeof configured === "number" && configured > 0 ? configured : SOUL_BUNDLE_RETENTION_MS;
+        const result = await pruneUnreferencedBundles({
+          store: bundles,
+          businessId,
+          now: now(),
+          retentionMs,
+        });
+        // The pass is bounded, so a large backlog drains across scheduled runs. Reporting every
+        // pass — including the zero-delete ones — is how an operator sees that it is keeping up.
+        options.log?.info?.(bundleRetentionMessage(businessId, result));
+      } catch (error) {
+        logHandlerThrew(options.log, SOUL_BUNDLE_PRUNE_QUEUE, error);
+        throw error;
+      }
     });
+    logSubscribed(options.log, SOUL_BUNDLE_PRUNE_QUEUE);
   }
 
   if (options.businessId !== undefined && options.taskStore && options.taskSignals) {
@@ -149,13 +191,19 @@ export async function startJobConsumers(options: JobConsumerOptions): Promise<Pg
     const curatorSweep = options.curatorSweep;
     await boss.createQueue(CURATOR_SWEEP_QUEUE);
     await boss.work(CURATOR_SWEEP_QUEUE, async () => {
-      // Deterministic first, and never inside the Curator's try: a model outage, an exhausted
-      // budget or a missing provider must still leave "Connect a model provider" on screen. That
-      // Task is how the operator fixes the very thing the Curator half needs.
-      const signals = await taskSignals.gather(businessId);
-      await reconcileTasks({ businessId, signals, taskStore, now: now() });
-      if (curatorSweep) await curatorSweep();
+      try {
+        // Deterministic first, and never inside the Curator's try: a model outage, an exhausted
+        // budget or a missing provider must still leave "Connect a model provider" on screen. That
+        // Task is how the operator fixes the very thing the Curator half needs.
+        const signals = await taskSignals.gather(businessId);
+        await reconcileTasks({ businessId, signals, taskStore, now: now() });
+        if (curatorSweep) await curatorSweep();
+      } catch (error) {
+        logHandlerThrew(options.log, CURATOR_SWEEP_QUEUE, error);
+        throw error;
+      }
     });
+    logSubscribed(options.log, CURATOR_SWEEP_QUEUE);
     // Minute 0, not minute 5. The cron alone leaves a fresh instance with an empty Tasks list
     // until the next tick, hiding the very setup gaps a first boot needs to surface. The
     // dedicated singletonKey keeps this out of the scheduler's own dedupe slot, so a boot kick can
@@ -171,16 +219,22 @@ export async function startJobConsumers(options: JobConsumerOptions): Promise<Pg
     const fileIndex = options.fileIndex;
     await boss.createQueue(FILE_INDEX_QUEUE);
     await boss.work<FileIndexJob>(FILE_INDEX_QUEUE, async (jobs) => {
-      for (const job of jobs) {
-        const outcome = await handleFileIndexJob(job.data, fileIndex);
-        // A skip is reported rather than thrown. Every reason for one is a fact about the File a
-        // retry cannot change, so failing the job would only re-read the same bytes three times
-        // before giving up, and say nothing about why to whoever asked for the indexing.
-        if (outcome.kind === "skipped") {
-          options.log?.info?.(`file ${job.data.fileId} not indexed: ${outcome.reason}`);
+      try {
+        for (const job of jobs) {
+          const outcome = await handleFileIndexJob(job.data, fileIndex);
+          // A skip is reported rather than thrown. Every reason for one is a fact about the File a
+          // retry cannot change, so failing the job would only re-read the same bytes three times
+          // before giving up, and say nothing about why to whoever asked for the indexing.
+          if (outcome.kind === "skipped") {
+            options.log?.info?.(`file ${job.data.fileId} not indexed: ${outcome.reason}`);
+          }
         }
+      } catch (error) {
+        logHandlerThrew(options.log, FILE_INDEX_QUEUE, error);
+        throw error;
       }
     });
+    logSubscribed(options.log, FILE_INDEX_QUEUE);
   }
 
   return boss;

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -416,7 +416,7 @@ export async function main(): Promise<void> {
     runs: runStore,
     events: runEventStore,
     budgets: budgetStore,
-    transitions: new RunStoreStateTransitions(runStore),
+    transitions: new RunStoreStateTransitions(runStore, logger),
     waits: turnHost,
     checkpoints: loopCheckpointStore,
     model: ({ events, budgets, businessId, runId, turnId, conversationId }) =>
@@ -468,7 +468,7 @@ export async function main(): Promise<void> {
       models: { model: (selector, requirements) => llm.model(selector, requirements) },
       artifacts: artifactService,
       runs: runStore,
-      transitions: new RunStoreStateTransitions(runStore),
+      transitions: new RunStoreStateTransitions(runStore, logger),
       log: logger,
     })
   );
@@ -493,7 +493,7 @@ export async function main(): Promise<void> {
       artifacts: artifactService,
       runs: runStore,
       scheduler: new RoutineStateScheduler(runStore),
-      transitions: new RunStoreStateTransitions(runStore),
+      transitions: new RunStoreStateTransitions(runStore, logger),
       // Durable retry budget for a State's authored `retry` policy; survives park/resume and crash.
       retries: stateRetryStore,
       // Durable, cross-worker exclusion for a State's authored `concurrencyKey`.
@@ -680,7 +680,10 @@ export async function main(): Promise<void> {
   if (jobBoss) {
     const settled = new Promise<void>((resolve, reject) => {
       stopJobConsumers = () => {
-        jobBoss.stop({ graceful: true }).then(resolve, reject);
+        jobBoss.stop({ graceful: true }).then(() => {
+          logger.info("queue consumers stopped");
+          resolve();
+        }, reject);
       };
     });
     loops.push({ name: "pg-boss-consumers", settled });

--- a/packages/turn-executor/src/kernel-ports.test.ts
+++ b/packages/turn-executor/src/kernel-ports.test.ts
@@ -1,5 +1,5 @@
 import type { PersistedState, RunStore, StateTransitionInput } from "@tulipfarm/storage";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { StateTransitionPort } from "./agent-state";
 import {
   MissingStateError,
@@ -112,6 +112,37 @@ describe("RunStoreStateTransitions", () => {
       reason: "ignored",
     });
     expect(succeeding.transitions[0]?.errorEvidenceRef).toBeUndefined();
+  });
+
+  it("logs an error carrying run id, state key, and evidence when a State fails", async () => {
+    const store = runs({ found: state(), moved: true });
+    const error = vi.fn();
+
+    await new RunStoreStateTransitions(store.runs, { error }).transition({
+      ...REQUEST,
+      from: "running",
+      to: "failed",
+      reason: "routine:agent_tool_call_limit",
+    });
+
+    expect(error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "run_id=run-1 state_key=invoke evidence=routine:agent_tool_call_limit"
+      )
+    );
+  });
+
+  it("does not log for a transition that is not a failure", async () => {
+    const store = runs({ found: state(), moved: true });
+    const error = vi.fn();
+
+    await new RunStoreStateTransitions(store.runs, { error }).transition({
+      ...REQUEST,
+      from: "running",
+      to: "succeeded",
+    });
+
+    expect(error).not.toHaveBeenCalled();
   });
 
   it("stamps started and finished times from the status it is moving to", async () => {

--- a/packages/turn-executor/src/kernel-ports.ts
+++ b/packages/turn-executor/src/kernel-ports.ts
@@ -34,7 +34,16 @@ export class MissingStateError extends Error {
 
 /** Record `reason` only for non-success; RunStore never clears error evidence. */
 export class RunStoreStateTransitions implements StateTransitionPort {
-  constructor(private readonly runs: Pick<RunStore, "findState" | "transitionState">) {}
+  constructor(
+    private readonly runs: Pick<RunStore, "findState" | "transitionState">,
+    /**
+     * Reports a State's durable move to `failed`. Optional so existing tests and callers need not
+     * wire one, but production always does — this is the one place every Run source (chat,
+     * Routine, subagent, curator) settles a State as failed, so it is the single chokepoint that
+     * can report it without each caller remembering to.
+     */
+    private readonly log?: { error(message: string, error?: unknown): void }
+  ) {}
 
   async transition(input: {
     businessId: string;
@@ -62,6 +71,12 @@ export class RunStoreStateTransitions implements StateTransitionPort {
 
     if (!moved) {
       throw new StateTransitionConflictError(input.runId, input.stateKey, input.from, input.to);
+    }
+
+    if (input.to === "failed") {
+      this.log?.error(
+        `state failed run_id=${input.runId} state_key=${input.stateKey} evidence=${input.reason ?? "unknown"}`
+      );
     }
   }
 }


### PR DESCRIPTION
The worker was operationally a black box: a Routine State could fail with zero log output, pg-boss queues gave no sign of being subscribed or of a handler throwing, and the obs-prune sweep discarded its own delete counts. Every finding in the recent staging triage had to be reconstructed from the Postgres log.

- Log an error on every State's durable move to `failed`, carrying `run_id`, `state_key` and the error evidence ref, from the single `RunStoreStateTransitions` chokepoint shared by the chat, Routine, subagent and curator Run sources.
- Log pg-boss queue subscribe/stop lifecycle and any handler throw.
- Log what the obs-prune sweep actually deleted, per spine.

Closes #757

## Test plan

- [x] `apps/worker/src/job-consumers.test.ts` and `packages/turn-executor/src/kernel-ports.test.ts` extended
- [ ] CI: Test packages + Test other apps