### PR TITLE
fix(llm): hydrate embedding entries from stored connection

### DIFF
--- a/apps/api/src/soul/llm-config/routes.test.ts
+++ b/apps/api/src/soul/llm-config/routes.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { SecretUnavailableError } from "@tulipfarm/secrets";
 import type { GitSyncService, SoulLoader } from "@tulipfarm/soul";
 import { makeSoulWriterDouble, type SoulWriterDouble } from "@tulipfarm/soul";
 import type { PaginatedResult } from "@tulipfarm/storage";
@@ -124,7 +125,7 @@ describe("llm-config routes", () => {
     // default — tests that exercise the openai-compatible live-fetch path override this.
     secretsGet = vi.fn(async (key: string) => {
       if (key === "azure-openai-resource-name") return "my-res";
-      throw new Error("unset");
+      throw new SecretUnavailableError(`secret not found: ${key}`);
     });
     const secretsService = {
       list: vi.fn().mockResolvedValue([]),
@@ -413,6 +414,11 @@ describe("llm-config routes", () => {
       // Regression for #755: an Azure embedding provider saved with neither field builds no
       // model at boot, and the runtime silently drops to lexical matching. The write path must
       // reject it instead of accepting a config that can only fail later.
+      // No stored connection either, unlike the beforeEach default — this proves the reject still
+      // fires when there is genuinely nothing to hydrate from.
+      secretsGet.mockImplementation(async (key: string) => {
+        throw new SecretUnavailableError(`secret not found: ${key}`);
+      });
       const res = await app.inject({
         method: "PUT",
         url: "/api/v1/llm-config",
@@ -435,6 +441,57 @@ describe("llm-config routes", () => {
       );
       expect(soulWriterDouble.applied).toEqual([]);
       expect(init).not.toHaveBeenCalled();
+    });
+
+    it("accepts an azure embedding provider missing resource_name/base_url when a connection is already stored", async () => {
+      // The beforeEach default stubs "azure-openai-resource-name" as already saved (e.g. an
+      // operator who added the Azure Foundry connection). The write path should hydrate the
+      // entry from it rather than force retyping the same value per embedding entry.
+      const res = await app.inject({
+        method: "PUT",
+        url: "/api/v1/llm-config",
+        cookies: cookies(adminSid),
+        headers,
+        payload: {
+          tiers: {
+            quick: {
+              providers: [
+                {
+                  provider: "anthropic",
+                  model: "claude-haiku-4-5",
+                  spec: { max_input_tokens: 200000 },
+                },
+              ],
+            },
+            standard: {
+              providers: [
+                {
+                  provider: "anthropic",
+                  model: "claude-sonnet-4-6",
+                  spec: { max_input_tokens: 200000 },
+                },
+              ],
+            },
+            complex: {
+              providers: [
+                {
+                  provider: "anthropic",
+                  model: "claude-opus-4-8",
+                  spec: { max_input_tokens: 200000 },
+                },
+              ],
+            },
+          },
+          embeddings: {
+            providers: [{ provider: "azure", model: "text-embedding-3-large" }],
+          },
+        },
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json().embeddings?.providers[0]).toMatchObject({
+        provider: "azure",
+        resource_name: "my-res",
+      });
     });
 
     it("rejects a structurally invalid config with 422, leaving the running config intact", async () => {

--- a/apps/api/src/soul/llm-config/routes.ts
+++ b/apps/api/src/soul/llm-config/routes.ts
@@ -12,16 +12,23 @@ import {
   litellmModelsForProvider,
   resolveModelSpec,
   resolveModelSpecCandidate,
+  resolveStored,
 } from "@tulipfarm/llm";
 import {
   deriveModelProfiles,
+  type EmbeddingsConfig,
   type LlmConfig,
   LlmConfigValidationError,
   ModelSpecSchema,
   type TierConfig,
   validateLlmConfig,
 } from "@tulipfarm/schema";
-import { LLM_PROVIDERS, type SecretsService } from "@tulipfarm/secrets";
+import {
+  LLM_PROVIDERS,
+  llmProviderById,
+  providerField,
+  type SecretsService,
+} from "@tulipfarm/secrets";
 import type { SoulLoader, SoulWriter } from "@tulipfarm/soul";
 import { isSoulWriteError, mergeLlmConfigIntoSoulYaml, soulWriteHttpError } from "@tulipfarm/soul";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
@@ -240,6 +247,34 @@ async function enrichSpecs(config: LlmConfig, force: boolean): Promise<LlmConfig
       complex: enrichTier(tiers.complex),
     },
   };
+}
+
+/**
+ * Fills a saved embedding entry's `resource_name`/`base_url` from the operator's stored provider
+ * connection when the entry sets neither — the same registry-keyed lookup `createModel` already
+ * gives a chat entry for free (`@tulipfarm/llm`'s `provider.ts`). Without this, an operator who
+ * already added a connection (e.g. Azure Foundry) still has to retype it per embedding entry to
+ * pass `validateLlmConfig`'s write-time check.
+ */
+async function hydrateEmbeddingConnections(
+  embeddings: EmbeddingsConfig | undefined,
+  secrets: SecretsService
+): Promise<EmbeddingsConfig | undefined> {
+  if (!embeddings) return embeddings;
+  const providers = await Promise.all(
+    embeddings.providers.map(async (entry) => {
+      if (entry.resource_name || entry.base_url) return entry;
+      const info = llmProviderById(entry.provider);
+      if (!info) return entry;
+      const [resourceName, baseUrl] = await Promise.all([
+        resolveStored(providerField(info, "resource_name")?.key, secrets),
+        resolveStored(providerField(info, "base_url")?.key, secrets),
+      ]);
+      if (!resourceName && !baseUrl) return entry;
+      return { ...entry, resource_name: resourceName, base_url: baseUrl };
+    })
+  );
+  return { ...embeddings, providers };
 }
 
 function validatePresetTargets(config: LlmConfig): string | null {
@@ -604,9 +639,14 @@ export function registerLlmConfigRoutes(
       },
     },
     async (req, reply) => {
+      const body = req.body as { embeddings?: EmbeddingsConfig };
+      const hydratedBody = {
+        ...body,
+        embeddings: await hydrateEmbeddingConnections(body.embeddings, secrets),
+      };
       let config: LlmConfig;
       try {
-        config = validateLlmConfig(req.body);
+        config = validateLlmConfig(hydratedBody);
       } catch (err) {
         if (err instanceof LlmConfigValidationError) {
           return reply.code(422).send({ error: err.message });

--- a/packages/llm/src/embedding-provider.test.ts
+++ b/packages/llm/src/embedding-provider.test.ts
@@ -1,4 +1,5 @@
 import { LlmConfigValidationError } from "@tulipfarm/schema";
+import { SecretUnavailableError } from "@tulipfarm/secrets";
 import { describe, expect, it, vi } from "vitest";
 import { createEmbeddingModel } from "./embedding-provider";
 
@@ -25,10 +26,13 @@ vi.mock("@ai-sdk/openai-compatible", () => ({
   })),
 }));
 
+// Mirror the real SecretsService: an unavailable key throws SecretUnavailableError, not a plain
+// Error — resolveStored (provider.ts) matches on that type to treat a missing config value as
+// unset rather than a hard failure.
 const makeSecrets = (values: Record<string, string> = {}) => ({
   get: vi.fn((key: string) => {
     if (key in values) return Promise.resolve(values[key]);
-    return Promise.reject(new Error(`secret not found: ${key}`));
+    return Promise.reject(new SecretUnavailableError(`secret not found: ${key}`));
   }),
 });
 
@@ -87,14 +91,31 @@ describe("createEmbeddingModel", () => {
     expect(model).toMatchObject({ provider: "azure" });
   });
 
-  it("throws when azure has neither resource_name nor base_url", async () => {
-    const secrets = makeSecrets();
+  it("throws when azure has neither resource_name nor base_url, and none is stored either", async () => {
+    const secrets = makeSecrets({ "azure-openai-api-key": "az-test" });
     await expect(
       createEmbeddingModel({ provider: "azure", model: "d" }, secrets as never)
     ).rejects.toThrow(LlmConfigValidationError);
     await expect(
       createEmbeddingModel({ provider: "azure", model: "d" }, secrets as never)
     ).rejects.toThrow("azure provider requires resource_name or base_url");
+  });
+
+  it("falls back to the stored Azure Foundry connection when the entry sets no resource_name/base_url", async () => {
+    const secrets = makeSecrets({
+      "azure-openai-api-key": "az-test",
+      "azure-openai-resource-name": "my-resource",
+    });
+    const model = await createEmbeddingModel(
+      { provider: "azure", model: "text-embedding-3-large" },
+      secrets as never
+    );
+    expect(model).toMatchObject({
+      provider: "azure",
+      modelId: "text-embedding-3-large",
+      resourceName: "my-resource",
+    });
+    expect(secrets.get).toHaveBeenCalledWith("azure-openai-resource-name");
   });
 
   it("creates an openai-compatible embedding model with base_url", async () => {

--- a/packages/llm/src/embedding-provider.ts
+++ b/packages/llm/src/embedding-provider.ts
@@ -3,24 +3,43 @@ import { createOpenAI } from "@ai-sdk/openai";
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import type { EmbeddingProviderEntry } from "@tulipfarm/schema";
 import { LlmConfigValidationError } from "@tulipfarm/schema";
-import type { SecretsService } from "@tulipfarm/secrets";
+import { llmProviderById, providerField, type SecretsService } from "@tulipfarm/secrets";
 import type { EmbeddingModel } from "ai";
-import { resolveApiKey } from "./provider";
+import { resolveApiKey, resolveStored } from "./provider";
 
 /**
  * Build a text-embedding model from one config entry. Mirrors `createModel`
  * (provider.ts) — same credential resolution, same provider-switch shape.
  *
- * These required-field checks stay a second guard even though `@tulipfarm/schema`'s
- * `validateLlmConfig` (via `describeMissingEmbeddingFields`) already rejects an incomplete entry
- * at write time: a config written before that check existed, or edited outside the write gate,
+ * Config fields fall back to the registry-keyed stored connection the same way `createModel`
+ * does: an entry that sets nothing still resolves through whatever the operator saved via
+ * Providers & credentials, rather than requiring a second, entry-local copy of the same value.
+ *
+ * These required-field checks are the only guard: `validateLlmConfig` allows an entry with
+ * neither field set (same as a chat entry), trusting the stored connection to cover it, so this
  * must still fail loud here rather than hand the AI SDK an unbuildable client.
  */
 export async function createEmbeddingModel(
   entry: EmbeddingProviderEntry,
   secrets: SecretsService
 ): Promise<EmbeddingModel> {
-  const apiKey = await resolveApiKey(entry.api_key_ref, secrets);
+  const info = llmProviderById(entry.provider);
+
+  const apiKeyField = info ? providerField(info, "api_key") : undefined;
+  const apiKey = entry.api_key_ref
+    ? await resolveApiKey(entry.api_key_ref, secrets)
+    : apiKeyField
+      ? apiKeyField.optional
+        ? await resolveStored(apiKeyField.key, secrets)
+        : await resolveApiKey(apiKeyField.key, secrets)
+      : undefined;
+
+  const resourceName =
+    entry.resource_name ??
+    (info ? await resolveStored(providerField(info, "resource_name")?.key, secrets) : undefined);
+  const baseUrl =
+    entry.base_url ??
+    (info ? await resolveStored(providerField(info, "base_url")?.key, secrets) : undefined);
 
   switch (entry.provider) {
     case "openai": {
@@ -28,33 +47,33 @@ export async function createEmbeddingModel(
       return p.textEmbeddingModel(entry.model);
     }
     case "azure": {
-      if (!entry.resource_name && !entry.base_url) {
+      if (!resourceName && !baseUrl) {
         throw new LlmConfigValidationError("azure provider requires resource_name or base_url");
       }
       const p = createAzure({
-        resourceName: entry.resource_name,
-        baseURL: entry.base_url,
+        resourceName,
+        baseURL: baseUrl,
         apiKey,
       });
       return p.textEmbeddingModel(entry.model);
     }
     case "openai-compatible": {
-      if (!entry.base_url) {
+      if (!baseUrl) {
         throw new LlmConfigValidationError("openai-compatible provider requires base_url");
       }
       const p = createOpenAICompatible({
-        baseURL: entry.base_url,
+        baseURL: baseUrl,
         name: "openai-compatible",
         apiKey,
       });
       return p.textEmbeddingModel(entry.model);
     }
     case "ollama": {
-      if (!entry.base_url) {
+      if (!baseUrl) {
         throw new LlmConfigValidationError("ollama provider requires base_url");
       }
       const p = createOpenAICompatible({
-        baseURL: entry.base_url,
+        baseURL: baseUrl,
         name: "ollama",
         // Ollama needs no key; a placeholder keeps the SDK from erroring.
         apiKey: apiKey ?? "ollama",

--- a/packages/llm/src/index.ts
+++ b/packages/llm/src/index.ts
@@ -53,6 +53,7 @@ export {
   createModel,
   type PrincipalCredentialResolver,
   type PrincipalRef,
+  resolveStored,
 } from "./provider";
 export {
   ClassifiedLanguageModel,

--- a/packages/llm/src/provider.ts
+++ b/packages/llm/src/provider.ts
@@ -49,7 +49,7 @@ export async function resolveApiKey(
 
 // Reads a registry config field's stored value. Unlike an API key, a missing config value is normal
 // (optional / not-yet-set) rather than an error, so SecretUnavailableError maps to undefined.
-async function resolveStored(
+export async function resolveStored(
   key: string | undefined,
   secrets: SecretsService
 ): Promise<string | undefined> {

--- a/packages/schema/src/llm.ts
+++ b/packages/schema/src/llm.ts
@@ -203,9 +203,10 @@ function describeConfigError(error: {
 
 /**
  * Fields a given embedding provider cannot build a model without. Mirrors the runtime switch in
- * `@tulipfarm/llm`'s `createEmbeddingModel` — unlike a chat {@link ProviderEntry}, an embedding
- * entry has no registry-keyed stored-secret fallback for `resource_name`/`base_url`, so a missing
- * field here is missing for good; only a write-time reject catches it before boot.
+ * `@tulipfarm/llm`'s `createEmbeddingModel` after its own registry-keyed stored-secret fallback
+ * (added alongside this) — a caller that already resolved `resource_name`/`base_url` from the
+ * operator's saved connection should hydrate the entry with them before validating, so this
+ * check only ever rejects an entry with truly nothing to build from, entry or connection alike.
  */
 const EMBEDDING_PROVIDER_REQUIREMENTS: Readonly<
   Record<string, (entry: EmbeddingProviderEntry) => string | null>
@@ -227,10 +228,12 @@ export function describeMissingEmbeddingFields(entry: EmbeddingProviderEntry): s
 /**
  * @param opts.strict Reject an embedding entry missing its provider-required fields
  * (`resource_name`/`base_url`). Defaults true for the write path (`PUT /api/v1/llm-config`),
- * which must never persist an unbuildable entry. Boot must tolerate a config that predates this
- * check — `createEmbeddingModel` (`@tulipfarm/llm`) fails loud lazily at first use instead, and
- * `embeddingsProbe` (`apps/api/src/admin/health.ts`) surfaces the ongoing degradation — so
- * `validateSoulConfig` calls this with `strict: false`.
+ * which must never persist an unbuildable entry — the route hydrates each entry from its stored
+ * connection first, so this only fires when neither the entry nor a connection has the field.
+ * Boot must tolerate a config that predates this check — `createEmbeddingModel`
+ * (`@tulipfarm/llm`) fails loud lazily at first use instead (falling back to its own stored
+ * connection lookup too), and `embeddingsProbe` (`apps/api/src/admin/health.ts`) surfaces the
+ * ongoing degradation — so `validateSoulConfig` calls this with `strict: false`.
  */
 export function validateLlmConfig(data: unknown, opts: { strict?: boolean } = {}): LlmConfig {
   if (!checkConfig(data)) {


### PR DESCRIPTION
## Summary
- An embedding provider entry (Azure/OpenAI-compatible/Ollama) had no fallback to an already-saved provider connection, unlike chat entries — saving with a connection already configured under Providers & credentials still failed write-time validation, forcing the operator to retype `resource_name`/`base_url`.
- `PUT /api/v1/llm-config` now hydrates each embedding entry from its stored connection before validating, preserving the #755 write-time reject for entries with genuinely nothing to build from.
- `createEmbeddingModel` gets the same stored-connection fallback at model-build time (mirroring the chat path), covering configs saved before this change.

## Test plan
- [x] `pnpm --filter @tulipfarm/api test src/soul/llm-config` — 47/47 pass, including the #755 regression test (still rejects with no stored connection) and a new test proving hydration succeeds when one is stored
- [x] `pnpm --filter @tulipfarm/llm test` (via `embedding-provider.test.ts`) — new fallback test passes
- [x] `pnpm lint && pnpm typecheck` — clean