### PR TITLE
fix(schema): don't crash boot on legacy embeddings config missing resource_name/base_url

### DIFF
--- a/packages/schema/src/llm.ts
+++ b/packages/schema/src/llm.ts
@@ -224,7 +224,15 @@ export function describeMissingEmbeddingFields(entry: EmbeddingProviderEntry): s
   return EMBEDDING_PROVIDER_REQUIREMENTS[entry.provider]?.(entry) ?? null;
 }
 
-export function validateLlmConfig(data: unknown): LlmConfig {
+/**
+ * @param opts.strict Reject an embedding entry missing its provider-required fields
+ * (`resource_name`/`base_url`). Defaults true for the write path (`PUT /api/v1/llm-config`),
+ * which must never persist an unbuildable entry. Boot must tolerate a config that predates this
+ * check — `createEmbeddingModel` (`@tulipfarm/llm`) fails loud lazily at first use instead, and
+ * `embeddingsProbe` (`apps/api/src/admin/health.ts`) surfaces the ongoing degradation — so
+ * `validateSoulConfig` calls this with `strict: false`.
+ */
+export function validateLlmConfig(data: unknown, opts: { strict?: boolean } = {}): LlmConfig {
   if (!checkConfig(data)) {
     const e = checkConfig.errors?.[0] ?? { instancePath: "", message: "invalid config" };
     throw new LlmConfigValidationError(describeConfigError(e));
@@ -234,12 +242,14 @@ export function validateLlmConfig(data: unknown): LlmConfig {
   if (config.tiers === undefined) {
     throw new LlmConfigValidationError("config must declare provider chains in tiers");
   }
-  config.embeddings?.providers.forEach((entry, index) => {
-    const problem = describeMissingEmbeddingFields(entry);
-    if (problem) {
-      throw new LlmConfigValidationError(`embeddings.providers[${index}]: ${problem}`);
-    }
-  });
+  if (opts.strict ?? true) {
+    config.embeddings?.providers.forEach((entry, index) => {
+      const problem = describeMissingEmbeddingFields(entry);
+      if (problem) {
+        throw new LlmConfigValidationError(`embeddings.providers[${index}]: ${problem}`);
+      }
+    });
+  }
   return config;
 }
 

--- a/packages/schema/src/soul-config.test.ts
+++ b/packages/schema/src/soul-config.test.ts
@@ -52,4 +52,17 @@ describe("validateSoulConfig", () => {
       "config must declare provider chains in tiers"
     );
   });
+
+  it("boots on a legacy embedding entry missing resource_name/base_url instead of crashing", () => {
+    // A config saved before validateLlmConfig's write-time embeddings guard existed. Boot must
+    // degrade (createEmbeddingModel fails loud lazily, embeddingsProbe reports it) rather than
+    // reject the whole soul.yaml — see validateLlmConfig's `strict` option.
+    const config = validateSoulConfig({
+      llm: {
+        ...validLlm,
+        embeddings: { providers: [{ provider: "azure", model: "text-embedding-3-large" }] },
+      },
+    });
+    expect(config.llm?.embeddings?.providers[0]).toMatchObject({ provider: "azure" });
+  });
 });

--- a/packages/schema/src/soul-config.ts
+++ b/packages/schema/src/soul-config.ts
@@ -55,6 +55,8 @@ export function validateSoulConfig(data: unknown): SoulConfig {
     );
   }
   const config = data as SoulConfig;
-  if (config.llm !== undefined) validateLlmConfig(config.llm);
+  // strict:false — boot must survive a config saved before the write-time embeddings guard
+  // existed; `createEmbeddingModel` degrades loud-but-lazily instead. See validateLlmConfig.
+  if (config.llm !== undefined) validateLlmConfig(config.llm, { strict: false });
   return config;
 }


### PR DESCRIPTION
## Summary
- #772 added a required-field check for embedding provider entries (`resource_name`/`base_url` for azure) inside `validateLlmConfig`, and wired it into `validateSoulConfig`, which runs on **every boot load** of `soul.yaml` — not just the write path (`PUT /api/v1/llm-config`).
- Any pre-existing config saved before that guard existed (staging's `soul.yaml`: azure embeddings with neither field) now throws an unhandled error at boot, crash-looping the app container (`docker compose` reports `container ... unhealthy`).
- This contradicts the intent already documented in `packages/llm/src/embedding-provider.ts`'s `createEmbeddingModel`: a legacy bad entry should fail loud *lazily*, at first use, so boot survives and `embeddingsProbe` (`apps/api/src/admin/health.ts`) reports ongoing degradation instead.
- `validateLlmConfig` now takes a `strict` option (default `true`, unchanged behavior for the write path). `validateSoulConfig` calls it with `strict: false` so boot tolerates a legacy embeddings entry and degrades instead of crashing.

## Test plan
- [x] `pnpm --filter @tulipfarm/schema test` — 480 passed (added regression test: `validateSoulConfig` boots on a legacy azure embedding entry missing `resource_name`/`base_url`)
- [x] `pnpm --filter @tulipfarm/soul test` — 755 passed
- [x] `pnpm --filter @tulipfarm/llm test` — 330 passed
- [x] `pnpm --filter @tulipfarm/api test` — 3740 passed