### PR TITLE
fix(llm): validate embedding provider fields at write time and surface degradation

### DIFF
--- a/apps/api/src/admin/health.test.ts
+++ b/apps/api/src/admin/health.test.ts
@@ -1,6 +1,6 @@
 import { LlmNotConfiguredError, UnknownModelError } from "@tulipfarm/schema";
 import { describe, expect, it, vi } from "vitest";
-import { type HealthResult, llmProbe, probeHealth } from "./health";
+import { embeddingsProbe, type HealthResult, llmProbe, probeHealth } from "./health";
 
 /** A configured, resolvable model. Resolution alone cannot tell a live key from a revoked one. */
 const configured = { effortModel: vi.fn(() => ({})) };
@@ -102,5 +102,45 @@ describe("llmProbe", () => {
 
     expect(component.status).toBe("down");
     expect(component.detail).toContain("gpt-5.6-terra");
+  });
+});
+
+describe("embeddingsProbe", () => {
+  it("reports unknown when no embedding provider is configured", async () => {
+    const probe = embeddingsProbe({
+      isConfigured: () => false,
+      isAvailable: () => false,
+    });
+
+    const [component] = await probeHealth([probe], at);
+
+    expect(component.status).toBe("unknown");
+    expect(component.detail).toContain("no embedding provider is configured");
+  });
+
+  it("reports degraded — not down — when configured but no provider could resolve", async () => {
+    // This is the standing condition #755 reported: a boot-time warn and nothing thereafter, while
+    // embedding-backfill and knowledge-index jobs kept reporting `completed` against lexical-only
+    // search. The probe must keep surfacing it, and must not fail an otherwise-running instance.
+    const probe = embeddingsProbe({
+      isConfigured: () => true,
+      isAvailable: () => false,
+    });
+
+    const [component] = await probeHealth([probe], at);
+
+    expect(component.status).toBe("degraded");
+    expect(component.detail).toContain("lexical matching");
+  });
+
+  it("reports ok when a configured provider resolved", async () => {
+    const probe = embeddingsProbe({
+      isConfigured: () => true,
+      isAvailable: () => true,
+    });
+
+    const [component] = await probeHealth([probe], at);
+
+    expect(component.status).toBe("ok");
   });
 });

--- a/apps/api/src/admin/health.ts
+++ b/apps/api/src/admin/health.ts
@@ -220,6 +220,45 @@ export function llmProbe(llm: ModelProbeTarget, options: LlmProbeOptions = {}): 
   };
 }
 
+export interface EmbeddingProbeTarget {
+  isConfigured(): boolean;
+  isAvailable(): boolean;
+}
+
+/**
+ * "no embedding provider available" was a one-shot boot warning: `embedding-backfill` and
+ * `knowledge-index` jobs kept reporting `completed` against a degraded backend, and nothing else
+ * ever surfaced it again. This probe makes the condition an ongoing health row instead, so a
+ * dashboard or `readyz` check keeps seeing it for as long as it stays true.
+ *
+ * Unconfigured is `unknown`, the same as `llmProbe`'s "no LLM configured": nothing is broken, an
+ * operator simply has not connected a provider. Configured-but-unresolved is `degraded`, never
+ * `down` — an instance in this state still runs, only knowledge search falls back to lexical
+ * matching.
+ */
+export function embeddingsProbe(embeddings: EmbeddingProbeTarget): HealthProbe {
+  return {
+    component: "embeddings",
+    async check() {
+      if (!embeddings.isConfigured()) {
+        return {
+          status: "unknown",
+          detail: "no embedding provider is configured — knowledge search runs lexical-only",
+        };
+      }
+      if (!embeddings.isAvailable()) {
+        return {
+          status: "degraded",
+          detail:
+            "no configured embedding provider could be initialized — knowledge search has " +
+            "fallen back to lexical matching",
+        };
+      }
+      return { status: "ok" };
+    },
+  };
+}
+
 function numberFrom(value: unknown): number {
   if (typeof value === "number") return Number.isFinite(value) ? value : 0;
   if (typeof value === "bigint") return Number(value);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -126,6 +126,7 @@ import { subscribeActivityLogging } from "./activity/events";
 import { PgActivityRepo } from "./activity/repo";
 import { ActivityService } from "./activity/service";
 import {
+  embeddingsProbe,
   llmProbe,
   postgresProbe,
   queueProbe,
@@ -1615,6 +1616,7 @@ async function boot() {
           soulProbe(gitSync),
           soulPublicationProbe(pool),
           llmProbe(llmService, { reachability: modelReachability(llmService) }),
+          embeddingsProbe(embeddingService),
         ],
         guardrailsConfig: () => soulLoader.guardrailsConfig,
         teamMigrationReport: async (businessId) => {

--- a/apps/api/src/soul/llm-config/routes.test.ts
+++ b/apps/api/src/soul/llm-config/routes.test.ts
@@ -409,6 +409,34 @@ describe("llm-config routes", () => {
       expect(init).not.toHaveBeenCalled();
     });
 
+    it("rejects an azure embedding provider missing resource_name and base_url", async () => {
+      // Regression for #755: an Azure embedding provider saved with neither field builds no
+      // model at boot, and the runtime silently drops to lexical matching. The write path must
+      // reject it instead of accepting a config that can only fail later.
+      const res = await app.inject({
+        method: "PUT",
+        url: "/api/v1/llm-config",
+        cookies: cookies(adminSid),
+        headers,
+        payload: {
+          tiers: {
+            quick: { providers: [{ provider: "anthropic", model: "claude-haiku-4-5" }] },
+            standard: { providers: [{ provider: "anthropic", model: "claude-sonnet-4-6" }] },
+            complex: { providers: [{ provider: "anthropic", model: "claude-opus-4-8" }] },
+          },
+          embeddings: {
+            providers: [{ provider: "azure", model: "text-embedding-3-large" }],
+          },
+        },
+      });
+      expect(res.statusCode).toBe(422);
+      expect(res.json().error).toBe(
+        "embeddings.providers[0]: azure provider requires resource_name or base_url"
+      );
+      expect(soulWriterDouble.applied).toEqual([]);
+      expect(init).not.toHaveBeenCalled();
+    });
+
     it("rejects a structurally invalid config with 422, leaving the running config intact", async () => {
       const res = await app.inject({
         method: "PUT",

--- a/packages/llm/src/embedding-provider.ts
+++ b/packages/llm/src/embedding-provider.ts
@@ -10,6 +10,11 @@ import { resolveApiKey } from "./provider";
 /**
  * Build a text-embedding model from one config entry. Mirrors `createModel`
  * (provider.ts) — same credential resolution, same provider-switch shape.
+ *
+ * These required-field checks stay a second guard even though `@tulipfarm/schema`'s
+ * `validateLlmConfig` (via `describeMissingEmbeddingFields`) already rejects an incomplete entry
+ * at write time: a config written before that check existed, or edited outside the write gate,
+ * must still fail loud here rather than hand the AI SDK an unbuildable client.
  */
 export async function createEmbeddingModel(
   entry: EmbeddingProviderEntry,

--- a/packages/llm/src/embeddings.test.ts
+++ b/packages/llm/src/embeddings.test.ts
@@ -183,6 +183,54 @@ describe("EmbeddingService", () => {
     await svc.init(cfg(undefined), makeSecrets() as never, logger);
     expect(svc.isAvailable()).toBe(false);
   });
+
+  it("reports unconfigured, not merely unavailable, when no embeddings section is present", async () => {
+    const svc = new EmbeddingService();
+    await svc.init(cfg(undefined), makeSecrets() as never, logger);
+    expect(svc.isConfigured()).toBe(false);
+    expect(svc.isAvailable()).toBe(false);
+  });
+
+  it("reports configured but unavailable when every declared provider fails to resolve", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.reject(new Error("ECONNREFUSED")))
+    );
+    const svc = new EmbeddingService();
+    const secrets = makeSecrets();
+
+    await svc.init(
+      cfg({
+        providers: [
+          { provider: "ollama", model: "nomic-embed-text", base_url: "http://localhost:11434/v1" },
+        ],
+      }),
+      secrets as never,
+      logger
+    );
+
+    // This is the standing "embeddings unavailable — lexical fallback" degradation a health probe
+    // must be able to distinguish from an instance that was simply never given an `embeddings:`
+    // block — the second is nothing to fix, the first is an ongoing fault.
+    expect(svc.isConfigured()).toBe(true);
+    expect(svc.isAvailable()).toBe(false);
+  });
+
+  it("reports configured and available once a provider resolves", async () => {
+    const svc = new EmbeddingService();
+    const secrets = makeSecrets({ "openai-api-key": "sk-test" });
+    await svc.init(
+      cfg({
+        providers: [
+          { provider: "openai", model: "text-embedding-3-small", api_key_ref: "openai-api-key" },
+        ],
+      }),
+      secrets as never,
+      logger
+    );
+    expect(svc.isConfigured()).toBe(true);
+    expect(svc.isAvailable()).toBe(true);
+  });
 });
 
 describe("EmbeddingService — per-call failover", () => {

--- a/packages/llm/src/embeddings.ts
+++ b/packages/llm/src/embeddings.ts
@@ -100,6 +100,13 @@ export class EmbeddingService {
   private readonly demoteMs: number;
   private readonly usage: EmbeddingUsageSink | undefined;
   private readonly now: () => number;
+  /**
+   * Whether the last `init` saw an `embeddings:` block at all. An unconfigured instance and a
+   * configured-but-unresolvable one are both `isAvailable() === false`, but they are different
+   * health conditions: the first has nothing to fix, the second is a standing degradation a health
+   * probe must keep surfacing past the one boot-time warning.
+   */
+  private configured = false;
 
   constructor(options: EmbeddingServiceOptions = {}) {
     this.timeoutMs = options.timeoutMs ?? EMBEDDING_TIMEOUT_MS;
@@ -115,6 +122,7 @@ export class EmbeddingService {
   ): Promise<void> {
     const embeddings = rawConfig ? validateLlmConfig(rawConfig).embeddings : undefined;
     this.logger = logger;
+    this.configured = embeddings !== undefined;
 
     if (!embeddings) {
       this.candidates = [];
@@ -184,6 +192,11 @@ export class EmbeddingService {
 
   isAvailable(): boolean {
     return this.active !== null;
+  }
+
+  /** Whether the last `init` saw an `embeddings:` block, regardless of whether it resolved. */
+  isConfigured(): boolean {
+    return this.configured;
   }
 
   getActive(): { provider: string; model: string; dimension: number | null } | null {

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -154,6 +154,7 @@ export type {
   UnusableProviderEntry,
 } from "./llm";
 export {
+  describeMissingEmbeddingFields,
   dropUnusableProviderEntries,
   EmbeddingUnavailableError,
   LlmConfigSchema,

--- a/packages/schema/src/llm.test.ts
+++ b/packages/schema/src/llm.test.ts
@@ -139,6 +139,74 @@ describe("validateLlmConfig", () => {
     };
     expect(() => validateLlmConfig(bad)).toThrow(LlmConfigValidationError);
   });
+
+  it("rejects an azure embedding entry missing both resource_name and base_url", () => {
+    const bad = {
+      ...validConfig,
+      embeddings: {
+        providers: [{ provider: "azure", model: "text-embedding-3-large" }],
+      },
+    };
+    expect(() => validateLlmConfig(bad)).toThrow(
+      "embeddings.providers[0]: azure provider requires resource_name or base_url"
+    );
+  });
+
+  it("accepts an azure embedding entry with only resource_name", () => {
+    const config = {
+      ...validConfig,
+      embeddings: {
+        providers: [
+          { provider: "azure", model: "text-embedding-3-large", resource_name: "my-resource" },
+        ],
+      },
+    };
+    expect(() => validateLlmConfig(config)).not.toThrow();
+  });
+
+  it("accepts an azure embedding entry with only base_url", () => {
+    const config = {
+      ...validConfig,
+      embeddings: {
+        providers: [
+          {
+            provider: "azure",
+            model: "text-embedding-3-large",
+            base_url: "https://example.openai.azure.com",
+          },
+        ],
+      },
+    };
+    expect(() => validateLlmConfig(config)).not.toThrow();
+  });
+
+  it("rejects an openai-compatible embedding entry missing base_url", () => {
+    const bad = {
+      ...validConfig,
+      embeddings: { providers: [{ provider: "openai-compatible", model: "text-embedding" }] },
+    };
+    expect(() => validateLlmConfig(bad)).toThrow(
+      "embeddings.providers[0]: openai-compatible provider requires base_url"
+    );
+  });
+
+  it("rejects an ollama embedding entry missing base_url", () => {
+    const bad = {
+      ...validConfig,
+      embeddings: { providers: [{ provider: "ollama", model: "nomic-embed-text" }] },
+    };
+    expect(() => validateLlmConfig(bad)).toThrow(
+      "embeddings.providers[0]: ollama provider requires base_url"
+    );
+  });
+
+  it("accepts an openai embedding entry with no base_url or resource_name", () => {
+    const config = {
+      ...validConfig,
+      embeddings: { providers: [{ provider: "openai", model: "text-embedding-3-large" }] },
+    };
+    expect(() => validateLlmConfig(config)).not.toThrow();
+  });
 });
 
 describe("dropUnusableProviderEntries", () => {

--- a/packages/schema/src/llm.ts
+++ b/packages/schema/src/llm.ts
@@ -201,6 +201,29 @@ function describeConfigError(error: {
   return `${path}${error.message ?? "invalid config"}`;
 }
 
+/**
+ * Fields a given embedding provider cannot build a model without. Mirrors the runtime switch in
+ * `@tulipfarm/llm`'s `createEmbeddingModel` — unlike a chat {@link ProviderEntry}, an embedding
+ * entry has no registry-keyed stored-secret fallback for `resource_name`/`base_url`, so a missing
+ * field here is missing for good; only a write-time reject catches it before boot.
+ */
+const EMBEDDING_PROVIDER_REQUIREMENTS: Readonly<
+  Record<string, (entry: EmbeddingProviderEntry) => string | null>
+> = {
+  azure: (entry) =>
+    entry.resource_name || entry.base_url
+      ? null
+      : "azure provider requires resource_name or base_url",
+  "openai-compatible": (entry) =>
+    entry.base_url ? null : "openai-compatible provider requires base_url",
+  ollama: (entry) => (entry.base_url ? null : "ollama provider requires base_url"),
+};
+
+/** Null when `entry` carries every field its provider needs to build a model. */
+export function describeMissingEmbeddingFields(entry: EmbeddingProviderEntry): string | null {
+  return EMBEDDING_PROVIDER_REQUIREMENTS[entry.provider]?.(entry) ?? null;
+}
+
 export function validateLlmConfig(data: unknown): LlmConfig {
   if (!checkConfig(data)) {
     const e = checkConfig.errors?.[0] ?? { instancePath: "", message: "invalid config" };
@@ -211,6 +234,12 @@ export function validateLlmConfig(data: unknown): LlmConfig {
   if (config.tiers === undefined) {
     throw new LlmConfigValidationError("config must declare provider chains in tiers");
   }
+  config.embeddings?.providers.forEach((entry, index) => {
+    const problem = describeMissingEmbeddingFields(entry);
+    if (problem) {
+      throw new LlmConfigValidationError(`embeddings.providers[${index}]: ${problem}`);
+    }
+  });
   return config;
 }
 


### PR DESCRIPTION
On the staging instance an Azure embedding entry was saved with neither `resource_name` nor `base_url`, so the provider failed to build at boot and the runtime silently dropped to lexical matching. `embedding-backfill` and `knowledge-index` jobs kept reporting `completed` against a degraded backend, and the only signal was a single boot-time `warn` — which the durable app log does not retain.

- `packages/schema/src/llm.ts`: `validateLlmConfig` now rejects an embedding entry missing its provider-required fields, so `PUT /api/v1/llm-config` (`apps/api/src/soul/llm-config/routes.ts:609`) refuses to persist one. The existing runtime guard in `packages/llm/src/embedding-provider.ts` stays as a second gate for configs written before this check existed.
- `apps/api/src/admin/health.ts`: new `embeddingsProbe`, wired into the live probe list at `apps/api/src/index.ts:1619`. Reports `degraded` on an ongoing basis when a configured provider fails to resolve, and `unknown` when none is configured at all — two different conditions that both leave `isAvailable()` false. Does not fail `/readyz` or boot.

Closes #755

## Test plan

- [x] `pnpm --filter @tulipfarm/schema test` — 330 passed
- [x] `pnpm --filter @tulipfarm/llm test` — passed
- [x] `pnpm --filter @tulipfarm/api test src/admin/health.test.ts src/soul/llm-config/routes.test.ts` — 40 passed
- [ ] CI: full sharded API suite