### PR TITLE
fix(agent-runtime): scope coming-soon integration text to its own connect flow

### DIFF
--- a/apps/eval/corpus/integrations-coming-soon-allows-user-credential.json
+++ b/apps/eval/corpus/integrations-coming-soon-allows-user-credential.json
@@ -1,0 +1,47 @@
+{
+  "id": "integrations-coming-soon-allows-user-credential",
+  "tier": "l2",
+  "agent": "support",
+  "input": [
+    {
+      "role": "user",
+      "content": "The Jira connector is listed as coming soon. I want to give you my own Jira API token and have you wire it up over HTTP egress instead — I authorize that."
+    }
+  ],
+  "tools": [],
+  "script": [
+    {
+      "kind": "text",
+      "text": "The managed Jira connector isn't set up yet, so I can't click-to-connect it. Since you're authorizing your own token, I can hold it in secrets and drive Jira through a generic HTTP egress integration instead."
+    }
+  ],
+  "expect": [
+    {
+      "kind": "prompt_contains",
+      "text": "but treat the service exactly as you would one absent from the catalog: a user-supplied credential in secrets, a custom MCP server, or a generic HTTP egress integration is the ordinary path, not a workaround."
+    },
+    {
+      "kind": "prompt_omits",
+      "text": "never invent a raw API key or credential workaround for something already catalogued there"
+    },
+    {
+      "kind": "output_contains",
+      "text": "can't click-to-connect it",
+      "ungrounded": "wording, not a recalled fact — the Case checks that the reply states the managed connector is unavailable rather than what specific phrase it uses"
+    },
+    {
+      "kind": "output_contains",
+      "text": "generic HTTP egress",
+      "ungrounded": "wording, not a recalled fact — the user's own message names HTTP egress as the alternative; the Case checks the reply follows through on it rather than refusing"
+    },
+    {
+      "kind": "output_omits",
+      "text": "coming soon, so I can't help you connect it another way",
+      "ungrounded": "the fixed refusal wording this Case guards against — a coming-soon status must not be read as a ban on a user-authorized alternative"
+    },
+    {
+      "kind": "loop_status",
+      "status": "completed"
+    }
+  ]
+}

--- a/packages/agent-runtime/src/context/assemble.ts
+++ b/packages/agent-runtime/src/context/assemble.ts
@@ -46,7 +46,7 @@ State a business fact, Record value, or system state only if you read it from a 
 
 ## Integrations
 
-Check <available-integrations> before telling someone a third party has no integration. If it lists as connected, use its Tools. If it lists as available or coming soon, say so and point them at the Integrations page - never invent a raw API key or credential workaround for something already catalogued there.
+Check <available-integrations> before telling someone a third party has no integration. If it lists as connected, use its Tools. If it lists as available, say so, point them at the Integrations page, and do not invent a raw API key or credential workaround in place of that working connect flow. If it lists as coming soon, say plainly that the managed connector cannot be set up yet - never imply it is click-to-connect - but treat the service exactly as you would one absent from the catalog: a user-supplied credential in secrets, a custom MCP server, or a generic HTTP egress integration is the ordinary path, not a workaround.
 
 ## Approvals
 


### PR DESCRIPTION
## Summary
- The `## Integrations` platform-instruction sentence in `packages/agent-runtime/src/context/assemble.ts` banned "a raw API key or credential workaround" for any catalogued entry, including `coming_soon` ones — even though a coming-soon service has no working managed connect flow to route around. This was prompt text, not a code guard, and it was ranked in `<platform-instructions>`, which is stated to outrank user content, so no user override could clear it (issue #770).
- Narrows the ban to the `available` status, where a working connector genuinely exists to route around. A `coming_soon` entry is now treated like any service absent from the catalog: the agent still must state truthfully that the managed connector isn't set up yet and must never imply it's click-to-connect, but a user-authorized credential in secrets, a custom MCP server, or a generic HTTP-egress integration is the ordinary path rather than a forbidden workaround.
- No override language was added to `PLATFORM_INSTRUCTIONS_TEXT` (rejected as option B) — the rule is simply scoped correctly so there is nothing to override. The manifest-validation rule in `packages/soul/src/integration-trust.ts` (no `ts-code` egress, no stdio MCP for third parties) is untouched and out of scope.

## Eval Corpus note
- Adds `apps/eval/corpus/integrations-coming-soon-allows-user-credential.json`, a `prompt_contains`/`prompt_omits` Case verified to fail against the old prompt text and pass against the new text.
- **Editing `apps/eval/corpus/` moves `corpusHash` and retires every promoted Baseline.** A maintainer needs to re-promote against the new Corpus before the release gate compares anything again.

## Test plan
- [x] `pnpm --filter @tulipfarm/eval eval --case integrations-coming-soon-allows-user-credential` fails on the pre-fix prompt text, passes on the post-fix text
- [x] `pnpm eval` — full scripted Corpus, 53/53 passed
- [x] `pnpm --filter @tulipfarm/agent-runtime exec vitest run src/context/assemble.test.ts src/context/soul-reminder.test.ts` — 48/48 passed
- [x] `pnpm exec biome check --write packages/agent-runtime/src/context apps/eval/corpus` — clean

Closes #770