### PR TITLE
fix(storage): let the recovery sweep see parked runs with no evidence ref

### DIFF
--- a/apps/worker/src/run-dispatcher.test.ts
+++ b/apps/worker/src/run-dispatcher.test.ts
@@ -1,5 +1,6 @@
 import { RunLeaseManager, type RunLeaseStore } from "@tulipfarm/run-kernel";
 import {
+  DISPATCH_REQUEUE_EXHAUSTED_REF,
   DISPATCH_REQUEUED_ONCE_REF,
   type PersistedRun,
   type PersistedRunStatus,
@@ -467,7 +468,7 @@ describe("RunDispatcher", () => {
     expect(store.releaseCalls).toEqual([
       expect.objectContaining({
         status: "failed",
-        errorEvidenceRef: "dispatch:handler_error_after_requeue",
+        errorEvidenceRef: DISPATCH_REQUEUE_EXHAUSTED_REF,
       }),
     ]);
   });
@@ -513,7 +514,7 @@ describe("RunDispatcher", () => {
     expect(store.releaseCalls).toEqual([
       expect.objectContaining({
         status: "failed",
-        errorEvidenceRef: "dispatch:handler_error_after_requeue",
+        errorEvidenceRef: DISPATCH_REQUEUE_EXHAUSTED_REF,
       }),
     ]);
   });

--- a/apps/worker/src/run-dispatcher.ts
+++ b/apps/worker/src/run-dispatcher.ts
@@ -1,6 +1,7 @@
 import type { RunLeaseManager, RunRecoveryManager } from "@tulipfarm/run-kernel";
 import {
   DISPATCH_HANDLER_ERROR_REF,
+  DISPATCH_REQUEUE_EXHAUSTED_REF,
   DISPATCH_REQUEUED_ONCE_REF,
   DISPATCH_UNSPECIFIED_PARK_REF,
   type PersistedRun,
@@ -110,7 +111,7 @@ export class RunDispatcher {
           started.run.errorEvidenceRef === DISPATCH_REQUEUED_ONCE_REF;
         const releaseStatus = exhaustedPark ? "failed" : outcome.status;
         const releaseEvidenceRef = exhaustedPark
-          ? "dispatch:handler_error_after_requeue"
+          ? DISPATCH_REQUEUE_EXHAUSTED_REF
           : (outcome.errorEvidenceRef ??
             (outcome.status === "needs_reconciliation"
               ? DISPATCH_UNSPECIFIED_PARK_REF
@@ -153,9 +154,7 @@ export class RunDispatcher {
           expectedStatus: "running",
           status,
           now: this.options.now(),
-          errorEvidenceRef: exhausted
-            ? "dispatch:handler_error_after_requeue"
-            : DISPATCH_HANDLER_ERROR_REF,
+          errorEvidenceRef: exhausted ? DISPATCH_REQUEUE_EXHAUSTED_REF : DISPATCH_HANDLER_ERROR_REF,
         });
         failed += 1;
       }

--- a/apps/worker/test/process/worker.test.ts
+++ b/apps/worker/test/process/worker.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { DEPLOYMENT_BUSINESS_ID } from "@tulipfarm/constants";
+import { DISPATCH_REQUEUE_EXHAUSTED_REF } from "@tulipfarm/storage";
 import { PgBoss } from "pg-boss";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
 import { REQUIRED_SCHEMA_VERSION } from "../../src/config";
@@ -214,7 +215,7 @@ describe("worker process", () => {
         { describe: "the replacement worker to reclaim, requeue once, and fail the abandoned Run" }
       );
       expect(recovered?.leaseOwner).toBeNull();
-      expect(recovered?.errorEvidenceRef).toBe("dispatch:handler_error_after_requeue");
+      expect(recovered?.errorEvidenceRef).toBe(DISPATCH_REQUEUE_EXHAUSTED_REF);
     },
     TIMEOUT
   );

--- a/packages/run-kernel/src/recover.ts
+++ b/packages/run-kernel/src/recover.ts
@@ -23,7 +23,7 @@ export interface TargetedRunRecoveryStore {
     businessId: string,
     runId: string,
     expectedVersion: number,
-    expectedEvidenceRef: string
+    expectedEvidenceRef: string | null
   ): Promise<PersistedRun | null>;
 }
 
@@ -89,10 +89,12 @@ export class RunRecoveryManager {
     if (current.version !== input.expectedVersion) {
       return { outcome: "version_conflict", run: current };
     }
+    // A NULL errorEvidenceRef is itself a recoverable case: it is how a Run parked before
+    // evidence-ref stamping existed (or by any future return path that forgets to name a reason)
+    // still surfaces here instead of being permanently unsupported.
     if (
       current.status !== "needs_reconciliation" ||
-      current.errorEvidenceRef === null ||
-      !RECOVERABLE_EVIDENCE.has(current.errorEvidenceRef)
+      (current.errorEvidenceRef !== null && !RECOVERABLE_EVIDENCE.has(current.errorEvidenceRef))
     ) {
       return { outcome: "unsupported", run: current };
     }

--- a/packages/storage/src/runs/index.ts
+++ b/packages/storage/src/runs/index.ts
@@ -52,6 +52,7 @@ export { MemoryWaitStore } from "./memory-wait-store";
 export {
   DISPATCH_HANDLER_ERROR_REF,
   DISPATCH_LEASE_EXPIRED_REF,
+  DISPATCH_REQUEUE_EXHAUSTED_REF,
   DISPATCH_REQUEUED_ONCE_REF,
   DISPATCH_UNSPECIFIED_PARK_REF,
 } from "./run-lease-store";

--- a/packages/storage/src/runs/run-lease-store.ts
+++ b/packages/storage/src/runs/run-lease-store.ts
@@ -142,13 +142,25 @@ export const DISPATCH_REQUEUED_ONCE_REF = "dispatch:requeued_once";
 
 /**
  * Recorded when an executor *returns* `needs_reconciliation` (rather than throwing) without
- * naming its own reason. Without this, such a park carries a null `error_evidence_ref` and the
- * recovery sweep's candidate query (`error_evidence_ref IN (...)`) never selects it — the Run
- * parks forever, invisible to the reconciliation path that would otherwise requeue or escalate it.
+ * naming its own reason. `listRecoveryCandidateRows` also selects a NULL `error_evidence_ref`
+ * directly, so this ref exists only as an operator-facing breadcrumb — it names *why* a Run with
+ * no thrown error still parked, it is not what makes the Run visible to the sweep.
  */
 export const DISPATCH_UNSPECIFIED_PARK_REF = "dispatch:unspecified_park";
 
-/** Lists the bounded recovery cases a manager must classify against durable effects. */
+/**
+ * Stamped in place of {@link DISPATCH_HANDLER_ERROR_REF} once a `needs_reconciliation` outcome
+ * (rather than a throw) has already been requeued once and parks again. Bounds the same way
+ * {@link DISPATCH_REQUEUED_ONCE_REF} bounds a thrown error's retry.
+ */
+export const DISPATCH_REQUEUE_EXHAUSTED_REF = "dispatch:handler_error_after_requeue";
+
+/**
+ * Lists the bounded recovery cases a manager must classify against durable effects. A NULL
+ * `error_evidence_ref` is included alongside the named dispatch refs so a Run parked before this
+ * evidence-ref stamping existed (or by any future return path that forgets to name a reason)
+ * still surfaces here instead of parking forever.
+ */
 export async function listRecoveryCandidateRows(
   transaction: Queryable,
   businessId: string,
@@ -160,21 +172,30 @@ export async function listRecoveryCandidateRows(
        FROM runs
       WHERE business_id = $1
         AND status = 'needs_reconciliation'
-        AND error_evidence_ref IN ($2, $3)
+        AND (error_evidence_ref IS NULL OR error_evidence_ref IN ($2, $3, $4))
       ORDER BY created_at
-      LIMIT $4`,
-    [businessId, DISPATCH_HANDLER_ERROR_REF, DISPATCH_LEASE_EXPIRED_REF, Math.max(0, limit)]
+      LIMIT $5`,
+    [
+      businessId,
+      DISPATCH_HANDLER_ERROR_REF,
+      DISPATCH_LEASE_EXPIRED_REF,
+      DISPATCH_UNSPECIFIED_PARK_REF,
+      Math.max(0, limit),
+    ]
   );
   return result.rows.map(persistedRun);
 }
 
-/** Requeues one classified recovery under status, version, and evidence CAS fences. */
+/**
+ * Requeues one classified recovery under status, version, and evidence CAS fences.
+ * `expectedEvidenceRef` may be `null` to match a Run parked before evidence-ref stamping existed.
+ */
 export async function requeueParkedRunRow(
   transaction: Queryable,
   businessId: string,
   runId: string,
   expectedVersion: number,
-  expectedEvidenceRef: string
+  expectedEvidenceRef: string | null
 ): Promise<PersistedRun | null> {
   const result = await transaction.query<RunRow>(
     `UPDATE runs
@@ -187,7 +208,7 @@ export async function requeueParkedRunRow(
         AND id = $2
         AND version = $3
         AND status = 'needs_reconciliation'
-        AND error_evidence_ref = $4
+        AND error_evidence_ref IS NOT DISTINCT FROM $4
       RETURNING id, business_id, source, bundle, identity, status, version, created_at, started_at,
                 finished_at, result_artifact_id, error_evidence_ref, lease_owner, lease_expires_at`,
     [businessId, runId, expectedVersion, expectedEvidenceRef, DISPATCH_REQUEUED_ONCE_REF]

--- a/packages/storage/src/runs/run-store.ts
+++ b/packages/storage/src/runs/run-store.ts
@@ -580,7 +580,7 @@ export class RunStore {
     businessId: string,
     runId: string,
     expectedVersion: number,
-    expectedEvidenceRef: string
+    expectedEvidenceRef: string | null
   ): Promise<PersistedRun | null> {
     return this.transactions.withTransaction((transaction) =>
       requeueParkedRunRow(transaction, businessId, runId, expectedVersion, expectedEvidenceRef)


### PR DESCRIPTION
PR #768 closed #756 but did not fix it. It stamps `DISPATCH_UNSPECIFIED_PARK_REF` on a `needs_reconciliation` outcome that named no reason, and adds that ref to the in-memory `RECOVERABLE_EVIDENCE` set — but never adds it to `listRecoveryCandidateRows`, the SQL predicate that actually gates the sweep. That query still reads `error_evidence_ref IN ($2, $3)`, so the Run stays invisible: same stuck Run, different reason. Runs parked before the stamping existed carry a NULL ref and were never covered at all.

- Select a NULL `error_evidence_ref`, and the unspecified-park ref, as recovery candidates — this covers already-stuck Runs without a migration, and is self-healing for any future return path that forgets to name a reason.
- Match a NULL ref in the requeue CAS fence via `IS NOT DISTINCT FROM` (plain `= $4` never matches NULL).
- Treat a NULL ref as recoverable rather than `unsupported` in `RunRecoveryManager`.
- Replace the inline `dispatch:handler_error_after_requeue` literal with an exported `DISPATCH_REQUEUE_EXHAUSTED_REF`, as its siblings already are.

Closes #756

## Test plan

- [x] `pnpm --filter @tulipfarm/storage test` — 547 passed, 16 skipped
- [x] `pnpm --filter @tulipfarm/run-kernel test` — 512 passed
- [x] `pnpm --filter @tulipfarm/worker test` — 525 passed
- [x] `pnpm exec biome check` clean
- [ ] CI green