### PR TITLE
fix(platform): gate Skill access by ownership, not silently degrade on it

### DIFF
--- a/apps/api/src/platform/tools.test.ts
+++ b/apps/api/src/platform/tools.test.ts
@@ -262,6 +262,81 @@ describe("skillTool loading a Skill", () => {
   });
 });
 
+describe("skillTool Team ownership gate", () => {
+  function ctxWithTeamAssets(
+    isGoverned: ReturnType<typeof vi.fn>,
+    requireAccess: ReturnType<typeof vi.fn> = vi.fn()
+  ): PlatformToolContext {
+    const ctx = makeCtx({ "data-analyst": makeSkill("data-analyst") });
+    ctx.requestContext = {
+      userId: "u1",
+      subject: { kind: "user", id: "u1" },
+      runId: "run-1",
+      stateKey: "invoke",
+      toolCallId: "call-1",
+    };
+    ctx.teamAssets = {
+      isGoverned,
+      require: requireAccess,
+    } as unknown as NonNullable<PlatformToolContext["teamAssets"]>;
+    return ctx;
+  }
+
+  it("loads a bundled/platform Skill with no ownership metadata and no ownership row for an ordinary member", async () => {
+    // Neither frontmatter ownership nor a row: not a Team-authored asset, falls through to the
+    // Tool's own role-grant check instead of the ownership gate.
+    const isGoverned = vi.fn(async () => false);
+    const requireAccess = vi.fn();
+    const ctx = ctxWithTeamAssets(isGoverned, requireAccess);
+
+    const res = await skillTool.handler({ name: "data-analyst" }, ctx);
+
+    expect(res).toMatchObject({ success: true, data: { name: "data-analyst" } });
+    expect(isGoverned).toHaveBeenCalledWith("skill", "data-analyst", undefined);
+    expect(requireAccess).not.toHaveBeenCalled();
+  });
+
+  it("still gates a Skill with an ownership row but no frontmatter metadata (anti-laundering)", async () => {
+    // A stripped-frontmatter Skill that already has an ownership row must not be laundered into
+    // ungated access: `isGoverned` consults the row, so this must return true and the gate must
+    // still run and deny an unauthorized principal.
+    const isGoverned = vi.fn(async () => true);
+    const requireAccess = vi.fn(async () => {
+      throw new Error("denied");
+    });
+    const ctx = ctxWithTeamAssets(isGoverned, requireAccess);
+
+    const res = await skillTool.handler({ name: "data-analyst" }, ctx);
+
+    expect(isGoverned).toHaveBeenCalledWith("skill", "data-analyst", undefined);
+    expect(requireAccess).toHaveBeenCalledWith(
+      "skill",
+      "data-analyst",
+      { id: "u1", kind: "user" },
+      "use",
+      undefined
+    );
+    expect(res).toMatchObject({ success: false, error: { code: "write_denied" } });
+  });
+
+  it("requires a Team-owned Skill's access grant when governed and it is granted", async () => {
+    const isGoverned = vi.fn(async () => true);
+    const requireAccess = vi.fn(async () => ({ levels: ["view", "use"] }));
+    const ctx = ctxWithTeamAssets(isGoverned, requireAccess);
+
+    const res = await skillTool.handler({ name: "data-analyst" }, ctx);
+
+    expect(res).toMatchObject({ success: true });
+    expect(requireAccess).toHaveBeenCalledWith(
+      "skill",
+      "data-analyst",
+      { id: "u1", kind: "user" },
+      "use",
+      undefined
+    );
+  });
+});
+
 // ── complete_task ─────────────────────────────────────────────────────────────
 
 describe("skillTool inspecting a Skill", () => {

--- a/apps/api/src/platform/tools.ts
+++ b/apps/api/src/platform/tools.ts
@@ -391,20 +391,27 @@ export const skillTool = defineApiTool<PlatformToolContext>({
     if (!skill) return err("not_found", `Skill "${name}" not found.`);
     const principal = assetPrincipal(ctx);
     if (ctx.teamAssets) {
-      if (!principal) return err("write_denied", "Skill access is required");
-      try {
-        await ctx.teamAssets.require(
-          "skill",
-          name,
-          principal,
-          mode === "inspect" ? "view" : "use",
-          typeof skill.frontmatter.ownership === "object" && skill.frontmatter.ownership !== null
-            ? (skill.frontmatter
-                .ownership as import("@tulipfarm/schema").TeamBusinessAssetOwnership)
-            : undefined
-        );
-      } catch {
-        return err("write_denied", "Skill access is required");
+      const ownership =
+        typeof skill.frontmatter.ownership === "object" && skill.frontmatter.ownership !== null
+          ? (skill.frontmatter.ownership as import("@tulipfarm/schema").TeamBusinessAssetOwnership)
+          : undefined;
+      // A platform/bundled Skill nobody ever authored as a business asset carries no ownership
+      // metadata and has no ownership row; it falls through to the Tool's own role-grant check
+      // instead. `isGoverned` still consults the row, not just the metadata, so a Team-authored
+      // Skill cannot be laundered into ungated access by stripping its frontmatter.
+      if (await ctx.teamAssets.isGoverned("skill", name, ownership)) {
+        if (!principal) return err("write_denied", "Skill access is required");
+        try {
+          await ctx.teamAssets.require(
+            "skill",
+            name,
+            principal,
+            mode === "inspect" ? "view" : "use",
+            ownership
+          );
+        } catch {
+          return err("write_denied", "Skill access is required");
+        }
       }
     }
 

--- a/apps/api/src/soul/skills/tools.test.ts
+++ b/apps/api/src/soul/skills/tools.test.ts
@@ -1063,6 +1063,64 @@ describe("skill_update", () => {
   });
 });
 
+describe("skill_update Team ownership gate", () => {
+  const existingSkill: SoulSkill = {
+    name: "code-review",
+    frontmatter: frontmatter("code-review", { tags: ["review"] }),
+    body: "Old body.",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function ctxWithTeamAssets(
+    isGoverned: ReturnType<typeof vi.fn>,
+    requireAccess: ReturnType<typeof vi.fn> = vi.fn()
+  ) {
+    const ctx = makeCtx([existingSkill], makeLlmService());
+    ctx.requestContext = { userId: "u1", subject: { kind: "user", id: "u1" } };
+    (ctx as SkillToolContext).teamAssets = {
+      isGoverned,
+      require: requireAccess,
+    } as unknown as NonNullable<SkillToolContext["teamAssets"]>;
+    return ctx;
+  }
+
+  it("edits a Skill with no ownership metadata and no ownership row without a grant check", async () => {
+    const isGoverned = vi.fn(async () => false);
+    const requireAccess = vi.fn();
+    const ctx = ctxWithTeamAssets(isGoverned, requireAccess);
+
+    const res = await runConfirmed(updateTool, { name: "code-review", body: "New body." }, ctx);
+
+    expect(res).toMatchObject({ success: true, data: { status: "updated" } });
+    expect(isGoverned).toHaveBeenCalledWith("skill", "code-review", undefined);
+    expect(requireAccess).not.toHaveBeenCalled();
+  });
+
+  it("still gates an edit when an ownership row exists but frontmatter carries no metadata (anti-laundering)", async () => {
+    const isGoverned = vi.fn(async () => true);
+    const requireAccess = vi.fn(async () => {
+      throw new Error("denied");
+    });
+    const ctx = ctxWithTeamAssets(isGoverned, requireAccess);
+
+    const res = await updateTool.handler({ name: "code-review", body: "New body." }, ctx);
+
+    expect(isGoverned).toHaveBeenCalledWith("skill", "code-review", undefined);
+    expect(requireAccess).toHaveBeenCalledWith(
+      "skill",
+      "code-review",
+      { id: "u1", kind: "user" },
+      "edit",
+      undefined
+    );
+    expect(res).toMatchObject({ success: false, error: { code: "write_denied" } });
+    expect(ctx.soulWriter.apply).not.toHaveBeenCalled();
+  });
+});
+
 // ── skill_list ────────────────────────────────────────────────────────────────
 
 describe("skill_list", () => {
@@ -1087,6 +1145,53 @@ describe("skill_list", () => {
       provenance: "curated",
     });
     expect(skills).toContainEqual({ name: "planner", frontmatter: {}, provenance: "curated" });
+  });
+});
+
+describe("skill_list Team ownership gate", () => {
+  const skill: SoulSkill = {
+    name: "code-review",
+    frontmatter: frontmatter("code-review", { tags: ["review"] }),
+    body: "Review.",
+  };
+
+  it("shows a Skill with no ownership metadata and no ownership row to any principal", async () => {
+    const isGoverned = vi.fn(async () => false);
+    const access = vi.fn();
+    const ctx = makeCtx([skill]);
+    ctx.requestContext = { userId: "u1", subject: { kind: "user", id: "u1" } };
+    (ctx as SkillToolContext).teamAssets = {
+      isGoverned,
+      access,
+    } as unknown as NonNullable<SkillToolContext["teamAssets"]>;
+
+    const res = await listTool.handler({}, ctx);
+
+    expect(res).toMatchObject({ success: true, data: { skills: [{ name: "code-review" }] } });
+    expect(isGoverned).toHaveBeenCalledWith("skill", "code-review", undefined);
+    expect(access).not.toHaveBeenCalled();
+  });
+
+  it("still hides a Skill with an ownership row but no frontmatter metadata when access is denied (anti-laundering)", async () => {
+    const isGoverned = vi.fn(async () => true);
+    const access = vi.fn(async () => ({ levels: [] }));
+    const ctx = makeCtx([skill]);
+    ctx.requestContext = { userId: "u1", subject: { kind: "user", id: "u1" } };
+    (ctx as SkillToolContext).teamAssets = {
+      isGoverned,
+      access,
+    } as unknown as NonNullable<SkillToolContext["teamAssets"]>;
+
+    const res = await listTool.handler({}, ctx);
+
+    expect(isGoverned).toHaveBeenCalledWith("skill", "code-review", undefined);
+    expect(access).toHaveBeenCalledWith(
+      "skill",
+      "code-review",
+      { id: "u1", kind: "user" },
+      undefined
+    );
+    expect(res).toMatchObject({ success: true, data: { skills: [] } });
   });
 });
 

--- a/apps/api/src/soul/skills/tools.ts
+++ b/apps/api/src/soul/skills/tools.ts
@@ -387,16 +387,11 @@ const skillUpdate = defineApiTool<SkillToolContext>({
     const existing = soulSkill ?? bundledSkill;
     if (!existing) return err("not_found", `skill not found: ${name}`);
     const principal = assetPrincipal(ctx);
-    if (ctx.teamAssets && !principal) return err("write_denied", "Skill edit access is required");
-    if (ctx.teamAssets && principal) {
+    const ownership = ownershipOf(existing.frontmatter);
+    if (ctx.teamAssets && (await ctx.teamAssets.isGoverned("skill", name, ownership))) {
+      if (!principal) return err("write_denied", "Skill edit access is required");
       try {
-        await ctx.teamAssets.require(
-          "skill",
-          name,
-          principal,
-          "edit",
-          ownershipOf(existing.frontmatter)
-        );
+        await ctx.teamAssets.require("skill", name, principal, "edit", ownership);
       } catch {
         return err("write_denied", "Skill edit access is required");
       }
@@ -676,26 +671,29 @@ const skillList = defineApiTool<SkillToolContext>({
     const lock = await readSkillsLock(ctx.gitSync.path);
     const listed = Array.from(mergedSkills(ctx.soulLoader, ctx.bundledSkills, hidden).values());
     const principal = assetPrincipal(ctx);
+    const teamAssets = ctx.teamAssets;
     const visible =
-      ctx.teamAssets === undefined
+      teamAssets === undefined
         ? listed
-        : principal === undefined
-          ? []
-          : (
-              await Promise.all(
-                listed.map(async (skill) => ({
-                  skill,
-                  access: await ctx.teamAssets?.access(
-                    "skill",
-                    skill.name,
-                    principal,
-                    ownershipOf(skill.frontmatter)
-                  ),
-                }))
-              )
+        : (
+            await Promise.all(
+              listed.map(async (skill) => {
+                const metadata = ownershipOf(skill.frontmatter);
+                // A platform/bundled Skill with no ownership metadata and no ownership row was
+                // never authored as a business asset, so it stays visible regardless of Team
+                // membership; the row check still applies, so a Team-authored Skill cannot be
+                // laundered into ungated visibility by stripping its frontmatter.
+                if (!(await teamAssets.isGoverned("skill", skill.name, metadata))) {
+                  return { skill, visible: true };
+                }
+                if (principal === undefined) return { skill, visible: false };
+                const access = await teamAssets.access("skill", skill.name, principal, metadata);
+                return { skill, visible: access.levels.includes("view") };
+              })
             )
-              .filter(({ access }) => access?.levels.includes("view"))
-              .map(({ skill }) => skill);
+          )
+            .filter(({ visible }) => visible)
+            .map(({ skill }) => skill);
     const skills = visible.map(({ name, frontmatter }) => ({
       name,
       frontmatter,

--- a/apps/api/src/team-assets/service.test.ts
+++ b/apps/api/src/team-assets/service.test.ts
@@ -136,6 +136,32 @@ describe("TeamAssetService", () => {
     });
   });
 
+  describe("isGoverned", () => {
+    it("is false for an asset with neither ownership metadata nor an ownership row", async () => {
+      const { service: assets } = service();
+
+      await expect(assets.isGoverned("skill", "bundled-skill", undefined)).resolves.toBe(false);
+    });
+
+    it("is true when authored ownership metadata is present", async () => {
+      const { service: assets } = service();
+
+      await expect(
+        assets.isGoverned("skill", "authored-skill", { owners: [{ teamId: TEAM_ID }] })
+      ).resolves.toBe(true);
+    });
+
+    // Anti-laundering: a Skill authored with ownership metadata always has an ownership row from
+    // `ensure`. Stripping the frontmatter afterward must not exempt it from the gate — `isGoverned`
+    // has to consult the row itself, not just whatever metadata this call happens to be given.
+    it("is true from the ownership row alone, once metadata is stripped", async () => {
+      const { service: assets } = service();
+      await assets.ensure("skill", "laundered-skill", { owners: [{ teamId: TEAM_ID }] });
+
+      await expect(assets.isGoverned("skill", "laundered-skill", undefined)).resolves.toBe(true);
+    });
+  });
+
   describe("a File's Knowledge Page after a Team share change", () => {
     const OTHER_TEAM = "223e4567-e89b-42d3-a456-426614174000";
     const sharer: TeamMembershipRecord = {

--- a/apps/api/src/team-assets/service.ts
+++ b/apps/api/src/team-assets/service.ts
@@ -187,6 +187,25 @@ export class TeamAssetService {
     }
   }
 
+  /**
+   * Whether this asset is subject to Team ownership gating at all.
+   *
+   * True when authored `ownership` frontmatter is present, or an ownership row already exists —
+   * the row check matters on its own: an authored asset that already has a row must stay gated
+   * even if its frontmatter is later stripped, or dropping the metadata would launder a
+   * Team-owned asset into ungated access. Only an asset with neither — a platform/bundled artifact
+   * nobody ever authored as a business asset — is exempt, and falls through to the owning Tool's
+   * own role-grant check instead.
+   */
+  async isGoverned(
+    assetType: TeamAssetType,
+    assetId: string,
+    metadata?: TeamBusinessAssetOwnership
+  ): Promise<boolean> {
+    if (metadata) return true;
+    return (await this.deps.ownershipRepo.get(this.businessId, assetType, assetId)) !== undefined;
+  }
+
   async access(
     assetType: TeamAssetType,
     assetId: string,

--- a/apps/worker/src/tools/routing-dispatch.ts
+++ b/apps/worker/src/tools/routing-dispatch.ts
@@ -124,7 +124,9 @@ function withCallId(callId: string, result: HostedToolResult): ToolDispatchResul
       };
     case "denied":
       return { status: "denied", callId, reason: result.reason, connectUrl: result.connectUrl };
+    case "invalid_arguments":
+      return { status: "invalid_arguments", callId, reason: result.reason };
     default:
-      return { status: result.status, callId, reason: result.reason };
+      return { status: "failed", callId, reason: result.reason, code: result.code };
   }
 }

--- a/packages/agent-runtime/src/loop/contract.ts
+++ b/packages/agent-runtime/src/loop/contract.ts
@@ -117,7 +117,19 @@ export type ToolDispatchResult =
       readonly connectUrl?: string;
     }
   | { readonly status: "invalid_arguments"; readonly callId: string; readonly reason: string }
-  | { readonly status: "failed"; readonly callId: string; readonly reason: string }
+  | {
+      readonly status: "failed";
+      readonly callId: string;
+      readonly reason: string;
+      /**
+       * The Tool host's own error code (e.g. `write_denied`, `not_found`, `credential_required`),
+       * structural rather than imported — this package may not depend on `@tulipfarm/tool-host` —
+       * so a caller that needs to tell "not entitled" apart from "not installed" from "auth
+       * expired" does not have to parse `reason` to do it. Absent for a failure the dispatcher
+       * itself raised with no underlying Tool error to carry.
+       */
+      readonly code?: string;
+    }
   | {
       readonly status: "awaiting_approval";
       readonly callId: string;
@@ -154,7 +166,15 @@ export type AgentLoopEventType =
   | "awaiting_child"
   | "completed"
   | "failed"
-  | "cancelled";
+  | "cancelled"
+  /**
+   * A `skill` call that would have adopted a Skill (any mode but `inspect`) came back denied or
+   * failed. Distinct from `tool_call_rejected` because the loop still continues the Turn on this
+   * outcome — silently, from the model's point of view, unless something makes the failure loud.
+   * This event is that something: a reader watching Run events sees the prerequisite guidance
+   * never loaded, instead of inferring it from an ordinary failed-call entry among many.
+   */
+  | "skill_load_failed";
 
 /** Loop events carry model text only; Tool args/output stay with `ToolDispatchPort`. */
 export interface AgentLoopEvent {

--- a/packages/agent-runtime/src/loop/loop.test.ts
+++ b/packages/agent-runtime/src/loop/loop.test.ts
@@ -1623,6 +1623,101 @@ describe("AgentLoop skill-scoped tool narrowing", () => {
   });
 });
 
+describe("AgentLoop a failed skill load is not silently continued past", () => {
+  const skillCatalog = [{ name: "skill", inputSchema: { type: "object" } }];
+
+  it("emits a distinct skill_load_failed event, not just an ordinary tool answer", async () => {
+    const tools = dispatcher({
+      status: "failed",
+      callId: "call-1",
+      reason: "Skill access is required",
+      code: "write_denied",
+    });
+    const model = scriptedModel(
+      toolCallResult([{ callId: "call-1", name: "skill", arguments: { name: "routine-forge" } }]),
+      textResult("done")
+    );
+    const events = collector();
+    const outcome = await loop({ model, tools, events: events.sink }).run(
+      input({ tools: skillCatalog })
+    );
+
+    expect(outcome).toMatchObject({ status: "completed" });
+    const skillLoadFailed = events.events.filter((e) => e.type === "skill_load_failed");
+    expect(skillLoadFailed).toHaveLength(1);
+    expect(skillLoadFailed[0]).toMatchObject({
+      toolName: "skill",
+      callId: "call-1",
+      outcome: "failed",
+    });
+  });
+
+  it("answers the model with a result it cannot mistake for the Skill having loaded", async () => {
+    const tools = dispatcher({
+      status: "failed",
+      callId: "call-1",
+      reason: "Skill access is required",
+      code: "write_denied",
+    });
+    const model = promptRecordingModel(
+      toolCallResult([{ callId: "call-1", name: "skill", arguments: { name: "routine-forge" } }]),
+      textResult("done")
+    );
+    const outcome = await loop({ model, tools }).run(input({ tools: skillCatalog }));
+
+    expect(outcome).toMatchObject({ status: "completed" });
+    // The second request's prompt carries the answer to call-1; it must say the Skill did not
+    // load and must not be a bare status word a model could shrug past.
+    const secondPrompt = model.prompts[1] ?? [];
+    const toolAnswer = secondPrompt.find(
+      (m) => m.role === "tool" && contentText(m.content).includes("call-1")
+    );
+    const answerText = toolAnswer ? contentText(toolAnswer.content) : "";
+    expect(answerText).toContain("routine-forge");
+    expect(answerText.toLowerCase()).toContain("not");
+  });
+
+  it("does not emit skill_load_failed for an ordinary (non-skill) Tool failure", async () => {
+    const tools = dispatcher({
+      status: "failed",
+      callId: "call-1",
+      reason: "boom",
+      code: "internal_error",
+    });
+    const model = scriptedModel(
+      toolCallResult([{ callId: "call-1", name: "record_search", arguments: {} }]),
+      textResult("done")
+    );
+    const events = collector();
+    const outcome = await loop({ model, tools, events: events.sink }).run(input());
+
+    expect(outcome).toMatchObject({ status: "completed" });
+    expect(events.events.some((e) => e.type === "skill_load_failed")).toBe(false);
+  });
+
+  it("does not emit skill_load_failed for a skill call in inspect mode", async () => {
+    const tools = dispatcher({
+      status: "failed",
+      callId: "call-1",
+      reason: "Skill access is required",
+      code: "write_denied",
+    });
+    const model = scriptedModel(
+      toolCallResult([
+        { callId: "call-1", name: "skill", arguments: { name: "routine-forge", mode: "inspect" } },
+      ]),
+      textResult("done")
+    );
+    const events = collector();
+    const outcome = await loop({ model, tools, events: events.sink }).run(
+      input({ tools: skillCatalog })
+    );
+
+    expect(outcome).toMatchObject({ status: "completed" });
+    expect(events.events.some((e) => e.type === "skill_load_failed")).toBe(false);
+  });
+});
+
 describe("AgentLoop resume after an approval park", () => {
   /** Records the prompt it was handed, so the recovered transcript can be inspected. */
   function promptRecordingModel(...results: readonly ModelInvocationResult[]): ModelPort & {

--- a/packages/agent-runtime/src/loop/loop.ts
+++ b/packages/agent-runtime/src/loop/loop.ts
@@ -493,6 +493,28 @@ export class AgentLoop {
           return { kind: "continue" };
         }
 
+        // A `skill` call that would have adopted a Skill (any mode but `inspect` — see
+        // `extractSkillName`) came back denied or failed. The model must not be left to silently
+        // carry on as though the Skill's guidance loaded: emit a distinct Run event so this is
+        // visible outside the ordinary failed-call noise, and answer with a result the model
+        // cannot plausibly read as "the Skill is available."
+        const failedSkillName =
+          call.name === SKILL_TOOL ? extractSkillName(call.arguments) : undefined;
+        if (failedSkillName !== undefined) {
+          await emit("skill_load_failed", {
+            toolName: call.name,
+            callId: call.callId,
+            outcome: dispatched.status,
+          });
+          answer(call.callId, {
+            error: dispatched.status,
+            detail: dispatched.reason,
+            blocking: true,
+            guidance: `Skill "${failedSkillName}" did not load (${dispatched.status}: ${dispatched.reason}). Its instructions are NOT available. Do not proceed as though they were loaded — resolve the failure or tell the user the Skill could not be used.`,
+          });
+          return { kind: "continue" };
+        }
+
         // Denied and failed calls are data the model must reason about, not a retry signal.
         answer(call.callId, { error: dispatched.status, detail: dispatched.reason });
         return { kind: "continue" };

--- a/packages/tool-host/src/authority.ts
+++ b/packages/tool-host/src/authority.ts
@@ -1,5 +1,6 @@
 import type { InvocationPrincipal } from "@tulipfarm/run-kernel";
 import type { HostedAgent } from "./ports";
+import type { ToolErrorCode } from "./types";
 
 /**
  * The Run-derived authority a Tool call executes under. It names only what the Run itself
@@ -90,7 +91,19 @@ export type HostedToolResult =
     }
   | { readonly status: "denied"; readonly reason: string; readonly connectUrl?: string }
   | { readonly status: "invalid_arguments"; readonly reason: string }
-  | { readonly status: "failed"; readonly reason: string }
+  | {
+      readonly status: "failed";
+      readonly reason: string;
+      /**
+       * The Tool's own {@link ToolErrorCode}, when a Tool handler produced this failure. Absent
+       * for a failure the dispatcher itself raised (a ledger conflict, a lost replay, an
+       * unacknowledged deadline) with no underlying Tool error to carry. Kept alongside `reason`
+       * so a caller that only wants prose loses nothing by ignoring it, while a caller that needs
+       * to tell "not entitled" apart from "not installed" from "auth expired" — which are three
+       * different remedies — does not have to parse `reason` to do it.
+       */
+      readonly code?: ToolErrorCode;
+    }
   | { readonly status: "awaiting_approval"; readonly approvalId: string }
   | {
       /** The Tool spawned a child Run and registered the wait that resumes this Turn. */

--- a/packages/tool-host/src/dispatcher.test.ts
+++ b/packages/tool-host/src/dispatcher.test.ts
@@ -628,7 +628,7 @@ describe("RegistryToolDispatcher", () => {
 
     await expect(
       dispatcher.dispatch(AUTHORITY, { callId: "c2", name: "declined", arguments: {} })
-    ).resolves.toEqual({ status: "failed", reason: "no such record" });
+    ).resolves.toEqual({ status: "failed", reason: "no such record", code: "not_found" });
   });
 
   it("classifies a handler's schema rejection as invalid_arguments, not a generic failure", async () => {

--- a/packages/tool-host/src/execution.test.ts
+++ b/packages/tool-host/src/execution.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { ChatEffectLedger } from "./effect-ledger";
 import { runToolAttempts } from "./execution";
 import type { ParkableToolDef, RequestContext, ToolDef } from "./types";
-import { ok, parked } from "./types";
+import { err, ok, parked } from "./types";
 
 const CONTEXT = {} as RequestContext;
 const CALL = { callId: "call-1", name: "slow", arguments: {} };
@@ -71,6 +71,63 @@ describe("execute deadline", () => {
 
     expect(settled).toMatchObject({ status: "succeeded" });
     expect(Date.now() - started).toBeLessThan(2_000);
+  });
+});
+
+describe("a failed call preserves its own ToolErrorCode", () => {
+  function failingTool(code: "write_denied" | "not_found" | "credential_required"): ToolDef {
+    return {
+      name: "denied-tool",
+      tier: "platform",
+      mutating: false,
+      description: "fails",
+      inputSchema: { type: "object" },
+      execute: async () => err(code, `tool refused: ${code}`),
+    };
+  }
+
+  it("keeps write_denied distinguishable from a bare 'failed'", async () => {
+    const settled = await runToolAttempts({
+      businessId: "business-1",
+      tool: failingTool("write_denied"),
+      call: CALL,
+      context: CONTEXT,
+    });
+    expect(settled).toMatchObject({ status: "failed", code: "write_denied" });
+  });
+
+  it("keeps not_found distinguishable from a bare 'failed'", async () => {
+    const settled = await runToolAttempts({
+      businessId: "business-1",
+      tool: failingTool("not_found"),
+      call: CALL,
+      context: CONTEXT,
+    });
+    expect(settled).toMatchObject({ status: "failed", code: "not_found" });
+  });
+
+  // credential_required maps to `status: "denied"`, a different branch entirely, but its remedy
+  // (reconnect) still has to survive — `connectUrl` is what a caller acts on there.
+  it("carries credential_required through as a denied result with its connect URL", async () => {
+    const tool: ToolDef = {
+      name: "denied-tool",
+      tier: "platform",
+      mutating: false,
+      description: "fails",
+      inputSchema: { type: "object" },
+      execute: async () =>
+        err("credential_required", "connect first", "https://example.test/connect"),
+    };
+    const settled = await runToolAttempts({
+      businessId: "business-1",
+      tool,
+      call: CALL,
+      context: CONTEXT,
+    });
+    expect(settled).toMatchObject({
+      status: "denied",
+      connectUrl: "https://example.test/connect",
+    });
   });
 });
 

--- a/packages/tool-host/src/execution.ts
+++ b/packages/tool-host/src/execution.ts
@@ -130,7 +130,11 @@ export async function runToolAttempts(input: ToolAttemptInput): Promise<HostedTo
   }
   if (isIndeterminateFault(failure.error.code)) {
     await settle("ambiguous", "tool_timeout");
-    return { status: "failed", reason: `tool "${call.name}" ${failure.error.message}` };
+    return {
+      status: "failed",
+      reason: `tool "${call.name}" ${failure.error.message}`,
+      code: failure.error.code,
+    };
   }
   // Structured errors have a known phase; there is nothing to reconcile.
   await settle("failed", failure.error.code);
@@ -147,6 +151,10 @@ export async function runToolAttempts(input: ToolAttemptInput): Promise<HostedTo
   }
   // Exhausted infra faults are machinery failures, not repairable argument failures.
   return isInfrastructureFault(failure.error.code)
-    ? { status: "failed", reason: `tool "${call.name}" is temporarily unavailable; try again` }
-    : { status: "failed", reason: failure.error.message };
+    ? {
+        status: "failed",
+        reason: `tool "${call.name}" is temporarily unavailable; try again`,
+        code: failure.error.code,
+      }
+    : { status: "failed", reason: failure.error.message, code: failure.error.code };
 }

--- a/packages/turn-executor/src/tool-events.test.ts
+++ b/packages/turn-executor/src/tool-events.test.ts
@@ -290,6 +290,43 @@ describe("announceToolCalls", () => {
     });
   });
 
+  it("reports a failed call's errorCode as its own ToolErrorCode, not the collapsed status", async () => {
+    const events = new FakeAppendPort();
+    const broker = port((request) => ({
+      status: "failed",
+      callId: request.callId,
+      reason: "Skill access is required",
+      code: "write_denied",
+    }));
+
+    await announceToolCalls(broker.port, writer(events), { now: clock() }).dispatch(REQUEST);
+
+    expect(events.appended.at(-1)).toMatchObject({
+      eventType: "tool.result",
+      payload: {
+        status: "error",
+        summary: "Skill access is required",
+        errorCode: "write_denied",
+      },
+    });
+  });
+
+  it("falls back to the bare status when a failed call carries no code", async () => {
+    const events = new FakeAppendPort();
+    const broker = port((request) => ({
+      status: "failed",
+      callId: request.callId,
+      reason: "dispatcher-raised, no underlying Tool error",
+    }));
+
+    await announceToolCalls(broker.port, writer(events), { now: clock() }).dispatch(REQUEST);
+
+    expect(events.appended.at(-1)).toMatchObject({
+      eventType: "tool.result",
+      payload: { status: "error", errorCode: "failed" },
+    });
+  });
+
   it("stays silent about the result of a call that is waiting on an approval", async () => {
     const events = new FakeAppendPort();
     const broker = port((request) => ({

--- a/packages/turn-executor/src/tool-events.ts
+++ b/packages/turn-executor/src/tool-events.ts
@@ -151,7 +151,11 @@ export function announceToolCalls(
               callId: result.callId,
               status: "error" as const,
               summary: result.reason,
-              errorCode: result.status,
+              // A `failed` result's own `code` (e.g. `write_denied`, `not_found`,
+              // `credential_required`) distinguishes remedies the collapsed `status` cannot; other
+              // statuses (`denied`, `invalid_arguments`) carry no such code, so `status` is the code.
+              errorCode:
+                result.status === "failed" ? (result.code ?? result.status) : result.status,
               durationMs,
               ...(result.status === "denied" && result.connectUrl !== undefined
                 ? { connectUrl: result.connectUrl }


### PR DESCRIPTION
## Summary
- Fix 1: `skillTool` and `skill_list`/`skill_update` gate a Skill's access only when it is governed — has ownership frontmatter metadata **or** an existing ownership row — falling through to the Tool's own role-grant check otherwise. `TeamAssetService.isGoverned` consults the row itself, so stripping frontmatter off an authored Skill cannot launder it into ungated access.
- Fix 2: `ToolErrorCode` (e.g. `write_denied`, `not_found`, `credential_required`) now survives end to end from `execution.ts` through `authority.ts`, the worker's `withCallId` adapter, `ToolDispatchResult`, and `tool-events.ts`, instead of collapsing to a bare `"failed"`.
- Fix 3: a `skill` call that would have adopted a Skill (any mode but `inspect`) and comes back denied/failed now emits a distinct `skill_load_failed` Run event and answers the model with an explicit "not loaded, do not proceed as though it were" message, instead of silently continuing the Turn.

Closes #771

## Test plan
- [x] `apps/api/src/team-assets/service.test.ts` — `isGoverned` (3 new tests: ungoverned false, metadata-governed true, **row-only after metadata stripped still true (anti-laundering)**). Fail before / pass after (TypeError pre-fix: `isGoverned is not a function`).
- [x] `apps/api/src/platform/tools.test.ts` — `skillTool` Team ownership gate (3 new tests, including the anti-laundering case: row present, no frontmatter → still denied). 2/3 fail before, pass after.
- [x] `apps/api/src/soul/skills/tools.test.ts` — `skill_update`/`skill_list` Team ownership gate (4 new tests, each family includes an anti-laundering case). All fail before, pass after.
- [x] `packages/tool-host/src/execution.test.ts` — a failed call preserves its own `ToolErrorCode` (3 new tests). 2/3 fail before, pass after.
- [x] `packages/turn-executor/src/tool-events.test.ts` — failed-call `errorCode` reports the underlying code, not the collapsed status (2 new tests). 1/2 fails before, passes after.
- [x] `packages/agent-runtime/src/loop/loop.test.ts` — a failed skill load is not silently continued past (4 new tests: distinct event, model-visible answer, no event on an ordinary Tool failure, no event on `inspect` mode). 2/4 fail before, pass after.
- [x] `pnpm --filter @tulipfarm/api test src/team-assets src/platform src/soul/skills` — 359 passed
- [x] `pnpm --filter @tulipfarm/tool-host test` — 153 passed (updated one pre-existing dispatcher test to expect the now-preserved `code` field)
- [x] `pnpm --filter @tulipfarm/agent-runtime test src/loop` — 185 passed
- [x] `pnpm --filter @tulipfarm/turn-executor test` — 136 passed
- [x] `pnpm --filter @tulipfarm/worker typecheck` — clean
- [x] `pnpm typecheck` — 41/41 workspaces clean