### PR TITLE
chore(release): v0.18.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.18.20](https://github.com/TulipFarm/tulipfarm/compare/v0.18.19...v0.18.20) (2026-09-09)
+
+### Bug Fixes
+
+* **schema:** don't crash boot on legacy embeddings config missing resource_name/base_url ([#778](https://github.com/TulipFarm/tulipfarm/issues/778)) ([b8b7d86](https://github.com/TulipFarm/tulipfarm/commit/b8b7d86c0ecc89d7678786b0587f632ce7d9629f)), references [#772](https://github.com/TulipFarm/tulipfarm/issues/772)
+
 ## [0.18.19](https://github.com/TulipFarm/tulipfarm/compare/v0.18.18...v0.18.19) (2026-09-09)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tulipfarm",
   "private": true,
-  "version": "0.18.19",
+  "version": "0.18.20",
   "repository": {
     "type": "git",
     "url": "https://github.com/TulipFarm/tulipfarm.git"


### PR DESCRIPTION
## Summary

- prepare TulipFarm v0.18.20
- update the package version and generated changelog
- publish the verified GHCR image and GitHub Release automatically after merge

## Test plan

- [ ] Required PR checks pass
- [ ] Version and changelog are approved
