### PR TITLE
ci(release): guard against manual release-branch and tag tampering

### DIFF
--- a/.github/workflows/release-branch-guard.yml
+++ b/.github/workflows/release-branch-guard.yml
@@ -1,0 +1,39 @@
+name: Release branch guard
+
+# v0.18.6 shipped a stray commit onto its release branch after the release PR was
+# already open. publish-image.yml's file-allowlist correctly rejected the merge, but
+# only at merge time -- by then the release PR had looked green for a while. This
+# fails loud the moment the extra commit lands, instead of waiting for a failed merge.
+on:
+  push:
+    branches: ["release/v**"]
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    name: Reject extra commits on a release branch
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Verify the branch holds only the automated version bump
+        run: |
+          set -euo pipefail
+          git fetch origin main --quiet
+          commits="$(git rev-list --count origin/main..HEAD)"
+          if [ "$commits" != "1" ]; then
+            echo "##[error]$GITHUB_REF has $commits commit(s) ahead of main; release branches must carry exactly the automated chore(release) commit. publish-image.yml will reject this at merge -- reset the branch instead of adding commits to it."
+            exit 1
+          fi
+          subject="$(git log -1 --format=%s)"
+          case "$subject" in
+            "chore(release): v"*) ;;
+            *)
+              echo "##[error]$GITHUB_REF's HEAD commit ('$subject') is not the automated chore(release) bump. Only release.yml should commit to a release branch."
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/release-tag-guard.yml
+++ b/.github/workflows/release-tag-guard.yml
@@ -1,0 +1,37 @@
+name: Release tag guard
+
+# After v0.18.6's publish run failed twice (see release-branch-guard.yml), someone
+# hand-pushed a `v0.18.6` tag to mark it released anyway -- no GitHub Release or
+# image was ever published for that version. publish-image.yml's own tag step
+# (.github/workflows/publish-image.yml, "Create source tag") only ever creates an
+# annotated tag carrying a `TulipFarm-Source-SHA:` marker. Anything else pushed to
+# a `v*` ref did not come from the pipeline.
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    name: Reject a hand-pushed release tag
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Verify the tag came from publish-image.yml
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF#refs/tags/}"
+          object_type="$(git cat-file -t "refs/tags/$tag")"
+          if [ "$object_type" != "tag" ]; then
+            echo "##[error]$tag is a lightweight tag; publish-image.yml only ever creates annotated tags. This looks hand-pushed -- delete it unless a matching GitHub Release and GHCR image already exist for $tag."
+            exit 1
+          fi
+          if ! git cat-file tag "$tag" | grep -q "^TulipFarm-Source-SHA:"; then
+            echo "##[error]$tag is annotated but missing the TulipFarm-Source-SHA marker publish-image.yml writes, so it was not created by the release pipeline. Delete it unless a matching GitHub Release and GHCR image already exist for $tag."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- v0.18.6 got a stray commit pushed onto its release branch after the release PR was already open; `publish-image.yml`'s file-allowlist only rejected it at merge time, by which point the PR had looked green for a while.
- Someone then hand-pushed a `v0.18.6` tag to mark it released even though no GitHub Release or GHCR image was ever published for that version.
- Adds two workflows that fail loud the moment either happens instead of waiting for a failed merge or leaving a fake release tag undetected: `release-branch-guard.yml` (push to `release/v**` must be exactly one `chore(release): vX` commit ahead of `main`) and `release-tag-guard.yml` (push of a `v*` tag must be annotated and carry the `TulipFarm-Source-SHA:` marker `publish-image.yml`'s "Create source tag" step writes).

## Test plan
- [x] Validated both workflow files as syntactically valid YAML
- [ ] Confirm `release-branch-guard.yml` passes on a normal `release/vX.Y.Z` branch push (single automated commit) and fails if a second commit is added
- [ ] Confirm `release-tag-guard.yml` passes on a tag created by `publish-image.yml` and fails on a manually/lightweight-pushed tag