### PR TITLE
fix(worker): stamp evidence ref for unspecified needs_reconciliation parks

### DIFF
--- a/apps/worker/src/run-dispatcher.test.ts
+++ b/apps/worker/src/run-dispatcher.test.ts
@@ -471,4 +471,50 @@ describe("RunDispatcher", () => {
       }),
     ]);
   });
+
+  it("stamps an unspecified needs_reconciliation outcome so the recovery sweep can see it", async () => {
+    const store = new FakeRunStore();
+    store.claimBatchResult = [persistedRun()];
+    const dispatcher = new RunDispatcher({
+      leases: new RunLeaseManager(store),
+      businessId: BUSINESS_ID,
+      owner: "worker-1",
+      now: () => new Date("2026-07-24T10:00:00.000Z"),
+      handler: async () => ({ status: "needs_reconciliation" }),
+    });
+
+    await dispatcher.dispatchBatch();
+
+    // Without a stamped evidence ref, this Run's `error_evidence_ref` stays null and the recovery
+    // sweep's candidate query never selects it, so it parks at `needs_reconciliation` forever.
+    expect(store.releaseCalls).toEqual([
+      expect.objectContaining({
+        status: "needs_reconciliation",
+        errorEvidenceRef: "dispatch:unspecified_park",
+      }),
+    ]);
+  });
+
+  it("fails a Run that returns needs_reconciliation again after already being requeued once", async () => {
+    const store = new FakeRunStore();
+    store.claimBatchResult = [persistedRun()];
+    store.findOverrides = { errorEvidenceRef: DISPATCH_REQUEUED_ONCE_REF };
+    const dispatcher = new RunDispatcher({
+      leases: new RunLeaseManager(store),
+      businessId: BUSINESS_ID,
+      owner: "worker-1",
+      now: () => new Date("2026-07-24T10:00:00.000Z"),
+      handler: async () => ({ status: "needs_reconciliation" }),
+    });
+
+    await dispatcher.dispatchBatch();
+
+    // Parking it again would feed it straight back to the sweep it just came from.
+    expect(store.releaseCalls).toEqual([
+      expect.objectContaining({
+        status: "failed",
+        errorEvidenceRef: "dispatch:handler_error_after_requeue",
+      }),
+    ]);
+  });
 });

--- a/apps/worker/src/run-dispatcher.ts
+++ b/apps/worker/src/run-dispatcher.ts
@@ -2,6 +2,7 @@ import type { RunLeaseManager, RunRecoveryManager } from "@tulipfarm/run-kernel"
 import {
   DISPATCH_HANDLER_ERROR_REF,
   DISPATCH_REQUEUED_ONCE_REF,
+  DISPATCH_UNSPECIFIED_PARK_REF,
   type PersistedRun,
 } from "@tulipfarm/storage";
 import type { RunOutcome } from "@tulipfarm/turn-executor";
@@ -101,28 +102,39 @@ export class RunDispatcher {
           waiting += 1;
           continue;
         }
+        // A Run already requeued once that parks again (without throwing) would otherwise carry
+        // no evidence ref and sit invisible to the sweep forever; fail it outright instead, same
+        // as the throwing path below.
+        const exhaustedPark =
+          outcome.status === "needs_reconciliation" &&
+          started.run.errorEvidenceRef === DISPATCH_REQUEUED_ONCE_REF;
+        const releaseStatus = exhaustedPark ? "failed" : outcome.status;
+        const releaseEvidenceRef = exhaustedPark
+          ? "dispatch:handler_error_after_requeue"
+          : (outcome.errorEvidenceRef ??
+            (outcome.status === "needs_reconciliation"
+              ? DISPATCH_UNSPECIFIED_PARK_REF
+              : undefined));
         const released = await this.options.leases.release({
           businessId: this.options.businessId,
           runId: run.id,
           expectedVersion: started.run.version,
           expectedStatus: "running",
-          status: outcome.status,
+          status: releaseStatus,
           now: this.options.now(),
-          ...(outcome.errorEvidenceRef === undefined
-            ? {}
-            : { errorEvidenceRef: outcome.errorEvidenceRef }),
+          ...(releaseEvidenceRef === undefined ? {} : { errorEvidenceRef: releaseEvidenceRef }),
         });
         if (!released) {
           failed += 1;
           continue;
         }
-        if (outcome.status === "succeeded") dispatched += 1;
-        else if (outcome.status === "waiting") waiting += 1;
+        if (releaseStatus === "succeeded") dispatched += 1;
+        else if (releaseStatus === "waiting") waiting += 1;
         else failed += 1;
-        if (outcome.status === "succeeded" || outcome.status === "failed") {
-          await this.notifyTerminal(started.run, outcome.status);
+        if (releaseStatus === "succeeded" || releaseStatus === "failed") {
+          await this.notifyTerminal(started.run, releaseStatus);
         }
-        if (outcome.status === "waiting") {
+        if (releaseStatus === "waiting") {
           await this.notifyWaiting(started.run);
         }
       } catch (error) {

--- a/packages/run-kernel/src/recover.test.ts
+++ b/packages/run-kernel/src/recover.test.ts
@@ -3,6 +3,7 @@ import {
   DISPATCH_HANDLER_ERROR_REF,
   DISPATCH_LEASE_EXPIRED_REF,
   DISPATCH_REQUEUED_ONCE_REF,
+  DISPATCH_UNSPECIFIED_PARK_REF,
 } from "@tulipfarm/storage";
 import { describe, expect, it } from "vitest";
 import {
@@ -67,7 +68,7 @@ function harness(
 }
 
 describe("RunRecoveryManager", () => {
-  it.each([DISPATCH_HANDLER_ERROR_REF, DISPATCH_LEASE_EXPIRED_REF])(
+  it.each([DISPATCH_HANDLER_ERROR_REF, DISPATCH_LEASE_EXPIRED_REF, DISPATCH_UNSPECIFIED_PARK_REF])(
     "requeues retryable abandoned work once for %s",
     async (errorEvidenceRef) => {
       const { manager } = harness(run({ errorEvidenceRef }), []);

--- a/packages/run-kernel/src/recover.ts
+++ b/packages/run-kernel/src/recover.ts
@@ -2,6 +2,7 @@ import {
   DISPATCH_HANDLER_ERROR_REF,
   DISPATCH_LEASE_EXPIRED_REF,
   DISPATCH_REQUEUED_ONCE_REF,
+  DISPATCH_UNSPECIFIED_PARK_REF,
   type PersistedRun,
 } from "@tulipfarm/storage";
 
@@ -42,6 +43,7 @@ export type RunRecoveryResult =
 const RECOVERABLE_EVIDENCE: ReadonlySet<string> = new Set([
   DISPATCH_HANDLER_ERROR_REF,
   DISPATCH_LEASE_EXPIRED_REF,
+  DISPATCH_UNSPECIFIED_PARK_REF,
 ]);
 
 const REPLAY_SAFE_EFFECT_STATES: ReadonlySet<string> = new Set([

--- a/packages/storage/src/runs/index.ts
+++ b/packages/storage/src/runs/index.ts
@@ -53,6 +53,7 @@ export {
   DISPATCH_HANDLER_ERROR_REF,
   DISPATCH_LEASE_EXPIRED_REF,
   DISPATCH_REQUEUED_ONCE_REF,
+  DISPATCH_UNSPECIFIED_PARK_REF,
 } from "./run-lease-store";
 export type {
   AppendAttemptInput,

--- a/packages/storage/src/runs/run-lease-store.ts
+++ b/packages/storage/src/runs/run-lease-store.ts
@@ -140,6 +140,14 @@ export const DISPATCH_LEASE_EXPIRED_REF = "dispatch:lease_expired";
  */
 export const DISPATCH_REQUEUED_ONCE_REF = "dispatch:requeued_once";
 
+/**
+ * Recorded when an executor *returns* `needs_reconciliation` (rather than throwing) without
+ * naming its own reason. Without this, such a park carries a null `error_evidence_ref` and the
+ * recovery sweep's candidate query (`error_evidence_ref IN (...)`) never selects it — the Run
+ * parks forever, invisible to the reconciliation path that would otherwise requeue or escalate it.
+ */
+export const DISPATCH_UNSPECIFIED_PARK_REF = "dispatch:unspecified_park";
+
 /** Lists the bounded recovery cases a manager must classify against durable effects. */
 export async function listRecoveryCandidateRows(
   transaction: Queryable,


### PR DESCRIPTION
## Summary
- `run_states`/`runs` were sitting parked at `claimed`/`pending`/`needs_reconciliation` for up to 12 days because the recovery sweep's candidate query only matches Runs whose `error_evidence_ref` is `dispatch:handler_error` or `dispatch:lease_expired` — both stamped only when a handler *throws*. Chat's `announceTurnFailure` and ~15+ routine executor sites *return* `{ status: "needs_reconciliation" }` with no `errorEvidenceRef`, so those Runs park with a null evidence ref and become permanently invisible to the sweep, even though the sweep itself runs on a real recurring pg-boss/dispatch-loop timer, not just at boot.
- `RunDispatcher.dispatchBatch()` (`apps/worker/src/run-dispatcher.ts`) now defaults a bare `needs_reconciliation` outcome to a new `DISPATCH_UNSPECIFIED_PARK_REF` evidence ref, making it visible to `RunRecoveryManager`'s sweep, and applies the existing "already requeued once -> fail" bound to this outcome-based path too, so a Run that parks unspecified twice fails instead of retrying forever.
- `run_states` itself still has no lease/expiry columns (`packages/storage/src/runs/state-store.ts`), but a State only ever progresses because its owning Run is redispatched — fixing Run-level candidate visibility is what actually clears the stuck States, since nothing else drives a State transition once its Run is invisible to reconciliation.

## Root cause (file:line evidence)
- `packages/storage/src/runs/run-lease-store.ts:152-169` — `listRecoveryCandidateRows` only selects `runs` with `status = 'needs_reconciliation' AND error_evidence_ref IN (DISPATCH_HANDLER_ERROR_REF, DISPATCH_LEASE_EXPIRED_REF)`.
- `packages/turn-executor/src/chat-executor.ts:148-162` — `announceTurnFailure()` returns `{ status: "needs_reconciliation" }` with no `errorEvidenceRef`.
- `packages/turn-executor/src/driver.ts:246` — same pattern, another layer.
- `apps/worker/src/routine/executor.ts` — ~15+ call sites return bare `"needs_reconciliation"` for routine `ChainOutcome`/State progression without an evidence ref.
- `apps/worker/src/run-dispatcher.ts` (pre-fix) only stamped `errorEvidenceRef` when the *handler threw* (the `catch` block), never for a returned `RunOutcome`.
- `apps/worker/src/main.ts:621-633` — `dispatchBatch()` already runs on a recurring `runLoop`, not boot-only, so the sweep's scheduling was never the bug — only candidate *visibility* was.
- `packages/storage/src/runs/state-store.ts` — `run_states` has no `lease_owner`/`lease_expires_at` columns at all, confirming States themselves carry no claim-lease expiry; State progression instead depends entirely on their Run being redispatched.

## Test plan
- [x] `pnpm --filter @tulipfarm/run-kernel test` — 512/512 pass (recover.test.ts 12/12, including a new case proving `DISPATCH_UNSPECIFIED_PARK_REF` is now a recoverable evidence ref)
- [x] `pnpm --filter @tulipfarm/storage test` — 547 pass / 16 skipped (unrelated pre-existing skips)
- [x] `pnpm --filter @tulipfarm/worker test` — 522/522 pass, including two new `run-dispatcher.test.ts` cases: a bare `needs_reconciliation` outcome now gets stamped with `dispatch:unspecified_park`, and a Run already at `dispatch:requeued_once` that parks again is released as `failed` instead of parked again
- [x] `pnpm exec biome check --write` on all changed files

No `apps/eval` Corpus change: this diff does not change what an Agent Turn *does* (no context/prompt/Tool-loop/guardrail change); it only changes which already-parked Runs the maintenance sweep can see and requeue/fail, so no Case applies.

Closes #756