### PR TITLE
fix(memory): carry the whole Memory Document in the reminder

### DIFF
--- a/packages/agent-runtime/src/context/soul-reminder.test.ts
+++ b/packages/agent-runtime/src/context/soul-reminder.test.ts
@@ -359,30 +359,22 @@ describe("renderSoulReminder — the personal blocks", () => {
     expect(out).not.toContain("<platform-instructions>");
   });
 
-  it("truncates memory that would crowd out the conversation", () => {
-    const out = renderSoulReminder(catalogue(), { memory: "x".repeat(9_000) });
+  it("carries the whole Memory Document, because the write path is what bounds it", () => {
+    // `MEMORY_DOCUMENT_CHAR_BUDGET`, inlined: importing it would make `@tulipfarm/memory` a
+    // dependency of this package for one number, and drag its storage graph along with it.
+    const memory = "x".repeat(20_000);
 
-    expect(out).toContain(`${"x".repeat(8_000)}…`);
-    expect(out).not.toContain("x".repeat(8_001));
+    const out = renderSoulReminder(catalogue(), { memory });
+
+    expect(out).toContain(`<user-memory>\n${memory}\n</user-memory>`);
+    expect(out).not.toContain("…");
   });
 
-  it("names get_memory when it cut the document, so the Agent knows it read a part", () => {
-    const out = renderSoulReminder(catalogue(), { memory: "x".repeat(9_000) });
-
-    expect(out).toContain("call get_memory for the rest");
-  });
-
-  it("says nothing about get_memory when the whole document fit", () => {
-    const out = renderSoulReminder(catalogue(), { memory: "- Likes cricket" });
-
-    expect(out).not.toContain("get_memory");
-  });
-
-  it("leaves standing instructions without the memory note when they are cut", () => {
+  it("still caps standing instructions, which have their own budget", () => {
     const out = renderSoulReminder(catalogue(), { customInstructions: "y".repeat(5_000) });
 
     expect(out).toContain("y…");
-    expect(out).not.toContain("get_memory");
+    expect(out).not.toContain("y".repeat(4_001));
   });
 });
 

--- a/packages/agent-runtime/src/context/soul-reminder.test.ts
+++ b/packages/agent-runtime/src/context/soul-reminder.test.ts
@@ -365,6 +365,25 @@ describe("renderSoulReminder — the personal blocks", () => {
     expect(out).toContain(`${"x".repeat(8_000)}…`);
     expect(out).not.toContain("x".repeat(8_001));
   });
+
+  it("names get_memory when it cut the document, so the Agent knows it read a part", () => {
+    const out = renderSoulReminder(catalogue(), { memory: "x".repeat(9_000) });
+
+    expect(out).toContain("call get_memory for the rest");
+  });
+
+  it("says nothing about get_memory when the whole document fit", () => {
+    const out = renderSoulReminder(catalogue(), { memory: "- Likes cricket" });
+
+    expect(out).not.toContain("get_memory");
+  });
+
+  it("leaves standing instructions without the memory note when they are cut", () => {
+    const out = renderSoulReminder(catalogue(), { customInstructions: "y".repeat(5_000) });
+
+    expect(out).toContain("y…");
+    expect(out).not.toContain("get_memory");
+  });
 });
 
 describe("filterSoulPersonal", () => {

--- a/packages/agent-runtime/src/context/soul-reminder.ts
+++ b/packages/agent-runtime/src/context/soul-reminder.ts
@@ -333,16 +333,6 @@ function line(value: string): string {
  */
 const EMPTY_SECTION = "(none)";
 
-/** Longest Memory Document the reminder carries; `get_memory` returns the whole thing. */
-const MAX_MEMORY_CHARS = 8_000;
-
-/**
- * Said out loud when the Memory Document did not fit, for the same reason as `EMPTY_SECTION`: the
- * Agent is told everywhere else that this block *is* its Memory, so a silent cut would have it act
- * on a partial document believing it read all of it. This names the Tool that returns the rest.
- */
-const MEMORY_TRUNCATED_NOTE = "(truncated here — call get_memory for the rest)";
-
 /**
  * Flattens one authored *block* into safe lines, keeping the line breaks.
  *
@@ -353,8 +343,13 @@ const MEMORY_TRUNCATED_NOTE = "(truncated here — call get_memory for the rest)
  * Angle brackets are still stripped per line, for the same reason as in `line()` — this is the
  * one part of the reminder whose text a user or a compromised Agent chooses, and a body that can
  * write `</user-memory>` can continue as if it were the platform speaking.
+ *
+ * `limit` is optional because not every block needs one. The Memory Document passes none: every
+ * write path already asserts `MEMORY_DOCUMENT_CHAR_BUDGET`, so a second ceiling here could only
+ * ever cut a document the writer had judged legal — and an Agent told this block *is* its Memory
+ * would then act on a fragment believing it read the whole thing.
  */
-function blockText(value: string, limit: number, truncationNote?: string): string {
+function blockText(value: string, limit?: number): string {
   const cleaned = value
     .replace(/[<>]/g, "")
     .split("\n")
@@ -362,9 +357,8 @@ function blockText(value: string, limit: number, truncationNote?: string): strin
     .join("\n")
     .replace(/\n{3,}/g, "\n\n")
     .trim();
-  if (cleaned.length <= limit) return cleaned;
-  const capped = `${cleaned.slice(0, limit).trimEnd()}…`;
-  return truncationNote === undefined ? capped : `${capped}\n${truncationNote}`;
+  if (limit === undefined || cleaned.length <= limit) return cleaned;
+  return `${cleaned.slice(0, limit).trimEnd()}…`;
 }
 
 function renderBlock(tag: string, body: string): string {
@@ -490,10 +484,7 @@ export function renderSoulReminder(
   const blocks = [
     renderBusiness(catalogue.business),
     `<soul>\n${soul}\n</soul>`,
-    renderBlock(
-      "user-memory",
-      blockText(personal.memory ?? "", MAX_MEMORY_CHARS, MEMORY_TRUNCATED_NOTE)
-    ),
+    renderBlock("user-memory", blockText(personal.memory ?? "")),
     renderBlock(
       "custom-instructions",
       blockText(personal.customInstructions ?? "", MAX_CUSTOM_INSTRUCTIONS_CHARS)

--- a/packages/agent-runtime/src/context/soul-reminder.ts
+++ b/packages/agent-runtime/src/context/soul-reminder.ts
@@ -337,6 +337,13 @@ const EMPTY_SECTION = "(none)";
 const MAX_MEMORY_CHARS = 8_000;
 
 /**
+ * Said out loud when the Memory Document did not fit, for the same reason as `EMPTY_SECTION`: the
+ * Agent is told everywhere else that this block *is* its Memory, so a silent cut would have it act
+ * on a partial document believing it read all of it. This names the Tool that returns the rest.
+ */
+const MEMORY_TRUNCATED_NOTE = "(truncated here — call get_memory for the rest)";
+
+/**
  * Flattens one authored *block* into safe lines, keeping the line breaks.
  *
  * `line()` cannot be used here: the Memory Document is Markdown whose headings and one-fact-per-
@@ -347,7 +354,7 @@ const MAX_MEMORY_CHARS = 8_000;
  * one part of the reminder whose text a user or a compromised Agent chooses, and a body that can
  * write `</user-memory>` can continue as if it were the platform speaking.
  */
-function blockText(value: string, limit: number): string {
+function blockText(value: string, limit: number, truncationNote?: string): string {
   const cleaned = value
     .replace(/[<>]/g, "")
     .split("\n")
@@ -355,7 +362,9 @@ function blockText(value: string, limit: number): string {
     .join("\n")
     .replace(/\n{3,}/g, "\n\n")
     .trim();
-  return cleaned.length > limit ? `${cleaned.slice(0, limit).trimEnd()}…` : cleaned;
+  if (cleaned.length <= limit) return cleaned;
+  const capped = `${cleaned.slice(0, limit).trimEnd()}…`;
+  return truncationNote === undefined ? capped : `${capped}\n${truncationNote}`;
 }
 
 function renderBlock(tag: string, body: string): string {
@@ -481,7 +490,10 @@ export function renderSoulReminder(
   const blocks = [
     renderBusiness(catalogue.business),
     `<soul>\n${soul}\n</soul>`,
-    renderBlock("user-memory", blockText(personal.memory ?? "", MAX_MEMORY_CHARS)),
+    renderBlock(
+      "user-memory",
+      blockText(personal.memory ?? "", MAX_MEMORY_CHARS, MEMORY_TRUNCATED_NOTE)
+    ),
     renderBlock(
       "custom-instructions",
       blockText(personal.customInstructions ?? "", MAX_CUSTOM_INSTRUCTIONS_CHARS)

--- a/packages/memory/src/document/tool.ts
+++ b/packages/memory/src/document/tool.ts
@@ -164,23 +164,29 @@ const GET_MEMORY_SCHEMA: Record<string, unknown> = {
 const validateGetMemory = ajv.compile(GET_MEMORY_SCHEMA);
 
 /**
- * The whole-document read path, and the only one that is authoritative.
+ * The fallback read path. In a healthy Turn nothing should call it.
  *
- * The Soul reminder already carries the document in `<user-memory>`, capped, so this is no longer
- * how an Agent first learns about the person — telling it otherwise bought a wasted call on every
- * conversation. What is left needs the Tool: a document too long for the reminder, a Turn that
- * renders no reminder at all, and `update_memory`'s `remove`, which matches lines verbatim and
- * therefore cannot name a line the model has never read.
+ * The Soul reminder carries the whole document in `<user-memory>`, re-rendered from the store on
+ * every Turn, so an Agent has already been handed everything this returns and cannot hold a stale
+ * copy. Two cases are left over, and both are the reminder failing rather than the Agent needing
+ * more: a Turn that renders no reminder (no authority-layer resolver composed), and a reminder
+ * dropped by the context budget — it sits at `skill_instructions`, which is compactable.
+ *
+ * The description therefore has to argue *against* itself. A read Tool that merely says what it
+ * returns gets called on reflex, and that reflex is what this Tool used to buy on every single
+ * conversation.
  */
 export const getMemoryTool = defineApiTool<MemoryDocumentToolContext>({
   name: "get_memory",
-  description: `Read the whole durable memory document for this user: who they are, how they want you to reply, and standing rules they have given you.
+  description: `Fallback read of this user's durable memory document. You will almost never need it.
 
-You have already been given it. The <user-memory> block in the system reminder carries this document, and <custom-instructions> carries the user's own standing instructions, on every Turn. Do not call this to start a conversation, to look up a preference, or to check whether anything is recorded — read the block.
+You already have the document. The <user-memory> block in the system reminder carries it in full, and <custom-instructions> carries the user's own standing instructions. Both are rebuilt from storage on every single turn, so what you can see is current — it cannot go stale mid-conversation, however long the conversation runs, and calling this returns exactly the text you already have.
 
-Call it only when the block cannot answer you: it says it was truncated, it is missing entirely, or you are about to call \`update_memory\` with \`remove\` (which matches lines verbatim, so read the exact line first).
+So do not call this to open a conversation, to look up a preference or a standing rule, to check whether anything is recorded about the user, or to re-read a line before removing it. Read the block instead.
 
-Returns the document as Markdown in \`document\`, plus any standing instructions the user wrote themselves in \`customInstructions\` — those are the user's own words and outrank your <agent-personality>. If \`timezone\` comes back, pass it to \`get_current_time\`; the clock defaults to UTC and will otherwise date things in the wrong day for this user.`,
+Call it only if <user-memory> is missing from your context entirely. That means the reminder failed to render, and this is the only way to recover what it would have told you.
+
+Returns the document as Markdown in \`document\`, plus any standing instructions in \`customInstructions\` — those are the user's own words and outrank your <agent-personality>. If \`timezone\` comes back, pass it to \`get_current_time\`; the clock defaults to UTC and will otherwise date things in the wrong day for this user.`,
   tier: "platform",
   mutating: false,
   inputSchema: GET_MEMORY_SCHEMA,

--- a/packages/memory/src/document/tool.ts
+++ b/packages/memory/src/document/tool.ts
@@ -164,19 +164,23 @@ const GET_MEMORY_SCHEMA: Record<string, unknown> = {
 const validateGetMemory = ajv.compile(GET_MEMORY_SCHEMA);
 
 /**
- * The one durable-memory read path.
+ * The whole-document read path, and the only one that is authoritative.
  *
- * Nothing puts Memory in the prompt, so an Agent that does not call this knows nothing durable
- * about the person it is talking to. It also gates `update_memory`'s `remove`, which matches lines
- * verbatim and therefore cannot name a line the model has never read.
+ * The Soul reminder already carries the document in `<user-memory>`, capped, so this is no longer
+ * how an Agent first learns about the person — telling it otherwise bought a wasted call on every
+ * conversation. What is left needs the Tool: a document too long for the reminder, a Turn that
+ * renders no reminder at all, and `update_memory`'s `remove`, which matches lines verbatim and
+ * therefore cannot name a line the model has never read.
  */
 export const getMemoryTool = defineApiTool<MemoryDocumentToolContext>({
   name: "get_memory",
-  description: `Read everything durable you have recorded about this user: who they are, how they want you to reply, and standing rules they have given you.
+  description: `Read the whole durable memory document for this user: who they are, how they want you to reply, and standing rules they have given you.
 
-Nothing else tells you any of it, so call this at the start of a conversation with a person, before you rely on a preference, and before \`update_memory\` with \`remove\` (which matches lines verbatim, so you must read the line first).
+You have already been given it. The <user-memory> block in the system reminder carries this document, and <custom-instructions> carries the user's own standing instructions, on every Turn. Do not call this to start a conversation, to look up a preference, or to check whether anything is recorded — read the block.
 
-Returns what you have recorded as Markdown in \`document\`, plus any standing instructions the user wrote themselves in \`customInstructions\` — those are the user's own words and outrank your <agent-personality>. If \`timezone\` comes back, pass it to \`get_current_time\`; the clock defaults to UTC and will otherwise date things in the wrong day for this user.`,
+Call it only when the block cannot answer you: it says it was truncated, it is missing entirely, or you are about to call \`update_memory\` with \`remove\` (which matches lines verbatim, so read the exact line first).
+
+Returns the document as Markdown in \`document\`, plus any standing instructions the user wrote themselves in \`customInstructions\` — those are the user's own words and outrank your <agent-personality>. If \`timezone\` comes back, pass it to \`get_current_time\`; the clock defaults to UTC and will otherwise date things in the wrong day for this user.`,
   tier: "platform",
   mutating: false,
   inputSchema: GET_MEMORY_SCHEMA,


### PR DESCRIPTION
## Summary

`get_memory` was being called on essentially every conversation, re-reading what the Agent had already been handed. Two causes, both fixed here.

**1. The reminder was cutting the document at 8k.** `MEMORY_DOCUMENT_CHAR_BUDGET` is 20k and every write path asserts it, so the reminder's own 8k ceiling could only ever cut a document the writer had already judged legal — and an Agent told everywhere else that `<user-memory>` *is* its Memory would then act on the fragment believing it read all of it. Cap removed: `blockText` takes an optional limit and the memory block passes none. `<custom-instructions>` keeps its own cap, which is its own budget rather than a second guess at this one.

**2. `get_memory`'s description was stale.** It said *"Nothing else tells you any of it, so call this at the start of a conversation with a person"* — true in #591, false since #595 the same day, when the reminder started carrying the document. The model obeyed the sentence.

With the cap gone, `get_memory` has nothing to add on a healthy Turn. The reminder is rebuilt from storage on **every** Turn (`turn-context.ts` calls `resolveSoulReminder` per `buildContext`, which does a live `memory.render()`), so the block cannot go stale mid-conversation however long it runs, and the Tool returns text the model already has. The description now argues against calling itself and leaves exactly one reason: `<user-memory>` absent from context — the reminder did not render (no authority-layer resolver composed) or was dropped by the context budget, since it sits at `skill_instructions`, which is compactable.

Dropping the "read the line before `remove`" reason is deliberate: the block now shows every line verbatim, so there is nothing to go and read first.

### Not in this PR

`document_over_budget` is a dead end for users. Only `recent_decisions` self-trims (15 entries); every other section, once at 6k, rejects every write forever until someone removes lines, and the Agent gets a bare `validation_error` with no instruction to prune. Filing separately.

No eval Case: the eval tiers wire no Memory Document, so nothing in the Corpus can observe `<user-memory>` today. `corpusHash` unchanged, Baselines still stand.

## Test plan

- [x] `pnpm exec biome check packages/agent-runtime/src/context packages/memory/src/document`
- [x] `pnpm --filter @tulipfarm/agent-runtime exec vitest run src/context/soul-reminder.test.ts` — 39 pass
- [x] `pnpm --filter @tulipfarm/memory exec vitest run` — 54 pass
- [x] `pnpm typecheck` — 41/41